### PR TITLE
Optimize Home startup scrolling and low-RAM performance

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/HomeStartupPerformance.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/HomeStartupPerformance.kt
@@ -1,0 +1,115 @@
+package com.luc4n3x.levyra.data
+
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+
+internal data class HomeStartupWorkPlan(
+    val idleWindowMs: Long,
+    val secondaryStartDelayMs: Long,
+    val priorityArtworkCount: Int,
+    val refreshedArtworkCount: Int,
+    val chartArtworkCount: Int,
+    val persistentArtworkCount: Int,
+    val chartEnrichmentCount: Int,
+    val chartEnrichmentConcurrency: Int,
+    val chartWarmCount: Int,
+    val releaseRadarArtistCount: Int,
+    val releasesPerArtist: Int
+)
+
+internal object HomeStartupWorkPolicy {
+    fun create(lowRam: Boolean, powerConstrained: Boolean): HomeStartupWorkPlan {
+        return when {
+            lowRam -> HomeStartupWorkPlan(
+                idleWindowMs = 700L,
+                secondaryStartDelayMs = 900L,
+                priorityArtworkCount = 2,
+                refreshedArtworkCount = 4,
+                chartArtworkCount = 3,
+                persistentArtworkCount = 1,
+                chartEnrichmentCount = 1,
+                chartEnrichmentConcurrency = 1,
+                chartWarmCount = 0,
+                releaseRadarArtistCount = 2,
+                releasesPerArtist = 4
+            )
+            powerConstrained -> HomeStartupWorkPlan(
+                idleWindowMs = 600L,
+                secondaryStartDelayMs = 800L,
+                priorityArtworkCount = 3,
+                refreshedArtworkCount = 5,
+                chartArtworkCount = 4,
+                persistentArtworkCount = 1,
+                chartEnrichmentCount = 2,
+                chartEnrichmentConcurrency = 1,
+                chartWarmCount = 1,
+                releaseRadarArtistCount = 3,
+                releasesPerArtist = 5
+            )
+            else -> HomeStartupWorkPlan(
+                idleWindowMs = 420L,
+                secondaryStartDelayMs = 550L,
+                priorityArtworkCount = 6,
+                refreshedArtworkCount = 10,
+                chartArtworkCount = 8,
+                persistentArtworkCount = 4,
+                chartEnrichmentCount = 6,
+                chartEnrichmentConcurrency = 2,
+                chartWarmCount = 2,
+                releaseRadarArtistCount = 6,
+                releasesPerArtist = 6
+            )
+        }
+    }
+}
+
+internal data class StartupPlaybackWarmPlan(
+    val delayMs: Long,
+    val trackCount: Int,
+    val concurrency: Int
+)
+
+internal object StartupPlaybackWarmPolicy {
+    fun create(lowRam: Boolean, powerConstrained: Boolean, preferredConcurrency: Int): StartupPlaybackWarmPlan {
+        return when {
+            lowRam -> StartupPlaybackWarmPlan(delayMs = 180L, trackCount = 1, concurrency = 1)
+            powerConstrained -> StartupPlaybackWarmPlan(delayMs = 140L, trackCount = 1, concurrency = 1)
+            else -> StartupPlaybackWarmPlan(
+                delayMs = 100L,
+                trackCount = 3,
+                concurrency = preferredConcurrency.coerceIn(1, 2)
+            )
+        }
+    }
+}
+
+internal class HomeInteractionGate(
+    private val nowMs: () -> Long = { System.nanoTime() / 1_000_000L }
+) {
+    @Volatile
+    private var scrolling = false
+
+    @Volatile
+    private var lastInteractionMs = nowMs()
+
+    fun update(isScrolling: Boolean) {
+        if (scrolling == isScrolling) return
+        scrolling = isScrolling
+        lastInteractionMs = nowMs()
+    }
+
+    fun remainingIdleMs(idleWindowMs: Long): Long {
+        if (scrolling) return idleWindowMs.coerceAtLeast(1L)
+        return (idleWindowMs - (nowMs() - lastInteractionMs)).coerceAtLeast(0L)
+    }
+
+    suspend fun awaitIdle(idleWindowMs: Long) {
+        val safeWindow = idleWindowMs.coerceAtLeast(0L)
+        while (currentCoroutineContext().isActive) {
+            val remaining = remainingIdleMs(safeWindow)
+            if (!scrolling && remaining == 0L) return
+            delay(if (scrolling) 80L else remaining.coerceIn(40L, 120L))
+        }
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/HomeStartupPerformance.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/HomeStartupPerformance.kt
@@ -3,6 +3,7 @@ package com.luc4n3x.levyra.data
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
+import java.util.concurrent.atomic.AtomicReference
 
 internal data class HomeStartupWorkPlan(
     val idleWindowMs: Long,
@@ -87,29 +88,60 @@ internal object StartupPlaybackWarmPolicy {
 internal class HomeInteractionGate(
     private val nowMs: () -> Long = { System.nanoTime() / 1_000_000L }
 ) {
-    @Volatile
-    private var scrolling = false
+    private data class InteractionState(
+        val scrolling: Boolean,
+        val lastInteractionMs: Long
+    )
 
-    @Volatile
-    private var lastInteractionMs = nowMs()
+    private data class IdleStatus(
+        val scrolling: Boolean,
+        val remainingMs: Long
+    )
+
+    private val state = AtomicReference(
+        InteractionState(
+            scrolling = false,
+            lastInteractionMs = nowMs()
+        )
+    )
 
     fun update(isScrolling: Boolean) {
-        if (scrolling == isScrolling) return
-        scrolling = isScrolling
-        lastInteractionMs = nowMs()
+        while (true) {
+            val current = state.get()
+            if (current.scrolling == isScrolling) return
+            val updated = InteractionState(
+                scrolling = isScrolling,
+                lastInteractionMs = nowMs()
+            )
+            if (state.compareAndSet(current, updated)) return
+        }
     }
 
     fun remainingIdleMs(idleWindowMs: Long): Long {
-        if (scrolling) return idleWindowMs.coerceAtLeast(1L)
-        return (idleWindowMs - (nowMs() - lastInteractionMs)).coerceAtLeast(0L)
+        return idleStatus(idleWindowMs).remainingMs
     }
 
     suspend fun awaitIdle(idleWindowMs: Long) {
         val safeWindow = idleWindowMs.coerceAtLeast(0L)
         while (currentCoroutineContext().isActive) {
-            val remaining = remainingIdleMs(safeWindow)
-            if (!scrolling && remaining == 0L) return
-            delay(if (scrolling) 80L else remaining.coerceIn(40L, 120L))
+            val status = idleStatus(safeWindow)
+            if (!status.scrolling && status.remainingMs == 0L) return
+            delay(if (status.scrolling) 80L else status.remainingMs.coerceIn(40L, 120L))
         }
+    }
+
+    private fun idleStatus(idleWindowMs: Long): IdleStatus {
+        val safeWindow = idleWindowMs.coerceAtLeast(0L)
+        val snapshot = state.get()
+        if (snapshot.scrolling) {
+            return IdleStatus(
+                scrolling = true,
+                remainingMs = safeWindow.coerceAtLeast(1L)
+            )
+        }
+        return IdleStatus(
+            scrolling = false,
+            remainingMs = (safeWindow - (nowMs() - snapshot.lastInteractionMs)).coerceAtLeast(0L)
+        )
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -168,6 +168,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.viewmodel.compose.viewModel as composeViewModel
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -276,7 +277,11 @@ import com.luc4n3x.levyra.viewmodel.PlayerViewModel
 import com.luc4n3x.levyra.viewmodel.SearchViewModel
 import com.valentinilk.shimmer.shimmer
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.launch
 import java.io.File
 import java.time.format.TextStyle as DayTextStyle
@@ -3144,9 +3149,6 @@ private fun HomeScreen(viewModel: HomeViewModel, state: LevyraUiState) {
     val otherSections = remember(state.homeSections) {
         state.homeSections.filter { !isVerifiedReleaseSectionTitle(it.title) && !isQuickPicksSectionTitle(it.title) }
     }
-    val secondaryPreloadTracks = remember(resonanceTracks, newReleases) {
-        (resonanceTracks + (newReleases?.tracks ?: emptyList())).distinctBy { it.id }.take(10)
-    }
     val chartChunks = remember(state.charts) { state.charts.chunked(4) }
     val homeContent = remember(
         state.tracks,
@@ -3202,17 +3204,19 @@ private fun HomeScreen(viewModel: HomeViewModel, state: LevyraUiState) {
         if (showHomeAlbumShimmer) LevyraArtworkStartupMetrics.recordShimmer(homeContent.hasUsableContent)
         if (showChartShimmer) LevyraArtworkStartupMetrics.recordShimmer(homeContent.hasUsableContent)
     }
+    LaunchedEffect(homeListState) {
+        snapshotFlow { homeListState.isScrollInProgress }
+            .distinctUntilChanged()
+            .collect { viewModel.setHomeScrollInProgress(it) }
+    }
+    DisposableEffect(viewModel) {
+        onDispose { viewModel.setHomeScrollInProgress(false) }
+    }
     LaunchedEffect(Unit) {
         delay(5_000L)
-        LevyraArtworkStartupMetrics.persistSnapshot(context)
-    }
-    LaunchedEffect(personalTracks, secondaryPreloadTracks) {
-        delay(500L)
-        while (homeListState.isScrollInProgress) delay(120L)
-        if (state.interfaceSettings.showPersonalOrbit && personalTracks.isNotEmpty()) {
-            LevyraArtworkCache.preloadPriority(context, personalTracks, LevyraPersonalOrbit.DISPLAY_LIMIT)
+        withContext(Dispatchers.IO) {
+            LevyraArtworkStartupMetrics.persistSnapshot(context)
         }
-        LevyraArtworkCache.preloadHome(context, secondaryPreloadTracks, 10)
     }
     LazyColumn(
         state = homeListState,
@@ -3254,15 +3258,12 @@ private fun HomeScreen(viewModel: HomeViewModel, state: LevyraUiState) {
         }
         if (state.currentTrack != null) {
             item(key = "home-continue", contentType = "home-card") {
-                HomeSectionInset {
-                    ContinueListeningCard(
-                        track = state.currentTrack,
-                        isPlaying = state.isPlaying,
-                        isResolving = state.isResolving,
-                        progress = progressOf(state.positionMs, state.durationMs),
-                        onResume = viewModel::togglePlay
-                    )
-                }
+                HomeContinueListeningCard(
+                    viewModel = viewModel,
+                    track = state.currentTrack,
+                    isPlaying = state.isPlaying,
+                    isResolving = state.isResolving
+                )
             }
         }
 
@@ -3327,12 +3328,13 @@ private fun HomeScreen(viewModel: HomeViewModel, state: LevyraUiState) {
                 )
             }
         }
-        otherSections.forEachIndexed { index, section ->
+        otherSections.forEach { section ->
             if (section.tracks.isNotEmpty()) {
-                item(key = "sec-other-${index}-header", contentType = "home-section-header") {
+                val sectionKey = "${section.title.trim().lowercase()}|${section.tracks.take(3).joinToString(".") { it.id }}"
+                item(key = "sec-other-$sectionKey-header", contentType = "home-section-header") {
                     HomeSectionInset { SectionHeaderAction(section.title, onPlayAll = { viewModel.playAll(section.tracks) }) }
                 }
-                item(key = "sec-other-${index}-row", contentType = "home-horizontal-row") {
+                item(key = "sec-other-$sectionKey-row", contentType = "home-horizontal-row") {
                     AlbumCardRow(
                         tracks = section.tracks,
                         currentId = state.currentTrack?.id,
@@ -3421,6 +3423,25 @@ private fun HomeScreen(viewModel: HomeViewModel, state: LevyraUiState) {
     }
 }
 
+@Composable
+private fun HomeContinueListeningCard(
+    viewModel: HomeViewModel,
+    track: Track,
+    isPlaying: Boolean,
+    isResolving: Boolean
+) {
+    val playbackProgress by viewModel.playbackProgress.collectAsState()
+    HomeSectionInset {
+        ContinueListeningCard(
+            track = track,
+            isPlaying = isPlaying,
+            isResolving = isResolving,
+            progress = progressOf(playbackProgress.positionMs, playbackProgress.durationMs),
+            onResume = viewModel::togglePlay
+        )
+    }
+}
+
 private data class HomeHeroUpdate(
     val track: Track,
     val sourceTitle: String,
@@ -3479,6 +3500,32 @@ private fun buildTrendingArtists(state: LevyraUiState): List<TrendingArtist> {
         .distinctBy { it.artist }
         .take(10)
         .map { TrendingArtist(name = it.artist, imageUrl = it.thumbnailUrl) }
+}
+
+@Composable
+private fun StableRemoteArtwork(
+    url: String,
+    contentDescription: String,
+    modifier: Modifier,
+    contentScale: ContentScale
+) {
+    val context = LocalContext.current
+    val resizedUrl = remember(url) { LevyraArtworkCache.small(url) }
+    val request = remember(context, resizedUrl) {
+        ImageRequest.Builder(context)
+            .data(resizedUrl)
+            .memoryCachePolicy(CachePolicy.ENABLED)
+            .diskCachePolicy(CachePolicy.ENABLED)
+            .networkCachePolicy(CachePolicy.ENABLED)
+            .crossfade(false)
+            .build()
+    }
+    AsyncImage(
+        model = request,
+        contentDescription = contentDescription,
+        contentScale = contentScale,
+        modifier = modifier
+    )
 }
 
 @Composable
@@ -3543,8 +3590,8 @@ private fun TrendingArtistsShelf(
                             .padding(2.dp),
                         contentAlignment = Alignment.Center
                     ) {
-                        AsyncImage(
-                            model = artist.imageUrl,
+                        StableRemoteArtwork(
+                            url = artist.imageUrl,
                             contentDescription = artist.name,
                             contentScale = ContentScale.Crop,
                             modifier = Modifier
@@ -9247,7 +9294,7 @@ private fun HomeAlbumHitRow(albums: List<AlbumHit>, animationsEnabled: Boolean, 
     ) {
         itemsIndexed(
             items = albums,
-            key = { index, album -> "home-album-card-$index-${album.title}-${album.artist}" },
+            key = { _, album -> album.browseId.ifBlank { "${album.title.trim().lowercase()}|${album.artist.trim().lowercase()}" } },
             contentType = { _, _ -> "home-album-card" }
         ) { index, album ->
             var isPressed by remember { mutableStateOf(false) }
@@ -9289,8 +9336,8 @@ private fun HomeAlbumHitRow(albums: List<AlbumHit>, animationsEnabled: Boolean, 
                             .aspectRatio(1f)
                     ) {
                         if (album.thumbnailUrl.isNotBlank()) {
-                            AsyncImage(
-                                model = album.thumbnailUrl,
+                            StableRemoteArtwork(
+                                url = album.thumbnailUrl,
                                 contentDescription = album.title,
                                 contentScale = ContentScale.Crop,
                                 modifier = Modifier
@@ -9351,7 +9398,7 @@ private fun AlbumCardRow(tracks: List<Track>, currentId: String?, animationsEnab
     ) {
         itemsIndexed(
             items = tracks,
-            key = { index, track -> "album-card-$index-${track.id}" },
+            key = { _, track -> track.id.ifBlank { "${track.title.trim().lowercase()}|${track.artist.trim().lowercase()}" } },
             contentType = { _, _ -> "album-card" }
         ) { index, track ->
             val isCurrent = track.id == currentId

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -3129,6 +3129,14 @@ private fun LevyraBackground(accentStart: Int?, accentEnd: Int?) {
     )
 }
 
+internal fun homeSectionLazyKey(
+    position: Int,
+    title: String,
+    trackIds: List<String>
+): String {
+    return "$position|${title.trim().lowercase(Locale.ROOT)}|${trackIds.take(3).joinToString(".")}"
+}
+
 @Composable
 private fun HomeScreen(viewModel: HomeViewModel, state: LevyraUiState) {
     val strings = LocalLevyraStrings.current
@@ -3328,9 +3336,13 @@ private fun HomeScreen(viewModel: HomeViewModel, state: LevyraUiState) {
                 )
             }
         }
-        otherSections.forEach { section ->
+        otherSections.forEachIndexed { sectionIndex, section ->
             if (section.tracks.isNotEmpty()) {
-                val sectionKey = "${section.title.trim().lowercase()}|${section.tracks.take(3).joinToString(".") { it.id }}"
+                val sectionKey = homeSectionLazyKey(
+                    position = sectionIndex,
+                    title = section.title,
+                    trackIds = section.tracks.take(3).map { it.id }
+                )
                 item(key = "sec-other-$sectionKey-header", contentType = "home-section-header") {
                     HomeSectionInset { SectionHeaderAction(section.title, onPlayAll = { viewModel.playAll(section.tracks) }) }
                 }

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -42,7 +42,7 @@ abstract class LevyraScreenViewModel(
         )
 }
 
-internal data class HomePlaybackProgress(
+data class HomePlaybackProgress(
     val positionMs: Long,
     val durationMs: Long
 )

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -42,7 +42,20 @@ abstract class LevyraScreenViewModel(
         )
 }
 
+internal data class HomePlaybackProgress(
+    val positionMs: Long,
+    val durationMs: Long
+)
+
 class HomeViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::homeProjection) {
+    val playbackProgress: StateFlow<HomePlaybackProgress> = root.state
+        .map { HomePlaybackProgress(it.positionMs, it.durationMs) }
+        .distinctUntilChanged()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000L),
+            initialValue = HomePlaybackProgress(root.state.value.positionMs, root.state.value.durationMs)
+        )
     fun addToPlaylist(playlistId: String, track: Track) = root.addToPlaylist(playlistId, track)
     fun addToQueue(track: Track) = root.addToQueue(track)
     fun createPlaylist(name: String, firstTrack: Track? = null) = root.createPlaylist(name, firstTrack)
@@ -59,6 +72,7 @@ class HomeViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::homeP
     fun selectMood(mood: Mood) = root.selectMood(mood)
     fun toggleFavorite(track: Track) = root.toggleFavorite(track)
     fun togglePlay() = root.togglePlay()
+    fun setHomeScrollInProgress(value: Boolean) = root.setHomeScrollInProgress(value)
 }
 
 class SearchViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::searchProjection) {
@@ -152,7 +166,6 @@ private data class HomeProjection(
     val chartRegions: List<ChartRegion>,
     val charts: List<Track>,
     val currentTrack: Track?,
-    val durationMs: Long,
     val favoriteIds: Set<String>,
     val favorites: List<Track>,
     val homeAlbums: List<AlbumHit>,
@@ -164,7 +177,6 @@ private data class HomeProjection(
     val moods: List<Mood>,
     val personalOrbitTracks: List<Track>,
     val playlists: List<Playlist>,
-    val positionMs: Long,
     val recentSearches: List<Track>,
     val releaseRadar: List<ReleaseRadarEntry>,
     val selectedChartId: String,
@@ -180,7 +192,6 @@ private fun homeProjection(state: LevyraUiState): HomeProjection = HomeProjectio
     chartRegions = state.chartRegions,
     charts = state.charts,
     currentTrack = state.currentTrack,
-    durationMs = state.durationMs,
     favoriteIds = state.favoriteIds,
     favorites = state.favorites,
     homeAlbums = state.homeAlbums,
@@ -192,7 +203,6 @@ private fun homeProjection(state: LevyraUiState): HomeProjection = HomeProjectio
     moods = state.moods,
     personalOrbitTracks = state.personalOrbitTracks,
     playlists = state.playlists,
-    positionMs = state.positionMs,
     recentSearches = state.recentSearches,
     releaseRadar = state.releaseRadar,
     selectedChartId = state.selectedChartId,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -16,6 +16,10 @@ import com.luc4n3x.levyra.data.LevyraBackupManager
 import com.luc4n3x.levyra.data.LevyraPreferences
 import com.luc4n3x.levyra.data.LevyraHomeSnapshotCache
 import com.luc4n3x.levyra.data.LevyraStartupCatalog
+import com.luc4n3x.levyra.data.HomeInteractionGate
+import com.luc4n3x.levyra.data.HomeStartupWorkPlan
+import com.luc4n3x.levyra.data.HomeStartupWorkPolicy
+import com.luc4n3x.levyra.data.StartupPlaybackWarmPolicy
 import com.luc4n3x.levyra.data.LevyraSmartMusicProfileStore
 import com.luc4n3x.levyra.data.ListeningPulseStore
 import com.luc4n3x.levyra.data.OfficialArtworkRepository
@@ -257,6 +261,24 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private val activeDownloadTitles = ConcurrentHashMap<String, String>()
     private val activeDownloadTracks = ConcurrentHashMap<String, Track>()
 
+    private val homeInteractionGate = HomeInteractionGate()
+
+    private fun homeStartupWorkPlan(): HomeStartupWorkPlan {
+        val playbackPlan = adaptivePlaybackPolicy.current(videoMode = false)
+        return HomeStartupWorkPolicy.create(
+            lowRam = playbackPlan.lowRam,
+            powerConstrained = playbackPlan.powerConstrained
+        )
+    }
+
+    fun setHomeScrollInProgress(value: Boolean) {
+        homeInteractionGate.update(value)
+    }
+
+    private suspend fun awaitHomeUiIdle(plan: HomeStartupWorkPlan = homeStartupWorkPlan()) {
+        homeInteractionGate.awaitIdle(plan.idleWindowMs)
+    }
+
     val state: StateFlow<LevyraUiState> = _state.asStateFlow()
     val playerController get() = player.controller
 
@@ -469,32 +491,52 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private fun scheduleColdStartRefresh(initialTracks: List<Track>) {
         val appContext = getApplication<Application>().applicationContext
         val orbitSeed = _state.value.personalOrbitTracks.take(LevyraPersonalOrbit.DISPLAY_LIMIT)
-        if (orbitSeed.isNotEmpty()) {
-            LevyraArtworkCache.preloadPriority(appContext, orbitSeed, LevyraPersonalOrbit.DISPLAY_LIMIT)
-            warmPersistentOrbit(orbitSeed, LevyraPersonalOrbit.DISPLAY_LIMIT, persist = false)
-            refreshMissingOfficialOrbitArtwork(orbitSeed)
-        }
+        val playbackPlan = adaptivePlaybackPolicy.current(videoMode = false)
+        val playbackWarmPlan = StartupPlaybackWarmPolicy.create(
+            lowRam = playbackPlan.lowRam,
+            powerConstrained = playbackPlan.powerConstrained,
+            preferredConcurrency = playbackPlan.concurrency
+        )
+        val startupPlan = homeStartupWorkPlan()
+
         viewModelScope.launch(Dispatchers.IO) {
-            delay(350L)
+            delay(playbackWarmPlan.delayMs)
             resolver.warmNetwork()
-            val hot = (orbitSeed.take(2) + initialTracks.take(4))
+            val hot = (orbitSeed.take(1) + initialTracks.take(playbackWarmPlan.trackCount))
                 .filter { it.id.isNotBlank() || it.videoUrl.isNotBlank() || it.title.isNotBlank() }
                 .distinctBy { playbackIdentity(it) }
-                .take(6)
-            warmTracks(hot, concurrency = 2, delayStepMs = 40L, prime = true)
+                .take(playbackWarmPlan.trackCount)
+            warmTracks(
+                tracks = hot,
+                concurrency = playbackWarmPlan.concurrency,
+                delayStepMs = playbackPlan.staggerMs,
+                prime = true
+            )
         }
+
+        if (orbitSeed.isNotEmpty()) {
+            viewModelScope.launch {
+                delay(startupPlan.secondaryStartDelayMs)
+                awaitHomeUiIdle(startupPlan)
+                LevyraArtworkCache.preloadPriority(appContext, orbitSeed, startupPlan.priorityArtworkCount)
+                warmPersistentOrbit(orbitSeed, startupPlan.persistentArtworkCount, persist = false)
+                refreshMissingOfficialOrbitArtwork(orbitSeed, deferUntilHomeIdle = true)
+            }
+        }
+
         viewModelScope.launch {
             delay(700L)
-            loadHomeFeed()
+            loadHomeFeed(deferUntilHomeIdle = true)
         }
         viewModelScope.launch {
-            delay(1600L)
-            loadCharts()
+            delay(1_600L)
+            loadCharts(deferUntilHomeIdle = true)
         }
         viewModelScope.launch {
-            delay(3200L)
+            delay(3_200L)
+            awaitHomeUiIdle(startupPlan)
             checkForUpdates(silent = true)
-            loadReleaseRadar()
+            loadReleaseRadar(deferUntilHomeIdle = true)
         }
     }
 
@@ -504,7 +546,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         viewModelScope.launch(Dispatchers.IO) {
             val languageCode = _state.value.languageCode
             if (persist) preferences.savePersonalOrbitTracks(limited, languageCode)
-            if (limited.isNotEmpty()) LevyraArtworkCache.cachePersistent(appContext, limited.take(4), 4)
+            if (limited.isNotEmpty()) LevyraArtworkCache.cachePersistent(appContext, limited, limited.size)
         }
     }
 
@@ -523,7 +565,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         )
     }
 
-    private fun loadReleaseRadar() {
+    private fun loadReleaseRadar(deferUntilHomeIdle: Boolean = false) {
         radarJob?.cancel()
         val followed = _state.value.followedArtists
         if (followed.isEmpty()) {
@@ -534,10 +576,14 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             val currentYear = java.util.Calendar.getInstance().get(java.util.Calendar.YEAR)
             val entries = mutableListOf<ReleaseRadarEntry>()
             val similar = LinkedHashMap<String, com.luc4n3x.levyra.domain.ArtistHit>()
-            followed.take(8).forEach { artist ->
+            val startupPlan = homeStartupWorkPlan()
+            val artistLimit = if (deferUntilHomeIdle) startupPlan.releaseRadarArtistCount else 8
+            val releaseLimit = if (deferUntilHomeIdle) startupPlan.releasesPerArtist else 8
+            followed.take(artistLimit).forEach { artist ->
+                if (deferUntilHomeIdle) awaitHomeUiIdle(startupPlan)
                 val profile = runCatching { artistRepository.profile(artist.browseId, artist.name) }.getOrNull() ?: return@forEach
                 if (!isActive) return@launch
-                (profile.albums + profile.singles).take(8).forEach { release ->
+                (profile.albums + profile.singles).take(releaseLimit).forEach { release ->
                     val year = release.year.toIntOrNull()
                     entries += ReleaseRadarEntry(
                         artistName = profile.name,
@@ -552,11 +598,16 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                         similar[key] = hit
                     }
                 }
-                val sorted = entries
-                    .distinctBy { it.release.browseId.ifBlank { "${it.artistName}|${it.release.title}" } }
-                    .sortedByDescending { it.release.year.toIntOrNull() ?: 0 }
-                    .take(20)
-                _state.update { it.copy(releaseRadar = sorted, similarArtists = similar.values.take(12).toList()) }
+            }
+            if (deferUntilHomeIdle) awaitHomeUiIdle()
+            val sorted = entries
+                .distinctBy { it.release.browseId.ifBlank { "${it.artistName}|${it.release.title}" } }
+                .sortedByDescending { it.release.year.toIntOrNull() ?: 0 }
+                .take(20)
+            val similarArtists = similar.values.take(12).toList()
+            _state.update { current ->
+                if (current.releaseRadar == sorted && current.similarArtists == similarArtists) current
+                else current.copy(releaseRadar = sorted, similarArtists = similarArtists)
             }
         }
     }
@@ -973,7 +1024,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     /** Loads the real YouTube Music home feed (sections), falling back to taste-based search. */
-    private fun loadHomeFeed() {
+    private fun loadHomeFeed(deferUntilHomeIdle: Boolean = false) {
         viewModelScope.launch {
             val hasVisibleHome = _state.value.homeSections.isNotEmpty() || _state.value.tracks.isNotEmpty()
             _state.update { it.copy(isSearching = !hasVisibleHome, searchError = null) }
@@ -981,7 +1032,8 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             val sections = runCatching { repository.homeFeed(languageCode) }.getOrDefault(emptyList())
             if (_state.value.languageCode != languageCode) return@launch
             if (sections.isEmpty()) {
-                loadHomeAlbums(languageCode)
+                loadHomeAlbums(languageCode, deferUntilHomeIdle)
+                if (deferUntilHomeIdle) awaitHomeUiIdle()
                 loadHome(preserveCurrent = hasVisibleHome)
                 return@launch
             }
@@ -990,39 +1042,58 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 _state.update { it.copy(isSearching = false) }
                 return@launch
             }
-            val queue = moodEngine.buildQueue(_state.value.selectedMood, flat)
             val instantAlbums = _state.value.homeAlbums.ifEmpty {
                 instantAlbumRecommendationsFromTracks(_state.value.personalOrbitTracks + _state.value.recentSearches + _state.value.favorites, flat, 10)
             }
             viewModelScope.launch(Dispatchers.IO) { preferences.saveHomeSections(sections, languageCode) }
-            _state.update {
-                it.copy(
-                    homeSections = sections,
-                    homeAlbums = instantAlbums,
-                    homeAlbumsLoading = instantAlbums.isEmpty(),
-                    tracks = flat,
-                    searchResults = flat.take(12),
-                    isSearching = false,
-                    cacheReport = repository.cacheReport(),
-                    searchError = null
-                )
+            if (deferUntilHomeIdle) awaitHomeUiIdle()
+            _state.update { current ->
+                val nextSearchResults = flat.take(12)
+                if (
+                    current.homeSections == sections &&
+                    current.homeAlbums == instantAlbums &&
+                    current.tracks == flat &&
+                    current.searchResults == nextSearchResults &&
+                    !current.isSearching &&
+                    current.searchError == null
+                ) {
+                    current
+                } else {
+                    current.copy(
+                        homeSections = sections,
+                        homeAlbums = instantAlbums,
+                        homeAlbumsLoading = instantAlbums.isEmpty(),
+                        tracks = flat,
+                        searchResults = nextSearchResults,
+                        isSearching = false,
+                        cacheReport = repository.cacheReport(),
+                        searchError = null
+                    )
+                }
             }
             persistHomeSnapshot()
-            val startupPlan = adaptivePlaybackPolicy.current(videoMode = false)
-            LevyraArtworkCache.preloadHome(getApplication<Application>().applicationContext, flat, if (startupPlan.lowRam) 8 else 18)
-            prefetchTop(flat, if (startupPlan.lowRam) 3 else 8)
-            loadHomeAlbums(languageCode)
+            val startupPlan = homeStartupWorkPlan()
+            viewModelScope.launch(Dispatchers.IO) {
+                if (deferUntilHomeIdle) awaitHomeUiIdle(startupPlan)
+                LevyraArtworkCache.preloadHome(
+                    getApplication<Application>().applicationContext,
+                    flat,
+                    startupPlan.refreshedArtworkCount
+                )
+            }
+            prefetchTop(flat, startupPlan.refreshedArtworkCount, respectHomeScroll = deferUntilHomeIdle)
+            loadHomeAlbums(languageCode, deferUntilHomeIdle)
         }
     }
 
-    private fun loadHomeAlbums(languageCode: String) {
+    private fun loadHomeAlbums(languageCode: String, deferUntilHomeIdle: Boolean = false) {
         viewModelScope.launch {
             val instantAlbums = instantAlbumRecommendations(_state.value)
             _state.update { current ->
-                current.copy(
-                    homeAlbums = if (current.homeAlbums.isEmpty() && instantAlbums.isNotEmpty()) instantAlbums else current.homeAlbums,
-                    homeAlbumsLoading = true
-                )
+                val visibleAlbums = if (current.homeAlbums.isEmpty() && instantAlbums.isNotEmpty()) instantAlbums else current.homeAlbums
+                val shouldLoadVisibly = visibleAlbums.isEmpty()
+                if (current.homeAlbums == visibleAlbums && current.homeAlbumsLoading == shouldLoadVisibly) current
+                else current.copy(homeAlbums = visibleAlbums, homeAlbumsLoading = shouldLoadVisibly)
             }
             val seedQueries = albumRecommendationSeeds(_state.value)
             val albums = runCatching { repository.homeAlbums(languageCode, seedQueries = seedQueries) }.getOrDefault(emptyList())
@@ -1033,7 +1104,11 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             }
             val mergedAlbums = mergeAlbums(albums, instantAlbums).take(10)
             viewModelScope.launch(Dispatchers.IO) { preferences.saveHomeAlbums(mergedAlbums, languageCode) }
-            _state.update { it.copy(homeAlbums = mergedAlbums, homeAlbumsLoading = false) }
+            if (deferUntilHomeIdle) awaitHomeUiIdle()
+            _state.update { current ->
+                if (current.homeAlbums == mergedAlbums && !current.homeAlbumsLoading) current
+                else current.copy(homeAlbums = mergedAlbums, homeAlbumsLoading = false)
+            }
         }
     }
 
@@ -1372,7 +1447,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         loadCharts(regionId)
     }
 
-    private fun loadCharts(regionId: String = _state.value.selectedChartId) {
+    private fun loadCharts(regionId: String = _state.value.selectedChartId, deferUntilHomeIdle: Boolean = false) {
         viewModelScope.launch {
             val hasVisibleCharts = _state.value.charts.isNotEmpty()
             _state.update { it.copy(isLoadingCharts = !hasVisibleCharts) }
@@ -1385,46 +1460,60 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 return@launch
             }
             viewModelScope.launch(Dispatchers.IO) { preferences.saveChartTracks(result, languageCode, regionId) }
-            _state.update {
-                if (it.selectedChartId != regionId) return@update it
-                it.copy(charts = result, isLoadingCharts = false)
+            if (deferUntilHomeIdle) awaitHomeUiIdle()
+            _state.update { current ->
+                if (current.selectedChartId != regionId) return@update current
+                if (current.charts == result && !current.isLoadingCharts) current
+                else current.copy(charts = result, isLoadingCharts = false)
             }
             persistHomeSnapshot()
-            LevyraArtworkCache.preloadHome(getApplication<Application>().applicationContext, result, 12)
-            enrichCharts(regionId, result)
+            val startupPlan = homeStartupWorkPlan()
+            viewModelScope.launch(Dispatchers.IO) {
+                if (deferUntilHomeIdle) awaitHomeUiIdle(startupPlan)
+                LevyraArtworkCache.preloadHome(
+                    getApplication<Application>().applicationContext,
+                    result,
+                    startupPlan.chartArtworkCount
+                )
+            }
+            enrichCharts(regionId, result, deferUntilHomeIdle)
         }
     }
 
-    private fun enrichCharts(regionId: String, charts: List<Track>) {
+    private fun enrichCharts(regionId: String, charts: List<Track>, deferUntilHomeIdle: Boolean = false) {
         chartEnrichJob?.cancel()
         chartEnrichJob = viewModelScope.launch(Dispatchers.IO) {
-            val hot = charts.take(6)
+            val startupPlan = homeStartupWorkPlan()
+            val enrichmentCount = if (deferUntilHomeIdle) startupPlan.chartEnrichmentCount else 6
+            val hot = charts.take(enrichmentCount)
             coroutineScope {
-                val semaphore = Semaphore(2)
+                val semaphore = Semaphore(if (deferUntilHomeIdle) startupPlan.chartEnrichmentConcurrency else 2)
                 hot.forEachIndexed { index, entry ->
                     launch {
                         semaphore.withPermit {
-                            enrichChartEntry(regionId, entry, warm = index < 2)
+                            enrichChartEntry(
+                                regionId = regionId,
+                                entry = entry,
+                                warm = index < if (deferUntilHomeIdle) startupPlan.chartWarmCount else 2,
+                                deferUntilHomeIdle = deferUntilHomeIdle
+                            )
                         }
                     }
                 }
             }
-            charts.drop(6).take(6).forEach { entry ->
-                if (!isActive || _state.value.selectedChartId != regionId) return@launch
-                enrichChartEntry(regionId, entry, warm = false)
-                delay(80L)
-            }
         }
     }
 
-    private suspend fun enrichChartEntry(regionId: String, entry: Track, warm: Boolean): Track? {
+    private suspend fun enrichChartEntry(regionId: String, entry: Track, warm: Boolean, deferUntilHomeIdle: Boolean = false): Track? {
         if (!currentCoroutineContext().isActive || _state.value.selectedChartId != regionId) return null
+        if (deferUntilHomeIdle) awaitHomeUiIdle()
         val match = if (entry.videoUrl.isNotBlank()) {
             entry
         } else {
             runCatching { repository.searchOne("${entry.title} ${entry.artist}", _state.value.languageCode) }.getOrNull() ?: return null
         }
         if (!currentCoroutineContext().isActive || _state.value.selectedChartId != regionId) return null
+        if (deferUntilHomeIdle) awaitHomeUiIdle()
         _state.update { st ->
             if (st.selectedChartId != regionId) return@update st
             st.copy(
@@ -1442,6 +1531,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             )
         }
         if (warm) {
+            if (deferUntilHomeIdle) awaitHomeUiIdle()
             val resolved = resolver.prefetch(match)
             if (resolved != null) runCatching { playbackWarmup.prime(resolved) }
         }
@@ -2097,7 +2187,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         }
     }
 
-    private fun refreshMissingOfficialOrbitArtwork(tracks: List<Track>) {
+    private fun refreshMissingOfficialOrbitArtwork(tracks: List<Track>, deferUntilHomeIdle: Boolean = false) {
         val pending = tracks
             .asSequence()
             .filter { it.title.isNotBlank() && it.artist.isNotBlank() }
@@ -2108,24 +2198,31 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         if (pending.isEmpty()) return
         orbitArtworkJob?.cancel()
         orbitArtworkJob = viewModelScope.launch {
-            delay(250L)
-            val semaphore = Semaphore(3)
+            val startupPlan = homeStartupWorkPlan()
+            delay(if (deferUntilHomeIdle) startupPlan.secondaryStartDelayMs else 250L)
+            if (deferUntilHomeIdle) awaitHomeUiIdle(startupPlan)
+            val enrichedTracks = Collections.synchronizedList(mutableListOf<Track>())
+            val semaphore = Semaphore(if (deferUntilHomeIdle) startupPlan.chartEnrichmentConcurrency else 3)
             coroutineScope {
-                pending.map { track ->
+                pending.take(if (deferUntilHomeIdle) startupPlan.refreshedArtworkCount else pending.size).map { track ->
                     launch {
                         semaphore.withPermit {
                             if (!isActive) return@withPermit
+                            if (deferUntilHomeIdle) awaitHomeUiIdle(startupPlan)
                             val key = LevyraPersonalOrbit.identityKey(track)
                             val current = _state.value.personalOrbitTracks.firstOrNull {
                                 LevyraPersonalOrbit.identityKey(it) == key
                             } ?: return@withPermit
                             if (LevyraPersonalOrbit.hasSquareAlbumArtwork(current)) return@withPermit
                             val enriched = resolveOfficialOrbitArtwork(current, _state.value.languageCode) ?: return@withPermit
-                            applyOfficialOrbitArtwork(enriched)
+                            enrichedTracks += enriched
                         }
                     }
                 }.forEach { it.join() }
             }
+            if (enrichedTracks.isEmpty()) return@launch
+            if (deferUntilHomeIdle) awaitHomeUiIdle(startupPlan)
+            applyOfficialOrbitArtworkBatch(enrichedTracks.toList())
         }
     }
 
@@ -2154,21 +2251,25 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     private suspend fun applyOfficialOrbitArtwork(enriched: Track) {
-        val targetKey = LevyraPersonalOrbit.identityKey(enriched)
+        applyOfficialOrbitArtworkBatch(listOf(enriched))
+    }
+
+    private suspend fun applyOfficialOrbitArtworkBatch(enrichedTracks: List<Track>) {
+        val enrichedByKey = enrichedTracks
+            .distinctBy { LevyraPersonalOrbit.identityKey(it) }
+            .associateBy { LevyraPersonalOrbit.identityKey(it) }
+        if (enrichedByKey.isEmpty()) return
         var persistedHistory: List<Track> = emptyList()
         var persistedOrbit: List<Track> = emptyList()
         var languageCode = _state.value.languageCode
         _state.update { current ->
             fun withArtwork(item: Track): Track {
-                return if (LevyraPersonalOrbit.identityKey(item) == targetKey) {
-                    item.copy(
-                        album = enriched.album.ifBlank { item.album },
-                        thumbnailUrl = enriched.thumbnailUrl,
-                        largeThumbnailUrl = enriched.largeThumbnailUrl
-                    )
-                } else {
-                    item
-                }
+                val enriched = enrichedByKey[LevyraPersonalOrbit.identityKey(item)] ?: return item
+                return item.copy(
+                    album = enriched.album.ifBlank { item.album },
+                    thumbnailUrl = enriched.thumbnailUrl,
+                    largeThumbnailUrl = enriched.largeThumbnailUrl
+                )
             }
 
             val currentTrack = current.currentTrack?.let(::withArtwork)
@@ -2198,17 +2299,30 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 searchResults = searchResults
             )
         }
-        queueEngine.updateTrackMetadata(enriched)
+        enrichedByKey.values.forEach { queueEngine.updateTrackMetadata(it) }
         val appContext = getApplication<Application>().applicationContext
-        val artworkTrack = persistedOrbit.firstOrNull {
-            LevyraPersonalOrbit.identityKey(it) == targetKey
-        } ?: enriched
-        withContext(Dispatchers.IO) {
-            preferences.saveRecentSearches(persistedHistory)
-            preferences.savePersonalOrbitTracks(persistedOrbit, languageCode)
-            LevyraArtworkCache.cachePersistent(appContext, listOf(artworkTrack), 1)
+        val startupPlan = homeStartupWorkPlan()
+        val artworkTracks = persistedOrbit
+            .filter { LevyraPersonalOrbit.identityKey(it) in enrichedByKey.keys }
+            .take(startupPlan.refreshedArtworkCount)
+        if (artworkTracks.isNotEmpty()) {
+            withContext(Dispatchers.IO) {
+                preferences.saveRecentSearches(persistedHistory)
+                preferences.savePersonalOrbitTracks(persistedOrbit, languageCode)
+                val persistentTracks = artworkTracks.take(startupPlan.persistentArtworkCount)
+                LevyraArtworkCache.cachePersistent(appContext, persistentTracks, persistentTracks.size)
+            }
+            LevyraArtworkCache.preloadPriority(
+                appContext,
+                artworkTracks,
+                startupPlan.priorityArtworkCount.coerceAtMost(artworkTracks.size)
+            )
+        } else {
+            withContext(Dispatchers.IO) {
+                preferences.saveRecentSearches(persistedHistory)
+                preferences.savePersonalOrbitTracks(persistedOrbit, languageCode)
+            }
         }
-        LevyraArtworkCache.preloadPriority(appContext, listOf(artworkTrack), 1)
     }
 
     fun playQueueTrack(track: Track) {
@@ -2578,7 +2692,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         }
     }
 
-    private fun prefetchTop(tracks: List<Track>, count: Int = 8) {
+    private fun prefetchTop(tracks: List<Track>, count: Int = 8, respectHomeScroll: Boolean = false) {
         val plan = adaptivePlaybackPolicy.current(videoMode = false)
         val effectiveCount = if (plan.lowRam || plan.powerConstrained) count.coerceAtMost(3) else count
         val candidates = tracks
@@ -2589,6 +2703,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         listPrefetchJob?.cancel()
         listPrefetchJob = viewModelScope.launch(Dispatchers.IO) {
             delay(if (plan.lowRam) 450L else 250L)
+            if (respectHomeScroll) awaitHomeUiIdle()
             resolver.warmNetwork()
             val hotCount = if (plan.lowRam || plan.powerConstrained) 1 else 4
             val hot = candidates.take(hotCount)

--- a/app/src/test/java/com/luc4n3x/levyra/data/HomeStartupPerformanceTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/HomeStartupPerformanceTest.kt
@@ -3,6 +3,11 @@ package com.luc4n3x.levyra.data
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 
 class HomeStartupPerformanceTest {
     @Test
@@ -62,5 +67,40 @@ class HomeStartupPerformanceTest {
         assertEquals(200L, gate.remainingIdleMs(500L))
         now += 200L
         assertEquals(0L, gate.remainingIdleMs(500L))
+    }
+
+    @Test
+    fun interactionGatePublishesScrollStateAndTimestampAtomically() {
+        val now = AtomicLong(1_000L)
+        val blockNextClockRead = AtomicBoolean(false)
+        val clockReadStarted = CountDownLatch(1)
+        val releaseClockRead = CountDownLatch(1)
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val gate = HomeInteractionGate {
+                if (blockNextClockRead.compareAndSet(true, false)) {
+                    clockReadStarted.countDown()
+                    check(releaseClockRead.await(2L, TimeUnit.SECONDS))
+                }
+                now.get()
+            }
+            gate.update(true)
+            now.set(10_000L)
+            blockNextClockRead.set(true)
+
+            val update = executor.submit { gate.update(false) }
+            assertTrue(clockReadStarted.await(2L, TimeUnit.SECONDS))
+            assertEquals(500L, gate.remainingIdleMs(500L))
+
+            releaseClockRead.countDown()
+            update.get(2L, TimeUnit.SECONDS)
+            assertEquals(500L, gate.remainingIdleMs(500L))
+
+            now.addAndGet(500L)
+            assertEquals(0L, gate.remainingIdleMs(500L))
+        } finally {
+            releaseClockRead.countDown()
+            executor.shutdownNow()
+        }
     }
 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/HomeStartupPerformanceTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/HomeStartupPerformanceTest.kt
@@ -1,0 +1,66 @@
+package com.luc4n3x.levyra.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HomeStartupPerformanceTest {
+    @Test
+    fun lowRamPlanKeepsBackgroundWorkSmall() {
+        val plan = HomeStartupWorkPolicy.create(lowRam = true, powerConstrained = true)
+        assertTrue(plan.priorityArtworkCount <= 2)
+        assertTrue(plan.refreshedArtworkCount <= 4)
+        assertEquals(1, plan.chartEnrichmentConcurrency)
+        assertEquals(0, plan.chartWarmCount)
+        assertTrue(plan.releaseRadarArtistCount <= 2)
+        assertTrue(plan.releasesPerArtist <= 4)
+        assertTrue(plan.idleWindowMs >= 650L)
+    }
+
+    @Test
+    fun normalPlanStillPreloadsUsefulArtwork() {
+        val plan = HomeStartupWorkPolicy.create(lowRam = false, powerConstrained = false)
+        assertTrue(plan.priorityArtworkCount >= 6)
+        assertTrue(plan.refreshedArtworkCount >= 10)
+        assertEquals(2, plan.chartEnrichmentConcurrency)
+        assertTrue(plan.chartWarmCount >= 1)
+        assertTrue(plan.releaseRadarArtistCount >= 6)
+    }
+
+    @Test
+    fun playbackWarmupRemainsImmediateOnOlderDevices() {
+        val plan = StartupPlaybackWarmPolicy.create(
+            lowRam = true,
+            powerConstrained = true,
+            preferredConcurrency = 2
+        )
+        assertTrue(plan.delayMs <= 180L)
+        assertEquals(1, plan.trackCount)
+        assertEquals(1, plan.concurrency)
+    }
+
+    @Test
+    fun playbackWarmupKeepsParallelCapacityOnModernDevices() {
+        val plan = StartupPlaybackWarmPolicy.create(
+            lowRam = false,
+            powerConstrained = false,
+            preferredConcurrency = 2
+        )
+        assertTrue(plan.delayMs <= 100L)
+        assertEquals(3, plan.trackCount)
+        assertEquals(2, plan.concurrency)
+    }
+
+    @Test
+    fun interactionGateRequiresAStableIdleWindow() {
+        var now = 1_000L
+        val gate = HomeInteractionGate { now }
+        gate.update(true)
+        assertTrue(gate.remainingIdleMs(500L) > 0L)
+        gate.update(false)
+        now += 300L
+        assertEquals(200L, gate.remainingIdleMs(500L))
+        now += 200L
+        assertEquals(0L, gate.remainingIdleMs(500L))
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/ui/HomeSectionLazyKeyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/HomeSectionLazyKeyTest.kt
@@ -1,0 +1,39 @@
+package com.luc4n3x.levyra.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class HomeSectionLazyKeyTest {
+    @Test
+    fun positionalFallbackKeepsDuplicateSectionsUnique() {
+        val first = homeSectionLazyKey(
+            position = 0,
+            title = "Daily mix",
+            trackIds = listOf("a", "b", "c", "d")
+        )
+        val second = homeSectionLazyKey(
+            position = 1,
+            title = "Daily mix",
+            trackIds = listOf("a", "b", "c", "e")
+        )
+
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun keyUsesOnlyTheLeadingThreeTrackIds() {
+        val first = homeSectionLazyKey(
+            position = 2,
+            title = "For You",
+            trackIds = listOf("a", "b", "c", "d")
+        )
+        val second = homeSectionLazyKey(
+            position = 2,
+            title = "For You",
+            trackIds = listOf("a", "b", "c", "e")
+        )
+
+        assertEquals(first, second)
+    }
+}


### PR DESCRIPTION
## Summary

- Optimized Home startup scrolling to reduce frame drops during the first seconds after launch.
- Added a startup performance policy inspired by SimpMusic and Metrolist, separating essential playback work from secondary Home refresh tasks.
- Improved behaviour on older and low-RAM Android devices without slowing down tap-to-play latency.

## Scope

- [ ] Player / audio
- [ ] Stream extraction
- [ ] Downloads
- [x] UI / Compose
- [ ] Localization
- [ ] Android Auto / media session
- [ ] CI / release
- [ ] Documentation
- [x] Performance
- [x] Low-RAM devices
- [x] Tests

## What changed

- Added a Home startup scroll guard that temporarily postpones non-essential refresh operations while the user is actively scrolling.
- Secondary tasks resume only after the Home has remained idle for a device-dependent interval.
- Added different startup profiles for:
  - standard devices;
  - battery-saver mode;
  - low-RAM and older devices.
- Reduced concurrent artwork enrichment and persistent-cache work on low-memory devices.
- Limited startup preload volume on older devices to reduce bitmap decoding, network pressure and garbage collection.
- Kept playback resolution outside the scroll guard so tapping a track still starts the existing fast resolver path immediately.
- Preserved the LevyraExtractor and Android VR immediate race used for tap-to-play.
- Isolated player-position updates so they no longer trigger unnecessary recomposition of the complete Home every second.
- Removed duplicated artwork preload work previously started directly from the UI.
- Routed additional Home artwork through stable Coil requests without unnecessary crossfade.
- Replaced index-based Compose keys with stable content-based identities where applicable.
- Moved startup diagnostic persistence to `Dispatchers.IO` to avoid file writes on the main thread.
- Batched artwork updates and prevented Home state publication when the resulting content is unchanged.
- Added startup-performance regression coverage for scroll blocking, low-RAM profiles and playback warm-up limits.

## Device behaviour

### Standard devices

- Short idle delay before secondary Home work resumes.
- Limited concurrent artwork enrichment.
- Playback warm-up remains active with a reduced startup footprint.

### Battery-saver mode

- Longer idle delay before background Home tasks resume.
- Reduced playback warm-up and artwork preload.
- Lower startup CPU and network activity.

### Low-RAM and older devices

- Maximum of two priority artwork items during startup.
- One enrichment operation at a time.
- Reduced persistent artwork writes per cycle.
- No unnecessary chart-track warm-up.
- Reduced Release Radar startup work.
- Longer idle period before non-essential Home updates resume.
- Playback requests triggered by a user tap remain immediate.

## Testing

- [ ] `gradle --no-daemon :app:lintRelease`
- [ ] `gradle --no-daemon testReleaseUnitTest`
- [ ] `gradle --no-daemon assembleRelease`
- [ ] APK installed on device
- [ ] Playback tested
- [ ] Downloads tested
- [ ] Language switching tested
- [x] Startup performance policy smoke-tested
- [x] Low-RAM profile behaviour covered by tests
- [x] Playback warm-up limits covered by tests
- [x] Generated project archive verified

## Release safety

- [x] No playback resolver priority changes
- [x] No stream extraction changes
- [x] No download pipeline changes
- [x] No secrets, keystores, APKs or ZIPs committed
- [x] No duplicated release workflows
- [x] No external components added
- [ ] `levyraVersionName` and `levyraVersionCode` are correct
- [ ] Credits and licenses updated when adding external components

## Expected result

- The Home remains responsive when the user starts scrolling immediately after opening Levyra.
- Cached content is rendered first while secondary refresh work waits for an idle window.
- Older phones perform less concurrent image and network work during startup.
- Player startup remains fast because user-triggered stream resolution is never delayed by Home scrolling.
- Home recompositions, duplicate artwork requests and main-thread file writes are reduced.

## Related issues

- Closes #
- Related to #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Home screen startup responsiveness, especially on low-memory or power-constrained devices.
  * Defers background loading, artwork enrichment, and prefetching while users scroll or interact.
  * Optimizes playback warm-up and artwork caching based on device conditions.

* **UI Improvements**
  * Stabilized artwork rendering and list updates to reduce visual refreshes.
  * Improved “Continue Listening” playback progress updates.
  * Added smoother Home feed loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->