### PR TITLE
Adaptive video engine, seamless mode switching and native PiP

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -194,6 +194,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.text.googlefonts)
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.media3.exoplayer.hls)
+    implementation(libs.androidx.media3.exoplayer.dash)
     implementation(libs.androidx.media3.session)
     implementation(libs.androidx.media3.ui)
     implementation(libs.androidx.media3.datasource.okhttp)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,8 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:resizeableActivity="true"
+            android:supportsPictureInPicture="true"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.Levyra">

--- a/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.luc4n3x.levyra
 
 import android.Manifest
+import android.app.PictureInPictureParams
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
@@ -9,21 +10,27 @@ import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Build
 import android.os.Bundle
+import android.util.Rational
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.mutableStateOf
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.luc4n3x.levyra.data.LevyraArtworkCache
+import com.luc4n3x.levyra.player.LevyraPipBridge
 import com.luc4n3x.levyra.ui.LevyraApp
 import com.luc4n3x.levyra.ui.theme.LevyraTheme
 import com.luc4n3x.levyra.ui.theme.LevyraThemeController
 import com.luc4n3x.levyra.ui.theme.LevyraThemes
 import com.luc4n3x.levyra.viewmodel.LevyraViewModel
+import kotlin.math.roundToInt
 
 class MainActivity : ComponentActivity() {
+    private val pipMode = mutableStateOf(false)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         applyOrientationPolicy()
@@ -51,10 +58,17 @@ class MainActivity : ComponentActivity() {
             window.attributes = params
         }
         requestHighRefreshRate()
+        LevyraPipBridge.bind(
+            enter = ::enterPictureInPicture,
+            update = ::updatePictureInPictureParams
+        )
         setContent {
             LevyraTheme {
                 val viewModel: LevyraViewModel = viewModel()
-                LevyraApp(viewModel = viewModel)
+                LevyraApp(
+                    viewModel = viewModel,
+                    isInPictureInPicture = pipMode.value
+                )
             }
         }
     }
@@ -70,11 +84,54 @@ class MainActivity : ComponentActivity() {
         applyOrientationPolicy()
     }
 
+    override fun onUserLeaveHint() {
+        super.onUserLeaveHint()
+        if (Build.VERSION.SDK_INT in Build.VERSION_CODES.O..Build.VERSION_CODES.R && LevyraPipBridge.current().playing) {
+            enterPictureInPicture()
+        }
+    }
+
+    override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
+        pipMode.value = isInPictureInPictureMode
+        LevyraPipBridge.updatePictureInPictureMode(isInPictureInPictureMode)
+        applyOrientationPolicy()
+    }
+
+    override fun onDestroy() {
+        LevyraPipBridge.unbind()
+        super.onDestroy()
+    }
+
+    private fun enterPictureInPicture(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return false
+        if (!packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)) return false
+        val state = LevyraPipBridge.current()
+        if (!state.canEnter) return false
+        updatePictureInPictureParams(state)
+        return runCatching { enterPictureInPictureMode(pictureInPictureParams) }.getOrDefault(false)
+    }
+
+    private fun updatePictureInPictureParams(state: LevyraPipBridge.State) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val aspect = state.aspectRatio.coerceIn(0.42f, 2.39f)
+        val denominator = 1000
+        val numerator = (aspect * denominator).roundToInt().coerceAtLeast(1)
+        val builder = PictureInPictureParams.Builder()
+            .setAspectRatio(Rational(numerator, denominator))
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            builder
+                .setAutoEnterEnabled(state.videoMode && state.playing)
+                .setSeamlessResizeEnabled(true)
+        }
+        setPictureInPictureParams(builder.build())
+    }
+
     private fun applyOrientationPolicy() {
-        requestedOrientation = if (resources.configuration.smallestScreenWidthDp >= 600) {
-            ActivityInfo.SCREEN_ORIENTATION_FULL_USER
-        } else {
-            ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        requestedOrientation = when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && isInPictureInPictureMode -> ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+            resources.configuration.smallestScreenWidthDp >= 600 -> ActivityInfo.SCREEN_ORIENTATION_FULL_USER
+            else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         }
     }
 
@@ -106,4 +163,3 @@ class MainActivity : ComponentActivity() {
         }
     }
 }
-

--- a/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
@@ -108,12 +108,25 @@ class MainActivity : ComponentActivity() {
         if (!packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)) return false
         val state = LevyraPipBridge.current()
         if (!state.canEnter) return false
-        updatePictureInPictureParams(state)
-        return runCatching { enterPictureInPictureMode(pictureInPictureParams) }.getOrDefault(false)
+        val params = buildPictureInPictureParams(state)
+        setPictureInPictureParams(params)
+        return try {
+            enterPictureInPictureMode(params)
+        } catch (_: IllegalArgumentException) {
+            false
+        } catch (_: IllegalStateException) {
+            false
+        } catch (_: SecurityException) {
+            false
+        }
     }
 
     private fun updatePictureInPictureParams(state: LevyraPipBridge.State) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        setPictureInPictureParams(buildPictureInPictureParams(state))
