### PR TITLE
Strip Wikipedia/CC attribution from artist bios

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/ArtistRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/ArtistRepository.kt
@@ -175,13 +175,13 @@ class ArtistRepository(private val music: YoutubeMusicRepository, private val co
         val sections = mutableListOf<JSONObject>()
         collectByKey(root, "musicDescriptionShelfRenderer", sections)
         sections.forEach { shelf ->
-            val text = shelf.optJSONObject("description")?.optJSONArray("runs")?.joinText().orEmpty().trim()
+            val text = shelf.optJSONObject("description")?.optJSONArray("runs")?.joinText().orEmpty().cleanAlbumDescription()
             if (text.length > 24) return text
         }
         val descriptions = mutableListOf<JSONObject>()
         collectByKey(root, "description", descriptions)
         descriptions.forEach { node ->
-            val text = node.optJSONArray("runs")?.joinText().orEmpty().trim()
+            val text = node.optJSONArray("runs")?.joinText().orEmpty().cleanAlbumDescription()
             if (text.length > 80) return text
         }
         return ""


### PR DESCRIPTION
## Summary

- Artist biographies now go through the same cleaner already used for album descriptions, so artist pages no longer show the raw "Da Wikipedia (…) soggetto a Creative Commons Attribution CC-BY-SA 3.0 (…)" trailer and bare URLs. The reader gets a clean bio, just like album descriptions.

## Scope

- [ ] Player / audio
- [ ] Stream extraction
- [ ] Downloads
- [ ] UI / Compose
- [ ] Localization
- [ ] Android Auto / media session
- [ ] CI / release
- [x] Documentation

## What changed

- `ArtistRepository.extractBio` now applies the existing `String.cleanAlbumDescription()` helper to both bio text sources instead of a plain `trim()`. That helper cuts the text at the first Wikipedia/Creative-Commons attribution marker and removes stray URLs, and it is already covered by unit tests. No new logic or duplicated marker list is introduced.

## Testing

- [ ] `gradle --no-daemon :app:lintRelease`
- [ ] `gradle --no-daemon testReleaseUnitTest`
- [ ] `gradle --no-daemon assembleRelease`
- [ ] APK installed on device
- [ ] Playback tested
- [ ] Downloads tested
- [ ] Language switching tested

Change is a two-line reuse of an already-tested helper; full Gradle validation runs in CI.

## Release safety

- [x] `levyraVersionName` and `levyraVersionCode` are correct (unchanged)
- [x] No secrets, keystores, APKs or ZIPs committed
- [x] No duplicated release workflows
- [x] Credits and licenses updated when adding external components (no external components added)

## Related issues

- Follow-up to the merged Listening Pulse work (#57): extends the "descriptions without Wikipedia attribution" cleanup from album descriptions to artist biographies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsCkvoNoQVMk1nE7jacq9V)_