### PR TITLE
Reduce playback resolver startup latency

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraStreamHedge.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraStreamHedge.kt
@@ -9,8 +9,8 @@ import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.atomic.AtomicInteger
 
 internal object LevyraResolverLatency {
-    const val INNER_TUBE_HEDGE_BUDGET_MS = 350L
-    private const val AUDIO_INNER_TUBE_FALLBACK_MS = 2_000L
+    const val INNER_TUBE_HEDGE_BUDGET_MS = 120L
+    private const val AUDIO_INNER_TUBE_FALLBACK_MS = 80L
     private const val VIDEO_INNER_TUBE_FALLBACK_MS = 2_500L
     private const val OFFLINE_INNER_TUBE_FALLBACK_MS = 2_500L
 

--- a/app/src/test/java/com/luc4n3x/levyra/data/LevyraStreamHedgeTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/LevyraStreamHedgeTest.kt
@@ -65,6 +65,16 @@ class LevyraStreamHedgeTest {
     }
 
     @Test
+    fun playbackInnerTubeFallbackStartsInsideTapLatencyBudget() {
+        assertTrue(LevyraResolverLatency.innerTubeFallbackDelayMs(isVideoMode = false, preferMp4Audio = false) <= 120L)
+    }
+
+    @Test
+    fun innerTubeProfilesFanOutInsideLowLatencyBudget() {
+        assertTrue(LevyraResolverLatency.INNER_TUBE_HEDGE_BUDGET_MS <= 150L)
+    }
+
+    @Test
     fun offlineMp4ExtractorStartsImmediately() {
         assertEquals(0L, LevyraResolverLatency.extractorHedgeDelayMs(isVideoMode = false, preferMp4Audio = true))
     }


### PR DESCRIPTION
## Summary
- Reduce the playback audio resolver's InnerTube fallback delay from 2000 ms to 80 ms.
- Reduce InnerTube client tier fan-out from 350 ms to 120 ms so alternate client profiles start sooner.
- Add regression tests that lock the tap-latency budgets for playback resolution.

## Root Cause
Playback audio resolution gave LevyraExtractor a 2 second head start before InnerTube was allowed to compete. When the extractor was slow or stalled, the user always felt that delay before ExoPlayer even received a playable stream URL.

## Validation
- `gradle testDebugUnitTest --rerun-tasks` passed locally with `ANDROID_HOME=C:\Users\Luca Drogo\AppData\Local\Android\Sdk`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced playback hedge and audio fallback delays for faster stream startup.
  * Improved responsiveness when selecting alternate playback sources.

* **Tests**
  * Added coverage to verify fallback timing remains within low-latency targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->