### PR TITLE
Replace LevyraExtractor with MetrolistExtractor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,7 +53,7 @@ updates:
           - "io.coil-kt*"
       extractor-stack:
         patterns:
-          - "com.github.luc4n3x*"
+          - "com.github.MetrolistGroup*"
           - "org.schabi*"
       build-analysis:
         patterns:

--- a/.github/workflows/nightly-extractor-check.yml
+++ b/.github/workflows/nightly-extractor-check.yml
@@ -66,15 +66,15 @@ jobs:
             -dname "CN=LEVYRA CI,O=LUC4N3X,C=IT" \
             >/dev/null
 
-      - name: Resolve LevyraExtractor Snapshot
+      - name: Resolve MetrolistExtractor Dependency
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p artifacts
           gradle --no-daemon --refresh-dependencies :app:dependencyInsight \
             --configuration releaseRuntimeClasspath \
-            --dependency levyraextractor \
-            | tee artifacts/levyra-extractor-dependency.txt
+            --dependency MetrolistExtractor \
+            | tee artifacts/metrolist-extractor-dependency.txt
 
       - name: Nightly Release Build
         shell: bash

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ## ✦ What is Levyra?
 
-Unlike typical wrapper or web-reskin apps, **Levyra** is a native, ground-up Android audio application. It queries, resolves, and streams music dynamically using YouTube Music's InnerTube API with a LevyraExtractor-powered fallback, routes audio via an optimized **AndroidX Media3/ExoPlayer** background service, and outputs full tracks straight into your local storage. 
+Unlike typical wrapper or web-reskin apps, **Levyra** is a native, ground-up Android audio application. It queries, resolves, and streams music dynamically using YouTube Music's InnerTube API with a MetrolistExtractor-powered fallback, routes audio via an optimized **AndroidX Media3/ExoPlayer** background service, and outputs full tracks straight into your local storage. 
 
 Every track you download is fully parsed, tagged, and structured as a clean M4A file in your system `Music/Levyra` directory, complete with embedded metadata, titles, artists, and album artwork. 
 
@@ -88,7 +88,7 @@ Every track you download is fully parsed, tagged, and structured as a clean M4A 
     </td>
     <td valign="top">
       <ul>
-        <li><strong>InnerTube + LevyraExtractor Resolver:</strong> Dual-channel media resolution with smarter Opus/M4A selection, fresh URL caching, and stronger fallback when YouTube changes stream signatures.</li>
+        <li><strong>InnerTube + MetrolistExtractor Resolver:</strong> Dual-channel media resolution with smarter Opus/M4A selection, fresh URL caching, and stronger fallback when YouTube changes stream signatures.</li>
         <li><strong>Intelligent Caching:</strong> TTL-based playback stream cache prevents duplicate server requests and speeds up loading.</li>
         <li><strong>Smart Search:</strong> Predictive search suggestions, categorized filters, and instant top-result matching.</li>
         <li><strong>Prefetching Engine:</strong> Ahead-of-time loading for top charts and queued songs to guarantee zero-gap playback.</li>
@@ -147,7 +147,7 @@ graph TD
     Player --> Media3["🎵 AndroidX Media3 / ExoPlayer Service"]:::engine
     
     Resolver --> InnerTube["☁️ YT Music InnerTube API"]:::ext
-    Resolver --> Extractor["🔌 LevyraExtractor Engine"]:::ext
+    Resolver --> Extractor["🔌 MetrolistExtractor Engine"]:::ext
     
     Work --> Exporter["📦 OfflineAudioExporter"]:::core
     Exporter --> MediaStore["💿 Android MediaStore API"]:::engine
@@ -181,7 +181,7 @@ graph TD
 *   **Build Pipeline:** Gradle Kotlin DSL (`.gradle.kts`), Version Catalogs (`libs.versions.toml`), KSP (Kotlin Symbol Processing)
 *   **APK Size Guard:** Spotify Ruler report workflow for bundle size analysis and dependency weight tracking
 *   **Player Architecture:** Mobius-sample-inspired `Model / Event / Effect / Update` foundation for safe player refactoring
-*   **Extraction Layer:** InnerTube resolver plus GPL-3.0 LevyraExtractor playback core via JitPack
+*   **Extraction Layer:** InnerTube resolver plus GPL-3.0 MetrolistExtractor playback core via JitPack
 
 <br>
 
@@ -275,9 +275,17 @@ If you intend to distribute custom builds of Levyra:
   </tr>
 </table>
 
