### PR TITLE
Improve playback startup latency with warm cache pipeline

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -47,14 +47,14 @@ class PlaybackResolver private constructor(private val context: Context) {
     private val inFlight = ConcurrentHashMap<String, Deferred<Track>>()
     private val fallbackTtlMs = 90L * 60L * 1000L
     private val maxTtlMs = 5L * 60L * 60L * 1000L
-    private val resolveTimeoutMs = 9_000L
+    private val resolveTimeoutMs = 7_500L
 
     private val profiles = listOf(
         ClientProfile("ANDROID_MUSIC", "8.10.52", "Android Music", "Mozilla/5.0 (Linux; Android 15; Pixel 8 Pro) AppleWebKit/537.36 (KHTML, like Gecko) com.google.android.apps.youtube.music/8.10.52", true, 0L),
-        ClientProfile("ANDROID", "19.44.38", "Android", "com.google.android.youtube/19.44.38 (Linux; U; Android 15)", true, 40L),
-        ClientProfile("IOS", "20.10.4", "iOS", "com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3 like Mac OS X; it_IT)", false, 80L),
-        ClientProfile("WEB_REMIX", "1.20260423.01.00", "YouTube Music Web", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36", false, 130L),
-        ClientProfile("WEB_EMBEDDED_PLAYER", "1.20260423.01.00", "Embedded Player", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36", false, 180L)
+        ClientProfile("ANDROID", "19.44.38", "Android", "com.google.android.youtube/19.44.38 (Linux; U; Android 15)", true, 0L),
+        ClientProfile("IOS", "20.10.4", "iOS", "com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3 like Mac OS X; it_IT)", false, 15L),
+        ClientProfile("WEB_REMIX", "1.20260423.01.00", "YouTube Music Web", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36", false, 35L),
+        ClientProfile("WEB_EMBEDDED_PLAYER", "1.20260423.01.00", "Embedded Player", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36", false, 60L)
     )
 
     init {
@@ -95,13 +95,16 @@ class PlaybackResolver private constructor(private val context: Context) {
         }
     }
 
-    suspend fun prefetch(track: Track, isVideoMode: Boolean = false) {
+    suspend fun prefetch(track: Track, isVideoMode: Boolean = false): Track? {
         if (track.streamUrl.isNotBlank()) {
-            if (streamStillFresh(track.streamUrl)) store(track)
-            return
+            if (streamStillFresh(track.streamUrl)) {
+                store(track, isVideoMode)
+                return track
+            }
+            return null
         }
-        if (cached(track, isVideoMode) != null) return
-        runCatching { resolve(track, isVideoMode) }
+        cached(track, isVideoMode)?.let { return it }
+        return runCatching { resolve(track, isVideoMode) }.getOrNull()
     }
 
     private suspend fun resolveUncached(track: Track, isVideoMode: Boolean = false): Track = withContext(Dispatchers.IO) {
@@ -148,33 +151,48 @@ class PlaybackResolver private constructor(private val context: Context) {
             throw PlaybackBlockedException(reason)
         }
 
-        val stream = raceInnerTube(track, errors, false)
-        if (stream != null) {
-            val resolved = track.copy(
-                streamUrl = stream.url,
-                videoStreamUrl = stream.videoUrl,
-                durationMs = stream.durationMs.takeIf { it > 0L } ?: track.durationMs,
-                thumbnailUrl = stream.thumbnailUrl.ifBlank { track.thumbnailUrl },
-                largeThumbnailUrl = stream.thumbnailUrl.ifBlank { track.largeThumbnailUrl },
-                source = stream.source
-            )
+        val resolved = resolveAudioFast(track, errors)
+        if (resolved != null) {
             store(resolved, isVideoMode)
             return@withContext resolved
         }
-
-        val newPipe = runCatching { resolveWithNewPipe(track) }
-        if (newPipe.isSuccess) {
-            val resolved = newPipe.getOrThrow()
-            store(resolved, isVideoMode)
-            return@withContext resolved
-        }
-        newPipe.exceptionOrNull()?.message?.takeIf { it.isNotBlank() }?.let { errors += "NewPipe: $it" }
 
         val reason = errors.firstOrNull { it.contains("age", true) || it.contains("anonymous", true) || it.contains("login", true) }
             ?: errors.firstOrNull()
             ?: "Stream non disponibile"
         throw PlaybackBlockedException(reason)
     }
+
+    private suspend fun resolveAudioFast(track: Track, errors: MutableList<String>): Track? = coroutineScope {
+        val winner = CompletableDeferred<Track?>()
+        val innerTubeJob = launch {
+            val stream = runCatching { raceInnerTube(track, errors, false) }.getOrNull()
+            if (stream != null) winner.complete(track.withDirectStream(stream))
+        }
+        val newPipeJob = launch {
+            delay(350L)
+            val resolved = runCatching { resolveWithNewPipe(track) }
+            resolved.onSuccess { winner.complete(it) }
+                .onFailure { it.message?.takeIf { message -> message.isNotBlank() }?.let { message -> errors += "NewPipe: $message" } }
+        }
+        launch {
+            innerTubeJob.join()
+            newPipeJob.join()
+            winner.complete(null)
+        }
+        val result = winner.await()
+        coroutineContext.cancelChildren()
+        result
+    }
+
+    private fun Track.withDirectStream(stream: DirectStream): Track = copy(
+        streamUrl = stream.url,
+        videoStreamUrl = stream.videoUrl,
+        durationMs = stream.durationMs.takeIf { it > 0L } ?: durationMs,
+        thumbnailUrl = stream.thumbnailUrl.ifBlank { thumbnailUrl },
+        largeThumbnailUrl = stream.thumbnailUrl.ifBlank { largeThumbnailUrl },
+        source = stream.source
+    )
 
     private suspend fun raceInnerTube(track: Track, errors: MutableList<String>, isVideoMode: Boolean = false): DirectStream? = coroutineScope {
         val winner = CompletableDeferred<DirectStream?>()
@@ -272,8 +290,8 @@ class PlaybackResolver private constructor(private val context: Context) {
         val body = buildPlayerBody(track.id, profile).toString().toByteArray(StandardCharsets.UTF_8)
         val connection = (URL(endpoint).openConnection() as HttpURLConnection).apply {
             requestMethod = "POST"
-            connectTimeout = 3_500
-            readTimeout = 6_500
+            connectTimeout = 2_400
+            readTimeout = 5_000
             doOutput = true
             setRequestProperty("Content-Type", "application/json")
             setRequestProperty("Accept", "application/json")

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaCache.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaCache.kt
@@ -9,7 +9,7 @@ import androidx.media3.common.util.UnstableApi
 
 @OptIn(UnstableApi::class)
 object LevyraMediaCache {
-    private const val MAX_BYTES = 384L * 1024L * 1024L
+    private const val MAX_BYTES = 768L * 1024L * 1024L
 
     @Volatile
     private var cache: SimpleCache? = null

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlaybackCacheKey.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlaybackCacheKey.kt
@@ -1,0 +1,11 @@
+package com.luc4n3x.levyra.player
+
+import com.luc4n3x.levyra.domain.Track
+
+object LevyraPlaybackCacheKey {
+    fun stream(track: Track): String {
+        val id = track.id.trim().ifBlank { track.videoUrl.trim() }.ifBlank { track.title.trim() }
+        val signature = track.streamUrl.hashCode().toUInt().toString(16)
+        return "levyra:$id:$signature"
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
@@ -78,13 +78,13 @@ class LevyraPlayer(context: Context) {
             return
         }
         ignoreEndedFromManualStop = false
+        active.playWhenReady = true
         if (loadedTrackId != track.id || loadedStreamUrl != track.streamUrl) {
             loadedTrackId = track.id
             loadedStreamUrl = track.streamUrl
             active.setMediaItem(buildItem(track))
             active.prepare()
         }
-        active.playWhenReady = true
         active.play()
     }
 
@@ -103,7 +103,7 @@ class LevyraPlayer(context: Context) {
             .build()
         return MediaItem.Builder()
             .setUri(track.streamUrl)
-            .setCustomCacheKey("levyra:${track.id}")
+            .setCustomCacheKey(LevyraPlaybackCacheKey.stream(track))
             .setMediaId(track.id)
             .setMediaMetadata(metadata)
             .build()

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -36,7 +36,7 @@ class PlaybackService : MediaSessionService() {
     override fun onCreate() {
         super.onCreate()
         val loadControl = DefaultLoadControl.Builder()
-            .setBufferDurationsMs(1_500, 50_000, 500, 1_000)
+            .setBufferDurationsMs(900, 36_000, 160, 450)
             .setPrioritizeTimeOverSizeThresholds(true)
             .build()
         val okHttpClient = LevyraHttpClientFactory.media(this)
@@ -52,12 +52,12 @@ class PlaybackService : MediaSessionService() {
         val cache = LevyraMediaCache.get(this)
         val cacheSinkFactory = CacheDataSink.Factory()
             .setCache(cache)
-            .setFragmentSize(2L * 1024L * 1024L)
+            .setFragmentSize(512L * 1024L)
         val cacheDataSourceFactory = CacheDataSource.Factory()
             .setCache(cache)
             .setUpstreamDataSourceFactory(upstreamFactory)
             .setCacheWriteDataSinkFactory(cacheSinkFactory)
-            .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
+            .setFlags(CacheDataSource.FLAG_BLOCK_ON_CACHE or CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
 
         val defaultFactory = DefaultMediaSourceFactory(cacheDataSourceFactory)
 

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackWarmup.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackWarmup.kt
@@ -1,0 +1,60 @@
+package com.luc4n3x.levyra.player
+
+import android.content.Context
+import android.net.Uri
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.cache.CacheDataSink
+import androidx.media3.datasource.cache.CacheDataSource
+import androidx.media3.datasource.cache.CacheWriter
+import androidx.media3.datasource.okhttp.OkHttpDataSource
+import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
+import com.luc4n3x.levyra.domain.Track
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@OptIn(UnstableApi::class)
+class PlaybackWarmup(context: Context) {
+    private val appContext = context.applicationContext
+    private val okHttpClient by lazy { LevyraHttpClientFactory.media(appContext) }
+
+    suspend fun prime(track: Track, bytes: Long = DEFAULT_PRIME_BYTES): Boolean = withContext(Dispatchers.IO) {
+        if (track.streamUrl.isBlank()) return@withContext false
+        runCatching {
+            val cache = LevyraMediaCache.get(appContext)
+            val upstream = OkHttpDataSource.Factory(okHttpClient)
+                .setUserAgent("LevyraPlayer/1.13 Android Music")
+                .setDefaultRequestProperties(
+                    mapOf(
+                        "Accept" to "*/*",
+                        "Accept-Encoding" to "identity",
+                        "Connection" to "keep-alive"
+                    )
+                )
+            val sink = CacheDataSink.Factory()
+                .setCache(cache)
+                .setFragmentSize(PRIME_FRAGMENT_BYTES)
+            val source = CacheDataSource.Factory()
+                .setCache(cache)
+                .setUpstreamDataSourceFactory(upstream)
+                .setCacheWriteDataSinkFactory(sink)
+                .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
+                .createDataSource()
+            val dataSpec = DataSpec.Builder()
+                .setUri(Uri.parse(track.streamUrl))
+                .setKey(LevyraPlaybackCacheKey.stream(track))
+                .setPosition(0L)
+                .setLength(bytes.coerceIn(MIN_PRIME_BYTES, MAX_PRIME_BYTES))
+                .build()
+            CacheWriter(source, dataSpec, ByteArray(64 * 1024), null).cache()
+            true
+        }.getOrDefault(false)
+    }
+
+    companion object {
+        private const val MIN_PRIME_BYTES = 96L * 1024L
+        private const val DEFAULT_PRIME_BYTES = 512L * 1024L
+        private const val MAX_PRIME_BYTES = 1L * 1024L * 1024L
+        private const val PRIME_FRAGMENT_BYTES = 256L * 1024L
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -31,6 +31,7 @@ import com.luc4n3x.levyra.domain.MoodEngine
 import com.luc4n3x.levyra.domain.RepeatMode
 import com.luc4n3x.levyra.domain.Track
 import com.luc4n3x.levyra.player.LevyraPlayer
+import com.luc4n3x.levyra.player.PlaybackWarmup
 import com.luc4n3x.levyra.player.offline.OfflineAudioExporter
 import com.luc4n3x.levyra.player.offline.work.OfflineExportWorker
 import kotlinx.coroutines.CancellationException
@@ -62,6 +63,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private val moodEngine = MoodEngine()
     private val lyricsEngine = LyricsEngine()
     private val player = LevyraPlayer(application.applicationContext)
+    private val playbackWarmup = PlaybackWarmup(application.applicationContext)
     private val offlineExporter = OfflineAudioExporter(application.applicationContext, resolver)
     private val favoritesStore = FavoritesStore(application.applicationContext)
     private val playlistStore = com.luc4n3x.levyra.data.PlaylistStore(application.applicationContext)
@@ -365,7 +367,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                     searchError = null
                 )
             }
-            prefetchTop(sections.first().tracks, 16)
+            prefetchTop(sections.first().tracks, 24)
         }
     }
 
@@ -764,7 +766,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                     searchError = if (data.isEmpty) "Nessun risultato trovato per $clean" else null
                 )
             }
-            prefetchTop(tracks, 16)
+            prefetchTop(tracks, 24)
         }.onFailure { error ->
             _state.update {
                 it.copy(
@@ -951,12 +953,12 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             if (queue.isEmpty()) return@launch
             val base = if (queueIndex in queue.indices) queueIndex else queue.indexOfFirst { it.id == playable.id }
             if (base < 0) return@launch
-            val offsets = if (_state.value.isVideoMode) listOf(1) else listOf(1, 2, -1)
+            val offsets = if (_state.value.isVideoMode) listOf(1) else listOf(1, 2, 3, -1)
             val candidates = offsets
                 .map { offset -> queue[(base + offset + queue.size) % queue.size] }
                 .filterNot { it.id == playable.id }
                 .distinctBy { it.id }
-            warmTracks(candidates, concurrency = 2, delayStepMs = 50L)
+            warmTracks(candidates, concurrency = 3, delayStepMs = 20L)
         }
     }
 
@@ -964,7 +966,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         if (tracks.isEmpty()) return
         listPrefetchJob?.cancel()
         listPrefetchJob = viewModelScope.launch {
-            warmTracks(tracks.take(count), concurrency = 3, delayStepMs = 55L)
+            warmTracks(tracks.take(count), concurrency = 4, delayStepMs = 25L)
         }
     }
 
@@ -981,12 +983,15 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private suspend fun warmTrack(track: Track) {
         val videoMode = _state.value.isVideoMode
         val youtube = youtubePlayableTrack(track)
-        if (youtube != null) {
+        val resolved = if (youtube != null) {
             resolver.prefetch(youtube, videoMode)
-            return
+        } else {
+            val match = runCatching { repository.searchOne("${track.title} ${track.artist}") }.getOrNull() ?: return
+            resolver.prefetch(match, videoMode)
         }
-        val match = runCatching { repository.searchOne("${track.title} ${track.artist}") }.getOrNull() ?: return
-        resolver.prefetch(match, videoMode)
+        if (!videoMode && resolved != null) {
+            runCatching { playbackWarmup.prime(resolved) }
+        }
     }
 
     private fun currentQueue(): List<Track> {
@@ -1073,7 +1078,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                         searchError = if (tracks.isEmpty()) "Home remota vuota: prova una ricerca" else null
                     )
                 }
-                prefetchTop(tracks, 16)
+                prefetchTop(tracks, 24)
             }.onFailure { error ->
                 _state.update {
                     it.copy(


### PR DESCRIPTION
## Summary

- Adds playback warmup for visible and upcoming tracks.
- Adds deterministic Media3 cache keys for resolved audio streams.
- Speeds up playback resolution with more aggressive parallel fallback.
- Increases local media cache capacity.
- Reduces initial playback buffering latency.
- Keeps audio quality aware cache separation for Auto, Alta and Bassa.

## Files changed

### Modified
- app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
- app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaCache.kt
- app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
- app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
- app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt

### Added
- app/src/main/java/com/luc4n3x/levyra/player/LevyraPlaybackCacheKey.kt
- app/src/main/java/com/luc4n3x/levyra/player/PlaybackWarmup.kt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playback now warms up media in the background to start audio faster and reduce initial buffering.
  * Search and home browsing now prefetch more items ahead of time for smoother playback preparation.

* **Improvements**
  * Playback caching has been expanded, helping keep more media ready for instant playback.
  * Stream resolution has been tuned to try faster paths sooner, improving track loading speed and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->