### PR TITLE
Add estimated dislikes and read-only YouTube comments

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -18,6 +18,7 @@ Levyra is licensed under the GNU General Public License v3.0. Third-party librar
 | Metrolist | https://github.com/MetrolistGroup/Metrolist | Android music client ecosystem reference | GPL-3.0 license notices must be preserved where code is reused |
 | zemer-cipher | https://github.com/ZemerTeam/zemer-cipher | Reference design and validated player configuration data for the local YouTube signature and n-parameter decoder | GPL-3.0; adapted decoder logic and configuration validation retain upstream attribution |
 | NewPipeExtractor | https://github.com/TeamNewPipe/NewPipeExtractor | Upstream extractor ecosystem reference | Original copyright and license notices remain with upstream authors |
+| Return YouTube Dislike | https://returnyoutubedislike.com | Read-only estimated dislike metadata | Counts are estimates, not official YouTube statistics; attribution and API rate limits must be preserved |
 | PipePipeExtractor | https://github.com/InfinityLoop1308/PipePipeExtractor | Upstream base for LevyraExtractor | Original copyright and license notices remain with upstream authors |
 | MusicApp-KMP | https://github.com/SEAbdulbasit/MusicApp-KMP | UI and modular styling inspiration only | No ownership claim is made over the original project |
 
@@ -53,6 +54,7 @@ Each dependency keeps its own upstream license. Dependency versions and package 
 |:---|:---|
 | LRCLIB-compatible lyrics metadata | Lyrics lookup where available |
 | SponsorBlock-compatible segment metadata | Optional segment metadata where supported |
+| Return YouTube Dislike API | Optional estimated dislike metadata; Levyra does not submit votes |
 | Third-party music metadata/search endpoints | Search, metadata and playback resolving where configured by the app |
 
 Levyra does not claim ownership over third-party metadata, album artwork, track names, artist names, lyrics, media content, logos, trademarks, or service names.

