### PR TITLE
Add in-app update system

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -1,0 +1,81 @@
+name: Publish LEVYRA Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag
+        required: true
+        default: v1.2.0
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Android SDK
+        run: |
+          yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses >/dev/null
+          "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" "platform-tools" "platforms;android-35" "build-tools;35.0.0"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: '8.13'
+
+      - name: Build Release APK
+        run: gradle --no-daemon clean assembleRelease
+
+      - name: Prepare Release
+        shell: bash
+        run: |
+          TAG_NAME="${GITHUB_REF_NAME}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG_NAME="${{ inputs.tag }}"
+          fi
+          VERSION="${TAG_NAME#v}"
+          mkdir -p artifacts
+          cp app/build/outputs/apk/release/app-release.apk "artifacts/LEVYRA-${VERSION}.apk"
+          cat > release-notes.md <<EOF_NOTES
+LEVYRA ${VERSION}
+
+Nuova build disponibile per il download diretto dall'app.
+
+Aggiorna dall'app aprendo Impostazioni > Aggiornamenti > Check.
+EOF_NOTES
+          echo "TAG_NAME=${TAG_NAME}" >> "$GITHUB_ENV"
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+
+      - name: Upload APK Artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: levyra-release-${{ env.VERSION }}
+          path: artifacts/LEVYRA-${{ env.VERSION }}.apk
+          if-no-files-found: error
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            gh release upload "$TAG_NAME" "artifacts/LEVYRA-${VERSION}.apk" --clobber
+            gh release edit "$TAG_NAME" --latest --title "LEVYRA ${VERSION}" --notes-file release-notes.md
+          else
+            gh release create "$TAG_NAME" "artifacts/LEVYRA-${VERSION}.apk" --latest --title "LEVYRA ${VERSION}" --notes-file release-notes.md
+          fi

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,16 +15,16 @@ android {
         applicationId = "com.luc4n3x.levyra"
         minSdk = 26
         targetSdk = 35
-        versionCode = 21
-        versionName = "1.14.0"
+        versionCode = 24
+        versionName = "1.2.0"
         vectorDrawables.useSupportLibrary = true
+        buildConfigField("String", "UPDATE_REPOSITORY", "\"LUC4N3X/Levyra-deepsound\"")
+        buildConfigField("String", "UPDATE_LATEST_URL", "\"https://api.github.com/repos/LUC4N3X/Levyra-deepsound/releases/latest\"")
     }
 
     signingConfigs {
         getByName("debug")
         create("release") {
-            // Stable self-signed release key so the APK is not flagged as a debug build
-            // and stays updatable across versions.
             storeFile = rootProject.file("app/levyra-release.jks")
             storePassword = "levyra2026"
             keyAlias = "levyra"

--- a/app/src/main/java/com/luc4n3x/levyra/data/AppUpdateRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/AppUpdateRepository.kt
@@ -1,0 +1,107 @@
+package com.luc4n3x.levyra.data
+
+import android.content.Context
+import com.luc4n3x.levyra.BuildConfig
+import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
+import com.luc4n3x.levyra.domain.AppUpdateInfo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.Request
+import org.json.JSONObject
+
+class AppUpdateRepository(context: Context) {
+    private val client = LevyraHttpClientFactory.general(context.applicationContext)
+
+    suspend fun latest(): AppUpdateInfo = withContext(Dispatchers.IO) {
+        val request = Request.Builder()
+            .url(BuildConfig.UPDATE_LATEST_URL)
+            .header("Accept", "application/vnd.github+json")
+            .header("User-Agent", "LEVYRA/${BuildConfig.VERSION_NAME}")
+            .build()
+        client.newCall(request).execute().use { response ->
+            val body = response.body?.string().orEmpty()
+            if (!response.isSuccessful) {
+                val message = when (response.code) {
+                    404 -> "Nessuna release pubblicata per LEVYRA"
+                    403 -> "Controllo aggiornamenti temporaneamente limitato"
+                    else -> "Controllo aggiornamenti non riuscito (${response.code})"
+                }
+                throw IllegalStateException(message)
+            }
+            parseLatestRelease(JSONObject(body))
+        }
+    }
+
+    private fun parseLatestRelease(root: JSONObject): AppUpdateInfo {
+        val latestTag = root.optString("tag_name").ifBlank { root.optString("name") }
+        val latestVersion = normalizeDisplayVersion(latestTag)
+        val releaseUrl = root.optString("html_url")
+        val asset = bestDownloadAsset(root)
+        val downloadUrl = asset?.downloadUrl?.ifBlank { releaseUrl } ?: releaseUrl
+        val releaseTitle = root.optString("name").ifBlank { "LEVYRA $latestVersion" }
+        val notes = root.optString("body").trim()
+        val current = BuildConfig.VERSION_NAME
+        return AppUpdateInfo(
+            currentVersionName = current,
+            latestVersionName = latestVersion,
+            latestTag = latestTag.ifBlank { latestVersion },
+            releaseTitle = releaseTitle,
+            releaseNotes = notes,
+            publishedAt = root.optString("published_at"),
+            downloadUrl = downloadUrl,
+            releaseUrl = releaseUrl.ifBlank { downloadUrl },
+            assetName = asset?.name.orEmpty(),
+            directApk = asset?.directApk ?: false,
+            isNewer = compareVersions(latestVersion, current) > 0
+        )
+    }
+
+    private fun bestDownloadAsset(root: JSONObject): ReleaseAsset? {
+        val assets = root.optJSONArray("assets") ?: return null
+        val parsed = buildList {
+            for (index in 0 until assets.length()) {
+                val item = assets.optJSONObject(index) ?: continue
+                val name = item.optString("name").trim()
+                val url = item.optString("browser_download_url").trim()
+                if (url.isBlank()) continue
+                val contentType = item.optString("content_type").lowercase()
+                val directApk = name.endsWith(".apk", ignoreCase = true) || contentType.contains("android.package-archive")
+                add(ReleaseAsset(name, url, directApk))
+            }
+        }
+        return parsed.firstOrNull { it.directApk && it.name.contains("release", ignoreCase = true) }
+            ?: parsed.firstOrNull { it.directApk }
+            ?: parsed.firstOrNull()
+    }
+
+    private fun normalizeDisplayVersion(value: String): String {
+        val clean = value.trim().removePrefix("v").removePrefix("V")
+        val match = Regex("\\d+(?:\\.\\d+){0,3}").find(clean)?.value
+        return match ?: clean.ifBlank { BuildConfig.VERSION_NAME }
+    }
+
+    private fun compareVersions(left: String, right: String): Int {
+        val a = numericParts(left)
+        val b = numericParts(right)
+        val size = maxOf(a.size, b.size, 1)
+        for (index in 0 until size) {
+            val av = a.getOrNull(index) ?: 0
+            val bv = b.getOrNull(index) ?: 0
+            if (av != bv) return av.compareTo(bv)
+        }
+        return 0
+    }
+
+    private fun numericParts(value: String): List<Int> {
+        return Regex("\\d+")
+            .findAll(value)
+            .mapNotNull { it.value.toIntOrNull() }
+            .toList()
+    }
+
+    private data class ReleaseAsset(
+        val name: String,
+        val downloadUrl: String,
+        val directApk: Boolean
+    )
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
@@ -72,6 +72,12 @@ class LevyraPreferences(context: Context) {
         write { it[KEY_SKIP_SILENCE] = value }
     }
 
+    fun dismissedUpdateVersion(): String = read("") { it[KEY_DISMISSED_UPDATE_VERSION].orEmpty() }
+
+    fun setDismissedUpdateVersion(version: String) {
+        write { it[KEY_DISMISSED_UPDATE_VERSION] = version }
+    }
+
     fun saveLastPlayback(track: Track?, positionMs: Long) {
         write {
             if (track == null) {
@@ -140,5 +146,6 @@ class LevyraPreferences(context: Context) {
         val KEY_SKIP_SILENCE = booleanPreferencesKey("skip_silence")
         val KEY_USER_NAME = stringPreferencesKey("user_name")
         val KEY_RECENT_SEARCHES = stringPreferencesKey("recent_searches")
+        val KEY_DISMISSED_UPDATE_VERSION = stringPreferencesKey("dismissed_update_version")
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/domain/Models.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/Models.kt
@@ -105,6 +105,20 @@ data class SponsorSegment(
     val category: String
 )
 
+data class AppUpdateInfo(
+    val currentVersionName: String,
+    val latestVersionName: String,
+    val latestTag: String,
+    val releaseTitle: String,
+    val releaseNotes: String,
+    val publishedAt: String,
+    val downloadUrl: String,
+    val releaseUrl: String,
+    val assetName: String,
+    val directApk: Boolean,
+    val isNewer: Boolean
+)
+
 fun Track.smartWeightFor(mood: Mood?): Int {
     if (mood == null) return replayScore
     val tagScore = mood.tags.intersect(moodTags).size * 18

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -2,9 +2,11 @@ package com.luc4n3x.levyra.ui
 
 import android.app.Activity
 import android.content.Intent
+import android.net.Uri
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.ui.res.painterResource
+import com.luc4n3x.levyra.BuildConfig
 import com.luc4n3x.levyra.R
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
@@ -127,6 +129,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.luc4n3x.levyra.domain.AppUpdateInfo
 import com.luc4n3x.levyra.domain.LevyraTab
 import com.luc4n3x.levyra.domain.Mood
 import com.luc4n3x.levyra.domain.Taste
@@ -168,7 +171,13 @@ fun LevyraApp(viewModel: LevyraViewModel) {
             viewModel.clearOfflineExportMessage()
         }
     }
-    BackHandler(enabled = state.showQueue || state.showLyrics || state.showSettings || state.selectedTab != LevyraTab.Home) {
+    LaunchedEffect(state.updateMessage) {
+        state.updateMessage?.let { message ->
+            Toast.makeText(toastContext, message, Toast.LENGTH_LONG).show()
+            viewModel.clearUpdateMessage()
+        }
+    }
+    BackHandler(enabled = state.showUpdatePrompt || state.showQueue || state.showLyrics || state.showSettings || state.selectedTab != LevyraTab.Home) {
         if (!viewModel.navigateBack()) {
             activity?.finish()
         }
@@ -251,10 +260,14 @@ fun LevyraApp(viewModel: LevyraViewModel) {
                     dynamicColor = state.dynamicColor,
                     sponsorBlock = state.sponsorBlockEnabled,
                     skipSilence = state.skipSilence,
+                    updateInfo = state.updateInfo,
+                    isCheckingUpdates = state.isCheckingUpdates,
                     onAnimations = viewModel::setAnimationsEnabled,
                     onDynamicColor = viewModel::setDynamicColor,
                     onSponsorBlock = viewModel::setSponsorBlock,
                     onSkipSilence = viewModel::setSkipSilence,
+                    onCheckUpdates = { viewModel.checkForUpdates(silent = false) },
+                    onDownloadUpdate = { state.updateInfo?.let { openExternalUrl(toastContext, it.downloadUrl) } },
                     onRedoQuestionnaire = viewModel::restartOnboarding,
                     onClose = viewModel::closeSettings
                 )
@@ -262,6 +275,19 @@ fun LevyraApp(viewModel: LevyraViewModel) {
 
             AnimatedVisibility(visible = state.showLyrics, enter = overlayEnter, exit = overlayExit) {
                 LyricsOverlay(state = state, onClose = viewModel::closeLyrics)
+            }
+
+            AnimatedVisibility(visible = state.showUpdatePrompt && state.updateInfo?.isNewer == true, enter = overlayEnter, exit = overlayExit) {
+                state.updateInfo?.let { update ->
+                    UpdateAvailableOverlay(
+                        update = update,
+                        onDownload = {
+                            openExternalUrl(toastContext, update.downloadUrl)
+                            viewModel.dismissUpdatePrompt()
+                        },
+                        onLater = viewModel::dismissUpdatePrompt
+                    )
+                }
             }
 
             AnimatedVisibility(visible = state.showQueue, enter = overlayEnter, exit = overlayExit) {
@@ -272,6 +298,180 @@ fun LevyraApp(viewModel: LevyraViewModel) {
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun UpdateAvailableOverlay(
+    update: AppUpdateInfo,
+    onDownload: () -> Unit,
+    onLater: () -> Unit
+) {
+    val blocker = remember { MutableInteractionSource() }
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.72f))
+            .clickable(interactionSource = blocker, indication = null) {},
+        contentAlignment = Alignment.Center
+    ) {
+        Surface(
+            color = Color.Transparent,
+            shape = RoundedCornerShape(28.dp),
+            border = BorderStroke(1.dp, LevyraCyan.copy(alpha = 0.28f)),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 22.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .background(
+                        Brush.linearGradient(
+                            listOf(
+                                LevyraCyan.copy(alpha = 0.22f),
+                                Color(0xFF0B1020),
+                                LevyraViolet.copy(alpha = 0.20f)
+                            )
+                        )
+                    )
+                    .padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Surface(
+                        color = LevyraCyan.copy(alpha = 0.15f),
+                        shape = CircleShape,
+                        border = BorderStroke(1.dp, LevyraCyan.copy(alpha = 0.25f))
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(7.dp)
+                        ) {
+                            Icon(Icons.Rounded.Bolt, null, tint = LevyraCyan, modifier = Modifier.size(17.dp))
+                            Text("AGGIORNAMENTO", color = LevyraText, fontSize = 11.sp, fontWeight = FontWeight.Black, letterSpacing = 1.1.sp)
+                        }
+                    }
+                    CircleIconButton(
+                        icon = Icons.Rounded.Close,
+                        tint = LevyraText,
+                        background = Color.White.copy(alpha = 0.08f),
+                        onClick = onLater
+                    )
+                }
+
+                Column(verticalArrangement = Arrangement.spacedBy(7.dp)) {
+                    Text(
+                        text = "LEVYRA ${update.latestVersionName} è pronta",
+                        color = LevyraText,
+                        fontSize = 27.sp,
+                        lineHeight = 30.sp,
+                        fontWeight = FontWeight.Black
+                    )
+                    Text(
+                        text = "Puoi scaricare la nuova versione e installarla quando vuoi.",
+                        color = LevyraMuted,
+                        fontSize = 14.sp,
+                        lineHeight = 20.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+
+                Surface(
+                    color = Color.White.copy(alpha = 0.055f),
+                    shape = RoundedCornerShape(18.dp),
+                    border = BorderStroke(1.dp, Color.White.copy(alpha = 0.08f))
+                ) {
+                    Column(
+                        modifier = Modifier.padding(14.dp),
+                        verticalArrangement = Arrangement.spacedBy(5.dp)
+                    ) {
+                        Text(update.releaseTitle.ifBlank { "Nuova versione" }, color = LevyraText, fontSize = 15.sp, fontWeight = FontWeight.Black, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                        Text(
+                            text = compactReleaseNotes(update.releaseNotes),
+                            color = LevyraMuted,
+                            fontSize = 12.sp,
+                            lineHeight = 17.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 4,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    Surface(
+                        color = Color.Transparent,
+                        shape = RoundedCornerShape(16.dp),
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(48.dp)
+                            .pressable(onClick = onDownload)
+                    ) {
+                        Box(
+                            modifier = Modifier.background(Brush.horizontalGradient(listOf(LevyraCyan, LevyraViolet))),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                Icon(Icons.Rounded.PlayArrow, null, tint = Color.White, modifier = Modifier.size(19.dp))
+                                Text("Scarica", color = Color.White, fontSize = 16.sp, fontWeight = FontWeight.Black)
+                            }
+                        }
+                    }
+                    Surface(
+                        color = Color.White.copy(alpha = 0.06f),
+                        shape = RoundedCornerShape(16.dp),
+                        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.09f)),
+                        modifier = Modifier
+                            .weight(0.72f)
+                            .height(48.dp)
+                            .pressable(onClick = onLater)
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Text("Più tardi", color = LevyraText, fontSize = 15.sp, fontWeight = FontWeight.Black)
+                        }
+                    }
+                }
+
+                Text(
+                    text = "Installata: ${update.currentVersionName} · Ultima: ${update.latestVersionName}",
+                    color = LevyraMuted.copy(alpha = 0.78f),
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
+    }
+}
+
+private fun compactReleaseNotes(notes: String): String {
+    val clean = notes
+        .lineSequence()
+        .map { it.trim().trimStart('-', '*', '•').trim() }
+        .filter { it.isNotBlank() }
+        .take(3)
+        .joinToString(" · ")
+    return clean.ifBlank { "Correzioni, rifiniture e miglioramenti generali." }
+}
+
+private fun openExternalUrl(context: android.content.Context, url: String) {
+    if (url.isBlank()) {
+        Toast.makeText(context, "Link aggiornamento non disponibile", Toast.LENGTH_LONG).show()
+        return
+    }
+    runCatching {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        context.startActivity(intent)
+    }.onFailure {
+        Toast.makeText(context, "Impossibile aprire il download", Toast.LENGTH_LONG).show()
     }
 }
 
@@ -2413,10 +2613,14 @@ private fun SettingsOverlay(
     dynamicColor: Boolean,
     sponsorBlock: Boolean,
     skipSilence: Boolean,
+    updateInfo: AppUpdateInfo?,
+    isCheckingUpdates: Boolean,
     onAnimations: (Boolean) -> Unit,
     onDynamicColor: (Boolean) -> Unit,
     onSponsorBlock: (Boolean) -> Unit,
     onSkipSilence: (Boolean) -> Unit,
+    onCheckUpdates: () -> Unit,
+    onDownloadUpdate: () -> Unit,
     onRedoQuestionnaire: () -> Unit,
     onClose: () -> Unit
 ) {
@@ -2500,9 +2704,18 @@ private fun SettingsOverlay(
                     onClick = onRedoQuestionnaire
                 )
             }
+            item { SettingsSectionLabel("APP") }
+            item {
+                SettingsUpdateCard(
+                    updateInfo = updateInfo,
+                    isChecking = isCheckingUpdates,
+                    onCheck = onCheckUpdates,
+                    onDownload = onDownloadUpdate
+                )
+            }
             item {
                 Text(
-                    "LEVYRA • YouTube & YouTube Music engine",
+                    "LEVYRA ${BuildConfig.VERSION_NAME} • YouTube & YouTube Music engine",
                     color = LevyraMuted,
                     fontSize = 12.sp,
                     fontWeight = FontWeight.Bold,
@@ -2584,6 +2797,150 @@ private fun SettingsButton(icon: ImageVector, title: String, subtitle: String, o
                 Text(title, color = LevyraText, fontSize = 15.sp, fontWeight = FontWeight.Black)
                 Text(subtitle, color = LevyraMuted, fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
             }
+        }
+    }
+}
+
+@Composable
+private fun SettingsUpdateCard(
+    updateInfo: AppUpdateInfo?,
+    isChecking: Boolean,
+    onCheck: () -> Unit,
+    onDownload: () -> Unit
+) {
+    val hasUpdate = updateInfo?.isNewer == true
+    Surface(
+        color = Color.Transparent,
+        border = BorderStroke(1.dp, if (hasUpdate) LevyraCyan.copy(alpha = 0.22f) else Color.White.copy(alpha = 0.1f)),
+        shape = RoundedCornerShape(20.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier
+                .background(
+                    Brush.linearGradient(
+                        listOf(
+                            if (hasUpdate) LevyraCyan.copy(alpha = 0.17f) else Color.White.copy(alpha = 0.055f),
+                            Color.White.copy(alpha = 0.035f),
+                            if (hasUpdate) LevyraViolet.copy(alpha = 0.13f) else Color.White.copy(alpha = 0.04f)
+                        )
+                    )
+                )
+                .padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(42.dp)
+                        .background(LevyraCyan.copy(alpha = 0.16f), RoundedCornerShape(14.dp)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (isChecking) {
+                        CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp, color = LevyraCyan)
+                    } else {
+                        Icon(Icons.Rounded.Bolt, null, tint = LevyraCyan, modifier = Modifier.size(21.dp))
+                    }
+                }
+                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                    Text(
+                        text = if (hasUpdate) "Aggiornamento disponibile" else "Aggiornamenti",
+                        color = LevyraText,
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Black
+                    )
+                    Text(
+                        text = when {
+                            isChecking -> "Controllo ultima versione…"
+                            hasUpdate -> "LEVYRA ${updateInfo?.latestVersionName.orEmpty()} pronta al download"
+                            updateInfo != null -> "Installata la versione più recente"
+                            else -> "Verifica nuove versioni pubblicate"
+                        },
+                        color = LevyraMuted,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+            }
+            if (hasUpdate && updateInfo != null) {
+                Surface(
+                    color = Color.Black.copy(alpha = 0.16f),
+                    shape = RoundedCornerShape(14.dp),
+                    border = BorderStroke(1.dp, Color.White.copy(alpha = 0.07f))
+                ) {
+                    Column(
+                        modifier = Modifier.padding(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Text(updateInfo.releaseTitle.ifBlank { "LEVYRA ${updateInfo.latestVersionName}" }, color = LevyraText, fontSize = 14.sp, fontWeight = FontWeight.Black, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        Text(
+                            text = if (updateInfo.directApk) "APK firmato pronto da installare" else "Pagina release pronta da aprire",
+                            color = LevyraMuted,
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    }
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                SettingsMiniButton(
+                    label = if (isChecking) "Controllo" else "Check",
+                    accent = LevyraCyan,
+                    enabled = !isChecking,
+                    modifier = Modifier.weight(1f),
+                    onClick = onCheck
+                )
+                if (hasUpdate) {
+                    SettingsMiniButton(
+                        label = "Scarica",
+                        accent = LevyraViolet,
+                        enabled = !isChecking,
+                        modifier = Modifier.weight(1f),
+                        onClick = onDownload
+                    )
+                }
+            }
+            Text(
+                text = "Versione installata: ${BuildConfig.VERSION_NAME}",
+                color = LevyraMuted.copy(alpha = 0.8f),
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}
+
+@Composable
+private fun SettingsMiniButton(
+    label: String,
+    accent: Color,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    Surface(
+        color = if (enabled) accent.copy(alpha = 0.15f) else Color.White.copy(alpha = 0.045f),
+        shape = RoundedCornerShape(14.dp),
+        border = BorderStroke(1.dp, if (enabled) accent.copy(alpha = 0.24f) else Color.White.copy(alpha = 0.07f)),
+        modifier = modifier
+            .height(42.dp)
+            .pressable(onClick = { if (enabled) onClick() })
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                text = label,
+                color = if (enabled) LevyraText else LevyraMuted,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Black
+            )
         }
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
@@ -1,6 +1,7 @@
 package com.luc4n3x.levyra.viewmodel
 
 import com.luc4n3x.levyra.domain.CacheReport
+import com.luc4n3x.levyra.domain.AppUpdateInfo
 import com.luc4n3x.levyra.domain.ChartRegion
 import com.luc4n3x.levyra.domain.HomeSection
 import com.luc4n3x.levyra.domain.LevyraTab
@@ -57,5 +58,9 @@ data class LevyraUiState(
     val showQueue: Boolean = false,
     val isOfflineExporting: Boolean = false,
     val offlineExportMessage: String? = null,
-    val embeddedMetadataWriterReady: Boolean = false
+    val embeddedMetadataWriterReady: Boolean = false,
+    val updateInfo: AppUpdateInfo? = null,
+    val isCheckingUpdates: Boolean = false,
+    val updateMessage: String? = null,
+    val showUpdatePrompt: Boolean = false
 )

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
+import com.luc4n3x.levyra.data.AppUpdateRepository
 import com.luc4n3x.levyra.data.ChartsRepository
 import com.luc4n3x.levyra.data.FavoritesStore
 import com.luc4n3x.levyra.data.LevyraPreferences
@@ -43,6 +44,7 @@ import timber.log.Timber
 class LevyraViewModel(application: Application) : AndroidViewModel(application) {
     private val repository = YoutubeMusicRepository()
     private val chartsRepository = ChartsRepository()
+    private val appUpdateRepository = AppUpdateRepository(application.applicationContext)
     private val lyricsRepository = LyricsRepository()
     private val sponsorBlockRepository = SponsorBlockRepository()
     private val resolver = PlaybackResolver.getInstance(application.applicationContext)
@@ -71,6 +73,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private var sponsorJob: Job? = null
     private var listPrefetchJob: Job? = null
     private var offlineExportJob: Job? = null
+    private var updateJob: Job? = null
     private var sponsorSegments: List<SponsorSegment> = emptyList()
     private val tabBackStack = ArrayDeque<LevyraTab>()
     private var playRequestId: Long = 0L
@@ -108,6 +111,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         loadHomeFeed()
         loadCharts()
         startTicker()
+        checkForUpdates(silent = true)
     }
 
     private fun onTrackCompleted() {
@@ -210,6 +214,51 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     fun closeSettings() {
         _state.update { it.copy(showSettings = false) }
+    }
+
+    fun checkForUpdates(silent: Boolean = false) {
+        if (updateJob?.isActive == true) return
+        updateJob = viewModelScope.launch {
+            _state.update {
+                it.copy(
+                    isCheckingUpdates = true,
+                    updateMessage = if (silent) it.updateMessage else null
+                )
+            }
+            val result = runCatching { appUpdateRepository.latest() }
+            result.onSuccess { info ->
+                val dismissed = preferences.dismissedUpdateVersion()
+                _state.update {
+                    it.copy(
+                        updateInfo = info,
+                        isCheckingUpdates = false,
+                        showUpdatePrompt = info.isNewer && (!silent || dismissed != info.latestVersionName),
+                        updateMessage = when {
+                            silent -> null
+                            info.isNewer -> "LEVYRA ${info.latestVersionName} è disponibile"
+                            else -> "LEVYRA è già aggiornata"
+                        }
+                    )
+                }
+            }.onFailure { error ->
+                if (error is CancellationException) throw error
+                _state.update {
+                    it.copy(
+                        isCheckingUpdates = false,
+                        updateMessage = if (silent) null else error.message ?: "Controllo aggiornamenti non riuscito"
+                    )
+                }
+            }
+        }
+    }
+
+    fun dismissUpdatePrompt() {
+        _state.value.updateInfo?.latestVersionName?.let { preferences.setDismissedUpdateVersion(it) }
+        _state.update { it.copy(showUpdatePrompt = false) }
+    }
+
+    fun clearUpdateMessage() {
+        _state.update { it.copy(updateMessage = null) }
     }
 
     fun setAnimationsEnabled(value: Boolean) {
@@ -378,6 +427,10 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     fun navigateBack(): Boolean {
         val snapshot = _state.value
         return when {
+            snapshot.showUpdatePrompt -> {
+                dismissUpdatePrompt()
+                true
+            }
             snapshot.showQueue -> {
                 closeQueue()
                 true


### PR DESCRIPTION
Adds the Levyra in-app update system with GitHub Releases checks, a manual update button inside Settings, update download handling and a release APK workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-app update checks with a prompt for newer Android releases.
  * Added a settings section showing update status, release details, and download actions.
  * Added automated Android APK release publishing for tag pushes and manual runs.

* **Bug Fixes**
  * Improved handling of update prompts so dismissed versions stay hidden.
  * Added safer opening of external download links and clearer error feedback.

* **Chores**
  * Updated app versioning and release metadata used by the app and build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->