### PR TITLE
perf(home): stabilize background refresh and improve scrolling performance

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -185,6 +185,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.ui)

--- a/app/src/main/java/com/luc4n3x/levyra/data/HomeRefreshStability.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/HomeRefreshStability.kt
@@ -1,0 +1,182 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.domain.HomeSection
+import com.luc4n3x.levyra.domain.LevyraPersonalOrbit
+import com.luc4n3x.levyra.domain.Track
+import java.text.Normalizer
+import java.util.Locale
+
+internal data class HomeSectionMergeResult(
+    val visible: List<HomeSection>,
+    val deferredStructural: List<HomeSection>?,
+    val changed: Boolean
+)
+
+internal object HomeRefreshStability {
+    private const val MIN_SECTION_TRACKS = 3
+    private const val MAX_SECTIONS = 10
+    private const val MAX_TRACKS_PER_SECTION = 20
+
+    fun sanitizeSections(sections: List<HomeSection>): List<HomeSection> {
+        val occurrences = HashMap<String, Int>()
+        return sections
+            .asSequence()
+            .mapNotNull { section ->
+                val title = section.title.trim()
+                if (title.length < 2) return@mapNotNull null
+                val tracks = sanitizeTracks(section.tracks)
+                if (tracks.size < MIN_SECTION_TRACKS) return@mapNotNull null
+                HomeSection(title = title, tracks = tracks)
+            }
+            .filter { section ->
+                val base = sectionIdentity(section.title)
+                val occurrence = occurrences.getOrDefault(base, 0)
+                occurrences[base] = occurrence + 1
+                occurrence < 2
+            }
+            .take(MAX_SECTIONS)
+            .toList()
+    }
+
+    fun mergeSections(
+        previous: List<HomeSection>,
+        incoming: List<HomeSection>,
+        allowStructuralChanges: Boolean
+    ): HomeSectionMergeResult {
+        val oldSections = previous
+        val newSections = sanitizeSections(incoming)
+        if (newSections.isEmpty()) {
+            return HomeSectionMergeResult(previous, null, false)
+        }
+        if (oldSections.isEmpty()) {
+            return HomeSectionMergeResult(newSections, null, newSections != previous)
+        }
+
+        val oldEntries = keyedSections(oldSections)
+        val newEntries = keyedSections(newSections)
+        val oldKeys = oldEntries.map { it.first }
+        val newKeys = newEntries.map { it.first }
+        val structuralChange = oldKeys != newKeys
+        val oldByKey = oldEntries.toMap()
+        val newByKey = newEntries.toMap()
+
+        if (allowStructuralChanges && structuralChange) {
+            val structurallyMerged = newEntries.map { (key, section) ->
+                mergeSection(oldByKey[key], section)
+            }
+            return HomeSectionMergeResult(
+                visible = structurallyMerged,
+                deferredStructural = null,
+                changed = !sameSections(previous, structurallyMerged)
+            )
+        }
+
+        val stableVisible = oldEntries.map { (key, oldSection) ->
+            val replacement = newByKey[key]
+            if (replacement == null) oldSection else mergeSection(oldSection, replacement)
+        }
+        return HomeSectionMergeResult(
+            visible = stableVisible,
+            deferredStructural = newSections.takeIf { structuralChange },
+            changed = !sameSections(previous, stableVisible)
+        )
+    }
+
+    fun sameSections(first: List<HomeSection>, second: List<HomeSection>): Boolean {
+        if (first.size != second.size) return false
+        return first.indices.all { index -> sameSection(first[index], second[index]) }
+    }
+
+    fun sectionIdentity(title: String): String {
+        val normalized = Normalizer.normalize(title.trim(), Normalizer.Form.NFD)
+            .replace(Regex("\\p{Mn}+"), "")
+            .lowercase(Locale.ROOT)
+            .replace(Regex("[^a-z0-9]+"), "-")
+            .trim('-')
+        return normalized.ifBlank { "section" }
+    }
+
+    private fun keyedSections(sections: List<HomeSection>): List<Pair<String, HomeSection>> {
+        val occurrences = HashMap<String, Int>()
+        return sections.map { section ->
+            val base = sectionIdentity(section.title)
+            val occurrence = occurrences.getOrDefault(base, 0)
+            occurrences[base] = occurrence + 1
+            "$base#$occurrence" to section
+        }
+    }
+
+    private fun mergeSection(previous: HomeSection?, incoming: HomeSection): HomeSection {
+        if (previous == null) return incoming
+        if (sameSection(previous, incoming)) return previous
+        val previousByIdentity = previous.tracks.associateBy(::trackIdentity)
+        val tracks = incoming.tracks.map { track ->
+            val oldTrack = previousByIdentity[trackIdentity(track)]
+            when {
+                oldTrack == null -> track
+                oldTrack == track -> oldTrack
+                else -> mergeTrack(oldTrack, track)
+            }
+        }
+        return HomeSection(title = incoming.title, tracks = tracks)
+    }
+
+
+    private fun mergeTrack(previous: Track, incoming: Track): Track {
+        val artworkMerged = LevyraPersonalOrbit.preferAlbumArtwork(incoming, previous)
+        val preferPreviousMetadata = previous.metadataConfidence > incoming.metadataConfidence
+        return artworkMerged.copy(
+            album = artworkMerged.album.ifBlank { previous.album },
+            durationMs = artworkMerged.durationMs.takeIf { it > 0L } ?: previous.durationMs,
+            streamUrl = artworkMerged.streamUrl.ifBlank { previous.streamUrl },
+            videoUrl = artworkMerged.videoUrl.ifBlank { previous.videoUrl },
+            source = artworkMerged.source.ifBlank { previous.source },
+            moodTags = artworkMerged.moodTags.ifEmpty { previous.moodTags },
+            videoStreamUrl = artworkMerged.videoStreamUrl.ifBlank { previous.videoStreamUrl },
+            sponsorSegments = artworkMerged.sponsorSegments.ifEmpty { previous.sponsorSegments },
+            youtubeLoudnessDb = artworkMerged.youtubeLoudnessDb ?: previous.youtubeLoudnessDb,
+            youtubePerceptualLoudnessDb = artworkMerged.youtubePerceptualLoudnessDb
+                ?: previous.youtubePerceptualLoudnessDb,
+            isrc = artworkMerged.isrc.ifBlank { previous.isrc },
+            upc = artworkMerged.upc.ifBlank { previous.upc },
+            releaseDate = artworkMerged.releaseDate.ifBlank { previous.releaseDate },
+            year = artworkMerged.year.ifBlank { previous.year },
+            trackNumber = artworkMerged.trackNumber.takeIf { it > 0 } ?: previous.trackNumber,
+            discNumber = artworkMerged.discNumber.takeIf { it > 0 } ?: previous.discNumber,
+            explicit = artworkMerged.explicit || previous.explicit,
+            albumBrowseId = artworkMerged.albumBrowseId.ifBlank { previous.albumBrowseId },
+            artistBrowseIds = artworkMerged.artistBrowseIds.ifEmpty { previous.artistBrowseIds },
+            counterpartVideoId = artworkMerged.counterpartVideoId.ifBlank { previous.counterpartVideoId },
+            videoType = artworkMerged.videoType.ifBlank { previous.videoType },
+            metadataProvider = if (preferPreviousMetadata) {
+                previous.metadataProvider.ifBlank { artworkMerged.metadataProvider }
+            } else {
+                artworkMerged.metadataProvider.ifBlank { previous.metadataProvider }
+            },
+            metadataConfidence = maxOf(previous.metadataConfidence, artworkMerged.metadataConfidence),
+            canonicalAlbumUrl = artworkMerged.canonicalAlbumUrl.ifBlank { previous.canonicalAlbumUrl }
+        )
+    }
+
+    private fun sanitizeTracks(tracks: List<Track>): List<Track> {
+        val unique = LinkedHashMap<String, Track>()
+        tracks.forEach { track ->
+            if (track.title.isBlank() || track.artist.isBlank()) return@forEach
+            val key = trackIdentity(track)
+            if (key.isNotBlank()) unique.putIfAbsent(key, track)
+        }
+        return unique.values.take(MAX_TRACKS_PER_SECTION)
+    }
+
+    private fun sameSection(first: HomeSection, second: HomeSection): Boolean {
+        return first.title == second.title && first.tracks == second.tracks
+    }
+
+    private fun trackIdentity(track: Track): String {
+        return track.id.trim().ifBlank {
+            track.videoUrl.trim().ifBlank {
+                "${track.title.trim().lowercase(Locale.ROOT)}|${track.artist.trim().lowercase(Locale.ROOT)}"
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -291,6 +291,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.luc4n3x.levyra.ui.theme.glassmorphism
 import com.luc4n3x.levyra.ui.i18n.LocalLevyraStrings
 import com.luc4n3x.levyra.viewmodel.ExploreViewModel
+import com.luc4n3x.levyra.viewmodel.HomeRenderSnapshot
 import com.luc4n3x.levyra.viewmodel.HomeViewModel
 import com.luc4n3x.levyra.viewmodel.LevyraScreenViewModelFactory
 import com.luc4n3x.levyra.viewmodel.LevyraUiState
@@ -908,8 +909,8 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
                 Box(modifier = Modifier.fillMaxSize()) {
                     when (tab) {
                         LevyraTab.Home -> {
-                            val screenState by homeViewModel.state.collectAsStateWithLifecycle()
-                            HomeScreen(homeViewModel, screenState)
+                            val renderSnapshot by homeViewModel.renderState.collectAsStateWithLifecycle()
+                            HomeScreen(homeViewModel, renderSnapshot)
                         }
                         LevyraTab.Search -> {
                             val screenState by searchViewModel.state.collectAsStateWithLifecycle()
@@ -4134,11 +4135,12 @@ internal fun homeSectionLazyKey(
 }
 
 @Composable
-private fun HomeScreen(viewModel: HomeViewModel, state: LevyraUiState) {
+private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnapshot) {
+    val state = renderSnapshot.state
+    val homeDerivedState = renderSnapshot.derived
     val strings = LocalLevyraStrings.current
     val context = LocalContext.current
     var addTarget by remember { mutableStateOf<Track?>(null) }
-    val homeDerivedState by viewModel.derivedState.collectAsStateWithLifecycle()
     LaunchedEffect(homeDerivedState.artistRefreshFingerprint) {
         viewModel.refreshHomeArtists()
     }
@@ -12886,9 +12888,9 @@ private fun SearchSummary(state: LevyraUiState) {
 
 @Composable
 private fun StatusBlock(state: LevyraUiState) {
-    if (state.searchError != null || state.playerError != null) {
+    if (state.homeError != null || state.playerError != null) {
         Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-            state.searchError?.let { GlassMessage(it, LevyraOrange) }
+            state.homeError?.let { GlassMessage(it, LevyraOrange) }
             state.playerError?.let { GlassMessage(it, LevyraOrange) }
         }
     }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -171,7 +171,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -180,6 +179,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel as composeViewModel
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -234,7 +234,6 @@ import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.luc4n3x.levyra.data.ArtworkRequestSource
-import com.luc4n3x.levyra.data.HomeContentAvailability
 import com.luc4n3x.levyra.data.HomeLoadingPolicy
 import com.luc4n3x.levyra.data.LevyraArtworkCache
 import com.luc4n3x.levyra.data.LevyraArtworkStartupMetrics
@@ -766,7 +765,7 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
     val exploreViewModel: ExploreViewModel = composeViewModel(key = "levyra-explore", factory = screenViewModelFactory)
     val libraryViewModel: LibraryViewModel = composeViewModel(key = "levyra-library", factory = screenViewModelFactory)
     val playerViewModel: PlayerViewModel = composeViewModel(key = "levyra-player", factory = screenViewModelFactory)
-    val state by viewModel.state.collectAsState()
+    val state by viewModel.state.collectAsStateWithLifecycle()
     val currentStrings = LevyraStrings.forCode(state.languageCode)
     LaunchedEffect(state.isVideoMode, state.isPlaying) {
         val currentPipState = LevyraPipBridge.current()
@@ -909,23 +908,23 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
                 Box(modifier = Modifier.fillMaxSize()) {
                     when (tab) {
                         LevyraTab.Home -> {
-                            val screenState by homeViewModel.state.collectAsState()
+                            val screenState by homeViewModel.state.collectAsStateWithLifecycle()
                             HomeScreen(homeViewModel, screenState)
                         }
                         LevyraTab.Search -> {
-                            val screenState by searchViewModel.state.collectAsState()
+                            val screenState by searchViewModel.state.collectAsStateWithLifecycle()
                             SearchScreen(searchViewModel, screenState)
                         }
                         LevyraTab.Explore -> {
-                            val screenState by exploreViewModel.state.collectAsState()
+                            val screenState by exploreViewModel.state.collectAsStateWithLifecycle()
                             ExploreScreen(exploreViewModel, screenState)
                         }
                         LevyraTab.Library -> {
-                            val screenState by libraryViewModel.state.collectAsState()
+                            val screenState by libraryViewModel.state.collectAsStateWithLifecycle()
                             LibraryScreen(libraryViewModel, screenState, onOpenDownloads = { showDownloadsFolder = true })
                         }
                         LevyraTab.Player -> {
-                            val screenState by playerViewModel.state.collectAsState()
+                            val screenState by playerViewModel.state.collectAsStateWithLifecycle()
                             PlayerScreen(playerViewModel, screenState)
                         }
                     }
@@ -2401,8 +2400,8 @@ private fun ReleaseRadarRow(
                     contentAlignment = Alignment.Center
                 ) {
                     if (entry.release.thumbnailUrl.isNotBlank()) {
-                        AsyncImage(
-                            model = ImageRequest.Builder(LocalContext.current).data(entry.release.thumbnailUrl).crossfade(false).build(),
+                        StableRemoteArtwork(
+                            url = entry.release.thumbnailUrl,
                             contentDescription = entry.release.title,
                             contentScale = ContentScale.Crop,
                             modifier = Modifier.matchParentSize()
@@ -4131,7 +4130,7 @@ internal fun homeSectionLazyKey(
     title: String,
     trackIds: List<String>
 ): String {
-    return "$position|${title.trim().lowercase(Locale.ROOT)}|${trackIds.take(3).joinToString(".")}"
+    return "$position|${title.trim().lowercase(Locale.ROOT)}"
 }
 
 @Composable
@@ -4139,101 +4138,19 @@ private fun HomeScreen(viewModel: HomeViewModel, state: LevyraUiState) {
     val strings = LocalLevyraStrings.current
     val context = LocalContext.current
     var addTarget by remember { mutableStateOf<Track?>(null) }
-    val homeArtistFingerprint = remember(
-        state.recentListens,
-        state.personalOrbitTracks,
-        state.favorites,
-        state.tracks,
-        state.homeSections,
-        state.charts,
-        state.languageCode
-    ) {
-        buildString {
-            append(state.languageCode)
-            append('|')
-            append(
-                (
-                    state.recentListens +
-                        state.personalOrbitTracks +
-                        state.favorites +
-                        state.tracks +
-                        state.homeSections.flatMap { it.tracks } +
-                        state.charts
-                )
-                    .asSequence()
-                    .filter { it.artistBrowseIds.firstOrNull().orEmpty().isNotBlank() }
-                    .distinctBy { it.artistBrowseIds.first().lowercase() }
-                    .take(48)
-                    .joinToString(",") { track ->
-                        "${track.artist}:${track.artistBrowseIds.first()}"
-                    }
-            )
-        }
-    }
-    LaunchedEffect(homeArtistFingerprint) {
+    val homeDerivedState by viewModel.derivedState.collectAsStateWithLifecycle()
+    LaunchedEffect(homeDerivedState.artistRefreshFingerprint) {
         viewModel.refreshHomeArtists()
     }
     val personalTracks = remember(state.personalOrbitTracks) {
         state.personalOrbitTracks.take(LevyraPersonalOrbit.DISPLAY_LIMIT)
     }
-    val resonanceTracks = remember(state.currentTrack, state.recentSearches, state.favorites, state.tracks, state.homeSections, state.charts) {
-        buildResonanceTracks(state)
-    }
-    val newReleases = remember(state.homeSections) {
-        state.homeSections.firstOrNull { isVerifiedReleaseSectionTitle(it.title) }
-    }
-    val otherSections = remember(state.homeSections) {
-        state.homeSections.filter {
-            !isVerifiedReleaseSectionTitle(it.title) &&
-                !isQuickPicksSectionTitle(it.title) &&
-                !isPersonalOrbitSectionTitle(it.title)
-        }
-    }
-    val chartChunks = remember(state.charts) { state.charts.chunked(4) }
-    val homeContent = remember(
-        state.tracks,
-        state.homeSections,
-        state.homeAlbums,
-        state.charts,
-        state.personalOrbitTracks,
-        state.releaseRadar,
-        state.similarArtists,
-        state.currentTrack
-    ) {
-        HomeContentAvailability(
-            trackCount = state.tracks.size,
-            homeSectionCount = state.homeSections.size,
-            homeSectionTrackCount = state.homeSections.sumOf { it.tracks.size },
-            albumCount = state.homeAlbums.size,
-            chartCount = state.charts.size,
-            personalOrbitCount = state.personalOrbitTracks.size,
-            releaseRadarCount = state.releaseRadar.size,
-            similarArtistCount = state.similarArtists.size,
-            hasCurrentTrack = state.currentTrack != null
-        )
-    }
-    val homeFingerprint = remember(
-        state.tracks,
-        state.homeSections,
-        state.homeAlbums,
-        state.charts,
-        state.personalOrbitTracks,
-        state.releaseRadar,
-        state.similarArtists,
-        state.currentTrack
-    ) {
-        buildString {
-            append(homeContent.fingerprint())
-            append('|')
-            append(state.tracks.take(12).joinToString(",") { it.id })
-            append('|')
-            append(state.homeSections.joinToString(",") { section -> "${section.title}:${section.tracks.take(4).joinToString(".") { it.id }}" })
-            append('|')
-            append(state.homeAlbums.take(10).joinToString(",") { it.browseId.ifBlank { "${it.title}:${it.artist}" } })
-            append('|')
-            append(state.charts.take(12).joinToString(",") { it.id })
-        }
-    }
+    val resonanceTracks = homeDerivedState.resonanceTracks
+    val newReleases = homeDerivedState.newReleases
+    val otherSections = homeDerivedState.otherSections
+    val chartChunks = homeDerivedState.chartChunks
+    val homeContent = homeDerivedState.contentAvailability
+    val homeFingerprint = homeDerivedState.contentFingerprint
     val showHomeAlbumShimmer = HomeLoadingPolicy.showAlbumShimmer(homeContent, state.homeAlbumsLoading)
     val showChartShimmer = HomeLoadingPolicy.showChartShimmer(homeContent, state.isLoadingCharts)
     val homeListState = rememberLazyListState()
@@ -4245,12 +4162,18 @@ private fun HomeScreen(viewModel: HomeViewModel, state: LevyraUiState) {
         if (showChartShimmer) LevyraArtworkStartupMetrics.recordShimmer(homeContent.hasUsableContent)
     }
     LaunchedEffect(homeListState) {
-        snapshotFlow { homeListState.isScrollInProgress }
+        snapshotFlow {
+            val atTop = homeListState.firstVisibleItemIndex == 0 && homeListState.firstVisibleItemScrollOffset == 0
+            homeListState.isScrollInProgress to atTop
+        }
             .distinctUntilChanged()
-            .collect { viewModel.setHomeScrollInProgress(it) }
+            .collect { (scrollInProgress, atTop) ->
+                viewModel.setHomeViewport(scrollInProgress, atTop)
+            }
     }
     DisposableEffect(viewModel) {
-        onDispose { viewModel.setHomeScrollInProgress(false) }
+        viewModel.onHomeEntered()
+        onDispose { viewModel.onHomeLeft() }
     }
     LaunchedEffect(Unit) {
         delay(5_000L)
@@ -4261,8 +4184,8 @@ private fun HomeScreen(viewModel: HomeViewModel, state: LevyraUiState) {
     LazyColumn(
         state = homeListState,
         modifier = Modifier.fillMaxSize().statusBarsPadding(),
-        contentPadding = PaddingValues(top = 10.dp, bottom = if (state.currentTrack != null) 188.dp else 104.dp),
-        verticalArrangement = Arrangement.spacedBy(if (state.interfaceSettings.compactHome) 14.dp else 24.dp)
+        contentPadding = PaddingValues(top = 8.dp, bottom = if (state.currentTrack != null) 188.dp else 104.dp),
+        verticalArrangement = Arrangement.spacedBy(if (state.interfaceSettings.compactHome) 12.dp else 22.dp)
     ) {
         item(key = "home-top", contentType = "home-header") {
             HomeSectionInset {
@@ -4367,7 +4290,7 @@ private fun HomeScreen(viewModel: HomeViewModel, state: LevyraUiState) {
             item(key = "home-trending-artists", contentType = "home-shelf") {
                 TrendingArtistsShelf(
                     artists = state.homeArtists.take(HOME_ARTIST_SHELF_SIZE),
-                    loadingSlots = (HOME_ARTIST_SHELF_SIZE - state.homeArtists.size).coerceAtLeast(0),
+                    loadingSlots = if (state.homeArtists.isEmpty() && state.homeArtistsLoading) HOME_ARTIST_SHELF_SIZE else 0,
                     onArtistClick = viewModel::openArtistFromHit
                 )
             }
@@ -4424,7 +4347,7 @@ private fun HomeScreen(viewModel: HomeViewModel, state: LevyraUiState) {
                     ) {
                         itemsIndexed(
                             items = chartChunks,
-                            key = { chunkIndex, chunk -> "chart-column-$chunkIndex-${chunk.joinToString("-") { it.id }}" },
+                            key = { chunkIndex, _ -> "chart-column-$chunkIndex" },
                             contentType = { _, _ -> "chart-column" }
                         ) { chunkIndex, chunk ->
                             Column(modifier = Modifier.width(320.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -4478,7 +4401,7 @@ private fun HomeContinueListeningCard(
     isPlaying: Boolean,
     isResolving: Boolean
 ) {
-    val playbackProgress by viewModel.playbackProgress.collectAsState()
+    val playbackProgress by viewModel.playbackProgress.collectAsStateWithLifecycle()
     HomeSectionInset {
         ContinueListeningCard(
             track = track,
@@ -4690,23 +4613,6 @@ private fun TrendingArtistLoadingItem() {
                 .background(CinematicGlassDeep)
         )
     }
-}
-
-private fun buildResonanceTracks(state: LevyraUiState): List<Track> {
-    return buildList {
-        addAll(state.charts)
-        addAll(state.homeSections.flatMap { it.tracks })
-        addAll(state.favorites)
-        addAll(state.tracks)
-        state.currentTrack?.let { add(it) }
-    }
-        .asSequence()
-        .filter { it.id.length == 11 && isReliableMusicUpdateCandidate(it) }
-        .filter { it.title.isNotBlank() && it.artist.isNotBlank() }
-        .distinctBy { it.id }
-        .sortedWith(compareByDescending<Track> { it.replayScore + it.vocal + it.cacheScore / 2 }.thenBy { it.title })
-        .take(8)
-        .toList()
 }
 
 @Composable

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -1,8 +1,10 @@
 package com.luc4n3x.levyra.viewmodel
 
+import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.luc4n3x.levyra.data.HomeContentAvailability
 import com.luc4n3x.levyra.domain.AlbumHit
 import com.luc4n3x.levyra.domain.ArtistHit
 import com.luc4n3x.levyra.domain.ChartRegion
@@ -22,11 +24,15 @@ import com.luc4n3x.levyra.domain.SearchFilter
 import com.luc4n3x.levyra.domain.SearchResults
 import com.luc4n3x.levyra.domain.Track
 import com.luc4n3x.levyra.ui.i18n.LevyraStrings
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.withContext
+import java.util.Locale
 
 abstract class LevyraScreenViewModel(
     protected val root: LevyraViewModel,
@@ -48,6 +54,46 @@ data class HomePlaybackProgress(
 )
 
 class HomeViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::homeProjection) {
+    internal val derivedState: StateFlow<HomeDerivedState> = state
+        .map { state ->
+            HomeDerivedInput(
+                languageCode = state.languageCode,
+                recentListens = state.recentListens,
+                personalOrbitTracks = state.personalOrbitTracks,
+                favorites = state.favorites,
+                tracks = state.tracks,
+                homeSections = state.homeSections,
+                homeAlbums = state.homeAlbums,
+                charts = state.charts,
+                releaseRadar = state.releaseRadar,
+                similarArtists = state.similarArtists,
+                currentTrack = state.currentTrack
+            )
+        }
+        .distinctUntilChanged()
+        .mapLatest { input ->
+            withContext(Dispatchers.Default) { buildHomeDerivedState(input) }
+        }
+        .distinctUntilChanged()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000L),
+            initialValue = buildHomeDerivedState(
+                HomeDerivedInput(
+                    languageCode = root.state.value.languageCode,
+                    recentListens = root.state.value.recentListens,
+                    personalOrbitTracks = root.state.value.personalOrbitTracks,
+                    favorites = root.state.value.favorites,
+                    tracks = root.state.value.tracks,
+                    homeSections = root.state.value.homeSections,
+                    homeAlbums = root.state.value.homeAlbums,
+                    charts = root.state.value.charts,
+                    releaseRadar = root.state.value.releaseRadar,
+                    similarArtists = root.state.value.similarArtists,
+                    currentTrack = root.state.value.currentTrack
+                )
+            )
+        )
     val playbackProgress: StateFlow<HomePlaybackProgress> = root.state
         .map { HomePlaybackProgress(it.positionMs, it.durationMs) }
         .distinctUntilChanged()
@@ -73,7 +119,9 @@ class HomeViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::homeP
     fun selectMood(mood: Mood) = root.selectMood(mood)
     fun toggleFavorite(track: Track) = root.toggleFavorite(track)
     fun togglePlay() = root.togglePlay()
-    fun setHomeScrollInProgress(value: Boolean) = root.setHomeScrollInProgress(value)
+    fun onHomeEntered() = root.onHomeEntered()
+    fun onHomeLeft() = root.onHomeLeft()
+    fun setHomeViewport(scrollInProgress: Boolean, atTop: Boolean) = root.setHomeViewport(scrollInProgress, atTop)
 }
 
 class SearchViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::searchProjection) {
@@ -162,6 +210,191 @@ class LevyraScreenViewModelFactory(
     }
 }
 
+@Immutable
+internal data class HomeDerivedState(
+    val resonanceTracks: List<Track>,
+    val artistRefreshFingerprint: String,
+    val newReleases: HomeSection?,
+    val otherSections: List<HomeSection>,
+    val chartChunks: List<List<Track>>,
+    val contentAvailability: HomeContentAvailability,
+    val contentFingerprint: String
+)
+
+private data class HomeDerivedInput(
+    val languageCode: String,
+    val recentListens: List<Track>,
+    val personalOrbitTracks: List<Track>,
+    val favorites: List<Track>,
+    val tracks: List<Track>,
+    val homeSections: List<HomeSection>,
+    val homeAlbums: List<AlbumHit>,
+    val charts: List<Track>,
+    val releaseRadar: List<ReleaseRadarEntry>,
+    val similarArtists: List<ArtistHit>,
+    val currentTrack: Track?
+)
+
+private fun buildHomeDerivedState(input: HomeDerivedInput): HomeDerivedState {
+    val newReleases = input.homeSections.firstOrNull { isVerifiedHomeReleaseSectionTitle(it.title) }
+    val otherSections = input.homeSections.filter {
+        !isVerifiedHomeReleaseSectionTitle(it.title) &&
+            !isHomeQuickPicksSectionTitle(it.title) &&
+            !isHomePersonalOrbitSectionTitle(it.title)
+    }
+    val contentAvailability = HomeContentAvailability(
+        trackCount = input.tracks.size,
+        homeSectionCount = input.homeSections.size,
+        homeSectionTrackCount = input.homeSections.sumOf { it.tracks.size },
+        albumCount = input.homeAlbums.size,
+        chartCount = input.charts.size,
+        personalOrbitCount = input.personalOrbitTracks.size,
+        releaseRadarCount = input.releaseRadar.size,
+        similarArtistCount = input.similarArtists.size,
+        hasCurrentTrack = input.currentTrack != null
+    )
+    return HomeDerivedState(
+        resonanceTracks = buildHomeResonanceTracks(input),
+        artistRefreshFingerprint = buildHomeArtistRefreshFingerprint(input),
+        newReleases = newReleases,
+        otherSections = otherSections,
+        chartChunks = input.charts.chunked(4),
+        contentAvailability = contentAvailability,
+        contentFingerprint = buildHomeContentFingerprint(input, contentAvailability)
+    )
+}
+
+private fun buildHomeResonanceTracks(input: HomeDerivedInput): List<Track> {
+    return buildList {
+        addAll(input.charts)
+        input.homeSections.forEach { section -> addAll(section.tracks) }
+        addAll(input.favorites)
+        addAll(input.tracks)
+        input.currentTrack?.let(::add)
+    }
+        .asSequence()
+        .filter { it.id.length == 11 && isReliableHomeMusicCandidate(it) }
+        .distinctBy { it.id }
+        .sortedWith(
+            compareByDescending<Track> { it.replayScore + it.vocal + it.cacheScore / 2 }
+                .thenBy { it.title }
+        )
+        .take(8)
+        .toList()
+}
+
+private fun buildHomeArtistRefreshFingerprint(input: HomeDerivedInput): String {
+    val tracks = sequence {
+        yieldAll(input.recentListens)
+        yieldAll(input.personalOrbitTracks)
+        yieldAll(input.favorites)
+        yieldAll(input.tracks)
+        input.homeSections.forEach { section -> yieldAll(section.tracks) }
+        yieldAll(input.charts)
+    }
+    return buildString {
+        append(input.languageCode)
+        append('|')
+        append(
+            tracks
+                .filter { it.artistBrowseIds.firstOrNull().orEmpty().isNotBlank() }
+                .distinctBy { it.artistBrowseIds.first().lowercase() }
+                .take(48)
+                .joinToString(",") { track ->
+                    "${track.artist}:${track.artistBrowseIds.first()}"
+                }
+        )
+    }
+}
+
+private fun buildHomeContentFingerprint(
+    input: HomeDerivedInput,
+    availability: HomeContentAvailability
+): String {
+    return buildString {
+        append(availability.fingerprint())
+        append('|')
+        append(input.tracks.take(12).joinToString(",") { it.id })
+        append('|')
+        append(
+            input.homeSections.joinToString(",") { section ->
+                "${section.title}:${section.tracks.take(4).joinToString(".") { it.id }}"
+            }
+        )
+        append('|')
+        append(input.homeAlbums.take(10).joinToString(",") { it.browseId.ifBlank { "${it.title}:${it.artist}" } })
+        append('|')
+        append(input.charts.take(12).joinToString(",") { it.id })
+    }
+}
+
+private fun isReliableHomeMusicCandidate(track: Track): Boolean {
+    val title = track.title.trim()
+    val artist = track.artist.trim()
+    if (title.length < 2 || artist.length < 2) return false
+    if (artist.equals("YouTube Music", ignoreCase = true) || artist.equals("YouTube", ignoreCase = true)) return false
+    return !isLikelyHomePlaylistOrCompilation(track)
+}
+
+private fun isVerifiedHomeReleaseSectionTitle(title: String): Boolean {
+    val normalized = title.lowercase(Locale.ROOT)
+    return normalized.contains("novità") ||
+        normalized.contains("nuove uscite") ||
+        normalized.contains("appena usciti") ||
+        normalized.contains("ultime uscite") ||
+        normalized.contains("nuovi album") ||
+        normalized.contains("nuovi singoli") ||
+        normalized.contains("new releases") ||
+        normalized.contains("new release") ||
+        normalized.contains("latest releases") ||
+        normalized.contains("latest release") ||
+        normalized.contains("new albums") ||
+        normalized.contains("new singles")
+}
+
+private fun isHomeQuickPicksSectionTitle(title: String): Boolean {
+    val normalized = title.lowercase(Locale.ROOT)
+    return normalized.contains("scelte rapide") ||
+        normalized.contains("quick picks") ||
+        normalized.contains("quick pick") ||
+        normalized.contains("scelte per te")
+}
+
+private fun isHomePersonalOrbitSectionTitle(title: String): Boolean {
+    val normalized = title.lowercase(Locale.ROOT)
+    return normalized.contains("nella tua orbita") ||
+        normalized.contains("la tua orbita") ||
+        normalized.contains("your orbit") ||
+        normalized.contains("in your orbit") ||
+        normalized.contains("tu órbita") ||
+        normalized.contains("ton orbite") ||
+        normalized.contains("deine umlaufbahn") ||
+        normalized.contains("jouw baan") ||
+        normalized.contains("twoja orbita")
+}
+
+private fun isLikelyHomePlaylistOrCompilation(track: Track): Boolean {
+    val combined = listOf(track.title, track.artist, track.album).joinToString(" ").lowercase()
+    return listOf(
+        "playlist",
+        "mix",
+        "top hit",
+        "top hits",
+        "hit italiane",
+        "canzoni italiane",
+        "musica italiana",
+        "estate mix",
+        "summer mix",
+        "best of",
+        "compilation",
+        "classifica",
+        "radio edit",
+        "sped up",
+        "slowed",
+        "nightcore"
+    ).any(combined::contains)
+}
+
 private data class HomeProjection(
     val animationsEnabled: Boolean,
     val chartRegions: List<ChartRegion>,
@@ -171,18 +404,23 @@ private data class HomeProjection(
     val favorites: List<Track>,
     val homeAlbums: List<AlbumHit>,
     val homeArtists: List<ArtistHit>,
+    val homeArtistsLoading: Boolean,
     val homeAlbumsLoading: Boolean,
     val homeSections: List<HomeSection>,
     val isLoadingCharts: Boolean,
     val isPlaying: Boolean,
     val isResolving: Boolean,
+    val languageCode: String,
     val moods: List<Mood>,
     val personalOrbitTracks: List<Track>,
     val playlists: List<Playlist>,
+    val recentListens: List<Track>,
     val recentSearches: List<Track>,
     val releaseRadar: List<ReleaseRadarEntry>,
     val selectedChartId: String,
     val selectedMood: Mood?,
+    val searchError: String?,
+    val playerError: String?,
     val similarArtists: List<ArtistHit>,
     val tracks: List<Track>,
     val userName: String,
@@ -198,18 +436,23 @@ private fun homeProjection(state: LevyraUiState): HomeProjection = HomeProjectio
     favorites = state.favorites,
     homeAlbums = state.homeAlbums,
     homeArtists = state.homeArtists,
+    homeArtistsLoading = state.homeArtistsLoading,
     homeAlbumsLoading = state.homeAlbumsLoading,
     homeSections = state.homeSections,
     isLoadingCharts = state.isLoadingCharts,
     isPlaying = state.isPlaying,
     isResolving = state.isResolving,
+    languageCode = state.languageCode,
     moods = state.moods,
     personalOrbitTracks = state.personalOrbitTracks,
     playlists = state.playlists,
+    recentListens = state.recentListens,
     recentSearches = state.recentSearches,
     releaseRadar = state.releaseRadar,
     selectedChartId = state.selectedChartId,
     selectedMood = state.selectedMood,
+    searchError = state.searchError,
+    playerError = state.playerError,
     similarArtists = state.similarArtists,
     tracks = state.tracks,
     userName = state.userName,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -54,45 +54,15 @@ data class HomePlaybackProgress(
 )
 
 class HomeViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::homeProjection) {
-    internal val derivedState: StateFlow<HomeDerivedState> = state
-        .map { state ->
-            HomeDerivedInput(
-                languageCode = state.languageCode,
-                recentListens = state.recentListens,
-                personalOrbitTracks = state.personalOrbitTracks,
-                favorites = state.favorites,
-                tracks = state.tracks,
-                homeSections = state.homeSections,
-                homeAlbums = state.homeAlbums,
-                charts = state.charts,
-                releaseRadar = state.releaseRadar,
-                similarArtists = state.similarArtists,
-                currentTrack = state.currentTrack
-            )
-        }
-        .distinctUntilChanged()
-        .mapLatest { input ->
-            withContext(Dispatchers.Default) { buildHomeDerivedState(input) }
+    internal val renderState: StateFlow<HomeRenderSnapshot> = state
+        .mapLatest { snapshot ->
+            withContext(Dispatchers.Default) { buildHomeRenderSnapshot(snapshot) }
         }
         .distinctUntilChanged()
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000L),
-            initialValue = buildHomeDerivedState(
-                HomeDerivedInput(
-                    languageCode = root.state.value.languageCode,
-                    recentListens = root.state.value.recentListens,
-                    personalOrbitTracks = root.state.value.personalOrbitTracks,
-                    favorites = root.state.value.favorites,
-                    tracks = root.state.value.tracks,
-                    homeSections = root.state.value.homeSections,
-                    homeAlbums = root.state.value.homeAlbums,
-                    charts = root.state.value.charts,
-                    releaseRadar = root.state.value.releaseRadar,
-                    similarArtists = root.state.value.similarArtists,
-                    currentTrack = root.state.value.currentTrack
-                )
-            )
+            initialValue = buildHomeRenderSnapshot(root.state.value)
         )
     val playbackProgress: StateFlow<HomePlaybackProgress> = root.state
         .map { HomePlaybackProgress(it.positionMs, it.durationMs) }
@@ -211,6 +181,12 @@ class LevyraScreenViewModelFactory(
 }
 
 @Immutable
+internal data class HomeRenderSnapshot(
+    val state: LevyraUiState,
+    val derived: HomeDerivedState
+)
+
+@Immutable
 internal data class HomeDerivedState(
     val resonanceTracks: List<Track>,
     val artistRefreshFingerprint: String,
@@ -234,6 +210,29 @@ private data class HomeDerivedInput(
     val similarArtists: List<ArtistHit>,
     val currentTrack: Track?
 )
+
+internal fun buildHomeRenderSnapshot(state: LevyraUiState): HomeRenderSnapshot {
+    return HomeRenderSnapshot(
+        state = state,
+        derived = buildHomeDerivedState(state.toHomeDerivedInput())
+    )
+}
+
+private fun LevyraUiState.toHomeDerivedInput(): HomeDerivedInput {
+    return HomeDerivedInput(
+        languageCode = languageCode,
+        recentListens = recentListens,
+        personalOrbitTracks = personalOrbitTracks,
+        favorites = favorites,
+        tracks = tracks,
+        homeSections = homeSections,
+        homeAlbums = homeAlbums,
+        charts = charts,
+        releaseRadar = releaseRadar,
+        similarArtists = similarArtists,
+        currentTrack = currentTrack
+    )
+}
 
 private fun buildHomeDerivedState(input: HomeDerivedInput): HomeDerivedState {
     val newReleases = input.homeSections.firstOrNull { isVerifiedHomeReleaseSectionTitle(it.title) }
@@ -408,6 +407,7 @@ private data class HomeProjection(
     val homeAlbumsLoading: Boolean,
     val homeSections: List<HomeSection>,
     val isLoadingCharts: Boolean,
+    val isLoadingHome: Boolean,
     val isPlaying: Boolean,
     val isResolving: Boolean,
     val languageCode: String,
@@ -419,7 +419,7 @@ private data class HomeProjection(
     val releaseRadar: List<ReleaseRadarEntry>,
     val selectedChartId: String,
     val selectedMood: Mood?,
-    val searchError: String?,
+    val homeError: String?,
     val playerError: String?,
     val similarArtists: List<ArtistHit>,
     val tracks: List<Track>,
@@ -440,6 +440,7 @@ private fun homeProjection(state: LevyraUiState): HomeProjection = HomeProjectio
     homeAlbumsLoading = state.homeAlbumsLoading,
     homeSections = state.homeSections,
     isLoadingCharts = state.isLoadingCharts,
+    isLoadingHome = state.isLoadingHome,
     isPlaying = state.isPlaying,
     isResolving = state.isResolving,
     languageCode = state.languageCode,
@@ -451,7 +452,7 @@ private fun homeProjection(state: LevyraUiState): HomeProjection = HomeProjectio
     releaseRadar = state.releaseRadar,
     selectedChartId = state.selectedChartId,
     selectedMood = state.selectedMood,
-    searchError = state.searchError,
+    homeError = state.homeError,
     playerError = state.playerError,
     similarArtists = state.similarArtists,
     tracks = state.tracks,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
@@ -1,5 +1,6 @@
 package com.luc4n3x.levyra.viewmodel
 
+import androidx.compose.runtime.Immutable
 import com.luc4n3x.levyra.domain.ArtistHit
 import com.luc4n3x.levyra.domain.ArtistProfile
 import com.luc4n3x.levyra.domain.AlbumHit
@@ -35,6 +36,7 @@ enum class DetailReturnTarget {
     Artist
 }
 
+@Immutable
 data class LevyraUiState(
     val selectedTab: LevyraTab = LevyraTab.Home,
     val moods: List<Mood> = emptyList(),

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
@@ -68,6 +68,8 @@ data class LevyraUiState(
     val homeArtists: List<ArtistHit> = emptyList(),
     val homeArtistsLoading: Boolean = false,
     val homeAlbumsLoading: Boolean = false,
+    val isLoadingHome: Boolean = false,
+    val homeError: String? = null,
     val showAlbum: Boolean = false,
     val albumLoading: Boolean = false,
     val albumError: String? = null,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -275,8 +275,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private var chartsJob: Job? = null
     private var homeSnapshotJob: Job? = null
     private var homeArtistsFingerprint: String = ""
-    @Volatile private var deferredHomeArtistsSnapshot: List<ArtistHit>? = null
-    @Volatile private var deferredHomeSectionsSnapshot: List<com.luc4n3x.levyra.domain.HomeSection>? = null
+    private val deferredHomeArtistsSnapshot = AtomicReference<List<ArtistHit>?>(null)
     private var radarJob: Job? = null
     private var radioJob: Job? = null
     private var sponsorSegments: List<SponsorSegment> = emptyList()
@@ -309,8 +308,10 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private val homeAlbumsRequestGeneration = AtomicLong(0L)
     private val chartsRequestGeneration = AtomicLong(0L)
     private val pendingHomeSectionsSnapshot = AtomicReference<List<com.luc4n3x.levyra.domain.HomeSection>?>(null)
+    private val deferredHomeSnapshotApplyScheduled = AtomicBoolean(false)
     @Volatile private var homeScreenActive = false
     @Volatile private var homeAtTop = true
+    @Volatile private var homeScrollInProgress = false
 
     private fun homeStartupWorkPlan(): HomeStartupWorkPlan {
         val playbackPlan = adaptivePlaybackPolicy.current(videoMode = false)
@@ -322,49 +323,107 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     fun setHomeViewport(scrollInProgress: Boolean, atTop: Boolean) {
         homeAtTop = atTop
+        homeScrollInProgress = scrollInProgress
         homeInteractionGate.update(scrollInProgress)
+        if (homeScreenActive && atTop && !scrollInProgress) {
+            scheduleDeferredHomeSnapshotApply()
+        }
     }
 
     fun onHomeEntered() {
         homeScreenActive = true
         homeAtTop = true
-        val pendingSections = pendingHomeSectionsSnapshot.getAndSet(null)
-        val pendingArtists = deferredHomeArtistsSnapshot
-        deferredHomeSectionsSnapshot = null
-        deferredHomeArtistsSnapshot = null
-        val snapshot = _state.value
-        val sectionResult = pendingSections?.let { sections ->
-            HomeRefreshStability.mergeSections(
-                previous = snapshot.homeSections,
-                incoming = sections,
-                allowStructuralChanges = true
-            )
-        }
-        val nextSections = sectionResult?.visible ?: snapshot.homeSections
-        val nextArtists = pendingArtists?.takeIf { it.isNotEmpty() } ?: snapshot.homeArtists
-        val flat = if (sectionResult?.changed == true) {
-            nextSections.flatMap { it.tracks }.distinctBy { it.id }
-        } else {
-            emptyList()
-        }
-        val changed = sectionResult?.changed == true || nextArtists != snapshot.homeArtists
-        if (!changed) return
-        _state.update { current ->
-            current.copy(
-                homeSections = nextSections,
-                homeArtists = nextArtists,
-                homeArtistsLoading = false,
-                tracks = flat.ifEmpty { current.tracks },
-                searchResults = flat.take(12).ifEmpty { current.searchResults }
-            )
-        }
-        persistHomeSnapshot()
+        homeScrollInProgress = false
+        homeInteractionGate.update(false)
+        scheduleDeferredHomeSnapshotApply(waitForIdle = false)
     }
 
     fun onHomeLeft() {
         homeScreenActive = false
         homeAtTop = true
+        homeScrollInProgress = false
         homeInteractionGate.update(false)
+    }
+
+    private fun canApplyHomeStructuralChanges(): Boolean {
+        return !homeScreenActive || (homeAtTop && !homeScrollInProgress)
+    }
+
+    private fun hasDeferredHomeSnapshots(): Boolean {
+        return pendingHomeSectionsSnapshot.get() != null || deferredHomeArtistsSnapshot.get() != null
+    }
+
+    private fun scheduleDeferredHomeSnapshotApply(waitForIdle: Boolean = true) {
+        if (!homeScreenActive || !homeAtTop || homeScrollInProgress || !hasDeferredHomeSnapshots()) return
+        if (!deferredHomeSnapshotApplyScheduled.compareAndSet(false, true)) return
+        viewModelScope.launch {
+            try {
+                if (waitForIdle) awaitHomeUiIdle()
+                if (homeScreenActive && homeAtTop && !homeScrollInProgress) {
+                    applyDeferredHomeSnapshots()
+                }
+            } finally {
+                deferredHomeSnapshotApplyScheduled.set(false)
+                if (homeScreenActive && homeAtTop && !homeScrollInProgress && hasDeferredHomeSnapshots()) {
+                    scheduleDeferredHomeSnapshotApply()
+                }
+            }
+        }
+    }
+
+    private suspend fun applyDeferredHomeSnapshots() {
+        val pendingSections = pendingHomeSectionsSnapshot.getAndSet(null)
+        val pendingArtists = deferredHomeArtistsSnapshot.getAndSet(null)
+        if (pendingSections == null && pendingArtists == null) return
+        if (!homeScreenActive || !homeAtTop || homeScrollInProgress) {
+            pendingSections?.let { pendingHomeSectionsSnapshot.compareAndSet(null, it) }
+            pendingArtists?.let { deferredHomeArtistsSnapshot.compareAndSet(null, it) }
+            return
+        }
+
+        var applied = false
+        while (true) {
+            val current = _state.value
+            val updated = withContext(Dispatchers.Default) {
+                val sectionResult = pendingSections?.let { sections ->
+                    HomeRefreshStability.mergeSections(
+                        previous = current.homeSections,
+                        incoming = sections,
+                        allowStructuralChanges = true
+                    )
+                }
+                val nextSections = sectionResult?.visible ?: current.homeSections
+                val nextArtists = pendingArtists?.takeIf { it.isNotEmpty() } ?: current.homeArtists
+                val sectionsChanged = sectionResult?.changed == true
+                val artistsChanged = nextArtists != current.homeArtists
+                if (!sectionsChanged && !artistsChanged) {
+                    current
+                } else {
+                    val nextTracks = if (sectionsChanged) {
+                        nextSections.flatMap { it.tracks }.distinctBy { it.id }.ifEmpty { current.tracks }
+                    } else {
+                        current.tracks
+                    }
+                    current.copy(
+                        homeSections = nextSections,
+                        homeArtists = nextArtists,
+                        homeArtistsLoading = if (pendingArtists != null) false else current.homeArtistsLoading,
+                        tracks = nextTracks
+                    )
+                }
+            }
+            if (updated === current) break
+            if (!homeScreenActive || !homeAtTop || homeScrollInProgress) {
+                pendingSections?.let { pendingHomeSectionsSnapshot.compareAndSet(null, it) }
+                pendingArtists?.let { deferredHomeArtistsSnapshot.compareAndSet(null, it) }
+                return
+            }
+            if (_state.compareAndSet(current, updated)) {
+                applied = true
+                break
+            }
+        }
+        if (applied) persistHomeSnapshot()
     }
 
     private suspend fun awaitHomeUiIdle(plan: HomeStartupWorkPlan = homeStartupWorkPlan()) {
@@ -693,10 +752,10 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         val snapshot = _state.value
         homeSnapshotCache.save(
             languageCode = languageCode,
-            homeSections = deferredHomeSectionsSnapshot ?: snapshot.homeSections,
+            homeSections = pendingHomeSectionsSnapshot.get() ?: snapshot.homeSections,
             charts = snapshot.charts,
             personalOrbit = snapshot.personalOrbitTracks,
-            homeArtists = deferredHomeArtistsSnapshot ?: snapshot.homeArtists
+            homeArtists = deferredHomeArtistsSnapshot.get() ?: snapshot.homeArtists
         )
     }
 
@@ -856,14 +915,15 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
             if (freezeVisibleShelf) {
                 if (complete) {
-                    deferredHomeArtistsSnapshot = finalArtists
+                    deferredHomeArtistsSnapshot.set(finalArtists)
+                    scheduleDeferredHomeSnapshotApply()
                     persistHomeSnapshotSync(startupSnapshot.languageCode)
                 }
                 _state.update { current -> current.copy(homeArtistsLoading = false) }
                 return@launch
             }
 
-            deferredHomeArtistsSnapshot = null
+            deferredHomeArtistsSnapshot.set(null)
             _state.update { current ->
                 current.copy(
                     homeArtists = finalArtists,
@@ -1344,8 +1404,8 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             _state.update { current ->
                 if (current.languageCode != languageCode) current
                 else current.copy(
-                    isSearching = !hasVisibleHome,
-                    searchError = if (hasVisibleHome) current.searchError else null
+                    isLoadingHome = true,
+                    homeError = null
                 )
             }
 
@@ -1371,8 +1431,8 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 loadHomeAlbums(languageCode, deferUntilHomeIdle)
                 if (hasVisibleHome) {
                     _state.update { current ->
-                        if (current.languageCode == languageCode && current.isSearching) {
-                            current.copy(isSearching = false)
+                        if (current.languageCode == languageCode && current.isLoadingHome) {
+                            current.copy(isLoadingHome = false)
                         } else {
                             current
                         }
@@ -1391,13 +1451,13 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 HomeRefreshStability.mergeSections(
                     previous = _state.value.homeSections,
                     incoming = sanitizedSections,
-                    allowStructuralChanges = !homeScreenActive
+                    allowStructuralChanges = canApplyHomeStructuralChanges()
                 )
             }
             withContext(Dispatchers.IO) {
                 preferences.saveHomeSections(sanitizedSections, languageCode)
             }
-            if (previewMerge.changed && (deferUntilHomeIdle || (homeScreenActive && !homeAtTop))) {
+            if (previewMerge.changed && (deferUntilHomeIdle || (homeScreenActive && (!homeAtTop || homeScrollInProgress)))) {
                 awaitHomeUiIdle()
             }
             if (
@@ -1411,7 +1471,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 HomeRefreshStability.mergeSections(
                     previous = mergeBaseSections,
                     incoming = sanitizedSections,
-                    allowStructuralChanges = !homeScreenActive
+                    allowStructuralChanges = canApplyHomeStructuralChanges()
                 )
             }
             if (_state.value.homeSections != mergeBaseSections) {
@@ -1420,7 +1480,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                     HomeRefreshStability.mergeSections(
                         previous = mergeBaseSections,
                         incoming = sanitizedSections,
-                        allowStructuralChanges = !homeScreenActive
+                        allowStructuralChanges = canApplyHomeStructuralChanges()
                     )
                 }
             }
@@ -1429,7 +1489,18 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             }
             if (visibleTracks.isEmpty()) {
                 _state.update { current ->
-                    if (current.languageCode == languageCode) current.copy(isSearching = false) else current
+                    if (current.languageCode == languageCode) {
+                        current.copy(
+                            isLoadingHome = false,
+                            homeError = if (current.homeSections.isEmpty() && current.tracks.isEmpty()) {
+                                "Home non disponibile"
+                            } else {
+                                current.homeError
+                            }
+                        )
+                    } else {
+                        current
+                    }
                 }
                 return@launch
             }
@@ -1452,13 +1523,12 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                     current.languageCode != languageCode ||
                     current.homeSections != mergeBaseSections
                 ) break
-                val nextSearchResults = visibleTracks.take(12)
                 val updated = if (
                     !mergeResult.changed &&
                     current.homeAlbums == instantAlbums &&
                     current.tracks == visibleTracks &&
-                    current.searchResults == nextSearchResults &&
-                    !current.isSearching
+                    !current.isLoadingHome &&
+                    current.homeError == null
                 ) {
                     current
                 } else {
@@ -1467,22 +1537,27 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                         homeAlbums = instantAlbums,
                         homeAlbumsLoading = instantAlbums.isEmpty(),
                         tracks = visibleTracks,
-                        searchResults = nextSearchResults,
-                        isSearching = false,
-                        cacheReport = repository.cacheReport(),
-                        searchError = null
+                        isLoadingHome = false,
+                        homeError = null,
+                        cacheReport = repository.cacheReport()
                     )
                 }
                 published = updated === current || _state.compareAndSet(current, updated)
             }
             if (!published) {
                 _state.update { current ->
-                    if (current.languageCode == languageCode && current.isSearching) current.copy(isSearching = false) else current
+                    if (current.languageCode == languageCode && current.isLoadingHome) {
+                        current.copy(isLoadingHome = false)
+                    } else {
+                        current
+                    }
                 }
                 return@launch
             }
             pendingHomeSectionsSnapshot.set(mergeResult.deferredStructural)
-            deferredHomeSectionsSnapshot = mergeResult.deferredStructural
+            if (mergeResult.deferredStructural != null) {
+                scheduleDeferredHomeSnapshotApply()
+            }
 
             persistHomeSnapshot()
             val startupPlan = homeStartupWorkPlan()
@@ -1960,8 +2035,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     private fun applyLanguageContent(languageCode: String, refreshRemote: Boolean) {
         pendingHomeSectionsSnapshot.set(null)
-        deferredHomeSectionsSnapshot = null
-        deferredHomeArtistsSnapshot = null
+        deferredHomeArtistsSnapshot.set(null)
         homeArtistsFingerprint = ""
         homeArtistsJob?.cancel()
         val defaultChartRegion = ChartsCatalog.defaultRegionForLanguage(languageCode)
@@ -2005,7 +2079,6 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             state = recommendationState,
             limit = HOME_ALBUM_RECOMMENDATION_LIMIT
         ).ifEmpty { localAlbums }
-        val queue = moodEngine.buildQueue(selectedMood, allTracks)
         exploreCache.clear()
         exploreVideosLoaded = false
         _state.update {
@@ -2018,10 +2091,12 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 homeSections = homeSections,
                 homeAlbums = instantAlbums,
                 homeAlbumsLoading = instantAlbums.isEmpty() && refreshRemote,
+                isLoadingHome = refreshRemote && homeSections.isEmpty() && allTracks.isEmpty(),
+                homeError = null,
                 charts = chartTracks,
                 personalOrbitTracks = orbit,
                 tracks = allTracks,
-                searchResults = allTracks.take(12),
+                searchResults = emptyList(),
                 searchSuggestions = emptyList(),
                 searchData = SearchResults(),
                 searchError = null,
@@ -3961,8 +4036,12 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             _state.update { current ->
                 if (current.languageCode != languageCode) current
                 else current.copy(
-                    isSearching = false,
-                    searchError = "Home remota vuota: prova una ricerca"
+                    isLoadingHome = false,
+                    homeError = if (current.homeSections.isEmpty() && current.tracks.isEmpty()) {
+                        "Home remota vuota: prova una ricerca"
+                    } else {
+                        current.homeError
+                    }
                 )
             }
             return
@@ -3985,11 +4064,10 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             else current.copy(
                 homeSections = if (shouldPublishSection) listOf(fallbackSection) else current.homeSections,
                 tracks = tracks,
-                searchResults = tracks.take(12),
-                isSearching = false,
+                isLoadingHome = false,
+                homeError = null,
                 smartScore = calculateSmartScore(moodEngine.buildQueue(current.selectedMood, tracks)),
-                cacheReport = repository.cacheReport(),
-                searchError = null
+                cacheReport = repository.cacheReport()
             )
         }
         withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -19,6 +19,7 @@ import com.luc4n3x.levyra.data.LevyraPreferences
 import com.luc4n3x.levyra.data.LevyraHomeSnapshotCache
 import com.luc4n3x.levyra.data.LevyraStartupCatalog
 import com.luc4n3x.levyra.data.HomeInteractionGate
+import com.luc4n3x.levyra.data.HomeRefreshStability
 import com.luc4n3x.levyra.data.HomeStartupWorkPlan
 import com.luc4n3x.levyra.data.HomeStartupWorkPolicy
 import com.luc4n3x.levyra.data.StartupPlaybackWarmPolicy
@@ -111,6 +112,8 @@ import timber.log.Timber
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 private const val ARTIST_PROFILE_UNAVAILABLE_ERROR = "artist_profile_unavailable"
 
@@ -266,10 +269,14 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private var updateJob: Job? = null
     private var artistJob: Job? = null
     private var albumJob: Job? = null
+    private var homeFeedJob: Job? = null
     private var homeAlbumsJob: Job? = null
     private var homeArtistsJob: Job? = null
+    private var chartsJob: Job? = null
+    private var homeSnapshotJob: Job? = null
     private var homeArtistsFingerprint: String = ""
     @Volatile private var deferredHomeArtistsSnapshot: List<ArtistHit>? = null
+    @Volatile private var deferredHomeSectionsSnapshot: List<com.luc4n3x.levyra.domain.HomeSection>? = null
     private var radarJob: Job? = null
     private var radioJob: Job? = null
     private var sponsorSegments: List<SponsorSegment> = emptyList()
@@ -298,6 +305,12 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private val officialMetadataDeferUntilIdle = AtomicBoolean(false)
 
     private val homeInteractionGate = HomeInteractionGate()
+    private val homeFeedRequestGeneration = AtomicLong(0L)
+    private val homeAlbumsRequestGeneration = AtomicLong(0L)
+    private val chartsRequestGeneration = AtomicLong(0L)
+    private val pendingHomeSectionsSnapshot = AtomicReference<List<com.luc4n3x.levyra.domain.HomeSection>?>(null)
+    @Volatile private var homeScreenActive = false
+    @Volatile private var homeAtTop = true
 
     private fun homeStartupWorkPlan(): HomeStartupWorkPlan {
         val playbackPlan = adaptivePlaybackPolicy.current(videoMode = false)
@@ -307,8 +320,51 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         )
     }
 
-    fun setHomeScrollInProgress(value: Boolean) {
-        homeInteractionGate.update(value)
+    fun setHomeViewport(scrollInProgress: Boolean, atTop: Boolean) {
+        homeAtTop = atTop
+        homeInteractionGate.update(scrollInProgress)
+    }
+
+    fun onHomeEntered() {
+        homeScreenActive = true
+        homeAtTop = true
+        val pendingSections = pendingHomeSectionsSnapshot.getAndSet(null)
+        val pendingArtists = deferredHomeArtistsSnapshot
+        deferredHomeSectionsSnapshot = null
+        deferredHomeArtistsSnapshot = null
+        val snapshot = _state.value
+        val sectionResult = pendingSections?.let { sections ->
+            HomeRefreshStability.mergeSections(
+                previous = snapshot.homeSections,
+                incoming = sections,
+                allowStructuralChanges = true
+            )
+        }
+        val nextSections = sectionResult?.visible ?: snapshot.homeSections
+        val nextArtists = pendingArtists?.takeIf { it.isNotEmpty() } ?: snapshot.homeArtists
+        val flat = if (sectionResult?.changed == true) {
+            nextSections.flatMap { it.tracks }.distinctBy { it.id }
+        } else {
+            emptyList()
+        }
+        val changed = sectionResult?.changed == true || nextArtists != snapshot.homeArtists
+        if (!changed) return
+        _state.update { current ->
+            current.copy(
+                homeSections = nextSections,
+                homeArtists = nextArtists,
+                homeArtistsLoading = false,
+                tracks = flat.ifEmpty { current.tracks },
+                searchResults = flat.take(12).ifEmpty { current.searchResults }
+            )
+        }
+        persistHomeSnapshot()
+    }
+
+    fun onHomeLeft() {
+        homeScreenActive = false
+        homeAtTop = true
+        homeInteractionGate.update(false)
     }
 
     private suspend fun awaitHomeUiIdle(plan: HomeStartupWorkPlan = homeStartupWorkPlan()) {
@@ -399,7 +455,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 homeSections = startupHomeSections,
                 homeAlbums = startupAlbums,
                 homeArtists = startupHomeArtists,
-                homeArtistsLoading = startupHomeArtists.size < HOME_ARTIST_SHELF_SIZE,
+                homeArtistsLoading = startupHomeArtists.isEmpty(),
                 homeAlbumsLoading = startupAlbums.isEmpty(),
                 tracks = initialTracks,
                 queue = initialQueue,
@@ -626,14 +682,18 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     private fun persistHomeSnapshot() {
         val languageCode = _state.value.languageCode
-        viewModelScope.launch(Dispatchers.IO) { persistHomeSnapshotSync(languageCode) }
+        homeSnapshotJob?.cancel()
+        homeSnapshotJob = viewModelScope.launch(Dispatchers.IO) {
+            delay(280L)
+            if (_state.value.languageCode == languageCode) persistHomeSnapshotSync(languageCode)
+        }
     }
 
     private fun persistHomeSnapshotSync(languageCode: String) {
         val snapshot = _state.value
         homeSnapshotCache.save(
             languageCode = languageCode,
-            homeSections = snapshot.homeSections,
+            homeSections = deferredHomeSectionsSnapshot ?: snapshot.homeSections,
             charts = snapshot.charts,
             personalOrbit = snapshot.personalOrbitTracks,
             homeArtists = deferredHomeArtistsSnapshot ?: snapshot.homeArtists
@@ -695,7 +755,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 _state.update { current ->
                     current.copy(
                         homeArtists = visibleArtists,
-                        homeArtistsLoading = visibleArtists.size < HOME_ARTIST_SHELF_SIZE
+                        homeArtistsLoading = visibleArtists.isEmpty()
                     )
                 }
                 return@launch
@@ -708,7 +768,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 _state.update { current ->
                     current.copy(
                         homeArtists = visibleArtists,
-                        homeArtistsLoading = true
+                        homeArtistsLoading = visibleArtists.isEmpty()
                     )
                 }
             }
@@ -807,7 +867,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             _state.update { current ->
                 current.copy(
                     homeArtists = finalArtists,
-                    homeArtistsLoading = !complete
+                    homeArtistsLoading = finalArtists.isEmpty()
                 )
             }
             persistHomeSnapshotSync(startupSnapshot.languageCode)
@@ -855,8 +915,10 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 .take(20)
             val similarArtists = similar.values.take(12).toList()
             _state.update { current ->
-                if (current.releaseRadar == sorted && current.similarArtists == similarArtists) current
-                else current.copy(releaseRadar = sorted, similarArtists = similarArtists)
+                val nextRadar = sorted.ifEmpty { current.releaseRadar }
+                val nextSimilarArtists = similarArtists.ifEmpty { current.similarArtists }
+                if (current.releaseRadar == nextRadar && current.similarArtists == nextSimilarArtists) current
+                else current.copy(releaseRadar = nextRadar, similarArtists = nextSimilarArtists)
             }
         }
     }
@@ -1272,92 +1334,195 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         applyLanguageContent(normalizedLanguage, refreshRemote = true)
     }
 
-    /** Loads the real YouTube Music home feed (sections), falling back to taste-based search. */
     private fun loadHomeFeed(deferUntilHomeIdle: Boolean = false) {
-        viewModelScope.launch {
-            val hasVisibleHome = _state.value.homeSections.isNotEmpty() || _state.value.tracks.isNotEmpty()
-            _state.update { it.copy(isSearching = !hasVisibleHome, searchError = null) }
-            val languageCode = _state.value.languageCode
-            val sections = runCatching { repository.homeFeed(languageCode) }.getOrDefault(emptyList())
-            if (_state.value.languageCode != languageCode) return@launch
-            if (sections.isEmpty()) {
-                loadHomeAlbums(languageCode, deferUntilHomeIdle)
-                if (deferUntilHomeIdle) awaitHomeUiIdle()
-                loadHome(preserveCurrent = hasVisibleHome)
-                return@launch
-            }
-            val flat = sections.flatMap { it.tracks }.distinctBy { it.id }
-            if (flat.isEmpty()) {
-                _state.update { it.copy(isSearching = false) }
-                return@launch
-            }
-            val instantAlbums = _state.value.homeAlbums.ifEmpty {
-                instantAlbumRecommendationsFromTracks(
-                    primary = _state.value.recentListens + _state.value.recentSearches + _state.value.favorites,
-                    secondary = _state.value.personalOrbitTracks + flat,
-                    limit = HOME_ALBUM_RECOMMENDATION_LIMIT,
-                    profile = _state.value.smartProfile
+        val requestGeneration = homeFeedRequestGeneration.incrementAndGet()
+        homeFeedJob?.cancel()
+        homeFeedJob = viewModelScope.launch {
+            val initialState = _state.value
+            val languageCode = initialState.languageCode
+            val hasVisibleHome = initialState.homeSections.isNotEmpty() || initialState.tracks.isNotEmpty()
+            _state.update { current ->
+                if (current.languageCode != languageCode) current
+                else current.copy(
+                    isSearching = !hasVisibleHome,
+                    searchError = if (hasVisibleHome) current.searchError else null
                 )
             }
-            viewModelScope.launch(Dispatchers.IO) { preferences.saveHomeSections(sections, languageCode) }
-            if (deferUntilHomeIdle) awaitHomeUiIdle()
-            _state.update { current ->
-                val nextSearchResults = flat.take(12)
+
+            val networkSections = try {
+                repository.homeFeed(languageCode)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                Timber.w(error, "Home feed refresh failed")
+                emptyList()
+            }
+
+            if (
+                !isActive ||
+                homeFeedRequestGeneration.get() != requestGeneration ||
+                _state.value.languageCode != languageCode
+            ) return@launch
+
+            val sanitizedSections = withContext(Dispatchers.Default) {
+                HomeRefreshStability.sanitizeSections(networkSections)
+            }
+            if (sanitizedSections.isEmpty()) {
+                loadHomeAlbums(languageCode, deferUntilHomeIdle)
+                if (hasVisibleHome) {
+                    _state.update { current ->
+                        if (current.languageCode == languageCode && current.isSearching) {
+                            current.copy(isSearching = false)
+                        } else {
+                            current
+                        }
+                    }
+                } else {
+                    loadFallbackHome(
+                        languageCode = languageCode,
+                        requestGeneration = requestGeneration,
+                        deferUntilHomeIdle = deferUntilHomeIdle
+                    )
+                }
+                return@launch
+            }
+
+            val previewMerge = withContext(Dispatchers.Default) {
+                HomeRefreshStability.mergeSections(
+                    previous = _state.value.homeSections,
+                    incoming = sanitizedSections,
+                    allowStructuralChanges = !homeScreenActive
+                )
+            }
+            withContext(Dispatchers.IO) {
+                preferences.saveHomeSections(sanitizedSections, languageCode)
+            }
+            if (previewMerge.changed && (deferUntilHomeIdle || (homeScreenActive && !homeAtTop))) {
+                awaitHomeUiIdle()
+            }
+            if (
+                !isActive ||
+                homeFeedRequestGeneration.get() != requestGeneration ||
+                _state.value.languageCode != languageCode
+            ) return@launch
+
+            var mergeBaseSections = _state.value.homeSections
+            var mergeResult = withContext(Dispatchers.Default) {
+                HomeRefreshStability.mergeSections(
+                    previous = mergeBaseSections,
+                    incoming = sanitizedSections,
+                    allowStructuralChanges = !homeScreenActive
+                )
+            }
+            if (_state.value.homeSections != mergeBaseSections) {
+                mergeBaseSections = _state.value.homeSections
+                mergeResult = withContext(Dispatchers.Default) {
+                    HomeRefreshStability.mergeSections(
+                        previous = mergeBaseSections,
+                        incoming = sanitizedSections,
+                        allowStructuralChanges = !homeScreenActive
+                    )
+                }
+            }
+            val visibleTracks = withContext(Dispatchers.Default) {
+                mergeResult.visible.flatMap { it.tracks }.distinctBy { it.id }
+            }
+            if (visibleTracks.isEmpty()) {
+                _state.update { current ->
+                    if (current.languageCode == languageCode) current.copy(isSearching = false) else current
+                }
+                return@launch
+            }
+
+            val latestState = _state.value
+            val instantAlbums = latestState.homeAlbums.ifEmpty {
+                withContext(Dispatchers.Default) {
+                    instantAlbumRecommendationsFromTracks(
+                        primary = latestState.recentListens + latestState.recentSearches + latestState.favorites,
+                        secondary = latestState.personalOrbitTracks + visibleTracks,
+                        limit = HOME_ALBUM_RECOMMENDATION_LIMIT,
+                        profile = latestState.smartProfile
+                    )
+                }
+            }
+            var published = false
+            while (!published) {
+                val current = _state.value
                 if (
-                    current.homeSections == sections &&
+                    current.languageCode != languageCode ||
+                    current.homeSections != mergeBaseSections
+                ) break
+                val nextSearchResults = visibleTracks.take(12)
+                val updated = if (
+                    !mergeResult.changed &&
                     current.homeAlbums == instantAlbums &&
-                    current.tracks == flat &&
+                    current.tracks == visibleTracks &&
                     current.searchResults == nextSearchResults &&
-                    !current.isSearching &&
-                    current.searchError == null
+                    !current.isSearching
                 ) {
                     current
                 } else {
                     current.copy(
-                        homeSections = sections,
+                        homeSections = if (mergeResult.changed) mergeResult.visible else current.homeSections,
                         homeAlbums = instantAlbums,
                         homeAlbumsLoading = instantAlbums.isEmpty(),
-                        tracks = flat,
+                        tracks = visibleTracks,
                         searchResults = nextSearchResults,
                         isSearching = false,
                         cacheReport = repository.cacheReport(),
                         searchError = null
                     )
                 }
+                published = updated === current || _state.compareAndSet(current, updated)
             }
+            if (!published) {
+                _state.update { current ->
+                    if (current.languageCode == languageCode && current.isSearching) current.copy(isSearching = false) else current
+                }
+                return@launch
+            }
+            pendingHomeSectionsSnapshot.set(mergeResult.deferredStructural)
+            deferredHomeSectionsSnapshot = mergeResult.deferredStructural
+
             persistHomeSnapshot()
             val startupPlan = homeStartupWorkPlan()
             viewModelScope.launch(Dispatchers.IO) {
                 if (deferUntilHomeIdle) awaitHomeUiIdle(startupPlan)
                 LevyraArtworkCache.preloadHome(
                     getApplication<Application>().applicationContext,
-                    flat,
+                    visibleTracks,
                     startupPlan.refreshedArtworkCount
                 )
             }
-            prefetchTop(flat, startupPlan.refreshedArtworkCount, respectHomeScroll = deferUntilHomeIdle)
-            refreshOfficialMetadataBatch(flat, 8, deferUntilHomeIdle)
+            prefetchTop(visibleTracks, startupPlan.refreshedArtworkCount, respectHomeScroll = deferUntilHomeIdle)
+            refreshOfficialMetadataBatch(visibleTracks, 8, deferUntilHomeIdle)
             loadHomeAlbums(languageCode, deferUntilHomeIdle)
         }
     }
 
     private fun loadHomeAlbums(languageCode: String, deferUntilHomeIdle: Boolean = false) {
+        val requestGeneration = homeAlbumsRequestGeneration.incrementAndGet()
         homeAlbumsJob?.cancel()
         homeAlbumsJob = viewModelScope.launch {
             val initialState = _state.value
             if (initialState.languageCode != languageCode) return@launch
-            val instantAlbums = instantAlbumRecommendations(initialState)
-            val visibleAlbums = rankAlbumRecommendations(
-                remote = initialState.homeAlbums,
-                instant = instantAlbums,
-                state = initialState,
-                limit = HOME_ALBUM_RECOMMENDATION_LIMIT
-            ).ifEmpty { instantAlbums.take(HOME_ALBUM_RECOMMENDATION_LIMIT) }
-            _state.update { current ->
-                val shouldLoadVisibly = visibleAlbums.isEmpty()
-                if (current.homeAlbums == visibleAlbums && current.homeAlbumsLoading == shouldLoadVisibly) current
-                else current.copy(homeAlbums = visibleAlbums, homeAlbumsLoading = shouldLoadVisibly)
+
+            if (initialState.homeAlbums.isEmpty()) {
+                val instantAlbums = instantAlbumRecommendations(initialState)
+                    .take(HOME_ALBUM_RECOMMENDATION_LIMIT)
+                _state.update { current ->
+                    if (current.languageCode != languageCode || current.homeAlbums.isNotEmpty()) current
+                    else current.copy(
+                        homeAlbums = instantAlbums,
+                        homeAlbumsLoading = instantAlbums.isEmpty()
+                    )
+                }
+            } else if (initialState.homeAlbumsLoading) {
+                _state.update { current ->
+                    if (current.languageCode == languageCode) current.copy(homeAlbumsLoading = false) else current
+                }
             }
+
             val seeds = albumRecommendationSeeds(_state.value)
             val albums = try {
                 repository.homeAlbums(
@@ -1371,19 +1536,53 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 Timber.w(error, "Personalized home albums failed")
                 emptyList()
             }
-            if (_state.value.languageCode != languageCode) return@launch
+            if (
+                !isActive ||
+                homeAlbumsRequestGeneration.get() != requestGeneration ||
+                _state.value.languageCode != languageCode
+            ) return@launch
+            if (albums.isEmpty()) {
+                _state.update { current ->
+                    if (current.languageCode == languageCode && current.homeAlbumsLoading) {
+                        current.copy(homeAlbumsLoading = false)
+                    } else {
+                        current
+                    }
+                }
+                return@launch
+            }
+
             val latestState = _state.value
             val latestInstantAlbums = instantAlbumRecommendations(latestState)
-            val rankedAlbums = rankAlbumRecommendations(
-                remote = albums,
-                instant = latestInstantAlbums,
-                state = latestState,
-                limit = HOME_ALBUM_RECOMMENDATION_LIMIT
-            ).ifEmpty { latestInstantAlbums.take(HOME_ALBUM_RECOMMENDATION_LIMIT) }
-            if (rankedAlbums.isNotEmpty()) {
-                viewModelScope.launch(Dispatchers.IO) { preferences.saveHomeAlbums(rankedAlbums, languageCode) }
+            val rankedAlbums = withContext(Dispatchers.Default) {
+                rankAlbumRecommendations(
+                    remote = albums,
+                    instant = latestInstantAlbums,
+                    state = latestState,
+                    limit = HOME_ALBUM_RECOMMENDATION_LIMIT
+                ).ifEmpty { latestInstantAlbums.take(HOME_ALBUM_RECOMMENDATION_LIMIT) }
             }
-            if (deferUntilHomeIdle) awaitHomeUiIdle()
+            if (rankedAlbums.isEmpty()) {
+                _state.update { current ->
+                    if (current.languageCode == languageCode && current.homeAlbumsLoading) {
+                        current.copy(homeAlbumsLoading = false)
+                    } else {
+                        current
+                    }
+                }
+                return@launch
+            }
+
+            withContext(Dispatchers.IO) {
+                preferences.saveHomeAlbums(rankedAlbums, languageCode)
+            }
+            if (deferUntilHomeIdle && _state.value.homeAlbums != rankedAlbums) awaitHomeUiIdle()
+            if (
+                !isActive ||
+                homeAlbumsRequestGeneration.get() != requestGeneration ||
+                _state.value.languageCode != languageCode
+            ) return@launch
+
             _state.update { current ->
                 if (current.languageCode != languageCode) current
                 else if (current.homeAlbums == rankedAlbums && !current.homeAlbumsLoading) current
@@ -1760,6 +1959,11 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     private fun applyLanguageContent(languageCode: String, refreshRemote: Boolean) {
+        pendingHomeSectionsSnapshot.set(null)
+        deferredHomeSectionsSnapshot = null
+        deferredHomeArtistsSnapshot = null
+        homeArtistsFingerprint = ""
+        homeArtistsJob?.cancel()
         val defaultChartRegion = ChartsCatalog.defaultRegionForLanguage(languageCode)
         val localizedMoods = moodEngine.moodsForLanguage(languageCode)
         val selectedMood = localizedMoods.firstOrNull { it.id == _state.value.selectedMood?.id } ?: localizedMoods.firstOrNull()
@@ -1902,22 +2106,54 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     private fun loadCharts(regionId: String = _state.value.selectedChartId, deferUntilHomeIdle: Boolean = false) {
-        viewModelScope.launch {
-            val hasVisibleCharts = _state.value.charts.isNotEmpty()
-            _state.update { it.copy(isLoadingCharts = !hasVisibleCharts) }
-            val languageCode = _state.value.languageCode
+        val requestGeneration = chartsRequestGeneration.incrementAndGet()
+        chartsJob?.cancel()
+        chartsJob = viewModelScope.launch {
+            val initialState = _state.value
+            val languageCode = initialState.languageCode
+            val hasVisibleCharts = initialState.charts.isNotEmpty()
+            _state.update { current ->
+                if (current.selectedChartId != regionId) current
+                else current.copy(isLoadingCharts = !hasVisibleCharts)
+            }
+
             val region = ChartsCatalog.region(regionId)
-            val result = runCatching { chartsRepository.topSongs(region.country) }.getOrDefault(emptyList())
-            if (_state.value.languageCode != languageCode) return@launch
+            val result = try {
+                chartsRepository.topSongs(region.country)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                Timber.w(error, "Charts refresh failed for %s", regionId)
+                emptyList()
+            }
+            if (
+                !isActive ||
+                chartsRequestGeneration.get() != requestGeneration ||
+                _state.value.languageCode != languageCode ||
+                _state.value.selectedChartId != regionId
+            ) return@launch
+
             if (result.isEmpty()) {
-                _state.update { if (it.selectedChartId == regionId) it.copy(isLoadingCharts = false) else it }
+                _state.update { current ->
+                    if (current.selectedChartId == regionId) current.copy(isLoadingCharts = false) else current
+                }
                 return@launch
             }
-            viewModelScope.launch(Dispatchers.IO) { preferences.saveChartTracks(result, languageCode, regionId) }
-            if (deferUntilHomeIdle) awaitHomeUiIdle()
+
+            withContext(Dispatchers.IO) {
+                preferences.saveChartTracks(result, languageCode, regionId)
+            }
+            if (deferUntilHomeIdle && _state.value.charts != result) awaitHomeUiIdle()
+            if (
+                !isActive ||
+                chartsRequestGeneration.get() != requestGeneration ||
+                _state.value.languageCode != languageCode ||
+                _state.value.selectedChartId != regionId
+            ) return@launch
+
             _state.update { current ->
-                if (current.selectedChartId != regionId) return@update current
-                if (current.charts == result && !current.isLoadingCharts) current
+                if (current.selectedChartId != regionId) current
+                else if (current.charts == result && !current.isLoadingCharts) current
                 else current.copy(charts = result, isLoadingCharts = false)
             }
             persistHomeSnapshot()
@@ -1941,10 +2177,10 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             val startupPlan = homeStartupWorkPlan()
             val enrichmentCount = if (deferUntilHomeIdle) startupPlan.chartEnrichmentCount else 6
             val hot = charts.take(enrichmentCount)
-            coroutineScope {
-                val semaphore = Semaphore(if (deferUntilHomeIdle) startupPlan.chartEnrichmentConcurrency else 2)
-                hot.forEachIndexed { index, entry ->
-                    launch {
+            val semaphore = Semaphore(if (deferUntilHomeIdle) startupPlan.chartEnrichmentConcurrency else 2)
+            val replacements = coroutineScope {
+                hot.mapIndexed { index, entry ->
+                    async {
                         semaphore.withPermit {
                             enrichChartEntry(
                                 regionId = regionId,
@@ -1954,43 +2190,46 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                             )
                         }
                     }
-                }
+                }.awaitAll().filterNotNull().toMap()
             }
+            if (replacements.isEmpty() || !isActive || _state.value.selectedChartId != regionId) return@launch
+            if (deferUntilHomeIdle) awaitHomeUiIdle()
+            _state.update { current ->
+                if (current.selectedChartId != regionId) return@update current
+                val updatedCharts = current.charts.map { chart -> replacements[chart.id] ?: chart }
+                if (updatedCharts == current.charts) current else current.copy(charts = updatedCharts)
+            }
+            persistHomeSnapshot()
         }
     }
 
-    private suspend fun enrichChartEntry(regionId: String, entry: Track, warm: Boolean, deferUntilHomeIdle: Boolean = false): Track? {
+    private suspend fun enrichChartEntry(
+        regionId: String,
+        entry: Track,
+        warm: Boolean,
+        deferUntilHomeIdle: Boolean = false
+    ): Pair<String, Track>? {
         if (!currentCoroutineContext().isActive || _state.value.selectedChartId != regionId) return null
         if (deferUntilHomeIdle) awaitHomeUiIdle()
         val match = if (entry.videoUrl.isNotBlank()) {
             entry
         } else {
-            runCatching { repository.searchOne("${entry.title} ${entry.artist}", _state.value.languageCode) }.getOrNull() ?: return null
+            runCatching {
+                repository.searchOne("${entry.title} ${entry.artist}", _state.value.languageCode)
+            }.getOrNull() ?: return null
         }
         if (!currentCoroutineContext().isActive || _state.value.selectedChartId != regionId) return null
-        if (deferUntilHomeIdle) awaitHomeUiIdle()
-        _state.update { st ->
-            if (st.selectedChartId != regionId) return@update st
-            st.copy(
-                charts = st.charts.map { c ->
-                    if (c.id == entry.id) {
-                        LevyraPersonalOrbit.preferAlbumArtwork(c, match).copy(
-                            id = match.id,
-                            videoUrl = match.videoUrl,
-                            durationMs = if (match.durationMs > 0L) match.durationMs else c.durationMs
-                        )
-                    } else {
-                        c
-                    }
-                }
-            )
-        }
+        val enriched = LevyraPersonalOrbit.preferAlbumArtwork(entry, match).copy(
+            id = match.id,
+            videoUrl = match.videoUrl,
+            durationMs = if (match.durationMs > 0L) match.durationMs else entry.durationMs
+        )
         if (warm) {
             if (deferUntilHomeIdle) awaitHomeUiIdle()
             val resolved = resolver.prefetch(match)
             if (resolved != null) runCatching { playbackWarmup.prime(resolved) }
         }
-        return match
+        return entry.id to enriched
     }
 
     fun removeRecentSearch(track: Track) {
@@ -3692,52 +3931,81 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         _state.update { it.copy(positionMs = target) }
     }
 
-    private fun loadHome(preserveCurrent: Boolean = false) {
-        viewModelScope.launch {
-            _state.update { it.copy(isSearching = !preserveCurrent, searchError = null) }
-            val languageCode = _state.value.languageCode
-            val tasteIds = preferences.tastes()
-            val queries = (LevyraLocalizedDiscovery.homeBoostQueries(languageCode, tasteIds) + moodEngine.queriesForTastes(tasteIds, languageCode)).distinct().take(12)
-            val result = runCatching { repository.home(queries, languageCode) }
-            result.onSuccess { tracks ->
-                if (_state.value.languageCode != languageCode) return@onSuccess
-                if (tracks.isEmpty()) {
-                    _state.update {
-                        it.copy(
-                            isSearching = false,
-                            searchError = if (preserveCurrent) null else "Home remota vuota: prova una ricerca"
-                        )
-                    }
-                    return@onSuccess
-                }
-                val selectedMood = _state.value.selectedMood
-                val queue = moodEngine.buildQueue(selectedMood, tracks)
-                _state.update {
-                    it.copy(
-                        tracks = tracks,
-                        searchResults = tracks.take(12),
-                        isSearching = false,
-                        smartScore = calculateSmartScore(queue),
-                        cacheReport = repository.cacheReport(),
-                        searchError = null
-                    )
-                }
-                val fallbackSection = com.luc4n3x.levyra.domain.HomeSection(LevyraContentLocales.forLanguage(languageCode).quickSectionTitle, tracks.take(20))
-                viewModelScope.launch(Dispatchers.IO) { preferences.saveHomeSections(listOf(fallbackSection), languageCode) }
-                _state.update { current -> if (current.homeSections.isEmpty()) current.copy(homeSections = listOf(fallbackSection)) else current }
-                    persistHomeSnapshot()
-                val startupPlan = adaptivePlaybackPolicy.current(videoMode = false)
-                LevyraArtworkCache.preloadHome(getApplication<Application>().applicationContext, tracks, if (startupPlan.lowRam) 8 else 18)
-                prefetchTop(tracks, if (startupPlan.lowRam) 3 else 8)
-            }.onFailure { error ->
-                _state.update {
-                    it.copy(
-                        isSearching = false,
-                        searchError = if (preserveCurrent) null else error.message ?: "Home non caricata"
-                    )
-                }
-            }
+    private suspend fun loadFallbackHome(
+        languageCode: String,
+        requestGeneration: Long,
+        deferUntilHomeIdle: Boolean
+    ) {
+        val tasteIds = preferences.tastes()
+        val queries = withContext(Dispatchers.Default) {
+            (LevyraLocalizedDiscovery.homeBoostQueries(languageCode, tasteIds) +
+                moodEngine.queriesForTastes(tasteIds, languageCode))
+                .distinct()
+                .take(12)
         }
+        val tracks = try {
+            repository.home(queries, languageCode)
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            Timber.w(error, "Fallback home refresh failed")
+            emptyList()
+        }
+        if (
+            !currentCoroutineContext().isActive ||
+            homeFeedRequestGeneration.get() != requestGeneration ||
+            _state.value.languageCode != languageCode
+        ) return
+
+        if (tracks.isEmpty()) {
+            _state.update { current ->
+                if (current.languageCode != languageCode) current
+                else current.copy(
+                    isSearching = false,
+                    searchError = "Home remota vuota: prova una ricerca"
+                )
+            }
+            return
+        }
+
+        val fallbackSection = com.luc4n3x.levyra.domain.HomeSection(
+            LevyraContentLocales.forLanguage(languageCode).quickSectionTitle,
+            tracks.take(20)
+        )
+        val shouldPublishSection = _state.value.homeSections.isEmpty()
+        if (deferUntilHomeIdle && shouldPublishSection) awaitHomeUiIdle()
+        if (
+            !currentCoroutineContext().isActive ||
+            homeFeedRequestGeneration.get() != requestGeneration ||
+            _state.value.languageCode != languageCode
+        ) return
+
+        _state.update { current ->
+            if (current.languageCode != languageCode) current
+            else current.copy(
+                homeSections = if (shouldPublishSection) listOf(fallbackSection) else current.homeSections,
+                tracks = tracks,
+                searchResults = tracks.take(12),
+                isSearching = false,
+                smartScore = calculateSmartScore(moodEngine.buildQueue(current.selectedMood, tracks)),
+                cacheReport = repository.cacheReport(),
+                searchError = null
+            )
+        }
+        withContext(Dispatchers.IO) {
+            preferences.saveHomeSections(listOf(fallbackSection), languageCode)
+        }
+        persistHomeSnapshot()
+        val startupPlan = homeStartupWorkPlan()
+        viewModelScope.launch(Dispatchers.IO) {
+            if (deferUntilHomeIdle) awaitHomeUiIdle(startupPlan)
+            LevyraArtworkCache.preloadHome(
+                getApplication<Application>().applicationContext,
+                tracks,
+                startupPlan.refreshedArtworkCount
+            )
+        }
+        prefetchTop(tracks, startupPlan.refreshedArtworkCount, respectHomeScroll = deferUntilHomeIdle)
     }
 
     private fun searchMood(mood: Mood) {
@@ -4190,7 +4458,11 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         queueEngine.updatePosition(player.positionMs)
         player.release()
         searchJob?.cancel()
+        homeFeedJob?.cancel()
         homeAlbumsJob?.cancel()
+        homeArtistsJob?.cancel()
+        chartsJob?.cancel()
+        homeSnapshotJob?.cancel()
         super.onCleared()
     }
 }

--- a/app/src/test/java/com/luc4n3x/levyra/ui/HomeSectionLazyKeyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/HomeSectionLazyKeyTest.kt
@@ -22,7 +22,7 @@ class HomeSectionLazyKeyTest {
     }
 
     @Test
-    fun keyUsesOnlyTheLeadingThreeTrackIds() {
+    fun contentRefreshDoesNotChangeSectionKey() {
         val first = homeSectionLazyKey(
             position = 2,
             title = "For You",
@@ -31,7 +31,7 @@ class HomeSectionLazyKeyTest {
         val second = homeSectionLazyKey(
             position = 2,
             title = "For You",
-            trackIds = listOf("a", "b", "c", "e")
+            trackIds = listOf("x", "y", "z", "w")
         )
 
         assertEquals(first, second)

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/HomeRenderSnapshotTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/HomeRenderSnapshotTest.kt
@@ -1,0 +1,41 @@
+package com.luc4n3x.levyra.viewmodel
+
+import com.luc4n3x.levyra.domain.Track
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class HomeRenderSnapshotTest {
+    @Test
+    fun keepsBaseChartsAndDerivedChunksFromTheSameState() {
+        val charts = listOf(track("aaaaaaaaaaa"), track("bbbbbbbbbbb"), track("ccccccccccc"), track("ddddddddddd"), track("eeeeeeeeeee"))
+        val state = LevyraUiState(charts = charts)
+
+        val snapshot = buildHomeRenderSnapshot(state)
+
+        assertSame(state, snapshot.state)
+        assertEquals(snapshot.state.charts, snapshot.derived.chartChunks.flatten())
+    }
+
+    private fun track(id: String): Track {
+        return Track(
+            id = id,
+            title = "Title $id",
+            artist = "Artist $id",
+            album = "Album $id",
+            durationMs = 180_000L,
+            streamUrl = "",
+            videoUrl = "https://music.youtube.com/watch?v=$id",
+            thumbnailUrl = "https://example.com/$id.jpg",
+            largeThumbnailUrl = "https://example.com/$id.jpg",
+            source = "YouTube Music",
+            moodTags = emptySet(),
+            energy = 50,
+            vocal = 50,
+            replayScore = 50,
+            cacheScore = 0,
+            accentStart = 0,
+            accentEnd = 0
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ ruler = "2.0.0-beta-3"
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }


### PR DESCRIPTION
## Summary
 
- Optimizes Levyra Home performance, refresh stability, and visual consistency.
- Introduces stale-while-revalidate behavior so cached content remains visible while fresh data loads in the background.
- Prevents sections from disappearing, returning to skeletons, changing order, or being replaced by older responses.
 
## Scope
 
- [ ] Player / audio
- [ ] Stream extraction
- [ ] Downloads
- [x] UI / Compose
- [ ] Localization
- [ ] Android Auto / media session
- [ ] CI / release
- [ ] Documentation
 
## What changed
 
- Serves Home content from memory and persistent cache before starting background network refreshes.
- Preserves previously loaded data during refresh failures, empty responses, and partial updates.
- Rejects stale responses and prevents older requests from overwriting newer Home state.
- Updates each Home section independently instead of rebuilding the entire screen.
- Defers structural section changes that could cause visible jumps until the next Home entry.
- Moves filtering, mapping, sorting, deduplication, and state preparation away from the main thread.
- Reduces duplicate requests, repeated Flow collection, unnecessary coroutine work, and redundant StateFlow emissions.
- Uses lifecycle-aware state collection and stable immutable Home UI models.
- Adds stable LazyColumn and LazyRow keys and content types to reduce unnecessary recompositions.
- Batches chart and metadata publication so users do not see incomplete intermediate states.
- Keeps better existing artwork and metadata when a newer response contains poorer data.
- Limits image decoding and prefetch work using stable URLs, memory and disk cache, and display-sized requests.
- Stops off-screen loading and visual work from competing with visible Home content.
- Applies small spacing and layout refinements without redesigning the Home.
 
## Testing
 
- [ ] `gradle --no-daemon :app:lintRelease`
- [ ] `gradle --no-daemon testReleaseUnitTest`
- [ ] `gradle --no-daemon assembleRelease`
- [ ] APK installed on device
- [ ] Playback tested
- [ ] Downloads tested
- [ ] Language switching tested
 
Additional verification:
 
- [x] Home refresh merge behavior tested in isolation
- [x] Stable section ordering verified
- [x] Incomplete section updates rejected
- [x] Older refresh results prevented from overwriting newer state
- [x] Existing metadata and artwork preservation verified
 
The complete Android Gradle test suite was not executed because Gradle 9.6.1 could not be downloaded from `services.gradle.org` in the execution environment.
 
## Release safety
 
- [ ] `levyraVersionName` and `levyraVersionCode` are correct
- [x] No secrets, keystores, APKs or ZIPs committed
- [x] No duplicated release workflows
- [x] Credits and licenses updated when adding external components
 
## Related issues
 
- Closes #
- Related to #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Home screen state updates, navigation handling, and viewport awareness.
  * Added more reliable loading and refresh behavior for Home content, albums, charts, and fallback content.
  * Improved chart enrichment and artwork loading.

* **Bug Fixes**
  * Prevented unnecessary UI updates and stale content during refreshes or language changes.
  * Improved playback progress and Home content synchronization.

* **Tests**
  * Updated coverage to verify section stability when content refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->