--- a/app/src/main/java/com/luc4n3x/levyra/data/ReturnYoutubeDislikeRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/ReturnYoutubeDislikeRepository.kt
@@ -70,8 +70,20 @@ internal class ReturnYoutubeDislikeRepository {
 
         val now = System.currentTimeMillis()
         cache[normalizedId]?.let { cached ->
-            if (now < cached.expiresAtMs) return cached.result
-            cache.remove(normalizedId, cached)
+            if (now < cached.expiresAtMs) {
+                val cachedResult = cached.result
+                if (cachedResult is ReturnYoutubeDislikeResult.RateLimited) {
+                    val remainingMs = blockedUntilMs.get() - now
+                    if (remainingMs > 0L) {
+                        return ReturnYoutubeDislikeResult.RateLimited(remainingMs)
+                    }
+                    cache.remove(normalizedId, cached)
+                } else {
+                    return cachedResult
+                }
+            } else {
+                cache.remove(normalizedId, cached)
+            }
         }
 
         val blockedUntil = blockedUntilMs.get()
@@ -193,7 +205,9 @@ internal fun parseReturnYoutubeDislikeResponse(
         val dislikes = root.optLongStrict("dislikes") ?: return null
         val rawLikes = root.optLongStrict("rawLikes") ?: 0L
         val rawDislikes = root.optLongStrict("rawDislikes") ?: 0L
-        val viewCount = root.optLongStrict("viewCount") ?: -1L
+        val parsedViewCount = root.optLongStrict("viewCount")
+        if (parsedViewCount != null && parsedViewCount < 0L) return null
+        val viewCount = parsedViewCount ?: -1L
         val rating = root.optDouble("rating", 0.0).takeIf(Double::isFinite) ?: 0.0
         val deleted = root.optBoolean("deleted", false)
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/ReturnYoutubeDislikeRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/ReturnYoutubeDislikeRepository.kt
@@ -1,0 +1,222 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.withContext
+import okhttp3.Request
+import org.json.JSONObject
+import timber.log.Timber
+import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+private const val RYD_API_HOST = "returnyoutubedislikeapi.com"
+private const val RYD_API_BASE_URL = "https://$RYD_API_HOST"
+private val YOUTUBE_VIDEO_ID = Regex("^[A-Za-z0-9_-]{11}$")
+
+internal data class ReturnYoutubeDislikeEstimate(
+    val videoId: String,
+    val likes: Long,
+    val dislikes: Long,
+    val rawLikes: Long,
+    val rawDislikes: Long,
+    val viewCount: Long,
+    val rating: Double,
+    val deleted: Boolean
+)
+
+internal sealed interface ReturnYoutubeDislikeResult {
+    data class Available(val estimate: ReturnYoutubeDislikeEstimate) : ReturnYoutubeDislikeResult
+    data object NotFound : ReturnYoutubeDislikeResult
+    data class RateLimited(val retryAfterMs: Long) : ReturnYoutubeDislikeResult
+    data class Failed(val cause: Throwable? = null) : ReturnYoutubeDislikeResult
+}
+
+/**
+ * Read-only client for Return YouTube Dislike.
+ *
+ * The service returns an estimate, not an official YouTube dislike counter. Levyra never submits
+ * votes to it and never presents the result as an official count.
+ */
+internal class ReturnYoutubeDislikeRepository {
+    private val client = LevyraHttpClientFactory.general().newBuilder()
+        .followRedirects(false)
+        .followSslRedirects(false)
+        .connectTimeout(4, TimeUnit.SECONDS)
+        .readTimeout(6, TimeUnit.SECONDS)
+        .writeTimeout(4, TimeUnit.SECONDS)
+        .callTimeout(8, TimeUnit.SECONDS)
+        .retryOnConnectionFailure(true)
+        .build()
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val cache = ConcurrentHashMap<String, CachedEstimate>()
+    private val inFlight = ConcurrentHashMap<String, Deferred<ReturnYoutubeDislikeResult>>()
+    private val blockedUntilMs = AtomicLong(0L)
+
+    suspend fun estimate(videoId: String): ReturnYoutubeDislikeResult {
+        val normalizedId = videoId.trim()
+        if (!YOUTUBE_VIDEO_ID.matches(normalizedId)) {
+            return ReturnYoutubeDislikeResult.Failed(IllegalArgumentException("Invalid YouTube video id"))
+        }
+
+        val now = System.currentTimeMillis()
+        cache[normalizedId]?.let { cached ->
+            if (now < cached.expiresAtMs) return cached.result
+            cache.remove(normalizedId, cached)
+        }
+
+        val blockedUntil = blockedUntilMs.get()
+        if (now < blockedUntil) {
+            return ReturnYoutubeDislikeResult.RateLimited(blockedUntil - now)
+        }
+
+        val created = scope.async(start = CoroutineStart.LAZY) { fetch(normalizedId) }
+        created.invokeOnCompletion { inFlight.remove(normalizedId, created) }
+        val shared = inFlight.putIfAbsent(normalizedId, created) ?: created
+        if (shared === created) {
+            created.start()
+        } else {
+            created.cancel()
+        }
+        return shared.await()
+    }
+
+    fun close() {
+        scope.cancel()
+        inFlight.clear()
+        cache.clear()
+    }
+
+    private suspend fun fetch(videoId: String): ReturnYoutubeDislikeResult = withContext(Dispatchers.IO) {
+        val request = Request.Builder()
+            .url("$RYD_API_BASE_URL/votes?videoId=$videoId")
+            .get()
+            .header("Accept", "application/json")
+            .header("User-Agent", "Levyra-Android/1.0 (read-only engagement metadata)")
+            .build()
+
+        val result = try {
+            client.newCall(request).execute().use { response ->
+                // Redirects are deliberately disabled. The API endpoint is fixed and must not move
+                // requests to an untrusted destination.
+                if (response.isRedirect) {
+                    ReturnYoutubeDislikeResult.Failed(IOException("Unexpected RYD redirect"))
+                } else {
+                    when (response.code) {
+                        200 -> {
+                            val body = response.body?.string().orEmpty()
+                            val estimate = parseReturnYoutubeDislikeResponse(body, videoId)
+                            if (estimate == null) {
+                                ReturnYoutubeDislikeResult.Failed(IOException("Invalid RYD response"))
+                            } else {
+                                ReturnYoutubeDislikeResult.Available(estimate)
+                            }
+                        }
+                        404 -> ReturnYoutubeDislikeResult.NotFound
+                        429 -> {
+                            val retryAfterMs = response.header("Retry-After")
+                                ?.trim()
+                                ?.toLongOrNull()
+                                ?.coerceIn(1L, 3_600L)
+                                ?.times(1_000L)
+                                ?: DEFAULT_RATE_LIMIT_BACKOFF_MS
+                            blockedUntilMs.set(System.currentTimeMillis() + retryAfterMs)
+                            ReturnYoutubeDislikeResult.RateLimited(retryAfterMs)
+                        }
+                        else -> ReturnYoutubeDislikeResult.Failed(IOException("RYD HTTP ${response.code}"))
+                    }
+                }
+            }
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Throwable) {
+            Timber.d(error, "Return YouTube Dislike unavailable for %s", videoId)
+            ReturnYoutubeDislikeResult.Failed(error)
+        }
+
+        val ttlMs = when (result) {
+            is ReturnYoutubeDislikeResult.Available -> POSITIVE_TTL_MS
+            ReturnYoutubeDislikeResult.NotFound -> NOT_FOUND_TTL_MS
+            is ReturnYoutubeDislikeResult.RateLimited -> result.retryAfterMs.coerceAtLeast(MIN_RATE_LIMIT_CACHE_MS)
+            is ReturnYoutubeDislikeResult.Failed -> FAILURE_TTL_MS
+        }
+        cacheResult(videoId, result, ttlMs)
+        result
+    }
+
+    private fun cacheResult(videoId: String, result: ReturnYoutubeDislikeResult, ttlMs: Long) {
+        val now = System.currentTimeMillis()
+        if (cache.size >= MAX_CACHE_ENTRIES) {
+            cache.entries.removeIf { now >= it.value.expiresAtMs }
+            if (cache.size >= MAX_CACHE_ENTRIES) {
+                cache.entries.minByOrNull { it.value.expiresAtMs }?.let { cache.remove(it.key, it.value) }
+            }
+        }
+        cache[videoId] = CachedEstimate(result, now + ttlMs)
+    }
+
+    private data class CachedEstimate(
+        val result: ReturnYoutubeDislikeResult,
+        val expiresAtMs: Long
+    )
+
+    private companion object {
+        const val MAX_CACHE_ENTRIES = 256
+        const val POSITIVE_TTL_MS = 2L * 60L * 60L * 1_000L
+        const val NOT_FOUND_TTL_MS = 30L * 60L * 1_000L
+        const val FAILURE_TTL_MS = 60L * 1_000L
+        const val DEFAULT_RATE_LIMIT_BACKOFF_MS = 15L * 60L * 1_000L
+        const val MIN_RATE_LIMIT_CACHE_MS = 60L * 1_000L
+    }
+}
+
+internal fun parseReturnYoutubeDislikeResponse(
+    json: String,
+    expectedVideoId: String
+): ReturnYoutubeDislikeEstimate? {
+    if (!YOUTUBE_VIDEO_ID.matches(expectedVideoId)) return null
+    return runCatching {
+        val root = JSONObject(json)
+        val responseId = root.optString("id").trim()
+        if (responseId != expectedVideoId) return null
+
+        val likes = root.optLongStrict("likes") ?: return null
+        val dislikes = root.optLongStrict("dislikes") ?: return null
+        val rawLikes = root.optLongStrict("rawLikes") ?: 0L
+        val rawDislikes = root.optLongStrict("rawDislikes") ?: 0L
+        val viewCount = root.optLongStrict("viewCount") ?: -1L
+        val rating = root.optDouble("rating", 0.0).takeIf(Double::isFinite) ?: 0.0
+        val deleted = root.optBoolean("deleted", false)
+
+        if (likes < 0L || dislikes < 0L || rawLikes < 0L || rawDislikes < 0L) return null
+
+        ReturnYoutubeDislikeEstimate(
+            videoId = responseId,
+            likes = likes,
+            dislikes = dislikes,
+            rawLikes = rawLikes,
+            rawDislikes = rawDislikes,
+            viewCount = viewCount,
+            rating = rating,
+            deleted = deleted
+        )
+    }.getOrNull()
+}
+
+private fun JSONObject.optLongStrict(name: String): Long? {
+    if (!has(name) || isNull(name)) return null
+    return when (val value = opt(name)) {
+        is Number -> value.toLong()
+        is String -> value.trim().toLongOrNull()
+        else -> null
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeCommentsRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeCommentsRepository.kt
@@ -41,12 +41,12 @@ internal class YoutubeCommentsRepository {
     private val cache = ConcurrentHashMap<RequestKey, CachedCommentsResult>()
     private val inFlight = ConcurrentHashMap<RequestKey, Deferred<YoutubeCommentsResult>>()
 
-    suspend fun initial(videoId: String): YoutubeCommentsResult {
+    suspend fun initial(videoId: String, forceRefresh: Boolean = false): YoutubeCommentsResult {
         val normalized = videoId.trim()
         if (!COMMENTS_VIDEO_ID.matches(normalized)) {
             return YoutubeCommentsResult.Failed(IllegalArgumentException("Invalid YouTube video id"))
         }
-        return resolve(RequestKey(normalized, "initial")) {
+        return resolve(RequestKey(normalized, "initial"), forceRefresh = forceRefresh) {
             NewPipeRuntime.ensure()
             val url = youtubeUrl(normalized)
             val info = CommentsInfo.getInfo(ServiceList.YouTube, url)
@@ -71,13 +71,17 @@ internal class YoutubeCommentsRepository {
         }
     }
 
-    suspend fun more(videoId: String, continuationToken: String): YoutubeCommentsResult {
+    suspend fun more(
+        videoId: String,
+        continuationToken: String,
+        forceRefresh: Boolean = false
+    ): YoutubeCommentsResult {
         val normalized = videoId.trim()
         val token = continuationToken.trim()
         if (!COMMENTS_VIDEO_ID.matches(normalized) || token.isBlank()) {
             return YoutubeCommentsResult.Failed(IllegalArgumentException("Invalid comments continuation"))
         }
-        return resolve(RequestKey(normalized, "page:$token")) {
+        return resolve(RequestKey(normalized, "page:$token"), forceRefresh = forceRefresh) {
             NewPipeRuntime.ensure()
             val firstPage = fetchContinuationPage(normalized, token)
             YoutubeCommentsResult.Available(
@@ -90,8 +94,11 @@ internal class YoutubeCommentsRepository {
         }
     }
 
-    suspend fun replies(videoId: String, continuationToken: String): YoutubeCommentsResult =
-        more(videoId, continuationToken)
+    suspend fun replies(
+        videoId: String,
+        continuationToken: String,
+        forceRefresh: Boolean = false
+    ): YoutubeCommentsResult = more(videoId, continuationToken, forceRefresh)
 
     fun close() {
         scope.cancel()
@@ -101,8 +108,10 @@ internal class YoutubeCommentsRepository {
 
     private suspend fun resolve(
         key: RequestKey,
+        forceRefresh: Boolean = false,
         loader: suspend () -> YoutubeCommentsResult
     ): YoutubeCommentsResult {
+        if (forceRefresh) cache.remove(key)
         val now = System.currentTimeMillis()
         cache[key]?.let { cached ->
             if (now < cached.expiresAtMs) return cached.result

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeCommentsRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeCommentsRepository.kt
@@ -1,0 +1,303 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.domain.YoutubeComment
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.withContext
+import org.schabi.newpipe.extractor.ListExtractor.InfoItemsPage
+import org.schabi.newpipe.extractor.Page
+import org.schabi.newpipe.extractor.ServiceList
+import org.schabi.newpipe.extractor.comments.CommentsInfo
+import org.schabi.newpipe.extractor.comments.CommentsInfoItem
+import timber.log.Timber
+import java.net.URI
+import java.util.concurrent.ConcurrentHashMap
+
+private val COMMENTS_VIDEO_ID = Regex("^[A-Za-z0-9_-]{11}$")
+
+internal data class YoutubeCommentsPage(
+    val videoId: String,
+    val countText: String,
+    val commentsDisabled: Boolean,
+    val items: List<YoutubeComment>,
+    val nextToken: String
+)
+
+internal sealed interface YoutubeCommentsResult {
+    data class Available(val page: YoutubeCommentsPage) : YoutubeCommentsResult
+    data object Disabled : YoutubeCommentsResult
+    data class Failed(val cause: Throwable? = null) : YoutubeCommentsResult
+}
+
+/** Read-only YouTube comments integration backed by LevyraExtractor/NewPipeExtractor. */
+internal class YoutubeCommentsRepository {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val cache = ConcurrentHashMap<RequestKey, CachedCommentsResult>()
+    private val inFlight = ConcurrentHashMap<RequestKey, Deferred<YoutubeCommentsResult>>()
+
+    suspend fun initial(videoId: String): YoutubeCommentsResult {
+        val normalized = videoId.trim()
+        if (!COMMENTS_VIDEO_ID.matches(normalized)) {
+            return YoutubeCommentsResult.Failed(IllegalArgumentException("Invalid YouTube video id"))
+        }
+        return resolve(RequestKey(normalized, "initial")) {
+            NewPipeRuntime.ensure()
+            val url = youtubeUrl(normalized)
+            val info = CommentsInfo.getInfo(ServiceList.YouTube, url)
+                ?: return@resolve YoutubeCommentsResult.Failed()
+            if (info.isCommentsDisabled) {
+                YoutubeCommentsResult.Disabled
+            } else {
+                val initialPage = YoutubeCommentsPage(
+                    videoId = normalized,
+                    countText = info.commentsCountText.orEmpty().trim().take(MAX_COUNT_TEXT_LENGTH),
+                    commentsDisabled = false,
+                    items = info.relatedItems.orEmpty().mapNotNull(::toComment),
+                    nextToken = info.nextPage?.id.orEmpty()
+                )
+                YoutubeCommentsResult.Available(
+                    advancePastEmptyParsedPages(
+                        videoId = normalized,
+                        initialPage = initialPage
+                    )
+                )
+            }
+        }
+    }
+
+    suspend fun more(videoId: String, continuationToken: String): YoutubeCommentsResult {
+        val normalized = videoId.trim()
+        val token = continuationToken.trim()
+        if (!COMMENTS_VIDEO_ID.matches(normalized) || token.isBlank()) {
+            return YoutubeCommentsResult.Failed(IllegalArgumentException("Invalid comments continuation"))
+        }
+        return resolve(RequestKey(normalized, "page:$token")) {
+            NewPipeRuntime.ensure()
+            val firstPage = fetchContinuationPage(normalized, token)
+            YoutubeCommentsResult.Available(
+                advancePastEmptyParsedPages(
+                    videoId = normalized,
+                    initialPage = firstPage,
+                    firstRequestedToken = token
+                )
+            )
+        }
+    }
+
+    suspend fun replies(videoId: String, continuationToken: String): YoutubeCommentsResult =
+        more(videoId, continuationToken)
+
+    fun close() {
+        scope.cancel()
+        inFlight.clear()
+        cache.clear()
+    }
+
+    private suspend fun resolve(
+        key: RequestKey,
+        loader: suspend () -> YoutubeCommentsResult
+    ): YoutubeCommentsResult {
+        val now = System.currentTimeMillis()
+        cache[key]?.let { cached ->
+            if (now < cached.expiresAtMs) return cached.result
+            cache.remove(key, cached)
+        }
+
+        val created = scope.async(start = CoroutineStart.LAZY) {
+            val result = withContext(Dispatchers.IO) {
+                try {
+                    loader()
+                } catch (cancelled: CancellationException) {
+                    throw cancelled
+                } catch (error: Throwable) {
+                    Timber.d(error, "YouTube comments unavailable for %s", key.videoId)
+                    YoutubeCommentsResult.Failed(error)
+                }
+            }
+            val ttlMs = when (result) {
+                is YoutubeCommentsResult.Available -> POSITIVE_TTL_MS
+                YoutubeCommentsResult.Disabled -> DISABLED_TTL_MS
+                is YoutubeCommentsResult.Failed -> FAILURE_TTL_MS
+            }
+            cacheResult(key, result, ttlMs)
+            result
+        }
+        created.invokeOnCompletion { inFlight.remove(key, created) }
+        val shared = inFlight.putIfAbsent(key, created) ?: created
+        if (shared === created) {
+            created.start()
+        } else {
+            created.cancel()
+        }
+        return shared.await()
+    }
+
+    private fun cacheResult(key: RequestKey, result: YoutubeCommentsResult, ttlMs: Long) {
+        val now = System.currentTimeMillis()
+        if (cache.size >= MAX_CACHE_ENTRIES) {
+            cache.entries.removeIf { now >= it.value.expiresAtMs }
+            if (cache.size >= MAX_CACHE_ENTRIES) {
+                cache.entries.minByOrNull { it.value.expiresAtMs }?.let { cache.remove(it.key, it.value) }
+            }
+        }
+        cache[key] = CachedCommentsResult(result, now + ttlMs)
+    }
+
+    private fun fetchContinuationPage(videoId: String, continuationToken: String): YoutubeCommentsPage {
+        val url = youtubeUrl(videoId)
+        return CommentsInfo.getMoreItems(
+            ServiceList.YouTube,
+            url,
+            Page(url, continuationToken)
+        ).toCommentsPage(videoId)
+    }
+
+    /**
+     * A legitimate YouTube page can contain only deleted, private, region-blocked or otherwise
+     * unsupported comment renderers. Those renderers are intentionally dropped by the mapper, but
+     * their valid continuation must not be mistaken for the end of the thread.
+     *
+     * Follow a small bounded number of empty parsed pages, reject repeated tokens, and preserve the
+     * last continuation if the safety budget is exhausted so the UI can continue later.
+     */
+    private fun advancePastEmptyParsedPages(
+        videoId: String,
+        initialPage: YoutubeCommentsPage,
+        firstRequestedToken: String = ""
+    ): YoutubeCommentsPage {
+        var page = initialPage
+        val seenTokens = linkedSetOf<String>()
+        if (firstRequestedToken.isNotBlank()) seenTokens += firstRequestedToken
+        var hops = 0
+
+        while (page.items.isEmpty()) {
+            val nextToken = nextEmptyCommentsContinuation(
+                parsedItemCount = page.items.size,
+                nextToken = page.nextToken,
+                seenTokens = seenTokens,
+                hops = hops,
+                maxHops = MAX_EMPTY_PAGE_HOPS
+            ) ?: break
+            seenTokens += nextToken
+            hops++
+            val nextPage = fetchContinuationPage(videoId, nextToken)
+            page = nextPage.copy(countText = page.countText.ifBlank { nextPage.countText })
+        }
+        return page
+    }
+
+    private fun InfoItemsPage<CommentsInfoItem>.toCommentsPage(videoId: String): YoutubeCommentsPage =
+        YoutubeCommentsPage(
+            videoId = videoId,
+            countText = "",
+            commentsDisabled = false,
+            items = items.orEmpty().mapNotNull(::toComment),
+            nextToken = nextPage?.id.orEmpty()
+        )
+
+    private fun toComment(item: CommentsInfoItem): YoutubeComment? {
+        val id = item.commentId.orEmpty().trim().take(MAX_COMMENT_ID_LENGTH)
+        val text = item.commentText.orEmpty().trim().take(MAX_COMMENT_TEXT_LENGTH)
+        val author = item.uploaderName.orEmpty().trim().take(MAX_AUTHOR_LENGTH)
+        if (id.isBlank() || text.isBlank() || author.isBlank()) return null
+
+        val textualLikes = item.textualLikeCount.orEmpty().trim().take(MAX_LIKE_TEXT_LENGTH)
+        val numericLikes = item.likeCount.takeIf { it >= 0 }?.toString().orEmpty()
+        return YoutubeComment(
+            id = id,
+            text = text,
+            author = author,
+            authorAvatarUrl = sanitizeYoutubeAvatarUrl(item.uploaderAvatarUrl.orEmpty()),
+            authorUrl = sanitizeYoutubeAuthorUrl(item.uploaderUrl.orEmpty()),
+            publishedText = item.textualUploadDate.orEmpty().trim().take(MAX_DATE_TEXT_LENGTH),
+            likeCountText = textualLikes.ifBlank { numericLikes },
+            pinned = item.isPinned,
+            heartedByUploader = item.isHeartedByUploader,
+            verifiedAuthor = item.isUploaderVerified,
+            streamPositionSeconds = item.streamPosition,
+            replyCount = item.replyCount.coerceAtLeast(0),
+            replyToken = item.replies?.id.orEmpty()
+        )
+    }
+
+    private fun youtubeUrl(videoId: String): String = "https://www.youtube.com/watch?v=$videoId"
+
+    private data class RequestKey(val videoId: String, val page: String)
+    private data class CachedCommentsResult(
+        val result: YoutubeCommentsResult,
+        val expiresAtMs: Long
+    )
+
+    private companion object {
+        const val MAX_CACHE_ENTRIES = 256
+        const val MAX_EMPTY_PAGE_HOPS = 6
+        const val POSITIVE_TTL_MS = 5L * 60L * 1_000L
+        const val DISABLED_TTL_MS = 30L * 60L * 1_000L
+        const val FAILURE_TTL_MS = 45L * 1_000L
+        const val MAX_COUNT_TEXT_LENGTH = 96
+        const val MAX_COMMENT_ID_LENGTH = 256
+        const val MAX_COMMENT_TEXT_LENGTH = 12_000
+        const val MAX_AUTHOR_LENGTH = 200
+        const val MAX_LIKE_TEXT_LENGTH = 40
+        const val MAX_DATE_TEXT_LENGTH = 120
+    }
+}
+
+internal fun nextEmptyCommentsContinuation(
+    parsedItemCount: Int,
+    nextToken: String,
+    seenTokens: Set<String>,
+    hops: Int,
+    maxHops: Int
+): String? {
+    val normalized = nextToken.trim()
+    return normalized.takeIf {
+        parsedItemCount == 0 &&
+            it.isNotBlank() &&
+            it !in seenTokens &&
+            hops < maxHops
+    }
+}
+
+internal fun sanitizeYoutubeAvatarUrl(value: String): String = sanitizeYoutubeUrl(
+    value = value,
+    allowedHosts = setOf("yt3.ggpht.com", "yt3.googleusercontent.com"),
+    allowedSuffixes = setOf(".ggpht.com", ".googleusercontent.com")
+)
+
+internal fun sanitizeYoutubeAuthorUrl(value: String): String = sanitizeYoutubeUrl(
+    value = value,
+    allowedHosts = setOf("youtube.com", "www.youtube.com", "m.youtube.com", "music.youtube.com"),
+    allowedSuffixes = emptySet()
+)
+
+private fun sanitizeYoutubeUrl(
+    value: String,
+    allowedHosts: Set<String>,
+    allowedSuffixes: Set<String>
+): String {
+    val candidate = value.trim()
+    if (candidate.isBlank() || candidate.length > 2_048) return ""
+    return runCatching {
+        val uri = URI(candidate)
+        val host = uri.host?.lowercase().orEmpty()
+        val allowedHost = host in allowedHosts || allowedSuffixes.any(host::endsWith)
+        if (
+            !uri.scheme.equals("https", ignoreCase = true) ||
+            uri.userInfo != null ||
+            uri.fragment != null ||
+            uri.port !in setOf(-1, 443) ||
+            !allowedHost
+        ) {
+            ""
+        } else {
+            uri.toASCIIString()
+        }
+    }.getOrDefault("")
+}

--- a/app/src/main/java/com/luc4n3x/levyra/domain/YoutubeEngagement.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/YoutubeEngagement.kt
@@ -1,0 +1,49 @@
+package com.luc4n3x.levyra.domain
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+data class YoutubeComment(
+    val id: String,
+    val text: String,
+    val author: String,
+    val authorAvatarUrl: String = "",
+    val authorUrl: String = "",
+    val publishedText: String = "",
+    val likeCountText: String = "",
+    val pinned: Boolean = false,
+    val heartedByUploader: Boolean = false,
+    val verifiedAuthor: Boolean = false,
+    val streamPositionSeconds: Int = -1,
+    val replyCount: Int = 0,
+    val replyToken: String = "",
+    val replies: List<YoutubeComment> = emptyList(),
+    val repliesNextToken: String = "",
+    val repliesExpanded: Boolean = false,
+    val repliesLoading: Boolean = false,
+    val repliesError: String? = null
+)
+
+@Immutable
+data class YoutubeCommentsState(
+    val videoId: String = "",
+    val visible: Boolean = false,
+    val loaded: Boolean = false,
+    val loading: Boolean = false,
+    val loadingMore: Boolean = false,
+    val disabled: Boolean = false,
+    val countText: String = "",
+    val items: List<YoutubeComment> = emptyList(),
+    val nextToken: String = "",
+    val error: String? = null
+)
+
+@Immutable
+data class YoutubeEngagementState(
+    val videoId: String = "",
+    val estimatedDislikeCount: Long = -1L,
+    val dislikeEstimateLoading: Boolean = false,
+    val dislikeEstimateAvailable: Boolean = false,
+    val dislikeEstimateError: String? = null,
+    val comments: YoutubeCommentsState = YoutubeCommentsState()
+)

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -9235,6 +9235,7 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                 onDismiss = viewModel::closeYoutubeComments,
                 onRetry = viewModel::retryYoutubeComments,
                 onLoadMore = viewModel::loadMoreYoutubeComments,
+                onRetryLoadMore = viewModel::retryYoutubeCommentsPage,
                 onToggleReplies = viewModel::toggleYoutubeCommentReplies,
                 onLoadMoreReplies = viewModel::loadMoreYoutubeCommentReplies
             )
@@ -9251,14 +9252,15 @@ private fun PlayerYoutubeCommentsSheet(
     onDismiss: () -> Unit,
     onRetry: () -> Unit,
     onLoadMore: () -> Unit,
+    onRetryLoadMore: () -> Unit,
     onToggleReplies: (String) -> Unit,
     onLoadMoreReplies: (String) -> Unit
 ) {
     val listState = rememberLazyListState()
     val sheetInteraction = remember { MutableInteractionSource() }
 
-    LaunchedEffect(comments.nextToken, comments.loadingMore, comments.items.size) {
-        if (comments.nextToken.isBlank()) return@LaunchedEffect
+    LaunchedEffect(comments.nextToken, comments.loadingMore, comments.items.size, comments.error) {
+        if (comments.error != null || comments.nextToken.isBlank()) return@LaunchedEffect
         snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1 }
             .distinctUntilChanged()
             .collect { lastVisible ->
@@ -9481,6 +9483,26 @@ private fun PlayerYoutubeCommentsSheet(
                                             modifier = Modifier.size(24.dp),
                                             strokeWidth = 2.4.dp,
                                             color = primary.playerMix(Color.White, 0.55f)
+                                        )
+                                    }
+                                }
+                            } else if (comments.error != null && comments.nextToken.isNotBlank()) {
+                                item(key = "comments-retry-more") {
+                                    TextButton(
+                                        onClick = onRetryLoadMore,
+                                        modifier = Modifier.fillMaxWidth()
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.Refresh,
+                                            contentDescription = null,
+                                            tint = primary.playerMix(Color.White, 0.52f),
+                                            modifier = Modifier.size(17.dp)
+                                        )
+                                        Spacer(modifier = Modifier.width(7.dp))
+                                        Text(
+                                            text = strings.check,
+                                            color = primary.playerMix(Color.White, 0.52f),
+                                            fontWeight = FontWeight.Bold
                                         )
                                     }
                                 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -144,6 +144,12 @@ import androidx.compose.material.icons.rounded.LocalFireDepartment
 import androidx.compose.material.icons.rounded.Schedule
 import androidx.compose.material.icons.rounded.TaskAlt
 import androidx.compose.material.icons.rounded.ThumbUp
+import androidx.compose.material.icons.rounded.ThumbDown
+import androidx.compose.material.icons.rounded.ChatBubbleOutline
+import androidx.compose.material.icons.rounded.PushPin
+import androidx.compose.material.icons.rounded.Reply
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.OpenInNew
 import androidx.compose.material.icons.rounded.Visibility
 import androidx.compose.material.icons.automirrored.rounded.Subject
 import androidx.compose.material.icons.rounded.ViewCompact
@@ -273,6 +279,9 @@ import com.luc4n3x.levyra.domain.MoodEngine
 import com.luc4n3x.levyra.domain.ReleaseRadarEntry
 import com.luc4n3x.levyra.domain.Taste
 import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.domain.YoutubeComment
+import com.luc4n3x.levyra.domain.YoutubeCommentsState
+import com.luc4n3x.levyra.domain.YoutubeEngagementState
 import com.luc4n3x.levyra.LevyraLaunchActions
 import com.luc4n3x.levyra.ui.theme.LevyraBlack
 import com.luc4n3x.levyra.ui.theme.LevyraInk
@@ -8452,64 +8461,177 @@ private fun compactYoutubeCount(value: Long): String {
 @Composable
 private fun PlayerYoutubeEngagementRow(
     track: Track,
+    engagement: YoutubeEngagementState,
     primary: Color,
-    secondary: Color
+    secondary: Color,
+    onComments: () -> Unit,
+    onOpenDislikeAttribution: () -> Unit
 ) {
-    val hasLikes = track.youtubeLikeCount > 0L
-    val hasViews = track.youtubeViewCount > 0L
+    val hasLikes = track.youtubeLikeCount >= 0L
+    val hasDislikeEstimate = engagement.dislikeEstimateAvailable && engagement.estimatedDislikeCount >= 0L
+    val comments = engagement.comments
+    val commentBadge = youtubeCommentCountBadge(comments.countText)
+    val canOpenComments = engagement.videoId.isNotBlank()
+    val visible = hasLikes || hasDislikeEstimate || engagement.dislikeEstimateLoading || canOpenComments
+
     AnimatedVisibility(
-        visible = hasLikes || hasViews,
+        visible = visible,
         enter = fadeIn(animationSpec = tween(220)) + slideInVertically(initialOffsetY = { it / 3 }),
         exit = fadeOut(animationSpec = tween(140))
     ) {
-        Surface(
-            modifier = Modifier.padding(top = 10.dp),
-            color = Color.White.copy(alpha = 0.08f),
-            shape = CircleShape
+        Column(
+            modifier = Modifier.padding(top = 11.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp)
         ) {
-            Row(
-                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            LazyRow(
+                horizontalArrangement = Arrangement.spacedBy(9.dp),
+                contentPadding = PaddingValues(end = 10.dp)
             ) {
-                if (hasLikes) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(6.dp)
+                item(key = "youtube-votes") {
+                    Surface(
+                        color = Color.White.copy(alpha = 0.085f),
+                        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.105f)),
+                        shape = CircleShape
                     ) {
-                        Text("👍", fontSize = 11.sp)
-                        Text(
-                            text = compactYoutubeCount(track.youtubeLikeCount),
-                            color = Color.White.copy(alpha = 0.9f),
-                            fontSize = 12.5.sp,
-                            fontWeight = FontWeight.Bold,
-                            letterSpacing = 0.2.sp
-                        )
+                        Row(
+                            modifier = Modifier.height(42.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(start = 13.dp, end = 11.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(7.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.ThumbUp,
+                                    contentDescription = null,
+                                    tint = Color.White.copy(alpha = if (hasLikes) 0.94f else 0.48f),
+                                    modifier = Modifier.size(20.dp)
+                                )
+                                if (hasLikes) {
+                                    Text(
+                                        text = compactYoutubeCount(track.youtubeLikeCount),
+                                        color = Color.White.copy(alpha = 0.94f),
+                                        fontSize = 13.sp,
+                                        fontWeight = FontWeight.ExtraBold
+                                    )
+                                }
+                            }
+                            Box(
+                                modifier = Modifier
+                                    .width(1.dp)
+                                    .height(24.dp)
+                                    .background(Color.White.copy(alpha = 0.14f))
+                            )
+                            Row(
+                                modifier = Modifier.padding(start = 11.dp, end = 13.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(7.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.ThumbDown,
+                                    contentDescription = null,
+                                    tint = if (hasDislikeEstimate) {
+                                        secondary.playerMix(Color.White, 0.58f)
+                                    } else {
+                                        Color.White.copy(alpha = 0.48f)
+                                    },
+                                    modifier = Modifier.size(20.dp)
+                                )
+                                when {
+                                    engagement.dislikeEstimateLoading -> CircularProgressIndicator(
+                                        modifier = Modifier.size(13.dp),
+                                        strokeWidth = 1.8.dp,
+                                        color = secondary.playerMix(Color.White, 0.58f)
+                                    )
+                                    hasDislikeEstimate -> Text(
+                                        text = "~${compactYoutubeCount(engagement.estimatedDislikeCount)}",
+                                        color = Color.White.copy(alpha = 0.90f),
+                                        fontSize = 13.sp,
+                                        fontWeight = FontWeight.ExtraBold
+                                    )
+                                }
+                            }
+                        }
                     }
                 }
-                
-                if (hasLikes && hasViews) {
-                    Box(modifier = Modifier.size(3.dp).background(Color.White.copy(alpha = 0.3f), CircleShape))
-                }
-                
-                if (hasViews) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(6.dp)
+
+                item(key = "youtube-comments") {
+                    Surface(
+                        color = Color.White.copy(alpha = 0.085f),
+                        border = BorderStroke(
+                            1.dp,
+                            if (comments.visible) primary.copy(alpha = 0.52f) else Color.White.copy(alpha = 0.105f)
+                        ),
+                        shape = CircleShape,
+                        modifier = Modifier.pressable(enabled = canOpenComments, onClick = onComments)
                     ) {
-                        Text("🎧", fontSize = 11.sp)
-                        Text(
-                            text = compactYoutubeCount(track.youtubeViewCount),
-                            color = Color.White.copy(alpha = 0.9f),
-                            fontSize = 12.5.sp,
-                            fontWeight = FontWeight.Bold,
-                            letterSpacing = 0.2.sp
-                        )
+                        Row(
+                            modifier = Modifier
+                                .height(42.dp)
+                                .padding(horizontal = 14.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.ChatBubbleOutline,
+                                contentDescription = null,
+                                tint = if (canOpenComments) Color.White.copy(alpha = 0.90f) else Color.White.copy(alpha = 0.42f),
+                                modifier = Modifier.size(20.dp)
+                            )
+                            when {
+                                comments.loading && !comments.loaded -> CircularProgressIndicator(
+                                    modifier = Modifier.size(13.dp),
+                                    strokeWidth = 1.8.dp,
+                                    color = primary.playerMix(Color.White, 0.52f)
+                                )
+                                commentBadge.isNotBlank() -> Text(
+                                    text = commentBadge,
+                                    color = Color.White.copy(alpha = 0.92f),
+                                    fontSize = 13.sp,
+                                    fontWeight = FontWeight.ExtraBold
+                                )
+                            }
+                        }
                     }
+                }
+            }
+
+            if (hasDislikeEstimate) {
+                Row(
+                    modifier = Modifier
+                        .clip(CircleShape)
+                        .clickable(onClick = onOpenDislikeAttribution)
+                        .padding(horizontal = 4.dp, vertical = 2.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Text(
+                        text = "~ Return YouTube Dislike",
+                        color = Color.White.copy(alpha = 0.48f),
+                        fontSize = 9.5.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                    Icon(
+                        imageVector = Icons.Rounded.OpenInNew,
+                        contentDescription = null,
+                        tint = Color.White.copy(alpha = 0.40f),
+                        modifier = Modifier.size(10.dp)
+                    )
                 }
             }
         }
     }
+}
+
+private fun youtubeCommentCountBadge(value: String): String {
+    val normalized = value.replace('\u00A0', ' ').trim()
+    if (normalized.isBlank()) return ""
+    return Regex("""\d[\d\s.,]*(?:[KMBkmb])?""")
+        .find(normalized)
+        ?.value
+        ?.replace(" ", "")
+        .orEmpty()
 }
 
 @Composable
@@ -8544,6 +8666,10 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
     var mediaSeekFeedbackEvent by remember(track?.id) { mutableStateOf(0) }
     var gestureFeedback by remember(track?.id) { mutableStateOf("") }
     var gestureFeedbackEvent by remember(track?.id) { mutableStateOf(0) }
+
+    BackHandler(enabled = state.youtubeEngagement.comments.visible) {
+        viewModel.closeYoutubeComments()
+    }
 
     LaunchedEffect(mediaSeekFeedbackEvent) {
         if (mediaSeekFeedbackEvent > 0) {
@@ -8931,8 +9057,17 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                             )
                             PlayerYoutubeEngagementRow(
                                 track = track,
+                                engagement = state.youtubeEngagement,
                                 primary = primary,
-                                secondary = secondary
+                                secondary = secondary,
+                                onComments = viewModel::openYoutubeComments,
+                                onOpenDislikeAttribution = {
+                                    openExternalUrl(
+                                        playerContext,
+                                        "https://returnyoutubedislike.com",
+                                        strings
+                                    )
+                                }
                             )
                         }
                         Spacer(modifier = Modifier.width(12.dp))
@@ -9088,6 +9223,607 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                     }
                 }
                 item { PlayerError(state.playerError) }
+            }
+        }
+
+        if (state.youtubeEngagement.comments.visible) {
+            PlayerYoutubeCommentsSheet(
+                comments = state.youtubeEngagement.comments,
+                primary = primary,
+                secondary = secondary,
+                strings = strings,
+                onDismiss = viewModel::closeYoutubeComments,
+                onRetry = viewModel::retryYoutubeComments,
+                onLoadMore = viewModel::loadMoreYoutubeComments,
+                onToggleReplies = viewModel::toggleYoutubeCommentReplies,
+                onLoadMoreReplies = viewModel::loadMoreYoutubeCommentReplies
+            )
+        }
+    }
+}
+
+@Composable
+private fun PlayerYoutubeCommentsSheet(
+    comments: YoutubeCommentsState,
+    primary: Color,
+    secondary: Color,
+    strings: LevyraStrings,
+    onDismiss: () -> Unit,
+    onRetry: () -> Unit,
+    onLoadMore: () -> Unit,
+    onToggleReplies: (String) -> Unit,
+    onLoadMoreReplies: (String) -> Unit
+) {
+    val listState = rememberLazyListState()
+    val sheetInteraction = remember { MutableInteractionSource() }
+
+    LaunchedEffect(comments.nextToken, comments.loadingMore, comments.items.size) {
+        if (comments.nextToken.isBlank()) return@LaunchedEffect
+        snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1 }
+            .distinctUntilChanged()
+            .collect { lastVisible ->
+                if (
+                    comments.nextToken.isNotBlank() &&
+                    !comments.loadingMore &&
+                    comments.items.isNotEmpty() &&
+                    lastVisible >= comments.items.lastIndex - 2
+                ) {
+                    onLoadMore()
+                }
+            }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .zIndex(100f)
+    ) {
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .background(Color.Black.copy(alpha = 0.62f))
+                .clickable(onClick = onDismiss)
+        )
+
+        Surface(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .widthIn(max = 620.dp)
+                .fillMaxHeight(0.82f)
+                .navigationBarsPadding()
+                .clickable(
+                    interactionSource = sheetInteraction,
+                    indication = null,
+                    onClick = {}
+                ),
+            color = Color(0xFF101114),
+            border = BorderStroke(1.dp, Color.White.copy(alpha = 0.12f)),
+            shape = RoundedCornerShape(topStart = 30.dp, topEnd = 30.dp)
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                Box(
+                    modifier = Modifier
+                        .padding(top = 10.dp)
+                        .align(Alignment.CenterHorizontally)
+                        .width(42.dp)
+                        .height(4.dp)
+                        .clip(CircleShape)
+                        .background(Color.White.copy(alpha = 0.24f))
+                )
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 20.dp, end = 12.dp, top = 12.dp, bottom = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = strings.totalComments,
+                            color = Color.White,
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.Black
+                        )
+                        if (comments.countText.isNotBlank()) {
+                            Text(
+                                text = comments.countText,
+                                color = Color.White.copy(alpha = 0.52f),
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Medium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
+                    PlayerRoundIconButton(
+                        icon = Icons.Rounded.Close,
+                        contentDescription = strings.close,
+                        size = 38.dp,
+                        iconSize = 20.dp,
+                        tint = Color.White.copy(alpha = 0.82f),
+                        background = Color.White.copy(alpha = 0.07f),
+                        borderColor = Color.White.copy(alpha = 0.10f),
+                        onClick = onDismiss
+                    )
+                }
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(1.dp)
+                        .background(
+                            Brush.horizontalGradient(
+                                listOf(
+                                    Color.Transparent,
+                                    primary.copy(alpha = 0.34f),
+                                    secondary.copy(alpha = 0.28f),
+                                    Color.Transparent
+                                )
+                            )
+                        )
+                )
+
+                when {
+                    comments.loading && comments.items.isEmpty() -> {
+                        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            CircularProgressIndicator(
+                                color = primary.playerMix(Color.White, 0.55f),
+                                strokeWidth = 3.dp
+                            )
+                        }
+                    }
+                    comments.disabled -> {
+                        YoutubeCommentsEmptyState(
+                            icon = Icons.Rounded.ChatBubbleOutline,
+                            label = "${strings.totalComments}: —",
+                            primary = primary
+                        )
+                    }
+                    comments.error != null && comments.items.isEmpty() -> {
+                        Column(
+                            modifier = Modifier.fillMaxSize(),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.Center
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.ChatBubbleOutline,
+                                contentDescription = null,
+                                tint = Color.White.copy(alpha = 0.38f),
+                                modifier = Modifier.size(38.dp)
+                            )
+                            Spacer(modifier = Modifier.height(14.dp))
+                            Surface(
+                                color = primary.copy(alpha = 0.18f),
+                                border = BorderStroke(1.dp, primary.copy(alpha = 0.34f)),
+                                shape = CircleShape,
+                                modifier = Modifier.pressable(onClick = onRetry)
+                            ) {
+                                Row(
+                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 9.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(7.dp)
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Rounded.Refresh,
+                                        contentDescription = null,
+                                        tint = Color.White,
+                                        modifier = Modifier.size(17.dp)
+                                    )
+                                    Text(
+                                        text = strings.check,
+                                        color = Color.White,
+                                        fontSize = 12.sp,
+                                        fontWeight = FontWeight.Bold
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    comments.items.isEmpty() -> {
+                        Column(
+                            modifier = Modifier.fillMaxSize(),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.Center
+                        ) {
+                            YoutubeCommentsEmptyState(
+                                icon = Icons.Rounded.ChatBubbleOutline,
+                                label = if (comments.nextToken.isBlank()) {
+                                    "${strings.totalComments}: 0"
+                                } else {
+                                    strings.totalComments
+                                },
+                                primary = primary,
+                                modifier = Modifier.weight(1f, fill = false)
+                            )
+                            if (comments.nextToken.isNotBlank()) {
+                                Spacer(modifier = Modifier.height(14.dp))
+                                TextButton(onClick = onLoadMore) {
+                                    Text(
+                                        text = strings.more,
+                                        color = primary.playerMix(Color.White, 0.52f),
+                                        fontWeight = FontWeight.Bold
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    else -> {
+                        LazyColumn(
+                            state = listState,
+                            modifier = Modifier.fillMaxSize(),
+                            contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 14.dp, bottom = 28.dp),
+                            verticalArrangement = Arrangement.spacedBy(10.dp)
+                        ) {
+                            items(
+                                items = comments.items,
+                                key = YoutubeComment::id,
+                                contentType = { "youtube-comment" }
+                            ) { comment ->
+                                YoutubeCommentCard(
+                                    comment = comment,
+                                    primary = primary,
+                                    secondary = secondary,
+                                    moreLabel = strings.more,
+                                    onToggleReplies = { onToggleReplies(comment.id) },
+                                    onLoadMoreReplies = { onLoadMoreReplies(comment.id) }
+                                )
+                            }
+                            if (comments.loadingMore) {
+                                item(key = "comments-loading-more") {
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(vertical = 14.dp),
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(24.dp),
+                                            strokeWidth = 2.4.dp,
+                                            color = primary.playerMix(Color.White, 0.55f)
+                                        )
+                                    }
+                                }
+                            } else if (comments.nextToken.isNotBlank()) {
+                                item(key = "comments-more") {
+                                    TextButton(
+                                        onClick = onLoadMore,
+                                        modifier = Modifier.fillMaxWidth()
+                                    ) {
+                                        Text(
+                                            text = strings.more,
+                                            color = primary.playerMix(Color.White, 0.52f),
+                                            fontWeight = FontWeight.Bold
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun YoutubeCommentsEmptyState(
+    icon: ImageVector,
+    label: String,
+    primary: Color,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Surface(
+            color = primary.copy(alpha = 0.10f),
+            shape = CircleShape
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = Color.White.copy(alpha = 0.44f),
+                modifier = Modifier.padding(16.dp).size(30.dp)
+            )
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        Text(
+            text = label,
+            color = Color.White.copy(alpha = 0.52f),
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+@Composable
+private fun YoutubeCommentCard(
+    comment: YoutubeComment,
+    primary: Color,
+    secondary: Color,
+    moreLabel: String,
+    onToggleReplies: () -> Unit,
+    onLoadMoreReplies: () -> Unit
+) {
+    Surface(
+        color = Color.White.copy(alpha = 0.055f),
+        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.08f)),
+        shape = RoundedCornerShape(20.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 13.dp, vertical = 13.dp),
+            verticalArrangement = Arrangement.spacedBy(9.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.Top,
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                YoutubeCommentAvatar(
+                    url = comment.authorAvatarUrl,
+                    author = comment.author,
+                    modifier = Modifier.size(36.dp)
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(5.dp)
+                    ) {
+                        Text(
+                            text = comment.author,
+                            color = Color.White.copy(alpha = 0.92f),
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.ExtraBold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f, fill = false)
+                        )
+                        if (comment.verifiedAuthor) {
+                            Icon(
+                                imageVector = Icons.Rounded.Verified,
+                                contentDescription = null,
+                                tint = primary.playerMix(Color.White, 0.44f),
+                                modifier = Modifier.size(13.dp)
+                            )
+                        }
+                        if (comment.pinned) {
+                            Icon(
+                                imageVector = Icons.Rounded.PushPin,
+                                contentDescription = null,
+                                tint = Color.White.copy(alpha = 0.46f),
+                                modifier = Modifier.size(12.dp)
+                            )
+                        }
+                    }
+                    if (comment.publishedText.isNotBlank()) {
+                        Text(
+                            text = comment.publishedText,
+                            color = Color.White.copy(alpha = 0.40f),
+                            fontSize = 10.sp,
+                            fontWeight = FontWeight.Medium
+                        )
+                    }
+                }
+                if (comment.heartedByUploader) {
+                    Icon(
+                        imageVector = Icons.Rounded.Favorite,
+                        contentDescription = null,
+                        tint = Color(0xFFFF5B72),
+                        modifier = Modifier.size(16.dp)
+                    )
+                }
+            }
+
+            Text(
+                text = comment.text,
+                color = Color.White.copy(alpha = 0.86f),
+                fontSize = 13.sp,
+                lineHeight = 18.sp,
+                fontWeight = FontWeight.Normal
+            )
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(14.dp)
+            ) {
+                if (comment.likeCountText.isNotBlank()) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(5.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Rounded.ThumbUp,
+                            contentDescription = null,
+                            tint = Color.White.copy(alpha = 0.46f),
+                            modifier = Modifier.size(14.dp)
+                        )
+                        Text(
+                            text = comment.likeCountText,
+                            color = Color.White.copy(alpha = 0.48f),
+                            fontSize = 10.5.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+
+                if (comment.replyCount > 0 && comment.replyToken.isNotBlank()) {
+                    Row(
+                        modifier = Modifier
+                            .clip(CircleShape)
+                            .clickable(onClick = onToggleReplies)
+                            .padding(horizontal = 7.dp, vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(5.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Rounded.Reply,
+                            contentDescription = null,
+                            tint = secondary.playerMix(Color.White, 0.58f),
+                            modifier = Modifier.size(15.dp)
+                        )
+                        Text(
+                            text = comment.replyCount.toString(),
+                            color = secondary.playerMix(Color.White, 0.58f),
+                            fontSize = 10.5.sp,
+                            fontWeight = FontWeight.ExtraBold
+                        )
+                    }
+                }
+            }
+
+            AnimatedVisibility(
+                visible = comment.repliesExpanded,
+                enter = fadeIn(tween(160)) + slideInVertically(initialOffsetY = { -it / 5 }),
+                exit = fadeOut(tween(120))
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 30.dp, top = 2.dp)
+                        .border(
+                            width = 1.dp,
+                            color = primary.copy(alpha = 0.18f),
+                            shape = RoundedCornerShape(16.dp)
+                        )
+                        .padding(horizontal = 10.dp, vertical = 10.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    comment.replies.forEach { reply ->
+                        YoutubeCommentReply(reply = reply, primary = primary)
+                    }
+                    if (comment.repliesLoading) {
+                        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(20.dp),
+                                strokeWidth = 2.dp,
+                                color = primary.playerMix(Color.White, 0.52f)
+                            )
+                        }
+                    } else if (comment.repliesError != null && comment.replies.isEmpty()) {
+                        TextButton(onClick = onToggleReplies, modifier = Modifier.fillMaxWidth()) {
+                            Icon(
+                                imageVector = Icons.Rounded.Refresh,
+                                contentDescription = null,
+                                tint = primary.playerMix(Color.White, 0.52f),
+                                modifier = Modifier.size(15.dp)
+                            )
+                        }
+                    } else if (comment.repliesNextToken.isNotBlank()) {
+                        TextButton(onClick = onLoadMoreReplies, modifier = Modifier.fillMaxWidth()) {
+                            Text(
+                                text = moreLabel,
+                                color = primary.playerMix(Color.White, 0.52f),
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun YoutubeCommentReply(
+    reply: YoutubeComment,
+    primary: Color
+) {
+    Row(
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        YoutubeCommentAvatar(
+            url = reply.authorAvatarUrl,
+            author = reply.author,
+            modifier = Modifier.size(28.dp)
+        )
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = reply.author,
+                    color = Color.White.copy(alpha = 0.86f),
+                    fontSize = 10.5.sp,
+                    fontWeight = FontWeight.ExtraBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false)
+                )
+                if (reply.verifiedAuthor) {
+                    Icon(
+                        imageVector = Icons.Rounded.Verified,
+                        contentDescription = null,
+                        tint = primary.playerMix(Color.White, 0.44f),
+                        modifier = Modifier.size(11.dp)
+                    )
+                }
+                if (reply.heartedByUploader) {
+                    Icon(
+                        imageVector = Icons.Rounded.Favorite,
+                        contentDescription = null,
+                        tint = Color(0xFFFF5B72),
+                        modifier = Modifier.size(12.dp)
+                    )
+                }
+            }
+            Text(
+                text = reply.text,
+                color = Color.White.copy(alpha = 0.75f),
+                fontSize = 11.5.sp,
+                lineHeight = 16.sp
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (reply.publishedText.isNotBlank()) {
+                    Text(
+                        text = reply.publishedText,
+                        color = Color.White.copy(alpha = 0.36f),
+                        fontSize = 9.5.sp
+                    )
+                }
+                if (reply.likeCountText.isNotBlank()) {
+                    Text(
+                        text = "👍 ${reply.likeCountText}",
+                        color = Color.White.copy(alpha = 0.36f),
+                        fontSize = 9.5.sp
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun YoutubeCommentAvatar(
+    url: String,
+    author: String,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier,
+        shape = CircleShape,
+        color = Color.White.copy(alpha = 0.08f),
+        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.10f))
+    ) {
+        if (url.isNotBlank()) {
+            AsyncImage(
+                model = url,
+                contentDescription = author,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize()
+            )
+        } else {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(
+                    text = author.trim().firstOrNull()?.uppercaseChar()?.toString().orEmpty(),
+                    color = Color.White.copy(alpha = 0.72f),
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.Black
+                )
             }
         }
     }

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -193,6 +193,7 @@ class PlayerViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::pla
     fun closeYoutubeComments() = root.closeYoutubeComments()
     fun retryYoutubeComments() = root.retryYoutubeComments()
     fun loadMoreYoutubeComments() = root.loadMoreYoutubeComments()
+    fun retryYoutubeCommentsPage() = root.retryYoutubeCommentsPage()
     fun toggleYoutubeCommentReplies(commentId: String) = root.toggleYoutubeCommentReplies(commentId)
     fun loadMoreYoutubeCommentReplies(commentId: String) = root.loadMoreYoutubeCommentReplies(commentId)
     fun previous() = root.previous()

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -23,6 +23,7 @@ import com.luc4n3x.levyra.domain.RepeatMode
 import com.luc4n3x.levyra.domain.SearchFilter
 import com.luc4n3x.levyra.domain.SearchResults
 import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.domain.YoutubeEngagementState
 import com.luc4n3x.levyra.ui.i18n.LevyraStrings
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -188,6 +189,12 @@ class PlayerViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::pla
     fun openAudioQualityPanel() = root.openAudioQualityPanel()
     fun openLyrics() = root.openLyrics()
     fun openQueue() = root.openQueue()
+    fun openYoutubeComments() = root.openYoutubeComments()
+    fun closeYoutubeComments() = root.closeYoutubeComments()
+    fun retryYoutubeComments() = root.retryYoutubeComments()
+    fun loadMoreYoutubeComments() = root.loadMoreYoutubeComments()
+    fun toggleYoutubeCommentReplies(commentId: String) = root.toggleYoutubeCommentReplies(commentId)
+    fun loadMoreYoutubeCommentReplies(commentId: String) = root.loadMoreYoutubeCommentReplies(commentId)
     fun previous() = root.previous()
     fun seekBy(deltaMs: Long) = root.seekBy(deltaMs)
     fun seekTo(progress: Float) = root.seekTo(progress)
@@ -693,7 +700,8 @@ private data class PlayerProjection(
     val repeatMode: RepeatMode,
     val shuffleEnabled: Boolean,
     val sleepTimerMinutes: Int,
-    val interfaceSettings: LevyraInterfaceSettings
+    val interfaceSettings: LevyraInterfaceSettings,
+    val youtubeEngagement: YoutubeEngagementState
 )
 
 private fun playerProjection(state: LevyraUiState): PlayerProjection = PlayerProjection(
@@ -714,5 +722,6 @@ private fun playerProjection(state: LevyraUiState): PlayerProjection = PlayerPro
     repeatMode = state.repeatMode,
     shuffleEnabled = state.shuffleEnabled,
     sleepTimerMinutes = state.sleepTimerMinutes,
-    interfaceSettings = state.interfaceSettings
+    interfaceSettings = state.interfaceSettings,
+    youtubeEngagement = state.youtubeEngagement
 )

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
@@ -28,6 +28,7 @@ import com.luc4n3x.levyra.domain.SearchResults
 import com.luc4n3x.levyra.domain.SmartMusicProfile
 import com.luc4n3x.levyra.domain.Taste
 import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.domain.YoutubeEngagementState
 import com.luc4n3x.levyra.feature.motion.MotionArtwork
 import com.luc4n3x.levyra.ui.theme.LevyraThemes
 
@@ -85,6 +86,7 @@ data class LevyraUiState(
     val currentTrack: Track? = null,
     val motionArtwork: MotionArtwork? = null,
     val motionArtworkLoading: Boolean = false,
+    val youtubeEngagement: YoutubeEngagementState = YoutubeEngagementState(),
     val lyrics: List<LyricLine> = emptyList(),
     val lyricsSections: List<LyricSection> = emptyList(),
     val activeLyric: LyricLine? = null,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -271,6 +271,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private var youtubeCommentsJob: Job? = null
     private var youtubeCommentsPageJob: Job? = null
     private val youtubeCommentReplyJobs = ConcurrentHashMap<String, Job>()
+    private val youtubeCommentContinuationHistory = linkedSetOf<String>()
     private val youtubeEngagementGeneration = AtomicLong(0L)
     private var prefetchJob: Job? = null
     private var chartEnrichJob: Job? = null
@@ -3513,6 +3514,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         youtubeCommentsPageJob?.cancel()
         youtubeCommentReplyJobs.values.forEach { it.cancel() }
         youtubeCommentReplyJobs.clear()
+        youtubeCommentContinuationHistory.clear()
         youtubeEngagementGeneration.incrementAndGet()
         val engagementVideoId = youtubeEngagementVideoId(track)
         if (!preserveCrossfade) {
@@ -3747,6 +3749,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         val current = _state.value.youtubeEngagement
         if (current.videoId == videoId) return youtubeEngagementGeneration.get()
         val generation = youtubeEngagementGeneration.incrementAndGet()
+        youtubeCommentContinuationHistory.clear()
         _state.update { state ->
             state.copy(youtubeEngagement = YoutubeEngagementState(videoId = videoId))
         }
@@ -3841,8 +3844,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             )
         }
         youtubeCommentsJob = viewModelScope.launch {
-            val result = youtubeCommentsRepository.initial(videoId)
+            val result = youtubeCommentsRepository.initial(videoId, forceRefresh = force)
             if (!isActive || !isYoutubeEngagementRequestCurrent(videoId, generation)) return@launch
+            if (result !is YoutubeCommentsResult.Failed) youtubeCommentContinuationHistory.clear()
             _state.update { state ->
                 if (state.youtubeEngagement.videoId != videoId) return@update state
                 val visible = state.youtubeEngagement.comments.visible
@@ -3919,11 +3923,24 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     fun loadMoreYoutubeComments() {
+        loadMoreYoutubeComments(forceRefresh = false)
+    }
+
+    fun retryYoutubeCommentsPage() {
+        loadMoreYoutubeComments(forceRefresh = true)
+    }
+
+    private fun loadMoreYoutubeComments(forceRefresh: Boolean) {
         val engagement = _state.value.youtubeEngagement
         val comments = engagement.comments
         val videoId = engagement.videoId
         val token = comments.nextToken
-        if (videoId.isBlank() || token.isBlank() || comments.loadingMore) return
+        if (
+            videoId.isBlank() ||
+            token.isBlank() ||
+            comments.loadingMore ||
+            (!forceRefresh && comments.error != null)
+        ) return
         val generation = youtubeEngagementGeneration.get()
         youtubeCommentsPageJob?.cancel()
         _state.update { state ->
@@ -3934,19 +3951,29 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             )
         }
         youtubeCommentsPageJob = viewModelScope.launch {
-            val result = youtubeCommentsRepository.more(videoId, token)
+            val result = youtubeCommentsRepository.more(
+                videoId = videoId,
+                continuationToken = token,
+                forceRefresh = forceRefresh
+            )
             if (!isActive || !isYoutubeEngagementRequestCurrent(videoId, generation)) return@launch
             _state.update { state ->
                 if (state.youtubeEngagement.videoId != videoId) return@update state
                 val currentComments = state.youtubeEngagement.comments
                 val updated = when (result) {
                     is YoutubeCommentsResult.Available -> {
+                        youtubeCommentContinuationHistory += token
                         val merged = (currentComments.items + result.page.items).distinctBy(YoutubeComment::id)
+                        val nextToken = nextYoutubeCommentsToken(
+                            requestedToken = token,
+                            candidateToken = result.page.nextToken,
+                            successfulTokens = youtubeCommentContinuationHistory
+                        )
                         currentComments.copy(
                             loaded = true,
                             loadingMore = false,
                             items = merged,
-                            nextToken = result.page.nextToken.takeUnless { it == token }.orEmpty(),
+                            nextToken = nextToken,
                             error = null
                         )
                     }
@@ -3997,7 +4024,11 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             it.copy(repliesExpanded = true, repliesLoading = true, repliesError = null)
         }
         val job = viewModelScope.launch {
-            val result = youtubeCommentsRepository.replies(videoId, token)
+            val result = youtubeCommentsRepository.replies(
+                videoId = videoId,
+                continuationToken = token,
+                forceRefresh = comment.repliesError != null
+            )
             if (!isActive || !isYoutubeEngagementRequestCurrent(videoId, generation)) return@launch
             when (result) {
                 is YoutubeCommentsResult.Available -> updateYoutubeComment(commentId) { current ->
@@ -4484,6 +4515,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         youtubeCommentsPageJob?.cancel()
         youtubeCommentReplyJobs.values.forEach { it.cancel() }
         youtubeCommentReplyJobs.clear()
+        youtubeCommentContinuationHistory.clear()
         youtubeEngagementGeneration.incrementAndGet()
         prefetchJob?.cancel()
         motionArtworkJob?.cancel()
@@ -5103,6 +5135,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         youtubeCommentsPageJob?.cancel()
         youtubeCommentReplyJobs.values.forEach { it.cancel() }
         youtubeCommentReplyJobs.clear()
+        youtubeCommentContinuationHistory.clear()
         returnYoutubeDislikeRepository.close()
         youtubeCommentsRepository.close()
         cancelBackgroundWarmups()
@@ -5146,13 +5179,37 @@ internal fun youtubePlayableTrack(track: Track): Track? {
 private val YOUTUBE_ENGAGEMENT_VIDEO_ID = Regex("^[A-Za-z0-9_-]{11}$")
 
 internal fun youtubeEngagementVideoId(track: Track): String {
-    val candidates = listOf(
-        youtubeVideoId(track.videoUrl),
-        youtubeVideoId(track.id),
-        track.counterpartVideoId,
-        track.id
-    )
-    return candidates.firstOrNull { YOUTUBE_ENGAGEMENT_VIDEO_ID.matches(it.trim()) }?.trim().orEmpty()
+    val urlVideoId = youtubeVideoId(track.videoUrl).trim()
+    if (YOUTUBE_ENGAGEMENT_VIDEO_ID.matches(urlVideoId)) return urlVideoId
+
+    val idUrlVideoId = youtubeVideoId(track.id).trim()
+    if (YOUTUBE_ENGAGEMENT_VIDEO_ID.matches(idUrlVideoId)) return idUrlVideoId
+
+    if (!isYoutubeBackedTrack(track)) return ""
+    return sequenceOf(track.counterpartVideoId, track.id)
+        .map(String::trim)
+        .firstOrNull(YOUTUBE_ENGAGEMENT_VIDEO_ID::matches)
+        .orEmpty()
+}
+
+
+internal fun nextYoutubeCommentsToken(
+    requestedToken: String,
+    candidateToken: String,
+    successfulTokens: Set<String>
+): String {
+    val requested = requestedToken.trim()
+    val candidate = candidateToken.trim()
+    if (candidate.isBlank() || candidate == requested || candidate in successfulTokens) return ""
+    return candidate
+}
+
+private fun isYoutubeBackedTrack(track: Track): Boolean {
+    val sourceMarker = "${track.source} ${track.metadataProvider}".lowercase()
+    return sourceMarker.contains("youtube") ||
+        track.videoType.isNotBlank() ||
+        track.videoUrl.contains("youtube.com", ignoreCase = true) ||
+        track.videoUrl.contains("youtu.be", ignoreCase = true)
 }
 
 private fun youtubeVideoId(url: String): String {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -28,6 +28,10 @@ import com.luc4n3x.levyra.data.ListeningPulseStore
 import com.luc4n3x.levyra.data.OfficialArtworkRepository
 import com.luc4n3x.levyra.data.LyricsRepository
 import com.luc4n3x.levyra.data.PlaybackResolver
+import com.luc4n3x.levyra.data.ReturnYoutubeDislikeRepository
+import com.luc4n3x.levyra.data.ReturnYoutubeDislikeResult
+import com.luc4n3x.levyra.data.YoutubeCommentsRepository
+import com.luc4n3x.levyra.data.YoutubeCommentsResult
 import com.luc4n3x.levyra.data.SponsorBlockRepository
 import com.luc4n3x.levyra.data.TrackPayloadCodec
 import com.luc4n3x.levyra.data.YoutubeMusicRepository
@@ -75,6 +79,9 @@ import com.luc4n3x.levyra.domain.OfflineDownloadTask
 import com.luc4n3x.levyra.domain.Playlist
 import com.luc4n3x.levyra.domain.RepeatMode
 import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.domain.YoutubeComment
+import com.luc4n3x.levyra.domain.YoutubeCommentsState
+import com.luc4n3x.levyra.domain.YoutubeEngagementState
 import com.luc4n3x.levyra.feature.motion.MotionArtworkEngine
 import com.luc4n3x.levyra.feature.motion.MotionArtworkIdentityKey
 import com.luc4n3x.levyra.ui.theme.LevyraThemes
@@ -214,6 +221,8 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private val lyricsRepository = LyricsRepository(application.applicationContext)
     private val sponsorBlockRepository = SponsorBlockRepository()
     private val resolver = PlaybackResolver.getInstance(application.applicationContext)
+    private val returnYoutubeDislikeRepository = ReturnYoutubeDislikeRepository()
+    private val youtubeCommentsRepository = YoutubeCommentsRepository()
     private val moodEngine = MoodEngine()
     private val lyricsEngine = LyricsEngine()
     private val localIntelligence = LevyraLocalIntelligence()
@@ -258,12 +267,16 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private var streamRecoveryJob: Job? = null
     private var alternateModePrefetchJob: Job? = null
     private var youtubeEngagementJob: Job? = null
+    private var youtubeDislikeJob: Job? = null
+    private var youtubeCommentsJob: Job? = null
+    private var youtubeCommentsPageJob: Job? = null
+    private val youtubeCommentReplyJobs = ConcurrentHashMap<String, Job>()
+    private val youtubeEngagementGeneration = AtomicLong(0L)
     private var prefetchJob: Job? = null
     private var chartEnrichJob: Job? = null
     private var orbitArtworkJob: Job? = null
     private var motionArtworkJob: Job? = null
     @Volatile private var motionArtworkRequestKey: String? = null
-    private val motionArtworkRequestGeneration = AtomicLong(0L)
     private var motionArtworkPrefetchJob: Job? = null
     private var sleepJob: Job? = null
     private var crossfadeJob: Job? = null
@@ -1282,6 +1295,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                     )
                 }
                 prefetchAlternateMode(resolved, targetMode)
+                if (_state.value.selectedTab == LevyraTab.Player) {
+                    refreshYoutubeEngagement(resolved)
+                }
                 updateWidget()
             } catch (error: Throwable) {
                 if (error is CancellationException) throw error
@@ -2009,7 +2025,6 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         if (value) {
             _state.value.currentTrack?.let(::refreshMotionArtworkAround)
         } else {
-            motionArtworkRequestGeneration.incrementAndGet()
             motionArtworkJob?.cancel()
             motionArtworkRequestKey = null
             motionArtworkPrefetchJob?.cancel()
@@ -2886,6 +2901,10 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     fun navigateBack(): Boolean {
         val snapshot = _state.value
         return when {
+            snapshot.youtubeEngagement.comments.visible -> {
+                closeYoutubeComments()
+                true
+            }
             snapshot.showUpdatePrompt -> {
                 dismissUpdatePrompt()
                 true
@@ -3486,10 +3505,16 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         streamRecoveryJob?.cancel()
         alternateModePrefetchJob?.cancel()
         youtubeEngagementJob?.cancel()
-        motionArtworkRequestGeneration.incrementAndGet()
         motionArtworkJob?.cancel()
         motionArtworkRequestKey = null
         motionArtworkPrefetchJob?.cancel()
+        youtubeDislikeJob?.cancel()
+        youtubeCommentsJob?.cancel()
+        youtubeCommentsPageJob?.cancel()
+        youtubeCommentReplyJobs.values.forEach { it.cancel() }
+        youtubeCommentReplyJobs.clear()
+        youtubeEngagementGeneration.incrementAndGet()
+        val engagementVideoId = youtubeEngagementVideoId(track)
         if (!preserveCrossfade) {
             crossfadeJob?.cancel()
             crossfadeInProgress = false
@@ -3504,6 +3529,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 isResolving = true,
                 playerError = null,
                 currentTrack = track.copy(streamUrl = ""),
+                youtubeEngagement = YoutubeEngagementState(videoId = engagementVideoId),
                 isPlaying = false,
                 positionMs = 0L,
                 durationMs = track.durationMs,
@@ -3682,13 +3708,21 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     private fun refreshYoutubeEngagement(track: Track) {
-        youtubeEngagementJob?.cancel()
         if (track.source.equals("Offline", ignoreCase = true)) return
+        val videoId = youtubeEngagementVideoId(track)
+        if (videoId.isBlank()) return
+        val generation = prepareYoutubeEngagement(videoId)
+
+        refreshYoutubeDislikeEstimate(videoId, generation)
+        refreshYoutubeCommentsSummary(videoId, generation)
+
+        youtubeEngagementJob?.cancel()
         if (track.youtubeLikeCount >= 0L && track.youtubeViewCount >= 0L) return
         val requestId = playRequestId
         youtubeEngagementJob = viewModelScope.launch {
             val enriched = resolver.enrichYoutubeEngagement(track)
             if (!isActive || requestId != playRequestId) return@launch
+            if (!isYoutubeEngagementRequestCurrent(videoId, generation)) return@launch
             val current = _state.value.currentTrack ?: return@launch
             if (!samePlayableTrack(current, enriched)) return@launch
             val merged = current.copy(
@@ -3706,6 +3740,302 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                     searchResults = mergeTracks(it.searchResults, listOf(merged))
                 )
             }
+        }
+    }
+
+    private fun prepareYoutubeEngagement(videoId: String): Long {
+        val current = _state.value.youtubeEngagement
+        if (current.videoId == videoId) return youtubeEngagementGeneration.get()
+        val generation = youtubeEngagementGeneration.incrementAndGet()
+        _state.update { state ->
+            state.copy(youtubeEngagement = YoutubeEngagementState(videoId = videoId))
+        }
+        return generation
+    }
+
+    private fun isYoutubeEngagementRequestCurrent(videoId: String, generation: Long): Boolean {
+        if (generation != youtubeEngagementGeneration.get()) return false
+        val snapshot = _state.value
+        if (snapshot.youtubeEngagement.videoId != videoId) return false
+        val current = snapshot.currentTrack ?: return false
+        return youtubeEngagementVideoId(current) == videoId
+    }
+
+    private fun refreshYoutubeDislikeEstimate(videoId: String, generation: Long) {
+        val current = _state.value.youtubeEngagement
+        if (current.videoId != videoId || current.dislikeEstimateLoading || current.dislikeEstimateAvailable) return
+        youtubeDislikeJob?.cancel()
+        _state.update { state ->
+            if (state.youtubeEngagement.videoId != videoId) state else state.copy(
+                youtubeEngagement = state.youtubeEngagement.copy(
+                    dislikeEstimateLoading = true,
+                    dislikeEstimateError = null
+                )
+            )
+        }
+        youtubeDislikeJob = viewModelScope.launch {
+            val result = returnYoutubeDislikeRepository.estimate(videoId)
+            if (!isActive || !isYoutubeEngagementRequestCurrent(videoId, generation)) return@launch
+            _state.update { state ->
+                if (state.youtubeEngagement.videoId != videoId) return@update state
+                val updated = when (result) {
+                    is ReturnYoutubeDislikeResult.Available -> {
+                        if (result.estimate.deleted) {
+                            state.youtubeEngagement.copy(
+                                estimatedDislikeCount = -1L,
+                                dislikeEstimateLoading = false,
+                                dislikeEstimateAvailable = false,
+                                dislikeEstimateError = null
+                            )
+                        } else {
+                            state.youtubeEngagement.copy(
+                                estimatedDislikeCount = result.estimate.dislikes,
+                                dislikeEstimateLoading = false,
+                                dislikeEstimateAvailable = true,
+                                dislikeEstimateError = null
+                            )
+                        }
+                    }
+                    ReturnYoutubeDislikeResult.NotFound -> state.youtubeEngagement.copy(
+                        estimatedDislikeCount = -1L,
+                        dislikeEstimateLoading = false,
+                        dislikeEstimateAvailable = false,
+                        dislikeEstimateError = null
+                    )
+                    is ReturnYoutubeDislikeResult.RateLimited -> state.youtubeEngagement.copy(
+                        estimatedDislikeCount = -1L,
+                        dislikeEstimateLoading = false,
+                        dislikeEstimateAvailable = false,
+                        dislikeEstimateError = "rate_limited"
+                    )
+                    is ReturnYoutubeDislikeResult.Failed -> state.youtubeEngagement.copy(
+                        estimatedDislikeCount = -1L,
+                        dislikeEstimateLoading = false,
+                        dislikeEstimateAvailable = false,
+                        dislikeEstimateError = "unavailable"
+                    )
+                }
+                state.copy(youtubeEngagement = updated)
+            }
+        }
+    }
+
+    private fun refreshYoutubeCommentsSummary(videoId: String, generation: Long, force: Boolean = false) {
+        val comments = _state.value.youtubeEngagement.comments
+        if (
+            comments.videoId == videoId &&
+            !force &&
+            (comments.loading || comments.loaded || comments.disabled)
+        ) return
+
+        youtubeCommentsJob?.cancel()
+        _state.update { state ->
+            if (state.youtubeEngagement.videoId != videoId) state else state.copy(
+                youtubeEngagement = state.youtubeEngagement.copy(
+                    comments = state.youtubeEngagement.comments.copy(
+                        videoId = videoId,
+                        loading = true,
+                        error = null
+                    )
+                )
+            )
+        }
+        youtubeCommentsJob = viewModelScope.launch {
+            val result = youtubeCommentsRepository.initial(videoId)
+            if (!isActive || !isYoutubeEngagementRequestCurrent(videoId, generation)) return@launch
+            _state.update { state ->
+                if (state.youtubeEngagement.videoId != videoId) return@update state
+                val visible = state.youtubeEngagement.comments.visible
+                val updatedComments = when (result) {
+                    is YoutubeCommentsResult.Available -> YoutubeCommentsState(
+                        videoId = videoId,
+                        visible = visible,
+                        loaded = true,
+                        loading = false,
+                        loadingMore = false,
+                        disabled = result.page.commentsDisabled,
+                        countText = result.page.countText,
+                        items = result.page.items.distinctBy(YoutubeComment::id),
+                        nextToken = result.page.nextToken,
+                        error = null
+                    )
+                    YoutubeCommentsResult.Disabled -> YoutubeCommentsState(
+                        videoId = videoId,
+                        visible = visible,
+                        loaded = true,
+                        loading = false,
+                        disabled = true
+                    )
+                    is YoutubeCommentsResult.Failed -> state.youtubeEngagement.comments.copy(
+                        videoId = videoId,
+                        loading = false,
+                        loaded = false,
+                        error = "unavailable"
+                    )
+                }
+                state.copy(
+                    youtubeEngagement = state.youtubeEngagement.copy(comments = updatedComments)
+                )
+            }
+        }
+    }
+
+    fun openYoutubeComments() {
+        val track = _state.value.currentTrack ?: return
+        val videoId = youtubeEngagementVideoId(track)
+        if (videoId.isBlank()) return
+        val generation = prepareYoutubeEngagement(videoId)
+        _state.update { state ->
+            state.copy(
+                youtubeEngagement = state.youtubeEngagement.copy(
+                    comments = state.youtubeEngagement.comments.copy(
+                        videoId = videoId,
+                        visible = true
+                    )
+                )
+            )
+        }
+        val comments = _state.value.youtubeEngagement.comments
+        if (!comments.loaded && !comments.loading && !comments.disabled) {
+            refreshYoutubeCommentsSummary(videoId, generation, force = true)
+        }
+    }
+
+    fun closeYoutubeComments() {
+        _state.update { state ->
+            state.copy(
+                youtubeEngagement = state.youtubeEngagement.copy(
+                    comments = state.youtubeEngagement.comments.copy(visible = false)
+                )
+            )
+        }
+    }
+
+    fun retryYoutubeComments() {
+        val videoId = _state.value.youtubeEngagement.videoId
+        if (videoId.isBlank()) return
+        val generation = prepareYoutubeEngagement(videoId)
+        refreshYoutubeCommentsSummary(videoId, generation, force = true)
+    }
+
+    fun loadMoreYoutubeComments() {
+        val engagement = _state.value.youtubeEngagement
+        val comments = engagement.comments
+        val videoId = engagement.videoId
+        val token = comments.nextToken
+        if (videoId.isBlank() || token.isBlank() || comments.loadingMore) return
+        val generation = youtubeEngagementGeneration.get()
+        youtubeCommentsPageJob?.cancel()
+        _state.update { state ->
+            if (state.youtubeEngagement.videoId != videoId) state else state.copy(
+                youtubeEngagement = state.youtubeEngagement.copy(
+                    comments = state.youtubeEngagement.comments.copy(loadingMore = true, error = null)
+                )
+            )
+        }
+        youtubeCommentsPageJob = viewModelScope.launch {
+            val result = youtubeCommentsRepository.more(videoId, token)
+            if (!isActive || !isYoutubeEngagementRequestCurrent(videoId, generation)) return@launch
+            _state.update { state ->
+                if (state.youtubeEngagement.videoId != videoId) return@update state
+                val currentComments = state.youtubeEngagement.comments
+                val updated = when (result) {
+                    is YoutubeCommentsResult.Available -> {
+                        val merged = (currentComments.items + result.page.items).distinctBy(YoutubeComment::id)
+                        currentComments.copy(
+                            loaded = true,
+                            loadingMore = false,
+                            items = merged,
+                            nextToken = result.page.nextToken.takeUnless { it == token }.orEmpty(),
+                            error = null
+                        )
+                    }
+                    YoutubeCommentsResult.Disabled -> currentComments.copy(
+                        loadingMore = false,
+                        disabled = true,
+                        nextToken = ""
+                    )
+                    is YoutubeCommentsResult.Failed -> currentComments.copy(
+                        loadingMore = false,
+                        error = "unavailable"
+                    )
+                }
+                state.copy(
+                    youtubeEngagement = state.youtubeEngagement.copy(comments = updated)
+                )
+            }
+        }
+    }
+
+    fun toggleYoutubeCommentReplies(commentId: String) {
+        val engagement = _state.value.youtubeEngagement
+        val comment = engagement.comments.items.firstOrNull { it.id == commentId } ?: return
+        if (comment.repliesExpanded) {
+            updateYoutubeComment(commentId) { it.copy(repliesExpanded = false) }
+            return
+        }
+        if (comment.replies.isNotEmpty()) {
+            updateYoutubeComment(commentId) { it.copy(repliesExpanded = true) }
+            return
+        }
+        loadYoutubeCommentReplies(commentId, append = false)
+    }
+
+    fun loadMoreYoutubeCommentReplies(commentId: String) {
+        loadYoutubeCommentReplies(commentId, append = true)
+    }
+
+    private fun loadYoutubeCommentReplies(commentId: String, append: Boolean) {
+        val engagement = _state.value.youtubeEngagement
+        val comment = engagement.comments.items.firstOrNull { it.id == commentId } ?: return
+        val token = if (append) comment.repliesNextToken else comment.replyToken
+        if (engagement.videoId.isBlank() || token.isBlank() || comment.repliesLoading) return
+        val videoId = engagement.videoId
+        val generation = youtubeEngagementGeneration.get()
+        youtubeCommentReplyJobs.remove(commentId)?.cancel()
+        updateYoutubeComment(commentId) {
+            it.copy(repliesExpanded = true, repliesLoading = true, repliesError = null)
+        }
+        val job = viewModelScope.launch {
+            val result = youtubeCommentsRepository.replies(videoId, token)
+            if (!isActive || !isYoutubeEngagementRequestCurrent(videoId, generation)) return@launch
+            when (result) {
+                is YoutubeCommentsResult.Available -> updateYoutubeComment(commentId) { current ->
+                    val base = if (append) current.replies else emptyList()
+                    current.copy(
+                        replies = (base + result.page.items).distinctBy(YoutubeComment::id),
+                        repliesNextToken = result.page.nextToken.takeUnless { it == token }.orEmpty(),
+                        repliesExpanded = true,
+                        repliesLoading = false,
+                        repliesError = null
+                    )
+                }
+                YoutubeCommentsResult.Disabled -> updateYoutubeComment(commentId) {
+                    it.copy(repliesLoading = false, repliesNextToken = "")
+                }
+                is YoutubeCommentsResult.Failed -> updateYoutubeComment(commentId) {
+                    it.copy(repliesLoading = false, repliesError = "unavailable")
+                }
+            }
+        }
+        youtubeCommentReplyJobs[commentId] = job
+        job.invokeOnCompletion { youtubeCommentReplyJobs.remove(commentId, job) }
+    }
+
+    private fun updateYoutubeComment(
+        commentId: String,
+        transform: (YoutubeComment) -> YoutubeComment
+    ) {
+        _state.update { state ->
+            val comments = state.youtubeEngagement.comments
+            val updatedItems = comments.items.map { comment ->
+                if (comment.id == commentId) transform(comment) else comment
+            }
+            state.copy(
+                youtubeEngagement = state.youtubeEngagement.copy(
+                    comments = comments.copy(items = updatedItems)
+                )
+            )
         }
     }
 
@@ -3835,7 +4165,6 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     private fun refreshMotionArtworkAround(current: Track) {
         if (!_state.value.animationsEnabled) {
-            motionArtworkRequestGeneration.incrementAndGet()
             motionArtworkJob?.cancel()
             motionArtworkRequestKey = null
             _state.update { it.copy(motionArtwork = null, motionArtworkLoading = false) }
@@ -3844,7 +4173,6 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         val expectedKey = MotionArtworkIdentityKey.create(current)
         if (motionArtworkJob?.isActive == true && motionArtworkRequestKey == expectedKey) return
         motionArtworkJob?.cancel()
-        val requestGeneration = motionArtworkRequestGeneration.incrementAndGet()
         motionArtworkRequestKey = expectedKey
         motionArtworkJob = viewModelScope.launch(Dispatchers.IO) {
             try {
@@ -3855,34 +4183,18 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                     }
                     .getOrNull()
                 if (!isActive) return@launch
-                var published = false
-                _state.update { latest ->
-                    val activeTrack = latest.currentTrack
-                    val stillOwnsRequest = motionArtworkRequestGeneration.get() == requestGeneration &&
-                        motionArtworkRequestKey == expectedKey &&
-                        latest.animationsEnabled &&
-                        activeTrack != null &&
-                        MotionArtworkIdentityKey.create(activeTrack) == expectedKey
-                    published = stillOwnsRequest
-                    if (stillOwnsRequest) {
-                        latest.copy(
+                val activeTrack = _state.value.currentTrack
+                if (activeTrack != null && MotionArtworkIdentityKey.create(activeTrack) == expectedKey) {
+                    _state.update {
+                        it.copy(
                             motionArtwork = resolved,
                             motionArtworkLoading = false
                         )
-                    } else {
-                        latest
                     }
                 }
-                if (published && motionArtworkRequestGeneration.get() == requestGeneration) {
-                    prefetchNextMotionArtwork(current)
-                }
+                prefetchNextMotionArtwork(current)
             } finally {
-                if (
-                    motionArtworkRequestGeneration.get() == requestGeneration &&
-                    motionArtworkRequestKey == expectedKey
-                ) {
-                    motionArtworkRequestKey = null
-                }
+                if (motionArtworkRequestKey == expectedKey) motionArtworkRequestKey = null
             }
         }
     }
@@ -4166,8 +4478,14 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         modeSwitchJob?.cancel()
         streamRecoveryJob?.cancel()
         alternateModePrefetchJob?.cancel()
+        youtubeEngagementJob?.cancel()
+        youtubeDislikeJob?.cancel()
+        youtubeCommentsJob?.cancel()
+        youtubeCommentsPageJob?.cancel()
+        youtubeCommentReplyJobs.values.forEach { it.cancel() }
+        youtubeCommentReplyJobs.clear()
+        youtubeEngagementGeneration.incrementAndGet()
         prefetchJob?.cancel()
-        motionArtworkRequestGeneration.incrementAndGet()
         motionArtworkJob?.cancel()
         motionArtworkRequestKey = null
         motionArtworkPrefetchJob?.cancel()
@@ -4192,6 +4510,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             it.copy(
                 selectedTab = if (it.selectedTab == LevyraTab.Player) LevyraTab.Home else it.selectedTab,
                 currentTrack = null,
+                youtubeEngagement = YoutubeEngagementState(),
                 queue = emptyList(),
                 queueCurrentIndex = -1,
                 queueUndoAvailable = false,
@@ -4779,6 +5098,13 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         streamRecoveryJob?.cancel()
         alternateModePrefetchJob?.cancel()
         youtubeEngagementJob?.cancel()
+        youtubeDislikeJob?.cancel()
+        youtubeCommentsJob?.cancel()
+        youtubeCommentsPageJob?.cancel()
+        youtubeCommentReplyJobs.values.forEach { it.cancel() }
+        youtubeCommentReplyJobs.clear()
+        returnYoutubeDislikeRepository.close()
+        youtubeCommentsRepository.close()
         cancelBackgroundWarmups()
         orbitArtworkJob?.cancel()
         officialMetadataSignal.close()
@@ -4814,6 +5140,19 @@ internal fun youtubePlayableTrack(track: Track): Track? {
     if (videoId.isBlank()) return null
     val videoUrl = track.videoUrl.ifBlank { "https://www.youtube.com/watch?v=$videoId" }
     return track.copy(id = videoId, videoUrl = videoUrl)
+}
+
+
+private val YOUTUBE_ENGAGEMENT_VIDEO_ID = Regex("^[A-Za-z0-9_-]{11}$")
+
+internal fun youtubeEngagementVideoId(track: Track): String {
+    val candidates = listOf(
+        youtubeVideoId(track.videoUrl),
+        youtubeVideoId(track.id),
+        track.counterpartVideoId,
+        track.id
+    )
+    return candidates.firstOrNull { YOUTUBE_ENGAGEMENT_VIDEO_ID.matches(it.trim()) }?.trim().orEmpty()
 }
 
 private fun youtubeVideoId(url: String): String {

--- a/app/src/test/java/com/luc4n3x/levyra/data/ReturnYoutubeDislikeRepositoryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/ReturnYoutubeDislikeRepositoryTest.kt
@@ -65,6 +65,12 @@ class ReturnYoutubeDislikeRepositoryTest {
         )
         assertNull(
             parseReturnYoutubeDislikeResponse(
+                json = """{"id":"kxOuG8jMIgI","likes":1,"dislikes":2,"viewCount":-1}""",
+                expectedVideoId = "kxOuG8jMIgI"
+            )
+        )
+        assertNull(
+            parseReturnYoutubeDislikeResponse(
                 json = "{}",
                 expectedVideoId = "not-a-video-id"
             )

--- a/app/src/test/java/com/luc4n3x/levyra/data/ReturnYoutubeDislikeRepositoryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/ReturnYoutubeDislikeRepositoryTest.kt
@@ -1,0 +1,73 @@
+package com.luc4n3x.levyra.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReturnYoutubeDislikeRepositoryTest {
+    @Test
+    fun parsesValidEstimateForExpectedVideo() {
+        val estimate = parseReturnYoutubeDislikeResponse(
+            json = """
+                {
+                  "id": "kxOuG8jMIgI",
+                  "likes": 31885,
+                  "rawDislikes": 31946,
+                  "rawLikes": 457,
+                  "dislikes": 579721,
+                  "rating": 1.2085329444119253,
+                  "viewCount": 3762293,
+                  "deleted": false
+                }
+            """.trimIndent(),
+            expectedVideoId = "kxOuG8jMIgI"
+        )
+
+        requireNotNull(estimate)
+        assertEquals("kxOuG8jMIgI", estimate.videoId)
+        assertEquals(31_885L, estimate.likes)
+        assertEquals(579_721L, estimate.dislikes)
+        assertEquals(31_946L, estimate.rawDislikes)
+        assertEquals(3_762_293L, estimate.viewCount)
+        assertTrue(estimate.rating > 0.0)
+    }
+
+    @Test
+    fun acceptsValidCountsWhenOptionalRatingIsMissing() {
+        val estimate = parseReturnYoutubeDislikeResponse(
+            json = """{"id":"kxOuG8jMIgI","likes":1,"dislikes":2}""",
+            expectedVideoId = "kxOuG8jMIgI"
+        )
+
+        requireNotNull(estimate)
+        assertEquals(2L, estimate.dislikes)
+        assertEquals(0.0, estimate.rating, 0.0)
+    }
+
+    @Test
+    fun rejectsResponseBelongingToAnotherVideo() {
+        val estimate = parseReturnYoutubeDislikeResponse(
+            json = """{"id":"aaaaaaaaaaa","likes":1,"dislikes":2,"rating":4.0}""",
+            expectedVideoId = "bbbbbbbbbbb"
+        )
+
+        assertNull(estimate)
+    }
+
+    @Test
+    fun rejectsNegativeCountsAndMalformedIds() {
+        assertNull(
+            parseReturnYoutubeDislikeResponse(
+                json = """{"id":"kxOuG8jMIgI","likes":1,"dislikes":-2,"rating":4.0}""",
+                expectedVideoId = "kxOuG8jMIgI"
+            )
+        )
+        assertNull(
+            parseReturnYoutubeDislikeResponse(
+                json = "{}",
+                expectedVideoId = "not-a-video-id"
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeCommentsRepositoryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeCommentsRepositoryTest.kt
@@ -1,0 +1,61 @@
+package com.luc4n3x.levyra.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class YoutubeCommentsRepositoryTest {
+    @Test
+    fun acceptsOnlyApprovedHttpsAvatarHosts() {
+        assertEquals(
+            "https://yt3.ggpht.com/avatar=s88-c-k-c0x00ffffff-no-rj",
+            sanitizeYoutubeAvatarUrl("https://yt3.ggpht.com/avatar=s88-c-k-c0x00ffffff-no-rj")
+        )
+        assertEquals("", sanitizeYoutubeAvatarUrl("http://yt3.ggpht.com/avatar"))
+        assertEquals("", sanitizeYoutubeAvatarUrl("https://127.0.0.1/avatar"))
+        assertEquals("", sanitizeYoutubeAvatarUrl("https://yt3.ggpht.com.evil.example/avatar"))
+    }
+
+    @Test
+    fun acceptsOnlyCanonicalYoutubeAuthorUrls() {
+        assertEquals(
+            "https://www.youtube.com/@artist",
+            sanitizeYoutubeAuthorUrl("https://www.youtube.com/@artist")
+        )
+        assertEquals("", sanitizeYoutubeAuthorUrl("https://example.com/@artist"))
+        assertEquals("", sanitizeYoutubeAuthorUrl("https://user@youtube.com/@artist"))
+    }
+
+    @Test
+    fun emptyParsedPagesKeepAdvancingWithoutLooping() {
+        assertEquals(
+            "next-token",
+            nextEmptyCommentsContinuation(
+                parsedItemCount = 0,
+                nextToken = " next-token ",
+                seenTokens = emptySet(),
+                hops = 0,
+                maxHops = 6
+            )
+        )
+        assertEquals(
+            null,
+            nextEmptyCommentsContinuation(
+                parsedItemCount = 0,
+                nextToken = "next-token",
+                seenTokens = setOf("next-token"),
+                hops = 1,
+                maxHops = 6
+            )
+        )
+        assertEquals(
+            null,
+            nextEmptyCommentsContinuation(
+                parsedItemCount = 1,
+                nextToken = "next-token",
+                seenTokens = emptySet(),
+                hops = 0,
+                maxHops = 6
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/YoutubeEngagementIdentityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/YoutubeEngagementIdentityTest.kt
@@ -32,10 +32,41 @@ class YoutubeEngagementIdentityTest {
         assertEquals("", youtubeEngagementVideoId(track(id = "not-a-video")))
     }
 
+    @Test
+    fun rawElevenCharacterIdsAreRejectedForNonYoutubeTracks() {
+        assertEquals(
+            "",
+            youtubeEngagementVideoId(
+                track(id = "abcdefghijk", source = "Local library")
+            )
+        )
+    }
+
+    @Test
+    fun continuationCyclesAreStoppedAcrossSuccessfulPages() {
+        assertEquals(
+            "",
+            nextYoutubeCommentsToken(
+                requestedToken = "token-b",
+                candidateToken = "token-a",
+                successfulTokens = setOf("token-a", "token-b")
+            )
+        )
+        assertEquals(
+            "token-c",
+            nextYoutubeCommentsToken(
+                requestedToken = "token-b",
+                candidateToken = "token-c",
+                successfulTokens = setOf("token-a", "token-b")
+            )
+        )
+    }
+
     private fun track(
         id: String,
         videoUrl: String = "",
-        counterpartVideoId: String = ""
+        counterpartVideoId: String = "",
+        source: String = "YouTube Music"
     ) = Track(
         id = id,
         title = "Title",
@@ -46,7 +77,7 @@ class YoutubeEngagementIdentityTest {
         videoUrl = videoUrl,
         thumbnailUrl = "",
         largeThumbnailUrl = "",
-        source = "YouTube Music",
+        source = source,
         moodTags = emptySet(),
         energy = 50,
         vocal = 50,

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/YoutubeEngagementIdentityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/YoutubeEngagementIdentityTest.kt
@@ -1,0 +1,59 @@
+package com.luc4n3x.levyra.viewmodel
+
+import com.luc4n3x.levyra.domain.Track
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class YoutubeEngagementIdentityTest {
+    @Test
+    fun exactVideoUrlWinsOverCatalogFallbacks() {
+        val track = track(
+            id = "aaaaaaaaaaa",
+            videoUrl = "https://www.youtube.com/watch?v=bbbbbbbbbbb",
+            counterpartVideoId = "ccccccccccc"
+        )
+
+        assertEquals("bbbbbbbbbbb", youtubeEngagementVideoId(track))
+    }
+
+    @Test
+    fun counterpartIsUsedWhenTrackIdIsNotAYouTubeId() {
+        val track = track(
+            id = "chart-123",
+            videoUrl = "",
+            counterpartVideoId = "ccccccccccc"
+        )
+
+        assertEquals("ccccccccccc", youtubeEngagementVideoId(track))
+    }
+
+    @Test
+    fun malformedIdentifiersAreRejected() {
+        assertEquals("", youtubeEngagementVideoId(track(id = "not-a-video")))
+    }
+
+    private fun track(
+        id: String,
+        videoUrl: String = "",
+        counterpartVideoId: String = ""
+    ) = Track(
+        id = id,
+        title = "Title",
+        artist = "Artist",
+        album = "Album",
+        durationMs = 180_000L,
+        streamUrl = "",
+        videoUrl = videoUrl,
+        thumbnailUrl = "",
+        largeThumbnailUrl = "",
+        source = "YouTube Music",
+        moodTags = emptySet(),
+        energy = 50,
+        vocal = 50,
+        replayScore = 50,
+        cacheScore = 50,
+        accentStart = 0,
+        accentEnd = 0,
+        counterpartVideoId = counterpartVideoId
+    )
+}

--- a/third_party/LevyraExtractor/extractor/src/main/java/org/schabi/newpipe/extractor/ListExtractor.java
+++ b/third_party/LevyraExtractor/extractor/src/main/java/org/schabi/newpipe/extractor/ListExtractor.java
@@ -115,9 +115,21 @@ public abstract class ListExtractor<R extends InfoItem> extends Extractor {
         }
 
         public InfoItemsPage(final List<T> itemsList,
-                             Page nextPage,
+                             final Page nextPage,
                              final List<Throwable> errors) {
-            if (itemsList.isEmpty()) {
+            this(itemsList, nextPage, errors, false);
+        }
+
+        /**
+         * Creates a page while optionally preserving a valid continuation when no items were
+         * successfully parsed. This is useful for feeds where a legitimate page can contain only
+         * unavailable, deleted or otherwise unsupported renderers while later pages remain valid.
+         */
+        public InfoItemsPage(final List<T> itemsList,
+                             Page nextPage,
+                             final List<Throwable> errors,
+                             final boolean preserveNextPageWhenEmpty) {
+            if (!preserveNextPageWhenEmpty && itemsList.isEmpty()) {
                 nextPage = null;
             }
             this.itemsList = itemsList;

--- a/third_party/LevyraExtractor/extractor/src/main/java/org/schabi/newpipe/extractor/ListInfo.java
+++ b/third_party/LevyraExtractor/extractor/src/main/java/org/schabi/newpipe/extractor/ListInfo.java
@@ -1,62 +1,156 @@
 package org.schabi.newpipe.extractor;
 
-import org.schabi.newpipe.extractor.search.filter.FilterItem;
-
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
-
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-public abstract class ListInfo<T extends InfoItem> extends Info {
-    private List<T> relatedItems;
-    private Page nextPage = null;
-    private final List<FilterItem> contentFilters;
-    private final List<FilterItem> sortFilter;
+import javax.annotation.Nonnull;
 
-    public ListInfo(final int serviceId,
-                    final String id,
-                    final String url,
-                    final String originalUrl,
-                    final String name,
-                    final List<FilterItem> contentFilter,
-                    final List<FilterItem> sortFilter) {
-        super(serviceId, id, url, originalUrl, name);
-        this.contentFilters = contentFilter;
-        this.sortFilter = sortFilter;
+
+/**
+ * Base class to extractors that have a list (e.g. playlists, users).
+ * @param <R> the info item type this list extractor provides
+ */
+public abstract class ListExtractor<R extends InfoItem> extends Extractor {
+    /**
+     * Constant that should be returned whenever
+     * a list has an unknown number of items.
+     */
+    public static final long ITEM_COUNT_UNKNOWN = -1;
+    /**
+     * Constant that should be returned whenever a list has an
+     * infinite number of items. For example a YouTube mix.
+     */
+    public static final long ITEM_COUNT_INFINITE = -2;
+    /**
+     * Constant that should be returned whenever a list
+     * has an unknown number of items bigger than 100.
+     */
+    public static final long ITEM_COUNT_MORE_THAN_100 = -3;
+
+    public ListExtractor(final StreamingService service, final ListLinkHandler linkHandler) {
+        super(service, linkHandler);
     }
 
-    public ListInfo(final int serviceId,
-                    final ListLinkHandler listUrlIdHandler,
-                    final String name) {
-        super(serviceId, listUrlIdHandler, name);
-        this.contentFilters = listUrlIdHandler.getContentFilters();
-        this.sortFilter = listUrlIdHandler.getSortFilter();
+    /**
+     * A {@link InfoItemsPage InfoItemsPage} corresponding to the initial page
+     * where the items are from the initial request and the nextPage relative to it.
+     *
+     * @return a {@link InfoItemsPage} corresponding to the initial page
+     */
+    @Nonnull
+    public abstract InfoItemsPage<R> getInitialPage() throws IOException, ExtractionException;
+
+    @Nonnull
+    public InfoItemsPage<R> getFullPage() throws IOException, ExtractionException {
+        InfoItemsPage<R> currentPage = getInitialPage();
+        final ArrayList<R> items = new ArrayList<>(currentPage.getItems());
+        final ArrayList<Throwable> errors = new ArrayList<>(currentPage.getErrors());
+        while (currentPage.hasNextPage()) {
+            currentPage = getPage(currentPage.getNextPage());
+            items.addAll(currentPage.getItems());
+            errors.addAll(currentPage.getErrors());
+        }
+        return new InfoItemsPage<>(items, null, errors);
     }
 
-    public List<T> getRelatedItems() {
-        return relatedItems;
+    /**
+     * Get a list of items corresponding to the specific requested page.
+     *
+     * @param page any page got from the exclusive implementation of the list extractor
+     * @return a {@link InfoItemsPage} corresponding to the requested page
+     * @see InfoItemsPage#getNextPage()
+     */
+    public abstract InfoItemsPage<R> getPage(Page page) throws IOException, ExtractionException;
+
+    @Nonnull
+    @Override
+    public ListLinkHandler getLinkHandler() {
+        return (ListLinkHandler) super.getLinkHandler();
     }
 
-    public void setRelatedItems(final List<T> relatedItems) {
-        this.relatedItems = relatedItems;
-    }
+    /*//////////////////////////////////////////////////////////////////////////
+    // Inner
+    //////////////////////////////////////////////////////////////////////////*/
 
-    public boolean hasNextPage() {
-        return Page.isValid(nextPage);
-    }
+    /**
+     * A class that is used to wrap a list of gathered items and eventual errors, it
+     * also contains a field that points to the next available page ({@link #nextPage}).
+     * @param <T> the info item type that this page is supposed to store and provide
+     */
+    public static class InfoItemsPage<T extends InfoItem> {
+        /**
+         * A convenient method that returns a representation of an empty page.
+         *
+         * @return a type-safe page with the list of items and errors empty and the nextPage set to
+         *         {@code null}.
+         */
+        public static <T extends InfoItem> InfoItemsPage<T> emptyPage() {
+            return new InfoItemsPage<>(Collections.emptyList(), null, Collections.emptyList());
+        }
 
-    public Page getNextPage() {
-        return nextPage;
-    }
+        /**
+         * The current list of items of this page
+         */
+        private final List<T> itemsList;
 
-    public void setNextPage(final Page page) {
-        this.nextPage = page;
-    }
+        /**
+         * Url pointing to the next page relative to this one
+         *
+         * @see ListExtractor#getPage(Page)
+         * @see Page
+         */
+        private final Page nextPage;
 
-    public List<FilterItem> getContentFilters() {
-        return contentFilters;
-    }
+        /**
+         * Errors that happened during the extraction
+         */
+        private final List<Throwable> errors;
 
-    public List<FilterItem> getSortFilter() {
-        return sortFilter;
+        public InfoItemsPage(final InfoItemsCollector<T, ?> collector, final Page nextPage) {
+            this(collector.getItems(), nextPage, collector.getErrors());
+        }
+
+        public InfoItemsPage(final List<T> itemsList,
+                             final Page nextPage,
+                             final List<Throwable> errors) {
+            this(itemsList, nextPage, errors, false);
+        }
+
+        /**
+         * Creates a page while optionally preserving a valid continuation when no items were
+         * successfully parsed. This is useful for feeds where a legitimate page can contain only
+         * unavailable, deleted or otherwise unsupported renderers while later pages remain valid.
+         */
+        public InfoItemsPage(final List<T> itemsList,
+                             Page nextPage,
+                             final List<Throwable> errors,
+                             final boolean preserveNextPageWhenEmpty) {
+            if (!preserveNextPageWhenEmpty && itemsList.isEmpty()) {
+                nextPage = null;
+            }
+            this.itemsList = itemsList;
+            this.nextPage = nextPage;
+            this.errors = errors;
+        }
+
+        public boolean hasNextPage() {
+            return Page.isValid(nextPage);
+        }
+
+        public List<T> getItems() {
+            return itemsList;
+        }
+
+        public Page getNextPage() {
+            return nextPage;
+        }
+
+        public List<Throwable> getErrors() {
+            return errors;
+        }
     }
 }

--- a/third_party/LevyraExtractor/extractor/src/main/java/org/schabi/newpipe/extractor/ListInfo.java
+++ b/third_party/LevyraExtractor/extractor/src/main/java/org/schabi/newpipe/extractor/ListInfo.java
@@ -1,156 +1,62 @@
 package org.schabi.newpipe.extractor;
 
-import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.search.filter.FilterItem;
+
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
+
 import java.util.List;
 
-import javax.annotation.Nonnull;
+public abstract class ListInfo<T extends InfoItem> extends Info {
+    private List<T> relatedItems;
+    private Page nextPage = null;
+    private final List<FilterItem> contentFilters;
+    private final List<FilterItem> sortFilter;
 
-
-/**
- * Base class to extractors that have a list (e.g. playlists, users).
- * @param <R> the info item type this list extractor provides
- */
-public abstract class ListExtractor<R extends InfoItem> extends Extractor {
-    /**
-     * Constant that should be returned whenever
-     * a list has an unknown number of items.
-     */
-    public static final long ITEM_COUNT_UNKNOWN = -1;
-    /**
-     * Constant that should be returned whenever a list has an
-     * infinite number of items. For example a YouTube mix.
-     */
-    public static final long ITEM_COUNT_INFINITE = -2;
-    /**
-     * Constant that should be returned whenever a list
-     * has an unknown number of items bigger than 100.
-     */
-    public static final long ITEM_COUNT_MORE_THAN_100 = -3;
-
-    public ListExtractor(final StreamingService service, final ListLinkHandler linkHandler) {
-        super(service, linkHandler);
+    public ListInfo(final int serviceId,
+                    final String id,
+                    final String url,
+                    final String originalUrl,
+                    final String name,
+                    final List<FilterItem> contentFilter,
+                    final List<FilterItem> sortFilter) {
+        super(serviceId, id, url, originalUrl, name);
+        this.contentFilters = contentFilter;
+        this.sortFilter = sortFilter;
     }
 
-    /**
-     * A {@link InfoItemsPage InfoItemsPage} corresponding to the initial page
-     * where the items are from the initial request and the nextPage relative to it.
-     *
-     * @return a {@link InfoItemsPage} corresponding to the initial page
-     */
-    @Nonnull
-    public abstract InfoItemsPage<R> getInitialPage() throws IOException, ExtractionException;
-
-    @Nonnull
-    public InfoItemsPage<R> getFullPage() throws IOException, ExtractionException {
-        InfoItemsPage<R> currentPage = getInitialPage();
-        final ArrayList<R> items = new ArrayList<>(currentPage.getItems());
-        final ArrayList<Throwable> errors = new ArrayList<>(currentPage.getErrors());
-        while (currentPage.hasNextPage()) {
-            currentPage = getPage(currentPage.getNextPage());
-            items.addAll(currentPage.getItems());
-            errors.addAll(currentPage.getErrors());
-        }
-        return new InfoItemsPage<>(items, null, errors);
+    public ListInfo(final int serviceId,
+                    final ListLinkHandler listUrlIdHandler,
+                    final String name) {
+        super(serviceId, listUrlIdHandler, name);
+        this.contentFilters = listUrlIdHandler.getContentFilters();
+        this.sortFilter = listUrlIdHandler.getSortFilter();
     }
 
-    /**
-     * Get a list of items corresponding to the specific requested page.
-     *
-     * @param page any page got from the exclusive implementation of the list extractor
-     * @return a {@link InfoItemsPage} corresponding to the requested page
-     * @see InfoItemsPage#getNextPage()
-     */
-    public abstract InfoItemsPage<R> getPage(Page page) throws IOException, ExtractionException;
-
-    @Nonnull
-    @Override
-    public ListLinkHandler getLinkHandler() {
-        return (ListLinkHandler) super.getLinkHandler();
+    public List<T> getRelatedItems() {
+        return relatedItems;
     }
 
-    /*//////////////////////////////////////////////////////////////////////////
-    // Inner
-    //////////////////////////////////////////////////////////////////////////*/
+    public void setRelatedItems(final List<T> relatedItems) {
+        this.relatedItems = relatedItems;
+    }
 
-    /**
-     * A class that is used to wrap a list of gathered items and eventual errors, it
-     * also contains a field that points to the next available page ({@link #nextPage}).
-     * @param <T> the info item type that this page is supposed to store and provide
-     */
-    public static class InfoItemsPage<T extends InfoItem> {
-        /**
-         * A convenient method that returns a representation of an empty page.
-         *
-         * @return a type-safe page with the list of items and errors empty and the nextPage set to
-         *         {@code null}.
-         */
-        public static <T extends InfoItem> InfoItemsPage<T> emptyPage() {
-            return new InfoItemsPage<>(Collections.emptyList(), null, Collections.emptyList());
-        }
+    public boolean hasNextPage() {
+        return Page.isValid(nextPage);
+    }
 
-        /**
-         * The current list of items of this page
-         */
-        private final List<T> itemsList;
+    public Page getNextPage() {
+        return nextPage;
+    }
 
-        /**
-         * Url pointing to the next page relative to this one
-         *
-         * @see ListExtractor#getPage(Page)
-         * @see Page
-         */
-        private final Page nextPage;
+    public void setNextPage(final Page page) {
+        this.nextPage = page;
+    }
 
-        /**
-         * Errors that happened during the extraction
-         */
-        private final List<Throwable> errors;
+    public List<FilterItem> getContentFilters() {
+        return contentFilters;
+    }
 
-        public InfoItemsPage(final InfoItemsCollector<T, ?> collector, final Page nextPage) {
-            this(collector.getItems(), nextPage, collector.getErrors());
-        }
-
-        public InfoItemsPage(final List<T> itemsList,
-                             final Page nextPage,
-                             final List<Throwable> errors) {
-            this(itemsList, nextPage, errors, false);
-        }
-
-        /**
-         * Creates a page while optionally preserving a valid continuation when no items were
-         * successfully parsed. This is useful for feeds where a legitimate page can contain only
-         * unavailable, deleted or otherwise unsupported renderers while later pages remain valid.
-         */
-        public InfoItemsPage(final List<T> itemsList,
-                             Page nextPage,
-                             final List<Throwable> errors,
-                             final boolean preserveNextPageWhenEmpty) {
-            if (!preserveNextPageWhenEmpty && itemsList.isEmpty()) {
-                nextPage = null;
-            }
-            this.itemsList = itemsList;
-            this.nextPage = nextPage;
-            this.errors = errors;
-        }
-
-        public boolean hasNextPage() {
-            return Page.isValid(nextPage);
-        }
-
-        public List<T> getItems() {
-            return itemsList;
-        }
-
-        public Page getNextPage() {
-            return nextPage;
-        }
-
-        public List<Throwable> getErrors() {
-            return errors;
-        }
+    public List<FilterItem> getSortFilter() {
+        return sortFilter;
     }
 }

--- a/third_party/LevyraExtractor/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsExtractor.java
+++ b/third_party/LevyraExtractor/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsExtractor.java
@@ -22,6 +22,15 @@ public abstract class CommentsExtractor extends ListExtractor<CommentsInfoItem> 
         return false;
     }
 
+    /**
+     * Human-readable total comment count as returned by the service, for example
+     * {@code "1.2K comments"}. Empty when the service does not expose it.
+     */
+    @Nonnull
+    public String getCommentsCountText() throws ExtractionException {
+        return "";
+    }
+
     @Nonnull
     @Override
     public String getName() throws ParsingException {

--- a/third_party/LevyraExtractor/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfo.java
+++ b/third_party/LevyraExtractor/extractor/src/main/java/org/schabi/newpipe/extractor/comments/CommentsInfo.java
@@ -48,6 +48,7 @@ public final class CommentsInfo extends ListInfo<CommentsInfoItem> {
         final InfoItemsPage<CommentsInfoItem> initialCommentsPage =
                 ExtractorHelper.getItemsPageOrLogError(commentsInfo, commentsExtractor);
         commentsInfo.setCommentsDisabled(commentsExtractor.isCommentsDisabled());
+        commentsInfo.setCommentsCountText(commentsExtractor.getCommentsCountText());
         commentsInfo.setRelatedItems(initialCommentsPage.getItems());
         commentsInfo.setNextPage(initialCommentsPage.getNextPage());
 
@@ -85,6 +86,7 @@ public final class CommentsInfo extends ListInfo<CommentsInfoItem> {
 
     private transient CommentsExtractor commentsExtractor;
     private boolean commentsDisabled = false;
+    private String commentsCountText = "";
 
     public CommentsExtractor getCommentsExtractor() {
         return commentsExtractor;
@@ -109,5 +111,16 @@ public final class CommentsInfo extends ListInfo<CommentsInfoItem> {
      */
     public void setCommentsDisabled(final boolean commentsDisabled) {
         this.commentsDisabled = commentsDisabled;
+    }
+
+    /**
+     * @return human-readable total comment count, or an empty string when unavailable
+     */
+    public String getCommentsCountText() {
+        return commentsCountText;
+    }
+
+    public void setCommentsCountText(final String commentsCountText) {
+        this.commentsCountText = commentsCountText == null ? "" : commentsCountText;
     }
 }

--- a/third_party/LevyraExtractor/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
+++ b/third_party/LevyraExtractor/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
@@ -39,6 +39,9 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
      */
     private boolean commentsDisabled;
 
+    /** Human-readable total comment count returned by YouTube. */
+    private String commentsCountText = "";
+
     /**
      * The second ajax <b>/next</b> response.
      */
@@ -278,7 +281,11 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
         if(jsonObjectSafe != null) {
             collectCommentsFrom(collector, jsonObject);
         }
-        return new InfoItemsPage<>(collector, getNextPage(jsonObject, jsonObjectSafe));
+        return new InfoItemsPage<>(
+                collector.getItems(),
+                getNextPage(jsonObject, jsonObjectSafe),
+                collector.getErrors(),
+                true);
     }
 
     private void collectCommentsFrom(@Nonnull final CommentsInfoItemsCollector collector,
@@ -394,6 +401,79 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
         }
     }
 
+    @Nonnull
+    @Override
+    public String getCommentsCountText() {
+        return commentsCountText;
+    }
+
+    @Nonnull
+    static String extractCommentsCountText(@Nullable final JSONObject root) {
+        if (root == null) {
+            return "";
+        }
+        final JSONObject header = findObjectForKey(root, "commentsHeaderRenderer", 0);
+        if (header == null) {
+            return "";
+        }
+        return extractText(header.optJSONObject("countText")).trim();
+    }
+
+    @Nullable
+    private static JSONObject findObjectForKey(@Nullable final Object node,
+                                               @Nonnull final String key,
+                                               final int depth) {
+        if (node == null || depth > 48) {
+            return null;
+        }
+        if (node instanceof JSONObject) {
+            final JSONObject object = (JSONObject) node;
+            final JSONObject direct = object.optJSONObject(key);
+            if (direct != null) {
+                return direct;
+            }
+            final java.util.Iterator<String> keys = object.keys();
+            while (keys.hasNext()) {
+                final JSONObject found = findObjectForKey(object.opt(keys.next()), key, depth + 1);
+                if (found != null) {
+                    return found;
+                }
+            }
+        } else if (node instanceof JSONArray) {
+            final JSONArray array = (JSONArray) node;
+            for (int index = 0; index < array.length(); index++) {
+                final JSONObject found = findObjectForKey(array.opt(index), key, depth + 1);
+                if (found != null) {
+                    return found;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Nonnull
+    private static String extractText(@Nullable final JSONObject textObject) {
+        if (textObject == null) {
+            return "";
+        }
+        final String simpleText = textObject.optString("simpleText", "").trim();
+        if (!simpleText.isEmpty()) {
+            return simpleText;
+        }
+        final JSONArray runs = textObject.optJSONArray("runs");
+        if (runs == null) {
+            return "";
+        }
+        final StringBuilder builder = new StringBuilder();
+        for (int index = 0; index < runs.length(); index++) {
+            final JSONObject run = runs.optJSONObject(index);
+            if (run != null) {
+                builder.append(run.optString("text", ""));
+            }
+        }
+        return builder.toString();
+    }
+
     @Override
     public void onFetchPage(@Nonnull final Downloader downloader)
             throws IOException, ExtractionException {
@@ -425,8 +505,10 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
         ajaxJson = JsonUtils.toJsonObject(resp);
         try {
             ajaxJsonSafe = new JSONObject(resp);
+            commentsCountText = extractCommentsCountText(ajaxJsonSafe);
         } catch (JSONException e) {
-            e.printStackTrace();
+            ajaxJsonSafe = null;
+            commentsCountText = "";
         }
     }
 

--- a/third_party/LevyraExtractor/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
+++ b/third_party/LevyraExtractor/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeCommentsExtractor.java
@@ -157,20 +157,24 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
             return null;
         }
 
-        if(jsonObjectSafe == null) {
-            return getNextPage(onResponseReceivedEndpoints
-                    .getObject(0)
-                    .getObject("reloadContinuationItemsCommand")
-                    .getArray("continuationItems")
-                    .getObject(0)
-                    .getObject("commentsHeaderRenderer")
-                    .getObject("sortMenu")
-                    .getObject("sortFilterSubMenuRenderer")
-                    .getArray("subMenuItems")
-                    .getObject(0)
-                    .getObject("serviceEndpoint")
-                    .getObject("continuationCommand")
-                    .getString("token"));
+        if (jsonObjectSafe == null) {
+            try {
+                return getNextPage(onResponseReceivedEndpoints
+                        .getObject(0)
+                        .getObject("reloadContinuationItemsCommand")
+                        .getArray("continuationItems")
+                        .getObject(0)
+                        .getObject("commentsHeaderRenderer")
+                        .getObject("sortMenu")
+                        .getObject("sortFilterSubMenuRenderer")
+                        .getArray("subMenuItems")
+                        .getObject(0)
+                        .getObject("serviceEndpoint")
+                        .getObject("continuationCommand")
+                        .getString("token"));
+            } catch (final Exception ignored) {
+                return null;
+            }
         }
 
         final JsonArray continuationItemsArray;
@@ -264,11 +268,12 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
 
         String resp = getJsonPostResponseRaw("next", body, localization);
         final JsonObject jsonObject = JsonUtils.toJsonObject(resp);
-        final JSONObject jsonObjectSafe;
+        JSONObject jsonObjectSafe = null;
         try {
             jsonObjectSafe = new JSONObject(resp);
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
+        } catch (final JSONException ignored) {
+            // NanoJSON already parsed the response. The org.json representation is optional and
+            // only used for a few defensive continuation/count fallbacks.
         }
 
         return extractComments(jsonObject, jsonObjectSafe);
@@ -278,9 +283,7 @@ public class YoutubeCommentsExtractor extends CommentsExtractor {
             throws ExtractionException {
         final CommentsInfoItemsCollector collector = new CommentsInfoItemsCollector(
                 getServiceId());
-        if(jsonObjectSafe != null) {
-            collectCommentsFrom(collector, jsonObject);
-        }
+        collectCommentsFrom(collector, jsonObject);
         return new InfoItemsPage<>(
                 collector.getItems(),
                 getNextPage(jsonObject, jsonObjectSafe),


### PR DESCRIPTION
## Summary

- Add reliable YouTube engagement information to the player.
- Show real like counts, estimated dislike counts and read-only comments.
- Keep engagement controls informational, without pretending to submit votes.

## Scope

- [ ] Player / audio
- [ ] Stream extraction
- [ ] Downloads
- [x] UI / Compose
- [ ] Localization
- [ ] Android Auto / media session
- [ ] CI / release
- [x] Documentation

## What changed

- Added estimated dislike counts using Return YouTube Dislike.
- Clearly mark dislike values as estimates using the `~` symbol.
- Added visible attribution for Return YouTube Dislike.
- Kept the like and dislike controls non-clickable to avoid fake voting behavior.
- Added the available YouTube like count to the player engagement row.
- Added the total comment count.
- Added an expandable read-only comments bottom sheet.
- Added support for comment avatars, authors, verified badges, pinned comments, creator hearts, publication dates and comment like counts.
- Added support for comment replies and continuation-based pagination.
- Added protection against repeated continuation tokens and pagination loops.
- Continue through valid comment pages even when a page contains no readable comments.
- Added caching, request sharing, timeouts and stale-result protection when changing tracks.
- Added secure handling for external URLs and Return YouTube Dislike requests.
- Preserve the existing Brano / Video selection, playback behavior and Motion Artwork.
- Keep the existing playlist pagination correction untouched.

## Testing

- [ ] `gradle --no-daemon :app:lintRelease`
- [ ] `gradle --no-daemon testReleaseUnitTest`
- [ ] `gradle --no-daemon assembleRelease`
- [x] APK installed on device
- [ ] Playback tested
- [ ] Downloads tested
- [ ] Language switching tested

Additional checks completed:

- [x] `git diff --check`
- [x] Patch application checked on a clean source tree
- [x] New Kotlin sources compiled with test stubs
- [x] Return YouTube Dislike response parsing tested
- [x] Comment continuation and anti-loop behavior tested
- [x] External avatar and author URL validation tested
- [x] Confirmed that `YoutubeMusicRepository.kt` is not overwritten by this patch

The full Gradle checks were not completed because the build environment could not download the required Gradle distribution.

## Release safety

- [ ] `levyraVersionName` and `levyraVersionCode` are correct
- [x] No secrets, keystores, APKs or ZIPs committed
- [x] No duplicated release workflows
- [x] Credits and licenses updated when adding external components