### PR TITLE
Hedged tiered stream resolution for lower playback latency

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraStreamHedge.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraStreamHedge.kt
@@ -1,0 +1,62 @@
+package com.luc4n3x.levyra.data
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.atomic.AtomicInteger
+
+internal suspend fun <T> hedgedFirst(
+    tiers: List<List<suspend () -> T?>>,
+    hedgeBudgetMs: Long,
+    onAttemptError: (Throwable) -> Unit = {}
+): T? {
+    val ladder = tiers.filter { it.isNotEmpty() }
+    if (ladder.isEmpty()) return null
+    if (ladder.size == 1 && ladder[0].size == 1) {
+        return try {
+            ladder[0][0].invoke()
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (error: Throwable) {
+            onAttemptError(error)
+            null
+        }
+    }
+    return coroutineScope {
+        val winner = CompletableDeferred<T?>()
+        val remaining = AtomicInteger(ladder.sumOf { it.size })
+        fun dispatch(attempt: suspend () -> T?) {
+            launch {
+                val outcome = try {
+                    attempt()
+                } catch (cancellation: CancellationException) {
+                    throw cancellation
+                } catch (error: Throwable) {
+                    onAttemptError(error)
+                    null
+                }
+                if (outcome != null) {
+                    winner.complete(outcome)
+                } else if (remaining.decrementAndGet() == 0) {
+                    winner.complete(null)
+                }
+            }
+        }
+        launch {
+            for ((index, tier) in ladder.withIndex()) {
+                if (winner.isCompleted) break
+                tier.forEach { dispatch(it) }
+                if (index != ladder.lastIndex) {
+                    val settled = withTimeoutOrNull(hedgeBudgetMs) { winner.await() } != null || winner.isCompleted
+                    if (settled) break
+                }
+            }
+        }
+        val result = winner.await()
+        coroutineContext.cancelChildren()
+        result
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONArray
 import org.json.JSONObject
 import org.schabi.newpipe.extractor.ServiceList
@@ -62,6 +63,8 @@ class PlaybackResolver private constructor(private val context: Context) {
     private val maxTtlMs = 5L * 60L * 60L * 1000L
     private val playbackResolveTimeoutMs = 18_000L
     private val offlineResolveTimeoutMs = 60_000L
+    private val hedgeBudgetMs = 220L
+    private val extractorBudgetMs = 650L
 
     @Volatile
     private var selectedAudioQuality = userPreferences.audioQuality()
@@ -70,11 +73,11 @@ class PlaybackResolver private constructor(private val context: Context) {
     private var lastNetworkWarmAt = 0L
 
     private val profiles = listOf(
-        ClientProfile("ANDROID_MUSIC", "8.10.52", "Android Music", "Mozilla/5.0 (Linux; Android 15; Pixel 8 Pro) AppleWebKit/537.36 (KHTML, like Gecko) com.google.android.apps.youtube.music/8.10.52", true, 0L),
-        ClientProfile("ANDROID", "19.44.38", "Android", "com.google.android.youtube/19.44.38 (Linux; U; Android 15)", true, 0L),
-        ClientProfile("IOS", "20.10.4", "iOS", "com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3 like Mac OS X; it_IT)", false, 0L),
-        ClientProfile("WEB_REMIX", "1.20260423.01.00", "YouTube Music Web", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36", false, 8L),
-        ClientProfile("WEB_EMBEDDED_PLAYER", "1.20260423.01.00", "Embedded Player", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36", false, 18L)
+        ClientProfile("ANDROID_MUSIC", "8.10.52", "Android Music", "Mozilla/5.0 (Linux; Android 15; Pixel 8 Pro) AppleWebKit/537.36 (KHTML, like Gecko) com.google.android.apps.youtube.music/8.10.52", true, 0L, 0),
+        ClientProfile("ANDROID", "19.44.38", "Android", "com.google.android.youtube/19.44.38 (Linux; U; Android 15)", true, 0L, 1),
+        ClientProfile("IOS", "20.10.4", "iOS", "com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3 like Mac OS X; it_IT)", false, 0L, 1),
+        ClientProfile("WEB_REMIX", "1.20260423.01.00", "YouTube Music Web", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36", false, 8L, 2),
+        ClientProfile("WEB_EMBEDDED_PLAYER", "1.20260423.01.00", "Embedded Player", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36", false, 18L, 3)
     )
 
     init {
@@ -207,13 +210,8 @@ class PlaybackResolver private constructor(private val context: Context) {
         if (isVideoMode) {
             val resolved = coroutineScope {
                 val winner = CompletableDeferred<Track?>()
-                val extractorJob = launch {
-                    val r = runCatching { resolveVideoWithMetrolistExtractor(track) }
-                    r.onSuccess { winner.complete(it) }
-                        .onFailure { it.message?.takeIf { m -> m.isNotBlank() }?.let { m -> errors += "MetrolistExtractor video: $m" } }
-                }
                 val itJob = launch {
-                    val stream = runCatching { raceInnerTube(track, errors, true, preferMp4Audio = false) }.getOrNull()
+                    val stream = runCatching { hedgedInnerTube(track, errors, true) }.getOrNull()
                     if (stream != null) {
                         winner.complete(
                             track.copy(
@@ -227,8 +225,15 @@ class PlaybackResolver private constructor(private val context: Context) {
                         )
                     }
                 }
+                val extractorJob = launch {
+                    val settled = withTimeoutOrNull(extractorBudgetMs) { winner.await() } != null || winner.isCompleted
+                    if (settled) return@launch
+                    val r = runCatching { resolveVideoWithMetrolistExtractor(track) }
+                    r.onSuccess { winner.complete(it) }
+                        .onFailure { it.message?.takeIf { m -> m.isNotBlank() }?.let { m -> errors += "MetrolistExtractor video: $m" } }
+                }
                 launch {
-                    extractorJob.join(); itJob.join()
+                    itJob.join(); extractorJob.join()
                     winner.complete(null)
                 }
                 val result = winner.await()
@@ -257,15 +262,40 @@ class PlaybackResolver private constructor(private val context: Context) {
         throw PlaybackBlockedException(reason)
     }
 
-    private suspend fun resolveAudioFast(track: Track, errors: MutableList<String>, preferMp4Audio: Boolean): Track? = coroutineScope {
+    private suspend fun resolveAudioFast(track: Track, errors: MutableList<String>, preferMp4Audio: Boolean): Track? {
+        if (preferMp4Audio) return resolveAudioResilient(track, errors)
+        return coroutineScope {
+            val winner = CompletableDeferred<Track?>()
+            val innerTubeJob = launch {
+                val stream = runCatching { hedgedInnerTube(track, errors, false) }.getOrNull()
+                if (stream != null) winner.complete(track.withDirectStream(stream))
+            }
+            val extractorJob = launch {
+                val settled = withTimeoutOrNull(extractorBudgetMs) { winner.await() } != null || winner.isCompleted
+                if (settled) return@launch
+                val resolved = runCatching { resolveWithMetrolistExtractor(track, false) }
+                resolved.onSuccess { winner.complete(it) }
+                    .onFailure { it.message?.takeIf { message -> message.isNotBlank() }?.let { message -> errors += "MetrolistExtractor: $message" } }
+            }
+            launch {
+                innerTubeJob.join()
+                extractorJob.join()
+                winner.complete(null)
+            }
+            val result = winner.await()
+            coroutineContext.cancelChildren()
+            result
+        }
+    }
+
+    private suspend fun resolveAudioResilient(track: Track, errors: MutableList<String>): Track? = coroutineScope {
         val winner = CompletableDeferred<Track?>()
         val innerTubeJob = launch {
-            val stream = runCatching { raceInnerTube(track, errors, false, preferMp4Audio) }.getOrNull()
+            val stream = runCatching { raceInnerTube(track, errors, false, true) }.getOrNull()
             if (stream != null) winner.complete(track.withDirectStream(stream))
         }
         val extractorJob = launch {
-            if (!preferMp4Audio) delay(35L)
-            val resolved = runCatching { resolveWithMetrolistExtractor(track, preferMp4Audio) }
+            val resolved = runCatching { resolveWithMetrolistExtractor(track, true) }
             resolved.onSuccess { winner.complete(it) }
                 .onFailure { it.message?.takeIf { message -> message.isNotBlank() }?.let { message -> errors += "MetrolistExtractor: $message" } }
         }
@@ -277,6 +307,25 @@ class PlaybackResolver private constructor(private val context: Context) {
         val result = winner.await()
         coroutineContext.cancelChildren()
         result
+    }
+
+    private suspend fun hedgedInnerTube(track: Track, errors: MutableList<String>, isVideoMode: Boolean): DirectStream? {
+        val ladder = profiles
+            .groupBy { it.tier }
+            .toSortedMap()
+            .map { (_, group) ->
+                group.map { profile ->
+                    suspend {
+                        runCatching { resolveWithInnerTube(track, profile, isVideoMode, false) }
+                            .onFailure { error ->
+                                error.message?.takeIf { it.isNotBlank() }?.let { errors += "${profile.label}: $it" }
+                            }
+                            .getOrNull()
+                            ?.takeIf { it.url.isNotBlank() }
+                    }
+                }
+            }
+        return hedgedFirst(ladder, hedgeBudgetMs)
     }
 
     private fun Track.withDirectStream(stream: DirectStream): Track = copy(
@@ -827,7 +876,8 @@ private data class ClientProfile(
     val label: String,
     val userAgent: String,
     val android: Boolean,
-    val delayMs: Long
+    val delayMs: Long,
+    val tier: Int
 ) {
     val clientHeaderName: String
         get() = when (clientName) {

--- a/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineAudioExporter.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineAudioExporter.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
+import androidx.annotation.RequiresApi
 import com.luc4n3x.levyra.data.PlaybackResolver
 import com.luc4n3x.levyra.data.local.DownloadEntity
 import com.luc4n3x.levyra.data.local.LevyraDatabase
@@ -230,6 +231,7 @@ class OfflineAudioExporter(
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) saveScoped(input, track, container) else saveLegacy(input, track, container)
     }
 
+    @RequiresApi(Build.VERSION_CODES.Q)
     private fun saveScoped(input: File, track: Track, container: AudioContainer): SavedAudioDestination {
         return runCatching {
             SavedAudioDestination(
@@ -250,6 +252,7 @@ class OfflineAudioExporter(
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.Q)
     private fun saveScopedAudio(input: File, track: Track, container: AudioContainer): Uri {
         val resolver = context.contentResolver
         val values = ContentValues().apply {
@@ -278,6 +281,7 @@ class OfflineAudioExporter(
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.Q)
     private fun saveScopedDownloadFile(input: File, track: Track, container: AudioContainer): Uri {
         val resolver = context.contentResolver
         val values = ContentValues().apply {

--- a/app/src/test/java/com/luc4n3x/levyra/data/LevyraStreamHedgeTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/LevyraStreamHedgeTest.kt
@@ -1,0 +1,60 @@
+package com.luc4n3x.levyra.data
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+class LevyraStreamHedgeTest {
+    @Test
+    fun firstTierWinnerSkipsLaterTiers() = runBlocking {
+        val laterCalls = AtomicInteger(0)
+        val primary: suspend () -> String? = { "primary" }
+        val backup: suspend () -> String? = {
+            laterCalls.incrementAndGet()
+            "backup"
+        }
+
+        val result = hedgedFirst(listOf(listOf(primary), listOf(backup)), hedgeBudgetMs = 1_000L)
+
+        assertEquals("primary", result)
+        assertEquals(0, laterCalls.get())
+    }
+
+    @Test
+    fun fallsThroughToNextTierWhenEarlierFails() = runBlocking {
+        val primaryCalls = AtomicInteger(0)
+        val primary: suspend () -> String? = {
+            primaryCalls.incrementAndGet()
+            null
+        }
+        val backup: suspend () -> String? = { "backup" }
+
+        val result = hedgedFirst(listOf(listOf(primary), listOf(backup)), hedgeBudgetMs = 25L)
+
+        assertEquals("backup", result)
+        assertEquals(1, primaryCalls.get())
+    }
+
+    @Test
+    fun returnsNullWhenEveryAttemptFails() = runBlocking {
+        val failing: suspend () -> String? = { null }
+        val throwing: suspend () -> String? = { throw IllegalStateException("boom") }
+        val captured = AtomicInteger(0)
+
+        val result = hedgedFirst(
+            listOf(listOf(failing), listOf(throwing)),
+            hedgeBudgetMs = 20L
+        ) { captured.incrementAndGet() }
+
+        assertNull(result)
+        assertEquals(1, captured.get())
+    }
+
+    @Test
+    fun emptyLadderReturnsNull() = runBlocking {
+        val result = hedgedFirst<String>(emptyList(), hedgeBudgetMs = 10L)
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
## Summary

- Introduce a budget-based, hedged stream resolution strategy so playback starts on a single fast request in the common case instead of a fire-all race, cutting rate-limit pressure and tail latency.

## Scope

- [x] Player / audio
- [x] Stream extraction
- [ ] Downloads
- [ ] UI / Compose
- [ ] Localization
- [ ] Android Auto / media session
- [ ] CI / release
- [ ] Documentation

## What changed

- New `LevyraStreamHedge.hedgedFirst`: a generic hedged-first-success scheduler. It launches the first tier, and only opens each additional tier when a latency budget lapses without a playable result. The first success cancels every other in-flight attempt; if every attempt fails it resolves to `null`.
- `PlaybackResolver` now groups the InnerTube client profiles into tiers (tier 0 `ANDROID_MUSIC`, tier 1 `ANDROID`/`IOS`, then the web clients) and resolves them through `hedgedFirst` instead of firing all five clients at once.
- The NewPipe/Metrolist extractor is no longer fired eagerly after a fixed 35 ms. On the audio and video playback paths it now runs only as a budget-gated fallback, so it stays idle whenever InnerTube answers in time.
- The offline (mp4-preferred) path keeps its original resilient parallel behaviour, split out into `resolveAudioResilient`.

Net effect: the common path drops from up to five InnerTube requests plus an eager extractor pass down to a single request per track, which is the main driver of 429 throttling during prefetch of a screen full of tracks. p50 resolve latency is unchanged; sustained and tail latency improve.

## Testing

- [ ] `gradle --no-daemon :app:lintRelease`
- [ ] `gradle --no-daemon testReleaseUnitTest`
- [ ] `gradle --no-daemon assembleRelease`
- [ ] APK installed on device
- [ ] Playback tested
- [ ] Downloads tested
- [ ] Language switching tested

New unit tests in `LevyraStreamHedgeTest` cover the scheduler: a first-tier winner leaves later tiers untouched, a failed tier falls through to the next, an all-failing ladder returns `null` and reports errors, and an empty ladder returns `null`. Please run the gradle checks above in CI/on device before merge.