### PR TITLE
perf: decouple Home render state and redesign Library

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -176,6 +176,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
@@ -890,6 +891,9 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
         ) {
             LevyraBackground(accent?.accentStart, accent?.accentEnd)
 
+            val homeListState = rememberLazyListState()
+            val libraryListState = rememberLazyListState()
+
             AnimatedContent(
                 targetState = state.selectedTab,
                 transitionSpec = {
@@ -914,7 +918,7 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
                     when (tab) {
                         LevyraTab.Home -> {
                             val renderSnapshot by homeViewModel.renderState.collectAsStateWithLifecycle()
-                            HomeScreen(homeViewModel, renderSnapshot)
+                            HomeScreen(homeViewModel, renderSnapshot, homeListState)
                         }
                         LevyraTab.Search -> {
                             val screenState by searchViewModel.state.collectAsStateWithLifecycle()
@@ -926,7 +930,7 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
                         }
                         LevyraTab.Library -> {
                             val screenState by libraryViewModel.state.collectAsStateWithLifecycle()
-                            LibraryScreen(libraryViewModel, screenState, onOpenDownloads = { showDownloadsFolder = true })
+                            LibraryScreen(libraryViewModel, screenState, libraryListState, onOpenDownloads = { showDownloadsFolder = true })
                         }
                         LevyraTab.Player -> {
                             val screenState by playerViewModel.state.collectAsStateWithLifecycle()
@@ -4139,7 +4143,7 @@ internal fun homeSectionLazyKey(
 }
 
 @Composable
-private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnapshot) {
+private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnapshot, homeListState: LazyListState) {
     val state = renderSnapshot.state
     val homeDerivedState = renderSnapshot.derived
     val strings = LocalLevyraStrings.current
@@ -4159,7 +4163,6 @@ private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnaps
     val homeFingerprint = homeDerivedState.contentFingerprint
     val showHomeAlbumShimmer = HomeLoadingPolicy.showAlbumShimmer(homeContent, state.homeAlbumsLoading)
     val showChartShimmer = HomeLoadingPolicy.showChartShimmer(homeContent, state.isLoadingCharts)
-    val homeListState = rememberLazyListState()
     LaunchedEffect(homeFingerprint) {
         LevyraArtworkStartupMetrics.recordHomeEmission(homeFingerprint, homeContent.hasUsableContent)
     }
@@ -6789,20 +6792,28 @@ private fun DownloadsFolderOverlay(
 private fun LibraryScreen(
     viewModel: LibraryViewModel,
     state: LevyraUiState,
+    listState: LazyListState,
     onOpenDownloads: () -> Unit
 ) {
     val strings = LocalLevyraStrings.current
     var addTarget by remember { mutableStateOf<Track?>(null) }
     var showCreate by remember { mutableStateOf(false) }
+    var filter by rememberSaveable { mutableStateOf(LibraryFilter.All) }
+    val showPlaylists = filter == LibraryFilter.All || filter == LibraryFilter.Playlists
+    val showDownloads = filter == LibraryFilter.All || filter == LibraryFilter.Downloads
+    val showSongs = filter == LibraryFilter.All || filter == LibraryFilter.Songs
+    val showArtists = filter == LibraryFilter.All || filter == LibraryFilter.Artists
+    val showPulse = filter == LibraryFilter.All
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
+            state = listState,
             modifier = Modifier
                 .fillMaxSize()
                 .statusBarsPadding(),
             contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 14.dp, bottom = if (state.currentTrack != null) 194.dp else 108.dp),
             verticalArrangement = Arrangement.spacedBy(18.dp)
         ) {
-            item {
+            item(key = "lib-header", contentType = "lib-header") {
                 LibraryHeader(
                     title = strings.libraryTitle,
                     subtitle = strings.librarySubtitle,
@@ -6812,103 +6823,120 @@ private fun LibraryScreen(
                 )
             }
 
-            item {
-                LibrarySectionHeader(
-                    title = cleanLibraryLabel(strings.playlists),
-                    detail = LocalLevyraStrings.current.personalPlaylists,
-                    count = state.playlists.size,
-                    icon = Icons.Rounded.QueueMusic,
-                    accent = LevyraViolet,
-                    actionLabel = strings.newItem,
-                    onAction = { showCreate = true }
+            item(key = "lib-filters", contentType = "lib-filters") {
+                LibraryFilterChips(
+                    selected = filter,
+                    playlistCount = state.playlists.size,
+                    songCount = state.favorites.size + state.recentListens.size,
+                    artistCount = state.followedArtists.size,
+                    downloadCount = state.downloads.size,
+                    onSelect = { filter = it }
                 )
             }
-            if (state.playlists.isEmpty()) {
-                item {
-                    LibraryEmptyState(
+
+            if (showPlaylists) {
+                item(key = "lib-playlists-header", contentType = "lib-section-header") {
+                    LibrarySectionHeader(
+                        title = cleanLibraryLabel(strings.playlists),
+                        detail = strings.personalPlaylists,
+                        count = state.playlists.size,
                         icon = Icons.Rounded.QueueMusic,
-                        title = strings.createFirstPlaylist,
-                        detail = strings.createFirstPlaylistSubtitle,
                         accent = LevyraViolet,
                         actionLabel = strings.newItem,
                         onAction = { showCreate = true }
                     )
                 }
-            } else {
-                items(state.playlists, key = { "pl-${it.id}" }) { playlist ->
-                    PlaylistRow(
-                        playlist = playlist,
-                        onOpen = { viewModel.openPlaylist(playlist.id) },
-                        onPlay = { viewModel.playPlaylist(playlist.id) },
-                        onDelete = { viewModel.deletePlaylist(playlist.id) }
-                    )
+                if (state.playlists.isEmpty()) {
+                    item(key = "lib-playlists-empty", contentType = "lib-empty") {
+                        LibraryEmptyState(
+                            icon = Icons.Rounded.QueueMusic,
+                            title = strings.createFirstPlaylist,
+                            detail = strings.createFirstPlaylistSubtitle,
+                            accent = LevyraViolet,
+                            actionLabel = strings.newItem,
+                            onAction = { showCreate = true }
+                        )
+                    }
+                } else {
+                    items(state.playlists, key = { "pl-${it.id}" }, contentType = { "lib-playlist" }) { playlist ->
+                        PlaylistRow(
+                            playlist = playlist,
+                            onOpen = { viewModel.openPlaylist(playlist.id) },
+                            onPlay = { viewModel.playPlaylist(playlist.id) },
+                            onDelete = { viewModel.deletePlaylist(playlist.id) }
+                        )
+                    }
                 }
             }
 
-            item {
-                LibrarySectionHeader(
-                    title = cleanLibraryLabel(strings.downloads),
-                    detail = LocalLevyraStrings.current.offline,
-                    count = state.downloads.size,
-                    icon = Icons.Rounded.DownloadDone,
-                    accent = LevyraCyan
-                )
-            }
-            if (state.downloads.isEmpty()) {
-                item {
-                    LibraryEmptyState(
-                        icon = Icons.Rounded.Download,
-                        title = LocalLevyraStrings.current.noOfflineDownloads,
-                        detail = strings.downloadTrackHint,
+            if (showDownloads) {
+                item(key = "lib-downloads-header", contentType = "lib-section-header") {
+                    LibrarySectionHeader(
+                        title = cleanLibraryLabel(strings.downloads),
+                        detail = strings.offline,
+                        count = state.downloads.size,
+                        icon = Icons.Rounded.DownloadDone,
                         accent = LevyraCyan
                     )
                 }
-            } else {
-                item {
-                    DownloadsFolderCard(
-                        count = state.downloads.size,
-                        onClick = onOpenDownloads
-                    )
+                if (state.downloads.isEmpty()) {
+                    item(key = "lib-downloads-empty", contentType = "lib-empty") {
+                        LibraryEmptyState(
+                            icon = Icons.Rounded.Download,
+                            title = strings.noOfflineDownloads,
+                            detail = strings.downloadTrackHint,
+                            accent = LevyraCyan
+                        )
+                    }
+                } else {
+                    item(key = "lib-downloads-card", contentType = "lib-downloads-card") {
+                        DownloadsFolderCard(
+                            count = state.downloads.size,
+                            onClick = onOpenDownloads
+                        )
+                    }
                 }
             }
 
-            item {
-                LibrarySectionHeader(
-                    title = cleanLibraryLabel(strings.favorites),
-                    detail = strings.savedTracks,
-                    count = state.favorites.size,
-                    icon = Icons.Rounded.Favorite,
-                    accent = LevyraPink
-                )
-            }
-            if (state.favorites.isEmpty()) {
-                item {
-                    LibraryEmptyState(
-                        icon = Icons.Rounded.FavoriteBorder,
-                        title = strings.favoritesEmpty,
-                        detail = LocalLevyraStrings.current.tapHeartToAdd,
+            if (showSongs) {
+                item(key = "lib-favorites-header", contentType = "lib-section-header") {
+                    LibrarySectionHeader(
+                        title = cleanLibraryLabel(strings.favorites),
+                        detail = strings.savedTracks,
+                        count = state.favorites.size,
+                        icon = Icons.Rounded.Favorite,
                         accent = LevyraPink
                     )
                 }
-            } else {
-                item {
-                    RowCarousel(
-                        tracks = state.favorites,
-                        currentId = state.currentTrack?.id,
-                        isPlaying = state.isPlaying,
-                        isResolving = state.isResolving,
-                        favoriteIds = state.favoriteIds,
-                        onPlay = { viewModel.playFrom(state.favorites, it) },
-                        onFavorite = { viewModel.toggleFavorite(it) },
-                        onAddToPlaylist = { addTarget = it },
-                        onAddToQueue = { viewModel.addToQueue(it) },
-                        onDownload = { viewModel.exportTrack(it) }
-                    )
+                if (state.favorites.isEmpty()) {
+                    item(key = "lib-favorites-empty", contentType = "lib-empty") {
+                        LibraryEmptyState(
+                            icon = Icons.Rounded.FavoriteBorder,
+                            title = strings.favoritesEmpty,
+                            detail = strings.tapHeartToAdd,
+                            accent = LevyraPink
+                        )
+                    }
+                } else {
+                    item(key = "lib-favorites-carousel", contentType = "lib-carousel") {
+                        RowCarousel(
+                            tracks = state.favorites,
+                            currentId = state.currentTrack?.id,
+                            isPlaying = state.isPlaying,
+                            isResolving = state.isResolving,
+                            favoriteIds = state.favoriteIds,
+                            onPlay = { viewModel.playFrom(state.favorites, it) },
+                            onFavorite = { viewModel.toggleFavorite(it) },
+                            onAddToPlaylist = { addTarget = it },
+                            onAddToQueue = { viewModel.addToQueue(it) },
+                            onDownload = { viewModel.exportTrack(it) }
+                        )
+                    }
                 }
             }
 
-            if (state.followedArtists.isNotEmpty()) {
-                item {
+            if (showArtists && state.followedArtists.isNotEmpty()) {
+                item(key = "lib-artists-header", contentType = "lib-section-header") {
                     LibrarySectionHeader(
                         title = strings.followedArtistsTitle,
                         detail = strings.followedArtistsSubtitle,
@@ -6917,7 +6945,7 @@ private fun LibraryScreen(
                         accent = CinematicGold
                     )
                 }
-                item {
+                item(key = "lib-artists-row", contentType = "lib-artists-row") {
                     FollowedArtistsRow(
                         artists = state.followedArtists,
                         onOpen = { viewModel.openArtistByName(it.name) }
@@ -6925,58 +6953,72 @@ private fun LibraryScreen(
                 }
             }
 
-            item {
-                LibrarySectionDivider(label = strings.pulseSectionBand)
-            }
-
-            item {
-                LibrarySectionHeader(
-                    title = strings.pulseTitle,
-                    detail = strings.pulseSubtitle,
-                    count = state.listeningPulse.plays,
-                    icon = Icons.Rounded.Insights,
-                    accent = LevyraCyan
-                )
-            }
-            item {
-                ListeningPulseCard(pulse = state.listeningPulse, strings = strings)
-            }
-
-            item {
-                LibrarySectionHeader(
-                    title = strings.listeningHistory,
-                    detail = strings.listeningHistorySubtitle,
-                    count = state.recentListens.size,
-                    icon = Icons.Rounded.History,
-                    accent = LevyraViolet
-                )
-            }
-            if (state.recentListens.isEmpty()) {
-                item {
+            if (showArtists && state.followedArtists.isEmpty() && filter == LibraryFilter.Artists) {
+                item(key = "lib-artists-empty", contentType = "lib-empty") {
                     LibraryEmptyState(
+                        icon = Icons.Rounded.Person,
+                        title = strings.followedArtistsTitle,
+                        detail = strings.followedArtistsSubtitle,
+                        accent = CinematicGold
+                    )
+                }
+            }
+
+            if (showPulse) {
+                item(key = "lib-pulse-divider", contentType = "lib-divider") {
+                    LibrarySectionDivider(label = strings.pulseSectionBand)
+                }
+                item(key = "lib-pulse-header", contentType = "lib-section-header") {
+                    LibrarySectionHeader(
+                        title = strings.pulseTitle,
+                        detail = strings.pulseSubtitle,
+                        count = state.listeningPulse.plays,
+                        icon = Icons.Rounded.Insights,
+                        accent = LevyraCyan
+                    )
+                }
+                item(key = "lib-pulse-card", contentType = "lib-pulse-card") {
+                    ListeningPulseCard(pulse = state.listeningPulse, strings = strings)
+                }
+            }
+
+            if (showSongs) {
+                item(key = "lib-history-header", contentType = "lib-section-header") {
+                    LibrarySectionHeader(
+                        title = strings.listeningHistory,
+                        detail = strings.listeningHistorySubtitle,
+                        count = state.recentListens.size,
                         icon = Icons.Rounded.History,
-                        title = strings.listeningHistoryEmptyTitle,
-                        detail = strings.listeningHistoryEmptyDetail,
                         accent = LevyraViolet
                     )
                 }
-            } else {
-                items(state.recentListens, key = { "hist-${it.id}" }) { track ->
-                    TrackRow(
-                        track = track,
-                        isCurrent = track.id == state.currentTrack?.id,
-                        isPlaying = state.isPlaying && track.id == state.currentTrack?.id,
-                        isResolving = state.isResolving && track.id == state.currentTrack?.id,
-                        isFavorite = track.id in state.favoriteIds,
-                        onClick = { viewModel.playFrom(state.recentListens, track) },
-                        onFavorite = { viewModel.toggleFavorite(track) },
-                        isDownloading = track.id in state.downloadingTrackIds,
-                        isDownloaded = track.id in state.downloadedTrackIds,
-                        downloadProgress = state.downloadProgressByTrackId[track.id],
-                        onDownload = { viewModel.exportTrack(track) },
-                        onArtist = { viewModel.openArtist(track) },
-                        onAddToPlaylist = { addTarget = track }
-                    )
+                if (state.recentListens.isEmpty()) {
+                    item(key = "lib-history-empty", contentType = "lib-empty") {
+                        LibraryEmptyState(
+                            icon = Icons.Rounded.History,
+                            title = strings.listeningHistoryEmptyTitle,
+                            detail = strings.listeningHistoryEmptyDetail,
+                            accent = LevyraViolet
+                        )
+                    }
+                } else {
+                    items(state.recentListens, key = { "hist-${it.id}" }, contentType = { "lib-track" }) { track ->
+                        TrackRow(
+                            track = track,
+                            isCurrent = track.id == state.currentTrack?.id,
+                            isPlaying = state.isPlaying && track.id == state.currentTrack?.id,
+                            isResolving = state.isResolving && track.id == state.currentTrack?.id,
+                            isFavorite = track.id in state.favoriteIds,
+                            onClick = { viewModel.playFrom(state.recentListens, track) },
+                            onFavorite = { viewModel.toggleFavorite(track) },
+                            isDownloading = track.id in state.downloadingTrackIds,
+                            isDownloaded = track.id in state.downloadedTrackIds,
+                            downloadProgress = state.downloadProgressByTrackId[track.id],
+                            onDownload = { viewModel.exportTrack(track) },
+                            onArtist = { viewModel.openArtist(track) },
+                            onAddToPlaylist = { addTarget = track }
+                        )
+                    }
                 }
             }
         }
@@ -7005,6 +7047,64 @@ private fun LibraryScreen(
                     addTarget = null
                 }
             )
+        }
+    }
+}
+
+private enum class LibraryFilter { All, Playlists, Songs, Artists, Downloads }
+
+@Composable
+private fun LibraryFilterChips(
+    selected: LibraryFilter,
+    playlistCount: Int,
+    songCount: Int,
+    artistCount: Int,
+    downloadCount: Int,
+    onSelect: (LibraryFilter) -> Unit
+) {
+    val strings = LocalLevyraStrings.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(9.dp)
+    ) {
+        LibraryFilterChip(strings.all, Icons.Rounded.LibraryMusic, LevyraCyan, null, selected == LibraryFilter.All) { onSelect(LibraryFilter.All) }
+        LibraryFilterChip(cleanLibraryLabel(strings.playlists), Icons.Rounded.QueueMusic, LevyraViolet, playlistCount, selected == LibraryFilter.Playlists) { onSelect(LibraryFilter.Playlists) }
+        LibraryFilterChip(cleanLibraryLabel(strings.songs), Icons.Rounded.MusicNote, LevyraPink, songCount, selected == LibraryFilter.Songs) { onSelect(LibraryFilter.Songs) }
+        LibraryFilterChip(cleanLibraryLabel(strings.artists), Icons.Rounded.Person, CinematicGold, artistCount, selected == LibraryFilter.Artists) { onSelect(LibraryFilter.Artists) }
+        LibraryFilterChip(cleanLibraryLabel(strings.downloads), Icons.Rounded.DownloadDone, LevyraCyan, downloadCount, selected == LibraryFilter.Downloads) { onSelect(LibraryFilter.Downloads) }
+    }
+}
+
+@Composable
+private fun LibraryFilterChip(
+    label: String,
+    icon: ImageVector,
+    accent: Color,
+    count: Int?,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    val background = if (selected) accent.copy(alpha = 0.18f) else CinematicGlass.copy(alpha = 0.5f)
+    val borderColor = if (selected) accent.copy(alpha = 0.55f) else Color.White.copy(alpha = 0.08f)
+    val contentColor = if (selected) LevyraText else LevyraMuted
+    Surface(
+        color = background,
+        border = BorderStroke(1.dp, borderColor),
+        shape = RoundedCornerShape(999.dp),
+        modifier = Modifier.pressable(onClick = onClick)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 13.dp, vertical = 9.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(7.dp)
+        ) {
+            Icon(icon, null, tint = if (selected) accent else LevyraMuted, modifier = Modifier.size(16.dp))
+            Text(label, color = contentColor, fontSize = 13.sp, fontWeight = FontWeight.Bold, maxLines = 1)
+            if (count != null && count > 0) {
+                Text(count.toString(), color = if (selected) accent else LevyraMuted.copy(alpha = 0.75f), fontSize = 12.sp, fontWeight = FontWeight.Black)
+            }
         }
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.withContext
 import java.util.Locale
@@ -55,8 +55,8 @@ data class HomePlaybackProgress(
 
 class HomeViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::homeProjection) {
     internal val renderState: StateFlow<HomeRenderSnapshot> = state
-        .mapLatest { snapshot ->
-            withContext(Dispatchers.Default) { buildHomeRenderSnapshot(snapshot) }
+        .scan(buildHomeRenderSnapshot(root.state.value)) { previous, snapshot ->
+            withContext(Dispatchers.Default) { buildHomeRenderSnapshot(snapshot, previous) }
         }
         .distinctUntilChanged()
         .stateIn(
@@ -216,6 +216,32 @@ internal fun buildHomeRenderSnapshot(state: LevyraUiState): HomeRenderSnapshot {
         state = state,
         derived = buildHomeDerivedState(state.toHomeDerivedInput())
     )
+}
+
+internal fun buildHomeRenderSnapshot(
+    state: LevyraUiState,
+    previous: HomeRenderSnapshot
+): HomeRenderSnapshot {
+    val derived = if (sameHomeDerivedInputs(previous.state, state)) {
+        previous.derived
+    } else {
+        buildHomeDerivedState(state.toHomeDerivedInput())
+    }
+    return HomeRenderSnapshot(state = state, derived = derived)
+}
+
+private fun sameHomeDerivedInputs(previous: LevyraUiState, current: LevyraUiState): Boolean {
+    return previous.languageCode == current.languageCode &&
+        previous.currentTrack === current.currentTrack &&
+        previous.recentListens === current.recentListens &&
+        previous.personalOrbitTracks === current.personalOrbitTracks &&
+        previous.favorites === current.favorites &&
+        previous.tracks === current.tracks &&
+        previous.homeSections === current.homeSections &&
+        previous.homeAlbums === current.homeAlbums &&
+        previous.charts === current.charts &&
+        previous.releaseRadar === current.releaseRadar &&
+        previous.similarArtists === current.similarArtists
 }
 
 private fun LevyraUiState.toHomeDerivedInput(): HomeDerivedInput {


### PR DESCRIPTION
## Summary

Deep performance work on the Home feed and a premium redesign of the Library, keeping Levyra's identity, architecture (Kotlin + Jetpack Compose), navigation, player and audio logic unchanged. No new dependencies, no new files.

## Diagnosis

- The Home render pipeline recomputed the whole derived state (resonance sorting, artist/content fingerprints, section splitting) on **every** change of the projected UI state, including transient player state such as play/pause, resolving and favorite toggles. Each recompute produced a brand-new snapshot whose derived lists were fresh instances, so the immutable shelves could never skip recomposition.
- Home and Library scroll state lived **inside** the screen composables, which are hosted in an `AnimatedContent` keyed on the selected tab. Switching tabs disposes the outgoing content, so the `LazyListState` was lost and scroll position/inertia reset on return (data was safe in the ViewModel, but the position was not).
- The Library was a single long feed with mixed hierarchy and no way to reach a specific category quickly; several items lacked stable keys and `contentType` hints.

## Changes

### Home performance
- Memoize the derived render state: the derived block is reused when its actual inputs (content lists, `currentTrack`, language) are referentially unchanged, so player-state changes no longer recompute the derivations or invalidate the whole Home. Because the reused derived instances are identical and `@Immutable`, the shelves now skip recomposition.
- The `mapLatest` transform is replaced by a sequential `scan` that carries the previous snapshot, keeping the heavy work off the main thread (`Dispatchers.Default`) and avoiding overlapping recomputations.

### Scroll retention
- Hoist the Home and Library `LazyListState` above the tab switcher and pass them into the screens, so scroll position and inertia are preserved when returning to a screen and content is not rebuilt from scratch.

### Library redesign
- Compact, persistent filter chips (All, Playlists, Songs, Artists, Downloads) with live counts, letting users jump straight to a category. The selection is remembered across configuration changes.
- Clearer visual hierarchy while keeping Levyra's colors, typography, surfaces and shapes; reuses existing components and existing localized strings (no i18n additions).
- Stable item keys and `contentType` hints across every section for smoother recycling on large libraries; robust empty/loaded states per category.

## Files changed
- `app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt`
- `app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt`

No files created or deleted.

## Build & verification
- `:app:compileReleaseKotlin` — BUILD SUCCESSFUL (0 errors; only pre-existing warnings unrelated to this change).
- `:app:assembleRelease` — BUILD SUCCESSFUL (release APK builds with the changes).

### Pre-existing environment notes (not caused by this change)
- `:app:lintRelease` reports a single `PropertyEscape` error that comes only from a local `local.properties` file (git-ignored, not part of this PR); the application code produces zero lint errors.
- A release-variant unit test task (`:app:testReleaseUnitTest`) is not defined in this project configuration.

## Constraints respected
- Kotlin + Compose + existing architecture preserved. No WebView, no app rewrite, no navigation/player/audio changes. No heavy dependencies, no new files, no temporary workarounds, no artificial delays, no code comments, no TODOs. All changes are thread-safe and lifecycle-aware.
