### PR TITLE
 update levyra extractor dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -204,7 +204,9 @@ dependencies {
     implementation(libs.coil.network.okhttp)
     implementation(libs.okhttp)
     implementation(libs.okhttp.brotli)
-    implementation(libs.newpipe.extractor)
+    implementation(libs.newpipe.extractor) {
+        exclude(group = "com.github.LUC4N3X.LevyraExtractor", module = "timeago-parser")
+    }
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
     implementation(libs.androidx.datastore.preferences)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ media3 = "1.10.1"
 coroutines = "1.11.0"
 coil = "3.5.0"
 okhttp = "5.4.0"
-newpipe = "033092921b"
+newpipe = "v1.0.0-levyra.9"
 desugar = "2.1.5"
 junit = "4.13.2"
 json = "20260522"
@@ -50,7 +50,7 @@ coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref 
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-brotli = { group = "com.squareup.okhttp3", name = "okhttp-brotli", version.ref = "okhttp" }
-newpipe-extractor = { group = "com.github.luc4n3x", name = "levyraextractor", version.ref = "newpipe" }
+newpipe-extractor = { group = "com.github.LUC4N3X", name = "LevyraExtractor", version.ref = "newpipe" }
 desugar-jdk-libs-nio = { group = "com.android.tools", name = "desugar_jdk_libs_nio", version.ref = "desugar" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 json = { group = "org.json", name = "json", version.ref = "json" }


### PR DESCRIPTION
## Summary
- update the app to use `com.github.LUC4N3X:LevyraExtractor:v1.0.0-levyra.9`
- keep the dependency on LevyraExtractor, not MetrolistExtractor
- exclude LevyraExtractor's broken `timeago-parser` transitive artifact so Gradle can resolve the current JitPack build

## Why
The old extractor ref was stale and the app was showing slow YouTube stream waits on normal playback/download paths. This keeps Levyra on your extractor while moving to the latest tagged LevyraExtractor release that resolves successfully from JitPack.

## Validation
- `./gradlew :app:compileDebugKotlin`
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug`
- `git diff --check`