### PR TITLE
Add native YouTube Music watch, related content, and lyrics

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/LyricsParsing.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LyricsParsing.kt
@@ -23,6 +23,19 @@ data class LyricsCandidate(
     val durationSec: Long
 )
 
+object LyricsProviderSelector {
+    fun select(
+        native: LyricsCandidate?,
+        lrcLib: List<LyricsCandidate>,
+        request: LyricsRequest
+    ): LyricsRepository.LyricsResult? {
+        native?.result?.takeIf { it.synced && it.lines.isNotEmpty() }?.let { return it }
+        LyricsResultRanker.best(lrcLib.filter { it.result.synced }, request)?.let { return it }
+        native?.result?.takeIf { !it.synced && it.lines.isNotEmpty() }?.let { return it }
+        return LyricsResultRanker.best(lrcLib.filterNot { it.result.synced }, request)
+    }
+}
+
 object LrcLyricsParser {
     private val timestampRegex = Regex("\\[(\\d{1,2}):(\\d{2})(?:[.:](\\d{1,3}))?]")
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/LyricsRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LyricsRepository.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import com.luc4n3x.levyra.domain.LyricLine
 import com.luc4n3x.levyra.domain.LyricWord
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
@@ -22,6 +24,7 @@ class LyricsRepository(context: Context? = null) {
     private val appContext = context?.applicationContext
     private val cacheDir = appContext?.cacheDir?.let { File(it, "lyrics_pro") }
     private val youtubeTranscript = appContext?.let(::YoutubeTranscriptLyricsProvider)
+    private val youtubeMusic = YoutubeMusicWatchRepository(appContext)
     private val memory = LinkedHashMap<String, LyricsResult>()
 
     data class LyricsResult(
@@ -42,54 +45,106 @@ class LyricsRepository(context: Context? = null) {
     ): LyricsResult? = withContext(Dispatchers.IO) {
         val cleanTitle = cleanTitle(title)
         val cleanArtist = cleanArtist(artist)
-        if (cleanTitle.length < 2 || cleanArtist.length < 2) return@withContext null
-        val key = cacheKey(cleanTitle, cleanArtist, durationSec, languageCode, translate)
+        if (cleanTitle.length < 2) return@withContext null
+        val key = cacheKey(cleanTitle, cleanArtist, durationSec, videoId, languageCode, translate)
         memory[key]?.let { return@withContext it.copy(cached = true) }
         readCache(key)?.let { cached ->
             memory[key] = cached
             return@withContext cached
         }
-        val candidates = mutableListOf<LyricsCandidate>()
-        artistVariants(cleanArtist).forEach { artistVariant ->
-            runCatching { getLrcLibExact(cleanTitle, artistVariant, durationSec) }
-                .getOrNull()
-                ?.let { candidates += it }
+
+        val request = LyricsRequest(cleanTitle, cleanArtist, durationSec)
+        val preferred = coroutineScope {
+            val nativeDeferred = async {
+                if (videoId.isBlank()) null else runCatching {
+                    youtubeMusic.getLyricsForVideo(videoId, languageCode)
+                }.getOrNull()?.toCandidate(cleanTitle, cleanArtist, durationSec)
+            }
+            val lrcLibDeferred = async {
+                if (cleanArtist.length < 2) emptyList() else collectLrcLibCandidates(cleanTitle, cleanArtist, durationSec)
+            }
+            LyricsProviderSelector.select(nativeDeferred.await(), lrcLibDeferred.await(), request)
         }
-        runCatching { searchLrcLib(cleanTitle, cleanArtist) }
-            .getOrDefault(emptyList())
-            .let { candidates += it }
-        if (videoId.isNotBlank()) {
-            runCatching { youtubeTranscript?.fetch(videoId, languageCode, translate) }
-                .getOrNull()
-                ?.takeIf { it.lines.isNotEmpty() }
-                ?.let { transcript ->
-                    val provider = buildString {
-                        append("YouTube Transcript")
-                        if (transcript.automatic) append(" Auto")
-                        append(" · ").append(transcript.sourceLanguage)
-                        if (transcript.translated) append(" → ").append(languageCode)
-                    }
-                    candidates += LyricsCandidate(
-                        result = LyricsResult(true, transcript.lines, provider, if (transcript.automatic) 72 else 82, false),
-                        title = cleanTitle,
-                        artist = cleanArtist,
-                        durationSec = durationSec
-                    )
-                }
-        }
-        if (candidates.none { it.result.lines.isNotEmpty() }) {
-            runCatching { lyricsOvh(cleanTitle, cleanArtist) }
-                .getOrNull()
-                ?.let { candidates += it }
-        }
-        val best = LyricsResultRanker.best(candidates, LyricsRequest(cleanTitle, cleanArtist, durationSec))
-            ?.let { normalizeTiming(it, durationSec) }
-        if (best != null) {
-            val stable = best.copy(cached = false)
+
+        val best = preferred
+            ?: fetchTranscriptCandidate(videoId, cleanTitle, cleanArtist, durationSec, languageCode, translate)
+                ?.result
+            ?: if (cleanArtist.length >= 2) runCatching { lyricsOvh(cleanTitle, cleanArtist) }.getOrNull()?.result else null
+
+        val normalized = best?.let { normalizeTiming(it, durationSec) }
+        if (normalized != null) {
+            val stable = normalized.copy(cached = false)
             memory[key] = stable
             writeCache(key, stable)
+            stable
+        } else {
+            null
         }
-        best
+    }
+
+    private suspend fun collectLrcLibCandidates(
+        title: String,
+        artist: String,
+        durationSec: Long
+    ): List<LyricsCandidate> = coroutineScope {
+        val exactDeferred = artistVariants(artist).map { artistVariant ->
+            async { runCatching { getLrcLibExact(title, artistVariant, durationSec) }.getOrNull() }
+        }
+        val searchDeferred = async { runCatching { searchLrcLib(title, artist) }.getOrDefault(emptyList()) }
+        buildList {
+            exactDeferred.mapNotNullTo(this) { it.await() }
+            addAll(searchDeferred.await())
+        }
+    }
+
+    private suspend fun fetchTranscriptCandidate(
+        videoId: String,
+        title: String,
+        artist: String,
+        durationSec: Long,
+        languageCode: String,
+        translate: Boolean
+    ): LyricsCandidate? {
+        if (videoId.isBlank()) return null
+        val transcript = runCatching { youtubeTranscript?.fetch(videoId, languageCode, translate) }
+            .getOrNull()
+            ?.takeIf { it.lines.isNotEmpty() }
+            ?: return null
+        val provider = buildString {
+            append("YouTube Transcript")
+            if (transcript.automatic) append(" Auto")
+            append(" · ").append(transcript.sourceLanguage)
+            if (transcript.translated) append(" → ").append(languageCode)
+        }
+        return LyricsCandidate(
+            result = LyricsResult(true, transcript.lines, provider, if (transcript.automatic) 72 else 82, false),
+            title = title,
+            artist = artist,
+            durationSec = durationSec
+        )
+    }
+
+    private fun YoutubeMusicNativeLyrics.toCandidate(
+        title: String,
+        artist: String,
+        durationSec: Long
+    ): LyricsCandidate {
+        val provider = buildString {
+            append("YouTube Music")
+            if (source.isNotBlank()) append(" · ").append(source)
+        }
+        return LyricsCandidate(
+            result = LyricsResult(
+                synced = synced,
+                lines = lines,
+                provider = provider,
+                confidence = if (synced) 100 else 90,
+                cached = false
+            ),
+            title = title,
+            artist = artist,
+            durationSec = durationSec
+        )
     }
 
     private fun getLrcLibExact(title: String, artist: String, durationSec: Long): LyricsCandidate? {
@@ -259,8 +314,15 @@ class LyricsRepository(context: Context? = null) {
         return clean.length >= 16 && !clean.equals("null", ignoreCase = true)
     }
 
-    private fun cacheKey(title: String, artist: String, durationSec: Long, languageCode: String, translate: Boolean): String {
-        val seed = "${title.cleanComparable()}|${artist.cleanComparable()}|${durationSec.coerceAtLeast(0L) / 10L}|${languageCode.lowercase(Locale.ROOT)}|$translate"
+    private fun cacheKey(
+        title: String,
+        artist: String,
+        durationSec: Long,
+        videoId: String,
+        languageCode: String,
+        translate: Boolean
+    ): String {
+        val seed = "${title.cleanComparable()}|${artist.cleanComparable()}|${durationSec.coerceAtLeast(0L) / 10L}|${videoId.trim()}|${languageCode.lowercase(Locale.ROOT)}|$translate"
         return MessageDigest.getInstance("SHA-256").digest(seed.toByteArray(StandardCharsets.UTF_8)).joinToString("") { "%02x".format(it) }
     }
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
@@ -569,6 +569,7 @@ class YoutubeMusicRepository(private val context: Context? = null) {
             ?.asSequence()
             ?.filter { it.videoId != videoId }
             ?.map { watchTrackToTrack(it, seed, query) }
+            ?.filterNot { candidate -> isLowQualityRadioCandidate(candidate.title, candidate.artist) }
             ?.forEach { track -> tracks.putIfAbsent(track.id, track) }
 
         val relatedBrowseId = watch?.relatedBrowseId.orEmpty()
@@ -580,13 +581,14 @@ class YoutubeMusicRepository(private val context: Context? = null) {
                 .filter { it.type == YoutubeMusicRelatedType.Song || it.type == YoutubeMusicRelatedType.Video }
                 .filter { it.videoId.isNotBlank() && it.videoId != videoId }
                 .map { relatedItemToTrack(it, seed, query) }
+                .filterNot { candidate -> isLowQualityRadioCandidate(candidate.title, candidate.artist) }
                 .forEach { track -> tracks.putIfAbsent(track.id, track) }
         }
 
         if (tracks.size < boundedLimit) {
             search("${seed.artist} ${seed.title} radio", boundedLimit + 4, languageCode)
                 .filter { it.id != videoId }
-                .filterNot(::isLowQualityRadioCandidate)
+                .filterNot { candidate -> isLowQualityRadioCandidate(candidate.title, candidate.artist) }
                 .forEach { candidate -> tracks.putIfAbsent(candidate.id, candidate) }
         }
 
@@ -628,11 +630,6 @@ class YoutubeMusicRepository(private val context: Context? = null) {
             query = query,
             source = "YouTube Music Related"
         )
-    }
-
-    private fun isLowQualityRadioCandidate(candidate: Track): Boolean {
-        val blob = "${candidate.title} ${candidate.artist}".lowercase()
-        return listOf("karaoke", "reaction", "nightcore", "slowed", "sped up").any(blob::contains)
     }
 
     fun searchSuggestions(query: String, languageCode: String = LevyraLanguageCatalog.deviceDefault()): List<String> {
@@ -1109,6 +1106,20 @@ class YoutubeMusicRepository(private val context: Context? = null) {
         return palettes[seed % palettes.size]
     }
 }
+
+internal fun isLowQualityRadioCandidate(title: String, artist: String): Boolean {
+    val value = "$title $artist"
+    return LOW_QUALITY_RADIO_PATTERNS.any { pattern -> pattern.containsMatchIn(value) }
+}
+
+private val LOW_QUALITY_RADIO_PATTERNS = listOf(
+    Regex("(?<![\\p{L}\\p{N}])karaoke(?![\\p{L}\\p{N}])", RegexOption.IGNORE_CASE),
+    Regex("(?<![\\p{L}\\p{N}])nightcore(?![\\p{L}\\p{N}])", RegexOption.IGNORE_CASE),
+    Regex("(?<![\\p{L}\\p{N}])slowed(?:\\s*(?:&|\\+|and)\\s*reverb)?(?![\\p{L}\\p{N}])", RegexOption.IGNORE_CASE),
+    Regex("(?<![\\p{L}\\p{N}])sped[\\s-]*up(?![\\p{L}\\p{N}])", RegexOption.IGNORE_CASE),
+    Regex("(?<![\\p{L}\\p{N}])(?:reaction\\s+(?:video|review)|reacts?\\s+to|first\\s+reaction)(?![\\p{L}\\p{N}])", RegexOption.IGNORE_CASE),
+    Regex("\\(\\s*reaction\\s*\\)", RegexOption.IGNORE_CASE)
+)
 
 internal fun String.cleanAlbumDescription(): String {
     if (isBlank()) return ""

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
@@ -29,6 +29,7 @@ class YoutubeMusicRepository(private val context: Context? = null) {
     private val apiKey = BuildConfig.YOUTUBE_INNERTUBE_API_KEY
     private val clientVersion = "1.20260423.01.00"
     private val memory = LinkedHashMap<String, Track>()
+    private val watchRepository = YoutubeMusicWatchRepository(context)
 
     suspend fun search(query: String, limit: Int = 36, languageCode: String = LevyraLanguageCatalog.deviceDefault()): List<Track> = withContext(Dispatchers.IO) {
         val cleanQuery = query.trim()
@@ -531,105 +532,107 @@ class YoutubeMusicRepository(private val context: Context? = null) {
         }.orEmpty()
     }
 
+    suspend fun getWatchPlaylist(
+        seed: Track,
+        languageCode: String = LevyraLanguageCatalog.deviceDefault(),
+        limit: Int = 25
+    ): YoutubeMusicWatchPlaylist? = withContext(Dispatchers.IO) {
+        val videoId = resolveVideoId(seed)
+        if (videoId.isBlank()) return@withContext null
+        runCatching { watchRepository.getWatchPlaylist(videoId, languageCode, limit) }.getOrNull()
+    }
+
+    suspend fun getSongRelated(
+        seed: Track,
+        languageCode: String = LevyraLanguageCatalog.deviceDefault()
+    ): List<YoutubeMusicRelatedSection> = withContext(Dispatchers.IO) {
+        val watch = getWatchPlaylist(seed, languageCode, 1) ?: return@withContext emptyList()
+        if (watch.relatedBrowseId.isBlank()) return@withContext emptyList()
+        runCatching { watchRepository.getSongRelated(watch.relatedBrowseId, languageCode) }.getOrDefault(emptyList())
+    }
+
     suspend fun radio(
         seed: Track,
         languageCode: String = LevyraLanguageCatalog.deviceDefault(),
         limit: Int = 20
     ): List<Track> = withContext(Dispatchers.IO) {
-        val videoId = seed.id.takeIf { it.isNotBlank() && !it.contains("://") }
-            ?: extractVideoId(seed.videoUrl)
+        val boundedLimit = limit.coerceIn(1, 30)
+        val videoId = resolveVideoId(seed)
         if (videoId.isBlank()) return@withContext emptyList()
-        val root = runCatching { requestRadioRoot(videoId, languageCode) }.getOrNull()
+        val query = "radio ${seed.artist} ${seed.title}".trim()
         val tracks = LinkedHashMap<String, Track>()
-        if (root != null) {
-            val panelRenderers = mutableListOf<JSONObject>()
-            collectObjectsByKey(root, "playlistPanelVideoRenderer", panelRenderers)
-            panelRenderers.forEach { renderer ->
-                parsePlaylistPanelTrack(renderer, seed)?.let { track ->
-                    if (track.id != videoId && !tracks.containsKey(track.id)) tracks[track.id] = track
-                }
-            }
-            val responsive = mutableListOf<JSONObject>()
-            collectObjectsByKey(root, "musicResponsiveListItemRenderer", responsive)
-            responsive.forEach { renderer ->
-                parseMusicRenderer(renderer, "radio ${seed.artist} ${seed.title}")?.let { track ->
-                    if (track.id != videoId && !tracks.containsKey(track.id)) tracks[track.id] = track
-                }
-            }
+        val watch = runCatching {
+            watchRepository.getWatchPlaylist(videoId, languageCode, boundedLimit + 8)
+        }.getOrNull()
+
+        watch?.tracks
+            ?.asSequence()
+            ?.filter { it.videoId != videoId }
+            ?.map { watchTrackToTrack(it, seed, query) }
+            ?.forEach { track -> tracks.putIfAbsent(track.id, track) }
+
+        val relatedBrowseId = watch?.relatedBrowseId.orEmpty()
+        if (tracks.size < boundedLimit && relatedBrowseId.isNotBlank()) {
+            runCatching { watchRepository.getSongRelated(relatedBrowseId, languageCode) }
+                .getOrDefault(emptyList())
+                .asSequence()
+                .flatMap { it.items.asSequence() }
+                .filter { it.type == YoutubeMusicRelatedType.Song || it.type == YoutubeMusicRelatedType.Video }
+                .filter { it.videoId.isNotBlank() && it.videoId != videoId }
+                .map { relatedItemToTrack(it, seed, query) }
+                .forEach { track -> tracks.putIfAbsent(track.id, track) }
         }
-        if (tracks.isEmpty()) {
-            search("${seed.artist} ${seed.title} radio", limit + 4, languageCode)
+
+        if (tracks.size < boundedLimit) {
+            search("${seed.artist} ${seed.title} radio", boundedLimit + 4, languageCode)
                 .filter { it.id != videoId }
-                .filterNot { candidate ->
-                    val blob = "${candidate.title} ${candidate.artist}".lowercase()
-                    listOf("karaoke", "reaction", "nightcore", "slowed", "sped up").any(blob::contains)
-                }
-                .forEach { candidate -> if (!tracks.containsKey(candidate.id)) tracks[candidate.id] = candidate }
+                .filterNot(::isLowQualityRadioCandidate)
+                .forEach { candidate -> tracks.putIfAbsent(candidate.id, candidate) }
         }
-        tracks.values.take(limit.coerceIn(1, 30)).also { items -> items.forEach { memory[it.id] = it } }
+
+        tracks.values.take(boundedLimit).also { items -> items.forEach { memory[it.id] = it } }
     }
 
-    private fun requestRadioRoot(videoId: String, languageCode: String): JSONObject? {
-        val endpoint = "https://music.youtube.com/youtubei/v1/next?key=$apiKey&prettyPrint=false"
-        val body = JSONObject()
-            .put("context", JSONObject().put("client", clientPayload(languageCode)))
-            .put("videoId", videoId)
-            .put("playlistId", "RDAMVM$videoId")
-            .put("isAudioOnly", true)
-            .put("enablePersistentPlaylistPanel", true)
-            .toString()
-        val bytes = body.toByteArray(StandardCharsets.UTF_8)
-        val connection = (URL(endpoint).openConnection() as HttpURLConnection).apply {
-            requestMethod = "POST"
-            connectTimeout = 8_000
-            readTimeout = 12_000
-            doOutput = true
-            setRequestProperty("Content-Type", "application/json")
-            setRequestProperty("Accept", "application/json")
-            setRequestProperty("Origin", "https://music.youtube.com")
-            setRequestProperty("Referer", "https://music.youtube.com/watch?v=$videoId")
-            setRequestProperty("User-Agent", "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Mobile Safari/537.36")
-            setRequestProperty("X-Youtube-Client-Name", "67")
-            setRequestProperty("X-Youtube-Client-Version", clientVersion)
-            GoogleApiKeyHeaders.applyTo(this, context)
-            setRequestProperty("Content-Length", bytes.size.toString())
-        }
-        return try {
-            connection.outputStream.use { it.write(bytes) }
-            val code = connection.responseCode
-            val stream = if (code in 200..299) connection.inputStream else connection.errorStream
-            val response = BufferedReader(InputStreamReader(stream, StandardCharsets.UTF_8)).use { it.readText() }
-            if (code !in 200..299 || response.isBlank()) null else JSONObject(response)
-        } finally {
-            connection.disconnect()
-        }
+    private fun resolveVideoId(seed: Track): String {
+        return seed.id.takeIf { it.isNotBlank() && !it.contains("://") }
+            ?: extractVideoId(seed.videoUrl)
     }
 
-    private fun parsePlaylistPanelTrack(renderer: JSONObject, seed: Track): Track? {
-        val videoId = renderer.optString("videoId")
-            .ifBlank { renderer.optJSONObject("navigationEndpoint")?.optJSONObject("watchEndpoint")?.optString("videoId").orEmpty() }
-        if (videoId.isBlank()) return null
-        val title = renderer.optJSONObject("title")?.optJSONArray("runs")?.joinText().orEmpty().trim()
-        if (title.isBlank()) return null
-        val byline = renderer.optJSONObject("longBylineText")?.optJSONArray("runs")?.joinText().orEmpty()
-        val tokens = byline.split(" • ", " · ").map { it.trim() }.filter { it.isNotBlank() }
-        val artist = tokens.firstOrNull().orEmpty().ifBlank { seed.artist.ifBlank { "YouTube Music" } }
-        val album = tokens.drop(1).firstOrNull().orEmpty().ifBlank { "YouTube Music Radio" }
-        val durationText = renderer.optJSONObject("lengthText")?.optString("simpleText").orEmpty()
-        val durationMs = durationText.durationToMs()
-        val thumbnail = findBestThumbnail(renderer)
+    private fun watchTrackToTrack(item: YoutubeMusicWatchTrack, seed: Track, query: String): Track {
+        val thumbnail = item.thumbnailUrl.ifBlank { seed.thumbnailUrl }
         return buildTrack(
-            id = videoId,
-            title = title,
-            artist = artist,
-            album = album,
-            durationMs = durationMs,
+            id = item.videoId,
+            title = item.title,
+            artist = item.artists.joinToString(", ") { it.name }.ifBlank { seed.artist.ifBlank { "YouTube Music" } },
+            album = item.albumTitle.ifBlank { "YouTube Music Radio" },
+            durationMs = item.durationMs,
             thumbnailUrl = thumbnail,
             largeThumbnailUrl = upgradeThumbnail(thumbnail),
-            videoUrl = "https://www.youtube.com/watch?v=$videoId",
-            query = "radio ${seed.artist} ${seed.title}",
-            source = "YouTube Music Radio"
+            videoUrl = "https://www.youtube.com/watch?v=${item.videoId}",
+            query = query,
+            source = "YouTube Music Watch"
         )
+    }
+
+    private fun relatedItemToTrack(item: YoutubeMusicRelatedItem, seed: Track, query: String): Track {
+        val thumbnail = item.thumbnailUrl.ifBlank { seed.thumbnailUrl }
+        return buildTrack(
+            id = item.videoId,
+            title = item.title,
+            artist = item.artists.joinToString(", ") { it.name }.ifBlank { seed.artist.ifBlank { "YouTube Music" } },
+            album = item.albumTitle.ifBlank { "YouTube Music Related" },
+            durationMs = item.durationMs,
+            thumbnailUrl = thumbnail,
+            largeThumbnailUrl = upgradeThumbnail(thumbnail),
+            videoUrl = "https://www.youtube.com/watch?v=${item.videoId}",
+            query = query,
+            source = "YouTube Music Related"
+        )
+    }
+
+    private fun isLowQualityRadioCandidate(candidate: Track): Boolean {
+        val blob = "${candidate.title} ${candidate.artist}".lowercase()
+        return listOf("karaoke", "reaction", "nightcore", "slowed", "sped up").any(blob::contains)
     }
 
     fun searchSuggestions(query: String, languageCode: String = LevyraLanguageCatalog.deviceDefault()): List<String> {

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicWatchRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicWatchRepository.kt
@@ -687,7 +687,7 @@ internal object YoutubeMusicWatchParser {
             val text = optJSONObject(index)?.optString("text").orEmpty()
             if (text.isBlank()) continue
             if (preserveNewLines && builder.isNotEmpty() && text.startsWith("\n").not() && builder.lastOrNull() != '\n') {
-                builder.append("")
+                builder.append('\n')
             }
             builder.append(text)
         }

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicWatchRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicWatchRepository.kt
@@ -1,0 +1,772 @@
+package com.luc4n3x.levyra.data
+
+import android.content.Context
+import com.luc4n3x.levyra.BuildConfig
+import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
+import com.luc4n3x.levyra.data.security.GoogleApiKeyHeaders
+import com.luc4n3x.levyra.domain.LevyraContentLocales
+import com.luc4n3x.levyra.domain.LevyraLanguageCatalog
+import com.luc4n3x.levyra.domain.LyricLine
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.util.Locale
+
+data class YoutubeMusicWatchArtist(
+    val name: String,
+    val browseId: String
+)
+
+data class YoutubeMusicWatchTrack(
+    val videoId: String,
+    val title: String,
+    val artists: List<YoutubeMusicWatchArtist>,
+    val albumTitle: String,
+    val albumBrowseId: String,
+    val durationMs: Long,
+    val thumbnailUrl: String,
+    val videoType: String,
+    val explicit: Boolean,
+    val counterpart: YoutubeMusicWatchTrack? = null
+)
+
+data class YoutubeMusicWatchPlaylist(
+    val tracks: List<YoutubeMusicWatchTrack>,
+    val playlistId: String,
+    val lyricsBrowseId: String,
+    val relatedBrowseId: String,
+    val continuation: String
+)
+
+enum class YoutubeMusicRelatedType {
+    Song,
+    Video,
+    Album,
+    Playlist,
+    Artist,
+    Unknown
+}
+
+data class YoutubeMusicRelatedItem(
+    val type: YoutubeMusicRelatedType,
+    val title: String,
+    val videoId: String,
+    val browseId: String,
+    val playlistId: String,
+    val artists: List<YoutubeMusicWatchArtist>,
+    val albumTitle: String,
+    val albumBrowseId: String,
+    val durationMs: Long,
+    val thumbnailUrl: String,
+    val description: String,
+    val year: String,
+    val explicit: Boolean
+)
+
+data class YoutubeMusicRelatedSection(
+    val title: String,
+    val items: List<YoutubeMusicRelatedItem>,
+    val description: String = ""
+)
+
+data class YoutubeMusicNativeLyrics(
+    val synced: Boolean,
+    val lines: List<LyricLine>,
+    val source: String
+)
+
+class YoutubeMusicWatchRepository(private val context: Context? = null) {
+    private val apiKey = BuildConfig.YOUTUBE_INNERTUBE_API_KEY
+    private val client = LevyraHttpClientFactory.youtubePlayer()
+
+    suspend fun getWatchPlaylist(
+        videoId: String,
+        languageCode: String = LevyraLanguageCatalog.deviceDefault(),
+        limit: Int = 25
+    ): YoutubeMusicWatchPlaylist = withContext(Dispatchers.IO) {
+        val cleanVideoId = videoId.trim()
+        require(cleanVideoId.isNotBlank())
+        val boundedLimit = limit.coerceIn(1, 100)
+        val requestBody = JSONObject()
+            .put("enablePersistentPlaylistPanel", true)
+            .put("isAudioOnly", true)
+            .put("tunerSettingValue", "AUTOMIX_SETTING_NORMAL")
+            .put("videoId", cleanVideoId)
+            .put("playlistId", "RDAMVM$cleanVideoId")
+            .put(
+                "watchEndpointMusicSupportedConfigs",
+                JSONObject().put(
+                    "watchEndpointMusicConfig",
+                    JSONObject()
+                        .put("hasPersistentPlaylistPanel", true)
+                        .put("musicVideoType", "MUSIC_VIDEO_TYPE_ATV")
+                )
+            )
+        val cacheKey = "$cleanVideoId|${languageCode.lowercase(Locale.ROOT)}"
+        val cachedPlaylist = cached(watchCache, cacheKey, WATCH_CACHE_TTL_MS)
+        if (cachedPlaylist != null && (cachedPlaylist.tracks.size >= boundedLimit || cachedPlaylist.continuation.isBlank())) {
+            return@withContext cachedPlaylist.copy(tracks = cachedPlaylist.tracks.take(boundedLimit))
+        }
+
+        val parsedInitial = cachedPlaylist ?: YoutubeMusicWatchParser.parseWatchPlaylist(
+            post("next", requestBody, languageCode, mobile = false)
+        )
+        var parsed = parsedInitial
+        val tracks = LinkedHashMap<String, YoutubeMusicWatchTrack>()
+        parsed.tracks.forEach { track -> tracks.putIfAbsent(track.videoId, track) }
+        var continuation = parsed.continuation
+        var requests = 0
+
+        while (tracks.size < boundedLimit && continuation.isNotBlank() && requests < MAX_CONTINUATION_REQUESTS) {
+            val response = runCatching {
+                post("next", requestBody, languageCode, mobile = false, continuation = continuation)
+            }.getOrNull() ?: break
+            val nextPage = YoutubeMusicWatchParser.parseWatchPlaylist(response)
+            val before = tracks.size
+            nextPage.tracks.forEach { track -> tracks.putIfAbsent(track.videoId, track) }
+            continuation = nextPage.continuation
+            parsed = parsed.copy(
+                playlistId = parsed.playlistId.ifBlank { nextPage.playlistId },
+                lyricsBrowseId = parsed.lyricsBrowseId.ifBlank { nextPage.lyricsBrowseId },
+                relatedBrowseId = parsed.relatedBrowseId.ifBlank { nextPage.relatedBrowseId },
+                continuation = continuation
+            )
+            requests += 1
+            if (tracks.size == before) break
+        }
+
+        val fullResult = parsed.copy(tracks = tracks.values.toList(), continuation = continuation)
+        putCached(watchCache, cacheKey, fullResult, WATCH_CACHE_MAX_ENTRIES)
+        fullResult.copy(tracks = fullResult.tracks.take(boundedLimit))
+    }
+
+    suspend fun getSongRelated(
+        browseId: String,
+        languageCode: String = LevyraLanguageCatalog.deviceDefault()
+    ): List<YoutubeMusicRelatedSection> = withContext(Dispatchers.IO) {
+        val cleanBrowseId = browseId.trim()
+        require(cleanBrowseId.isNotBlank())
+        val cacheKey = "$cleanBrowseId|${languageCode.lowercase(Locale.ROOT)}"
+        cached(relatedCache, cacheKey, RELATED_CACHE_TTL_MS)?.let { return@withContext it }
+        val response = post("browse", JSONObject().put("browseId", cleanBrowseId), languageCode, mobile = false)
+        val result = YoutubeMusicWatchParser.parseRelated(response)
+        putCached(relatedCache, cacheKey, result, RELATED_CACHE_MAX_ENTRIES)
+        result
+    }
+
+    suspend fun getLyricsForVideo(
+        videoId: String,
+        languageCode: String = LevyraLanguageCatalog.deviceDefault()
+    ): YoutubeMusicNativeLyrics? = withContext(Dispatchers.IO) {
+        val watch = runCatching { getWatchPlaylist(videoId, languageCode, 1) }.getOrNull() ?: return@withContext null
+        if (watch.lyricsBrowseId.isBlank()) return@withContext null
+        getLyrics(watch.lyricsBrowseId, languageCode)
+    }
+
+    suspend fun getLyrics(
+        browseId: String,
+        languageCode: String = LevyraLanguageCatalog.deviceDefault()
+    ): YoutubeMusicNativeLyrics? = withContext(Dispatchers.IO) {
+        val cleanBrowseId = browseId.trim()
+        if (cleanBrowseId.isBlank()) return@withContext null
+        val cacheKey = "$cleanBrowseId|${languageCode.lowercase(Locale.ROOT)}"
+        cached(lyricsCache, cacheKey, LYRICS_CACHE_TTL_MS)?.let { return@withContext it }
+
+        val body = JSONObject().put("browseId", cleanBrowseId)
+        val mobileResponse = runCatching { post("browse", body, languageCode, mobile = true) }.getOrNull()
+        val timed = mobileResponse?.let(YoutubeMusicWatchParser::parseLyrics)
+        if (timed != null && timed.lines.isNotEmpty()) {
+            putCached(lyricsCache, cacheKey, timed, LYRICS_CACHE_MAX_ENTRIES)
+            return@withContext timed
+        }
+
+        val webResponse = runCatching { post("browse", body, languageCode, mobile = false) }.getOrNull()
+        val plain = webResponse?.let(YoutubeMusicWatchParser::parseLyrics)
+        if (plain != null && plain.lines.isNotEmpty()) {
+            putCached(lyricsCache, cacheKey, plain, LYRICS_CACHE_MAX_ENTRIES)
+        }
+        plain
+    }
+
+    private fun post(
+        endpoint: String,
+        payload: JSONObject,
+        languageCode: String,
+        mobile: Boolean,
+        continuation: String = ""
+    ): JSONObject {
+        check(apiKey.isNotBlank())
+        val continuationQuery = continuation.takeIf { it.isNotBlank() }?.let {
+            val encoded = URLEncoder.encode(it, StandardCharsets.UTF_8.name())
+            "&ctoken=$encoded&continuation=$encoded"
+        }.orEmpty()
+        val url = "https://music.youtube.com/youtubei/v1/$endpoint?key=$apiKey&prettyPrint=false$continuationQuery"
+        val body = JSONObject(payload.toString())
+            .put("context", JSONObject().put("client", clientPayload(languageCode, mobile)).put("user", JSONObject()))
+            .toString()
+            .toRequestBody(JSON_MEDIA_TYPE)
+        val requestBuilder = Request.Builder()
+            .url(url)
+            .post(body)
+            .header("Accept", "application/json")
+            .header("Accept-Encoding", "br,gzip")
+            .header("Origin", "https://music.youtube.com")
+            .header("Referer", "https://music.youtube.com/")
+            .header("User-Agent", if (mobile) MOBILE_USER_AGENT else WEB_USER_AGENT)
+            .header("X-Youtube-Client-Name", if (mobile) ANDROID_MUSIC_CLIENT_ID else WEB_REMIX_CLIENT_ID)
+            .header("X-Youtube-Client-Version", if (mobile) ANDROID_MUSIC_CLIENT_VERSION else WEB_REMIX_CLIENT_VERSION)
+        GoogleApiKeyHeaders.applyTo(requestBuilder, context)
+        return client.newCall(requestBuilder.build()).execute().use { response ->
+            val responseBody = response.body?.string().orEmpty()
+            if (!response.isSuccessful || responseBody.isBlank()) {
+                throw YoutubeMusicRequestException(endpoint, response.code, responseBody.take(512))
+            }
+            JSONObject(responseBody)
+        }
+    }
+
+    private fun clientPayload(languageCode: String, mobile: Boolean): JSONObject {
+        val locale = LevyraContentLocales.forLanguage(languageCode)
+        return if (mobile) {
+            JSONObject()
+                .put("clientName", "ANDROID_MUSIC")
+                .put("clientVersion", ANDROID_MUSIC_CLIENT_VERSION)
+                .put("hl", locale.hl)
+                .put("gl", locale.gl)
+                .put("androidSdkVersion", 35)
+                .put("platform", "MOBILE")
+        } else {
+            JSONObject()
+                .put("clientName", "WEB_REMIX")
+                .put("clientVersion", WEB_REMIX_CLIENT_VERSION)
+                .put("hl", locale.hl)
+                .put("gl", locale.gl)
+                .put("platform", "DESKTOP")
+        }
+    }
+
+    private fun <T> cached(cache: LinkedHashMap<String, TimedValue<T>>, key: String, ttl: Long): T? {
+        val value = synchronized(cache) { cache[key] } ?: return null
+        if (System.currentTimeMillis() - value.createdAt > ttl) {
+            synchronized(cache) { cache.remove(key) }
+            return null
+        }
+        return value.value
+    }
+
+    private fun <T> putCached(cache: LinkedHashMap<String, TimedValue<T>>, key: String, value: T, maxEntries: Int) {
+        synchronized(cache) {
+            cache[key] = TimedValue(value, System.currentTimeMillis())
+            while (cache.size > maxEntries) {
+                val oldest = cache.entries.firstOrNull()?.key ?: break
+                cache.remove(oldest)
+            }
+        }
+    }
+
+    private data class TimedValue<T>(val value: T, val createdAt: Long)
+
+    companion object {
+        private const val WEB_REMIX_CLIENT_VERSION = "1.20260423.01.00"
+        private const val WEB_REMIX_CLIENT_ID = "67"
+        private const val ANDROID_MUSIC_CLIENT_VERSION = "7.21.50"
+        private const val ANDROID_MUSIC_CLIENT_ID = "21"
+        private const val WEB_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36"
+        private const val MOBILE_USER_AGENT = "com.google.android.apps.youtube.music/7.21.50 (Linux; U; Android 15) gzip"
+        private const val MAX_CONTINUATION_REQUESTS = 4
+        private const val WATCH_CACHE_TTL_MS = 20L * 60L * 1000L
+        private const val RELATED_CACHE_TTL_MS = 6L * 60L * 60L * 1000L
+        private const val LYRICS_CACHE_TTL_MS = 30L * 24L * 60L * 60L * 1000L
+        private const val WATCH_CACHE_MAX_ENTRIES = 64
+        private const val RELATED_CACHE_MAX_ENTRIES = 64
+        private const val LYRICS_CACHE_MAX_ENTRIES = 128
+        private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+        private val watchCache = LinkedHashMap<String, TimedValue<YoutubeMusicWatchPlaylist>>()
+        private val relatedCache = LinkedHashMap<String, TimedValue<List<YoutubeMusicRelatedSection>>>()
+        private val lyricsCache = LinkedHashMap<String, TimedValue<YoutubeMusicNativeLyrics>>()
+    }
+}
+
+class YoutubeMusicRequestException(endpoint: String, statusCode: Int, response: String) :
+    IllegalStateException("YouTube Music $endpoint failed with HTTP $statusCode: $response")
+
+internal object YoutubeMusicWatchParser {
+    fun parseWatchPlaylist(root: JSONObject): YoutubeMusicWatchPlaylist {
+        val browseIds = extractTabBrowseIds(root)
+        val tracks = ArrayList<YoutubeMusicWatchTrack>()
+        val counterpartIds = HashSet<String>()
+        val wrappers = mutableListOf<JSONObject>()
+        collectObjectsByKey(root, "playlistPanelVideoWrapperRenderer", wrappers)
+        wrappers.forEach { wrapper ->
+            val primary = wrapper.optJSONObject("primaryRenderer")
+                ?.optJSONObject("playlistPanelVideoRenderer")
+                ?: return@forEach
+            if (primary.has("unplayableText")) return@forEach
+            val counterpartRenderer = wrapper.optJSONArray("counterpart")
+                ?.optJSONObject(0)
+                ?.optJSONObject("counterpartRenderer")
+                ?.optJSONObject("playlistPanelVideoRenderer")
+            val counterpart = counterpartRenderer?.takeUnless { it.has("unplayableText") }?.let(::parseWatchTrack)
+            counterpart?.videoId?.takeIf { it.isNotBlank() }?.let(counterpartIds::add)
+            parseWatchTrack(primary)?.copy(counterpart = counterpart)?.let(tracks::add)
+        }
+
+        val direct = mutableListOf<JSONObject>()
+        collectObjectsByKey(root, "playlistPanelVideoRenderer", direct)
+        direct.forEach { renderer ->
+            if (renderer.has("unplayableText")) return@forEach
+            parseWatchTrack(renderer)?.let { track ->
+                if (track.videoId !in counterpartIds && tracks.none { it.videoId == track.videoId }) tracks += track
+            }
+        }
+
+        return YoutubeMusicWatchPlaylist(
+            tracks = tracks,
+            playlistId = findPlaylistId(root),
+            lyricsBrowseId = browseIds["MUSIC_PAGE_TYPE_TRACK_LYRICS"].orEmpty(),
+            relatedBrowseId = browseIds["MUSIC_PAGE_TYPE_TRACK_RELATED"].orEmpty(),
+            continuation = findContinuation(root)
+        )
+    }
+
+    fun parseRelated(root: JSONObject): List<YoutubeMusicRelatedSection> {
+        val sections = ArrayList<YoutubeMusicRelatedSection>()
+        val carousels = mutableListOf<JSONObject>()
+        collectObjectsByKey(root, "musicCarouselShelfRenderer", carousels)
+        carousels.forEach { carousel ->
+            val title = carousel.optJSONObject("header")
+                ?.optJSONObject("musicCarouselShelfBasicHeaderRenderer")
+                ?.optJSONObject("title")
+                ?.optJSONArray("runs")
+                .joinText()
+                .ifBlank { carousel.optJSONObject("header")?.findText().orEmpty() }
+            val items = parseRelatedContents(carousel.optJSONArray("contents"))
+            if (items.isNotEmpty()) sections += YoutubeMusicRelatedSection(title, items)
+        }
+
+        val shelves = mutableListOf<JSONObject>()
+        collectObjectsByKey(root, "musicShelfRenderer", shelves)
+        shelves.forEach { shelf ->
+            val title = shelf.optJSONObject("title")?.optJSONArray("runs").joinText()
+            val items = parseRelatedContents(shelf.optJSONArray("contents"))
+            if (items.isNotEmpty() && sections.none { it.title == title && it.items == items }) {
+                sections += YoutubeMusicRelatedSection(title, items)
+            }
+        }
+
+        val descriptions = mutableListOf<JSONObject>()
+        collectObjectsByKey(root, "musicDescriptionShelfRenderer", descriptions)
+        descriptions.forEach { shelf ->
+            val title = shelf.optJSONObject("header")?.optJSONArray("runs").joinText()
+            val description = shelf.optJSONObject("description")?.optJSONArray("runs").joinText(preserveNewLines = true)
+            if (description.isNotBlank() && sections.none { it.title == title && it.description == description }) {
+                sections += YoutubeMusicRelatedSection(title, emptyList(), description)
+            }
+        }
+
+        if (sections.isEmpty()) {
+            val fallbackItems = mutableListOf<YoutubeMusicRelatedItem>()
+            val responsive = mutableListOf<JSONObject>()
+            collectObjectsByKey(root, "musicResponsiveListItemRenderer", responsive)
+            responsive.mapNotNullTo(fallbackItems, ::parseRelatedRenderer)
+            val twoRows = mutableListOf<JSONObject>()
+            collectObjectsByKey(root, "musicTwoRowItemRenderer", twoRows)
+            twoRows.mapNotNullTo(fallbackItems, ::parseRelatedRenderer)
+            if (fallbackItems.isNotEmpty()) sections += YoutubeMusicRelatedSection("", fallbackItems.distinctBy { it.identityKey() })
+        }
+
+        return sections
+    }
+
+    fun parseLyrics(root: JSONObject): YoutubeMusicNativeLyrics? {
+        val timedModel = root
+            .optJSONObject("contents")
+            ?.optJSONObject("elementRenderer")
+            ?.optJSONObject("newElement")
+            ?.optJSONObject("type")
+            ?.optJSONObject("componentType")
+            ?.optJSONObject("model")
+            ?.optJSONObject("timedLyricsModel")
+            ?.optJSONObject("lyricsData")
+        val timedData = timedModel?.optJSONArray("timedLyricsData")
+        if (timedData != null) {
+            val lines = ArrayList<LyricLine>()
+            for (index in 0 until timedData.length()) {
+                val item = timedData.optJSONObject(index) ?: continue
+                val text = item.optString("lyricLine").trim()
+                val cue = item.optJSONObject("cueRange") ?: continue
+                val start = cue.optString("startTimeMilliseconds").toLongOrNull()
+                    ?: cue.optLong("startTimeMilliseconds", -1L)
+                val end = cue.optString("endTimeMilliseconds").toLongOrNull()
+                    ?: cue.optLong("endTimeMilliseconds", -1L)
+                if (text.isBlank() || start < 0L || end <= start) continue
+                lines += LyricLine(start, end, text, "")
+            }
+            if (lines.isNotEmpty()) {
+                return YoutubeMusicNativeLyrics(
+                    synced = true,
+                    lines = lines.sortedBy { it.startMs },
+                    source = timedModel.optString("sourceMessage").cleanSource()
+                )
+            }
+        }
+
+        val descriptions = mutableListOf<JSONObject>()
+        collectObjectsByKey(root, "musicDescriptionShelfRenderer", descriptions)
+        descriptions.forEach { shelf ->
+            val text = shelf.optJSONObject("description")?.optJSONArray("runs").joinText(preserveNewLines = true).trim()
+            if (text.length < 16) return@forEach
+            val source = shelf.optJSONArray("runs").joinText().cleanSource()
+                .ifBlank { shelf.optJSONObject("footer")?.optJSONArray("runs").joinText().cleanSource() }
+                .ifBlank { shelf.optJSONObject("subheader")?.optJSONArray("runs").joinText().cleanSource() }
+            val lines = plainLyricsLines(text)
+            if (lines.isNotEmpty()) return YoutubeMusicNativeLyrics(false, lines, source)
+        }
+
+        return null
+    }
+
+    private fun parseRelatedContents(contents: JSONArray?): List<YoutubeMusicRelatedItem> {
+        if (contents == null) return emptyList()
+        val items = ArrayList<YoutubeMusicRelatedItem>()
+        for (index in 0 until contents.length()) {
+            val wrapper = contents.optJSONObject(index) ?: continue
+            val renderer = wrapper.optJSONObject("musicResponsiveListItemRenderer")
+                ?: wrapper.optJSONObject("musicTwoRowItemRenderer")
+                ?: wrapper.optJSONObject("musicNavigationButtonRenderer")
+                ?: continue
+            parseRelatedRenderer(renderer)?.let(items::add)
+        }
+        return items.distinctBy { it.identityKey() }
+    }
+
+    private fun parseRelatedRenderer(renderer: JSONObject): YoutubeMusicRelatedItem? {
+        val title = renderer.optJSONObject("title")?.optJSONArray("runs").joinText()
+            .ifBlank { renderer.extractFlexLines().firstOrNull().orEmpty() }
+            .ifBlank { renderer.optJSONObject("buttonText")?.optJSONArray("runs").joinText() }
+            .trim()
+        if (title.isBlank()) return null
+        val watchEndpoints = mutableListOf<JSONObject>()
+        collectObjectsByKey(renderer, "watchEndpoint", watchEndpoints)
+        val browseEndpoints = mutableListOf<JSONObject>()
+        collectObjectsByKey(renderer, "browseEndpoint", browseEndpoints)
+        val watch = watchEndpoints.firstOrNull { it.optString("videoId").isNotBlank() }
+        val topLevelBrowse = renderer.optJSONObject("navigationEndpoint")?.optJSONObject("browseEndpoint")
+        val browse = topLevelBrowse?.takeIf { it.optString("browseId").isNotBlank() }
+            ?: browseEndpoints.firstOrNull { endpoint ->
+                endpoint.optJSONObject("browseEndpointContextSupportedConfigs")
+                    ?.optJSONObject("browseEndpointContextMusicConfig")
+                    ?.optString("pageType")
+                    ?.let { pageType -> pageType.contains("ALBUM") || pageType.contains("PLAYLIST") }
+                    ?: false
+            }
+            ?: browseEndpoints.firstOrNull { endpoint ->
+                endpoint.optJSONObject("browseEndpointContextSupportedConfigs")
+                    ?.optJSONObject("browseEndpointContextMusicConfig")
+                    ?.optString("pageType")
+                    ?.let { pageType -> pageType.contains("ARTIST") || pageType.contains("USER_CHANNEL") }
+                    ?: false
+            }
+            ?: browseEndpoints.firstOrNull { it.optString("browseId").isNotBlank() }
+        val videoId = watch?.optString("videoId").orEmpty()
+        val playlistId = watch?.optString("playlistId").orEmpty().ifBlank {
+            browseEndpoints.firstNotNullOfOrNull { endpoint -> endpoint.optString("browseId").takeIf { it.startsWith("VL") }?.removePrefix("VL") }.orEmpty()
+        }
+        val browseId = browse?.optString("browseId").orEmpty()
+        val pageType = browse?.optJSONObject("browseEndpointContextSupportedConfigs")
+            ?.optJSONObject("browseEndpointContextMusicConfig")
+            ?.optString("pageType")
+            .orEmpty()
+        val type = when {
+            videoId.isNotBlank() && watch?.optJSONObject("watchEndpointMusicSupportedConfigs")
+                ?.optJSONObject("watchEndpointMusicConfig")
+                ?.optString("musicVideoType")
+                ?.contains("OMV") == true -> YoutubeMusicRelatedType.Video
+            videoId.isNotBlank() -> YoutubeMusicRelatedType.Song
+            pageType.contains("ALBUM") || browseId.startsWith("MPRE") -> YoutubeMusicRelatedType.Album
+            pageType.contains("ARTIST") || pageType.contains("USER_CHANNEL") || browseId.startsWith("UC") -> YoutubeMusicRelatedType.Artist
+            pageType.contains("PLAYLIST") || browseId.startsWith("VL") || playlistId.isNotBlank() -> YoutubeMusicRelatedType.Playlist
+            else -> YoutubeMusicRelatedType.Unknown
+        }
+        val runs = renderer.allTextRuns()
+        val artists = runs.mapNotNull { run ->
+            val endpoint = run.optJSONObject("navigationEndpoint")?.optJSONObject("browseEndpoint") ?: return@mapNotNull null
+            val id = endpoint.optString("browseId")
+            val runPageType = endpoint.optJSONObject("browseEndpointContextSupportedConfigs")
+                ?.optJSONObject("browseEndpointContextMusicConfig")
+                ?.optString("pageType")
+                .orEmpty()
+            if (id.startsWith("UC") || runPageType.contains("ARTIST")) YoutubeMusicWatchArtist(run.optString("text"), id) else null
+        }.filter { it.name.isNotBlank() }.distinctBy { it.browseId.ifBlank { it.name.lowercase(Locale.ROOT) } }
+        val albumRun = runs.firstOrNull { run ->
+            val endpoint = run.optJSONObject("navigationEndpoint")?.optJSONObject("browseEndpoint")
+            endpoint?.optString("browseId")?.startsWith("MPRE") == true
+        }
+        val subtitle = renderer.extractFlexLines().drop(1).joinToString(" • ").ifBlank {
+            renderer.optJSONObject("subtitle")?.optJSONArray("runs").joinText()
+        }
+        val durationMs = Regex("\\b\\d{1,2}:\\d{2}(?::\\d{2})?\\b")
+            .find(renderer.toString())
+            ?.value
+            ?.durationToMs()
+            ?: 0L
+        val year = Regex("\\b(?:19|20)\\d{2}\\b").find(subtitle)?.value.orEmpty()
+        return YoutubeMusicRelatedItem(
+            type = type,
+            title = title,
+            videoId = videoId,
+            browseId = browseId,
+            playlistId = playlistId,
+            artists = artists,
+            albumTitle = albumRun?.optString("text").orEmpty(),
+            albumBrowseId = albumRun?.optJSONObject("navigationEndpoint")?.optJSONObject("browseEndpoint")?.optString("browseId").orEmpty(),
+            durationMs = durationMs,
+            thumbnailUrl = renderer.findBestThumbnail(),
+            description = subtitle,
+            year = year,
+            explicit = renderer.toString().contains("MUSIC_ITEM_BADGE_EXPLICIT")
+        )
+    }
+
+    private fun parseWatchTrack(renderer: JSONObject): YoutubeMusicWatchTrack? {
+        val videoId = renderer.optString("videoId")
+            .ifBlank { renderer.optJSONObject("navigationEndpoint")?.optJSONObject("watchEndpoint")?.optString("videoId").orEmpty() }
+        val title = renderer.optJSONObject("title")?.optJSONArray("runs").joinText().trim()
+        if (videoId.isBlank() || title.isBlank()) return null
+        val bylineRuns = renderer.optJSONObject("longBylineText")?.optJSONArray("runs") ?: JSONArray()
+        val artists = ArrayList<YoutubeMusicWatchArtist>()
+        var albumTitle = ""
+        var albumBrowseId = ""
+        for (index in 0 until bylineRuns.length()) {
+            val run = bylineRuns.optJSONObject(index) ?: continue
+            val text = run.optString("text").trim()
+            val endpoint = run.optJSONObject("navigationEndpoint")?.optJSONObject("browseEndpoint")
+            val browseId = endpoint?.optString("browseId").orEmpty()
+            val pageType = endpoint?.optJSONObject("browseEndpointContextSupportedConfigs")
+                ?.optJSONObject("browseEndpointContextMusicConfig")
+                ?.optString("pageType")
+                .orEmpty()
+            when {
+                browseId.startsWith("MPRE") || pageType.contains("ALBUM") -> {
+                    albumTitle = text
+                    albumBrowseId = browseId
+                }
+                browseId.startsWith("UC") || pageType.contains("ARTIST") || pageType.contains("USER_CHANNEL") -> {
+                    if (text.isNotBlank()) artists += YoutubeMusicWatchArtist(text, browseId)
+                }
+            }
+        }
+        if (artists.isEmpty()) {
+            val byline = bylineRuns.joinText()
+            val fallback = byline.split(" • ", " · ").firstOrNull()?.trim().orEmpty()
+            if (fallback.isNotBlank()) artists += YoutubeMusicWatchArtist(fallback, "")
+        }
+        val length = renderer.optJSONObject("lengthText")?.optJSONArray("runs").joinText()
+            .ifBlank { renderer.optJSONObject("lengthText")?.optString("simpleText").orEmpty() }
+        val videoType = renderer.optJSONObject("navigationEndpoint")
+            ?.optJSONObject("watchEndpoint")
+            ?.optJSONObject("watchEndpointMusicSupportedConfigs")
+            ?.optJSONObject("watchEndpointMusicConfig")
+            ?.optString("musicVideoType")
+            .orEmpty()
+        return YoutubeMusicWatchTrack(
+            videoId = videoId,
+            title = title,
+            artists = artists.distinctBy { it.browseId.ifBlank { it.name.lowercase(Locale.ROOT) } },
+            albumTitle = albumTitle,
+            albumBrowseId = albumBrowseId,
+            durationMs = length.durationToMs(),
+            thumbnailUrl = renderer.optJSONObject("thumbnail")?.optJSONArray("thumbnails").bestThumbnail(),
+            videoType = videoType,
+            explicit = renderer.toString().contains("MUSIC_ITEM_BADGE_EXPLICIT")
+        )
+    }
+
+    private fun extractTabBrowseIds(root: JSONObject): Map<String, String> {
+        val result = LinkedHashMap<String, String>()
+        val tabs = mutableListOf<JSONObject>()
+        collectObjectsByKey(root, "tabRenderer", tabs)
+        tabs.forEach { tab ->
+            if (tab.optBoolean("unselectable")) return@forEach
+            val endpoint = tab.optJSONObject("endpoint")?.optJSONObject("browseEndpoint") ?: return@forEach
+            val browseId = endpoint.optString("browseId")
+            val pageType = endpoint.optJSONObject("browseEndpointContextSupportedConfigs")
+                ?.optJSONObject("browseEndpointContextMusicConfig")
+                ?.optString("pageType")
+                .orEmpty()
+            if (browseId.isNotBlank() && pageType.isNotBlank()) result[pageType] = browseId
+        }
+        if (!result.containsKey("MUSIC_PAGE_TYPE_TRACK_LYRICS")) {
+            findAllStrings(root, "browseId").firstOrNull { it.startsWith("MPLYt") }?.let { result["MUSIC_PAGE_TYPE_TRACK_LYRICS"] = it }
+        }
+        return result
+    }
+
+    private fun findPlaylistId(root: JSONObject): String {
+        val endpoints = mutableListOf<JSONObject>()
+        collectObjectsByKey(root, "watchEndpoint", endpoints)
+        return endpoints.firstNotNullOfOrNull { endpoint -> endpoint.optString("playlistId").takeIf { it.isNotBlank() } }.orEmpty()
+    }
+
+    private fun findContinuation(root: JSONObject): String {
+        val candidates = listOf("nextRadioContinuationData", "nextContinuationData", "reloadContinuationData", "continuationCommand")
+        candidates.forEach { key ->
+            val objects = mutableListOf<JSONObject>()
+            collectObjectsByKey(root, key, objects)
+            objects.firstNotNullOfOrNull { value ->
+                value.optString("continuation").ifBlank { value.optString("token") }.takeIf(String::isNotBlank)
+            }?.let { return it }
+        }
+        return ""
+    }
+
+    private fun plainLyricsLines(text: String): List<LyricLine> {
+        val lines = text.lineSequence().map(String::trim).filter(String::isNotBlank).toList()
+        return lines.mapIndexed { index, line ->
+            val start = index * 4_200L
+            LyricLine(start, start + 4_200L, line, "")
+        }
+    }
+
+    private fun YoutubeMusicRelatedItem.identityKey(): String {
+        return when {
+            videoId.isNotBlank() -> "v:$videoId"
+            browseId.isNotBlank() -> "b:$browseId"
+            playlistId.isNotBlank() -> "p:$playlistId"
+            else -> "t:${title.lowercase(Locale.ROOT)}"
+        }
+    }
+
+    private fun JSONObject.extractFlexLines(): List<String> {
+        val lines = ArrayList<String>()
+        val columns = optJSONArray("flexColumns") ?: JSONArray()
+        for (index in 0 until columns.length()) {
+            val value = columns.optJSONObject(index)
+                ?.optJSONObject("musicResponsiveListItemFlexColumnRenderer")
+                ?.optJSONObject("text")
+                ?.optJSONArray("runs")
+                .joinText()
+                .trim()
+            if (value.isNotBlank()) lines += value
+        }
+        return lines
+    }
+
+    private fun JSONObject.allTextRuns(): List<JSONObject> {
+        val arrays = mutableListOf<JSONArray>()
+        collectArraysByKey(this, "runs", arrays)
+        val result = ArrayList<JSONObject>()
+        arrays.forEach { array ->
+            for (index in 0 until array.length()) array.optJSONObject(index)?.let(result::add)
+        }
+        return result
+    }
+
+    private fun JSONObject.findText(): String {
+        val arrays = mutableListOf<JSONArray>()
+        collectArraysByKey(this, "runs", arrays)
+        return arrays.firstNotNullOfOrNull { array -> array.joinText().takeIf(String::isNotBlank) }.orEmpty()
+    }
+
+    private fun JSONObject.findBestThumbnail(): String {
+        val arrays = mutableListOf<JSONArray>()
+        collectArraysByKey(this, "thumbnails", arrays)
+        return arrays.asSequence().map { it.bestThumbnail() }.firstOrNull { it.isNotBlank() }.orEmpty()
+    }
+
+    private fun JSONArray?.joinText(preserveNewLines: Boolean = false): String {
+        if (this == null) return ""
+        val builder = StringBuilder()
+        for (index in 0 until length()) {
+            val text = optJSONObject(index)?.optString("text").orEmpty()
+            if (text.isBlank()) continue
+            if (preserveNewLines && builder.isNotEmpty() && text.startsWith("\n").not() && builder.lastOrNull() != '\n') {
+                builder.append("")
+            }
+            builder.append(text)
+        }
+        return builder.toString().replace("\\n", "\n").trim()
+    }
+
+    private fun JSONArray?.bestThumbnail(): String {
+        if (this == null) return ""
+        var best = ""
+        var bestArea = -1L
+        for (index in 0 until length()) {
+            val item = optJSONObject(index) ?: continue
+            val url = item.optString("url")
+            val area = item.optLong("width", 0L) * item.optLong("height", 0L)
+            if (url.isNotBlank() && area >= bestArea) {
+                best = url
+                bestArea = area
+            }
+        }
+        return best
+    }
+
+    private fun String.durationToMs(): Long {
+        val parts = split(":").mapNotNull(String::toLongOrNull)
+        return when (parts.size) {
+            2 -> (parts[0] * 60L + parts[1]) * 1_000L
+            3 -> (parts[0] * 3_600L + parts[1] * 60L + parts[2]) * 1_000L
+            else -> 0L
+        }
+    }
+
+    private fun String.cleanSource(): String {
+        return replace(Regex("(?i)^source:\\s*"), "").trim()
+    }
+
+    private fun collectObjectsByKey(value: Any?, key: String, out: MutableList<JSONObject>) {
+        when (value) {
+            is JSONObject -> {
+                val keys = value.keys()
+                while (keys.hasNext()) {
+                    val current = keys.next()
+                    val child = value.opt(current)
+                    if (current == key && child is JSONObject) out += child
+                    collectObjectsByKey(child, key, out)
+                }
+            }
+            is JSONArray -> for (index in 0 until value.length()) collectObjectsByKey(value.opt(index), key, out)
+        }
+    }
+
+    private fun collectArraysByKey(value: Any?, key: String, out: MutableList<JSONArray>) {
+        when (value) {
+            is JSONObject -> {
+                val keys = value.keys()
+                while (keys.hasNext()) {
+                    val current = keys.next()
+                    val child = value.opt(current)
+                    if (current == key && child is JSONArray) out += child
+                    collectArraysByKey(child, key, out)
+                }
+            }
+            is JSONArray -> for (index in 0 until value.length()) collectArraysByKey(value.opt(index), key, out)
+        }
+    }
+
+    private fun findAllStrings(value: Any?, key: String): List<String> {
+        val result = ArrayList<String>()
+        when (value) {
+            is JSONObject -> {
+                val keys = value.keys()
+                while (keys.hasNext()) {
+                    val current = keys.next()
+                    val child = value.opt(current)
+                    if (current == key && child is String && child.isNotBlank()) result += child
+                    result += findAllStrings(child, key)
+                }
+            }
+            is JSONArray -> for (index in 0 until value.length()) result += findAllStrings(value.opt(index), key)
+        }
+        return result
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/LyricsParsingTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/LyricsParsingTest.kt
@@ -74,4 +74,52 @@ class LyricsParsingTest {
         assertEquals("Synced", best?.provider)
         assertTrue((best?.confidence ?: 0) >= 80)
     }
+
+    @Test
+    fun providerSelectorUsesNativeTimedLyricsBeforeLrcLib() {
+        val request = LyricsRequest("Song", "Artist", 180)
+        val native = candidate("YouTube Music", synced = true)
+        val lrc = candidate("LRCLIB", synced = true)
+
+        val selected = LyricsProviderSelector.select(native, listOf(lrc), request)
+
+        assertEquals("YouTube Music", selected?.provider)
+    }
+
+    @Test
+    fun providerSelectorUsesSyncedLrcLibBeforeNativePlainLyrics() {
+        val request = LyricsRequest("Song", "Artist", 180)
+        val native = candidate("YouTube Music", synced = false)
+        val lrc = candidate("LRCLIB", synced = true)
+
+        val selected = LyricsProviderSelector.select(native, listOf(lrc), request)
+
+        assertEquals("LRCLIB", selected?.provider)
+    }
+
+    @Test
+    fun providerSelectorUsesNativePlainLyricsBeforeLrcLibPlainLyrics() {
+        val request = LyricsRequest("Song", "Artist", 180)
+        val native = candidate("YouTube Music", synced = false)
+        val lrc = candidate("LRCLIB", synced = false)
+
+        val selected = LyricsProviderSelector.select(native, listOf(lrc), request)
+
+        assertEquals("YouTube Music", selected?.provider)
+    }
+
+    private fun candidate(provider: String, synced: Boolean): LyricsCandidate {
+        return LyricsCandidate(
+            result = LyricsRepository.LyricsResult(
+                synced = synced,
+                lines = listOf(com.luc4n3x.levyra.domain.LyricLine(1_000L, 2_000L, "Line", "")),
+                provider = provider,
+                confidence = 90,
+                cached = false
+            ),
+            title = "Song",
+            artist = "Artist",
+            durationSec = 180
+        )
+    }
 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicWatchParserTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicWatchParserTest.kt
@@ -368,4 +368,40 @@ class YoutubeMusicWatchParserTest {
         assertEquals("Musixmatch", plainResult?.source)
         assertEquals(listOf("First plain line", "Second plain line"), plainResult?.lines?.map { it.text })
     }
+
+    @Test
+    fun relatedDescriptionPreservesAdjacentRunBoundaries() {
+        val root = JSONObject(
+            """
+            {
+              "contents": {
+                "musicDescriptionShelfRenderer": {
+                  "header": {"runs": [{"text": "About"}]},
+                  "description": {
+                    "runs": [
+                      {"text": "First paragraph"},
+                      {"text": "Second paragraph"}
+                    ]
+                  }
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val sections = YoutubeMusicWatchParser.parseRelated(root)
+
+        assertEquals(1, sections.size)
+        assertEquals("First paragraph\nSecond paragraph", sections.first().description)
+    }
+
+    @Test
+    fun lowQualityRadioFilterAppliesContextualMarkersWithoutDroppingLegitimateTitles() {
+        assertTrue(isLowQualityRadioCandidate("Song Name (Slowed + Reverb)", "Artist"))
+        assertTrue(isLowQualityRadioCandidate("Artist reacts to Song Name", "Reaction Channel"))
+        assertTrue(isLowQualityRadioCandidate("Song Name Karaoke", "Artist"))
+        assertFalse(isLowQualityRadioCandidate("Chain Reaction", "Diana Ross"))
+        assertFalse(isLowQualityRadioCandidate("Reaction", "New Order"))
+    }
+
 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicWatchParserTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicWatchParserTest.kt
@@ -1,0 +1,371 @@
+package com.luc4n3x.levyra.data
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class YoutubeMusicWatchParserTest {
+    @Test
+    fun watchPlaylistExtractsQueueTabsContinuationAndCounterpart() {
+        val root = JSONObject(
+            """
+            {
+              "contents": {
+                "singleColumnMusicWatchNextResultsRenderer": {
+                  "tabbedRenderer": {
+                    "watchNextTabbedResultsRenderer": {
+                      "tabs": [
+                        {
+                          "tabRenderer": {
+                            "endpoint": {
+                              "browseEndpoint": {
+                                "browseId": "MPLYt_LYRICS",
+                                "browseEndpointContextSupportedConfigs": {
+                                  "browseEndpointContextMusicConfig": {
+                                    "pageType": "MUSIC_PAGE_TYPE_TRACK_LYRICS"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "tabRenderer": {
+                            "endpoint": {
+                              "browseEndpoint": {
+                                "browseId": "MPTR_RELATED",
+                                "browseEndpointContextSupportedConfigs": {
+                                  "browseEndpointContextMusicConfig": {
+                                    "pageType": "MUSIC_PAGE_TYPE_TRACK_RELATED"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "playlist": {
+                "playlistPanelRenderer": {
+                  "contents": [
+                    {
+                      "playlistPanelVideoWrapperRenderer": {
+                        "primaryRenderer": {
+                          "playlistPanelVideoRenderer": {
+                            "videoId": "audio_id",
+                            "title": {"runs": [{"text": "Audio title"}]},
+                            "longBylineText": {
+                              "runs": [
+                                {
+                                  "text": "Artist",
+                                  "navigationEndpoint": {
+                                    "browseEndpoint": {
+                                      "browseId": "UC_ARTIST",
+                                      "browseEndpointContextSupportedConfigs": {
+                                        "browseEndpointContextMusicConfig": {
+                                          "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                {"text": " • "},
+                                {
+                                  "text": "Album",
+                                  "navigationEndpoint": {
+                                    "browseEndpoint": {
+                                      "browseId": "MPRE_ALBUM",
+                                      "browseEndpointContextSupportedConfigs": {
+                                        "browseEndpointContextMusicConfig": {
+                                          "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              ]
+                            },
+                            "lengthText": {"runs": [{"text": "3:42"}]},
+                            "thumbnail": {"thumbnails": [{"url": "small", "width": 120, "height": 120}, {"url": "large", "width": 544, "height": 544}]},
+                            "navigationEndpoint": {
+                              "watchEndpoint": {
+                                "videoId": "audio_id",
+                                "playlistId": "RDAMVMaudio_id",
+                                "watchEndpointMusicSupportedConfigs": {
+                                  "watchEndpointMusicConfig": {
+                                    "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "counterpart": [
+                          {
+                            "counterpartRenderer": {
+                              "playlistPanelVideoRenderer": {
+                                "videoId": "video_id",
+                                "title": {"runs": [{"text": "Official video"}]},
+                                "longBylineText": {"runs": [{"text": "Artist"}]},
+                                "lengthText": {"simpleText": "3:45"},
+                                "navigationEndpoint": {
+                                  "watchEndpoint": {
+                                    "videoId": "video_id",
+                                    "watchEndpointMusicSupportedConfigs": {
+                                      "watchEndpointMusicConfig": {
+                                        "musicVideoType": "MUSIC_VIDEO_TYPE_OMV"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "playlistPanelVideoRenderer": {
+                        "videoId": "next_id",
+                        "title": {"runs": [{"text": "Next song"}]},
+                        "longBylineText": {"runs": [{"text": "Next artist"}]},
+                        "lengthText": {"simpleText": "4:01"},
+                        "navigationEndpoint": {"watchEndpoint": {"videoId": "next_id", "playlistId": "RDAMVMaudio_id"}}
+                      }
+                    }
+                  ],
+                  "continuations": [{"nextRadioContinuationData": {"continuation": "CONT_TOKEN"}}]
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val parsed = YoutubeMusicWatchParser.parseWatchPlaylist(root)
+
+        assertEquals("RDAMVMaudio_id", parsed.playlistId)
+        assertEquals("MPLYt_LYRICS", parsed.lyricsBrowseId)
+        assertEquals("MPTR_RELATED", parsed.relatedBrowseId)
+        assertEquals("CONT_TOKEN", parsed.continuation)
+        assertEquals(listOf("audio_id", "next_id"), parsed.tracks.map { it.videoId })
+        assertEquals("video_id", parsed.tracks.first().counterpart?.videoId)
+        assertEquals("Artist", parsed.tracks.first().artists.first().name)
+        assertEquals("Album", parsed.tracks.first().albumTitle)
+        assertEquals(222_000L, parsed.tracks.first().durationMs)
+        assertEquals("large", parsed.tracks.first().thumbnailUrl)
+    }
+
+    @Test
+    fun relatedParserKeepsMixedSectionsAndTypedItems() {
+        val root = JSONObject(
+            """
+            {
+              "contents": {
+                "sectionListRenderer": {
+                  "contents": [
+                    {
+                      "musicCarouselShelfRenderer": {
+                        "header": {
+                          "musicCarouselShelfBasicHeaderRenderer": {
+                            "title": {"runs": [{"text": "You might also like"}]}
+                          }
+                        },
+                        "contents": [
+                          {
+                            "musicResponsiveListItemRenderer": {
+                              "title": {"runs": [{"text": "Related song"}]},
+                              "flexColumns": [
+                                {
+                                  "musicResponsiveListItemFlexColumnRenderer": {
+                                    "text": {
+                                      "runs": [
+                                        {"text": "Related song"}
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "musicResponsiveListItemFlexColumnRenderer": {
+                                    "text": {
+                                      "runs": [
+                                        {
+                                          "text": "Related artist",
+                                          "navigationEndpoint": {
+                                            "browseEndpoint": {
+                                              "browseId": "UC_RELATED",
+                                              "browseEndpointContextSupportedConfigs": {
+                                                "browseEndpointContextMusicConfig": {
+                                                  "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        {"text": " • "},
+                                        {
+                                          "text": "Related album",
+                                          "navigationEndpoint": {
+                                            "browseEndpoint": {
+                                              "browseId": "MPRE_RELATED_ALBUM",
+                                              "browseEndpointContextSupportedConfigs": {
+                                                "browseEndpointContextMusicConfig": {
+                                                  "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        {"text": " • 3:33"}
+                                      ]
+                                    }
+                                  }
+                                }
+                              ],
+                              "thumbnail": {"musicThumbnailRenderer": {"thumbnail": {"thumbnails": [{"url": "song-art", "width": 400, "height": 400}]}}},
+                              "navigationEndpoint": {
+                                "watchEndpoint": {
+                                  "videoId": "related_video",
+                                  "watchEndpointMusicSupportedConfigs": {
+                                    "watchEndpointMusicConfig": {
+                                      "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "musicTwoRowItemRenderer": {
+                              "title": {"runs": [{"text": "Related album card"}]},
+                              "subtitle": {
+                                "runs": [
+                                  {"text": "Album • "},
+                                  {
+                                    "text": "Related artist",
+                                    "navigationEndpoint": {
+                                      "browseEndpoint": {
+                                        "browseId": "UC_ALBUM_ARTIST",
+                                        "browseEndpointContextSupportedConfigs": {
+                                          "browseEndpointContextMusicConfig": {
+                                            "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  {"text": " • 2026"}
+                                ]
+                              },
+                              "thumbnailRenderer": {"musicThumbnailRenderer": {"thumbnail": {"thumbnails": [{"url": "album-art", "width": 512, "height": 512}]}}},
+                              "navigationEndpoint": {
+                                "browseEndpoint": {
+                                  "browseId": "MPRE_CARD",
+                                  "browseEndpointContextSupportedConfigs": {
+                                    "browseEndpointContextMusicConfig": {
+                                      "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val sections = YoutubeMusicWatchParser.parseRelated(root)
+
+        assertEquals(1, sections.size)
+        assertEquals("You might also like", sections.first().title)
+        assertEquals(2, sections.first().items.size)
+        val song = sections.first().items.first()
+        assertEquals(YoutubeMusicRelatedType.Song, song.type)
+        assertEquals("related_video", song.videoId)
+        assertEquals("Related artist", song.artists.first().name)
+        assertEquals("Related album", song.albumTitle)
+        assertEquals(213_000L, song.durationMs)
+        assertEquals("song-art", song.thumbnailUrl)
+        val album = sections.first().items.last()
+        assertEquals(YoutubeMusicRelatedType.Album, album.type)
+        assertEquals("MPRE_CARD", album.browseId)
+        assertEquals("2026", album.year)
+        assertEquals("album-art", album.thumbnailUrl)
+    }
+
+    @Test
+    fun lyricsParserReadsTimedMobileModelAndPlainWebFallback() {
+        val timed = JSONObject(
+            """
+            {
+              "contents": {
+                "elementRenderer": {
+                  "newElement": {
+                    "type": {
+                      "componentType": {
+                        "model": {
+                          "timedLyricsModel": {
+                            "lyricsData": {
+                              "sourceMessage": "Source: LyricFind",
+                              "timedLyricsData": [
+                                {
+                                  "lyricLine": "First line",
+                                  "cueRange": {
+                                    "startTimeMilliseconds": "1000",
+                                    "endTimeMilliseconds": "2500"
+                                  }
+                                },
+                                {
+                                  "lyricLine": "Second line",
+                                  "cueRange": {
+                                    "startTimeMilliseconds": "2600",
+                                    "endTimeMilliseconds": "4200"
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """.trimIndent()
+        )
+        val plain = JSONObject(
+            """
+            {
+              "contents": {
+                "musicDescriptionShelfRenderer": {
+                  "description": {"runs": [{"text": "First plain line\\nSecond plain line"}]},
+                  "footer": {"runs": [{"text": "Source: Musixmatch"}]}
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val timedResult = YoutubeMusicWatchParser.parseLyrics(timed)
+        val plainResult = YoutubeMusicWatchParser.parseLyrics(plain)
+
+        assertTrue(timedResult?.synced == true)
+        assertEquals("LyricFind", timedResult?.source)
+        assertEquals(1_000L, timedResult?.lines?.first()?.startMs)
+        assertEquals(4_200L, timedResult?.lines?.last()?.endMs)
+        assertFalse(plainResult?.synced ?: true)
+        assertEquals("Musixmatch", plainResult?.source)
+        assertEquals(listOf("First plain line", "Second plain line"), plainResult?.lines?.map { it.text })
+    }
+}


### PR DESCRIPTION
## Summary

- add complete YouTube Music watch playlist parsing
- extract queue continuations, lyrics browse IDs, related browse IDs, and song/video counterparts
- add native YouTube Music related-content parsing
- add native YouTube Music timed and plain lyrics
- preserve LRCLIB as the synchronized lyrics fallback
- add parser and provider-priority regression tests

## Files

- app/src/main/java/com/luc4n3x/levyra/data/LyricsParsing.kt
- app/src/main/java/com/luc4n3x/levyra/data/LyricsRepository.kt
- app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
- app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicWatchRepository.kt
- app/src/test/java/com/luc4n3x/levyra/data/LyricsParsingTest.kt
- app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicWatchParserTest.kt

## Validation

- watch playlist queue parsing
- continuation token parsing
- song/video counterpart extraction
- mixed related-section parsing
- YouTube Music timed and plain lyrics parsing
- YouTube Music and LRCLIB provider-priority tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved YouTube Music integration for song queues, related tracks, and playlist content.
  * Expanded lyrics support with native YouTube Music lyrics, synchronized timing, translation options, and additional fallback sources.
  * Improved radio recommendations using related content and higher-quality search results.

* **Bug Fixes**
  * Lyrics selection now prioritizes the most accurate synchronized results and reliably falls back when needed.
  * Improved lyrics caching for different videos, languages, and translation settings.

* **Tests**
  * Added coverage for lyrics provider selection, YouTube Music content parsing, related tracks, playlists, and timed lyrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->