### PR TITLE
feat(player): experimental opt-in WEB PoToken pipeline

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
@@ -147,6 +147,24 @@ class LevyraPreferences(context: Context) {
         write { it[KEY_AUDIO_QUALITY] = normalizeAudioQuality(value) }
     }
 
+    fun poTokenEnabled(): Boolean = read(false) { it[KEY_POTOKEN_ENABLED] ?: false }
+
+    fun setPoTokenEnabled(value: Boolean) {
+        write { it[KEY_POTOKEN_ENABLED] = value }
+    }
+
+    fun poToken(): String = read("") { it[KEY_POTOKEN].orEmpty().trim() }
+
+    fun setPoToken(value: String) {
+        write { it[KEY_POTOKEN] = value.trim() }
+    }
+
+    fun poVisitorData(): String = read("") { it[KEY_PO_VISITOR_DATA].orEmpty().trim() }
+
+    fun setPoVisitorData(value: String) {
+        write { it[KEY_PO_VISITOR_DATA] = value.trim() }
+    }
+
     fun dismissedUpdateVersion(): String = read("") { it[KEY_DISMISSED_UPDATE_VERSION].orEmpty() }
 
     fun setDismissedUpdateVersion(version: String) {
@@ -426,6 +444,9 @@ class LevyraPreferences(context: Context) {
         val KEY_ANIMATIONS = booleanPreferencesKey("animations_enabled")
         val KEY_DYNAMIC_COLOR = booleanPreferencesKey("dynamic_color")
         val KEY_SPONSORBLOCK = booleanPreferencesKey("sponsorblock_enabled")
+        val KEY_POTOKEN_ENABLED = booleanPreferencesKey("potoken_enabled")
+        val KEY_POTOKEN = stringPreferencesKey("potoken_value")
+        val KEY_PO_VISITOR_DATA = stringPreferencesKey("potoken_visitor_data")
         val KEY_SKIP_SILENCE = booleanPreferencesKey("skip_silence")
         val KEY_AUDIO_QUALITY = stringPreferencesKey("audio_quality")
         val KEY_USER_NAME = stringPreferencesKey("user_name")

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -86,6 +86,14 @@ class PlaybackResolver private constructor(private val context: Context) {
     @Volatile
     private var lastNetworkWarmAt = 0L
 
+    @Volatile
+    private var poTokenValue = ""
+
+    @Volatile
+    private var poVisitorData = ""
+
+    private val webPoTokenProfile = ClientProfile("WEB", "2.20250312.04.00", "WEB PoToken", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36", false, 0L, -1)
+
     private val profiles = listOf(
         ClientProfile("ANDROID_MUSIC", "8.10.52", "Android Music", "Mozilla/5.0 (Linux; Android 15; Pixel 8 Pro) AppleWebKit/537.36 (KHTML, like Gecko) com.google.android.apps.youtube.music/8.10.52", true, 0L, 0),
         ClientProfile("ANDROID", "19.44.38", "Android", "com.google.android.youtube/19.44.38 (Linux; U; Android 15)", true, 0L, 1),
@@ -104,6 +112,20 @@ class PlaybackResolver private constructor(private val context: Context) {
             "low" -> "Low"
             else -> "Auto"
         }
+    }
+
+    fun refreshPoTokenSettings() {
+        poTokenValue = if (userPreferences.poTokenEnabled()) userPreferences.poToken() else ""
+        poVisitorData = userPreferences.poVisitorData()
+    }
+
+    private fun poTokenActive(): Boolean = poTokenValue.isNotBlank()
+
+    private fun appendPoToken(url: String, profile: ClientProfile): String {
+        if (url.isBlank() || profile.clientName != "WEB" || poTokenValue.isBlank()) return url
+        if (url.contains("&pot=") || url.contains("?pot=")) return url
+        val separator = if (url.contains('?')) "&" else "?"
+        return "$url${separator}pot=${poTokenValue.urlEncode()}"
     }
 
     fun warmNetwork() {
@@ -224,6 +246,7 @@ class PlaybackResolver private constructor(private val context: Context) {
 
     private suspend fun resolveUncached(track: Track, isVideoMode: Boolean = false, preferMp4Audio: Boolean = false): Track = withContext(Dispatchers.IO) {
         val errors = Collections.synchronizedList(mutableListOf<String>())
+        refreshPoTokenSettings()
 
         if (isVideoMode) {
             val resolved = coroutineScope {
@@ -470,7 +493,7 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     private suspend fun hedgedInnerTube(track: Track, errors: MutableList<String>, isVideoMode: Boolean): DirectStream? {
-        val ladder = profiles
+        val ladder = (if (poTokenActive()) listOf(webPoTokenProfile) + profiles else profiles)
             .groupBy { it.tier }
             .toSortedMap()
             .map { (_, group) ->
@@ -811,7 +834,7 @@ class PlaybackResolver private constructor(private val context: Context) {
             val duration = details?.optString("lengthSeconds")?.toLongOrNull()?.times(1000L) ?: 0L
             val thumbnail = details?.optJSONObject("thumbnail")?.optJSONArray("thumbnails")?.bestThumbnail().orEmpty()
             return DirectStream(
-                url = bestAudioUrl,
+                url = appendPoToken(bestAudioUrl, profile),
                 videoUrl = "",
                 durationMs = duration,
                 thumbnailUrl = thumbnail,
@@ -991,7 +1014,10 @@ class PlaybackResolver private constructor(private val context: Context) {
             client.put("clientScreen", "EMBED")
                 .put("thirdParty", JSONObject().put("embedUrl", "https://www.youtube.com/embed/$videoId"))
         }
-        return JSONObject()
+        if (profile.clientName == "WEB" && poVisitorData.isNotBlank()) {
+            client.put("visitorData", poVisitorData)
+        }
+        val body = JSONObject()
             .put("context", JSONObject().put("client", client))
             .put("videoId", videoId)
             .put("contentCheckOk", true)
@@ -999,6 +1025,10 @@ class PlaybackResolver private constructor(private val context: Context) {
             .put("playbackContext", JSONObject().put("contentPlaybackContext", JSONObject().put("html5Preference", "HTML5_PREF_WANTS")))
             .put("params", "CgIQBg")
             .put("watchEndpointMusicSupportedConfigs", JSONObject().put("watchEndpointMusicConfig", JSONObject().put("musicVideoType", "MUSIC_VIDEO_TYPE_ATV")))
+        if (profile.clientName == "WEB" && poTokenValue.isNotBlank()) {
+            body.put("serviceIntegrityDimensions", JSONObject().put("poToken", poTokenValue))
+        }
+        return body
     }
 
     private fun scoreAudioFormat(mime: String, itag: Int, bitrate: Int, audioQuality: String, preferMp4Audio: Boolean): Int {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -170,6 +170,7 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import com.luc4n3x.levyra.data.LevyraPreferences
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalView
@@ -6930,6 +6931,7 @@ private fun SettingsOverlay(
                     onCheckedChange = onSkipSilence
                 )
             }
+            item { PoTokenSettingsCard() }
             item { SettingsSectionLabel(strings.preferences) }
             item {
                 SettingsButton(
@@ -7050,6 +7052,82 @@ private fun ThemePresetCard(preset: LevyraPalette, selected: Boolean, onClick: (
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
+        }
+    }
+}
+
+@Composable
+private fun PoTokenSettingsCard() {
+    val context = LocalContext.current
+    val prefs = remember { LevyraPreferences(context) }
+    var enabled by remember { mutableStateOf(prefs.poTokenEnabled()) }
+    var token by remember { mutableStateOf(prefs.poToken()) }
+    var visitor by remember { mutableStateOf(prefs.poVisitorData()) }
+    Surface(
+        color = LevyraAdaptiveCard,
+        border = BorderStroke(1.dp, LevyraAdaptiveHairline),
+        shape = RoundedCornerShape(18.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .background(LevyraCyan.copy(alpha = 0.16f), RoundedCornerShape(12.dp)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(Icons.Rounded.Bolt, null, tint = LevyraCyan, modifier = Modifier.size(20.dp))
+                }
+                Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text("PoToken WEB (sperimentale)", color = LevyraText, fontSize = 15.sp, fontWeight = FontWeight.Black)
+                    Text(
+                        "Client WEB con PoToken per stream protetti. Incolla poToken e visitorData ottenuti da browser/tool.",
+                        color = LevyraMuted,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+                Switch(
+                    checked = enabled,
+                    onCheckedChange = {
+                        enabled = it
+                        prefs.setPoTokenEnabled(it)
+                    },
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = LevyraBlack,
+                        checkedTrackColor = LevyraCyan,
+                        uncheckedThumbColor = LevyraMuted,
+                        uncheckedTrackColor = LevyraAdaptiveTrack
+                    )
+                )
+            }
+            if (enabled) {
+                OutlinedTextField(
+                    value = token,
+                    onValueChange = {
+                        token = it
+                        prefs.setPoToken(it)
+                    },
+                    label = { Text("poToken") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = visitor,
+                    onValueChange = {
+                        visitor = it
+                        prefs.setPoVisitorData(it)
+                    },
+                    label = { Text("visitorData") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Phase 2 sandbox (draft): lands the full WEB **PoToken** pipeline in the playback resolver, **opt-in** and fed by a user-supplied token, so it can be tested on-device without touching `main`. Automatic BotGuard minting becomes a later drop-in as the token source.

## Scope

- [x] Player / audio
- [x] Stream extraction
- [ ] Downloads
- [ ] UI / Compose
- [ ] Localization
- [ ] Android Auto / media session
- [ ] CI / release
- [ ] Documentation

## What changed

- **`LevyraPreferences`**: new `poTokenEnabled`, `poToken`, `visitorData` accessors (DataStore).
- **`PlaybackResolver`**: a `WEB` client tier that is added to the hedge ladder only when a token is configured. It sends `visitorData` in the client context and `serviceIntegrityDimensions.poToken` in the player body, then appends `&pot=` to the resolved stream URL. When the toggle is off / no token, the resolver is byte-for-byte unchanged, so default playback is untouched.
- **Settings**: an experimental "PoToken WEB" card (toggle + `poToken` / `visitorData` fields) that persists to preferences.

## How to test on device

1. Build the APK from this branch.
2. Settings → enable **PoToken WEB (sperimentale)**, paste a `poToken` and `visitorData` obtained from a browser/tool.
3. Play a track (ideally one that normally fails) and confirm the WEB tier resolves; source label shows `YouTube WEB PoToken`.
4. Toggle off → behaviour returns to the current default path.

## Known limits (honest)

- This is the **pipeline**; it needs a valid WEB `poToken` + matching `visitorData`. Automatic BotGuard/WebView minting is deliberately **not** in this PR (it is device-dependent and cannot be verified in CI).
- The app does not transform the `n` throttling parameter, so sustained WEB streaming may still be rate-limited; this is expected for v1 and informs whether the SABR path is worth wiring next.

## Testing

- [ ] `gradle --no-daemon :app:lintRelease`
- [ ] `gradle --no-daemon testReleaseUnitTest`
- [ ] `gradle --no-daemon assembleRelease`
- [ ] APK installed on device
- [ ] Playback tested with a pasted poToken
- [ ] Toggle-off parity confirmed

> Compilation validated by CI; on-device behaviour to be validated from this branch's APK.

## Release safety

- [x] `levyraVersionName` and `levyraVersionCode` are correct
- [x] No secrets, keystores, APKs or ZIPs committed
- [x] No duplicated release workflows
- [x] Off by default — no change to current playback when disabled

## Related issues

- Closes #
- Related to #


---
_Generated by [Claude Code](https://claude.ai/code/session_019uSgy4DRicyvLAiFdMc7Sf)_