### PR TITLE
perf(player): fuse InnerTube and LevyraExtractor onto one warm HTTP stack

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/LevyraApplication.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/LevyraApplication.kt
@@ -2,6 +2,8 @@ package com.luc4n3x.levyra
 
 import android.app.Application
 import com.luc4n3x.levyra.data.LevyraArtworkCache
+import com.luc4n3x.levyra.data.NewPipeRuntime
+import com.luc4n3x.levyra.data.PlaybackResolver
 import com.luc4n3x.levyra.data.ReleaseRadarWorker
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -17,10 +19,21 @@ class LevyraApplication : Application() {
         super.onCreate()
         if (BuildConfig.DEBUG) Timber.plant(Timber.DebugTree())
         LevyraArtworkCache.configure(this)
+        warmPlaybackPipeline()
         startupScope.launch {
             delay(1800L)
             runCatching { ReleaseRadarWorker.schedule(this@LevyraApplication) }
                 .onFailure { Timber.w(it, "Release radar scheduling failed") }
+        }
+    }
+
+    private fun warmPlaybackPipeline() {
+        startupScope.launch {
+            delay(400L)
+            runCatching { NewPipeRuntime.ensure() }
+                .onFailure { Timber.w(it, "Extractor warmup failed") }
+            runCatching { PlaybackResolver.getInstance(this@LevyraApplication).warmNetwork() }
+                .onFailure { Timber.w(it, "Network warmup failed") }
         }
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
@@ -1,5 +1,6 @@
 package com.luc4n3x.levyra.data
 
+import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -12,7 +13,6 @@ import org.schabi.newpipe.extractor.localization.ContentCountry
 import org.schabi.newpipe.extractor.localization.Localization
 import java.io.IOException
 import java.nio.charset.StandardCharsets
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 object NewPipeRuntime {
@@ -26,14 +26,7 @@ object NewPipeRuntime {
 }
 
 private class OkHttpNewPipeDownloader : Downloader() {
-    private val client = OkHttpClient.Builder()
-        .followRedirects(true)
-        .followSslRedirects(true)
-        .connectTimeout(5, TimeUnit.SECONDS)
-        .readTimeout(12, TimeUnit.SECONDS)
-        .writeTimeout(8, TimeUnit.SECONDS)
-        .callTimeout(18, TimeUnit.SECONDS)
-        .build()
+    private val client: OkHttpClient = LevyraHttpClientFactory.extractor()
 
     override fun execute(request: Request): Response {
         client.newCall(toOkHttpRequest(request)).execute().use { response ->

--- a/app/src/main/java/com/luc4n3x/levyra/data/network/LevyraHttpClientFactory.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/network/LevyraHttpClientFactory.kt
@@ -28,6 +28,9 @@ object LevyraHttpClientFactory {
     @Volatile
     private var youtubePlayerClient: OkHttpClient? = null
 
+    @Volatile
+    private var extractorClient: OkHttpClient? = null
+
     fun media(context: Context? = null): OkHttpClient {
         return mediaClient ?: synchronized(this) {
             mediaClient ?: OkHttpClient.Builder()
@@ -59,6 +62,20 @@ object LevyraHttpClientFactory {
                 .retryOnConnectionFailure(true)
                 .build()
                 .also { youtubePlayerClient = it }
+        }
+    }
+
+    fun extractor(): OkHttpClient {
+        return extractorClient ?: synchronized(this) {
+            extractorClient ?: youtubePlayer().newBuilder()
+                .connectTimeout(4, TimeUnit.SECONDS)
+                .readTimeout(12, TimeUnit.SECONDS)
+                .writeTimeout(8, TimeUnit.SECONDS)
+                .callTimeout(18, TimeUnit.SECONDS)
+                .followRedirects(true)
+                .followSslRedirects(true)
+                .build()
+                .also { extractorClient = it }
         }
     }
 


### PR DESCRIPTION
## Summary

- Make the InnerTube fast path and the LevyraExtractor fallback share a single warm OkHttp stack so the extractor reuses hot TLS connections instead of paying a cold handshake, and pre-warm the whole pipeline at startup.

## Scope

- [x] Player / audio
- [x] Stream extraction
- [ ] Downloads
- [ ] UI / Compose
- [ ] Localization
- [ ] Android Auto / media session
- [ ] CI / release
- [ ] Documentation

## What changed

- `LevyraHttpClientFactory.extractor()`: new client derived from the InnerTube `youtubePlayer()` client via `newBuilder()`, so it shares the same `ConnectionPool`, `Dispatcher` and Brotli interceptor.
- `NewPipeRuntime`: the NewPipe/LevyraExtractor downloader now uses that shared client instead of allocating its own separate pool. When the InnerTube race has already opened TLS to `youtube.com`/`googlevideo.com`, the extractor fallback reuses those sockets.
- `LevyraApplication`: pre-warms the pipeline on a background thread — pays `NewPipe.init` once and pre-opens the pooled TLS connections off the cold-start path, so the first track resolves hot.

## Testing

- [ ] `gradle --no-daemon :app:lintRelease`
- [ ] `gradle --no-daemon testReleaseUnitTest`
- [ ] `gradle --no-daemon assembleRelease`
- [ ] APK installed on device
- [ ] Playback tested
- [ ] Downloads tested
- [ ] Language switching tested

> Build/lint/unit tests are delegated to CI (`pr-check` / `quick-apk`). No unit test was modified; the change is confined to HTTP client wiring and a startup warm-up.

## Release safety

- [x] `levyraVersionName` and `levyraVersionCode` are correct
- [x] No secrets, keystores, APKs or ZIPs committed
- [x] No duplicated release workflows
- [x] Credits and licenses updated when adding external components

## Related issues

- Closes #
- Related to #