-*UI and modular styling conventions draw structural inspiration from the open-source projects [Metrolist](https://github.com/MetrolistGroup/Metrolist) and [MusicApp-KMP](https://github.com/SEAbdulbasit/MusicApp-KMP).*
+### Open-source acknowledgements
 
-*The stream extraction core uses [LevyraExtractor](https://github.com/LUC4N3X/LevyraExtractor), a GPL-3.0 fork derived from [PipePipeExtractor](https://github.com/InfinityLoop1308/PipePipeExtractor) in the NewPipe/PipePipe ecosystem.*
+| Project | Contribution |
+|:---|:---|
+| [MetrolistExtractor](https://github.com/MetrolistGroup/MetrolistExtractor) | Primary GPL-3.0 stream extraction engine used by Levyra. The dependency is pinned to commit `3cd3341` for reproducible builds. |
+| [Metrolist](https://github.com/MetrolistGroup/Metrolist) | Reference implementation for extractor integration and selected music-client architecture patterns. |
+| [PipePipeExtractor](https://github.com/InfinityLoop1308/PipePipeExtractor) | Upstream base of MetrolistExtractor. |
+| [NewPipeExtractor](https://github.com/TeamNewPipe/NewPipeExtractor) | Original extractor ecosystem and API foundation. |
+| [MusicApp-KMP](https://github.com/SEAbdulbasit/MusicApp-KMP) | UI and modular styling inspiration. |
+
+Levyra remains an independent project. Upstream projects, contributors, licenses, trademarks, and copyright notices remain the property of their respective owners.
 
 ---
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -14,10 +14,10 @@ Levyra is licensed under the GNU General Public License v3.0. Third-party librar
 
 | Project | URL | Role | Notice |
 |:---|:---|:---|:---|
-| LevyraExtractor | https://github.com/LUC4N3X/LevyraExtractor | Primary extractor playback core used by Levyra resolver logic | GPL-3.0 derivative source and upstream notices must be preserved |
+| MetrolistExtractor | https://github.com/MetrolistGroup/MetrolistExtractor | Primary extractor playback core used by Levyra resolver logic, pinned to commit `3cd3341` | GPL-3.0 license and upstream notices must be preserved |
 | Metrolist | https://github.com/MetrolistGroup/Metrolist | Android music client ecosystem reference | GPL-3.0 license notices must be preserved where code is reused |
 | NewPipeExtractor | https://github.com/TeamNewPipe/NewPipeExtractor | Upstream extractor ecosystem reference | Original copyright and license notices remain with upstream authors |
-| PipePipeExtractor | https://github.com/InfinityLoop1308/PipePipeExtractor | Upstream base for LevyraExtractor | Original copyright and license notices remain with upstream authors |
+| PipePipeExtractor | https://github.com/InfinityLoop1308/PipePipeExtractor | Upstream base of MetrolistExtractor | Original copyright and license notices remain with upstream authors |
 | MusicApp-KMP | https://github.com/SEAbdulbasit/MusicApp-KMP | UI and modular styling inspiration only | No ownership claim is made over the original project |
 
 ## Runtime and Build Dependencies
@@ -66,7 +66,7 @@ Release derivative source under GPL-3.0-compatible terms
 
 ```text
 This build is a modified version of Levyra maintained by LUC4N3X.
-It includes changes to playback resolution, UI, offline export, caching, artwork handling and release automation.
+It includes changes to playback resolution, MetrolistExtractor integration, UI, offline export, caching, artwork handling and release automation.
 The complete corresponding source code is available in this repository under the GNU General Public License v3.0.
 ```
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -204,7 +204,7 @@ dependencies {
     implementation(libs.coil.network.okhttp)
     implementation(libs.okhttp)
     implementation(libs.okhttp.brotli)
-    implementation(libs.newpipe.extractor)
+    implementation(libs.metrolist.extractor)
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
     implementation(libs.androidx.datastore.preferences)

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraStreamHedge.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraStreamHedge.kt
@@ -9,13 +9,14 @@ import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.atomic.AtomicInteger
 
 internal object LevyraResolverLatency {
-    const val INNER_TUBE_HEDGE_BUDGET_MS = 55L
-    private const val AUDIO_EXTRACTOR_HEDGE_MS = 35L
-    private const val VIDEO_EXTRACTOR_HEDGE_MS = 45L
+    const val INNER_TUBE_HEDGE_BUDGET_MS = 350L
+    private const val AUDIO_INNER_TUBE_FALLBACK_MS = 900L
+    private const val VIDEO_INNER_TUBE_FALLBACK_MS = 1_200L
+    private const val OFFLINE_INNER_TUBE_FALLBACK_MS = 1_200L
 
-    fun extractorHedgeDelayMs(isVideoMode: Boolean, preferMp4Audio: Boolean): Long {
-        if (preferMp4Audio) return 0L
-        return if (isVideoMode) VIDEO_EXTRACTOR_HEDGE_MS else AUDIO_EXTRACTOR_HEDGE_MS
+    fun innerTubeFallbackDelayMs(isVideoMode: Boolean, preferMp4Audio: Boolean): Long {
+        if (preferMp4Audio) return OFFLINE_INNER_TUBE_FALLBACK_MS
+        return if (isVideoMode) VIDEO_INNER_TUBE_FALLBACK_MS else AUDIO_INNER_TUBE_FALLBACK_MS
     }
 }
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
@@ -1,6 +1,5 @@
 package com.luc4n3x.levyra.data
 
-import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.schabi.newpipe.extractor.NewPipe
@@ -13,6 +12,7 @@ import org.schabi.newpipe.extractor.localization.ContentCountry
 import org.schabi.newpipe.extractor.localization.Localization
 import java.io.IOException
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 object NewPipeRuntime {
@@ -27,7 +27,15 @@ object NewPipeRuntime {
 }
 
 private class OkHttpNewPipeDownloader : Downloader() {
-    private val client: OkHttpClient = LevyraHttpClientFactory.extractor()
+    private val client = OkHttpClient.Builder()
+        .followRedirects(true)
+        .followSslRedirects(true)
+        .connectTimeout(5, TimeUnit.SECONDS)
+        .readTimeout(12, TimeUnit.SECONDS)
+        .writeTimeout(8, TimeUnit.SECONDS)
+        .callTimeout(18, TimeUnit.SECONDS)
+        .retryOnConnectionFailure(true)
+        .build()
 
     override fun execute(request: Request): Response {
         clientFor(request).newCall(toOkHttpRequest(request)).execute().use { response ->
@@ -82,35 +90,24 @@ private class OkHttpNewPipeDownloader : Downloader() {
         request.headers().forEach { (name, values) ->
             values.filter { it.isNotBlank() }.forEach { value -> builder.addHeader(name, value) }
         }
-        if (!request.headers().containsHeader("User-Agent")) {
-            builder.header(
-                "User-Agent",
-                "Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Mobile Safari/537.36"
-            )
-        }
-        if (!request.headers().containsHeader("Accept")) {
-            builder.header("Accept", "*/*")
-        }
-        return builder.build()
+        return builder
+            .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36")
+            .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,application/json;q=0.8,*/*;q=0.7")
+            .header("Accept-Language", "it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7")
+            .header("Connection", "keep-alive")
+            .build()
     }
 
     private fun toExtractorResponse(response: okhttp3.Response): Response {
         val responseBytes = response.body?.bytes() ?: ByteArray(0)
         val responseText = responseBytes.toString(StandardCharsets.UTF_8)
-        if (response.code == 429) {
-            throw IOException("YouTube ha limitato temporaneamente le richieste")
-        }
+        if (response.code == 429) throw IOException("YouTube ha limitato temporaneamente le richieste")
         return Response(
             response.code,
             response.message,
             response.headers.toMultimap(),
             responseText,
-            responseBytes,
-            response.request.url.toString()
+            response.latestNetworkResponse?.request?.url.toString()
         )
-    }
-
-    private fun Map<String, List<String>>.containsHeader(name: String): Boolean {
-        return keys.any { it.equals(name, ignoreCase = true) }
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
@@ -107,7 +107,8 @@ private class OkHttpNewPipeDownloader : Downloader() {
             response.message,
             response.headers.toMultimap(),
             responseText,
-            response.latestNetworkResponse?.request?.url.toString()
+            responseBytes,
+            response.request.url.toString()
         )
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
@@ -1,10 +1,10 @@
 package com.luc4n3x.levyra.data
 
 import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
-import okhttp3.Headers.Companion.toHeaders
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.schabi.newpipe.extractor.NewPipe
+import org.schabi.newpipe.extractor.ServiceList
 import org.schabi.newpipe.extractor.downloader.CancellableCall
 import org.schabi.newpipe.extractor.downloader.Downloader
 import org.schabi.newpipe.extractor.downloader.Request
@@ -21,6 +21,7 @@ object NewPipeRuntime {
     fun ensure() {
         if (initialized.compareAndSet(false, true)) {
             NewPipe.init(OkHttpNewPipeDownloader(), Localization("it", "IT"), ContentCountry("IT"))
+            ServiceList.YouTube.setLoadingTimeout(12)
         }
     }
 }
@@ -29,31 +30,42 @@ private class OkHttpNewPipeDownloader : Downloader() {
     private val client: OkHttpClient = LevyraHttpClientFactory.extractor()
 
     override fun execute(request: Request): Response {
-        client.newCall(toOkHttpRequest(request)).execute().use { response ->
+        clientFor(request).newCall(toOkHttpRequest(request)).execute().use { response ->
             return toExtractorResponse(response)
         }
     }
 
     override fun executeAsync(request: Request, callback: Downloader.AsyncCallback): CancellableCall {
-        val call = client.newCall(toOkHttpRequest(request))
+        val call = clientFor(request).newCall(toOkHttpRequest(request))
         val cancellableCall = CancellableCall(call)
         call.enqueue(object : okhttp3.Callback {
-            override fun onFailure(call: okhttp3.Call, e: IOException) {
-                cancellableCall.setFinished()
-                callback.onError(e)
+            override fun onFailure(call: okhttp3.Call, error: IOException) {
+                try {
+                    callback.onError(error)
+                } finally {
+                    cancellableCall.setFinished()
+                }
             }
 
             override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
                 try {
                     response.use { callback.onSuccess(toExtractorResponse(it)) }
-                } catch (e: Exception) {
-                    callback.onError(e)
+                } catch (error: Exception) {
+                    callback.onError(error)
                 } finally {
                     cancellableCall.setFinished()
                 }
             }
         })
         return cancellableCall
+    }
+
+    private fun clientFor(request: Request): OkHttpClient {
+        if (request.followRedirects()) return client
+        return client.newBuilder()
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .build()
     }
 
     private fun toOkHttpRequest(request: Request): okhttp3.Request {
@@ -64,21 +76,30 @@ private class OkHttpNewPipeDownloader : Downloader() {
             data != null -> data.toRequestBody()
             else -> ByteArray(0).toRequestBody()
         }
-        return okhttp3.Request.Builder()
+        val builder = okhttp3.Request.Builder()
             .url(request.url())
             .method(method, body)
-            .headers(request.headers().flattenHeaders().toHeaders())
-            .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36")
-            .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,application/json;q=0.8,*/*;q=0.7")
-            .header("Accept-Language", "it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7")
-            .header("Connection", "keep-alive")
-            .build()
+        request.headers().forEach { (name, values) ->
+            values.filter { it.isNotBlank() }.forEach { value -> builder.addHeader(name, value) }
+        }
+        if (!request.headers().containsHeader("User-Agent")) {
+            builder.header(
+                "User-Agent",
+                "Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Mobile Safari/537.36"
+            )
+        }
+        if (!request.headers().containsHeader("Accept")) {
+            builder.header("Accept", "*/*")
+        }
+        return builder.build()
     }
 
     private fun toExtractorResponse(response: okhttp3.Response): Response {
         val responseBytes = response.body?.bytes() ?: ByteArray(0)
         val responseText = responseBytes.toString(StandardCharsets.UTF_8)
-        if (response.code == 429) throw IOException("YouTube ha limitato temporaneamente le richieste")
+        if (response.code == 429) {
+            throw IOException("YouTube ha limitato temporaneamente le richieste")
+        }
         return Response(
             response.code,
             response.message,
@@ -89,11 +110,7 @@ private class OkHttpNewPipeDownloader : Downloader() {
         )
     }
 
-    private fun Map<String, List<String>>.flattenHeaders(): Map<String, String> {
-        val out = LinkedHashMap<String, String>()
-        forEach { (key, values) ->
-            if (key.isNotBlank() && values.isNotEmpty()) out[key] = values.joinToString(",")
-        }
-        return out
+    private fun Map<String, List<String>>.containsHeader(name: String): Boolean {
+        return keys.any { it.equals(name, ignoreCase = true) }
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -281,7 +281,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         }
 
         val innerTube = runCatching { hedgedInnerTube(track, errors, false) }.getOrNull()
-        return innerTube?.let(track::withDirectStream)
+        return innerTube?.let { stream -> track.withDirectStream(stream) }
     }
 
     private suspend fun resolveAudioResilient(track: Track, errors: MutableList<String>): Track? {
@@ -296,7 +296,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         }
 
         val innerTube = runCatching { raceInnerTube(track, errors, false, true) }.getOrNull()
-        return innerTube?.let(track::withDirectStream)
+        return innerTube?.let { stream -> track.withDirectStream(stream) }
     }
 
     private suspend fun resolveAudioWithSearchFallback(track: Track, errors: MutableList<String>, preferMp4Audio: Boolean): Track? {

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -225,21 +225,26 @@ class PlaybackResolver private constructor(private val context: Context) {
         val errors = Collections.synchronizedList(mutableListOf<String>())
 
         if (isVideoMode) {
-            val resolved = runCatching { resolveVideoWithMetrolistExtractor(track) }
+            val metrolist = runCatching { resolveVideoWithMetrolistExtractor(track) }
                 .onFailure { error ->
                     error.message?.takeIf { it.isNotBlank() }
                         ?.let { errors += "MetrolistExtractor video: $it" }
                 }
                 .getOrNull()
-                ?: runCatching { hedgedInnerTube(track, errors, true) }
-                    .getOrNull()
-                    ?.let { stream -> track.withDirectStream(stream) }
-            if (resolved != null) {
+            if (metrolist != null && metrolist.streamUrl.isNotBlank() && streamStillFresh(metrolist.streamUrl)) {
+                store(metrolist, isVideoMode)
+                return@withContext metrolist
+            }
+
+            val innerTube = runCatching { hedgedInnerTube(track, errors, true) }.getOrNull()
+            if (innerTube != null) {
+                val resolved = track.withDirectStream(innerTube)
                 store(resolved, isVideoMode)
                 return@withContext resolved
             }
-            val reason = errors.firstOrNull { it.contains("age", true) || it.contains("login", true) }
-                ?: errors.firstOrNull()
+
+            val reason = errors.firstOrNull { it.startsWith("MetrolistExtractor", ignoreCase = true) }
+                ?: errors.firstOrNull { !it.contains("accedi", ignoreCase = true) && !it.contains("login", ignoreCase = true) }
                 ?: "Video non disponibile"
             throw PlaybackBlockedException(reason)
         }
@@ -256,24 +261,27 @@ class PlaybackResolver private constructor(private val context: Context) {
             return@withContext alternate
         }
 
-        val reason = errors.firstOrNull { it.contains("age", true) || it.contains("anonymous", true) || it.contains("login", true) || it.contains("accedi", true) }
-            ?: errors.firstOrNull()
+        val reason = errors.firstOrNull { it.startsWith("MetrolistExtractor", ignoreCase = true) }
+            ?: errors.firstOrNull { !it.contains("accedi", ignoreCase = true) && !it.contains("login", ignoreCase = true) }
             ?: "Stream non disponibile"
         throw PlaybackBlockedException(reason)
     }
 
     private suspend fun resolveAudioFast(track: Track, errors: MutableList<String>, preferMp4Audio: Boolean): Track? {
         if (preferMp4Audio) return resolveAudioResilient(track, errors)
+
         val metrolist = runCatching { resolveWithMetrolistExtractor(track, false) }
             .onFailure { error ->
                 error.message?.takeIf { it.isNotBlank() }
                     ?.let { errors += "MetrolistExtractor: $it" }
             }
             .getOrNull()
-        if (metrolist != null) return metrolist
-        return runCatching { hedgedInnerTube(track, errors, false) }
-            .getOrNull()
-            ?.let { stream -> track.withDirectStream(stream) }
+        if (metrolist != null && metrolist.streamUrl.isNotBlank() && streamStillFresh(metrolist.streamUrl) && isDirectAudioUrl(metrolist.streamUrl)) {
+            return metrolist
+        }
+
+        val innerTube = runCatching { hedgedInnerTube(track, errors, false) }.getOrNull()
+        return innerTube?.let(track::withDirectStream)
     }
 
     private suspend fun resolveAudioResilient(track: Track, errors: MutableList<String>): Track? {
@@ -283,10 +291,12 @@ class PlaybackResolver private constructor(private val context: Context) {
                     ?.let { errors += "MetrolistExtractor: $it" }
             }
             .getOrNull()
-        if (metrolist != null) return metrolist
-        return runCatching { raceInnerTube(track, errors, false, true) }
-            .getOrNull()
-            ?.let { stream -> track.withDirectStream(stream) }
+        if (metrolist != null && metrolist.streamUrl.isNotBlank() && streamStillFresh(metrolist.streamUrl) && isDirectAudioUrl(metrolist.streamUrl)) {
+            return metrolist
+        }
+
+        val innerTube = runCatching { raceInnerTube(track, errors, false, true) }.getOrNull()
+        return innerTube?.let(track::withDirectStream)
     }
 
     private suspend fun resolveAudioWithSearchFallback(track: Track, errors: MutableList<String>, preferMp4Audio: Boolean): Track? {

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -225,33 +225,15 @@ class PlaybackResolver private constructor(private val context: Context) {
         val errors = Collections.synchronizedList(mutableListOf<String>())
 
         if (isVideoMode) {
-            val resolved = coroutineScope {
-                val winner = CompletableDeferred<Track?>()
-                val extractorJob = launch {
-                    val result = runCatching { resolveVideoWithMetrolistExtractor(track) }
-                    result.onSuccess { winner.complete(it) }
-                        .onFailure { error ->
-                            error.message?.takeIf { it.isNotBlank() }
-                                ?.let { errors += "MetrolistExtractor video: $it" }
-                        }
+            val resolved = runCatching { resolveVideoWithMetrolistExtractor(track) }
+                .onFailure { error ->
+                    error.message?.takeIf { it.isNotBlank() }
+                        ?.let { errors += "MetrolistExtractor video: $it" }
                 }
-                val innerTubeJob = launch {
-                    delay(LevyraResolverLatency.innerTubeFallbackDelayMs(isVideoMode = true, preferMp4Audio = false))
-                    if (winner.isCompleted) return@launch
-                    val stream = runCatching { hedgedInnerTube(track, errors, true) }.getOrNull()
-                    if (stream != null) {
-                        winner.complete(track.withDirectStream(stream))
-                    }
-                }
-                launch {
-                    extractorJob.join()
-                    innerTubeJob.join()
-                    winner.complete(null)
-                }
-                val result = winner.await()
-                coroutineContext.cancelChildren()
-                result
-            }
+                .getOrNull()
+                ?: runCatching { hedgedInnerTube(track, errors, true) }
+                    .getOrNull()
+                    ?.let { stream -> track.withDirectStream(stream) }
             if (resolved != null) {
                 store(resolved, isVideoMode)
                 return@withContext resolved
@@ -282,57 +264,29 @@ class PlaybackResolver private constructor(private val context: Context) {
 
     private suspend fun resolveAudioFast(track: Track, errors: MutableList<String>, preferMp4Audio: Boolean): Track? {
         if (preferMp4Audio) return resolveAudioResilient(track, errors)
-        return coroutineScope {
-            val winner = CompletableDeferred<Track?>()
-            val extractorJob = launch {
-                val resolved = runCatching { resolveWithMetrolistExtractor(track, false) }
-                resolved.onSuccess { winner.complete(it) }
-                    .onFailure { error ->
-                        error.message?.takeIf { it.isNotBlank() }
-                            ?.let { errors += "MetrolistExtractor: $it" }
-                    }
+        val metrolist = runCatching { resolveWithMetrolistExtractor(track, false) }
+            .onFailure { error ->
+                error.message?.takeIf { it.isNotBlank() }
+                    ?.let { errors += "MetrolistExtractor: $it" }
             }
-            val innerTubeJob = launch {
-                delay(LevyraResolverLatency.innerTubeFallbackDelayMs(isVideoMode = false, preferMp4Audio = false))
-                if (winner.isCompleted) return@launch
-                val stream = runCatching { hedgedInnerTube(track, errors, false) }.getOrNull()
-                if (stream != null) winner.complete(track.withDirectStream(stream))
-            }
-            launch {
-                extractorJob.join()
-                innerTubeJob.join()
-                winner.complete(null)
-            }
-            val result = winner.await()
-            coroutineContext.cancelChildren()
-            result
-        }
+            .getOrNull()
+        if (metrolist != null) return metrolist
+        return runCatching { hedgedInnerTube(track, errors, false) }
+            .getOrNull()
+            ?.let { stream -> track.withDirectStream(stream) }
     }
 
-    private suspend fun resolveAudioResilient(track: Track, errors: MutableList<String>): Track? = coroutineScope {
-        val winner = CompletableDeferred<Track?>()
-        val extractorJob = launch {
-            val resolved = runCatching { resolveWithMetrolistExtractor(track, true) }
-            resolved.onSuccess { winner.complete(it) }
-                .onFailure { error ->
-                    error.message?.takeIf { it.isNotBlank() }
-                        ?.let { errors += "MetrolistExtractor: $it" }
-                }
-        }
-        val innerTubeJob = launch {
-            delay(LevyraResolverLatency.innerTubeFallbackDelayMs(isVideoMode = false, preferMp4Audio = true))
-            if (winner.isCompleted) return@launch
-            val stream = runCatching { raceInnerTube(track, errors, false, true) }.getOrNull()
-            if (stream != null) winner.complete(track.withDirectStream(stream))
-        }
-        launch {
-            extractorJob.join()
-            innerTubeJob.join()
-            winner.complete(null)
-        }
-        val result = winner.await()
-        coroutineContext.cancelChildren()
-        result
+    private suspend fun resolveAudioResilient(track: Track, errors: MutableList<String>): Track? {
+        val metrolist = runCatching { resolveWithMetrolistExtractor(track, true) }
+            .onFailure { error ->
+                error.message?.takeIf { it.isNotBlank() }
+                    ?.let { errors += "MetrolistExtractor: $it" }
+            }
+            .getOrNull()
+        if (metrolist != null) return metrolist
+        return runCatching { raceInnerTube(track, errors, false, true) }
+            .getOrNull()
+            ?.let { stream -> track.withDirectStream(stream) }
     }
 
     private suspend fun resolveAudioWithSearchFallback(track: Track, errors: MutableList<String>, preferMp4Audio: Boolean): Track? {

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -63,7 +63,7 @@ class PlaybackResolver private constructor(private val context: Context) {
     private val jsonMediaType = "application/json; charset=utf-8".toMediaType()
     private val fallbackTtlMs = 90L * 60L * 1000L
     private val maxTtlMs = 5L * 60L * 60L * 1000L
-    private val playbackResolveTimeoutMs = 9_000L
+    private val playbackResolveTimeoutMs = 30_000L
     private val offlineResolveTimeoutMs = 60_000L
     private val hedgeBudgetMs = LevyraResolverLatency.INNER_TUBE_HEDGE_BUDGET_MS
     private val streamProbeClient: OkHttpClient = youtubeHttpClient.newBuilder()
@@ -88,9 +88,9 @@ class PlaybackResolver private constructor(private val context: Context) {
     private val profiles = listOf(
         ClientProfile("ANDROID_MUSIC", "8.10.52", "Android Music", "Mozilla/5.0 (Linux; Android 15; Pixel 8 Pro) AppleWebKit/537.36 (KHTML, like Gecko) com.google.android.apps.youtube.music/8.10.52", true, 0L, 0),
         ClientProfile("ANDROID", "19.44.38", "Android", "com.google.android.youtube/19.44.38 (Linux; U; Android 15)", true, 0L, 1),
-        ClientProfile("IOS", "20.10.4", "iOS", "com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3 like Mac OS X; it_IT)", false, 0L, 1),
-        ClientProfile("WEB_REMIX", "1.20260423.01.00", "YouTube Music Web", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36", false, 8L, 2),
-        ClientProfile("WEB_EMBEDDED_PLAYER", "1.20260423.01.00", "Embedded Player", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36", false, 18L, 3)
+        ClientProfile("IOS", "20.10.4", "iOS", "com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3 like Mac OS X; it_IT)", false, 0L, 2),
+        ClientProfile("WEB_REMIX", "1.20260423.01.00", "YouTube Music Web", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36", false, 0L, 3),
+        ClientProfile("WEB_EMBEDDED_PLAYER", "1.20260423.01.00", "Embedded Player", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36", false, 0L, 4)
     )
 
     init {
@@ -227,21 +227,25 @@ class PlaybackResolver private constructor(private val context: Context) {
         if (isVideoMode) {
             val resolved = coroutineScope {
                 val winner = CompletableDeferred<Track?>()
-                val itJob = launch {
+                val extractorJob = launch {
+                    val result = runCatching { resolveVideoWithMetrolistExtractor(track) }
+                    result.onSuccess { winner.complete(it) }
+                        .onFailure { error ->
+                            error.message?.takeIf { it.isNotBlank() }
+                                ?.let { errors += "MetrolistExtractor video: $it" }
+                        }
+                }
+                val innerTubeJob = launch {
+                    delay(LevyraResolverLatency.innerTubeFallbackDelayMs(isVideoMode = true, preferMp4Audio = false))
+                    if (winner.isCompleted) return@launch
                     val stream = runCatching { hedgedInnerTube(track, errors, true) }.getOrNull()
                     if (stream != null) {
                         winner.complete(track.withDirectStream(stream))
                     }
                 }
-                val extractorJob = launch {
-                    delay(LevyraResolverLatency.extractorHedgeDelayMs(isVideoMode = true, preferMp4Audio = false))
-                    if (winner.isCompleted) return@launch
-                    val r = runCatching { resolveVideoWithLevyraExtractor(track) }
-                    r.onSuccess { winner.complete(it) }
-                        .onFailure { it.message?.takeIf { m -> m.isNotBlank() }?.let { m -> errors += "LevyraExtractor video: $m" } }
-                }
                 launch {
-                    itJob.join(); extractorJob.join()
+                    extractorJob.join()
+                    innerTubeJob.join()
                     winner.complete(null)
                 }
                 val result = winner.await()
@@ -280,20 +284,23 @@ class PlaybackResolver private constructor(private val context: Context) {
         if (preferMp4Audio) return resolveAudioResilient(track, errors)
         return coroutineScope {
             val winner = CompletableDeferred<Track?>()
+            val extractorJob = launch {
+                val resolved = runCatching { resolveWithMetrolistExtractor(track, false) }
+                resolved.onSuccess { winner.complete(it) }
+                    .onFailure { error ->
+                        error.message?.takeIf { it.isNotBlank() }
+                            ?.let { errors += "MetrolistExtractor: $it" }
+                    }
+            }
             val innerTubeJob = launch {
+                delay(LevyraResolverLatency.innerTubeFallbackDelayMs(isVideoMode = false, preferMp4Audio = false))
+                if (winner.isCompleted) return@launch
                 val stream = runCatching { hedgedInnerTube(track, errors, false) }.getOrNull()
                 if (stream != null) winner.complete(track.withDirectStream(stream))
             }
-            val extractorJob = launch {
-                delay(LevyraResolverLatency.extractorHedgeDelayMs(isVideoMode = false, preferMp4Audio = false))
-                if (winner.isCompleted) return@launch
-                val resolved = runCatching { resolveWithLevyraExtractor(track, false) }
-                resolved.onSuccess { winner.complete(it) }
-                    .onFailure { it.message?.takeIf { message -> message.isNotBlank() }?.let { message -> errors += "LevyraExtractor: $message" } }
-            }
             launch {
-                innerTubeJob.join()
                 extractorJob.join()
+                innerTubeJob.join()
                 winner.complete(null)
             }
             val result = winner.await()
@@ -304,18 +311,23 @@ class PlaybackResolver private constructor(private val context: Context) {
 
     private suspend fun resolveAudioResilient(track: Track, errors: MutableList<String>): Track? = coroutineScope {
         val winner = CompletableDeferred<Track?>()
+        val extractorJob = launch {
+            val resolved = runCatching { resolveWithMetrolistExtractor(track, true) }
+            resolved.onSuccess { winner.complete(it) }
+                .onFailure { error ->
+                    error.message?.takeIf { it.isNotBlank() }
+                        ?.let { errors += "MetrolistExtractor: $it" }
+                }
+        }
         val innerTubeJob = launch {
+            delay(LevyraResolverLatency.innerTubeFallbackDelayMs(isVideoMode = false, preferMp4Audio = true))
+            if (winner.isCompleted) return@launch
             val stream = runCatching { raceInnerTube(track, errors, false, true) }.getOrNull()
             if (stream != null) winner.complete(track.withDirectStream(stream))
         }
-        val extractorJob = launch {
-            val resolved = runCatching { resolveWithLevyraExtractor(track, true) }
-            resolved.onSuccess { winner.complete(it) }
-                .onFailure { it.message?.takeIf { message -> message.isNotBlank() }?.let { message -> errors += "LevyraExtractor: $message" } }
-        }
         launch {
-            innerTubeJob.join()
             extractorJob.join()
+            innerTubeJob.join()
             winner.complete(null)
         }
         val result = winner.await()
@@ -861,7 +873,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         }.getOrDefault(false)
     }
 
-    private fun resolveWithLevyraExtractor(track: Track, preferMp4Audio: Boolean = false): Track {
+    private fun resolveWithMetrolistExtractor(track: Track, preferMp4Audio: Boolean = false): Track {
         NewPipeRuntime.ensure()
         val info = StreamInfo.getInfo(ServiceList.YouTube, track.videoUrl)
         val audio = selectAudioStream(info.audioStreams, preferMp4Audio)
@@ -878,11 +890,11 @@ class PlaybackResolver private constructor(private val context: Context) {
         return artworkSafe.copy(
             streamUrl = url,
             durationMs = if (info.duration > 0L) info.duration * 1000L else track.durationMs,
-            source = "LevyraExtractor${label.takeIf { it.isNotBlank() }?.let { " · $it" }.orEmpty()}"
+            source = "MetrolistExtractor${label.takeIf { it.isNotBlank() }?.let { " · $it" }.orEmpty()}"
         )
     }
 
-    private fun resolveVideoWithLevyraExtractor(track: Track): Track {
+    private fun resolveVideoWithMetrolistExtractor(track: Track): Track {
         NewPipeRuntime.ensure()
         val info = StreamInfo.getInfo(ServiceList.YouTube, track.videoUrl)
 
@@ -909,7 +921,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 streamUrl = muxed.content,
                 videoStreamUrl = "",
                 durationMs = durationMs,
-                source = "LevyraExtractor Fast Muxed"
+                source = "MetrolistExtractor Fast Muxed"
             )
         }
 
@@ -928,7 +940,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 streamUrl = bestAudio,
                 videoStreamUrl = bestVideoOnly,
                 durationMs = durationMs,
-                source = "LevyraExtractor Video"
+                source = "MetrolistExtractor Video"
             )
         }
 
@@ -937,7 +949,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 streamUrl = muxed.content,
                 videoStreamUrl = "",
                 durationMs = durationMs,
-                source = "LevyraExtractor Muxed"
+                source = "MetrolistExtractor Muxed"
             )
         }
 
@@ -947,7 +959,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 streamUrl = hls,
                 videoStreamUrl = "",
                 durationMs = durationMs,
-                source = "LevyraExtractor HLS"
+                source = "MetrolistExtractor HLS"
             )
         }
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
@@ -690,7 +690,7 @@ class YoutubeMusicRepository(private val context: Context? = null) {
                     largeThumbnailUrl = upgradeThumbnail(thumbnail),
                     videoUrl = item.url,
                     query = query,
-                    source = "LevyraExtractor Search"
+                    source = "MetrolistExtractor Search"
                 )
             }
             .distinctBy { it.id }

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -968,21 +968,10 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private fun enrichCharts(regionId: String, charts: List<Track>) {
         chartEnrichJob?.cancel()
         chartEnrichJob = viewModelScope.launch(Dispatchers.IO) {
-            val hot = charts.take(6)
-            coroutineScope {
-                val semaphore = Semaphore(2)
-                hot.forEachIndexed { index, entry ->
-                    launch {
-                        semaphore.withPermit {
-                            enrichChartEntry(regionId, entry, warm = index < 2)
-                        }
-                    }
-                }
-            }
-            charts.drop(6).take(6).forEach { entry ->
+            charts.take(40).forEachIndexed { index, entry ->
                 if (!isActive || _state.value.selectedChartId != regionId) return@launch
-                enrichChartEntry(regionId, entry, warm = false)
-                delay(80L)
+                enrichChartEntry(regionId, entry, warm = index < 3)
+                delay(90L)
             }
         }
     }
@@ -1690,7 +1679,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         }
         val requestId = ++playRequestId
         playJob?.cancel()
-        cancelBackgroundWarmups(cancelList = false)
+        cancelBackgroundWarmups()
         resolver.warmNetwork()
 
         val playableTrack = youtubePlayableTrack(track) ?: track

--- a/docs/METROLIST_EXTRACTOR_INTEGRATION.md
+++ b/docs/METROLIST_EXTRACTOR_INTEGRATION.md
@@ -1,0 +1,32 @@
+# MetrolistExtractor integration
+
+Levyra uses MetrolistExtractor as its primary NewPipe-compatible extraction dependency.
+
+## Dependency
+
+```text
+Group: com.github.MetrolistGroup
+Artifact: MetrolistExtractor
+Version: 3cd3341
+Repository: https://jitpack.io
+```
+
+The version is pinned to the same MetrolistExtractor commit used by the Metrolist Android project at the time of this integration. Pinning prevents an unreviewed upstream change from altering release behavior between builds.
+
+## Runtime behavior
+
+Levyra initializes the extractor through its OkHttp-backed NewPipe downloader, preserves extractor-provided request headers, respects redirect policy, and uses the extractor as the primary playback resolver. The direct InnerTube resolver remains a delayed fallback when extraction fails or times out.
+
+MetrolistExtractor handles the YouTube player-client strategy internally. Levyra does not override the player client through fork-specific APIs.
+
+## Updating
+
+1. Review the target MetrolistExtractor commit and its YouTube extraction changes.
+2. Update `metrolistExtractor` in `gradle/libs.versions.toml`.
+3. Run the dependency insight task and release build.
+4. Test audio-only playback, muxed video, HLS, search fallback, downloads, and expired-stream recovery.
+5. Update this document and `THIRD_PARTY_NOTICES.md` when the pinned commit changes.
+
+## License
+
+MetrolistExtractor is distributed under GPL-3.0. Levyra preserves the project attribution and license notices in the README, LICENSE, and THIRD_PARTY_NOTICES files.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ media3 = "1.10.1"
 coroutines = "1.11.0"
 coil = "3.5.0"
 okhttp = "5.4.0"
-newpipe = "033092921b"
+metrolistExtractor = "3cd3341"
 desugar = "2.1.5"
 junit = "4.13.2"
 json = "20260522"
@@ -50,7 +50,7 @@ coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref 
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-brotli = { group = "com.squareup.okhttp3", name = "okhttp-brotli", version.ref = "okhttp" }
-newpipe-extractor = { group = "com.github.luc4n3x", name = "levyraextractor", version.ref = "newpipe" }
+metrolist-extractor = { group = "com.github.MetrolistGroup", name = "MetrolistExtractor", version.ref = "metrolistExtractor" }
 desugar-jdk-libs-nio = { group = "com.android.tools", name = "desugar_jdk_libs_nio", version.ref = "desugar" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 json = { group = "org.json", name = "json", version.ref = "json" }


### PR DESCRIPTION
## Summary

This pull request replaces the custom LevyraExtractor integration with MetrolistExtractor to improve YouTube stream resolution reliability.

## Changes

- Replace LevyraExtractor with MetrolistExtractor
- Pin the extractor dependency to the tested MetrolistExtractor revision
- Adapt the NewPipe runtime to the supported MetrolistExtractor APIs
- Preserve extractor-generated request headers and redirect handling
- Keep direct InnerTube resolution as a delayed fallback
- Update playback resolver and YouTube repository integration
- Update Dependabot and the nightly extractor compatibility workflow
- Add third-party notices and integration documentation
- Update README credits and acknowledgements

## Validation

- Kotlin compilation completed successfully
- Gradle catalog and dependency coordinates updated
- No LevyraExtractor-specific runtime calls remain
- Documentation and third-party attribution included