### PR TITLE
perf(home): defer feed updates until scroll settles

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraHomeSnapshotCache.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraHomeSnapshotCache.kt
@@ -28,20 +28,23 @@ class LevyraHomeSnapshotCache(context: Context) {
             val parsedHomeSections = parseHomeSections(rootJson.optJSONArray("homeSections") ?: JSONArray())
             val parsedCharts = parseTracks(rootJson.optJSONArray("charts") ?: JSONArray())
             val parsedPersonalOrbit = parseTracks(rootJson.optJSONArray("personalOrbit") ?: JSONArray())
+            val parsedResonance = if (schema >= 12) parseTracks(rootJson.optJSONArray("resonanceTracks") ?: JSONArray()) else emptyList()
             val homeSections = if (schema >= 7) parsedHomeSections else parsedHomeSections.map { section ->
                 section.copy(tracks = section.tracks.map { track -> track.copy(artistBrowseIds = emptyList()) })
             }
             val charts = if (schema >= 7) parsedCharts else parsedCharts.map { track -> track.copy(artistBrowseIds = emptyList()) }
             val personalOrbit = if (schema >= 7) parsedPersonalOrbit else parsedPersonalOrbit.map { track -> track.copy(artistBrowseIds = emptyList()) }
             val homeArtists = if (schema >= 11) parseArtists(rootJson.optJSONArray("homeArtists") ?: JSONArray()) else emptyList()
-            if (homeSections.isEmpty() && charts.isEmpty() && personalOrbit.isEmpty() && homeArtists.isEmpty()) return null
+            if (homeSections.isEmpty() && charts.isEmpty() && personalOrbit.isEmpty() && homeArtists.isEmpty() && parsedResonance.isEmpty()) return null
             LevyraHomeSnapshot(
                 languageCode = storedLanguage,
                 createdAt = createdAt,
                 homeSections = homeSections,
                 charts = charts,
                 personalOrbit = personalOrbit,
-                homeArtists = homeArtists
+                homeArtists = homeArtists,
+                resonanceTracks = parsedResonance,
+                resonanceUpdatedAt = if (schema >= 12) rootJson.optLong("resonanceUpdatedAt", 0L) else 0L
             )
         }.onFailure { Timber.w(it, "Home snapshot restore failed") }.getOrNull()
     }
