### PR TITLE
fix long offline downloads

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
@@ -63,6 +65,11 @@
                 <action android:name="android.media.browse.MediaBrowserService" />
             </intent-filter>
         </service>
+
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineAudioExporter.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineAudioExporter.kt
@@ -14,6 +14,7 @@ import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
 import com.luc4n3x.levyra.domain.Track
 import com.luc4n3x.levyra.player.offline.tagging.LevyraM4aMetadata
 import com.luc4n3x.levyra.player.offline.tagging.LevyraM4aTagWriter
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -41,6 +42,7 @@ class OfflineAudioExporter(
             reportProgress(4)
             if (track.id.isNotBlank() || track.videoUrl.isNotBlank()) resolver.resolveForOffline(track.copy(streamUrl = "")) else track
         }.getOrElse { error ->
+            if (error is CancellationException) throw error
             if (track.streamUrl.isNotBlank()) track else throw error
         }
         if (playable.streamUrl.isBlank()) throw IOException("Stream audio non disponibile")
@@ -51,6 +53,7 @@ class OfflineAudioExporter(
         val downloaded = runCatching {
             downloadAudio(playable, workspace)
         }.getOrElse { firstError ->
+            if (firstError is CancellationException) throw firstError
             val canRefresh = track.id.isNotBlank() || track.videoUrl.isNotBlank()
             if (!canRefresh) throw firstError
             reportProgress(7)

--- a/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineAudioExporter.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineAudioExporter.kt
@@ -16,16 +16,69 @@ import com.luc4n3x.levyra.player.offline.tagging.LevyraM4aMetadata
 import com.luc4n3x.levyra.player.offline.tagging.LevyraM4aTagWriter
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
+import java.io.RandomAccessFile
 import java.util.Locale
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import timber.log.Timber
+
+internal const val DEFAULT_PARALLEL_RANGE_CHUNK_BYTES = 4L * 1024L * 1024L
+internal const val MIN_PARALLEL_AUDIO_BYTES = 16L * 1024L * 1024L
+
+internal data class AudioDownloadRange(
+    val start: Long,
+    val endInclusive: Long
+) {
+    val length: Long
+        get() = endInclusive - start + 1L
+}
+
+internal fun planParallelAudioRanges(
+    contentLength: Long,
+    chunkSize: Long = DEFAULT_PARALLEL_RANGE_CHUNK_BYTES,
+    minLength: Long = MIN_PARALLEL_AUDIO_BYTES
+): List<AudioDownloadRange> {
+    if (contentLength < minLength || chunkSize <= 0L) return emptyList()
+    val ranges = mutableListOf<AudioDownloadRange>()
+    var start = 0L
+    while (start < contentLength) {
+        val end = minOf(start + chunkSize - 1L, contentLength - 1L)
+        ranges += AudioDownloadRange(start = start, endInclusive = end)
+        start = end + 1L
+    }
+    return ranges
+}
+
+internal fun isUsableAudioRangeResponse(
+    code: Int,
+    bodyLength: Long,
+    contentRange: String,
+    range: AudioDownloadRange,
+    rangeParamApplied: Boolean
+): Boolean {
+    if (code == 206) return true
+    if (!rangeParamApplied || code !in 200..299) return false
+    if (bodyLength != range.length) return false
+    if (contentRange.isBlank()) return true
+    return contentRange.contains("${range.start}-") && contentRange.substringAfterLast('/').toLongOrNull() != null
+}
+
+internal fun audioContentLengthFromUrl(url: String): Long {
+    return Regex("(?:[?&])clen=(\\d+)").find(url)?.groupValues?.getOrNull(1)?.toLongOrNull() ?: -1L
+}
 
 class OfflineAudioExporter(
     private val context: Context,
@@ -103,7 +156,26 @@ class OfflineAudioExporter(
 
     private suspend fun downloadAudioAttempt(track: Track, workspace: File, useRange: Boolean): DownloadedAudio {
         reportProgress(12)
-        val expectedLength = probeContentLength(track.streamUrl)
+        val probe = probeAudio(track.streamUrl)
+        val expectedLength = probe.contentLength
+        val parallelRanges = if (!useRange && !hasRangeParameter(track.streamUrl)) {
+            planParallelAudioRanges(expectedLength)
+        } else {
+            emptyList()
+        }
+        if (parallelRanges.isNotEmpty()) {
+            runCatching {
+                return downloadAudioRanges(
+                    track = track,
+                    workspace = workspace,
+                    targetLength = expectedLength,
+                    contentType = probe.contentType,
+                    ranges = parallelRanges
+                )
+            }.onFailure { error ->
+                Timber.w(error, "Parallel offline download failed, falling back to serial")
+            }
+        }
         val downloadUrl = if (useRange) withGoogleVideoRange(track.streamUrl, expectedLength) else track.streamUrl
         val rangeParamApplied = downloadUrl != track.streamUrl
         val request = Request.Builder()
@@ -116,7 +188,7 @@ class OfflineAudioExporter(
             .build()
         client.newCall(request).execute().use { response ->
             if (!response.isSuccessful) throw IOException("Download audio fallito: HTTP ${response.code}")
-            val body = response.body ?: throw IOException("Risposta audio vuota")
+            val body = response.body
             val declaredLength = body.contentLength()
             val contentRangeTotal = response.header("Content-Range")?.substringAfterLast('/')?.toLongOrNull() ?: -1L
             val targetLength = when {
@@ -163,27 +235,144 @@ class OfflineAudioExporter(
         }
     }
 
-    private fun probeContentLength(url: String): Long {
+    private suspend fun downloadAudioRanges(
+        track: Track,
+        workspace: File,
+        targetLength: Long,
+        contentType: String,
+        ranges: List<AudioDownloadRange>
+    ): DownloadedAudio = coroutineScope {
+        val container = detectContainer(contentType, track.streamUrl)
+        val temp = File(workspace, "raw-${System.nanoTime()}.${container.extension}")
+        val downloadedBytes = AtomicLong(0L)
+        val lastProgress = AtomicInteger(12)
+        val limiter = Semaphore(PARALLEL_RANGE_CONCURRENCY)
+        try {
+            RandomAccessFile(temp, "rw").use { file -> file.setLength(targetLength) }
+            ranges.map { range ->
+                async(Dispatchers.IO) {
+                    limiter.withPermit {
+                        downloadAudioRange(track.streamUrl, range, temp, downloadedBytes, lastProgress, targetLength)
+                    }
+                }
+            }.awaitAll()
+            if (temp.length() != targetLength) {
+                throw IOException("Download parallelo incompleto: ${temp.length()}/$targetLength byte")
+            }
+            reportProgress(82)
+            DownloadedAudio(temp, container)
+        } catch (error: CancellationException) {
+            runCatching { temp.delete() }
+            throw error
+        } catch (error: IOException) {
+            runCatching { temp.delete() }
+            throw error
+        }
+    }
+
+    private suspend fun downloadAudioRange(
+        url: String,
+        range: AudioDownloadRange,
+        outputFile: File,
+        downloadedBytes: AtomicLong,
+        lastProgress: AtomicInteger,
+        targetLength: Long
+    ) {
+        val rangeUrl = withGoogleVideoRange(url, range)
+        val rangeParamApplied = rangeUrl != url
+        val request = Request.Builder()
+            .url(rangeUrl)
+            .header("User-Agent", USER_AGENT)
+            .header("Accept", "audio/*,*/*;q=0.8")
+            .header("Accept-Encoding", "identity")
+            .header("Connection", "keep-alive")
+            .apply { if (!rangeParamApplied) header("Range", "bytes=${range.start}-${range.endInclusive}") }
+            .build()
+        client.newCall(request).execute().use { response ->
+            val body = response.body
+            val contentLength = body.contentLength()
+            val contentRange = response.header("Content-Range").orEmpty()
+            if (!isUsableAudioRangeResponse(response.code, contentLength, contentRange, range, rangeParamApplied)) {
+                throw IOException("Range audio non supportato: HTTP ${response.code}")
+            }
+            body.byteStream().use { input ->
+                RandomAccessFile(outputFile, "rw").use { output ->
+                    output.seek(range.start)
+                    val buffer = ByteArray(DOWNLOAD_BUFFER_BYTES)
+                    var written = 0L
+                    while (written < range.length) {
+                        val maxRead = minOf(buffer.size.toLong(), range.length - written).toInt()
+                        val read = input.read(buffer, 0, maxRead)
+                        if (read < 0) break
+                        output.write(buffer, 0, read)
+                        written += read.toLong()
+                        val total = downloadedBytes.addAndGet(read.toLong())
+                        val nextProgress = downloadProgress(total, targetLength)
+                        updateParallelProgress(lastProgress, nextProgress)
+                    }
+                    if (written != range.length) {
+                        throw IOException("Range troncato: ${range.start}-${range.endInclusive} ($written/${range.length} byte)")
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun updateParallelProgress(lastProgress: AtomicInteger, nextProgress: Int) {
+        while (true) {
+            val current = lastProgress.get()
+            if (nextProgress <= current) return
+            if (lastProgress.compareAndSet(current, nextProgress)) {
+                reportProgress(nextProgress)
+                return
+            }
+        }
+    }
+
+    private fun probeAudio(url: String): AudioProbe {
+        val urlLength = audioContentLengthFromUrl(url)
         val request = Request.Builder()
             .url(url)
             .head()
             .header("User-Agent", USER_AGENT)
+            .header("Accept-Encoding", "identity")
             .build()
         return runCatching {
             client.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) -1L
-                else response.header("Content-Length")?.toLongOrNull() ?: -1L
+                if (!response.isSuccessful) {
+                    AudioProbe()
+                } else {
+                    AudioProbe(
+                        contentLength = response.header("Content-Length")?.toLongOrNull()?.takeIf { it > 0L } ?: urlLength,
+                        contentType = response.header("Content-Type").orEmpty().substringBefore(';').trim().lowercase(Locale.US)
+                    )
+                }
             }
-        }.getOrDefault(-1L)
+        }.getOrDefault(AudioProbe(contentLength = urlLength))
     }
 
     private fun withGoogleVideoRange(url: String, contentLength: Long): String {
         if (contentLength <= 0L) return url
-        val host = url.substringAfter("://").substringBefore('/').substringBefore(':').lowercase(Locale.US)
-        if (!host.endsWith("googlevideo.com")) return url
-        if (url.contains("&range=") || url.contains("?range=")) return url
+        if (!isGoogleVideoUrl(url)) return url
+        if (hasRangeParameter(url)) return url
         val separator = if (url.contains('?')) '&' else '?'
         return "$url${separator}range=0-${contentLength - 1}"
+    }
+
+    private fun withGoogleVideoRange(url: String, range: AudioDownloadRange): String {
+        if (!isGoogleVideoUrl(url)) return url
+        if (hasRangeParameter(url)) return url
+        val separator = if (url.contains('?')) '&' else '?'
+        return "$url${separator}range=${range.start}-${range.endInclusive}"
+    }
+
+    private fun isGoogleVideoUrl(url: String): Boolean {
+        val host = url.substringAfter("://").substringBefore('/').substringBefore(':').lowercase(Locale.US)
+        return host.endsWith("googlevideo.com")
+    }
+
+    private fun hasRangeParameter(url: String): Boolean {
+        return url.contains("&range=", ignoreCase = true) || url.contains("?range=", ignoreCase = true)
     }
 
     private fun maybeEmbedMetadata(
@@ -351,7 +540,7 @@ class OfflineAudioExporter(
         return runCatching {
             client.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) return@use null
-                val body = response.body ?: return@use null
+                val body = response.body
                 val length = body.contentLength()
                 if (length > MAX_ARTWORK_BYTES) return@use null
                 val bytes = body.bytes()
@@ -422,6 +611,7 @@ class OfflineAudioExporter(
         private const val MAX_ARTWORK_BYTES = 4 * 1024 * 1024
         private const val DOWNLOAD_BUFFER_BYTES = 256 * 1024
         private const val COPY_BUFFER_BYTES = 512 * 1024
+        private const val PARALLEL_RANGE_CONCURRENCY = 4
         private const val USER_AGENT = "Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36"
         private val MUSIC_DESTINATION_LABEL = "${Environment.DIRECTORY_MUSIC}/Levyra"
         private val DOWNLOADS_DESTINATION_LABEL = "${Environment.DIRECTORY_DOWNLOADS}/Levyra"
@@ -451,6 +641,11 @@ private data class PreparedAudioFile(
     val fileName: String,
     val container: AudioContainer,
     val fileMetadataEmbedded: Boolean
+)
+
+private data class AudioProbe(
+    val contentLength: Long = -1L,
+    val contentType: String = ""
 )
 
 private data class AudioContainer(

--- a/app/src/main/java/com/luc4n3x/levyra/player/offline/work/OfflineExportWorker.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/offline/work/OfflineExportWorker.kt
@@ -1,19 +1,32 @@
 package com.luc4n3x.levyra.player.offline.work
 
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.core.app.NotificationCompat
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
+import com.luc4n3x.levyra.MainActivity
+import com.luc4n3x.levyra.R
 import com.luc4n3x.levyra.data.PlaybackResolver
 import com.luc4n3x.levyra.data.TrackPayloadCodec
+import com.luc4n3x.levyra.domain.Track
 import com.luc4n3x.levyra.player.offline.OfflineAudioExporter
+import kotlinx.coroutines.CancellationException
 import timber.log.Timber
 import java.io.IOException
 import java.util.UUID
@@ -28,10 +41,19 @@ class OfflineExportWorker(
         val track = TrackPayloadCodec.decode(payload) ?: return Result.failure(errorData("Traccia non valida"))
         return try {
             setProgress(workDataOf(KEY_PROGRESS to 1))
+            setForeground(createForegroundInfo(track, 1))
+            var foregroundProgress = 1
             val exporter = OfflineAudioExporter(
                 context = applicationContext,
                 resolver = PlaybackResolver.getInstance(applicationContext),
-                progress = { value -> setProgress(workDataOf(KEY_PROGRESS to value.coerceIn(0, 100))) }
+                progress = { value ->
+                    val safeProgress = value.coerceIn(0, 100)
+                    setProgress(workDataOf(KEY_PROGRESS to safeProgress))
+                    if (safeProgress == 100 || safeProgress >= foregroundProgress + FOREGROUND_PROGRESS_STEP) {
+                        foregroundProgress = safeProgress
+                        setForeground(createForegroundInfo(track, safeProgress))
+                    }
+                }
             )
             val result = exporter.export(track)
             Result.success(
@@ -43,6 +65,8 @@ class OfflineExportWorker(
                     KEY_DESTINATION_LABEL to result.destinationLabel
                 )
             )
+        } catch (error: CancellationException) {
+            throw error
         } catch (error: Throwable) {
             if (error is IOException && runAttemptCount < 2) {
                 Timber.w(error, "Offline export retry scheduled")
@@ -56,6 +80,56 @@ class OfflineExportWorker(
 
     private fun errorData(message: String): Data = workDataOf(KEY_ERROR to message)
 
+    private fun createForegroundInfo(track: Track, progress: Int): ForegroundInfo {
+        ensureNotificationChannel()
+        val notification = buildForegroundNotification(track, progress.coerceIn(0, 100))
+        val notificationId = NOTIFICATION_ID_BASE + (track.id.hashCode() and Int.MAX_VALUE) % NOTIFICATION_ID_RANGE
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(notificationId, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        } else {
+            ForegroundInfo(notificationId, notification)
+        }
+    }
+
+    private fun buildForegroundNotification(track: Track, progress: Int): Notification {
+        val title = track.title.ifBlank { "Download offline" }
+        val artist = track.artist.ifBlank { "LEVYRA" }
+        val percent = progress.coerceIn(0, 100)
+        return NotificationCompat.Builder(applicationContext, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_widget_download)
+            .setContentTitle("Download offline")
+            .setContentText("$percent% - $title")
+            .setStyle(NotificationCompat.BigTextStyle().bigText("$title\n$artist"))
+            .setContentIntent(openAppIntent())
+            .setOngoing(percent < 100)
+            .setOnlyAlertOnce(true)
+            .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setProgress(100, percent, false)
+            .build()
+    }
+
+    private fun openAppIntent(): PendingIntent {
+        val intent = Intent(applicationContext, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        return PendingIntent.getActivity(applicationContext, 0, intent, flags)
+    }
+
+    private fun ensureNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = applicationContext.getSystemService(NotificationManager::class.java)
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Download offline",
+            NotificationManager.IMPORTANCE_LOW
+        ).apply {
+            description = "Stato dei download offline Levyra"
+        }
+        manager.createNotificationChannel(channel)
+    }
+
     companion object {
         const val KEY_TRACK_PAYLOAD = "track_payload"
         const val KEY_FILE_NAME = "file_name"
@@ -65,6 +139,10 @@ class OfflineExportWorker(
         const val KEY_DESTINATION_LABEL = "destination_label"
         const val KEY_ERROR = "error"
         const val KEY_PROGRESS = "progress"
+        private const val CHANNEL_ID = "levyra_offline_downloads"
+        private const val FOREGROUND_PROGRESS_STEP = 2
+        private const val NOTIFICATION_ID_BASE = 4200
+        private const val NOTIFICATION_ID_RANGE = 5000
 
         fun enqueue(context: Context, trackId: String, trackPayload: String): UUID {
             val workManager = WorkManager.getInstance(context.applicationContext)

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -81,6 +81,12 @@ import timber.log.Timber
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 
+internal fun monotonicDownloadProgress(current: Int?, incoming: Int): Int {
+    val safeIncoming = incoming.coerceIn(1, 99)
+    val safeCurrent = current?.coerceIn(1, 99) ?: 1
+    return maxOf(safeCurrent, safeIncoming)
+}
+
 class LevyraViewModel(application: Application) : AndroidViewModel(application) {
     private val repository = YoutubeMusicRepository(application.applicationContext)
     private val artistRepository = ArtistRepository(repository, application.applicationContext)
@@ -1306,11 +1312,11 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     private fun updateDownloadProgress(trackId: String, progress: Int) {
-        val safeProgress = progress.coerceIn(1, 99)
         _state.update {
             if (trackId !in it.downloadingTrackIds) {
                 it
             } else {
+                val safeProgress = monotonicDownloadProgress(it.downloadProgressByTrackId[trackId], progress)
                 it.copy(
                     downloadProgressByTrackId = it.downloadProgressByTrackId + (trackId to safeProgress)
                 )

--- a/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineAudioExporterTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineAudioExporterTest.kt
@@ -1,0 +1,89 @@
+package com.luc4n3x.levyra.player.offline
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OfflineAudioExporterTest {
+    @Test
+    fun longKnownDownloadsAreSplitIntoBoundedRanges() {
+        val oneMb = 1024L * 1024L
+
+        val ranges = planParallelAudioRanges(
+            contentLength = 10L * oneMb,
+            chunkSize = 4L * oneMb,
+            minLength = 8L * oneMb
+        )
+
+        assertEquals(
+            listOf(
+                AudioDownloadRange(start = 0L, endInclusive = 4L * oneMb - 1L),
+                AudioDownloadRange(start = 4L * oneMb, endInclusive = 8L * oneMb - 1L),
+                AudioDownloadRange(start = 8L * oneMb, endInclusive = 10L * oneMb - 1L)
+            ),
+            ranges
+        )
+    }
+
+    @Test
+    fun smallOrUnknownDownloadsStaySerial() {
+        val oneMb = 1024L * 1024L
+
+        assertTrue(
+            planParallelAudioRanges(
+                contentLength = 6L * oneMb,
+                chunkSize = 4L * oneMb,
+                minLength = 8L * oneMb
+            ).isEmpty()
+        )
+        assertTrue(planParallelAudioRanges(contentLength = -1L).isEmpty())
+    }
+
+    @Test
+    fun rangeQueryResponsesCanBeSuccessfulPartialBodies() {
+        val range = AudioDownloadRange(start = 1024L, endInclusive = 2047L)
+
+        assertTrue(
+            isUsableAudioRangeResponse(
+                code = 200,
+                bodyLength = 1024L,
+                contentRange = "",
+                range = range,
+                rangeParamApplied = true
+            )
+        )
+    }
+
+    @Test
+    fun fullBodyResponsesAreRejectedForRangeChunks() {
+        val range = AudioDownloadRange(start = 1024L, endInclusive = 2047L)
+
+        assertFalse(
+            isUsableAudioRangeResponse(
+                code = 200,
+                bodyLength = 4096L,
+                contentRange = "",
+                range = range,
+                rangeParamApplied = true
+            )
+        )
+        assertFalse(
+            isUsableAudioRangeResponse(
+                code = 200,
+                bodyLength = 1024L,
+                contentRange = "",
+                range = range,
+                rangeParamApplied = false
+            )
+        )
+    }
+
+    @Test
+    fun contentLengthCanBeReadFromGoogleVideoClenParameter() {
+        val url = "https://rr1---sn.googlevideo.com/videoplayback?mime=audio%2Fmp4&clen=73400320&expire=9999999999"
+
+        assertEquals(73400320L, audioContentLengthFromUrl(url))
+        assertEquals(-1L, audioContentLengthFromUrl("https://example.com/audio.m4a"))
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/DownloadProgressTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/DownloadProgressTest.kt
@@ -1,0 +1,22 @@
+package com.luc4n3x.levyra.viewmodel
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DownloadProgressTest {
+    @Test
+    fun progressNeverMovesBackward() {
+        assertEquals(36, monotonicDownloadProgress(current = 36, incoming = 12))
+    }
+
+    @Test
+    fun progressStillMovesForward() {
+        assertEquals(48, monotonicDownloadProgress(current = 36, incoming = 48))
+    }
+
+    @Test
+    fun progressStaysInsideVisibleDownloadRange() {
+        assertEquals(1, monotonicDownloadProgress(current = null, incoming = 0))
+        assertEquals(99, monotonicDownloadProgress(current = 98, incoming = 100))
+    }
+}


### PR DESCRIPTION
## Summary
- Run long offline exports as foreground WorkManager work with a progress notification.
- Speed up long known-size audio downloads by splitting them into bounded Range chunks and fetching up to four chunks in parallel.
- Keep download progress monotonic in the UI so retries do not appear to jump backward.
- Preserve coroutine cancellation semantics and cover progress/range planning behavior with unit tests.

## Root Cause
Long offline downloads were handled as regular background work and the audio transfer itself used one serial HTTP stream. For long mixes, that single stream can be slow or throttled, and if WorkManager retried the export the UI accepted lower progress values from the new attempt, making the download appear to regress and disappear.

## Impact
Long mixes and playlist-like tracks should be less likely to be killed mid-transfer, should download faster when YouTube exposes a usable content length/range, and any fallback retry will no longer make the progress HUD move backward. If a server ignores Range requests, Levyra falls back to the existing serial path instead of risking a corrupt file.

## Test Plan
- `ANDROID_HOME=C:\Users\Luca Drogo\AppData\Local\Android\Sdk gradle :app:testDebugUnitTest --tests "com.luc4n3x.levyra.player.offline.OfflineAudioExporterTest"`
- `ANDROID_HOME=C:\Users\Luca Drogo\AppData\Local\Android\Sdk gradle :app:testDebugUnitTest`
- `ANDROID_HOME=C:\Users\Luca Drogo\AppData\Local\Android\Sdk gradle :app:lintDebug`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added foreground notifications showing offline export progress and providing quick access back to the app.
  * Improved offline audio downloads with faster parallel transfers for large files, while retaining a fallback download method.
  * Download progress now advances smoothly without moving backward.

* **Bug Fixes**
  * Improved cancellation handling so cancelled exports stop promptly.

* **Tests**
  * Added coverage for parallel download ranges, response validation, content-length detection, and progress behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->