### PR TITLE
Feature/update 2.3.5

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -9,7 +9,7 @@ on:
       tag:
         description: "Release tag"
         required: true
-        default: "v2.3.3"
+        default: "v2.3.5"
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ docs/PLAYER_MOBIUS_SAMPLE_ARCHITECTURE.md
 ### Version Control & CI overrides
 The application's version numbering is centralized inside `gradle.properties`:
 ```properties
-levyraVersionName=2.3.3
-levyraVersionCode=2030300
+levyraVersionName=2.3.5
+levyraVersionCode=2030500
 ```
 *Version code logic is calculated sequentially to prevent duplicate deployment IDs:*
 `versionCode = major * 1_000_000 + minor * 10_000 + patch * 100 + build`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,7 +62,7 @@ if (isReleaseTaskRequested() && (!releaseStoreFile.isFile || releaseStorePasswor
 fun normalizedVersionName(value: String): String {
     val clean = value.trim().removePrefix("v").removePrefix("V")
     val match = Regex("\\d+(?:\\.\\d+){0,3}(?:[-+][0-9A-Za-z.-]+)?").find(clean)?.value
-    return match ?: clean.ifBlank { "2.3.3" }
+    return match ?: clean.ifBlank { "2.3.5" }
 }
 
 fun generatedVersionCode(versionName: String): Int {
@@ -93,7 +93,7 @@ val levyraVersionName = normalizedVersionName(
     (findProperty("levyraVersionName") as? String)
         ?: System.getenv("LEVYRA_VERSION_NAME")
         ?: githubTagVersionName()
-        ?: "2.3.3"
+        ?: "2.3.5"
 )
 
 val levyraVersionCode = ((findProperty("levyraVersionCode") as? String)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,4 @@
 org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8 -XX:+UseParallelGC
-# Wait for JitPack cold builds of the LevyraExtractor artifact instead of failing:
-# the first request for a new commit blocks while JitPack compiles it on-demand.
 systemProp.org.gradle.internal.http.socketTimeout=600000
 systemProp.org.gradle.internal.http.connectionTimeout=120000
 org.gradle.parallel=true
@@ -10,5 +8,5 @@ android.useAndroidX=true
 android.nonTransitiveRClass=true
 android.enableR8.fullMode=true
 kotlin.code.style=official
-levyraVersionName=2.3.3
-levyraVersionCode=2030300
+levyraVersionName=2.3.5
+levyraVersionCode=2030500


### PR DESCRIPTION
  * Updated the application version to **2.3.5**.
  * Updated the release build metadata to match version 2.3.5.
  * Manual release builds now default to the 2.3.5 release tag.