@@ -51,10 +54,12 @@ class LevyraHomeSnapshotCache(context: Context) {
         homeSections: List<HomeSection>,
         charts: List<Track>,
         personalOrbit: List<Track>,
-        homeArtists: List<ArtistHit>
+        homeArtists: List<ArtistHit>,
+        resonanceTracks: List<Track>,
+        resonanceUpdatedAt: Long
     ) {
         val normalized = LevyraLanguageCatalog.normalize(languageCode)
-        if (homeSections.isEmpty() && charts.isEmpty() && personalOrbit.isEmpty() && homeArtists.isEmpty()) return
+        if (homeSections.isEmpty() && charts.isEmpty() && personalOrbit.isEmpty() && homeArtists.isEmpty() && resonanceTracks.isEmpty()) return
         runCatching {
             val json = JSONObject()
                 .put("schema", SCHEMA)
@@ -64,6 +69,8 @@ class LevyraHomeSnapshotCache(context: Context) {
                 .put("charts", tracksToJson(charts.take(60)))
                 .put("personalOrbit", tracksToJson(personalOrbit.take(40)))
                 .put("homeArtists", artistsToJson(homeArtists.take(HOME_ARTIST_LIMIT)))
+                .put("resonanceTracks", tracksToJson(resonanceTracks.take(RESONANCE_TRACK_LIMIT)))
+                .put("resonanceUpdatedAt", resonanceUpdatedAt)
             val target = fileFor(normalized)
             val tmp = File(target.parentFile, "${target.name}.tmp")
             tmp.writeText(json.toString())
@@ -173,8 +180,9 @@ class LevyraHomeSnapshotCache(context: Context) {
 
     private companion object {
         const val HOME_ARTIST_LIMIT = 13
+        const val RESONANCE_TRACK_LIMIT = 8
         const val MIN_SUPPORTED_SCHEMA = 5
-        const val SCHEMA = 11
+        const val SCHEMA = 12
         const val MAX_STALE_MS = 21L * 24L * 60L * 60L * 1000L
     }
 }
@@ -185,5 +193,7 @@ data class LevyraHomeSnapshot(
     val homeSections: List<HomeSection>,
     val charts: List<Track>,
     val personalOrbit: List<Track>,
-    val homeArtists: List<ArtistHit>
+    val homeArtists: List<ArtistHit>,
+    val resonanceTracks: List<Track>,
+    val resonanceUpdatedAt: Long
 )

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -4270,8 +4270,9 @@ private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnaps
                 viewModel.setHomeViewport(scrollInProgress, atTop)
             }
     }
-    DisposableEffect(viewModel) {
-        viewModel.onHomeEntered()
+    DisposableEffect(viewModel, homeListState) {
+        val atTop = homeListState.firstVisibleItemIndex == 0 && homeListState.firstVisibleItemScrollOffset == 0
+        viewModel.onHomeEntered(atTop)
         onDispose { viewModel.onHomeLeft() }
     }
     LaunchedEffect(Unit) {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -105,10 +105,10 @@ class HomeViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::homeP
     fun selectMood(mood: Mood) = root.selectMood(mood)
     fun toggleFavorite(track: Track) = root.toggleFavorite(track)
     fun togglePlay() = root.togglePlay()
-    fun onHomeEntered() {
+    fun onHomeEntered(atTop: Boolean) {
         homeRenderSettleJob?.cancel()
-        freezeHomeContent.value = false
-        root.onHomeEntered()
+        freezeHomeContent.value = shouldFreezeHomeStructure(scrollInProgress = false, atTop = atTop)
+        root.onHomeEntered(atTop)
     }
 
     fun onHomeLeft() {
@@ -120,7 +120,7 @@ class HomeViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::homeP
     fun setHomeViewport(scrollInProgress: Boolean, atTop: Boolean) {
         root.setHomeViewport(scrollInProgress, atTop)
         homeRenderSettleJob?.cancel()
-        if (scrollInProgress) {
+        if (shouldFreezeHomeStructure(scrollInProgress, atTop)) {
             freezeHomeContent.value = true
         } else {
             homeRenderSettleJob = viewModelScope.launch {
@@ -219,6 +219,10 @@ class LevyraScreenViewModelFactory(
 
 
 private const val HOME_RENDER_SETTLE_MS = 360L
+
+internal fun shouldFreezeHomeStructure(scrollInProgress: Boolean, atTop: Boolean): Boolean {
+    return scrollInProgress || !atTop
+}
 
 private data class HomeRenderInput(
     val state: LevyraUiState,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -25,8 +25,13 @@ import com.luc4n3x.levyra.domain.SearchResults
 import com.luc4n3x.levyra.domain.Track
 import com.luc4n3x.levyra.ui.i18n.LevyraStrings
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.scan
@@ -54,11 +59,22 @@ data class HomePlaybackProgress(
 )
 
 class HomeViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::homeProjection) {
-    internal val renderState: StateFlow<HomeRenderSnapshot> = state
-        .scan(buildHomeRenderSnapshot(root.state.value)) { previous, snapshot ->
-            withContext(Dispatchers.Default) { buildHomeRenderSnapshot(snapshot, previous) }
+    private val freezeHomeContent = MutableStateFlow(false)
+    private var homeRenderSettleJob: Job? = null
+
+    internal val renderState: StateFlow<HomeRenderSnapshot> = combine(state, freezeHomeContent) { snapshot, freeze ->
+        HomeRenderInput(snapshot, freeze)
+    }
+        .scan(buildHomeRenderSnapshot(root.state.value)) { previous, input ->
+            withContext(Dispatchers.Default) {
+                buildStableHomeRenderSnapshot(
+                    state = input.state,
+                    previous = previous,
+                    freezeContent = input.freezeContent
+                )
+            }
         }
-        .distinctUntilChanged()
+        .distinctUntilChanged(::sameHomeRenderSnapshot)
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000L),
@@ -89,9 +105,30 @@ class HomeViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::homeP
     fun selectMood(mood: Mood) = root.selectMood(mood)
     fun toggleFavorite(track: Track) = root.toggleFavorite(track)
     fun togglePlay() = root.togglePlay()
-    fun onHomeEntered() = root.onHomeEntered()
-    fun onHomeLeft() = root.onHomeLeft()
-    fun setHomeViewport(scrollInProgress: Boolean, atTop: Boolean) = root.setHomeViewport(scrollInProgress, atTop)
+    fun onHomeEntered() {
+        homeRenderSettleJob?.cancel()
+        freezeHomeContent.value = false
+        root.onHomeEntered()
+    }
+
+    fun onHomeLeft() {
+        homeRenderSettleJob?.cancel()
+        freezeHomeContent.value = false
+        root.onHomeLeft()
+    }
+
+    fun setHomeViewport(scrollInProgress: Boolean, atTop: Boolean) {
+        root.setHomeViewport(scrollInProgress, atTop)
+        homeRenderSettleJob?.cancel()
+        if (scrollInProgress) {
+            freezeHomeContent.value = true
+        } else {
+            homeRenderSettleJob = viewModelScope.launch {
+                delay(HOME_RENDER_SETTLE_MS)
+                freezeHomeContent.value = false
+            }
+        }
+    }
 }
 
 class SearchViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::searchProjection) {
@@ -178,6 +215,48 @@ class LevyraScreenViewModelFactory(
             else -> throw IllegalArgumentException("Unsupported screen ViewModel: ${modelClass.name}")
         } as T
     }
+}
+
+
+private const val HOME_RENDER_SETTLE_MS = 220L
+
+private data class HomeRenderInput(
+    val state: LevyraUiState,
+    val freezeContent: Boolean
+)
+
+internal fun buildStableHomeRenderSnapshot(
+    state: LevyraUiState,
+    previous: HomeRenderSnapshot,
+    freezeContent: Boolean
+): HomeRenderSnapshot {
+    val visibleState = if (freezeContent) state.withFrozenHomeContent(previous.state) else state
+    return buildHomeRenderSnapshot(visibleState, previous)
+}
+
+private fun LevyraUiState.withFrozenHomeContent(previous: LevyraUiState): LevyraUiState {
+    return copy(
+        tracks = previous.tracks,
+        recentSearches = previous.recentSearches,
+        recentListens = previous.recentListens,
+        personalOrbitTracks = previous.personalOrbitTracks,
+        favorites = previous.favorites,
+        charts = previous.charts,
+        isLoadingCharts = previous.isLoadingCharts,
+        homeSections = previous.homeSections,
+        homeAlbums = previous.homeAlbums,
+        homeArtists = previous.homeArtists,
+        homeArtistsLoading = previous.homeArtistsLoading,
+        homeAlbumsLoading = previous.homeAlbumsLoading,
+        isLoadingHome = previous.isLoadingHome,
+        homeError = previous.homeError,
+        releaseRadar = previous.releaseRadar,
+        similarArtists = previous.similarArtists
+    )
+}
+
+private fun sameHomeRenderSnapshot(previous: HomeRenderSnapshot, current: HomeRenderSnapshot): Boolean {
+    return homeProjection(previous.state) == homeProjection(current.state) && previous.derived == current.derived
 }
 
 @Immutable

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -218,7 +218,7 @@ class LevyraScreenViewModelFactory(
 }
 
 
-private const val HOME_RENDER_SETTLE_MS = 220L
+private const val HOME_RENDER_SETTLE_MS = 360L
 
 private data class HomeRenderInput(
     val state: LevyraUiState,
@@ -246,6 +246,7 @@ private fun LevyraUiState.withFrozenHomeContent(previous: LevyraUiState): Levyra
         homeSections = previous.homeSections,
         homeAlbums = previous.homeAlbums,
         homeArtists = previous.homeArtists,
+        homeResonanceTracks = previous.homeResonanceTracks,
         homeArtistsLoading = previous.homeArtistsLoading,
         homeAlbumsLoading = previous.homeAlbumsLoading,
         isLoadingHome = previous.isLoadingHome,
@@ -285,6 +286,7 @@ private data class HomeDerivedInput(
     val homeSections: List<HomeSection>,
     val homeAlbums: List<AlbumHit>,
     val charts: List<Track>,
+    val cachedResonanceTracks: List<Track>,
     val releaseRadar: List<ReleaseRadarEntry>,
     val similarArtists: List<ArtistHit>,
     val currentTrack: Track?
@@ -319,6 +321,7 @@ private fun sameHomeDerivedInputs(previous: LevyraUiState, current: LevyraUiStat
         previous.homeSections === current.homeSections &&
         previous.homeAlbums === current.homeAlbums &&
         previous.charts === current.charts &&
+        previous.homeResonanceTracks === current.homeResonanceTracks &&
         previous.releaseRadar === current.releaseRadar &&
         previous.similarArtists === current.similarArtists
 }
@@ -333,6 +336,7 @@ private fun LevyraUiState.toHomeDerivedInput(): HomeDerivedInput {
         homeSections = homeSections,
         homeAlbums = homeAlbums,
         charts = charts,
+        cachedResonanceTracks = homeResonanceTracks,
         releaseRadar = releaseRadar,
         similarArtists = similarArtists,
         currentTrack = currentTrack
@@ -358,7 +362,7 @@ private fun buildHomeDerivedState(input: HomeDerivedInput): HomeDerivedState {
         hasCurrentTrack = input.currentTrack != null
     )
     return HomeDerivedState(
-        resonanceTracks = buildHomeResonanceTracks(input),
+        resonanceTracks = input.cachedResonanceTracks.ifEmpty { buildHomeResonanceTracks(input) },
         artistRefreshFingerprint = buildHomeArtistRefreshFingerprint(input),
         newReleases = newReleases,
         otherSections = otherSections,
@@ -385,6 +389,10 @@ private fun buildHomeResonanceTracks(input: HomeDerivedInput): List<Track> {
         )
         .take(8)
         .toList()
+}
+
+internal fun buildHomeResonanceTracks(state: LevyraUiState): List<Track> {
+    return buildHomeResonanceTracks(state.toHomeDerivedInput())
 }
 
 private fun buildHomeArtistRefreshFingerprint(input: HomeDerivedInput): String {
@@ -508,6 +516,7 @@ private data class HomeProjection(
     val favorites: List<Track>,
     val homeAlbums: List<AlbumHit>,
     val homeArtists: List<ArtistHit>,
+    val homeResonanceTracks: List<Track>,
     val homeArtistsLoading: Boolean,
     val homeAlbumsLoading: Boolean,
     val homeSections: List<HomeSection>,
@@ -541,6 +550,7 @@ private fun homeProjection(state: LevyraUiState): HomeProjection = HomeProjectio
     favorites = state.favorites,
     homeAlbums = state.homeAlbums,
     homeArtists = state.homeArtists,
+    homeResonanceTracks = state.homeResonanceTracks,
     homeArtistsLoading = state.homeArtistsLoading,
     homeAlbumsLoading = state.homeAlbumsLoading,
     homeSections = state.homeSections,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
@@ -66,6 +66,8 @@ data class LevyraUiState(
     val homeSections: List<HomeSection> = emptyList(),
     val homeAlbums: List<AlbumHit> = emptyList(),
     val homeArtists: List<ArtistHit> = emptyList(),
+    val homeResonanceTracks: List<Track> = emptyList(),
+    val homeResonanceUpdatedAt: Long = 0L,
     val homeArtistsLoading: Boolean = false,
     val homeAlbumsLoading: Boolean = false,
     val isLoadingHome: Boolean = false,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -274,6 +274,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private var homeArtistsJob: Job? = null
     private var chartsJob: Job? = null
     private var homeSnapshotJob: Job? = null
+    private var homeResonanceJob: Job? = null
     private var homeArtistsFingerprint: String = ""
     private val deferredHomeArtistsSnapshot = AtomicReference<List<ArtistHit>?>(null)
     private var radarJob: Job? = null
@@ -463,6 +464,8 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             cachedCharts.ifEmpty { LevyraStartupCatalog.chartTracks(settings.languageCode) },
             settings.languageCode
         )
+        val startupResonanceTracks = instantSnapshot?.resonanceTracks.orEmpty()
+        val startupResonanceUpdatedAt = instantSnapshot?.resonanceUpdatedAt ?: 0L
         val rawCachedOrbitTracks = LevyraStartupCatalog.repairTracks(
             settings.personalOrbitTracks
                 .ifEmpty { instantSnapshot?.personalOrbit.orEmpty() }
@@ -519,6 +522,8 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 homeSections = startupHomeSections,
                 homeAlbums = startupAlbums,
                 homeArtists = startupHomeArtists,
+                homeResonanceTracks = startupResonanceTracks,
+                homeResonanceUpdatedAt = startupResonanceUpdatedAt,
                 homeArtistsLoading = startupHomeArtists.isEmpty(),
                 homeAlbumsLoading = startupAlbums.isEmpty(),
                 tracks = initialTracks,
@@ -720,13 +725,14 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             }
         }
 
+        loadCharts(deferUntilHomeIdle = true)
         viewModelScope.launch {
-            delay(900L)
+            delay(350L)
             loadHomeFeed(deferUntilHomeIdle = true)
         }
         viewModelScope.launch {
-            delay(2_200L)
-            loadCharts(deferUntilHomeIdle = true)
+            delay(1_200L)
+            refreshHomeResonanceIfStale()
         }
         viewModelScope.launch {
             delay(3_200L)
@@ -764,8 +770,43 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             homeSections = pendingHomeSectionsSnapshot.get() ?: snapshot.homeSections,
             charts = snapshot.charts,
             personalOrbit = snapshot.personalOrbitTracks,
-            homeArtists = deferredHomeArtistsSnapshot.get() ?: snapshot.homeArtists
+            homeArtists = deferredHomeArtistsSnapshot.get() ?: snapshot.homeArtists,
+            resonanceTracks = snapshot.homeResonanceTracks,
+            resonanceUpdatedAt = snapshot.homeResonanceUpdatedAt
         )
+    }
+
+    private fun refreshHomeResonanceIfStale() {
+        val initial = _state.value
+        if (isHomeResonanceFresh(initial, System.currentTimeMillis())) return
+        if (homeResonanceJob?.isActive == true) return
+        val languageCode = initial.languageCode
+        homeResonanceJob = viewModelScope.launch(Dispatchers.Default) {
+            val source = _state.value
+            if (source.languageCode != languageCode) return@launch
+            val resolved = buildHomeResonanceTracks(source)
+            if (resolved.isEmpty()) return@launch
+            val updatedAt = System.currentTimeMillis()
+            var changed = false
+            _state.update { current ->
+                if (current.languageCode != languageCode || isHomeResonanceFresh(current, updatedAt)) {
+                    current
+                } else {
+                    changed = current.homeResonanceTracks != resolved || current.homeResonanceUpdatedAt != updatedAt
+                    current.copy(
+                        homeResonanceTracks = resolved,
+                        homeResonanceUpdatedAt = updatedAt
+                    )
+                }
+            }
+            if (changed) persistHomeSnapshot()
+        }
+    }
+
+    private fun isHomeResonanceFresh(state: LevyraUiState, now: Long): Boolean {
+        return state.homeResonanceTracks.isNotEmpty() &&
+            state.homeResonanceUpdatedAt > 0L &&
+            now - state.homeResonanceUpdatedAt < HOME_RESONANCE_REFRESH_INTERVAL_MS
     }
 
     fun refreshHomeArtists() {
@@ -1443,12 +1484,11 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             val initialState = _state.value
             val languageCode = initialState.languageCode
             val hasVisibleHome = initialState.homeSections.isNotEmpty() || initialState.tracks.isNotEmpty()
-            if (deferUntilHomeIdle) awaitHomeUiIdle()
             if (!isActive || _state.value.languageCode != languageCode) return@launch
             _state.update { current ->
                 if (current.languageCode != languageCode) current
                 else current.copy(
-                    isLoadingHome = true,
+                    isLoadingHome = !hasVisibleHome,
                     homeError = null
                 )
             }
@@ -1616,6 +1656,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             prefetchTop(visibleTracks, HOME_STARTUP_STREAM_PREFETCH_COUNT, respectHomeScroll = deferUntilHomeIdle)
             refreshOfficialMetadataBatch(visibleTracks, HOME_STARTUP_METADATA_REFRESH_COUNT, deferUntilHomeIdle)
             loadHomeAlbums(languageCode, deferUntilHomeIdle)
+            refreshHomeResonanceIfStale()
         }
     }
 
@@ -2116,7 +2157,8 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             personalOrbitTracks = orbit,
             tracks = allTracks
         )
-        val localizedCachedArtists = homeSnapshotCache.load(languageCode)?.homeArtists
+        val localizedSnapshot = homeSnapshotCache.load(languageCode)
+        val localizedCachedArtists = localizedSnapshot?.homeArtists
             .orEmpty()
             .filter { artist ->
                 artist.name.isNotBlank() &&
@@ -2145,6 +2187,8 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 homeSections = homeSections,
                 homeAlbums = instantAlbums,
                 homeArtists = localizedCachedArtists,
+                homeResonanceTracks = localizedSnapshot?.resonanceTracks.orEmpty(),
+                homeResonanceUpdatedAt = localizedSnapshot?.resonanceUpdatedAt ?: 0L,
                 homeArtistsLoading = localizedCachedArtists.isEmpty() && refreshRemote,
                 homeAlbumsLoading = instantAlbums.isEmpty() && refreshRemote,
                 isLoadingHome = refreshRemote && homeSections.isEmpty() && allTracks.isEmpty(),
@@ -2243,7 +2287,6 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             val initialState = _state.value
             val languageCode = initialState.languageCode
             val hasVisibleCharts = initialState.charts.isNotEmpty()
-            if (deferUntilHomeIdle) awaitHomeUiIdle()
             if (!isActive || _state.value.languageCode != languageCode || _state.value.selectedChartId != regionId) return@launch
             _state.update { current ->
                 if (current.selectedChartId != regionId) current
@@ -2290,6 +2333,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 else current.copy(charts = result, isLoadingCharts = false)
             }
             persistHomeSnapshot()
+            refreshHomeResonanceIfStale()
             val startupPlan = homeStartupWorkPlan()
             viewModelScope.launch(Dispatchers.IO) {
                 if (deferUntilHomeIdle) awaitHomeUiIdle(startupPlan)
@@ -4567,6 +4611,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         private const val HOME_ARTIST_STARTUP_GRACE_MS = 850L
         private const val HOME_STARTUP_STREAM_PREFETCH_COUNT = 2
         private const val HOME_STARTUP_METADATA_REFRESH_COUNT = 4
+        private const val HOME_RESONANCE_REFRESH_INTERVAL_MS = 12L * 60L * 60L * 1000L
         private const val HOME_ALBUM_RECOMMENDATION_LIMIT = 10
         private const val HOME_ALBUM_REMOTE_CANDIDATE_LIMIT = 24
         private const val HOME_ALBUM_SEED_LIMIT = 12
@@ -4602,6 +4647,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         homeFeedJob?.cancel()
         homeAlbumsJob?.cancel()
         homeArtistsJob?.cancel()
+        homeResonanceJob?.cancel()
         chartsJob?.cancel()
         homeSnapshotJob?.cancel()
         super.onCleared()

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -325,7 +325,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         homeAtTop = atTop
         homeScrollInProgress = scrollInProgress
         homeInteractionGate.update(scrollInProgress)
-        if (homeScreenActive && atTop && !scrollInProgress) {
+        if (homeScreenActive && !scrollInProgress) {
             scheduleDeferredHomeSnapshotApply()
         }
     }
@@ -346,7 +346,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     private fun canApplyHomeStructuralChanges(): Boolean {
-        return !homeScreenActive || (homeAtTop && !homeScrollInProgress)
+        return !homeScreenActive || !homeScrollInProgress
     }
 
     private fun hasDeferredHomeSnapshots(): Boolean {
@@ -354,17 +354,17 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     private fun scheduleDeferredHomeSnapshotApply(waitForIdle: Boolean = true) {
-        if (!homeScreenActive || !homeAtTop || homeScrollInProgress || !hasDeferredHomeSnapshots()) return
+        if (!homeScreenActive || homeScrollInProgress || !hasDeferredHomeSnapshots()) return
         if (!deferredHomeSnapshotApplyScheduled.compareAndSet(false, true)) return
         viewModelScope.launch {
             try {
                 if (waitForIdle) awaitHomeUiIdle()
-                if (homeScreenActive && homeAtTop && !homeScrollInProgress) {
+                if (homeScreenActive && !homeScrollInProgress) {
                     applyDeferredHomeSnapshots()
                 }
             } finally {
                 deferredHomeSnapshotApplyScheduled.set(false)
-                if (homeScreenActive && homeAtTop && !homeScrollInProgress && hasDeferredHomeSnapshots()) {
+                if (homeScreenActive && !homeScrollInProgress && hasDeferredHomeSnapshots()) {
                     scheduleDeferredHomeSnapshotApply()
                 }
             }
@@ -375,7 +375,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         val pendingSections = pendingHomeSectionsSnapshot.getAndSet(null)
         val pendingArtists = deferredHomeArtistsSnapshot.getAndSet(null)
         if (pendingSections == null && pendingArtists == null) return
-        if (!homeScreenActive || !homeAtTop || homeScrollInProgress) {
+        if (!homeScreenActive || homeScrollInProgress) {
             pendingSections?.let { pendingHomeSectionsSnapshot.compareAndSet(null, it) }
             pendingArtists?.let { deferredHomeArtistsSnapshot.compareAndSet(null, it) }
             return
@@ -413,7 +413,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 }
             }
             if (updated === current) break
-            if (!homeScreenActive || !homeAtTop || homeScrollInProgress) {
+            if (!homeScreenActive || homeScrollInProgress) {
                 pendingSections?.let { pendingHomeSectionsSnapshot.compareAndSet(null, it) }
                 pendingArtists?.let { deferredHomeArtistsSnapshot.compareAndSet(null, it) }
                 return
@@ -1501,7 +1501,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             withContext(Dispatchers.IO) {
                 preferences.saveHomeSections(sanitizedSections, languageCode)
             }
-            if (previewMerge.changed && (deferUntilHomeIdle || (homeScreenActive && (!homeAtTop || homeScrollInProgress)))) {
+            if (previewMerge.changed && (deferUntilHomeIdle || (homeScreenActive && homeScrollInProgress))) {
                 awaitHomeUiIdle()
             }
             if (

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -326,17 +326,19 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         homeAtTop = atTop
         homeScrollInProgress = scrollInProgress
         homeInteractionGate.update(scrollInProgress)
-        if (homeScreenActive && !scrollInProgress) {
+        if (homeScreenActive && canApplyHomeStructuralChanges()) {
             scheduleDeferredHomeSnapshotApply()
         }
     }
 
-    fun onHomeEntered() {
+    fun onHomeEntered(atTop: Boolean) {
         homeScreenActive = true
-        homeAtTop = true
+        homeAtTop = atTop
         homeScrollInProgress = false
         homeInteractionGate.update(false)
-        scheduleDeferredHomeSnapshotApply(waitForIdle = false)
+        if (canApplyHomeStructuralChanges()) {
+            scheduleDeferredHomeSnapshotApply(waitForIdle = false)
+        }
     }
 
     fun onHomeLeft() {
@@ -347,7 +349,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     private fun canApplyHomeStructuralChanges(): Boolean {
-        return !homeScreenActive || !homeScrollInProgress
+        return !homeScreenActive || !shouldFreezeHomeStructure(homeScrollInProgress, homeAtTop)
     }
 
     private fun hasDeferredHomeSnapshots(): Boolean {
@@ -355,17 +357,17 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     private fun scheduleDeferredHomeSnapshotApply(waitForIdle: Boolean = true) {
-        if (!homeScreenActive || homeScrollInProgress || !hasDeferredHomeSnapshots()) return
+        if (!homeScreenActive || !canApplyHomeStructuralChanges() || !hasDeferredHomeSnapshots()) return
         if (!deferredHomeSnapshotApplyScheduled.compareAndSet(false, true)) return
         viewModelScope.launch {
             try {
                 if (waitForIdle) awaitHomeUiIdle()
-                if (homeScreenActive && !homeScrollInProgress) {
+                if (homeScreenActive && canApplyHomeStructuralChanges()) {
                     applyDeferredHomeSnapshots()
                 }
             } finally {
                 deferredHomeSnapshotApplyScheduled.set(false)
-                if (homeScreenActive && !homeScrollInProgress && hasDeferredHomeSnapshots()) {
+                if (homeScreenActive && canApplyHomeStructuralChanges() && hasDeferredHomeSnapshots()) {
                     scheduleDeferredHomeSnapshotApply()
                 }
             }
@@ -376,7 +378,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         val pendingSections = pendingHomeSectionsSnapshot.getAndSet(null)
         val pendingArtists = deferredHomeArtistsSnapshot.getAndSet(null)
         if (pendingSections == null && pendingArtists == null) return
-        if (!homeScreenActive || homeScrollInProgress) {
+        if (!homeScreenActive || !canApplyHomeStructuralChanges()) {
             pendingSections?.let { pendingHomeSectionsSnapshot.compareAndSet(null, it) }
             pendingArtists?.let { deferredHomeArtistsSnapshot.compareAndSet(null, it) }
             return
@@ -414,7 +416,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 }
             }
             if (updated === current) break
-            if (!homeScreenActive || homeScrollInProgress) {
+            if (!homeScreenActive || !canApplyHomeStructuralChanges()) {
                 pendingSections?.let { pendingHomeSectionsSnapshot.compareAndSet(null, it) }
                 pendingArtists?.let { deferredHomeArtistsSnapshot.compareAndSet(null, it) }
                 return

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/HomeRenderSnapshotTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/HomeRenderSnapshotTest.kt
@@ -1,7 +1,9 @@
 package com.luc4n3x.levyra.viewmodel
 
+import com.luc4n3x.levyra.domain.HomeSection
 import com.luc4n3x.levyra.domain.Track
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
 import org.junit.Test
 
@@ -15,6 +17,93 @@ class HomeRenderSnapshotTest {
 
         assertSame(state, snapshot.state)
         assertEquals(snapshot.state.charts, snapshot.derived.chartChunks.flatten())
+    }
+
+    @Test
+    fun keepsHomeStructureFrozenWhileIdleAwayFromTop() {
+        assertEquals(true, shouldFreezeHomeStructure(scrollInProgress = false, atTop = false))
+        assertEquals(true, shouldFreezeHomeStructure(scrollInProgress = true, atTop = true))
+        assertEquals(false, shouldFreezeHomeStructure(scrollInProgress = false, atTop = true))
+    }
+
+    @Test
+    fun freezesStructuralHomeContentWhileScrolling() {
+        val initialTrack = track("aaaaaaaaaaa")
+        val refreshedTrack = track("bbbbbbbbbbb")
+        val initialState = LevyraUiState(
+            tracks = listOf(initialTrack),
+            homeSections = listOf(HomeSection("Initial", listOf(initialTrack)))
+        )
+        val previous = buildHomeRenderSnapshot(initialState)
+        val refreshedState = initialState.copy(
+            tracks = listOf(refreshedTrack),
+            homeSections = listOf(HomeSection("Refreshed", listOf(refreshedTrack))),
+            isPlaying = true
+        )
+
+        val frozen = buildStableHomeRenderSnapshot(refreshedState, previous, freezeContent = true)
+
+        assertSame(previous.state.tracks, frozen.state.tracks)
+        assertSame(previous.state.homeSections, frozen.state.homeSections)
+        assertEquals(true, frozen.state.isPlaying)
+        assertSame(previous.derived, frozen.derived)
+    }
+
+    @Test
+    fun publishesLatestStructuralHomeContentAfterScrollingSettles() {
+        val initialTrack = track("aaaaaaaaaaa")
+        val refreshedTrack = track("bbbbbbbbbbb")
+        val initialState = LevyraUiState(
+            tracks = listOf(initialTrack),
+            homeSections = listOf(HomeSection("Initial", listOf(initialTrack)))
+        )
+        val previous = buildHomeRenderSnapshot(initialState)
+        val refreshedState = initialState.copy(
+            tracks = listOf(refreshedTrack),
+            homeSections = listOf(HomeSection("Refreshed", listOf(refreshedTrack)))
+        )
+
+        val published = buildStableHomeRenderSnapshot(refreshedState, previous, freezeContent = false)
+
+        assertSame(refreshedState.tracks, published.state.tracks)
+        assertSame(refreshedState.homeSections, published.state.homeSections)
+        assertNotSame(previous.derived, published.derived)
+        assertEquals(listOf(refreshedTrack), published.derived.otherSections.single().tracks)
+    }
+
+    @Test
+    fun keepsCachedResonanceStableAcrossOtherHomeChanges() {
+        val cachedResonance = track("aaaaaaaaaaa")
+        val refreshedTrack = track("bbbbbbbbbbb")
+        val initialState = LevyraUiState(
+            tracks = listOf(cachedResonance),
+            homeResonanceTracks = listOf(cachedResonance),
+            homeResonanceUpdatedAt = 100L
+        )
+        val previous = buildHomeRenderSnapshot(initialState)
+        val refreshedState = initialState.copy(
+            tracks = listOf(refreshedTrack),
+            homeSections = listOf(HomeSection("Refreshed", listOf(refreshedTrack)))
+        )
+
+        val refreshed = buildStableHomeRenderSnapshot(refreshedState, previous, freezeContent = false)
+
+        assertEquals(listOf(cachedResonance), refreshed.derived.resonanceTracks)
+    }
+
+    @Test
+    fun defersResonanceReplacementUntilScrollingSettles() {
+        val initialTrack = track("aaaaaaaaaaa")
+        val refreshedTrack = track("bbbbbbbbbbb")
+        val initialState = LevyraUiState(homeResonanceTracks = listOf(initialTrack))
+        val previous = buildHomeRenderSnapshot(initialState)
+        val refreshedState = initialState.copy(homeResonanceTracks = listOf(refreshedTrack))
+
+        val frozen = buildStableHomeRenderSnapshot(refreshedState, previous, freezeContent = true)
+        val published = buildStableHomeRenderSnapshot(refreshedState, previous, freezeContent = false)
+
+        assertEquals(listOf(initialTrack), frozen.derived.resonanceTracks)
+        assertEquals(listOf(refreshedTrack), published.derived.resonanceTracks)
     }
 
     private fun track(id: String): Track {


### PR DESCRIPTION
## Summary

-

## Scope

- [ ] Player / audio
- [ ] Stream extraction
- [ ] Downloads
- [ ] UI / Compose
- [ ] Localization
- [ ] Android Auto / media session
- [ ] CI / release
- [ ] Documentation

## What changed

-
## Testing

- [ ] `gradle --no-daemon :app:lintRelease`
- [ ] `gradle --no-daemon testReleaseUnitTest`
- [ ] `gradle --no-daemon assembleRelease`
- [ ] APK installed on device
- [ ] Playback tested
- [ ] Downloads tested
- [ ] Language switching tested

## Release safety

- [ ] `levyraVersionName` and `levyraVersionCode` are correct
- [ ] No secrets, keystores, APKs or ZIPs committed
- [ ] No duplicated release workflows
- [ ] Credits and licenses updated when adding external components

## Related issues

- Closes #
- Related to #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved home screen scrolling by reducing unnecessary UI recomputation and animation updates.
  * Stabilized home content during scroll transitions for smoother visual performance.

* **Bug Fixes**
  * Deferred home feed updates while scrolling and applied them automatically after scrolling stops.
  * Improved update handling when returning to the home screen or scrolling away from the top.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->