### PR TITLE
Clean up deprecated Android, Media3 and Compose APIs

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/LevyraApplication.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/LevyraApplication.kt
@@ -36,7 +36,7 @@ class LevyraApplication : Application() {
 
     override fun onTrimMemory(level: Int) {
         super.onTrimMemory(level)
-        if (level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW) YoutubeLocalDecoder.trimMemory()
+        if (level >= ComponentCallbacks2.TRIM_MEMORY_BACKGROUND) YoutubeLocalDecoder.trimMemory()
     }
 
     private fun warmPlaybackPipeline() {

--- a/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
@@ -13,6 +13,7 @@ import android.os.Bundle
 import android.util.Rational
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.mutableStateOf
 import androidx.core.app.ActivityCompat
@@ -32,6 +33,7 @@ class MainActivity : ComponentActivity() {
     private val pipMode = mutableStateOf(false)
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         applyOrientationPolicy()
         configureFastImageLoader()
@@ -39,19 +41,12 @@ class MainActivity : ComponentActivity() {
         requestLegacyStoragePermission()
         val startPalette = LevyraThemes.byId(LevyraThemes.APPLE_MUSIC)
         LevyraThemeController.apply(startPalette.id)
-        WindowCompat.setDecorFitsSystemWindows(window, false)
-        window.statusBarColor = Color.TRANSPARENT
-        window.navigationBarColor = Color.TRANSPARENT
         window.setBackgroundDrawable(ColorDrawable(if (startPalette.isLight) Color.WHITE else Color.BLACK))
         WindowCompat.getInsetsController(window, window.decorView).apply {
             isAppearanceLightStatusBars = startPalette.isLight
             isAppearanceLightNavigationBars = startPalette.isLight
         }
         LevyraLaunchActions.consumeFrom(intent)
-        if (Build.VERSION.SDK_INT >= 29) {
-            window.isStatusBarContrastEnforced = false
-            window.isNavigationBarContrastEnforced = false
-        }
         if (Build.VERSION.SDK_INT >= 28) {
             val params = window.attributes
             params.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
@@ -168,7 +163,7 @@ class MainActivity : ComponentActivity() {
 
     private fun requestHighRefreshRate() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            window.windowManager.defaultDisplay.supportedModes.maxByOrNull { it.refreshRate }?.let { mode ->
+            window.decorView.display?.supportedModes?.maxByOrNull { it.refreshRate }?.let { mode ->
                 val params = window.attributes
                 params.preferredDisplayModeId = mode.modeId
                 window.attributes = params

--- a/app/src/main/java/com/luc4n3x/levyra/data/AppUpdateRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/AppUpdateRepository.kt
@@ -19,7 +19,7 @@ class AppUpdateRepository(context: Context) {
             .header("User-Agent", "LEVYRA/${BuildConfig.VERSION_NAME}")
             .build()
         client.newCall(request).execute().use { response ->
-            val body = response.body?.string().orEmpty()
+            val body = response.body.string()
             if (!response.isSuccessful) {
                 val message = when (response.code) {
                     404 -> "Nessuna release pubblicata per LEVYRA"

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraArtworkCache.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraArtworkCache.kt
@@ -246,7 +246,7 @@ object LevyraArtworkCache {
                         .build()
                     LevyraHttpClientFactory.media().newCall(request).execute().use { response ->
                         if (!response.isSuccessful) return@use false
-                        val body = response.body ?: return@use false
+                        val body = response.body
                         val length = body.contentLength()
                         if (length > MAX_FILE_BYTES) return@use false
                         val bytes = body.bytes()

--- a/app/src/main/java/com/luc4n3x/levyra/data/LyricsPlusProvider.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LyricsPlusProvider.kt
@@ -380,9 +380,9 @@ internal class LyricsPlusProvider(private val client: OkHttpClient) {
             continuation.invokeOnCancellation { call.cancel() }
             call.enqueue(
                 object : Callback {
-                    override fun onFailure(call: Call, exception: IOException) {
+                    override fun onFailure(call: Call, e: IOException) {
                         if (continuation.isActive) {
-                            Timber.d(exception, "LyricsPlus request failed for %s", request.url.host)
+                            Timber.d(e, "LyricsPlus request failed for %s", request.url.host)
                             continuation.resume(HttpOutcome.Failure)
                         }
                     }
@@ -393,7 +393,7 @@ internal class LyricsPlusProvider(private val client: OkHttpClient) {
                                 when {
                                     it.code == 404 -> HttpOutcome.NotFound
                                     !it.isSuccessful -> HttpOutcome.Failure
-                                    else -> it.body?.string()?.takeIf(String::isNotBlank)
+                                    else -> it.body.string().takeIf(String::isNotBlank)
                                         ?.let(HttpOutcome::Success)
                                         ?: HttpOutcome.Failure
                                 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/LyricsRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LyricsRepository.kt
@@ -131,8 +131,9 @@ class LyricsRepository(context: Context? = null) {
         var current: LyricsResult? = null
         val cached = readCached(query)
         cached.result?.let { result ->
-            current = result.copy(cached = true)
-            send(current!!)
+            val cachedResult = result.copy(cached = true)
+            current = cachedResult
+            send(cachedResult)
         }
         if (cached.negative) return@channelFlow
         if (!cached.refreshRequired) return@channelFlow
@@ -155,8 +156,8 @@ class LyricsRepository(context: Context? = null) {
             memoryPut(query.key, stable, System.currentTimeMillis())
             persistPositive(query, stable)
             send(stable)
-        } else if (final != null && current != null) {
-            persistPositive(query, current!!.copy(cached = false))
+        } else if (final != null) {
+            current?.let { persistPositive(query, it.copy(cached = false)) }
         }
 
         if (current == null && outcome.attempted && !outcome.hadTransientFailure) {
@@ -540,9 +541,9 @@ class LyricsRepository(context: Context? = null) {
             continuation.invokeOnCancellation { call.cancel() }
             call.enqueue(
                 object : Callback {
-                    override fun onFailure(call: Call, exception: IOException) {
+                    override fun onFailure(call: Call, e: IOException) {
                         if (continuation.isActive) {
-                            Timber.w(exception, "Lyrics request failed for %s", request.url.host)
+                            Timber.w(e, "Lyrics request failed for %s", request.url.host)
                             continuation.resume(HttpGetResult.Failure)
                         }
                     }
@@ -553,7 +554,7 @@ class LyricsRepository(context: Context? = null) {
                                 when {
                                     it.code == 404 -> HttpGetResult.NotFound
                                     !it.isSuccessful -> HttpGetResult.Failure
-                                    else -> it.body?.string()?.takeIf(String::isNotBlank)
+                                    else -> it.body.string().takeIf(String::isNotBlank)
                                         ?.let(HttpGetResult::Success)
                                         ?: HttpGetResult.Failure
                                 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
@@ -91,7 +91,7 @@ private class OkHttpNewPipeDownloader : Downloader() {
     }
 
     private fun toExtractorResponse(response: okhttp3.Response): Response {
-        val responseBytes = response.body?.bytes() ?: ByteArray(0)
+        val responseBytes = response.body.bytes()
         val responseText = responseBytes.toString(StandardCharsets.UTF_8)
         if (response.code == 429) {
             throw IOException("YouTube ha limitato temporaneamente le richieste")

--- a/app/src/main/java/com/luc4n3x/levyra/data/OfficialArtworkRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/OfficialArtworkRepository.kt
@@ -158,7 +158,7 @@ class OfficialArtworkRepository(context: Context) {
         return runCatching {
             client.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) return@use null
-                val body = response.body?.string().orEmpty()
+                val body = response.body.string()
                 if (body.isBlank()) null else JSONObject(body)
             }
         }.getOrNull()

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -1266,12 +1266,12 @@ class PlaybackResolver private constructor(private val context: Context) {
             mimeType = format?.mimeType.orEmpty(),
             codec = stream.codec.orEmpty(),
             width = stream.width,
-            height = stream.height.takeIf { it > 0 } ?: heightOf(stream.resolution),
+            height = stream.height.takeIf { it > 0 } ?: heightOf(stream.getResolution()),
             fps = stream.fps,
             bitrate = stream.bitrate,
             itag = stream.itag,
-            muxed = !stream.isVideoOnly,
-            label = stream.resolution
+            muxed = !stream.isVideoOnly(),
+            label = stream.getResolution()
         )
     }
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
@@ -1389,7 +1389,6 @@ private class YoutubeCipherWebRuntime private constructor(
                 run { webView.settings.allowFileAccessFromFileURLs = true }
                 webView.settings.blockNetworkLoads = true
                 webView.settings.domStorageEnabled = false
-                webView.settings.databaseEnabled = false
                 webView.addJavascriptInterface(bridge, JS_INTERFACE)
                 webView.webChromeClient = WebChromeClient()
                 webView.webViewClient = object : WebViewClient() {
@@ -1495,8 +1494,8 @@ private suspend fun OkHttpClient.awaitText(request: Request, maxBytes: Int): You
         val call = newCall(request)
         continuation.invokeOnCancellation { call.cancel() }
         call.enqueue(object : Callback {
-            override fun onFailure(call: Call, error: IOException) {
-                if (continuation.isActive) runCatching { continuation.resumeWithException(error) }
+            override fun onFailure(call: Call, e: IOException) {
+                if (continuation.isActive) runCatching { continuation.resumeWithException(e) }
             }
 
             override fun onResponse(call: Call, response: Response) {

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicWatchRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicWatchRepository.kt
@@ -223,7 +223,7 @@ class YoutubeMusicWatchRepository(private val context: Context? = null) {
             .header("X-Youtube-Client-Version", if (mobile) ANDROID_MUSIC_CLIENT_VERSION else WEB_REMIX_CLIENT_VERSION)
         GoogleApiKeyHeaders.applyTo(requestBuilder, context)
         return client.newCall(requestBuilder.build()).execute().use { response ->
-            val responseBody = response.body?.string().orEmpty()
+            val responseBody = response.body.string()
             if (!response.isSuccessful || responseBody.isBlank()) {
                 throw YoutubeMusicRequestException(endpoint, response.code, responseBody.take(512))
             }

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
@@ -347,7 +347,6 @@ internal class YoutubePoTokenRuntime private constructor(
         webView.settings.javaScriptCanOpenWindowsAutomatically = false
         webView.settings.setSupportMultipleWindows(false)
         webView.settings.domStorageEnabled = false
-        webView.settings.databaseEnabled = false
         webView.addJavascriptInterface(this, JS_INTERFACE)
         webView.webChromeClient = object : WebChromeClient() {
             override fun onConsoleMessage(consoleMessage: ConsoleMessage): Boolean {

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeTranscriptLyricsProvider.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeTranscriptLyricsProvider.kt
@@ -75,7 +75,7 @@ class YoutubeTranscriptLyricsProvider(context: Context) {
         GoogleApiKeyHeaders.applyTo(requestBuilder, appContext)
         return client.newCall(requestBuilder.build()).execute().use { response ->
             if (!response.isSuccessful) return null
-            response.body?.string()?.takeIf { it.isNotBlank() }?.let(::JSONObject)
+            response.body.string().takeIf { it.isNotBlank() }?.let(::JSONObject)
         }
     }
 
@@ -105,7 +105,7 @@ class YoutubeTranscriptLyricsProvider(context: Context) {
             .build()
         return client.newCall(request).execute().use { response ->
             if (!response.isSuccessful) return emptyList()
-            val root = response.body?.string()?.takeIf { it.isNotBlank() }?.let(::JSONObject) ?: return emptyList()
+            val root = response.body.string().takeIf { it.isNotBlank() }?.let(::JSONObject) ?: return emptyList()
             parseEvents(root.optJSONArray("events") ?: JSONArray())
         }
     }

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaCache.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaCache.kt
@@ -2,13 +2,11 @@ package com.luc4n3x.levyra.player
 
 import android.app.ActivityManager
 import android.content.Context
-import androidx.media3.common.util.UnstableApi
 import androidx.media3.database.StandaloneDatabaseProvider
 import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
 import androidx.media3.datasource.cache.SimpleCache
 import java.io.File
 
-@OptIn(UnstableApi::class)
 object LevyraMediaCache {
     private const val LOW_RAM_MAX_BYTES = 160L * 1024L * 1024L
     private const val DEFAULT_MAX_BYTES = 384L * 1024L * 1024L

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
@@ -7,7 +7,6 @@ import androidx.media3.common.C
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
-import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
@@ -22,7 +21,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
-@OptIn(UnstableApi::class)
 class LevyraPlayer(context: Context) {
     var onCompletion: (() -> Unit)? = null
     var onError: ((String) -> Unit)? = null

--- a/app/src/main/java/com/luc4n3x/levyra/player/NormalizationAudioProcessor.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/NormalizationAudioProcessor.kt
@@ -8,6 +8,7 @@ import java.nio.ByteOrder
 import kotlin.math.pow
 import kotlin.math.sqrt
 
+@Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
 class NormalizationAudioProcessor : AudioProcessor {
 
     @Volatile
@@ -48,7 +49,7 @@ class NormalizationAudioProcessor : AudioProcessor {
     internal fun metadataGain(): Float? {
         val loudness = youtubePerceptualLoudnessDb ?: youtubeLoudnessDb ?: return null
         val attenuationDb = loudness.coerceAtLeast(0.0f)
-        return 10.0.pow((-attenuationDb / 20.0).toDouble()).toFloat().coerceIn(0.25f, 1.0f)
+        return 10.0.pow(-attenuationDb / 20.0).toFloat().coerceIn(0.25f, 1.0f)
     }
 
     override fun configure(inputAudioFormat: AudioFormat): AudioFormat {

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -573,7 +573,6 @@ class PlaybackService : MediaLibraryService() {
     }
 }
 
-@UnstableApi
 private class LevyraMediaSourceFactory(
     private val delegate: DefaultMediaSourceFactory,
     private val dataSourceFactory: DataSource.Factory,

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -9,7 +9,6 @@ import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
-import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.cache.CacheDataSink
@@ -55,7 +54,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
-@OptIn(UnstableApi::class)
 class PlaybackService : MediaLibraryService() {
     private var mediaSession: MediaLibrarySession? = null
     private lateinit var autoLibrary: AndroidAutoLibrary
@@ -166,7 +164,7 @@ class PlaybackService : MediaLibraryService() {
             ): AudioSink {
                 return DefaultAudioSink.Builder(context)
                     .setEnableFloatOutput(enableFloatOutput)
-                    .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
+                    .setEnableAudioOutputPlaybackParameters(enableAudioTrackPlaybackParams)
                     .setAudioProcessors(arrayOf(normalizationProcessor, visualizerProcessor))
                     .build()
             }
@@ -491,7 +489,7 @@ class PlaybackService : MediaLibraryService() {
 
     override fun onTrimMemory(level: Int) {
         super.onTrimMemory(level)
-        if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW) {
+        if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_BACKGROUND) {
             servicePrefetchJob?.cancel()
         }
     }

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackWarmup.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackWarmup.kt
@@ -2,7 +2,6 @@ package com.luc4n3x.levyra.player
 
 import android.content.Context
 import android.net.Uri
-import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSpec
 import androidx.media3.datasource.cache.CacheDataSink
 import androidx.media3.datasource.cache.CacheDataSource
@@ -18,7 +17,6 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
-@OptIn(UnstableApi::class)
 class PlaybackWarmup(context: Context) {
     private val appContext = context.applicationContext
     private val primeLocks = ConcurrentHashMap<String, Mutex>()

--- a/app/src/main/java/com/luc4n3x/levyra/player/PremiumAudioEffects.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PremiumAudioEffects.kt
@@ -8,6 +8,7 @@ import com.luc4n3x.levyra.domain.LevyraAudioPresets
 import com.luc4n3x.levyra.domain.LevyraAudioSettings
 import kotlin.math.roundToInt
 
+@Suppress("DEPRECATION")
 class PremiumAudioEffects {
     private var audioSessionId: Int = 0
     private var settings: LevyraAudioSettings = LevyraAudioSettings()

--- a/app/src/main/java/com/luc4n3x/levyra/player/VisualizerAudioProcessor.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/VisualizerAudioProcessor.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
+@Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
 class VisualizerAudioProcessor : AudioProcessor {
 
     companion object {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -1,4 +1,3 @@
-@file:OptIn(androidx.media3.common.util.UnstableApi::class)
 package com.luc4n3x.levyra.ui
 
 import androidx.compose.animation.core.spring
@@ -110,13 +109,13 @@ import androidx.compose.material.icons.rounded.Bolt
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.DragHandle
-import androidx.compose.material.icons.rounded.Undo
+import androidx.compose.material.icons.automirrored.rounded.Undo
 import androidx.compose.material.icons.rounded.Translate
 import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.DownloadDone
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
-import androidx.compose.material.icons.rounded.QueueMusic
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.rounded.Repeat
 import androidx.compose.material.icons.rounded.RepeatOne
 import androidx.compose.material.icons.rounded.Search
@@ -126,7 +125,7 @@ import androidx.compose.material.icons.rounded.Shuffle
 import androidx.compose.material.icons.rounded.SkipNext
 import androidx.compose.material.icons.rounded.SkipPrevious
 import androidx.compose.material.icons.rounded.Speed
-import androidx.compose.material.icons.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.Mic
 import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.Person
@@ -135,7 +134,7 @@ import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.Verified
 import androidx.compose.material.icons.rounded.KeyboardArrowDown
-import androidx.compose.material.icons.rounded.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
 import androidx.compose.material.icons.rounded.Videocam
 import androidx.compose.material.icons.rounded.PictureInPictureAlt
 import androidx.compose.material.icons.rounded.Notifications
@@ -144,7 +143,7 @@ import androidx.compose.material.icons.rounded.Insights
 import androidx.compose.material.icons.rounded.LocalFireDepartment
 import androidx.compose.material.icons.rounded.Schedule
 import androidx.compose.material.icons.rounded.TaskAlt
-import androidx.compose.material.icons.rounded.Subject
+import androidx.compose.material.icons.automirrored.rounded.Subject
 import androidx.compose.material.icons.rounded.ViewCompact
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -157,8 +156,8 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material.icons.rounded.Add
-import androidx.compose.material.icons.rounded.PlaylistAdd
-import androidx.compose.material.icons.rounded.PlaylistPlay
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.LocalContentColor
@@ -1357,7 +1356,7 @@ private fun AlbumOverlay(
                         modifier = Modifier.size(44.dp).pressable(onClick = onClose)
                     ) {
                         Box(contentAlignment = Alignment.Center) {
-                            Icon(Icons.Rounded.ArrowBack, contentDescription = strings.back, tint = LevyraText)
+                            Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = strings.back, tint = LevyraText)
                         }
                     }
                     Spacer(modifier = Modifier.weight(1f))
@@ -1906,7 +1905,7 @@ private fun AlbumTrackItem(
                 }
                 DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
                     DropdownMenuItem(text = { Text(if (isFavorite) strings.removeFromFavorites else strings.addToFavorites) }, leadingIcon = { Icon(if (isFavorite) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder, null) }, onClick = { expanded = false; onFavorite() })
-                    DropdownMenuItem(text = { Text(strings.addToPlaylist) }, leadingIcon = { Icon(Icons.Rounded.PlaylistAdd, null) }, onClick = { expanded = false; onAddToPlaylist() })
+                    DropdownMenuItem(text = { Text(strings.addToPlaylist) }, leadingIcon = { Icon(Icons.AutoMirrored.Rounded.PlaylistAdd, null) }, onClick = { expanded = false; onAddToPlaylist() })
                     DropdownMenuItem(text = { Text(if (isDownloaded) strings.alreadyOffline else strings.download) }, leadingIcon = { Icon(if (isDownloaded) Icons.Rounded.DownloadDone else Icons.Rounded.Download, null) }, onClick = { expanded = false; if (!isDownloaded) onDownload() })
                     DropdownMenuItem(text = { Text(strings.openArtist) }, leadingIcon = { Icon(Icons.Rounded.Person, null) }, onClick = { expanded = false; onArtist() })
                     DropdownMenuItem(text = { Text(strings.share) }, leadingIcon = { Icon(Icons.Rounded.Share, null) }, onClick = {
@@ -1974,7 +1973,7 @@ private fun ArtistOverlay(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     IconButton(onClick = onClose) {
-                        Icon(Icons.Rounded.ArrowBack, contentDescription = strings.back, tint = LevyraText)
+                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = strings.back, tint = LevyraText)
                     }
                     Spacer(modifier = Modifier.weight(1f))
                     Icon(Icons.Rounded.Person, contentDescription = null, tint = LevyraText.copy(alpha = 0.7f))
@@ -2551,7 +2550,7 @@ private fun QueueOverlay(
                         Switch(checked = state.radioEnabled, onCheckedChange = { onToggleRadio() })
                         if (state.queueUndoAvailable) {
                             IconButton(onClick = onUndo) {
-                                Icon(Icons.Rounded.Undo, strings.undoRemoval, tint = LevyraCyan)
+                                Icon(Icons.AutoMirrored.Rounded.Undo, strings.undoRemoval, tint = LevyraCyan)
                             }
                         }
                     }
@@ -2994,7 +2993,7 @@ private fun LyricsOverlay(
                         }
                         val modeIcon = when (viewMode) {
                             LyricsViewMode.CINEMA -> Icons.Rounded.GraphicEq
-                            LyricsViewMode.PAGE -> Icons.Rounded.Subject
+                            LyricsViewMode.PAGE -> Icons.AutoMirrored.Rounded.Subject
                             LyricsViewMode.COMPACT -> Icons.Rounded.ViewCompact
                         }
                         LyricsControlChip(
@@ -4474,7 +4473,7 @@ private fun ResonanceShelf(
                         letterSpacing = (-0.55).sp
                     )
                     Icon(
-                        imageVector = Icons.Rounded.KeyboardArrowRight,
+                        imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
                         contentDescription = null,
                         tint = LevyraMuted,
                         modifier = Modifier.size(22.dp)
@@ -4729,7 +4728,7 @@ private fun PersonalListeningShelf(
                         letterSpacing = (-0.65).sp
                     )
                     Icon(
-                        imageVector = Icons.Rounded.KeyboardArrowRight,
+                        imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
                         contentDescription = null,
                         tint = LevyraMuted,
                         modifier = Modifier.size(23.dp)
@@ -5727,7 +5726,7 @@ private fun TrackOverflowMenu(
         ) {
             DropdownMenuItem(
                 text = { Text(strings.addToQueue) },
-                leadingIcon = { Icon(Icons.Rounded.QueueMusic, null) },
+                leadingIcon = { Icon(Icons.AutoMirrored.Rounded.QueueMusic, null) },
                 onClick = {
                     expanded = false
                     onAddToQueue()
@@ -6063,7 +6062,7 @@ private fun SearchHeader(
             modifier = Modifier.size(40.dp)
         ) {
             Icon(
-                imageVector = Icons.Rounded.ArrowBack,
+                imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
                 contentDescription = LocalLevyraStrings.current.back,
                 tint = LevyraText
             )
@@ -6256,7 +6255,7 @@ private fun RecentSearchesRow(
                                 )
                                 DropdownMenuItem(
                                     text = { Text(strings.playNext) },
-                                    leadingIcon = { Icon(Icons.Rounded.PlaylistPlay, null) },
+                                    leadingIcon = { Icon(Icons.AutoMirrored.Rounded.PlaylistPlay, null) },
                                     onClick = {
                                         menuExpanded = false
                                         onPlayNext(track)
@@ -6264,7 +6263,7 @@ private fun RecentSearchesRow(
                                 )
                                 DropdownMenuItem(
                                     text = { Text(strings.addToQueue) },
-                                    leadingIcon = { Icon(Icons.Rounded.QueueMusic, null) },
+                                    leadingIcon = { Icon(Icons.AutoMirrored.Rounded.QueueMusic, null) },
                                     onClick = {
                                         menuExpanded = false
                                         onAddToQueue(track)
@@ -6272,7 +6271,7 @@ private fun RecentSearchesRow(
                                 )
                                 DropdownMenuItem(
                                     text = { Text(strings.addToPlaylist) },
-                                    leadingIcon = { Icon(Icons.Rounded.PlaylistAdd, null) },
+                                    leadingIcon = { Icon(Icons.AutoMirrored.Rounded.PlaylistAdd, null) },
                                     onClick = {
                                         menuExpanded = false
                                         onAddToPlaylist(track)
@@ -6432,7 +6431,7 @@ private fun SuggestionsList(
                             modifier = Modifier.weight(1f)
                         )
                         Icon(
-                            imageVector = Icons.Rounded.ArrowBack,
+                            imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
                             contentDescription = LocalLevyraStrings.current.complete,
                             tint = accent.copy(alpha = 0.78f),
                             modifier = Modifier
@@ -6510,7 +6509,7 @@ private fun DownloadsFolderCard(count: Int, onClick: () -> Unit) {
                 )
             }
             Icon(
-                imageVector = Icons.Rounded.KeyboardArrowRight,
+                imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
                 contentDescription = null,
                 tint = LevyraMuted,
                 modifier = Modifier.size(24.dp)
@@ -6544,7 +6543,7 @@ private fun DownloadsFolderOverlay(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     IconButton(onClick = onClose) {
-                        Icon(Icons.Rounded.ArrowBack, contentDescription = LocalLevyraStrings.current.back, tint = LevyraText)
+                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = LocalLevyraStrings.current.back, tint = LevyraText)
                     }
                     Spacer(Modifier.width(8.dp))
                     Column(modifier = Modifier.weight(1f)) {
@@ -6612,7 +6611,7 @@ private fun LibraryScreen(
                     title = cleanLibraryLabel(strings.playlists),
                     detail = LocalLevyraStrings.current.personalPlaylists,
                     count = state.playlists.size,
-                    icon = Icons.Rounded.QueueMusic,
+                    icon = Icons.AutoMirrored.Rounded.QueueMusic,
                     accent = LevyraViolet,
                     actionLabel = strings.newItem,
                     onAction = { showCreate = true }
@@ -6621,7 +6620,7 @@ private fun LibraryScreen(
             if (state.playlists.isEmpty()) {
                 item {
                     LibraryEmptyState(
-                        icon = Icons.Rounded.QueueMusic,
+                        icon = Icons.AutoMirrored.Rounded.QueueMusic,
                         title = strings.createFirstPlaylist,
                         detail = strings.createFirstPlaylistSubtitle,
                         accent = LevyraViolet,
@@ -6858,7 +6857,7 @@ private fun LibraryHeader(
             modifier = Modifier.horizontalScroll(rememberScrollState()),
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            LibraryStatPill(Icons.Rounded.QueueMusic, playlistCount.toString(), strings.playlistsPlain, LevyraViolet)
+            LibraryStatPill(Icons.AutoMirrored.Rounded.QueueMusic, playlistCount.toString(), strings.playlistsPlain, LevyraViolet)
             LibraryStatPill(Icons.Rounded.DownloadDone, downloadCount.toString(), strings.offline, LevyraCyan)
             LibraryStatPill(Icons.Rounded.Favorite, favoriteCount.toString(), strings.favoritesPlain, LevyraPink)
         }
@@ -7349,7 +7348,7 @@ private fun PlaylistRow(
                     contentScale = ContentScale.Crop
                 )
             } else {
-                Icon(Icons.Rounded.QueueMusic, null, tint = LevyraMuted, modifier = Modifier.size(26.dp))
+                Icon(Icons.AutoMirrored.Rounded.QueueMusic, null, tint = LevyraMuted, modifier = Modifier.size(26.dp))
             }
         }
         Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
@@ -7455,7 +7454,7 @@ private fun AddToPlaylistDialog(
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(10.dp)
                         ) {
-                            Icon(Icons.Rounded.QueueMusic, null, tint = LevyraMuted)
+                            Icon(Icons.AutoMirrored.Rounded.QueueMusic, null, tint = LevyraMuted)
                             Text(pl.name, color = LevyraText, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
                         }
                     }
@@ -7493,7 +7492,7 @@ private fun PlaylistDetailOverlay(viewModel: LevyraViewModel, state: LevyraUiSta
             item {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     IconButton(onClick = { viewModel.closePlaylist() }) {
-                        Icon(Icons.Rounded.ArrowBack, contentDescription = LocalLevyraStrings.current.back, tint = LevyraText)
+                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = LocalLevyraStrings.current.back, tint = LevyraText)
                     }
                     Spacer(Modifier.width(4.dp))
                     Column(modifier = Modifier.weight(1f)) {
@@ -7505,7 +7504,7 @@ private fun PlaylistDetailOverlay(viewModel: LevyraViewModel, state: LevyraUiSta
                             Icon(Icons.Rounded.DownloadDone, contentDescription = LocalLevyraStrings.current.downloadPlaylist, tint = LevyraViolet, modifier = Modifier.size(27.dp))
                         }
                         IconButton(onClick = { viewModel.playPlaylist(playlist.id) }) {
-                            Icon(Icons.Rounded.PlaylistPlay, contentDescription = LocalLevyraStrings.current.playAll, tint = LevyraCyan, modifier = Modifier.size(30.dp))
+                            Icon(Icons.AutoMirrored.Rounded.PlaylistPlay, contentDescription = LocalLevyraStrings.current.playAll, tint = LevyraCyan, modifier = Modifier.size(30.dp))
                         }
                     }
                 }
@@ -8003,13 +8002,13 @@ private fun PlayerUtilityDock(
             verticalAlignment = Alignment.CenterVertically
         ) {
             PlayerDockAction(
-                icon = Icons.Rounded.QueueMusic,
+                icon = Icons.AutoMirrored.Rounded.QueueMusic,
                 label = strings.queue,
                 tint = Color.White.copy(alpha = 0.86f),
                 onClick = onQueue
             )
             PlayerDockAction(
-                icon = Icons.Rounded.Subject,
+                icon = Icons.AutoMirrored.Rounded.Subject,
                 label = strings.lyrics,
                 tint = if (lyricsAvailable) activeColor else Color.White.copy(alpha = 0.70f),
                 onClick = onLyrics
@@ -8566,11 +8565,11 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                                     horizontalArrangement = Arrangement.SpaceBetween
                                 ) {
                                     Row(verticalAlignment = Alignment.CenterVertically) {
-                                        Icon(Icons.Rounded.Subject, null, tint = primaryContent, modifier = Modifier.size(19.dp))
+                                        Icon(Icons.AutoMirrored.Rounded.Subject, null, tint = primaryContent, modifier = Modifier.size(19.dp))
                                         Spacer(modifier = Modifier.width(9.dp))
                                         Text(strings.showLyrics, color = Color.White, fontSize = 13.sp, fontWeight = FontWeight.Bold)
                                     }
-                                    Icon(Icons.Rounded.KeyboardArrowRight, null, tint = Color.White.copy(alpha = 0.55f), modifier = Modifier.size(20.dp))
+                                    Icon(Icons.AutoMirrored.Rounded.KeyboardArrowRight, null, tint = Color.White.copy(alpha = 0.55f), modifier = Modifier.size(20.dp))
                                 }
                             }
                         } else {
@@ -9589,7 +9588,7 @@ private fun SettingsOverlay(
             }
             item {
                 SettingsChoiceRow(
-                    icon = Icons.Rounded.QueueMusic,
+                    icon = Icons.AutoMirrored.Rounded.QueueMusic,
                     title = strings.simultaneousDownloads,
                     subtitle = strings.simultaneousDownloadsSubtitle,
                     options = listOf("1" to "1", "2" to "2", "3" to "3", "4" to "4"),
@@ -10020,7 +10019,7 @@ private fun SettingsUpdateCard(
                     Text(
                         text = when {
                             isChecking -> LocalLevyraStrings.current.checkingLatestVersion
-                            hasUpdate -> LocalLevyraStrings.current.formatLatestVersionReady(updateInfo?.latestVersionName.orEmpty())
+                            hasUpdate -> LocalLevyraStrings.current.formatLatestVersionReady(updateInfo.latestVersionName)
                             updateInfo != null -> LocalLevyraStrings.current.latestInstalled
                             else -> LocalLevyraStrings.current.checkNewVersions
                         },
@@ -10030,7 +10029,7 @@ private fun SettingsUpdateCard(
                     )
                 }
             }
-            if (hasUpdate && updateInfo != null) {
+            if (hasUpdate) {
                 Surface(
                     color = Color.Black.copy(alpha = 0.16f),
                     shape = RoundedCornerShape(14.dp),
@@ -10347,7 +10346,7 @@ private fun MetroHeroDeck(
                         Text(hero.title, color = LevyraText, fontSize = 24.sp, lineHeight = 27.sp, fontWeight = FontWeight.Black, maxLines = 2, overflow = TextOverflow.Ellipsis)
                         Text(hero.artist, color = LevyraText.copy(alpha = 0.78f), fontSize = 14.sp, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            MetroStatPill(Icons.Rounded.QueueMusic, queueCount.coerceAtLeast(tracks.size).toString(), LocalLevyraStrings.current.queue)
+                            MetroStatPill(Icons.AutoMirrored.Rounded.QueueMusic, queueCount.coerceAtLeast(tracks.size).toString(), LocalLevyraStrings.current.queue)
                             MetroStatPill(Icons.Rounded.Favorite, favoritesCount.toString(), LocalLevyraStrings.current.saved)
                         }
                     }
@@ -11003,7 +11002,7 @@ private fun CompactRow(
                 )
                 DropdownMenuItem(
                     text = { Text(LocalLevyraStrings.current.addToPlaylist) },
-                    leadingIcon = { Icon(Icons.Rounded.PlaylistAdd, null) },
+                    leadingIcon = { Icon(Icons.AutoMirrored.Rounded.PlaylistAdd, null) },
                     onClick = {
                         expanded = false
                         onAddToPlaylist()
@@ -11011,7 +11010,7 @@ private fun CompactRow(
                 )
                 DropdownMenuItem(
                     text = { Text(LocalLevyraStrings.current.addToQueue) },
-                    leadingIcon = { Icon(Icons.Rounded.QueueMusic, null) },
+                    leadingIcon = { Icon(Icons.AutoMirrored.Rounded.QueueMusic, null) },
                     onClick = {
                         expanded = false
                         onAddToQueue()
@@ -11126,7 +11125,7 @@ private fun ChartRow(
                     )
                     DropdownMenuItem(
                         text = { Text(LocalLevyraStrings.current.addToQueue) },
-                        leadingIcon = { Icon(Icons.Rounded.QueueMusic, null) },
+                        leadingIcon = { Icon(Icons.AutoMirrored.Rounded.QueueMusic, null) },
                         onClick = {
                             expanded = false
                             onAddToQueue()
@@ -11134,7 +11133,7 @@ private fun ChartRow(
                     )
                     DropdownMenuItem(
                         text = { Text(LocalLevyraStrings.current.addToPlaylist) },
-                        leadingIcon = { Icon(Icons.Rounded.PlaylistAdd, null) },
+                        leadingIcon = { Icon(Icons.AutoMirrored.Rounded.PlaylistAdd, null) },
                         onClick = {
                             expanded = false
                             onAddToPlaylist()
@@ -11456,7 +11455,7 @@ private fun TopResultCard(
                     }
                     Surface(color = Color.White.copy(alpha = 0.08f), shape = CircleShape, modifier = Modifier.size(46.dp).clickable { onAddToPlaylist() }) {
                         Box(contentAlignment = Alignment.Center) {
-                            Icon(Icons.Rounded.PlaylistAdd, null, tint = LevyraText, modifier = Modifier.size(22.dp))
+                            Icon(Icons.AutoMirrored.Rounded.PlaylistAdd, null, tint = LevyraText, modifier = Modifier.size(22.dp))
                         }
                     }
                     Surface(color = Color.White.copy(alpha = 0.08f), shape = CircleShape, modifier = Modifier.size(46.dp).clickable { onFavorite() }) {
@@ -11538,7 +11537,7 @@ private fun SearchTrackCard(
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(0.dp)) {
             DownloadButton(isDownloading = isDownloading, isDownloaded = isDownloaded, progress = downloadProgress, onDownload = onDownload)
             IconButton(onClick = onAddToPlaylist, modifier = Modifier.size(36.dp)) {
-                Icon(Icons.Rounded.PlaylistAdd, contentDescription = LocalLevyraStrings.current.addToPlaylist, tint = LevyraMuted, modifier = Modifier.size(24.dp))
+                Icon(Icons.AutoMirrored.Rounded.PlaylistAdd, contentDescription = LocalLevyraStrings.current.addToPlaylist, tint = LevyraMuted, modifier = Modifier.size(24.dp))
             }
             IconButton(onClick = onFavorite, modifier = Modifier.size(36.dp)) {
                 Icon(
@@ -11702,7 +11701,7 @@ private fun TrackRow(
             }
             if (onAddToPlaylist != null) {
                 IconButton(onClick = onAddToPlaylist, modifier = Modifier.size(36.dp)) {
-                    Icon(Icons.Rounded.PlaylistAdd, contentDescription = LocalLevyraStrings.current.addToPlaylist, tint = LevyraMuted, modifier = Modifier.size(24.dp))
+                    Icon(Icons.AutoMirrored.Rounded.PlaylistAdd, contentDescription = LocalLevyraStrings.current.addToPlaylist, tint = LevyraMuted, modifier = Modifier.size(24.dp))
                 }
             }
             IconButton(onClick = onFavorite, modifier = Modifier.size(36.dp)) {
@@ -12949,37 +12948,4 @@ private fun formatDuration(ms: Long): String {
     val seconds = totalSeconds % 60L
     return "$minutes:${seconds.toString().padStart(2, '0')}"
 }
-
-private val LevyraUiState.offlineExportMessageCompat: String?
-    get() = null
-
-private val LevyraUiState.isOfflineExportingCompat: Boolean
-    get() = false
-
-private val LevyraUiState.embeddedMetadataWriterReadyCompat: Boolean
-    get() = false
-
-private val LevyraUiState.offlineExportMessage: String?
-    get() = null
-
-private val LevyraUiState.isOfflineExporting: Boolean
-    get() = false
-
-private val LevyraUiState.embeddedMetadataWriterReady: Boolean
-    get() = false
-
-private fun LevyraViewModel.clearOfflineExportMessage() = Unit
-
-private fun LevyraViewModel.addToQueue(track: Track) {
-    play(track)
-}
-
-private fun LevyraViewModel.exportTrack(track: Track) {
-    play(track)
-}
-
-private fun LevyraViewModel.exportCurrentTrack() {
-    selectTab(LevyraTab.Player)
-}
-
 

--- a/app/src/main/java/com/luc4n3x/levyra/ui/WaveformVisualizer.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/WaveformVisualizer.kt
@@ -45,7 +45,7 @@ fun WaveformVisualizer(
             
             // Draw upper curve
             val targetY = centerY - magnitude / 2f
-            path.quadraticBezierTo(controlX, targetY, nextX, targetY)
+            path.quadraticTo(controlX, targetY, nextX, targetY)
             
             startX = nextX
         }
@@ -57,7 +57,7 @@ fun WaveformVisualizer(
             val controlX = startX - barWidth / 2f
             
             val targetY = centerY + magnitude / 2f
-            path.quadraticBezierTo(controlX, targetY, nextX, targetY)
+            path.quadraticTo(controlX, targetY, nextX, targetY)
             
             startX = nextX
         }


### PR DESCRIPTION
## Summary

- Replaces deprecated Android, Media3, Compose and graphics APIs where modern equivalents are available.
- Removes redundant Kotlin nullability operations and shadowed compatibility extensions.
- Keeps targeted compatibility handling where upstream APIs remain deprecated without a behavior-equivalent replacement.

## Scope

- [x] Player / audio
- [x] Stream extraction
- [ ] Downloads
- [x] UI / Compose
- [ ] Localization
- [ ] Android Auto / media session
- [ ] CI / release
- [ ] Documentation

## What changed

- Migrates system-bar and display handling to current Android APIs.
- Replaces deprecated directional icons with AutoMirrored variants.
- Updates deprecated Media3, NewPipe, WebView and Compose drawing calls.
- Removes unnecessary safe calls, non-null assertions and redundant compatibility extensions.
- Preserves existing playback, audio-effect and extraction behavior.

## Testing

- [ ] `gradle --no-daemon :app:lintRelease`
- [ ] `gradle --no-daemon testReleaseUnitTest`
- [ ] `gradle --no-daemon assembleRelease`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved edge-to-edge display handling and system bar appearance.
  * Updated navigation and queue icons to support right-to-left layouts.
  * Added stricter WebView settings for enhanced privacy and behavior control.
  * Improved audio playback parameter handling and memory cleanup under system pressure.

* **Bug Fixes**
  * Improved waveform rendering and playback stream information handling.
  * Strengthened handling of update, artwork, lyrics, and transcript responses.
  * Refined update card display logic for available versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->