+    }
+
+    private fun buildPictureInPictureParams(state: LevyraPipBridge.State): PictureInPictureParams {
         val aspect = state.aspectRatio.coerceIn(0.42f, 2.39f)
         val denominator = 1000
         val numerator = (aspect * denominator).roundToInt().coerceAtLeast(1)
@@ -124,7 +137,7 @@ class MainActivity : ComponentActivity() {
                 .setAutoEnterEnabled(state.videoMode && state.playing)
                 .setSeamlessResizeEnabled(true)
         }
-        setPictureInPictureParams(builder.build())
+        return builder.build()
     }
 
     private fun applyOrientationPolicy() {

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraVideoStreamSelector.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraVideoStreamSelector.kt
@@ -1,0 +1,228 @@
+package com.luc4n3x.levyra.data
+
+import android.app.ActivityManager
+import android.content.Context
+import android.media.MediaCodecInfo
+import android.media.MediaCodecList
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
+import android.os.PowerManager
+import kotlin.math.abs
+import kotlin.math.max
+
+internal data class LevyraVideoCandidate(
+    val url: String,
+    val mimeType: String,
+    val codec: String,
+    val width: Int,
+    val height: Int,
+    val fps: Int,
+    val bitrate: Int,
+    val itag: Int,
+    val muxed: Boolean,
+    val label: String
+)
+
+internal data class LevyraVideoSelection(
+    val candidate: LevyraVideoCandidate,
+    val targetHeight: Int,
+    val hardwareDecoded: Boolean,
+    val reason: String
+)
+
+internal class LevyraVideoStreamSelector(context: Context) {
+    private val appContext = context.applicationContext
+    private val activityManager = appContext.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+    private val connectivityManager = appContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    private val powerManager = appContext.getSystemService(Context.POWER_SERVICE) as PowerManager
+    private val decoderCapabilities by lazy { readDecoderCapabilities() }
+
+    fun select(
+        muxedCandidates: List<LevyraVideoCandidate>,
+        videoOnlyCandidates: List<LevyraVideoCandidate>,
+        hasSeparateAudio: Boolean,
+        blocked: (String) -> Boolean
+    ): LevyraVideoSelection? {
+        val targetHeight = targetHeight()
+        val rawMuxed = muxedCandidates.filter { it.url.isNotBlank() && !blocked(it.url) }
+        val rawVideoOnly = if (hasSeparateAudio) {
+            videoOnlyCandidates.filter { it.url.isNotBlank() && !blocked(it.url) }
+        } else {
+            emptyList()
+        }
+        val usableMuxed = compatibleCandidates(rawMuxed)
+        val usableVideoOnly = compatibleCandidates(rawVideoOnly)
+        val bestMuxed = usableMuxed.maxByOrNull { score(it, targetHeight) }
+        val bestVideoOnly = usableVideoOnly.maxByOrNull { score(it, targetHeight) }
+        val chosen = when {
+            bestVideoOnly == null -> bestMuxed
+            bestMuxed == null -> bestVideoOnly
+            shouldPreferSeparated(bestMuxed, bestVideoOnly, targetHeight) -> bestVideoOnly
+            else -> bestMuxed
+        } ?: return null
+        val hardware = decoderSupport(chosen).hardware
+        val reason = buildString {
+            append(chosen.height.takeIf { it > 0 }?.let { "${it}p" } ?: "auto")
+            append(" · ")
+            append(codecFamily(chosen))
+            append(if (hardware) " HW" else " compat")
+            append(if (chosen.muxed) " · avvio rapido" else " · qualità separata")
+        }
+        return LevyraVideoSelection(chosen, targetHeight, hardware, reason)
+    }
+
+    fun targetHeight(): Int {
+        val lowRam = activityManager.isLowRamDevice
+        val powerSave = powerManager.isPowerSaveMode
+        val network = connectivityManager.activeNetwork
+        val capabilities = network?.let(connectivityManager::getNetworkCapabilities)
+        val unmetered = !connectivityManager.isActiveNetworkMetered
+        val fastTransport = capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true ||
+            capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) == true
+        val metrics = appContext.resources.displayMetrics
+        val displayShortSide = minOf(metrics.widthPixels, metrics.heightPixels)
+        return when {
+            lowRam || powerSave -> 720
+            !unmetered || !fastTransport -> 720
+            displayShortSide >= 1800 && decoderCapabilities.any { it.hardware && it.family == CodecFamily.AV1 } -> 2160
+            displayShortSide >= 1200 -> 1440
+            displayShortSide >= 900 -> 1080
+            else -> 720
+        }
+    }
+
+    private fun compatibleCandidates(candidates: List<LevyraVideoCandidate>): List<LevyraVideoCandidate> {
+        val compatible = candidates.filter { candidate ->
+            val support = decoderSupport(candidate)
+            support.family == CodecFamily.OTHER || support.supported
+        }
+        return compatible.ifEmpty { candidates }
+    }
+
+    private fun shouldPreferSeparated(
+        muxed: LevyraVideoCandidate,
+        videoOnly: LevyraVideoCandidate,
+        targetHeight: Int
+    ): Boolean {
+        val lowRam = activityManager.isLowRamDevice
+        val constrained = powerManager.isPowerSaveMode || connectivityManager.isActiveNetworkMetered
+        if (lowRam || constrained) return false
+        val muxedHeight = muxed.height.coerceAtLeast(0)
+        val videoHeight = videoOnly.height.coerceAtLeast(0)
+        if (videoHeight <= muxedHeight) return false
+        if (videoHeight > targetHeight && muxedHeight >= targetHeight) return false
+        return videoHeight - muxedHeight >= 240 || videoHeight >= 1080 && muxedHeight < 1080
+    }
+
+    private fun score(candidate: LevyraVideoCandidate, targetHeight: Int): Int {
+        val height = candidate.height.takeIf { it > 0 } ?: 360
+        val distance = abs(targetHeight - height)
+        val withinTarget = height <= targetHeight
+        val qualityScore = if (withinTarget) {
+            height * 18
+        } else {
+            targetHeight * 18 - distance * 22
+        }
+        val support = decoderSupport(candidate)
+        val codecScore = when (support.family) {
+            CodecFamily.AV1 -> if (support.hardware) 2_300 else -6_000
+            CodecFamily.VP9 -> if (support.hardware) 1_850 else -3_000
+            CodecFamily.AVC -> if (support.hardware) 1_700 else 900
+            CodecFamily.HEVC -> if (support.hardware) 1_500 else -2_500
+            CodecFamily.OTHER -> if (support.supported) 300 else -4_000
+        }
+        val containerScore = when {
+            candidate.mimeType.contains("mp4", true) -> 900
+            candidate.mimeType.contains("webm", true) -> 350
+            else -> 0
+        }
+        val startScore = if (candidate.muxed) 2_600 else 1_300
+        val fpsScore = when {
+            candidate.fps <= 0 -> 0
+            candidate.fps <= 30 -> 250
+            support.hardware && !activityManager.isLowRamDevice -> 500
+            else -> -800
+        }
+        val bitrateScore = (candidate.bitrate / 250_000).coerceIn(0, 900)
+        return qualityScore + codecScore + containerScore + startScore + fpsScore + bitrateScore
+    }
+
+    private fun decoderSupport(candidate: LevyraVideoCandidate): DecoderSupport {
+        val family = codecFamilyValue(candidate)
+        val matching = decoderCapabilities.filter { it.family == family }
+        return DecoderSupport(
+            family = family,
+            supported = matching.isNotEmpty(),
+            hardware = matching.any { it.hardware }
+        )
+    }
+
+    private fun codecFamily(candidate: LevyraVideoCandidate): String {
+        return when (codecFamilyValue(candidate)) {
+            CodecFamily.AV1 -> "AV1"
+            CodecFamily.VP9 -> "VP9"
+            CodecFamily.AVC -> "H.264"
+            CodecFamily.HEVC -> "HEVC"
+            CodecFamily.OTHER -> candidate.codec.ifBlank { candidate.mimeType.substringAfter('/') }.ifBlank { "video" }
+        }
+    }
+
+    private fun codecFamilyValue(candidate: LevyraVideoCandidate): CodecFamily {
+        val raw = "${candidate.codec} ${candidate.mimeType}".lowercase()
+        return when {
+            raw.contains("av01") || raw.contains("av1") -> CodecFamily.AV1
+            raw.contains("vp09") || raw.contains("vp9") -> CodecFamily.VP9
+            raw.contains("avc1") || raw.contains("avc") || raw.contains("h264") -> CodecFamily.AVC
+            raw.contains("hev1") || raw.contains("hvc1") || raw.contains("hevc") || raw.contains("h265") -> CodecFamily.HEVC
+            else -> CodecFamily.OTHER
+        }
+    }
+
+    private fun readDecoderCapabilities(): List<CodecCapability> {
+        return runCatching {
+            MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos
+                .asSequence()
+                .filterNot { info -> info.isEncoder }
+                .flatMap { info ->
+                    val hardware = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        info.isHardwareAccelerated
+                    } else {
+                        !info.name.contains("google", true) && !info.name.contains("software", true)
+                    }
+                    info.supportedTypes.asSequence().map { mime ->
+                        CodecCapability(
+                            family = when {
+                                mime.equals("video/av01", true) -> CodecFamily.AV1
+                                mime.equals("video/x-vnd.on2.vp9", true) -> CodecFamily.VP9
+                                mime.equals("video/avc", true) -> CodecFamily.AVC
+                                mime.equals("video/hevc", true) -> CodecFamily.HEVC
+                                else -> CodecFamily.OTHER
+                            },
+                            hardware = hardware
+                        )
+                    }
+                }
+                .toList()
+        }.getOrDefault(emptyList())
+    }
+
+    private data class DecoderSupport(
+        val family: CodecFamily,
+        val supported: Boolean,
+        val hardware: Boolean
+    )
+
+    private data class CodecCapability(
+        val family: CodecFamily,
+        val hardware: Boolean
+    )
+
+    private enum class CodecFamily {
+        AV1,
+        VP9,
+        AVC,
+        HEVC,
+        OTHER
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraVideoStreamSelector.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraVideoStreamSelector.kt
@@ -93,11 +93,9 @@ internal class LevyraVideoStreamSelector(context: Context) {
     }
 
     private fun compatibleCandidates(candidates: List<LevyraVideoCandidate>): List<LevyraVideoCandidate> {
-        val compatible = candidates.filter { candidate ->
-            val support = decoderSupport(candidate)
-            support.family == CodecFamily.OTHER || support.supported
+        return candidates.filter { candidate ->
+            decoderSupport(candidate).supported
         }
-        return compatible.ifEmpty { candidates }
     }
 
     private fun shouldPreferSeparated(
@@ -150,11 +148,17 @@ internal class LevyraVideoStreamSelector(context: Context) {
 
     private fun decoderSupport(candidate: LevyraVideoCandidate): DecoderSupport {
         val family = codecFamilyValue(candidate)
-        val matching = decoderCapabilities.filter { it.family == family }
+        val candidateMime = candidate.mimeType.substringBefore(';').trim()
+        val compatible = decoderCapabilities.filter { capability ->
+            val familyMatches = capability.family == family
+            val mimeMatches = family != CodecFamily.OTHER ||
+                candidateMime.isNotBlank() && capability.mimeType.equals(candidateMime, true)
+            familyMatches && mimeMatches && capability.supports(candidate)
+        }
         return DecoderSupport(
             family = family,
-            supported = matching.isNotEmpty(),
-            hardware = matching.any { it.hardware }
+            supported = compatible.isNotEmpty(),
+            hardware = compatible.any { it.hardware }
         )
     }
 
@@ -190,18 +194,25 @@ internal class LevyraVideoStreamSelector(context: Context) {
                     } else {
                         !info.name.contains("google", true) && !info.name.contains("software", true)
                     }
-                    info.supportedTypes.asSequence().map { mime ->
-                        CodecCapability(
-                            family = when {
-                                mime.equals("video/av01", true) -> CodecFamily.AV1
-                                mime.equals("video/x-vnd.on2.vp9", true) -> CodecFamily.VP9
-                                mime.equals("video/avc", true) -> CodecFamily.AVC
-                                mime.equals("video/hevc", true) -> CodecFamily.HEVC
-                                else -> CodecFamily.OTHER
-                            },
-                            hardware = hardware
-                        )
-                    }
+                    info.supportedTypes.asSequence()
+                        .filter { mime -> mime.startsWith("video/", true) }
+                        .mapNotNull { mime ->
+                            runCatching {
+                                val capabilities = info.getCapabilitiesForType(mime)
+                                CodecCapability(
+                                    family = when {
+                                        mime.equals("video/av01", true) -> CodecFamily.AV1
+                                        mime.equals("video/x-vnd.on2.vp9", true) -> CodecFamily.VP9
+                                        mime.equals("video/avc", true) -> CodecFamily.AVC
+                                        mime.equals("video/hevc", true) -> CodecFamily.HEVC
+                                        else -> CodecFamily.OTHER
+                                    },
+                                    mimeType = mime,
+                                    hardware = hardware,
+                                    videoCapabilities = capabilities.videoCapabilities
+                                )
+                            }.getOrNull()
+                        }
                 }
                 .toList()
         }.getOrDefault(emptyList())
@@ -215,8 +226,28 @@ internal class LevyraVideoStreamSelector(context: Context) {
 
     private data class CodecCapability(
         val family: CodecFamily,
-        val hardware: Boolean
-    )
+        val mimeType: String,
+        val hardware: Boolean,
+        val videoCapabilities: MediaCodecInfo.VideoCapabilities?
+    ) {
+        fun supports(candidate: LevyraVideoCandidate): Boolean {
+            val width = candidate.width
+            val height = candidate.height
+            if (width <= 0 || height <= 0) return true
+            val capabilities = videoCapabilities ?: return false
+            val frameRate = candidate.fps.takeIf { it > 0 }?.toDouble()
+            fun supportsSize(testWidth: Int, testHeight: Int): Boolean {
+                return runCatching {
+                    if (frameRate != null) {
+                        capabilities.areSizeAndRateSupported(testWidth, testHeight, frameRate)
+                    } else {
+                        capabilities.isSizeSupported(testWidth, testHeight)
+                    }
+                }.getOrDefault(false)
+            }
+            return supportsSize(width, height) || supportsSize(height, width)
+        }
+    }
 
     private enum class CodecFamily {
         AV1,

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -1060,6 +1060,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         )
         return artworkSafe.copy(
             streamUrl = url,
+            videoStreamUrl = if (audio == null) "" else artworkSafe.videoStreamUrl,
             durationMs = if (info.duration > 0L) info.duration * 1000L else track.durationMs,
             source = if (audio != null) {
                 "LevyraExtractor${label.takeIf { it.isNotBlank() }?.let { " · $it" }.orEmpty()}"

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -61,6 +61,8 @@ class PlaybackResolver private constructor(private val context: Context) {
     private val streamCache = ConcurrentHashMap<String, CachedStream>()
     private val inFlight = ConcurrentHashMap<String, Deferred<Track>>()
     private val clientHealth = ConcurrentHashMap<String, ClientHealth>()
+    private val failedPlaybackUrls = ConcurrentHashMap<String, Long>()
+    private val videoSelector = LevyraVideoStreamSelector(context)
     private val youtubeHttpClient = LevyraHttpClientFactory.youtubePlayer()
     private val jsonMediaType = "application/json; charset=utf-8".toMediaType()
     private val fallbackTtlMs = 90L * 60L * 1000L
@@ -136,6 +138,7 @@ class PlaybackResolver private constructor(private val context: Context) {
 
     fun cached(track: Track, isVideoMode: Boolean = false): Track? {
         if (track.streamUrl.isNotBlank()) {
+            if (isPlaybackUrlBlocked(track.streamUrl) || track.videoStreamUrl.isNotBlank() && isPlaybackUrlBlocked(track.videoStreamUrl)) return null
             if (!isVideoMode && !isPlayableAudioUrl(track.streamUrl)) return null
             return if (streamStillFresh(track.streamUrl)) track else null
         }
@@ -154,6 +157,28 @@ class PlaybackResolver private constructor(private val context: Context) {
 
     fun invalidate(track: Track, isVideoMode: Boolean = false) {
         remove(cacheKey(track, isVideoMode))
+    }
+
+    fun reportPlaybackFailure(track: Track, isVideoMode: Boolean, reason: String) {
+        invalidate(track, isVideoMode)
+        val now = System.currentTimeMillis()
+        val lower = reason.lowercase()
+        val ttl = when {
+            lower.contains("403") || lower.contains("410") || lower.contains("429") || lower.contains("scadut") -> 10L * 60L * 1000L
+            lower.contains("decoder") || lower.contains("format") || lower.contains("codec") -> 30L * 60L * 1000L
+            else -> 2L * 60L * 1000L
+        }
+        listOf(track.streamUrl, track.videoStreamUrl)
+            .filter { it.isNotBlank() }
+            .forEach { failedPlaybackUrls[it] = now + ttl }
+    }
+
+    private fun isPlaybackUrlBlocked(url: String): Boolean {
+        if (url.isBlank()) return true
+        val until = failedPlaybackUrls[url] ?: return false
+        if (until > System.currentTimeMillis()) return true
+        failedPlaybackUrls.remove(url, until)
+        return false
     }
 
     suspend fun resolve(track: Track, isVideoMode: Boolean = false): Track {
@@ -183,7 +208,13 @@ class PlaybackResolver private constructor(private val context: Context) {
         preferMp4Audio: Boolean,
         requestKind: String
     ): Track = coroutineScope {
-        track.streamUrl.takeIf { it.isNotBlank() && streamStillFresh(it) && (isVideoMode || isPlayableAudioUrl(it)) }?.let { return@coroutineScope track }
+        track.streamUrl.takeIf {
+            it.isNotBlank() &&
+                !isPlaybackUrlBlocked(it) &&
+                (track.videoStreamUrl.isBlank() || !isPlaybackUrlBlocked(track.videoStreamUrl)) &&
+                streamStillFresh(it) &&
+                (isVideoMode || isPlayableAudioUrl(it))
+        }?.let { return@coroutineScope track }
         cached(track, isVideoMode)?.let { return@coroutineScope it }
 
         val key = "${cacheKey(track, isVideoMode)}_$requestKind"
@@ -731,6 +762,10 @@ class PlaybackResolver private constructor(private val context: Context) {
 
     private fun acceptResolvedStream(stream: DirectStream, isVideoMode: Boolean, label: String, errors: MutableList<String>): Boolean {
         if (stream.url.isBlank()) return false
+        if (isPlaybackUrlBlocked(stream.url) || stream.videoUrl.isNotBlank() && isPlaybackUrlBlocked(stream.videoUrl)) {
+            errors += "$label: stream temporaneamente escluso dopo un errore di riproduzione"
+            return false
+        }
         if (!streamStillFresh(stream.url)) {
             errors += "$label: URL scaduto"
             return false
@@ -847,7 +882,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 val format = adaptiveFormats.optJSONObject(i) ?: continue
                 val mime = format.optString("mimeType")
                 val url = format.directFormatUrl()
-                if (!mime.startsWith("audio/", true) || url.isBlank()) continue
+                if (!mime.startsWith("audio/", true) || url.isBlank() || isPlaybackUrlBlocked(url)) continue
                 val itag = format.optInt("itag", 0)
                 val bitrate = format.optInt("bitrate", 0)
                 val audioQuality = format.optString("audioQuality")
@@ -860,68 +895,77 @@ class PlaybackResolver private constructor(private val context: Context) {
             }
 
             if (isVideoMode) {
-                var bestVideoUrl = ""
-                var bestVideoScore = -1
-                for (i in 0 until adaptiveFormats.length()) {
-                    val format = adaptiveFormats.optJSONObject(i) ?: continue
-                    val mime = format.optString("mimeType")
-                    val url = format.directFormatUrl()
-                    if (!mime.startsWith("video/", true) || url.isBlank()) continue
-                    val height = format.optInt("height", 0)
-                    val penalty = if (height > 1080) -1 else 0
-                    val mimeBoost = if (mime.contains("mp4", true)) 5000 else 0
-                    val score = height + mimeBoost + penalty
-                    if (score > bestVideoScore) {
-                        bestVideoScore = score
-                        bestVideoUrl = url
+                val videoOnlyCandidates = buildList {
+                    for (i in 0 until adaptiveFormats.length()) {
+                        val format = adaptiveFormats.optJSONObject(i) ?: continue
+                        val mime = format.optString("mimeType")
+                        val url = format.directFormatUrl()
+                        if (!mime.startsWith("video/", true) || url.isBlank()) continue
+                        add(
+                            LevyraVideoCandidate(
+                                url = url,
+                                mimeType = mime.substringBefore(';'),
+                                codec = codecFromMimeType(mime),
+                                width = format.optInt("width", 0),
+                                height = format.optInt("height", 0),
+                                fps = format.optInt("fps", 0),
+                                bitrate = format.optInt("bitrate", 0),
+                                itag = format.optInt("itag", 0),
+                                muxed = false,
+                                label = "adaptive"
+                            )
+                        )
                     }
                 }
-
-                var muxedUrl = ""
-                var muxedScore = -1
-                for (i in 0 until muxedFormats.length()) {
-                    val format = muxedFormats.optJSONObject(i) ?: continue
-                    val mime = format.optString("mimeType")
-                    val url = format.directFormatUrl()
-                    if (!mime.startsWith("video/", true) || url.isBlank()) continue
-                    val height = format.optInt("height", 0)
-                    if (height > muxedScore) {
-                        muxedScore = height
-                        muxedUrl = url
+                val muxedCandidates = buildList {
+                    for (i in 0 until muxedFormats.length()) {
+                        val format = muxedFormats.optJSONObject(i) ?: continue
+                        val mime = format.optString("mimeType")
+                        val url = format.directFormatUrl()
+                        if (!mime.startsWith("video/", true) || url.isBlank()) continue
+                        add(
+                            LevyraVideoCandidate(
+                                url = url,
+                                mimeType = mime.substringBefore(';'),
+                                codec = codecFromMimeType(mime),
+                                width = format.optInt("width", 0),
+                                height = format.optInt("height", 0),
+                                fps = format.optInt("fps", 0),
+                                bitrate = format.optInt("bitrate", 0),
+                                itag = format.optInt("itag", 0),
+                                muxed = true,
+                                label = "muxed"
+                            )
+                        )
                     }
                 }
-
-                val hlsUrl = streamingData.optString("hlsManifestUrl").takeIf { isVerifiedHlsManifest(it) }.orEmpty()
-
+                val selection = videoSelector.select(
+                    muxedCandidates = muxedCandidates,
+                    videoOnlyCandidates = videoOnlyCandidates,
+                    hasSeparateAudio = bestAudioUrl.isNotBlank(),
+                    blocked = ::isPlaybackUrlBlocked
+                )
+                val hlsUrl = streamingData.optString("hlsManifestUrl")
+                    .takeIf { it.isNotBlank() && !isPlaybackUrlBlocked(it) && isVerifiedHlsManifest(it) }
+                    .orEmpty()
                 val details = root.optJSONObject("videoDetails")
                 val duration = details?.optString("lengthSeconds")?.toLongOrNull()?.times(1000L) ?: 0L
                 val thumbnail = details?.optJSONObject("thumbnail")?.optJSONArray("thumbnails")?.bestThumbnail().orEmpty()
-
                 return@responseUse when {
-                    muxedUrl.isNotBlank() && muxedScore >= 480 -> DirectStream(
-                        url = muxedUrl,
+                    selection?.candidate?.muxed == true -> DirectStream(
+                        url = selection.candidate.url,
                         videoUrl = "",
                         durationMs = duration,
                         thumbnailUrl = thumbnail,
-                        source = "YouTube Fast Muxed ${profile.label}"
+                        source = "YouTube ${profile.label} · ${selection.reason}"
                     )
-
-                    bestAudioUrl.isNotBlank() && bestVideoUrl.isNotBlank() -> DirectStream(
+                    selection != null && bestAudioUrl.isNotBlank() -> DirectStream(
                         url = bestAudioUrl,
-                        videoUrl = bestVideoUrl,
+                        videoUrl = selection.candidate.url,
                         durationMs = duration,
                         thumbnailUrl = thumbnail,
-                        source = "YouTube Video ${profile.label}"
+                        source = "YouTube ${profile.label} · ${selection.reason}"
                     )
-
-                    muxedUrl.isNotBlank() -> DirectStream(
-                        url = muxedUrl,
-                        videoUrl = "",
-                        durationMs = duration,
-                        thumbnailUrl = thumbnail,
-                        source = "YouTube Muxed ${profile.label}"
-                    )
-
                     hlsUrl.isNotBlank() -> DirectStream(
                         url = hlsUrl,
                         videoUrl = "",
@@ -929,7 +973,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                         thumbnailUrl = thumbnail,
                         source = "YouTube HLS ${profile.label}"
                     )
-                    else -> throw IllegalStateException("Nessuno stream video disponibile")
+                    else -> throw IllegalStateException("Nessuno stream video compatibile disponibile")
                 }
             }
 
@@ -953,7 +997,12 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     private fun selectAudioStream(streams: List<AudioStream>, preferMp4Audio: Boolean): AudioStream? {
-        val direct = streams.filter { it.isUrl && it.content.isNotBlank() && isDirectAudioUrl(it.content) }
+        val direct = streams.filter {
+            it.isUrl &&
+                it.content.isNotBlank() &&
+                !isPlaybackUrlBlocked(it.content) &&
+                isDirectAudioUrl(it.content)
+        }
         val playable = direct.filter { streamStillFresh(it.content) }.ifEmpty { direct }
         return playable.maxByOrNull { scoreExtractorAudio(it, preferMp4Audio) }
     }
@@ -1023,7 +1072,6 @@ class PlaybackResolver private constructor(private val context: Context) {
     private fun resolveVideoWithLevyraExtractor(track: Track): Track {
         NewPipeRuntime.ensure()
         val info = StreamInfo.getInfo(ServiceList.YouTube, track.videoUrl)
-
         val bestThumb = info.thumbnails.maxByOrNull { image ->
             image.width.coerceAtLeast(0) * image.height.coerceAtLeast(0)
         }?.url.orEmpty()
@@ -1032,54 +1080,39 @@ class PlaybackResolver private constructor(private val context: Context) {
             donor = track.copy(thumbnailUrl = bestThumb, largeThumbnailUrl = bestThumb)
         )
         val durationMs = if (info.duration > 0L) info.duration * 1000L else track.durationMs
-
         val bestAudio = selectAudioStream(info.audioStreams, preferMp4Audio = false)?.content
-
-        val muxed = info.videoStreams
+        val muxedCandidates = info.videoStreams
             .filter { it.isUrl && it.content.isNotBlank() && streamStillFresh(it.content) }
-            .maxByOrNull { heightOf(it.getResolution()) }
-            ?: info.videoStreams
-                .filter { it.isUrl && it.content.isNotBlank() }
-                .maxByOrNull { heightOf(it.getResolution()) }
-
-        if (muxed != null && heightOf(muxed.getResolution()) >= 480) {
-            return artworkSafe.copy(
-                streamUrl = muxed.content,
-                videoStreamUrl = "",
-                durationMs = durationMs,
-                source = "LevyraExtractor Fast Muxed"
-            )
-        }
-
-        val bestVideoOnly = info.videoOnlyStreams
+            .ifEmpty { info.videoStreams.filter { it.isUrl && it.content.isNotBlank() } }
+            .map(::extractorVideoCandidate)
+        val videoOnlyCandidates = info.videoOnlyStreams
             .filter { it.isUrl && it.content.isNotBlank() && streamStillFresh(it.content) }
             .ifEmpty { info.videoOnlyStreams.filter { it.isUrl && it.content.isNotBlank() } }
-            .filter { heightOf(it.getResolution()) in 1..1080 }
-            .maxWithOrNull(
-                compareBy<VideoStream> { heightOf(it.getResolution()) }
-                    .thenBy { if (it.getFormat()?.name?.contains("MPEG", true) == true) 1 else 0 }
-            )
-            ?.content
-
-        if (bestVideoOnly != null && bestAudio != null) {
-            return artworkSafe.copy(
-                streamUrl = bestAudio,
-                videoStreamUrl = bestVideoOnly,
-                durationMs = durationMs,
-                source = "LevyraExtractor Video"
-            )
+            .map(::extractorVideoCandidate)
+        val selection = videoSelector.select(
+            muxedCandidates = muxedCandidates,
+            videoOnlyCandidates = videoOnlyCandidates,
+            hasSeparateAudio = !bestAudio.isNullOrBlank(),
+            blocked = ::isPlaybackUrlBlocked
+        )
+        if (selection != null) {
+            return if (selection.candidate.muxed) {
+                artworkSafe.copy(
+                    streamUrl = selection.candidate.url,
+                    videoStreamUrl = "",
+                    durationMs = durationMs,
+                    source = "LevyraExtractor · ${selection.reason}"
+                )
+            } else {
+                artworkSafe.copy(
+                    streamUrl = bestAudio.orEmpty(),
+                    videoStreamUrl = selection.candidate.url,
+                    durationMs = durationMs,
+                    source = "LevyraExtractor · ${selection.reason}"
+                )
+            }
         }
-
-        if (muxed != null) {
-            return artworkSafe.copy(
-                streamUrl = muxed.content,
-                videoStreamUrl = "",
-                durationMs = durationMs,
-                source = "LevyraExtractor Muxed"
-            )
-        }
-
-        val hls = info.hlsUrl.takeIf { isVerifiedHlsManifest(it) }
+        val hls = info.hlsUrl.takeIf { it.isNotBlank() && !isPlaybackUrlBlocked(it) && isVerifiedHlsManifest(it) }
         if (hls != null) {
             return artworkSafe.copy(
                 streamUrl = hls,
@@ -1088,8 +1121,31 @@ class PlaybackResolver private constructor(private val context: Context) {
                 source = "LevyraExtractor HLS"
             )
         }
+        throw IllegalStateException("Nessuno stream video compatibile per ${track.title}")
+    }
 
-        throw IllegalStateException("Nessuno stream video disponibile per ${track.title}")
+    private fun extractorVideoCandidate(stream: VideoStream): LevyraVideoCandidate {
+        val format = stream.getFormat()
+        return LevyraVideoCandidate(
+            url = stream.content,
+            mimeType = format?.mimeType.orEmpty(),
+            codec = stream.codec.orEmpty(),
+            width = stream.width,
+            height = stream.height.takeIf { it > 0 } ?: heightOf(stream.resolution),
+            fps = stream.fps,
+            bitrate = stream.bitrate,
+            itag = stream.itag,
+            muxed = !stream.isVideoOnly,
+            label = stream.resolution
+        )
+    }
+
+    private fun codecFromMimeType(mimeType: String): String {
+        return Regex("codecs=\"([^\"]+)\"", RegexOption.IGNORE_CASE)
+            .find(mimeType)
+            ?.groupValues
+            ?.getOrNull(1)
+            .orEmpty()
     }
 
     private fun streamLabel(stream: AudioStream): String {

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -945,9 +945,13 @@ class PlaybackResolver private constructor(private val context: Context) {
                     hasSeparateAudio = bestAudioUrl.isNotBlank(),
                     blocked = ::isPlaybackUrlBlocked
                 )
-                val hlsUrl = streamingData.optString("hlsManifestUrl")
-                    .takeIf { it.isNotBlank() && !isPlaybackUrlBlocked(it) && isVerifiedHlsManifest(it) }
-                    .orEmpty()
+                val hlsUrl = if (selection == null) {
+                    streamingData.optString("hlsManifestUrl")
+                        .takeIf { it.isNotBlank() && !isPlaybackUrlBlocked(it) && isVerifiedHlsManifest(it) }
+                        .orEmpty()
+                } else {
+                    ""
+                }
                 val details = root.optJSONObject("videoDetails")
                 val duration = details?.optString("lengthSeconds")?.toLongOrNull()?.times(1000L) ?: 0L
                 val thumbnail = details?.optJSONObject("thumbnail")?.optJSONArray("thumbnails")?.bestThumbnail().orEmpty()
@@ -1047,7 +1051,11 @@ class PlaybackResolver private constructor(private val context: Context) {
         NewPipeRuntime.ensure()
         val info = StreamInfo.getInfo(ServiceList.YouTube, track.videoUrl)
         val audio = selectAudioStream(info.audioStreams, preferMp4Audio)
-        val hlsUrl = if (preferMp4Audio) null else info.hlsUrl.takeIf { isVerifiedHlsManifest(it) }
+        val hlsUrl = if (audio == null && !preferMp4Audio) {
+            info.hlsUrl.takeIf { isVerifiedHlsManifest(it) }
+        } else {
+            null
+        }
         val url = audio?.content ?: hlsUrl
             ?: throw IllegalStateException("LevyraExtractor non ha restituito stream audio diretti o HLS per ${track.title}")
         val bestThumb = info.thumbnails.maxByOrNull { image ->
@@ -1084,11 +1092,9 @@ class PlaybackResolver private constructor(private val context: Context) {
         val bestAudio = selectAudioStream(info.audioStreams, preferMp4Audio = false)?.content
         val muxedCandidates = info.videoStreams
             .filter { it.isUrl && it.content.isNotBlank() && streamStillFresh(it.content) }
-            .ifEmpty { info.videoStreams.filter { it.isUrl && it.content.isNotBlank() } }
             .map(::extractorVideoCandidate)
         val videoOnlyCandidates = info.videoOnlyStreams
             .filter { it.isUrl && it.content.isNotBlank() && streamStillFresh(it.content) }
-            .ifEmpty { info.videoOnlyStreams.filter { it.isUrl && it.content.isNotBlank() } }
             .map(::extractorVideoCandidate)
         val selection = videoSelector.select(
             muxedCandidates = muxedCandidates,

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaItemFactory.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaItemFactory.kt
@@ -9,22 +9,49 @@ import com.luc4n3x.levyra.domain.Track
 object LevyraMediaItemFactory {
     fun metadataOnly(track: Track): MediaItem {
         return MediaItem.Builder()
-            .setMediaId(track.id.ifBlank { track.videoUrl.ifBlank { "${track.artist}-${track.title}" } })
-            .setMediaMetadata(metadata(track))
+            .setMediaId(mediaId(track))
+            .setMediaMetadata(metadata(track, false))
             .build()
     }
 
-    fun build(track: Track): MediaItem {
+    fun build(track: Track, videoMode: Boolean = false): MediaItem {
+        val streamUrl = track.streamUrl
         return MediaItem.Builder()
-            .setUri(track.streamUrl)
-            .setMimeType(mimeTypeFor(track.streamUrl))
-            .setCustomCacheKey(LevyraPlaybackCacheKey.stream(track))
-            .setMediaId(track.id.ifBlank { track.videoUrl.ifBlank { "${track.artist}-${track.title}" } })
-            .setMediaMetadata(metadata(track))
+            .setUri(streamUrl)
+            .setMimeType(mimeTypeFor(streamUrl, videoMode))
+            .setCustomCacheKey(
+                if (videoMode && track.videoStreamUrl.isBlank()) {
+                    LevyraPlaybackCacheKey.video(track)
+                } else {
+                    LevyraPlaybackCacheKey.stream(track)
+                }
+            )
+            .setMediaId(mediaId(track))
+            .setMediaMetadata(metadata(track, videoMode))
             .build()
     }
 
-    private fun metadata(track: Track): MediaMetadata {
+    internal fun mimeTypeFor(url: String, videoMode: Boolean): String {
+        val clean = url.substringBefore('#').lowercase()
+        val path = clean.substringBefore('?')
+        return when {
+            path.endsWith(".m3u8") || path.contains("/hls_playlist") || path.contains("/manifest/hls") || clean.contains("mime=application%2fx-mpegurl") || clean.contains("mime=application/vnd.apple.mpegurl") || clean.contains("type=application%2fx-mpegurl") -> "application/x-mpegURL"
+            path.endsWith(".mpd") || clean.contains("mime=application%2fdash+xml") || clean.contains("mime=application/dash+xml") -> "application/dash+xml"
+            clean.contains("mime=video%2fwebm") || clean.contains("mime=video/webm") -> "video/webm"
+            clean.contains("mime=video%2fmp4") || clean.contains("mime=video/mp4") -> "video/mp4"
+            clean.contains("mime=audio%2fwebm") || clean.contains("mime=audio/webm") -> "audio/webm"
+            clean.contains("mime=audio%2fmpeg") || clean.contains("mime=audio/mpeg") -> "audio/mpeg"
+            clean.contains("mime=audio%2fmp4") || clean.contains("mime=audio/mp4") -> "audio/mp4"
+            path.endsWith(".webm") -> if (videoMode) "video/webm" else "audio/webm"
+            path.endsWith(".mp3") -> "audio/mpeg"
+            path.endsWith(".m4a") -> "audio/mp4"
+            path.endsWith(".mp4") -> if (videoMode) "video/mp4" else "audio/mp4"
+            videoMode -> "video/mp4"
+            else -> "audio/mp4"
+        }
+    }
+
+    private fun metadata(track: Track, videoMode: Boolean): MediaMetadata {
         val art = track.largeThumbnailUrl.ifBlank { track.thumbnailUrl }
         val extras = Bundle().apply {
             putString("levyra.title", track.title)
@@ -32,9 +59,11 @@ object LevyraMediaItemFactory {
             putString("levyra.album", track.album)
             putLong("levyra.durationMs", track.durationMs.coerceAtLeast(0L))
             putString("levyra.source", track.source)
-            if (track.videoStreamUrl.isNotBlank()) {
+            putBoolean(PlaybackService.EXTRA_VIDEO_MODE, videoMode)
+            if (videoMode && track.videoStreamUrl.isNotBlank()) {
                 putString(PlaybackService.EXTRA_VIDEO_URL, track.videoStreamUrl)
                 putString(PlaybackService.EXTRA_VIDEO_CACHE_KEY, LevyraPlaybackCacheKey.video(track))
+                putString(PlaybackService.EXTRA_VIDEO_MIME_TYPE, mimeTypeFor(track.videoStreamUrl, true))
             }
         }
         return MediaMetadata.Builder()
@@ -48,16 +77,7 @@ object LevyraMediaItemFactory {
             .build()
     }
 
-    private fun mimeTypeFor(url: String): String {
-        val clean = url.substringBefore('#').lowercase()
-        val path = clean.substringBefore('?')
-        return when {
-            path.endsWith(".m3u8") || path.contains("/hls_playlist") || path.contains("/manifest/hls") || clean.contains("mime=application%2fx-mpegurl") || clean.contains("mime=application/vnd.apple.mpegurl") || clean.contains("type=application%2fx-mpegurl") -> "application/x-mpegURL"
-            path.endsWith(".mpd") -> "application/dash+xml"
-            path.endsWith(".webm") || clean.contains("mime=audio%2fwebm") || clean.contains("mime=audio/webm") -> "audio/webm"
-            path.endsWith(".mp3") || clean.contains("mime=audio%2fmpeg") || clean.contains("mime=audio/mpeg") -> "audio/mpeg"
-            path.endsWith(".m4a") || path.endsWith(".mp4") || clean.contains("mime=audio%2fmp4") || clean.contains("mime=audio/mp4") -> "audio/mp4"
-            else -> "audio/mp4"
-        }
+    private fun mediaId(track: Track): String {
+        return track.id.ifBlank { track.videoUrl.ifBlank { "${track.artist}-${track.title}" } }
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraPipBridge.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraPipBridge.kt
@@ -1,0 +1,51 @@
+package com.luc4n3x.levyra.player
+
+object LevyraPipBridge {
+    data class State(
+        val videoMode: Boolean = false,
+        val playing: Boolean = false,
+        val aspectRatio: Float = 16f / 9f,
+        val inPictureInPicture: Boolean = false
+    ) {
+        val canEnter: Boolean
+            get() = videoMode && !inPictureInPicture
+    }
+
+    @Volatile
+    private var state = State()
+
+    @Volatile
+    private var enterAction: (() -> Boolean)? = null
+
+    @Volatile
+    private var updateAction: ((State) -> Unit)? = null
+
+    fun bind(enter: () -> Boolean, update: (State) -> Unit) {
+        enterAction = enter
+        updateAction = update
+        update(state)
+    }
+
+    fun unbind() {
+        enterAction = null
+        updateAction = null
+    }
+
+    fun updatePlayback(videoMode: Boolean, playing: Boolean, aspectRatio: Float) {
+        val safeAspect = aspectRatio.takeIf { it.isFinite() && it in 0.42f..2.39f } ?: 16f / 9f
+        state = state.copy(videoMode = videoMode, playing = playing, aspectRatio = safeAspect)
+        updateAction?.invoke(state)
+    }
+
+    fun updatePictureInPictureMode(active: Boolean) {
+        state = state.copy(inPictureInPicture = active)
+        updateAction?.invoke(state)
+    }
+
+    fun current(): State = state
+
+    fun enter(): Boolean {
+        if (!state.canEnter) return false
+        return enterAction?.invoke() == true
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
@@ -5,19 +5,28 @@ import android.content.Context
 import androidx.core.content.ContextCompat
 import androidx.media3.common.C
 import androidx.media3.common.PlaybackException
-import androidx.media3.common.Player
 import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.HttpDataSource
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
-import com.luc4n3x.levyra.domain.Track
 import com.luc4n3x.levyra.domain.LevyraAudioSettings
-import androidx.media3.common.util.UnstableApi
-import kotlinx.coroutines.*
+import com.luc4n3x.levyra.domain.Track
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 
 @OptIn(UnstableApi::class)
 class LevyraPlayer(context: Context) {
     var onCompletion: (() -> Unit)? = null
     var onError: ((String) -> Unit)? = null
+    var onRecoverableStreamError: ((Track, Long, Boolean, String) -> Unit)? = null
 
     var controller: MediaController? = null
     private val controllerFuture = MediaController.Builder(
@@ -25,12 +34,15 @@ class LevyraPlayer(context: Context) {
         SessionToken(context, ComponentName(context, PlaybackService::class.java))
     ).buildAsync()
 
-    private var loadedTrackId: String? = null
-    private var loadedStreamUrl: String? = null
-    private var pendingPlay: Track? = null
+    private var loadedTrack: Track? = null
+    private var loadedStreamIdentity: String? = null
+    private var loadedVideoMode = false
+    private var pendingPlayback: PendingPlayback? = null
     private var ignoreEndedFromManualStop = false
+    private var recoveryInFlight = false
+    private var recoveryAttempts = 0
+    private var recoveryResetJob: Job? = null
     private var audioSettings = LevyraAudioSettings()
-    
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var sponsorJob: Job? = null
 
@@ -43,8 +55,15 @@ class LevyraPlayer(context: Context) {
             controller = connected
             connected.addListener(object : Player.Listener {
                 override fun onPlaybackStateChanged(playbackState: Int) {
+                    if (playbackState == Player.STATE_READY) {
+                        recoveryResetJob?.cancel()
+                        recoveryResetJob = scope.launch {
+                            delay(5_000L)
+                            if (connected.playbackState == Player.STATE_READY) recoveryAttempts = 0
+                        }
+                    }
                     if (playbackState != Player.STATE_ENDED) return
-                    if (ignoreEndedFromManualStop || loadedTrackId == null || loadedStreamUrl == null || connected.mediaItemCount == 0) {
+                    if (ignoreEndedFromManualStop || loadedTrack == null || loadedStreamIdentity == null || connected.mediaItemCount == 0) {
                         ignoreEndedFromManualStop = false
                         return
                     }
@@ -52,23 +71,40 @@ class LevyraPlayer(context: Context) {
                 }
 
                 override fun onPlayerError(error: PlaybackException) {
-                    if (ignoreEndedFromManualStop || loadedTrackId == null || loadedStreamUrl == null || connected.mediaItemCount == 0) return
+                    if (ignoreEndedFromManualStop || connected.mediaItemCount == 0) return
+                    val track = loadedTrack ?: return
+                    val message = cleanError(error)
+                    if (isRecoverable(error) && !recoveryInFlight && recoveryAttempts < 3 && onRecoverableStreamError != null) {
+                        recoveryInFlight = true
+                        recoveryAttempts++
+                        connected.pause()
+                        onRecoverableStreamError?.invoke(track, connected.currentPosition.coerceAtLeast(0L), loadedVideoMode, message)
+                        return
+                    }
+                    clearLoadedState()
                     connected.pause()
-                    loadedTrackId = null
-                    loadedStreamUrl = null
-                    onError?.invoke(cleanError(error))
+                    onError?.invoke(message)
                 }
             })
-            pendingPlay?.let { play(it) }
-            pendingPlay = null
+            pendingPlayback?.let { pending ->
+                replaceSource(
+                    track = pending.track,
+                    positionMs = pending.positionMs,
+                    videoMode = pending.videoMode,
+                    playWhenReady = pending.playWhenReady
+                )
+            }
+            pendingPlayback = null
         }, ContextCompat.getMainExecutor(context))
     }
 
     val isPlaying: Boolean
-        get() = controller?.let { it.isPlaying || (it.playWhenReady && it.playbackState == Player.STATE_BUFFERING) } ?: (pendingPlay != null)
+        get() = controller?.let { it.isPlaying || it.playWhenReady && it.playbackState == Player.STATE_BUFFERING }
+            ?: pendingPlayback?.playWhenReady
+            ?: false
 
     val positionMs: Long
-        get() = controller?.currentPosition?.coerceAtLeast(0L) ?: 0L
+        get() = controller?.currentPosition?.coerceAtLeast(0L) ?: pendingPlayback?.positionMs ?: 0L
 
     val durationMs: Long
         get() {
@@ -76,48 +112,63 @@ class LevyraPlayer(context: Context) {
             return if (duration == C.TIME_UNSET) 0L else duration.coerceAtLeast(0L)
         }
 
-
-    fun play(track: Track) {
+    fun play(track: Track, videoMode: Boolean = false) {
         require(track.streamUrl.isNotBlank()) { "Stream URL assente per ${track.title}" }
+        val identity = streamIdentity(track, videoMode)
         val active = controller
         if (active == null) {
-            pendingPlay = track
+            pendingPlayback = PendingPlayback(track, 0L, videoMode, true)
             return
         }
         ignoreEndedFromManualStop = false
-        active.playWhenReady = true
+        recoveryInFlight = false
+        recoveryAttempts = 0
         applyPlaybackParameters(active)
-        if (loadedTrackId != track.id || loadedStreamUrl != track.streamUrl) {
-            loadedTrackId = track.id
-            loadedStreamUrl = track.streamUrl
-            PlaybackService.consumePreparedQueueNext(track.id)
-            active.setMediaItem(LevyraMediaItemFactory.build(track))
-            active.prepare()
+        if (loadedTrack?.id != track.id || loadedStreamIdentity != identity || loadedVideoMode != videoMode) {
+            replaceSource(track, 0L, videoMode, true)
+            return
         }
+        active.playWhenReady = true
         active.play()
         startSponsorBlockMonitor(track)
     }
 
-    private fun startSponsorBlockMonitor(track: Track) {
-        sponsorJob?.cancel()
-        if (track.sponsorSegments.isEmpty()) return
-        sponsorJob = scope.launch {
-            while (isActive) {
-                if (isPlaying) {
-                    val current = positionMs
-                    for (segment in track.sponsorSegments) {
-                        if (current >= segment.startMs && current < segment.endMs) {
-                            seekTo(segment.endMs)
-                            break
-                        }
-                    }
-                }
-                delay(500)
-            }
+    fun replaceSource(
+        track: Track,
+        positionMs: Long,
+        videoMode: Boolean,
+        playWhenReady: Boolean
+    ) {
+        require(track.streamUrl.isNotBlank()) { "Stream URL assente per ${track.title}" }
+        val active = controller
+        if (active == null) {
+            pendingPlayback = PendingPlayback(track, positionMs.coerceAtLeast(0L), videoMode, playWhenReady)
+            return
         }
+        ignoreEndedFromManualStop = false
+        val recoveryReplacement = recoveryInFlight
+        recoveryInFlight = false
+        if (!recoveryReplacement) recoveryAttempts = 0
+        loadedTrack = track
+        loadedStreamIdentity = streamIdentity(track, videoMode)
+        loadedVideoMode = videoMode
+        PlaybackService.consumePreparedQueueNext(track.id)
+        applyPlaybackParameters(active)
+        active.playWhenReady = playWhenReady
+        active.setMediaItem(LevyraMediaItemFactory.build(track, videoMode), positionMs.coerceAtLeast(0L))
+        active.prepare()
+        if (playWhenReady) active.play() else active.pause()
+        startSponsorBlockMonitor(track)
     }
 
-
+    fun failRecovery(message: String) {
+        recoveryInFlight = false
+        recoveryAttempts = 0
+        recoveryResetJob?.cancel()
+        clearLoadedState()
+        controller?.pause()
+        onError?.invoke(message)
+    }
 
     fun pause() {
         controller?.pause()
@@ -125,9 +176,11 @@ class LevyraPlayer(context: Context) {
 
     fun stop() {
         ignoreEndedFromManualStop = true
-        loadedTrackId = null
-        loadedStreamUrl = null
-        pendingPlay = null
+        recoveryInFlight = false
+        recoveryAttempts = 0
+        recoveryResetJob?.cancel()
+        clearLoadedState()
+        pendingPlayback = null
         sponsorJob?.cancel()
         controller?.let {
             it.pause()
@@ -144,7 +197,10 @@ class LevyraPlayer(context: Context) {
     }
 
     fun setPlayback(speed: Float, pitch: Float) {
-        audioSettings = audioSettings.copy(playbackSpeed = speed.coerceIn(0.5f, 2f), pitch = pitch.coerceIn(0.5f, 2f)).normalized()
+        audioSettings = audioSettings.copy(
+            playbackSpeed = speed.coerceIn(0.5f, 2f),
+            pitch = pitch.coerceIn(0.5f, 2f)
+        ).normalized()
         controller?.let { applyPlaybackParameters(it) }
     }
 
@@ -176,25 +232,84 @@ class LevyraPlayer(context: Context) {
         }
     }
 
-    private fun applyPlaybackParameters(active: Player) {
-        active.setPlaybackParameters(PlaybackParameters(audioSettings.playbackSpeed, audioSettings.pitch))
-    }
-
     fun setRepeatOne(one: Boolean) {
         controller?.repeatMode = if (one) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
     }
 
     fun release() {
         sponsorJob?.cancel()
+        recoveryResetJob?.cancel()
         scope.cancel()
         controller?.release()
         controller = null
         MediaController.releaseFuture(controllerFuture)
     }
 
-    private fun cleanError(error: PlaybackException): String {
-        var cause: Throwable? = error
-        while (cause?.cause != null && cause.cause != cause) cause = cause.cause
-        return cause?.message?.takeIf { it.isNotBlank() } ?: error.message ?: "Riproduzione non riuscita"
+    private fun startSponsorBlockMonitor(track: Track) {
+        sponsorJob?.cancel()
+        if (track.sponsorSegments.isEmpty()) return
+        sponsorJob = scope.launch {
+            while (isActive) {
+                if (isPlaying) {
+                    val current = positionMs
+                    track.sponsorSegments.firstOrNull { current >= it.startMs && current < it.endMs }?.let {
+                        seekTo(it.endMs)
+                    }
+                }
+                delay(500L)
+            }
+        }
     }
+
+    private fun applyPlaybackParameters(active: Player) {
+        active.setPlaybackParameters(PlaybackParameters(audioSettings.playbackSpeed, audioSettings.pitch))
+    }
+
+    private fun clearLoadedState() {
+        loadedTrack = null
+        loadedStreamIdentity = null
+        loadedVideoMode = false
+    }
+
+    private fun streamIdentity(track: Track, videoMode: Boolean): String {
+        return buildString {
+            append(track.streamUrl)
+            append('|')
+            append(track.videoStreamUrl)
+            append('|')
+            append(videoMode)
+        }
+    }
+
+    private fun isRecoverable(error: PlaybackException): Boolean {
+        var current: Throwable? = error
+        while (current != null) {
+            if (current is HttpDataSource.InvalidResponseCodeException && current.responseCode in setOf(403, 404, 410, 416, 429, 500, 502, 503, 504)) {
+                return true
+            }
+            val next = current.cause
+            if (next === current) break
+            current = next
+        }
+        return error.errorCode in 2000..2008 || error.errorCode in 4001..4005
+    }
+
+    private fun cleanError(error: PlaybackException): String {
+        var current: Throwable? = error
+        var root: Throwable = error
+        while (current != null) {
+            root = current
+            val next = current.cause
+            if (next === current) break
+            current = next
+        }
+        return root.message?.takeIf { it.isNotBlank() } ?: error.message ?: "Riproduzione non riuscita"
+    }
+
+    private data class PendingPlayback(
+        val track: Track,
+        val positionMs: Long,
+        val videoMode: Boolean,
+        val playWhenReady: Boolean
+    )
 }

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.launch
 class LevyraPlayer(context: Context) {
     var onCompletion: (() -> Unit)? = null
     var onError: ((String) -> Unit)? = null
-    var onRecoverableStreamError: ((Track, Long, Boolean, String) -> Unit)? = null
+    var onRecoverableStreamError: ((Track, Long, Boolean, Boolean, String) -> Unit)? = null
 
     var controller: MediaController? = null
     private val controllerFuture = MediaController.Builder(
@@ -63,6 +63,8 @@ class LevyraPlayer(context: Context) {
                         }
                     }
                     if (playbackState != Player.STATE_ENDED) return
+                    sponsorJob?.cancel()
+                    sponsorJob = null
                     if (ignoreEndedFromManualStop || loadedTrack == null || loadedStreamIdentity == null || connected.mediaItemCount == 0) {
                         ignoreEndedFromManualStop = false
                         return
@@ -77,10 +79,21 @@ class LevyraPlayer(context: Context) {
                     if (isRecoverable(error) && !recoveryInFlight && recoveryAttempts < 3 && onRecoverableStreamError != null) {
                         recoveryInFlight = true
                         recoveryAttempts++
+                        val playWhenReadyBeforeError = connected.playWhenReady
+                        sponsorJob?.cancel()
+                        sponsorJob = null
                         connected.pause()
-                        onRecoverableStreamError?.invoke(track, connected.currentPosition.coerceAtLeast(0L), loadedVideoMode, message)
+                        onRecoverableStreamError?.invoke(
+                            track,
+                            connected.currentPosition.coerceAtLeast(0L),
+                            loadedVideoMode,
+                            playWhenReadyBeforeError,
+                            message
+                        )
                         return
                     }
+                    sponsorJob?.cancel()
+                    sponsorJob = null
                     clearLoadedState()
                     connected.pause()
                     onError?.invoke(message)
@@ -165,6 +178,8 @@ class LevyraPlayer(context: Context) {
         recoveryInFlight = false
         recoveryAttempts = 0
         recoveryResetJob?.cancel()
+        sponsorJob?.cancel()
+        sponsorJob = null
         clearLoadedState()
         controller?.pause()
         onError?.invoke(message)
@@ -179,9 +194,10 @@ class LevyraPlayer(context: Context) {
         recoveryInFlight = false
         recoveryAttempts = 0
         recoveryResetJob?.cancel()
+        sponsorJob?.cancel()
+        sponsorJob = null
         clearLoadedState()
         pendingPlayback = null
-        sponsorJob?.cancel()
         controller?.let {
             it.pause()
             it.clearMediaItems()
@@ -238,6 +254,7 @@ class LevyraPlayer(context: Context) {
 
     fun release() {
         sponsorJob?.cancel()
+        sponsorJob = null
         recoveryResetJob?.cancel()
         scope.cancel()
         controller?.release()

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraYoutubeDataSource.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraYoutubeDataSource.kt
@@ -1,0 +1,110 @@
+package com.luc4n3x.levyra.player
+
+import android.net.Uri
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.HttpDataSource
+import androidx.media3.datasource.TransferListener
+import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper
+import java.util.concurrent.atomic.AtomicLong
+
+@UnstableApi
+class LevyraYoutubeDataSource private constructor(
+    private val delegate: DataSource
+) : DataSource {
+    companion object {
+        private val requestNumber = AtomicLong(1L)
+    }
+
+    class Factory(
+        private val upstreamFactory: DataSource.Factory
+    ) : DataSource.Factory {
+        override fun createDataSource(): DataSource {
+            return LevyraYoutubeDataSource(upstreamFactory.createDataSource())
+        }
+    }
+
+    override fun addTransferListener(transferListener: TransferListener) {
+        delegate.addTransferListener(transferListener)
+    }
+
+    override fun open(dataSpec: DataSpec): Long {
+        val originalUrl = dataSpec.uri.toString()
+        if (!isYoutubeMediaUrl(dataSpec.uri)) return delegate.open(dataSpec)
+        val adaptedUri = appendRequestNumber(dataSpec.uri)
+        val headers = requestHeaders(originalUrl)
+        val httpDelegate = delegate as? HttpDataSource
+        if (httpDelegate != null) {
+            httpDelegate.clearAllRequestProperties()
+            headers.forEach { (name, value) -> httpDelegate.setRequestProperty(name, value) }
+        }
+        val adaptedSpec = dataSpec
+            .withUri(adaptedUri)
+            .withAdditionalHeaders(headers.filterKeys { !it.equals("User-Agent", true) })
+        return delegate.open(adaptedSpec)
+    }
+
+    override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+        return delegate.read(buffer, offset, length)
+    }
+
+    override fun getUri(): Uri? = delegate.uri
+
+    override fun getResponseHeaders(): Map<String, List<String>> = delegate.responseHeaders
+
+    override fun close() {
+        delegate.close()
+    }
+
+    private fun appendRequestNumber(uri: Uri): Uri {
+        if (!isProgressiveGoogleVideo(uri)) return uri
+        if (!uri.getQueryParameter("rn").isNullOrBlank()) return uri
+        return uri.buildUpon()
+            .appendQueryParameter("rn", requestNumber.getAndIncrement().toString())
+            .build()
+    }
+
+    private fun requestHeaders(url: String): Map<String, String> {
+        val userAgent = when {
+            runCatching { YoutubeParsingHelper.isIosStreamingUrl(url) }.getOrDefault(false) -> YoutubeParsingHelper.getIosUserAgent(null)
+            runCatching { YoutubeParsingHelper.isAndroidStreamingUrl(url) }.getOrDefault(false) -> YoutubeParsingHelper.getAndroidUserAgent(null)
+            else -> "Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Mobile Safari/537.36"
+        }
+        val web = runCatching { YoutubeParsingHelper.isWebStreamingUrl(url) }.getOrDefault(false)
+        val embedded = runCatching { YoutubeParsingHelper.isTvHtml5SimplyEmbeddedPlayerStreamingUrl(url) }.getOrDefault(false)
+        return linkedMapOf(
+            "User-Agent" to userAgent,
+            "Accept" to "*/*",
+            "Accept-Encoding" to "identity",
+            "Connection" to "keep-alive",
+            "TE" to "trailers"
+        ).apply {
+            if (web || embedded) {
+                put("Origin", "https://www.youtube.com")
+                put("Referer", if (embedded) "https://www.youtube.com/embed/" else "https://www.youtube.com/")
+                put("Sec-Fetch-Dest", "empty")
+                put("Sec-Fetch-Mode", "cors")
+                put("Sec-Fetch-Site", "cross-site")
+            }
+        }
+    }
+
+    private fun isYoutubeMediaUrl(uri: Uri): Boolean {
+        val host = uri.host.orEmpty().lowercase()
+        return host.endsWith("googlevideo.com") ||
+            host.endsWith("youtube.com") ||
+            host.endsWith("youtube-nocookie.com") ||
+            host.endsWith("ytimg.com")
+    }
+
+    private fun isProgressiveGoogleVideo(uri: Uri): Boolean {
+        val host = uri.host.orEmpty().lowercase()
+        val path = uri.path.orEmpty().lowercase()
+        if (!host.endsWith("googlevideo.com")) return false
+        if (!path.contains("videoplayback")) return false
+        if (uri.getQueryParameter("sq") != null) return false
+        if (path.endsWith(".m3u8") || path.endsWith(".mpd")) return false
+        return true
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -20,6 +20,7 @@ import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.audio.DefaultAudioSink
+import androidx.media3.exoplayer.dash.DashMediaSource
 import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MediaSource
@@ -72,6 +73,8 @@ class PlaybackService : MediaLibraryService() {
     companion object {
         const val EXTRA_VIDEO_URL = "levyra.videoUrl"
         const val EXTRA_VIDEO_CACHE_KEY = "levyra.videoCacheKey"
+        const val EXTRA_VIDEO_MIME_TYPE = "levyra.videoMimeType"
+        const val EXTRA_VIDEO_MODE = "levyra.videoMode"
         private const val ACTION_QUEUE_PREVIOUS = "levyra.queue.previous"
         private const val ACTION_QUEUE_NEXT = "levyra.queue.next"
 
@@ -131,7 +134,7 @@ class PlaybackService : MediaLibraryService() {
             .setPrioritizeTimeOverSizeThresholds(true)
             .build()
         val okHttpClient = LevyraHttpClientFactory.media(this)
-        val upstreamFactory = OkHttpDataSource.Factory(okHttpClient)
+        val baseHttpFactory = OkHttpDataSource.Factory(okHttpClient)
             .setUserAgent("LevyraPlayer/1.13 Android Music")
             .setDefaultRequestProperties(
                 mapOf(
@@ -140,6 +143,7 @@ class PlaybackService : MediaLibraryService() {
                     "Connection" to "keep-alive"
                 )
             )
+        val upstreamFactory = LevyraYoutubeDataSource.Factory(baseHttpFactory)
         val cache = LevyraMediaCache.get(this)
         val cacheSinkFactory = CacheDataSink.Factory()
             .setCache(cache)
@@ -170,6 +174,7 @@ class PlaybackService : MediaLibraryService() {
                     .build()
             }
         }
+        renderersFactory.setEnableDecoderFallback(true)
 
         val player = ExoPlayer.Builder(this)
             .setLoadControl(loadControl)
@@ -597,11 +602,16 @@ private class LevyraMediaSourceFactory(
 
         val videoCacheKey = mediaItem.mediaMetadata.extras?.getString(PlaybackService.EXTRA_VIDEO_CACHE_KEY)
             ?: mediaItem.requestMetadata.extras?.getString(PlaybackService.EXTRA_VIDEO_CACHE_KEY)
+        val videoMimeType = mediaItem.mediaMetadata.extras?.getString(PlaybackService.EXTRA_VIDEO_MIME_TYPE)
+            ?: mediaItem.requestMetadata.extras?.getString(PlaybackService.EXTRA_VIDEO_MIME_TYPE)
 
         val audioSource = mediaSourceFor(mediaItem)
         val videoItem = MediaItem.Builder()
             .setUri(videoUrl)
-            .apply { if (!videoCacheKey.isNullOrBlank()) setCustomCacheKey(videoCacheKey) }
+            .apply {
+                if (!videoCacheKey.isNullOrBlank()) setCustomCacheKey(videoCacheKey)
+                if (!videoMimeType.isNullOrBlank()) setMimeType(videoMimeType)
+            }
             .build()
         val videoSource = mediaSourceFor(videoItem)
 
@@ -616,10 +626,10 @@ private class LevyraMediaSourceFactory(
             return ProgressiveMediaSource.Factory(localDataSourceFactory).createMediaSource(localItem)
         }
         val uri = localUri?.toString().orEmpty()
-        return if (isHlsManifestUri(uri)) {
-            HlsMediaSource.Factory(dataSourceFactory).createMediaSource(mediaItem)
-        } else {
-            ProgressiveMediaSource.Factory(dataSourceFactory).createMediaSource(mediaItem)
+        return when {
+            isHlsManifestUri(uri) -> HlsMediaSource.Factory(dataSourceFactory).createMediaSource(mediaItem)
+            isDashManifestUri(uri) -> DashMediaSource.Factory(dataSourceFactory).createMediaSource(mediaItem)
+            else -> ProgressiveMediaSource.Factory(dataSourceFactory).createMediaSource(mediaItem)
         }
     }
 
@@ -632,5 +642,13 @@ private class LevyraMediaSourceFactory(
             clean.contains("mime=application%2fx-mpegurl") ||
             clean.contains("mime=application/vnd.apple.mpegurl") ||
             clean.contains("type=application%2fx-mpegurl")
+    }
+
+    private fun isDashManifestUri(uri: String): Boolean {
+        val clean = uri.substringBefore('#').lowercase()
+        val path = clean.substringBefore('?')
+        return path.endsWith(".mpd") ||
+            clean.contains("mime=application%2fdash+xml") ||
+            clean.contains("mime=application/dash+xml")
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -121,6 +121,7 @@ import androidx.compose.material.icons.rounded.Verified
 import androidx.compose.material.icons.rounded.KeyboardArrowDown
 import androidx.compose.material.icons.rounded.KeyboardArrowRight
 import androidx.compose.material.icons.rounded.Videocam
+import androidx.compose.material.icons.rounded.PictureInPictureAlt
 import androidx.compose.material.icons.rounded.Notifications
 import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.Insights
@@ -150,6 +151,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -180,6 +182,9 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+import androidx.media3.common.Player
+import androidx.media3.common.VideoSize
+import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -197,6 +202,8 @@ import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.luc4n3x.levyra.data.LevyraArtworkCache
+import com.luc4n3x.levyra.player.LevyraPipBridge
+import com.luc4n3x.levyra.player.PlaybackService
 import com.luc4n3x.levyra.domain.AppUpdateInfo
 import com.luc4n3x.levyra.domain.ArtistProfile
 import com.luc4n3x.levyra.domain.AlbumHit
@@ -693,8 +700,20 @@ private fun Modifier.pressable(
 }
 
 @Composable
-fun LevyraApp(viewModel: LevyraViewModel) {
+fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false) {
     val state by viewModel.state.collectAsState()
+    LaunchedEffect(state.isVideoMode, state.isPlaying) {
+        val currentPipState = LevyraPipBridge.current()
+        LevyraPipBridge.updatePlayback(
+            videoMode = state.isVideoMode,
+            playing = state.isPlaying,
+            aspectRatio = currentPipState.aspectRatio
+        )
+    }
+    if (isInPictureInPicture) {
+        LevyraPictureInPictureSurface(state)
+        return
+    }
     val toastContext = LocalContext.current
     val activity = toastContext as? Activity
     var showLanguageRestartDialog by remember { mutableStateOf(false) }
@@ -6660,6 +6679,18 @@ private fun PlayerScreen(viewModel: LevyraViewModel, state: LevyraUiState) {
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
+                        if (state.isVideoMode) {
+                            PlayerRoundIconButton(
+                                icon = Icons.Rounded.PictureInPictureAlt,
+                                contentDescription = "Picture in Picture",
+                                size = 42.dp,
+                                iconSize = 21.dp,
+                                tint = LevyraText,
+                                background = Color.White.copy(alpha = 0.075f),
+                                borderColor = LevyraCyan.copy(alpha = 0.18f),
+                                onClick = { LevyraPipBridge.enter() }
+                            )
+                        }
                         PlayerRoundIconButton(
                             icon = Icons.Rounded.Close,
                             contentDescription = "Chiudi player",
@@ -6690,55 +6721,19 @@ private fun PlayerScreen(viewModel: LevyraViewModel, state: LevyraUiState) {
             } else {
                 item {
                     if (state.isVideoMode && track.videoUrl.isNotBlank()) {
-                        val exo = com.luc4n3x.levyra.player.PlaybackService.activePlayer
-                        if (exo != null) {
-                            AndroidView(
-                                factory = { ctx ->
-                                    androidx.media3.ui.PlayerView(ctx).apply {
-                                        useController = false
-                                        setShowBuffering(androidx.media3.ui.PlayerView.SHOW_BUFFERING_ALWAYS)
-                                        setBackgroundColor(android.graphics.Color.BLACK)
-                                        player = exo
-                                    }
-                                },
-                                update = { view ->
-                                    val current = com.luc4n3x.levyra.player.PlaybackService.activePlayer
-                                    if (view.player !== current) view.player = current
-                                },
-                                onRelease = { view ->
-                                    view.player = null
-                                },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .aspectRatio(1f)
-                                    .padding(vertical = 16.dp)
-                                    .graphicsLayer {
-                                        scaleX = artScale
-                                        scaleY = artScale
-                                        shadowElevation = artShadow
-                                        shape = RoundedCornerShape(artCorner)
-                                        clip = true
-                                    }
-                            )
-                        } else {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .aspectRatio(1f)
-                                    .padding(vertical = 16.dp)
-                                    .graphicsLayer {
-                                        scaleX = artScale
-                                        scaleY = artScale
-                                        shadowElevation = artShadow
-                                        shape = RoundedCornerShape(artCorner)
-                                        clip = true
-                                    }
-                                    .background(Color.Black),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                VideoLoadingSkeleton()
-                            }
-                        }
+                        LevyraVideoSurface(
+                            state = state,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 16.dp)
+                                .graphicsLayer {
+                                    scaleX = artScale
+                                    scaleY = artScale
+                                    shadowElevation = artShadow
+                                    shape = RoundedCornerShape(artCorner)
+                                    clip = true
+                                }
+                        )
                     } else {
                         // Artwork
                         Box(
@@ -10107,6 +10102,92 @@ private fun ChartLoadingSkeleton() {
             ) {
                 repeat(4) { LoadingLine(height = 56.dp, radius = 16.dp) }
             }
+        }
+    }
+}
+
+@Composable
+private fun LevyraPictureInPictureSurface(state: LevyraUiState) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black)
+    ) {
+        LevyraVideoSurface(
+            state = state,
+            modifier = Modifier.fillMaxSize(),
+            pictureInPicture = true
+        )
+    }
+}
+
+@Composable
+private fun LevyraVideoSurface(
+    state: LevyraUiState,
+    modifier: Modifier,
+    pictureInPicture: Boolean = false
+) {
+    val player = PlaybackService.activePlayer
+    var aspectRatio by remember(player, state.currentTrack?.id) {
+        mutableFloatStateOf(
+            player?.videoSize?.let { size ->
+                if (size.width > 0 && size.height > 0) size.width.toFloat() / size.height.toFloat() else 16f / 9f
+            } ?: 16f / 9f
+        )
+    }
+    DisposableEffect(player) {
+        val listener = object : Player.Listener {
+            override fun onVideoSizeChanged(videoSize: VideoSize) {
+                if (videoSize.width > 0 && videoSize.height > 0) {
+                    aspectRatio = (videoSize.width.toFloat() / videoSize.height.toFloat()).coerceIn(0.42f, 2.39f)
+                }
+            }
+        }
+        player?.addListener(listener)
+        onDispose { player?.removeListener(listener) }
+    }
+    LaunchedEffect(state.isVideoMode, state.isPlaying, aspectRatio) {
+        LevyraPipBridge.updatePlayback(
+            videoMode = state.isVideoMode,
+            playing = state.isPlaying,
+            aspectRatio = aspectRatio
+        )
+    }
+    val surfaceModifier = if (pictureInPicture) {
+        modifier
+    } else {
+        modifier.aspectRatio(aspectRatio.coerceIn(0.56f, 2.1f))
+    }
+    Box(
+        modifier = surfaceModifier.background(Color.Black),
+        contentAlignment = Alignment.Center
+    ) {
+        if (player != null) {
+            AndroidView(
+                factory = { context ->
+                    androidx.media3.ui.PlayerView(context).apply {
+                        useController = false
+                        resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
+                        setShowBuffering(androidx.media3.ui.PlayerView.SHOW_BUFFERING_ALWAYS)
+                        setBackgroundColor(android.graphics.Color.BLACK)
+                        keepScreenOn = true
+                        this.player = player
+                    }
+                },
+                update = { view ->
+                    val active = PlaybackService.activePlayer
+                    if (view.player !== active) view.player = active
+                    view.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
+                    view.keepScreenOn = state.isPlaying
+                },
+                onRelease = { view ->
+                    view.player = null
+                    view.keepScreenOn = false
+                },
+                modifier = Modifier.fillMaxSize()
+            )
+        } else if (!pictureInPicture) {
+            VideoLoadingSkeleton()
         }
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -206,6 +206,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     )
     private var searchJob: Job? = null
     private var playJob: Job? = null
+    private var modeSwitchJob: Job? = null
+    private var streamRecoveryJob: Job? = null
+    private var alternateModePrefetchJob: Job? = null
     private var prefetchJob: Job? = null
     private var chartEnrichJob: Job? = null
     private var orbitArtworkJob: Job? = null
@@ -223,6 +226,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private var sponsorSegments: List<SponsorSegment> = emptyList()
     private val tabBackStack = ArrayDeque<LevyraTab>()
     private var playRequestId: Long = 0L
+    private var streamTransitionId: Long = 0L
     private var pendingSeekMs: Long = 0L
     private var queueIndex: Int = -1
     private var loopCurrentQueueOnCompletion: Boolean = false
@@ -368,6 +372,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         player.setPremiumAudioSettings(settings.audioSettings)
         player.setPlayback(settings.audioSettings.playbackSpeed, settings.audioSettings.pitch)
         player.onCompletion = { onTrackCompleted() }
+        player.onRecoverableStreamError = { track, positionMs, videoMode, errorMessage ->
+            recoverPlaybackStream(track, positionMs, videoMode, errorMessage)
+        }
         player.onError = { errorMsg ->
             _state.value.currentTrack?.let { resolver.invalidate(it, _state.value.isVideoMode) }
             _state.update { it.copy(playerError = cleanUserError(errorMsg), isPlaying = false, isResolving = false) }
@@ -674,27 +681,118 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     fun toggleVideoMode() {
-        val current = _state.value.isVideoMode
-        val track = _state.value.currentTrack ?: return
-        val newVideoMode = !current
-        _state.update { it.copy(isVideoMode = newVideoMode, isResolving = true) }
-        val oldPosition = player.positionMs
-        player.stop()
-        viewModelScope.launch {
+        val snapshot = _state.value
+        val track = snapshot.currentTrack ?: return
+        if (track.videoUrl.isBlank() || snapshot.isResolving) return
+        val sourceMode = snapshot.isVideoMode
+        val targetMode = !sourceMode
+        val positionMs = player.positionMs.coerceAtLeast(snapshot.positionMs)
+        val shouldPlay = player.isPlaying || snapshot.isPlaying
+        val transitionId = ++streamTransitionId
+        streamRecoveryJob?.cancel()
+        modeSwitchJob?.cancel()
+        _state.update { it.copy(isResolving = true, playerError = null) }
+        modeSwitchJob = viewModelScope.launch {
             try {
+                val baseTrack = (youtubePlayableTrack(track) ?: track).copy(streamUrl = "", videoStreamUrl = "")
                 val resolved = withContext(Dispatchers.IO) {
-                    resolver.resolve(track.copy(streamUrl = ""), newVideoMode)
+                    resolver.cached(baseTrack, targetMode) ?: resolver.resolve(baseTrack, targetMode)
                 }
-                _state.update { it.copy(currentTrack = resolved, isResolving = false, isPlaying = true) }
-                player.play(resolved)
-                if (oldPosition > 0L) {
-                    delay(300)
-                    player.seekTo(oldPosition)
+                if (!isActive || transitionId != streamTransitionId) return@launch
+                val currentIndex = queueEngine.state.value.currentIndex
+                if (currentIndex >= 0) queueEngine.updateTrackAt(currentIndex, resolved)
+                repository.replace(resolved)
+                player.replaceSource(
+                    track = resolved,
+                    positionMs = positionMs,
+                    videoMode = targetMode,
+                    playWhenReady = shouldPlay
+                )
+                queueEngine.updatePosition(positionMs)
+                _state.update {
+                    it.copy(
+                        currentTrack = resolved,
+                        isVideoMode = targetMode,
+                        isResolving = false,
+                        isPlaying = shouldPlay,
+                        positionMs = positionMs,
+                        durationMs = resolved.durationMs.takeIf { duration -> duration > 0L } ?: it.durationMs,
+                        playerError = null
+                    )
                 }
-            } catch (e: Exception) {
-                if (e is CancellationException) throw e
-                _state.update { it.copy(isResolving = false, isVideoMode = current, playerError = cleanUserError(e)) }
+                prefetchAlternateMode(resolved, targetMode)
+                updateWidget()
+            } catch (error: Throwable) {
+                if (error is CancellationException) throw error
+                if (transitionId != streamTransitionId) return@launch
+                _state.update {
+                    it.copy(
+                        isVideoMode = sourceMode,
+                        isResolving = false,
+                        isPlaying = player.isPlaying || snapshot.isPlaying,
+                        playerError = cleanUserError(error)
+                    )
+                }
             }
+        }
+    }
+
+    private fun recoverPlaybackStream(
+        failedTrack: Track,
+        positionMs: Long,
+        videoMode: Boolean,
+        errorMessage: String
+    ) {
+        val transitionId = ++streamTransitionId
+        modeSwitchJob?.cancel()
+        streamRecoveryJob?.cancel()
+        resolver.reportPlaybackFailure(failedTrack, videoMode, errorMessage)
+        _state.update { it.copy(isResolving = true, isPlaying = false, playerError = null) }
+        streamRecoveryJob = viewModelScope.launch {
+            try {
+                val baseTrack = (youtubePlayableTrack(failedTrack) ?: failedTrack).copy(streamUrl = "", videoStreamUrl = "")
+                val resolved = withContext(Dispatchers.IO) { resolver.resolve(baseTrack, videoMode) }
+                if (!isActive || transitionId != streamTransitionId) return@launch
+                val currentIndex = queueEngine.state.value.currentIndex
+                if (currentIndex >= 0) queueEngine.updateTrackAt(currentIndex, resolved)
+                repository.replace(resolved)
+                player.replaceSource(
+                    track = resolved,
+                    positionMs = positionMs,
+                    videoMode = videoMode,
+                    playWhenReady = true
+                )
+                queueEngine.updatePosition(positionMs)
+                _state.update {
+                    it.copy(
+                        currentTrack = resolved,
+                        isVideoMode = videoMode,
+                        isResolving = false,
+                        isPlaying = true,
+                        positionMs = positionMs,
+                        durationMs = resolved.durationMs.takeIf { duration -> duration > 0L } ?: it.durationMs,
+                        playerError = null
+                    )
+                }
+                prefetchAlternateMode(resolved, videoMode)
+                updateWidget()
+            } catch (error: Throwable) {
+                if (error is CancellationException) throw error
+                if (transitionId != streamTransitionId) return@launch
+                val message = cleanUserError(error)
+                player.failRecovery(message)
+                _state.update { it.copy(isResolving = false, isPlaying = false, playerError = message) }
+            }
+        }
+    }
+
+    private fun prefetchAlternateMode(track: Track, activeVideoMode: Boolean) {
+        alternateModePrefetchJob?.cancel()
+        if (track.id.isBlank() || track.videoUrl.isBlank() || track.source.equals("Offline", true)) return
+        alternateModePrefetchJob = viewModelScope.launch(Dispatchers.IO) {
+            delay(350L)
+            val cleanTrack = (youtubePlayableTrack(track) ?: track).copy(streamUrl = "", videoStreamUrl = "")
+            resolver.prefetch(cleanTrack, !activeVideoMode)
         }
     }
 
@@ -1877,6 +1975,10 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     private fun startResolve(track: Track, preserveCrossfade: Boolean = false) {
+        streamTransitionId++
+        modeSwitchJob?.cancel()
+        streamRecoveryJob?.cancel()
+        alternateModePrefetchJob?.cancel()
         if (!preserveCrossfade) {
             crossfadeJob?.cancel()
             crossfadeInProgress = false
@@ -2027,7 +2129,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         val selectedIndex = queueEngine.state.value.currentIndex
         if (selectedIndex >= 0) queueEngine.updateTrackAt(selectedIndex, playable)
         repository.replace(playable)
-        player.play(playable)
+        player.play(playable, _state.value.isVideoMode)
         // Resume from the saved position when continuing the last session's track.
         val resumeMs = pendingSeekMs.takeIf { it > 1500L && it < playable.durationMs } ?: 0L
         if (resumeMs > 0L) player.seekTo(resumeMs)
@@ -2053,6 +2155,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         recordSmartPlayback(playable)
         fetchLyrics(playable)
         fetchSponsorSegments(playable)
+        prefetchAlternateMode(playable, _state.value.isVideoMode)
         updateWidget()
     }
 
@@ -2291,7 +2394,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private fun playbackIdentity(track: Track): String = youtubePlayableTrack(track)?.id?.takeIf { it.isNotBlank() }
         ?: track.id.ifBlank { track.videoUrl.ifBlank { "${track.artist}|${track.title}" } }.trim().lowercase()
 
-    fun play() = _state.value.currentTrack?.let { player.play(it) }
+    fun play() = _state.value.currentTrack?.let { current ->
+        if (current.streamUrl.isBlank()) play(current) else player.play(current, _state.value.isVideoMode)
+    }
     fun pause() = player.pause()
 
     fun togglePlay() {
@@ -2305,7 +2410,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             saveLastPlaybackAsync(current, player.positionMs)
             _state.update { it.copy(isPlaying = false) }
         } else {
-            player.play(current)
+            player.play(current, _state.value.isVideoMode)
             _state.update { it.copy(isPlaying = true) }
         }
         updateWidget()
@@ -2313,6 +2418,10 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     fun closePlayer() {
         loopCurrentQueueOnCompletion = false
+        streamTransitionId++
+        modeSwitchJob?.cancel()
+        streamRecoveryJob?.cancel()
+        alternateModePrefetchJob?.cancel()
         player.stop()
         _state.update {
             it.copy(
@@ -2781,6 +2890,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         _state.value.currentTrack?.let { preferences.saveLastPlayback(it, player.positionMs) }
         flushListenSessionBlocking()
         playJob?.cancel()
+        modeSwitchJob?.cancel()
+        streamRecoveryJob?.cancel()
+        alternateModePrefetchJob?.cancel()
         cancelBackgroundWarmups()
         chartEnrichJob?.cancel()
         sleepJob?.cancel()

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -372,8 +372,8 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         player.setPremiumAudioSettings(settings.audioSettings)
         player.setPlayback(settings.audioSettings.playbackSpeed, settings.audioSettings.pitch)
         player.onCompletion = { onTrackCompleted() }
-        player.onRecoverableStreamError = { track, positionMs, videoMode, errorMessage ->
-            recoverPlaybackStream(track, positionMs, videoMode, errorMessage)
+        player.onRecoverableStreamError = { track, positionMs, videoMode, playWhenReady, errorMessage ->
+            recoverPlaybackStream(track, positionMs, videoMode, playWhenReady, errorMessage)
         }
         player.onError = { errorMsg ->
             _state.value.currentTrack?.let { resolver.invalidate(it, _state.value.isVideoMode) }
@@ -686,7 +686,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         if (track.videoUrl.isBlank() || snapshot.isResolving) return
         val sourceMode = snapshot.isVideoMode
         val targetMode = !sourceMode
-        val positionMs = player.positionMs.coerceAtLeast(snapshot.positionMs)
+        val positionMs = player.positionMs.coerceAtLeast(0L)
         val shouldPlay = player.isPlaying || snapshot.isPlaying
         val transitionId = ++streamTransitionId
         streamRecoveryJob?.cancel()
@@ -741,13 +741,14 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         failedTrack: Track,
         positionMs: Long,
         videoMode: Boolean,
+        playWhenReady: Boolean,
         errorMessage: String
     ) {
         val transitionId = ++streamTransitionId
         modeSwitchJob?.cancel()
         streamRecoveryJob?.cancel()
         resolver.reportPlaybackFailure(failedTrack, videoMode, errorMessage)
-        _state.update { it.copy(isResolving = true, isPlaying = false, playerError = null) }
+        _state.update { it.copy(isResolving = true, isPlaying = playWhenReady, playerError = null) }
         streamRecoveryJob = viewModelScope.launch {
             try {
                 val baseTrack = (youtubePlayableTrack(failedTrack) ?: failedTrack).copy(streamUrl = "", videoStreamUrl = "")
@@ -760,7 +761,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                     track = resolved,
                     positionMs = positionMs,
                     videoMode = videoMode,
-                    playWhenReady = true
+                    playWhenReady = playWhenReady
                 )
                 queueEngine.updatePosition(positionMs)
                 _state.update {
@@ -768,7 +769,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                         currentTrack = resolved,
                         isVideoMode = videoMode,
                         isResolving = false,
-                        isPlaying = true,
+                        isPlaying = playWhenReady,
                         positionMs = positionMs,
                         durationMs = resolved.durationMs.takeIf { duration -> duration > 0L } ?: it.durationMs,
                         playerError = null

--- a/app/src/test/java/com/luc4n3x/levyra/player/LevyraMediaItemFactoryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/LevyraMediaItemFactoryTest.kt
@@ -1,0 +1,20 @@
+package com.luc4n3x.levyra.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LevyraMediaItemFactoryTest {
+    @Test
+    fun detectsHlsAcrossSupportedUrlForms() {
+        assertEquals("application/x-mpegURL", LevyraMediaItemFactory.mimeTypeFor("https://example.com/live.m3u8", true))
+        assertEquals("application/x-mpegURL", LevyraMediaItemFactory.mimeTypeFor("https://example.com/videoplayback?mime=application%2Fx-mpegurl", true))
+        assertEquals("application/x-mpegURL", LevyraMediaItemFactory.mimeTypeFor("https://example.com/videoplayback?mime=application/vnd.apple.mpegurl", true))
+    }
+
+    @Test
+    fun detectsDashAndDirectVideoContainers() {
+        assertEquals("application/dash+xml", LevyraMediaItemFactory.mimeTypeFor("https://example.com/manifest.mpd", true))
+        assertEquals("video/webm", LevyraMediaItemFactory.mimeTypeFor("https://example.com/videoplayback?mime=video%2Fwebm", true))
+        assertEquals("video/mp4", LevyraMediaItemFactory.mimeTypeFor("https://example.com/videoplayback?mime=video%2Fmp4", true))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ androidx-compose-material-icons-extended = { group = "androidx.compose.material"
 androidx-compose-ui-text-googlefonts = { group = "androidx.compose.ui", name = "ui-text-google-fonts" }
 androidx-media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3" }
 androidx-media3-exoplayer-hls = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3" }
+androidx-media3-exoplayer-dash = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3" }
 androidx-media3-session = { group = "androidx.media3", name = "media3-session", version.ref = "media3" }
 androidx-media3-ui = { group = "androidx.media3", name = "media3-ui", version.ref = "media3" }
 androidx-media3-datasource-okhttp = { group = "androidx.media3", name = "media3-datasource-okhttp", version.ref = "media3" }


### PR DESCRIPTION
## Summary

This pull request adds Levyra's new video playback architecture.

## Changes

- Adaptive video stream selection based on device codecs, network and power state
- Dedicated YouTube Media3 data source
- Seamless Song and Video switching while preserving playback position
- Native Android Picture-in-Picture
- Automatic stream recovery after expired URLs, HTTP failures or decoder errors
- HLS, DASH, progressive and separate audio/video stream support
- Compatibility with the persistent queue, Samsung stability fixes and MediaSession controls

## Validation

GitHub Actions will run Release compilation and automated tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Picture-in-Picture support, including automatic entry while video is playing.
  * Improved video playback with DASH support, adaptive stream selection, and video/audio mode switching.
  * Added playback recovery to retry alternate streams after recoverable failures.
  * Enhanced compatibility for YouTube video streams and varied media formats.

* **Bug Fixes**
  * Blocked previously failing stream URLs to avoid repeated playback errors.
  * Improved orientation and video sizing behavior in Picture-in-Picture mode.

* **Tests**
  * Added coverage for HLS, DASH, and direct video MIME type detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->