### PR TITLE
feat: add enhanced lyrics parsing foundation

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/LyricsParsing.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LyricsParsing.kt
@@ -1,0 +1,192 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.domain.LyricLine
+import com.luc4n3x.levyra.domain.LyricWord
+import java.io.StringReader
+import java.util.Locale
+import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.math.absoluteValue
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+import org.xml.sax.InputSource
+
+data class LyricsRequest(
+    val title: String,
+    val artist: String,
+    val durationSec: Long
+)
+
+data class LyricsCandidate(
+    val result: LyricsRepository.LyricsResult,
+    val title: String,
+    val artist: String,
+    val durationSec: Long
+)
+
+object LrcLyricsParser {
+    private val timestampRegex = Regex("\\[(\\d{1,2}):(\\d{2})(?:[.:](\\d{1,3}))?]")
+
+    fun parse(lrc: String): List<LyricLine> {
+        val raw = mutableListOf<Pair<Long, String>>()
+        lrc.lineSequence().forEach { line ->
+            val matches = timestampRegex.findAll(line).toList()
+            if (matches.isEmpty()) return@forEach
+            val text = line.substring(matches.last().range.last + 1).trim()
+            if (text.isBlank()) return@forEach
+            matches.forEach { match ->
+                raw += timestampMs(match.groupValues) to text
+            }
+        }
+
+        val sorted = raw.sortedBy { it.first }
+        return sorted.mapIndexed { index, (start, text) ->
+            val end = sorted.getOrNull(index + 1)?.first?.minus(80L)?.coerceAtLeast(start + 800L) ?: (start + 6_000L)
+            LyricLine(startMs = start, endMs = end, text = text, translated = "")
+        }
+    }
+
+    private fun timestampMs(groups: List<String>): Long {
+        val min = groups[1].toLongOrNull() ?: 0L
+        val sec = groups[2].toLongOrNull() ?: 0L
+        val frac = groups[3]
+        val ms = when (frac.length) {
+            1 -> frac.toLongOrNull()?.times(100L) ?: 0L
+            2 -> frac.toLongOrNull()?.times(10L) ?: 0L
+            3 -> frac.toLongOrNull() ?: 0L
+            else -> 0L
+        }
+        return min * 60_000L + sec * 1_000L + ms
+    }
+}
+
+object TtmlLyricsParser {
+    fun parse(ttml: String): List<LyricLine> {
+        val document = runCatching {
+            val factory = DocumentBuilderFactory.newInstance().apply {
+                isNamespaceAware = false
+                runCatching { setFeature("http://apache.org/xml/features/disallow-doctype-decl", true) }
+                runCatching { setFeature("http://xml.org/sax/features/external-general-entities", false) }
+                runCatching { setFeature("http://xml.org/sax/features/external-parameter-entities", false) }
+            }
+            factory.newDocumentBuilder().parse(InputSource(StringReader(ttml)))
+        }.getOrNull() ?: return emptyList()
+
+        val nodes = document.getElementsByTagName("p")
+        val lines = ArrayList<LyricLine>()
+        for (i in 0 until nodes.length) {
+            val element = nodes.item(i) as? Element ?: continue
+            val start = element.timeAttribute("begin") ?: continue
+            val words = element.wordSpans()
+            val text = if (words.isNotEmpty()) {
+                words.joinToString(" ") { it.text }.replace(Regex("\\s+"), " ").trim()
+            } else {
+                element.textContent.orEmpty().replace(Regex("\\s+"), " ").trim()
+            }
+            if (text.isBlank()) continue
+            val end = element.timeAttribute("end")
+                ?: element.timeAttribute("dur")?.let { start + it }
+                ?: words.lastOrNull()?.endMs
+                ?: (start + 6_000L)
+            lines += LyricLine(startMs = start, endMs = end.coerceAtLeast(start + 500L), text = text, translated = "", words = words)
+        }
+        return lines.sortedBy { it.startMs }
+    }
+
+    private fun Element.wordSpans(): List<LyricWord> {
+        val out = ArrayList<LyricWord>()
+        val spans = getElementsByTagName("span")
+        for (i in 0 until spans.length) {
+            val span = spans.item(i) as? Element ?: continue
+            val role = span.getAttribute("ttm:role").ifBlank { span.getAttribute("role") }
+            if (role == "x-translation" || role == "x-roman" || role == "x-bg") continue
+            val start = span.timeAttribute("begin") ?: continue
+            val end = span.timeAttribute("end") ?: continue
+            val text = span.directText().trim()
+            if (text.isNotBlank()) {
+                out += LyricWord(startMs = start, endMs = end.coerceAtLeast(start), text = text)
+            }
+        }
+        return out
+    }
+
+    private fun Element.directText(): String = buildString {
+        val children = childNodes
+        for (i in 0 until children.length) {
+            val child = children.item(i)
+            if (child.nodeType == Node.TEXT_NODE || child.nodeType == Node.CDATA_SECTION_NODE) {
+                append(child.nodeValue)
+            }
+        }
+    }.replace(Regex("\\s+"), " ")
+
+    private fun Element.timeAttribute(name: String): Long? = getAttribute(name).takeIf { it.isNotBlank() }?.let(::parseTimeMs)
+
+    private fun parseTimeMs(raw: String): Long? {
+        val value = raw.trim()
+        if (value.endsWith("ms")) return value.removeSuffix("ms").toDoubleOrNull()?.toLong()
+        if (value.endsWith("s")) return value.removeSuffix("s").toDoubleOrNull()?.times(1_000L)?.toLong()
+        val parts = value.split(":")
+        return when (parts.size) {
+            2 -> {
+                val minutes = parts[0].toLongOrNull() ?: return null
+                val seconds = parts[1].toDoubleOrNull() ?: return null
+                minutes * 60_000L + (seconds * 1_000L).toLong()
+            }
+            3 -> {
+                val hours = parts[0].toLongOrNull() ?: return null
+                val minutes = parts[1].toLongOrNull() ?: return null
+                val seconds = parts[2].toDoubleOrNull() ?: return null
+                hours * 3_600_000L + minutes * 60_000L + (seconds * 1_000L).toLong()
+            }
+            else -> value.toDoubleOrNull()?.times(1_000L)?.toLong()
+        }
+    }
+}
+
+object LyricsResultRanker {
+    fun best(candidates: List<LyricsCandidate>, request: LyricsRequest): LyricsRepository.LyricsResult? {
+        return candidates
+            .map { candidate -> candidate.result.copy(confidence = score(candidate, request)) }
+            .filter { it.lines.isNotEmpty() && it.confidence >= 42 }
+            .sortedWith(
+                compareByDescending<LyricsRepository.LyricsResult> { it.synced }
+                    .thenByDescending { it.lines.any { line -> line.words.isNotEmpty() } }
+                    .thenByDescending { it.confidence }
+                    .thenByDescending { it.lines.size }
+            )
+            .firstOrNull()
+    }
+
+    fun score(candidate: LyricsCandidate, request: LyricsRequest): Int {
+        val titleScore = similarity(candidate.title.cleanComparable(), request.title.cleanComparable())
+        val artistScore = similarity(candidate.artist.cleanComparable(), request.artist.cleanComparable())
+        val durationScore = when {
+            request.durationSec <= 0L || candidate.durationSec <= 0L -> 12
+            (candidate.durationSec - request.durationSec).absoluteValue <= 3L -> 18
+            (candidate.durationSec - request.durationSec).absoluteValue <= 8L -> 12
+            (candidate.durationSec - request.durationSec).absoluteValue <= 16L -> 6
+            else -> -12
+        }
+        val syncScore = if (candidate.result.synced) 18 else 4
+        val wordScore = if (candidate.result.lines.any { it.words.isNotEmpty() }) 8 else 0
+        val sizeScore = candidate.result.lines.size.coerceAtMost(40) / 2
+        return (titleScore * 36 / 100 + artistScore * 26 / 100 + durationScore + syncScore + wordScore + sizeScore).coerceIn(0, 100)
+    }
+
+    private fun similarity(left: String, right: String): Int {
+        if (left.isBlank() || right.isBlank()) return 0
+        if (left == right) return 100
+        if (left.contains(right) || right.contains(left)) return 84
+        val a = left.split(" ").filter { it.isNotBlank() }.toSet()
+        val b = right.split(" ").filter { it.isNotBlank() }.toSet()
+        if (a.isEmpty() || b.isEmpty()) return 0
+        val intersection = a.intersect(b).size
+        val union = a.union(b).size.coerceAtLeast(1)
+        return (intersection * 100 / union).coerceIn(0, 100)
+    }
+
+    private fun String.cleanComparable(): String = lowercase(Locale.ROOT)
+        .replace(Regex("[^\\p{L}\\p{N} ]+"), " ")
+        .replace(Regex("\\s+"), " ")
+        .trim()
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/LyricsRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LyricsRepository.kt
@@ -2,6 +2,7 @@ package com.luc4n3x.levyra.data
 
 import android.content.Context
 import com.luc4n3x.levyra.domain.LyricLine
+import com.luc4n3x.levyra.domain.LyricWord
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
@@ -16,7 +17,6 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.util.Locale
-import kotlin.math.absoluteValue
 
 class LyricsRepository(context: Context? = null) {
     private val cacheDir = context?.applicationContext?.cacheDir?.let { File(it, "lyrics_pro") }
@@ -30,13 +30,6 @@ class LyricsRepository(context: Context? = null) {
         val cached: Boolean
     )
 
-    private data class Candidate(
-        val result: LyricsResult,
-        val title: String,
-        val artist: String,
-        val durationSec: Long
-    )
-
     suspend fun fetch(title: String, artist: String, durationSec: Long): LyricsResult? = withContext(Dispatchers.IO) {
         val cleanTitle = cleanTitle(title)
         val cleanArtist = cleanArtist(artist)
@@ -47,7 +40,7 @@ class LyricsRepository(context: Context? = null) {
             memory[key] = cached
             return@withContext cached
         }
-        val candidates = mutableListOf<Candidate>()
+        val candidates = mutableListOf<LyricsCandidate>()
         artistVariants(cleanArtist).forEach { artistVariant ->
             runCatching { getLrcLibExact(cleanTitle, artistVariant, durationSec) }
                 .getOrNull()
@@ -61,11 +54,7 @@ class LyricsRepository(context: Context? = null) {
                 .getOrNull()
                 ?.let { candidates += it }
         }
-        val best = candidates
-            .map { candidate -> candidate.result.copy(confidence = score(candidate, cleanTitle, cleanArtist, durationSec)) }
-            .filter { it.lines.isNotEmpty() && it.confidence >= 42 }
-            .sortedWith(compareByDescending<LyricsResult> { it.synced }.thenByDescending { it.confidence }.thenByDescending { it.lines.size })
-            .firstOrNull()
+        val best = LyricsResultRanker.best(candidates, LyricsRequest(cleanTitle, cleanArtist, durationSec))
         if (best != null) {
             val stable = best.copy(cached = false)
             memory[key] = stable
@@ -74,7 +63,7 @@ class LyricsRepository(context: Context? = null) {
         best
     }
 
-    private fun getLrcLibExact(title: String, artist: String, durationSec: Long): Candidate? {
+    private fun getLrcLibExact(title: String, artist: String, durationSec: Long): LyricsCandidate? {
         val url = buildString {
             append("https://lrclib.net/api/get?track_name=")
             append(enc(title))
@@ -85,35 +74,35 @@ class LyricsRepository(context: Context? = null) {
         val body = httpGet(url, "application/json") ?: return null
         val json = JSONObject(body)
         val result = parseLrcLibEntry(json, "LRCLIB Exact") ?: return null
-        return Candidate(result, json.optString("trackName", title), json.optString("artistName", artist), json.optLong("duration", durationSec))
+        return LyricsCandidate(result, json.optString("trackName", title), json.optString("artistName", artist), json.optLong("duration", durationSec))
     }
 
-    private fun searchLrcLib(title: String, artist: String): List<Candidate> {
+    private fun searchLrcLib(title: String, artist: String): List<LyricsCandidate> {
         val url = "https://lrclib.net/api/search?track_name=${enc(title)}&artist_name=${enc(artist)}"
         val body = httpGet(url, "application/json") ?: return emptyList()
         val array = JSONArray(body)
-        val out = ArrayList<Candidate>()
+        val out = ArrayList<LyricsCandidate>()
         for (i in 0 until array.length()) {
             val json = array.optJSONObject(i) ?: continue
             val result = parseLrcLibEntry(json, "LRCLIB Search") ?: continue
-            out += Candidate(result, json.optString("trackName", title), json.optString("artistName", artist), json.optLong("duration", 0L))
+            out += LyricsCandidate(result, json.optString("trackName", title), json.optString("artistName", artist), json.optLong("duration", 0L))
         }
         return out.take(12)
     }
 
-    private fun lyricsOvh(title: String, artist: String): Candidate? {
+    private fun lyricsOvh(title: String, artist: String): LyricsCandidate? {
         val url = "https://api.lyrics.ovh/v1/${encPath(artist)}/${encPath(title)}"
         val body = httpGet(url, "application/json") ?: return null
         val lyrics = JSONObject(body).optString("lyrics").trim()
         val lines = plainLines(lyrics)
         if (lines.isEmpty()) return null
-        return Candidate(LyricsResult(false, lines, "Lyrics.ovh", 54, false), title, artist, 0L)
+        return LyricsCandidate(LyricsResult(false, lines, "Lyrics.ovh", 54, false), title, artist, 0L)
     }
 
     private fun parseLrcLibEntry(json: JSONObject, provider: String): LyricsResult? {
         val syncedText = json.optString("syncedLyrics").takeIf { it.isMeaningfulLyrics() }
         if (syncedText != null) {
-            val lines = parseLrc(syncedText)
+            val lines = LrcLyricsParser.parse(syncedText)
             if (lines.isNotEmpty()) return LyricsResult(true, lines, provider, 88, false)
         }
         val plain = json.optString("plainLyrics").takeIf { it.isMeaningfulLyrics() } ?: return null
@@ -128,60 +117,6 @@ class LyricsRepository(context: Context? = null) {
             .filter { it.isNotBlank() }
             .filterNot { it.equals("embed", ignoreCase = true) }
             .mapIndexed { index, line -> LyricLine(index * 4200L, (index + 1) * 4200L, line, "") }
-    }
-
-    private fun parseLrc(lrc: String): List<LyricLine> {
-        val regex = Regex("\\[(\\d{1,2}):(\\d{2})(?:[.:](\\d{1,3}))?]")
-        val raw = mutableListOf<Pair<Long, String>>()
-        lrc.split("\n").forEach { line ->
-            val matches = regex.findAll(line).toList()
-            if (matches.isEmpty()) return@forEach
-            val text = line.substring(matches.last().range.last + 1).trim()
-            matches.forEach { match ->
-                val min = match.groupValues[1].toLongOrNull() ?: 0L
-                val sec = match.groupValues[2].toLongOrNull() ?: 0L
-                val frac = match.groupValues[3]
-                val ms = when (frac.length) {
-                    1 -> frac.toLongOrNull()?.times(100L) ?: 0L
-                    2 -> frac.toLongOrNull()?.times(10L) ?: 0L
-                    3 -> frac.toLongOrNull() ?: 0L
-                    else -> 0L
-                }
-                raw += (min * 60_000L + sec * 1000L + ms) to text
-            }
-        }
-        val sorted = raw.filter { it.second.isNotBlank() }.sortedBy { it.first }
-        return sorted.mapIndexed { index, (start, text) ->
-            val end = sorted.getOrNull(index + 1)?.first?.minus(80L)?.coerceAtLeast(start + 800L) ?: (start + 6000L)
-            LyricLine(start, end, text, "")
-        }
-    }
-
-    private fun score(candidate: Candidate, title: String, artist: String, durationSec: Long): Int {
-        val titleScore = similarity(candidate.title.cleanComparable(), title.cleanComparable())
-        val artistScore = similarity(candidate.artist.cleanComparable(), artist.cleanComparable())
-        val durationScore = when {
-            durationSec <= 0L || candidate.durationSec <= 0L -> 12
-            (candidate.durationSec - durationSec).absoluteValue <= 3L -> 18
-            (candidate.durationSec - durationSec).absoluteValue <= 8L -> 12
-            (candidate.durationSec - durationSec).absoluteValue <= 16L -> 6
-            else -> -12
-        }
-        val syncScore = if (candidate.result.synced) 18 else 4
-        val sizeScore = candidate.result.lines.size.coerceAtMost(40) / 2
-        return (titleScore * 36 / 100 + artistScore * 26 / 100 + durationScore + syncScore + sizeScore).coerceIn(0, 100)
-    }
-
-    private fun similarity(left: String, right: String): Int {
-        if (left.isBlank() || right.isBlank()) return 0
-        if (left == right) return 100
-        if (left.contains(right) || right.contains(left)) return 84
-        val a = left.split(" ").filter { it.isNotBlank() }.toSet()
-        val b = right.split(" ").filter { it.isNotBlank() }.toSet()
-        if (a.isEmpty() || b.isEmpty()) return 0
-        val intersection = a.intersect(b).size
-        val union = a.union(b).size.coerceAtLeast(1)
-        return (intersection * 100 / union).coerceIn(0, 100)
     }
 
     private fun httpGet(url: String, accept: String): String? {
@@ -212,7 +147,23 @@ class LyricsRepository(context: Context? = null) {
             val parsed = ArrayList<LyricLine>()
             for (i in 0 until lines.length()) {
                 val item = lines.optJSONObject(i) ?: continue
-                parsed += LyricLine(item.optLong("startMs"), item.optLong("endMs"), item.optString("text"), item.optString("translated"))
+                val wordsJson = item.optJSONArray("words") ?: JSONArray()
+                val words = ArrayList<LyricWord>()
+                for (wordIndex in 0 until wordsJson.length()) {
+                    val word = wordsJson.optJSONObject(wordIndex) ?: continue
+                    words += LyricWord(
+                        startMs = word.optLong("startMs"),
+                        endMs = word.optLong("endMs"),
+                        text = word.optString("text")
+                    )
+                }
+                parsed += LyricLine(
+                    startMs = item.optLong("startMs"),
+                    endMs = item.optLong("endMs"),
+                    text = item.optString("text"),
+                    translated = item.optString("translated"),
+                    words = words
+                )
             }
             if (parsed.isEmpty()) null else LyricsResult(json.optBoolean("synced"), parsed, json.optString("provider"), json.optInt("confidence", 70), true)
         }.onFailure { Timber.w(it, "Lyrics cache restore failed") }.getOrNull()
@@ -224,7 +175,23 @@ class LyricsRepository(context: Context? = null) {
             if (!dir.isDirectory) dir.mkdirs()
             val lines = JSONArray()
             result.lines.take(500).forEach { line ->
-                lines.put(JSONObject().put("startMs", line.startMs).put("endMs", line.endMs).put("text", line.text).put("translated", line.translated))
+                val words = JSONArray()
+                line.words.take(80).forEach { word ->
+                    words.put(
+                        JSONObject()
+                            .put("startMs", word.startMs)
+                            .put("endMs", word.endMs)
+                            .put("text", word.text)
+                    )
+                }
+                lines.put(
+                    JSONObject()
+                        .put("startMs", line.startMs)
+                        .put("endMs", line.endMs)
+                        .put("text", line.text)
+                        .put("translated", line.translated)
+                        .put("words", words)
+                )
             }
             File(dir, "$key.json").writeText(
                 JSONObject()

--- a/app/src/main/java/com/luc4n3x/levyra/domain/Models.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/Models.kt
@@ -90,7 +90,14 @@ data class LyricLine(
     val startMs: Long,
     val endMs: Long,
     val text: String,
-    val translated: String
+    val translated: String,
+    val words: List<LyricWord> = emptyList()
+)
+
+data class LyricWord(
+    val startMs: Long,
+    val endMs: Long,
+    val text: String
 )
 
 data class CacheReport(

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -175,9 +175,12 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
@@ -2428,7 +2431,7 @@ private fun LyricsOverlay(state: LevyraUiState, onClose: () -> Unit) {
             .clickable(interactionSource = blocker, indication = null) {}
     ) {
         LevyraBackground(accentStart = track?.accentStart, accentEnd = track?.accentEnd)
-        Box(modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.4f))) // Dark overlay for readability
+        Box(modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.72f)))
         
         LazyColumn(
             state = listState,
@@ -2477,13 +2480,32 @@ private fun LyricsOverlay(state: LevyraUiState, onClose: () -> Unit) {
             } else {
                 itemsIndexed(state.lyrics) { index, line ->
                     val isActive = state.lyricsSynced && index == activeIndex
+                    val lineColor = when {
+                        isActive -> Color.White
+                        state.lyricsSynced -> Color.White.copy(alpha = 0.5f)
+                        else -> Color.White.copy(alpha = 0.85f)
+                    }
+                    val annotatedLine = buildAnnotatedString {
+                        if (isActive && line.words.isNotEmpty()) {
+                            line.words.forEachIndexed { wordIndex, word ->
+                                val wordActive = state.positionMs >= word.startMs && state.positionMs <= word.endMs
+                                withStyle(
+                                    SpanStyle(
+                                        color = if (wordActive) accentStart else Color.White.copy(alpha = 0.56f),
+                                        fontWeight = if (wordActive) FontWeight.Black else FontWeight.Bold
+                                    )
+                                ) {
+                                    append(word.text)
+                                }
+                                if (wordIndex < line.words.lastIndex) append(" ")
+                            }
+                        } else {
+                            append(line.text)
+                        }
+                    }
                     Text(
-                        text = line.text,
-                        color = when {
-                            isActive -> Color.White
-                            state.lyricsSynced -> Color.White.copy(alpha = 0.5f)
-                            else -> Color.White.copy(alpha = 0.85f)
-                        },
+                        text = annotatedLine,
+                        color = lineColor,
                         fontSize = if (isActive) 28.sp else 22.sp,
                         lineHeight = if (isActive) 34.sp else 28.sp,
                         fontWeight = if (isActive) FontWeight.Black else FontWeight.Bold,

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -243,6 +243,8 @@ private val CinematicGold = Color(0xFFFFC46B)
 private val CinematicGlass = Color(0xFF151321)
 private val CinematicGlassDeep = Color(0xFF0B0A14)
 private val CinematicHairline = Color.White.copy(alpha = 0.105f)
+private val HomeHorizontalInset = 16.dp
+private val HomeHorizontalShelfEndPadding = 32.dp
 
 private val LevyraIsLight: Boolean get() = LevyraActivePalette.isLight
 private val LevyraReadableOnArtwork: Color get() = Color.White
@@ -254,6 +256,13 @@ private val LevyraAdaptiveCardDeep: Color get() = if (LevyraIsLight) Color.White
 private val LevyraAdaptiveChip: Color get() = if (LevyraIsLight) Color.White.copy(alpha = 0.82f) else Color.White.copy(alpha = 0.06f)
 private val LevyraAdaptiveChipSelected: Color get() = if (LevyraIsLight) Color.White.copy(alpha = 0.92f) else Color.White.copy(alpha = 0.12f)
 private val LevyraAdaptiveTrack: Color get() = if (LevyraIsLight) Color(0x1A11131F) else Color.White.copy(alpha = 0.08f)
+
+@Composable
+private fun HomeSectionInset(content: @Composable () -> Unit) {
+    Box(modifier = Modifier.padding(horizontal = HomeHorizontalInset)) {
+        content()
+    }
+}
 
 private fun cinematicGlassBrush(
     accentStart: Color = LevyraCyan,
@@ -1979,7 +1988,10 @@ private fun ReleaseRadarRow(
     onOpen: (ReleaseRadarEntry) -> Unit,
     onArtist: (String) -> Unit
 ) {
-    LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
+    ) {
         items(
             items = entries,
             key = { "radar-${it.artistName}-${it.release.browseId.ifBlank { it.release.title }}" },
@@ -2817,13 +2829,15 @@ private fun HomeScreen(viewModel: LevyraViewModel, state: LevyraUiState) {
     LazyColumn(
         state = homeListState,
         modifier = Modifier.fillMaxSize().statusBarsPadding(),
-        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 14.dp, bottom = if (state.currentTrack != null) 188.dp else 100.dp),
+        contentPadding = PaddingValues(top = 14.dp, bottom = if (state.currentTrack != null) 188.dp else 100.dp),
         verticalArrangement = Arrangement.spacedBy(28.dp)
     ) {
         item(key = "home-top", contentType = "home-header") {
-            Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-                GreetingBar(state.userName, state.isResolving, onSettings = viewModel::openSettings)
-                MoodRow(moods = state.moods, selectedId = state.selectedMood?.id, onSelect = viewModel::selectMood)
+            HomeSectionInset {
+                Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+                    GreetingBar(state.userName, state.isResolving, onSettings = viewModel::openSettings)
+                    MoodRow(moods = state.moods, selectedId = state.selectedMood?.id, onSelect = viewModel::selectMood)
+                }
             }
         }
         if (personalTracks.isNotEmpty()) {
@@ -2852,13 +2866,15 @@ private fun HomeScreen(viewModel: LevyraViewModel, state: LevyraUiState) {
         }
         if (state.currentTrack != null) {
             item(key = "home-continue", contentType = "home-card") {
-                ContinueListeningCard(
-                    track = state.currentTrack,
-                    isPlaying = state.isPlaying,
-                    isResolving = state.isResolving,
-                    progress = progressOf(state.positionMs, state.durationMs),
-                    onResume = viewModel::togglePlay
-                )
+                HomeSectionInset {
+                    ContinueListeningCard(
+                        track = state.currentTrack,
+                        isPlaying = state.isPlaying,
+                        isResolving = state.isResolving,
+                        progress = progressOf(state.positionMs, state.durationMs),
+                        onResume = viewModel::togglePlay
+                    )
+                }
             }
         }
 
@@ -2872,7 +2888,7 @@ private fun HomeScreen(viewModel: LevyraViewModel, state: LevyraUiState) {
         }
         if (state.releaseRadar.isNotEmpty()) {
             item(key = "sec-release-radar-header", contentType = "home-section-header") {
-                SectionTitle("📡 ${strings.releaseRadar}")
+                HomeSectionInset { SectionTitle("📡 ${strings.releaseRadar}") }
             }
             item(key = "sec-release-radar-row", contentType = "home-horizontal-row") {
                 ReleaseRadarRow(
@@ -2884,15 +2900,19 @@ private fun HomeScreen(viewModel: LevyraViewModel, state: LevyraUiState) {
         }
         if (state.similarArtists.isNotEmpty()) {
             item(key = "sec-similar-artists-header", contentType = "home-section-header") {
-                SectionTitle("✨ ${strings.similarToFollowed}")
+                HomeSectionInset { SectionTitle("✨ ${strings.similarToFollowed}") }
             }
             item(key = "sec-similar-artists-row", contentType = "home-horizontal-row") {
-                ArtistHitRow(state.similarArtists, onClick = viewModel::openArtistFromHit)
+                ArtistHitRow(
+                    artists = state.similarArtists,
+                    contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding),
+                    onClick = viewModel::openArtistFromHit
+                )
             }
         }
         if (newReleases != null && newReleases.tracks.isNotEmpty()) {
             item(key = "sec-new-releases-header", contentType = "home-section-header") {
-                SectionHeaderAction(strings.newReleases, onPlayAll = { viewModel.playAll(newReleases.tracks) })
+                HomeSectionInset { SectionHeaderAction(strings.newReleases, onPlayAll = { viewModel.playAll(newReleases.tracks) }) }
             }
             item(key = "sec-new-releases-row", contentType = "home-horizontal-row") {
                 AlbumCardRow(
@@ -2905,7 +2925,7 @@ private fun HomeScreen(viewModel: LevyraViewModel, state: LevyraUiState) {
         }
         if (state.homeAlbums.isNotEmpty() || state.homeAlbumsLoading) {
             item(key = "sec-home-albums-header", contentType = "home-section-header") {
-                SectionHeaderAction(strings.albumsForYou, onPlayAll = { viewModel.playAlbumRecommendations(state.homeAlbums) })
+                HomeSectionInset { SectionHeaderAction(strings.albumsForYou, onPlayAll = { viewModel.playAlbumRecommendations(state.homeAlbums) }) }
             }
             item(key = "sec-home-albums-row", contentType = "home-horizontal-row") {
                 if (state.homeAlbums.isNotEmpty()) {
@@ -2922,7 +2942,7 @@ private fun HomeScreen(viewModel: LevyraViewModel, state: LevyraUiState) {
         otherSections.forEachIndexed { index, section ->
             if (section.tracks.isNotEmpty()) {
                 item(key = "sec-other-${index}-header", contentType = "home-section-header") {
-                    SectionHeaderAction(section.title, onPlayAll = { viewModel.playAll(section.tracks) })
+                    HomeSectionInset { SectionHeaderAction(section.title, onPlayAll = { viewModel.playAll(section.tracks) }) }
                 }
                 item(key = "sec-other-${index}-row", contentType = "home-horizontal-row") {
                     AlbumCardRow(
@@ -2936,23 +2956,33 @@ private fun HomeScreen(viewModel: LevyraViewModel, state: LevyraUiState) {
         }
         item(key = "home-chart-title", contentType = "home-section-header") {
             val region = state.chartRegions.firstOrNull { it.id == state.selectedChartId }
-            SectionHeaderAction("Top 50 ${region?.label ?: "Global"} ${region?.emoji ?: ""}", onPlayAll = { viewModel.playAll(state.charts) })
+            HomeSectionInset {
+                SectionHeaderAction("Top 50 ${region?.label ?: "Global"} ${region?.emoji ?: ""}", onPlayAll = { viewModel.playAll(state.charts) })
+            }
         }
         item(key = "home-chart-regions", contentType = "home-horizontal-row") {
-            ChartRegionRow(regions = state.chartRegions, selectedId = state.selectedChartId, loading = state.isLoadingCharts, onSelect = viewModel::selectChart)
+            HomeSectionInset {
+                ChartRegionRow(regions = state.chartRegions, selectedId = state.selectedChartId, loading = state.isLoadingCharts, onSelect = viewModel::selectChart)
+            }
         }
         if (state.charts.isEmpty()) {
             item(key = "home-chart-empty", contentType = "home-card") {
-                if (state.isLoadingCharts) {
-                    ChartLoadingSkeleton()
-                } else {
-                    GlassMessage(strings.top50Unavailable, LevyraOrange)
+                HomeSectionInset {
+                    if (state.isLoadingCharts) {
+                        ChartLoadingSkeleton()
+                    } else {
+                        GlassMessage(strings.top50Unavailable, LevyraOrange)
+                    }
                 }
             }
         }
         if (state.charts.isNotEmpty()) {
             item(key = "home-chart-row", contentType = "home-horizontal-row") {
-                LazyRow(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                LazyRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
+                ) {
                     val chunks = state.charts.chunked(4)
                     itemsIndexed(
                         items = chunks,
@@ -2980,7 +3010,9 @@ private fun HomeScreen(viewModel: LevyraViewModel, state: LevyraUiState) {
                 }
             }
         }
-        item(key = "home-status", contentType = "home-card") { StatusBlock(state) }
+        item(key = "home-status", contentType = "home-card") {
+            HomeSectionInset { StatusBlock(state) }
+        }
     }
 
     addTarget?.let { track ->
@@ -3067,6 +3099,7 @@ private fun TrendingArtistsShelf(
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
         Row(
+            modifier = Modifier.padding(horizontal = HomeHorizontalInset),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(11.dp)
         ) {
@@ -3086,7 +3119,8 @@ private fun TrendingArtistsShelf(
             )
         }
         LazyRow(
-            horizontalArrangement = Arrangement.spacedBy(20.dp)
+            horizontalArrangement = Arrangement.spacedBy(20.dp),
+            contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
         ) {
             items(
                 items = artists,
@@ -3184,7 +3218,9 @@ private fun ResonanceShelf(
     val strings = LocalLevyraStrings.current
     Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = HomeHorizontalInset),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -3239,7 +3275,7 @@ private fun ResonanceShelf(
         LazyRow(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(14.dp),
-            contentPadding = PaddingValues(end = 6.dp)
+            contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
         ) {
             itemsIndexed(
                 items = tracks,
@@ -3431,7 +3467,9 @@ private fun PersonalListeningShelf(
     val shelfTracks = remember(tracks) { tracks.distinctBy { it.id } }
     Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = HomeHorizontalInset),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -3475,7 +3513,7 @@ private fun PersonalListeningShelf(
         LazyRow(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
-            contentPadding = PaddingValues(end = 4.dp)
+            contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
         ) {
             val columns = shelfTracks.chunked(2)
             itemsIndexed(
@@ -7807,7 +7845,7 @@ private fun SectionHeaderAction(title: String, onPlayAll: () -> Unit) {
 private fun HomeAlbumLoadingRow() {
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
-        contentPadding = PaddingValues(end = 4.dp)
+        contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
     ) {
         items(4, key = { "home-album-loading-$it" }) {
             Column(
@@ -7845,7 +7883,7 @@ private fun HomeAlbumHitRow(albums: List<AlbumHit>, animationsEnabled: Boolean, 
     if (albums.isEmpty()) return
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
-        contentPadding = PaddingValues(end = 4.dp)
+        contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
     ) {
         itemsIndexed(
             items = albums,
@@ -7954,7 +7992,7 @@ private fun AlbumCardRow(tracks: List<Track>, currentId: String?, animationsEnab
     if (tracks.isEmpty()) return
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
-        contentPadding = PaddingValues(end = 4.dp)
+        contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
     ) {
         itemsIndexed(
             items = tracks,
@@ -8631,8 +8669,15 @@ private fun SearchTrackCard(
 }
 
 @Composable
-private fun ArtistHitRow(artists: List<ArtistHit>, onClick: (ArtistHit) -> Unit) {
-    LazyRow(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+private fun ArtistHitRow(
+    artists: List<ArtistHit>,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    onClick: (ArtistHit) -> Unit
+) {
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+        contentPadding = contentPadding
+    ) {
         items(artists, key = { "artist-hit-${it.name}" }) { hit ->
             Column(
                 modifier = Modifier.width(104.dp).clickable { onClick(hit) },

--- a/app/src/test/java/com/luc4n3x/levyra/data/LyricsParsingTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/LyricsParsingTest.kt
@@ -1,0 +1,77 @@
+package com.luc4n3x.levyra.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LyricsParsingTest {
+    @Test
+    fun lrcParserExpandsMultipleTimestampsAndComputesEndTimes() {
+        val lines = LrcLyricsParser.parse(
+            """
+            [00:10.00][00:20.50]Same hook
+            [00:25.00]Next line
+            """.trimIndent()
+        )
+
+        assertEquals(3, lines.size)
+        assertEquals(10_000L, lines[0].startMs)
+        assertEquals("Same hook", lines[0].text)
+        assertEquals(20_500L, lines[1].startMs)
+        assertEquals(24_920L, lines[1].endMs)
+        assertEquals("Next line", lines[2].text)
+    }
+
+    @Test
+    fun ttmlParserKeepsLineTimingAndWordTiming() {
+        val lines = TtmlLyricsParser.parse(
+            """
+            <tt>
+              <body>
+                <div>
+                  <p begin="00:01.000" end="00:03.500">
+                    <span begin="00:01.000" end="00:01.400">Hello </span>
+                    <span begin="00:01.500" end="00:02.100">world</span>
+                  </p>
+                </div>
+              </body>
+            </tt>
+            """.trimIndent()
+        )
+
+        assertEquals(1, lines.size)
+        assertEquals(1_000L, lines[0].startMs)
+        assertEquals(3_500L, lines[0].endMs)
+        assertEquals("Hello world", lines[0].text)
+        assertEquals(2, lines[0].words.size)
+        assertEquals("Hello", lines[0].words[0].text)
+        assertEquals(1_400L, lines[0].words[0].endMs)
+        assertEquals("world", lines[0].words[1].text)
+    }
+
+    @Test
+    fun rankerPrefersSyncedCloseDurationCandidate() {
+        val requested = LyricsRequest("Song", "Artist", 180)
+        val syncedClose = LyricsCandidate(
+            result = LyricsRepository.LyricsResult(
+                synced = true,
+                lines = listOf(LrcLyricsParser.parse("[00:01.00]Line").first()),
+                provider = "Synced",
+                confidence = 0,
+                cached = false
+            ),
+            title = "Song",
+            artist = "Artist",
+            durationSec = 181
+        )
+        val plainExact = syncedClose.copy(
+            result = syncedClose.result.copy(synced = false, provider = "Plain"),
+            durationSec = 180
+        )
+
+        val best = LyricsResultRanker.best(listOf(plainExact, syncedClose), requested)
+
+        assertEquals("Synced", best?.provider)
+        assertTrue((best?.confidence ?: 0) >= 80)
+    }
+}

--- a/docs/pr-plans/2026-07-08-lyrics-experience-reference-plan.md
+++ b/docs/pr-plans/2026-07-08-lyrics-experience-reference-plan.md
@@ -1,0 +1,209 @@
+# Levyra Reference-Inspired PR Plan: Lyrics Experience + Player Polish
+
+Date: 2026-07-08
+
+## Goal
+
+Open the next Levyra PR around a focused, defensible upgrade: a richer lyrics/player experience inspired by SimpMusic, LyricsPlus, Metrolist, and a Spotify-like dark music UI language, while keeping Levyra's own cinematic identity.
+
+## Recommended PR Scope
+
+Build "Levyra Lyrics Pro v2":
+
+- Multi-source lyrics pipeline with clearer provider priority and confidence reporting.
+- Optional TTML/word-timed lyrics parsing path, prepared for LyricsPlus-style data.
+- Fullscreen lyrics overlay polish: denser, darker, artwork-driven, and easier to scan during playback.
+- Small component extraction from `LevyraApp.kt` so the PR improves maintainability instead of only adding more code to an already large file.
+
+This is the best PR candidate because Levyra already has:
+
+- `LyricsRepository.kt` with LRCLIB + Lyrics.ovh fallback, local cache, scoring, and provider metadata.
+- `LevyraUiState.kt` with lyrics state fields: provider, confidence, synced, cached, loading, active line.
+- `LyricsOverlay`, `LyricsProStatusRow`, and `LyricsButton` in `LevyraApp.kt`.
+- Existing tests around repository/domain behavior.
+
+## What To Take, Levyra-Style
+
+### From SimpMusic
+
+Useful ideas:
+
+- Treat lyrics as a first-class playback feature, not a small side panel.
+- Expose provider labels and user-facing settings for lyrics behavior.
+- Keep future room for AI translation, but do not ship it in this PR unless we have a clear API-key/privacy story.
+- Study the separation of view models/screens as a direction for future cleanup.
+
+Do not take now:
+
+- Full KMP/Desktop scope.
+- Spotify login/canvas complexity.
+- SimpMusic-specific database/provider branding.
+- AI translation runtime in the first PR.
+
+### From LyricsPlus
+
+Useful ideas:
+
+- API contract shape: `title`, `artist`, `album`, `duration`, optional `isrc`/`platformId`, optional `source`, and `forceReload`.
+- Multiple result formats: v2 structured lyrics, TTML, raw source data.
+- Cache-first behavior and explicit source/processing metadata.
+- User-submission architecture as a later idea, not a phone-client feature for this PR.
+
+Do not take now:
+
+- Hardcoded dependency on a third-party LyricsPlus server.
+- Server-side Google Drive cache assumptions.
+- Upload/submission flow and proof-of-work challenge.
+- Provider credentials or anything requiring Apple/Musixmatch/Spotify accounts.
+
+### From Metrolist
+
+Useful ideas:
+
+- Keep LRCLIB logic modular and testable.
+- Use multiple search strategies: cleaned title+artist, title-only fallback, combined query, original title fallback.
+- Add relaxed duration matching for better real-world lyric matches.
+- Add TTML parsing tests inspired by its BetterLyrics module.
+- Use Material 3 theme/palette flexibility as inspiration, not a direct visual copy.
+
+Do not take now:
+
+- Listen-together backend.
+- Account sync and full library import.
+- Full BetterLyrics remote dependency.
+- Large module import that would change Levyra's build shape too much.
+
+## Visual Direction
+
+Reference: `awesome-design-md/design-md/spotify/DESIGN.md`.
+
+Adapted Levyra direction:
+
+- Add a "Studio Black" treatment for lyrics/player: near-black surfaces, compact typography, pill/circle controls.
+- Let album artwork provide most color; use Levyra cyan/violet only for functional states.
+- Reduce decorative gradient noise in the lyrics overlay.
+- Keep Levyra's identity: cinematic glass, cyan/violet accents, high-contrast readability.
+- Avoid making it look like Spotify; use the music-app ergonomics, not the brand.
+
+## Candidate Approaches
+
+### Approach A: Lyrics Pro v2 (Recommended)
+
+Scope:
+
+- Refactor lyrics parsing/scoring into smaller classes.
+- Add TTML parser + word timing model.
+- Add optional LyricsPlus-compatible client interface, disabled unless configured.
+- Improve fullscreen lyrics overlay with word-aware rendering when available.
+- Add unit tests for LRC parsing, TTML parsing, scoring, cache restore, and fallback ordering.
+
+Why recommended:
+
+- Strong overlap between all three reference repos.
+- Uses existing Levyra architecture.
+- Creates a PR that is featureful but still reviewable.
+
+Risk:
+
+- TTML/word timing adds data-model complexity.
+- Remote lyrics providers need privacy and reliability guardrails.
+
+### Approach B: Discovery + Library Upgrade
+
+Scope:
+
+- More personalized quick picks.
+- Better artist/release cards.
+- Listening Pulse expansion with local "scrobble" style sections.
+- Home/library visual reordering.
+
+Why not first:
+
+- Levyra already recently touched Listening Pulse and Library.
+- Higher risk of a broad UI PR with fewer clear tests.
+
+### Approach C: Pure Visual Refresh
+
+Scope:
+
+- Player/lyrics/home polish only.
+- Add Studio Black theme.
+- Extract Compose components.
+- No new network/provider work.
+
+Why not first:
+
+- Safer, but less meaningful as a new PR if the goal is to learn from all three reference repos.
+- Does not use LyricsPlus beyond design inspiration.
+
+## Proposed Implementation Plan
+
+1. Create branch:
+   - `feature/lyrics-pro-v2-player-polish`
+
+2. Add domain models:
+   - Extend or wrap `LyricLine` with optional `words: List<LyricWord>`.
+   - Add `LyricsProviderPriority` or equivalent sealed model for source ordering.
+
+3. Split lyrics repository internals:
+   - Keep public API stable where possible: `fetch(title, artist, durationSec)`.
+   - Extract title/artist normalization.
+   - Extract LRC parser.
+   - Add TTML parser.
+   - Add result scoring/fallback ordering tests.
+
+4. Add optional LyricsPlus-compatible provider:
+   - Do not hardcode a single unofficial production URL.
+   - Gate via local config/build field or disabled default.
+   - Accept `title`, `artist`, `album`, `duration`.
+   - Parse v2/TTML response into Levyra models.
+   - Fail closed and fall back to LRCLIB.
+
+5. Improve UI:
+   - Extract lyrics UI to `ui/lyrics/`.
+   - Add `LyricsOverlay`, `LyricsStatusPill`, `SyncedLyricLine`, `WordTimedLyricLine`.
+   - Make fullscreen lyrics use near-black surfaces and artwork accent.
+   - Keep active line readable and animated, but avoid over-animation.
+
+6. Add settings copy/state:
+   - Show provider, confidence, synced/static, cached/remote.
+   - Optionally add a "prefer enhanced lyrics" toggle only if provider integration lands.
+
+7. Tests and verification:
+   - `./gradlew testDebugUnitTest`
+   - If Android environment allows: `./gradlew assembleDebug`
+   - Manual smoke test: play track, open lyrics, verify active line follows playback, no crash when no lyrics.
+
+## PR Guardrails
+
+- No direct visual clone of Spotify, SimpMusic, or Metrolist.
+- No bundled secrets, provider account tokens, or hardcoded private endpoints.
+- GPL-compatible attribution stays in README or PR body when adapting code-level ideas.
+- Keep PR under one theme: lyrics/player experience. Discovery, accounts, listen-together, and desktop stay out.
+- Prefer tests before UI breadth.
+
+## PR Body Draft
+
+Title:
+
+`feat: upgrade lyrics pipeline and polish fullscreen player lyrics`
+
+Summary:
+
+- Adds a modular lyrics pipeline with stronger fallback ordering and provider metadata.
+- Adds TTML/word-timing support foundation for enhanced synced lyrics.
+- Refreshes fullscreen lyrics with a darker, artwork-led player treatment.
+- Extracts lyrics UI/parsing pieces into focused files for maintainability.
+
+References:
+
+- SimpMusic for multi-provider lyrics/player experience concepts.
+- LyricsPlus for API-shape and TTML/raw lyrics ideas.
+- Metrolist for LRCLIB fallback strategy and BetterLyrics TTML parsing inspiration.
+- Spotify-inspired design reference for content-first dark music UI ergonomics.
+
+Testing:
+
+- `./gradlew testDebugUnitTest`
+- `./gradlew assembleDebug`
+


### PR DESCRIPTION
## Summary
- Adds a modular enhanced lyrics parsing foundation with LRC parsing, TTML line/word timing, and reusable result ranking.
- Persists optional word-level lyric timing in the local lyrics cache and keeps the existing LRCLIB/Lyrics.ovh public fetch API intact.
- Polishes the fullscreen lyrics overlay with a darker Studio Black treatment and word-aware active-line highlighting.
- Documents the reference plan for what to adapt from SimpMusic, LyricsPlus, Metrolist, and the Spotify-inspired design guide.

## Reference direction
- SimpMusic: lyrics as a first-class playback experience.
- LyricsPlus: TTML/structured lyrics API shape and provider metadata ideas.
- Metrolist: LRCLIB fallback/ranking and BetterLyrics-style TTML parsing inspiration.
- Spotify design reference: dense, content-first dark player ergonomics adapted into Levyra's own cinematic style.

## Test plan
- `gradle-9.4.1 testDebugUnitTest --tests com.luc4n3x.levyra.data.LyricsParsingTest` using temporary JDK 17/Gradle outside the repo.
- `gradle-9.4.1 testDebugUnitTest` using temporary JDK 17/Gradle outside the repo.
- `gradle-9.4.1 assembleDebug` using temporary JDK 17/Gradle outside the repo.

## Notes
The repo currently does not include a Gradle wrapper, so validation used downloaded temporary toolchains under `%TEMP%` and did not add those files to the repository.
