### PR TITLE
Polish home screen visual design

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -4858,13 +4858,12 @@ private fun HomeQuickPicksShelf(
     onPlay: (Track) -> Unit,
     onPlayAll: () -> Unit
 ) {
-    val shelfTracks = remember(tracks) {
+    val columns = remember(tracks) {
         tracks
             .distinctBy(LevyraPersonalOrbit::identityKey)
             .take(21)
+            .chunked(3)
     }
-    val featured = shelfTracks.firstOrNull()
-    val columns = remember(shelfTracks) { shelfTracks.drop(1).chunked(2) }
     Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
         HomeSectionInset {
             SectionHeaderAction(title, onPlayAll)
@@ -4877,20 +4876,6 @@ private fun HomeQuickPicksShelf(
                 end = HomeHorizontalShelfEndPadding
             )
         ) {
-            if (featured != null) {
-                item(
-                    key = "quick-picks-featured-${featured.id}",
-                    contentType = "quick-picks-featured"
-                ) {
-                    HomeQuickPickFeaturedCard(
-                        track = featured,
-                        isCurrent = featured.id == currentId,
-                        isPlaying = isPlaying && featured.id == currentId,
-                        isResolving = isResolving && featured.id == currentId,
-                        onPlay = { onPlay(featured) }
-                    )
-                }
-            }
             itemsIndexed(
                 items = columns,
                 key = { columnIndex, column ->
@@ -4912,107 +4897,6 @@ private fun HomeQuickPicksShelf(
                         )
                     }
                 }
-            }
-        }
-    }
-}
-
-@Composable
-private fun HomeQuickPickFeaturedCard(
-    track: Track,
-    isCurrent: Boolean,
-    isPlaying: Boolean,
-    isResolving: Boolean,
-    onPlay: () -> Unit
-) {
-    val shape = RoundedCornerShape(17.dp)
-    Box(
-        modifier = Modifier
-            .width(168.dp)
-            .height(148.dp)
-            .clip(shape)
-            .border(
-                width = if (isCurrent) 1.5.dp else Dp.Hairline,
-                color = if (isCurrent) LevyraCyan.copy(alpha = 0.8f) else Color.White.copy(alpha = 0.10f),
-                shape = shape
-            )
-            .pressable(onClick = onPlay)
-    ) {
-        CoverImage(
-            track = track,
-            modifier = Modifier.fillMaxSize(),
-            highRes = true
-        )
-        Box(
-            modifier = Modifier
-                .matchParentSize()
-                .background(
-                    Brush.verticalGradient(
-                        listOf(
-                            Color.Transparent,
-                            Color.Black.copy(alpha = 0.32f),
-                            Color.Black.copy(alpha = 0.82f)
-                        )
-                    )
-                )
-        )
-        Column(
-            modifier = Modifier
-                .align(Alignment.BottomStart)
-                .fillMaxWidth()
-                .padding(start = 12.dp, end = 12.dp, bottom = 10.dp),
-            verticalArrangement = Arrangement.spacedBy(2.dp)
-        ) {
-            Text(
-                text = track.title,
-                color = Color.White,
-                fontSize = 14.5.sp,
-                lineHeight = 17.sp,
-                fontWeight = FontWeight.Black,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            Text(
-                text = track.artist,
-                color = Color.White.copy(alpha = 0.72f),
-                fontSize = 11.5.sp,
-                lineHeight = 14.sp,
-                fontWeight = FontWeight.SemiBold,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
-        Box(
-            modifier = Modifier
-                .align(Alignment.TopEnd)
-                .padding(8.dp)
-                .size(30.dp)
-                .background(Color.Black.copy(alpha = 0.45f), CircleShape)
-                .border(
-                    Dp.Hairline,
-                    if (isCurrent) LevyraCyan.copy(alpha = 0.5f) else Color.White.copy(alpha = 0.14f),
-                    CircleShape
-                ),
-            contentAlignment = Alignment.Center
-        ) {
-            when {
-                isResolving -> CircularProgressIndicator(
-                    modifier = Modifier.size(14.dp),
-                    strokeWidth = 1.8.dp,
-                    color = LevyraCyan
-                )
-                isCurrent && isPlaying -> ActiveTrackEqualizer(
-                    color = LevyraCyan,
-                    isPlaying = true,
-                    width = 14.dp,
-                    height = 10.dp
-                )
-                else -> Icon(
-                    imageVector = Icons.Rounded.PlayArrow,
-                    contentDescription = null,
-                    tint = Color.White,
-                    modifier = Modifier.size(17.dp)
-                )
             }
         }
     }
@@ -13366,25 +13250,27 @@ private fun HomeAlbumLoadingRow() {
     ) {
         items(4, key = { "home-album-loading-$it" }) {
             Column(
-                modifier = Modifier.width(176.dp).shimmer(),
+                modifier = Modifier.width(156.dp).shimmer(),
                 verticalArrangement = Arrangement.spacedBy(10.dp)
             ) {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(148.dp)
+                        .height(166.dp)
                 ) {
                     Box(
                         modifier = Modifier
-                            .size(132.dp)
-                            .align(Alignment.CenterEnd)
-                            .clip(CircleShape)
+                            .size(134.dp)
+                            .align(Alignment.TopCenter)
+                            .offset(y = 6.dp)
+                            .graphicsLayer { rotationZ = 5f }
+                            .clip(RoundedCornerShape(18.dp))
                             .background(Color.White.copy(alpha = 0.05f))
                     )
                     Box(
                         modifier = Modifier
                             .size(148.dp)
-                            .align(Alignment.CenterStart)
+                            .align(Alignment.BottomCenter)
                             .clip(RoundedCornerShape(18.dp))
                             .background(Color.White.copy(alpha = 0.075f))
                     )
@@ -13405,68 +13291,6 @@ private fun HomeAlbumLoadingRow() {
                 )
             }
         }
-    }
-}
-
-@Composable
-private fun VinylDisc(modifier: Modifier = Modifier) {
-    Canvas(modifier = modifier) {
-        val radius = size.minDimension / 2f
-        val discCenter = center
-        drawCircle(
-            brush = Brush.radialGradient(
-                colors = listOf(
-                    Color(0xFF23242B),
-                    Color(0xFF101116),
-                    Color(0xFF07080B)
-                ),
-                center = discCenter,
-                radius = radius
-            ),
-            radius = radius,
-            center = discCenter
-        )
-        drawCircle(
-            color = Color.White.copy(alpha = 0.09f),
-            radius = radius - 0.5.dp.toPx(),
-            center = discCenter,
-            style = Stroke(width = 1.dp.toPx())
-        )
-        listOf(0.88f, 0.76f, 0.64f, 0.52f).forEach { fraction ->
-            drawCircle(
-                color = Color.White.copy(alpha = 0.045f),
-                radius = radius * fraction,
-                center = discCenter,
-                style = Stroke(width = 1.dp.toPx())
-            )
-        }
-        drawArc(
-            color = Color.White.copy(alpha = 0.07f),
-            startAngle = -108f,
-            sweepAngle = 76f,
-            useCenter = false,
-            topLeft = androidx.compose.ui.geometry.Offset(
-                discCenter.x - radius * 0.70f,
-                discCenter.y - radius * 0.70f
-            ),
-            size = androidx.compose.ui.geometry.Size(radius * 1.40f, radius * 1.40f),
-            style = Stroke(width = 1.5.dp.toPx())
-        )
-        drawCircle(
-            brush = Brush.linearGradient(
-                listOf(
-                    LevyraCyan.copy(alpha = 0.85f),
-                    LevyraViolet.copy(alpha = 0.85f)
-                )
-            ),
-            radius = radius * 0.32f,
-            center = discCenter
-        )
-        drawCircle(
-            color = Color(0xFF0A0B0E),
-            radius = radius * 0.06f,
-            center = discCenter
-        )
     }
 }
 
@@ -13496,7 +13320,7 @@ private fun HomeAlbumHitRow(albums: List<AlbumHit>, animationsEnabled: Boolean, 
                         scaleX = scale
                         scaleY = scale
                     }
-                    .width(176.dp)
+                    .width(156.dp)
                     .clickable(
                         interactionSource = interaction,
                         indication = null,
@@ -13507,12 +13331,27 @@ private fun HomeAlbumHitRow(albums: List<AlbumHit>, animationsEnabled: Boolean, 
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(148.dp)
+                        .height(166.dp)
                 ) {
-                    VinylDisc(
+                    Box(
                         modifier = Modifier
-                            .size(132.dp)
-                            .align(Alignment.CenterEnd)
+                            .size(134.dp)
+                            .align(Alignment.TopCenter)
+                            .offset(y = 4.dp)
+                            .graphicsLayer { rotationZ = -7f }
+                            .clip(RoundedCornerShape(18.dp))
+                            .background(cinematicGlassBrush(LevyraViolet, LevyraPink, 0.9f))
+                            .border(Dp.Hairline, Color.White.copy(alpha = 0.08f), RoundedCornerShape(18.dp))
+                    )
+                    Box(
+                        modifier = Modifier
+                            .size(134.dp)
+                            .align(Alignment.TopCenter)
+                            .offset(y = 9.dp)
+                            .graphicsLayer { rotationZ = 5f }
+                            .clip(RoundedCornerShape(18.dp))
+                            .background(cinematicGlassBrush(LevyraCyan, LevyraViolet, 0.9f))
+                            .border(Dp.Hairline, Color.White.copy(alpha = 0.10f), RoundedCornerShape(18.dp))
                     )
                     Surface(
                         color = CinematicGlass.copy(alpha = 0.3f),
@@ -13521,7 +13360,7 @@ private fun HomeAlbumHitRow(albums: List<AlbumHit>, animationsEnabled: Boolean, 
                         shadowElevation = 0.dp,
                         modifier = Modifier
                             .size(148.dp)
-                            .align(Alignment.CenterStart)
+                            .align(Alignment.BottomCenter)
                     ) {
                         Box(modifier = Modifier.fillMaxSize()) {
                             if (album.thumbnailUrl.isNotBlank()) {
@@ -13549,6 +13388,24 @@ private fun HomeAlbumHitRow(albums: List<AlbumHit>, animationsEnabled: Boolean, 
                                     .matchParentSize()
                                     .background(Brush.verticalGradient(listOf(Color.Transparent, Color.Transparent, Color.Black.copy(alpha = 0.34f))))
                             )
+                            if (album.year.isNotBlank()) {
+                                Surface(
+                                    color = CinematicGlassDeep.copy(alpha = 0.55f),
+                                    border = BorderStroke(Dp.Hairline, Color.White.copy(alpha = 0.15f)),
+                                    shape = RoundedCornerShape(8.dp),
+                                    modifier = Modifier
+                                        .align(Alignment.BottomStart)
+                                        .padding(8.dp)
+                                ) {
+                                    Text(
+                                        text = album.year,
+                                        color = Color.White,
+                                        fontSize = 9.5.sp,
+                                        fontWeight = FontWeight.Bold,
+                                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 3.dp)
+                                    )
+                                }
+                            }
                             if (album.explicit) {
                                 Surface(
                                     color = CinematicGlassDeep.copy(alpha = 0.55f),
@@ -13561,7 +13418,7 @@ private fun HomeAlbumHitRow(albums: List<AlbumHit>, animationsEnabled: Boolean, 
                                     Icon(
                                         imageVector = Icons.Rounded.Explicit,
                                         contentDescription = null,
-                                        tint = LevyraText,
+                                        tint = Color.White,
                                         modifier = Modifier
                                             .padding(3.dp)
                                             .size(13.dp)
@@ -13573,7 +13430,7 @@ private fun HomeAlbumHitRow(albums: List<AlbumHit>, animationsEnabled: Boolean, 
                 }
                 Column(modifier = Modifier.padding(horizontal = 4.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     Text(album.title, color = LevyraText, fontSize = 13.5.sp, lineHeight = 15.5.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = (-0.3).sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                    val subtitle = listOf(LocalLevyraStrings.current.albumPlain, album.artist, album.year).filter { it.isNotBlank() }.joinToString(" • ")
+                    val subtitle = listOf(LocalLevyraStrings.current.albumPlain, album.artist).filter { it.isNotBlank() }.joinToString(" • ")
                     Text(subtitle, color = LevyraMuted, fontSize = 11.5.sp, fontWeight = FontWeight.Medium, maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -100,6 +100,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Album
+import androidx.compose.material.icons.rounded.Explicit
 import androidx.compose.material.icons.rounded.Explore
 import androidx.compose.material.icons.rounded.GraphicEq
 import androidx.compose.material.icons.rounded.Headphones
@@ -4857,12 +4858,13 @@ private fun HomeQuickPicksShelf(
     onPlay: (Track) -> Unit,
     onPlayAll: () -> Unit
 ) {
-    val columns = remember(tracks) {
+    val shelfTracks = remember(tracks) {
         tracks
             .distinctBy(LevyraPersonalOrbit::identityKey)
-            .take(20)
-            .chunked(2)
+            .take(21)
     }
+    val featured = shelfTracks.firstOrNull()
+    val columns = remember(shelfTracks) { shelfTracks.drop(1).chunked(2) }
     Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
         HomeSectionInset {
             SectionHeaderAction(title, onPlayAll)
@@ -4875,6 +4877,20 @@ private fun HomeQuickPicksShelf(
                 end = HomeHorizontalShelfEndPadding
             )
         ) {
+            if (featured != null) {
+                item(
+                    key = "quick-picks-featured-${featured.id}",
+                    contentType = "quick-picks-featured"
+                ) {
+                    HomeQuickPickFeaturedCard(
+                        track = featured,
+                        isCurrent = featured.id == currentId,
+                        isPlaying = isPlaying && featured.id == currentId,
+                        isResolving = isResolving && featured.id == currentId,
+                        onPlay = { onPlay(featured) }
+                    )
+                }
+            }
             itemsIndexed(
                 items = columns,
                 key = { columnIndex, column ->
@@ -4902,6 +4918,107 @@ private fun HomeQuickPicksShelf(
 }
 
 @Composable
+private fun HomeQuickPickFeaturedCard(
+    track: Track,
+    isCurrent: Boolean,
+    isPlaying: Boolean,
+    isResolving: Boolean,
+    onPlay: () -> Unit
+) {
+    val shape = RoundedCornerShape(17.dp)
+    Box(
+        modifier = Modifier
+            .width(168.dp)
+            .height(148.dp)
+            .clip(shape)
+            .border(
+                width = if (isCurrent) 1.5.dp else Dp.Hairline,
+                color = if (isCurrent) LevyraCyan.copy(alpha = 0.8f) else Color.White.copy(alpha = 0.10f),
+                shape = shape
+            )
+            .pressable(onClick = onPlay)
+    ) {
+        CoverImage(
+            track = track,
+            modifier = Modifier.fillMaxSize(),
+            highRes = true
+        )
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .background(
+                    Brush.verticalGradient(
+                        listOf(
+                            Color.Transparent,
+                            Color.Black.copy(alpha = 0.32f),
+                            Color.Black.copy(alpha = 0.82f)
+                        )
+                    )
+                )
+        )
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .fillMaxWidth()
+                .padding(start = 12.dp, end = 12.dp, bottom = 10.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
+            Text(
+                text = track.title,
+                color = Color.White,
+                fontSize = 14.5.sp,
+                lineHeight = 17.sp,
+                fontWeight = FontWeight.Black,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = track.artist,
+                color = Color.White.copy(alpha = 0.72f),
+                fontSize = 11.5.sp,
+                lineHeight = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(8.dp)
+                .size(30.dp)
+                .background(Color.Black.copy(alpha = 0.45f), CircleShape)
+                .border(
+                    Dp.Hairline,
+                    if (isCurrent) LevyraCyan.copy(alpha = 0.5f) else Color.White.copy(alpha = 0.14f),
+                    CircleShape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            when {
+                isResolving -> CircularProgressIndicator(
+                    modifier = Modifier.size(14.dp),
+                    strokeWidth = 1.8.dp,
+                    color = LevyraCyan
+                )
+                isCurrent && isPlaying -> ActiveTrackEqualizer(
+                    color = LevyraCyan,
+                    isPlaying = true,
+                    width = 14.dp,
+                    height = 10.dp
+                )
+                else -> Icon(
+                    imageVector = Icons.Rounded.PlayArrow,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(17.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
 private fun HomeQuickPickRow(
     track: Track,
     isCurrent: Boolean,
@@ -4913,18 +5030,22 @@ private fun HomeQuickPickRow(
     val background = if (isCurrent) {
         Brush.horizontalGradient(
             listOf(
-                LevyraCyan.copy(alpha = 0.13f),
-                LevyraViolet.copy(alpha = 0.045f),
+                LevyraCyan.copy(alpha = 0.16f),
+                LevyraViolet.copy(alpha = 0.06f),
                 Color.Transparent
             )
         )
     } else {
-        SolidColor(Color.Transparent)
+        cinematicGlassBrush(
+            accentStart = Color(track.accentStart),
+            accentEnd = Color(track.accentEnd),
+            intensity = 0.6f
+        )
     }
     val outlineColor = if (isCurrent) {
         LevyraCyan.copy(alpha = 0.24f)
     } else {
-        Color.White.copy(alpha = 0.055f)
+        LevyraAdaptiveSoftHairline
     }
 
     Row(
@@ -13245,16 +13366,29 @@ private fun HomeAlbumLoadingRow() {
     ) {
         items(4, key = { "home-album-loading-$it" }) {
             Column(
-                modifier = Modifier.width(148.dp).shimmer(),
+                modifier = Modifier.width(176.dp).shimmer(),
                 verticalArrangement = Arrangement.spacedBy(10.dp)
             ) {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .aspectRatio(1f)
-                        .clip(RoundedCornerShape(18.dp))
-                        .background(Color.White.copy(alpha = 0.075f))
-                )
+                        .height(148.dp)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(132.dp)
+                            .align(Alignment.CenterEnd)
+                            .clip(CircleShape)
+                            .background(Color.White.copy(alpha = 0.05f))
+                    )
+                    Box(
+                        modifier = Modifier
+                            .size(148.dp)
+                            .align(Alignment.CenterStart)
+                            .clip(RoundedCornerShape(18.dp))
+                            .background(Color.White.copy(alpha = 0.075f))
+                    )
+                }
                 Box(
                     modifier = Modifier
                         .fillMaxWidth(0.78f)
@@ -13275,6 +13409,68 @@ private fun HomeAlbumLoadingRow() {
 }
 
 @Composable
+private fun VinylDisc(modifier: Modifier = Modifier) {
+    Canvas(modifier = modifier) {
+        val radius = size.minDimension / 2f
+        val discCenter = center
+        drawCircle(
+            brush = Brush.radialGradient(
+                colors = listOf(
+                    Color(0xFF23242B),
+                    Color(0xFF101116),
+                    Color(0xFF07080B)
+                ),
+                center = discCenter,
+                radius = radius
+            ),
+            radius = radius,
+            center = discCenter
+        )
+        drawCircle(
+            color = Color.White.copy(alpha = 0.09f),
+            radius = radius - 0.5.dp.toPx(),
+            center = discCenter,
+            style = Stroke(width = 1.dp.toPx())
+        )
+        listOf(0.88f, 0.76f, 0.64f, 0.52f).forEach { fraction ->
+            drawCircle(
+                color = Color.White.copy(alpha = 0.045f),
+                radius = radius * fraction,
+                center = discCenter,
+                style = Stroke(width = 1.dp.toPx())
+            )
+        }
+        drawArc(
+            color = Color.White.copy(alpha = 0.07f),
+            startAngle = -108f,
+            sweepAngle = 76f,
+            useCenter = false,
+            topLeft = androidx.compose.ui.geometry.Offset(
+                discCenter.x - radius * 0.70f,
+                discCenter.y - radius * 0.70f
+            ),
+            size = androidx.compose.ui.geometry.Size(radius * 1.40f, radius * 1.40f),
+            style = Stroke(width = 1.5.dp.toPx())
+        )
+        drawCircle(
+            brush = Brush.linearGradient(
+                listOf(
+                    LevyraCyan.copy(alpha = 0.85f),
+                    LevyraViolet.copy(alpha = 0.85f)
+                )
+            ),
+            radius = radius * 0.32f,
+            center = discCenter
+        )
+        drawCircle(
+            color = Color(0xFF0A0B0E),
+            radius = radius * 0.06f,
+            center = discCenter
+        )
+    }
+}
+
+@Composable
 private fun HomeAlbumHitRow(albums: List<AlbumHit>, animationsEnabled: Boolean, onOpen: (AlbumHit) -> Unit) {
     if (albums.isEmpty()) return
     val effectiveAnimationsEnabled = animationsEnabled && LocalAnimationsEnabled.current
@@ -13286,7 +13482,7 @@ private fun HomeAlbumHitRow(albums: List<AlbumHit>, animationsEnabled: Boolean, 
             items = albums,
             key = { index, album -> "home-album-$index-${album.browseId.ifBlank { "${album.title.trim().lowercase()}|${album.artist.trim().lowercase()}" }}" },
             contentType = { _, _ -> "home-album-card" }
-        ) { index, album ->
+        ) { _, album ->
             val interaction = remember { MutableInteractionSource() }
             val isPressed by interaction.collectIsPressedAsState()
             val scale by animateFloatAsState(
@@ -13300,7 +13496,7 @@ private fun HomeAlbumHitRow(albums: List<AlbumHit>, animationsEnabled: Boolean, 
                         scaleX = scale
                         scaleY = scale
                     }
-                    .width(148.dp)
+                    .width(176.dp)
                     .clickable(
                         interactionSource = interaction,
                         indication = null,
@@ -13308,57 +13504,69 @@ private fun HomeAlbumHitRow(albums: List<AlbumHit>, animationsEnabled: Boolean, 
                     ),
                 verticalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-                Surface(
-                    color = CinematicGlass.copy(alpha = 0.3f),
-                    border = BorderStroke(Dp.Hairline, Color.White.copy(alpha = 0.12f)),
-                    shape = RoundedCornerShape(18.dp),
-                    shadowElevation = 0.dp
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(148.dp)
                 ) {
-                    Box(
+                    VinylDisc(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .aspectRatio(1f)
+                            .size(132.dp)
+                            .align(Alignment.CenterEnd)
+                    )
+                    Surface(
+                        color = CinematicGlass.copy(alpha = 0.3f),
+                        border = BorderStroke(Dp.Hairline, Color.White.copy(alpha = 0.12f)),
+                        shape = RoundedCornerShape(18.dp),
+                        shadowElevation = 0.dp,
+                        modifier = Modifier
+                            .size(148.dp)
+                            .align(Alignment.CenterStart)
                     ) {
-                        if (album.thumbnailUrl.isNotBlank()) {
-                            StableRemoteArtwork(
-                                url = album.thumbnailUrl,
-                                contentDescription = album.title,
-                                contentScale = ContentScale.Crop,
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .clip(RoundedCornerShape(18.dp))
-                            )
-                        } else {
+                        Box(modifier = Modifier.fillMaxSize()) {
+                            if (album.thumbnailUrl.isNotBlank()) {
+                                StableRemoteArtwork(
+                                    url = album.thumbnailUrl,
+                                    contentDescription = album.title,
+                                    contentScale = ContentScale.Crop,
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .clip(RoundedCornerShape(18.dp))
+                                )
+                            } else {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .clip(RoundedCornerShape(18.dp))
+                                        .background(Brush.linearGradient(listOf(LevyraPanel, LevyraInk))),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Icon(Icons.Rounded.Album, null, tint = LevyraCyan, modifier = Modifier.size(42.dp))
+                                }
+                            }
                             Box(
                                 modifier = Modifier
-                                    .fillMaxSize()
-                                    .clip(RoundedCornerShape(18.dp))
-                                    .background(Brush.linearGradient(listOf(LevyraPanel, LevyraInk))),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Icon(Icons.Rounded.Album, null, tint = LevyraCyan, modifier = Modifier.size(42.dp))
-                            }
-                        }
-                        Box(
-                            modifier = Modifier
-                                .matchParentSize()
-                                .background(Brush.verticalGradient(listOf(Color.Transparent, Color.Black.copy(alpha = 0.42f), Color.Black.copy(alpha = 0.76f))))
-                        )
-                        Surface(
-                            color = CinematicGlassDeep.copy(alpha = 0.52f),
-                            border = BorderStroke(Dp.Hairline, Color.White.copy(alpha = 0.15f)),
-                            shape = CircleShape,
-                            modifier = Modifier
-                                .align(Alignment.BottomEnd)
-                                .padding(10.dp)
-                        ) {
-                            Row(
-                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 5.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(4.dp)
-                            ) {
-                                Icon(Icons.Rounded.Album, null, tint = LevyraCyan, modifier = Modifier.size(12.dp))
-                                Text("${index + 1}", color = LevyraText, fontSize = 10.sp, fontWeight = FontWeight.Bold)
+                                    .matchParentSize()
+                                    .background(Brush.verticalGradient(listOf(Color.Transparent, Color.Transparent, Color.Black.copy(alpha = 0.34f))))
+                            )
+                            if (album.explicit) {
+                                Surface(
+                                    color = CinematicGlassDeep.copy(alpha = 0.55f),
+                                    border = BorderStroke(Dp.Hairline, Color.White.copy(alpha = 0.15f)),
+                                    shape = RoundedCornerShape(7.dp),
+                                    modifier = Modifier
+                                        .align(Alignment.BottomEnd)
+                                        .padding(8.dp)
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Rounded.Explicit,
+                                        contentDescription = null,
+                                        tint = LevyraText,
+                                        modifier = Modifier
+                                            .padding(3.dp)
+                                            .size(13.dp)
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -611,17 +611,59 @@ private fun ActiveTrackEqualizer(
     }
 }
 @Composable
+private fun SectionAccentBar(height: Dp = 20.dp, width: Dp = 3.5.dp) {
+    Box(
+        modifier = Modifier
+            .width(width)
+            .height(height)
+            .background(Brush.verticalGradient(listOf(LevyraCyan, LevyraViolet)), RoundedCornerShape(99.dp))
+    )
+}
+
+@Composable
+private fun HomePlayAllButton(onClick: () -> Unit, size: Dp = 36.dp) {
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(
+                Brush.linearGradient(
+                    listOf(
+                        LevyraCyan.copy(alpha = 0.15f),
+                        LevyraViolet.copy(alpha = 0.11f)
+                    )
+                ),
+                CircleShape
+            )
+            .border(
+                1.dp,
+                Brush.linearGradient(
+                    listOf(
+                        LevyraCyan.copy(alpha = 0.45f),
+                        LevyraViolet.copy(alpha = 0.32f)
+                    )
+                ),
+                CircleShape
+            )
+            .pressable(onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = Icons.Rounded.PlayArrow,
+            contentDescription = LocalLevyraStrings.current.play,
+            tint = LevyraCyan,
+            modifier = Modifier.size(size * 0.55f)
+        )
+    }
+}
+
+@Composable
 private fun SectionTitle(title: String) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(9.dp)
     ) {
-        Box(
-            modifier = Modifier
-                .width(3.5.dp)
-                .height(20.dp)
-                .background(Brush.verticalGradient(listOf(LevyraCyan, LevyraViolet)), RoundedCornerShape(99.dp))
-        )
+        SectionAccentBar()
         Text(title, color = LevyraText, fontSize = 20.sp, fontWeight = FontWeight.Black, letterSpacing = (-0.4).sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
     }
 }
@@ -4240,12 +4282,28 @@ private fun LevyraBackground(accentStart: Int?, accentEnd: Int?) {
                         center = haloCenter,
                         radius = haloRadius
                     )
+                    val violetHaloCenter = androidx.compose.ui.geometry.Offset(width * 0.94f, height * 0.12f)
+                    val violetHaloRadius = width * 0.64f
+                    val violetHaloBrush = Brush.radialGradient(
+                        colors = listOf(
+                            LevyraViolet.copy(alpha = 0.05f),
+                            LevyraViolet.copy(alpha = 0.015f),
+                            Color.Transparent
+                        ),
+                        center = violetHaloCenter,
+                        radius = violetHaloRadius
+                    )
                     onDrawBehind {
                         drawRect(backgroundBrush)
                         drawCircle(
                             brush = haloBrush,
                             radius = haloRadius,
                             center = haloCenter
+                        )
+                        drawCircle(
+                            brush = violetHaloBrush,
+                            radius = violetHaloRadius,
+                            center = violetHaloCenter
                         )
                     }
                 } else {
@@ -4280,6 +4338,17 @@ private fun LevyraBackground(accentStart: Int?, accentEnd: Int?) {
                         ),
                         center = rightHalo,
                         radius = rightHaloRadius
+                    )
+                    val leftHalo = androidx.compose.ui.geometry.Offset(-width * 0.06f, height * 0.56f)
+                    val leftHaloRadius = width * 0.62f
+                    val leftHaloBrush = Brush.radialGradient(
+                        colors = listOf(
+                            primaryAccent.copy(alpha = 0.055f),
+                            primaryAccent.copy(alpha = 0.018f),
+                            Color.Transparent
+                        ),
+                        center = leftHalo,
+                        radius = leftHaloRadius
                     )
                     val signalPath = androidx.compose.ui.graphics.Path().apply {
                         moveTo(-width * 0.10f, height * 0.27f)
@@ -4374,6 +4443,11 @@ private fun LevyraBackground(accentStart: Int?, accentEnd: Int?) {
                             brush = rightHaloBrush,
                             radius = rightHaloRadius,
                             center = rightHalo
+                        )
+                        drawCircle(
+                            brush = leftHaloBrush,
+                            radius = leftHaloRadius,
+                            center = leftHalo
                         )
                         drawPath(
                             path = signalPath,
@@ -5034,13 +5108,7 @@ private fun TrendingArtistsShelf(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(10.dp)
         ) {
-            Box(
-                modifier = Modifier
-                    .height(22.dp)
-                    .width(4.dp)
-                    .clip(RoundedCornerShape(99.dp))
-                    .background(Brush.verticalGradient(listOf(LevyraCyan, LevyraViolet)))
-            )
+            SectionAccentBar(height = 22.dp, width = 4.dp)
             Text(
                 text = strings.artists,
                 color = LevyraText,
@@ -5171,47 +5239,44 @@ private fun ResonanceShelf(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Column(
+            Row(
                 modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(5.dp)
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(3.dp)
-                ) {
+                SectionAccentBar(height = 32.dp, width = 4.dp)
+                Column(verticalArrangement = Arrangement.spacedBy(5.dp)) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(3.dp)
+                    ) {
+                        Text(
+                            text = strings.voicesTitle,
+                            color = LevyraText,
+                            fontSize = 24.sp,
+                            lineHeight = 27.sp,
+                            fontWeight = FontWeight.Black,
+                            letterSpacing = (-0.55).sp
+                        )
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                            contentDescription = null,
+                            tint = LevyraMuted,
+                            modifier = Modifier.size(22.dp)
+                        )
+                    }
                     Text(
-                        text = strings.voicesTitle,
-                        color = LevyraText,
-                        fontSize = 24.sp,
-                        lineHeight = 27.sp,
-                        fontWeight = FontWeight.Black,
-                        letterSpacing = (-0.55).sp
-                    )
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
-                        contentDescription = null,
-                        tint = LevyraMuted,
-                        modifier = Modifier.size(22.dp)
+                        text = strings.voicesSubtitle,
+                        color = LevyraMuted,
+                        fontSize = 12.5.sp,
+                        lineHeight = 16.sp,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
                     )
                 }
-                Text(
-                    text = strings.voicesSubtitle,
-                    color = LevyraMuted,
-                    fontSize = 12.5.sp,
-                    lineHeight = 16.sp,
-                    fontWeight = FontWeight.Medium,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
-                )
             }
-            IconButton(onClick = onPlayAll) {
-                Icon(
-                    imageVector = Icons.Rounded.PlayArrow,
-                    contentDescription = strings.play,
-                    tint = LevyraText,
-                    modifier = Modifier.size(22.dp)
-                )
-            }
+            HomePlayAllButton(onClick = onPlayAll)
         }
         LazyRow(
             modifier = Modifier.fillMaxWidth(),
@@ -5426,47 +5491,44 @@ private fun PersonalListeningShelf(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Column(
+            Row(
                 modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(3.dp)
-                ) {
+                SectionAccentBar(height = 34.dp, width = 4.dp)
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(3.dp)
+                    ) {
+                        Text(
+                            text = strings.personalOrbitTitle,
+                            color = LevyraText,
+                            fontSize = 26.sp,
+                            lineHeight = 29.sp,
+                            fontWeight = FontWeight.Black,
+                            letterSpacing = (-0.65).sp
+                        )
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                            contentDescription = null,
+                            tint = LevyraMuted,
+                            modifier = Modifier.size(23.dp)
+                        )
+                    }
                     Text(
-                        text = strings.personalOrbitTitle,
-                        color = LevyraText,
-                        fontSize = 26.sp,
-                        lineHeight = 29.sp,
-                        fontWeight = FontWeight.Black,
-                        letterSpacing = (-0.65).sp
-                    )
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
-                        contentDescription = null,
-                        tint = LevyraMuted,
-                        modifier = Modifier.size(23.dp)
+                        text = strings.personalOrbitSubtitle,
+                        color = LevyraMuted,
+                        fontSize = 12.5.sp,
+                        lineHeight = 16.sp,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
                 }
-                Text(
-                    text = strings.personalOrbitSubtitle,
-                    color = LevyraMuted,
-                    fontSize = 12.5.sp,
-                    lineHeight = 16.sp,
-                    fontWeight = FontWeight.Medium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
             }
-            IconButton(onClick = onPlayAll) {
-                Icon(
-                    imageVector = Icons.Rounded.PlayArrow,
-                    contentDescription = strings.play,
-                    tint = LevyraText,
-                    modifier = Modifier.size(22.dp)
-                )
-            }
+            HomePlayAllButton(onClick = onPlayAll)
         }
 
         HorizontalPager(
@@ -6183,7 +6245,8 @@ private fun ContinueListeningCard(
                 modifier = Modifier
                     .align(Alignment.BottomStart)
                     .fillMaxWidth(progress.coerceIn(0f, 1f))
-                    .height(2.dp)
+                    .height(3.dp)
+                    .clip(RoundedCornerShape(topEnd = 3.dp))
                     .background(Brush.horizontalGradient(listOf(accentStart, accentEnd)))
             )
         }
@@ -12714,58 +12777,58 @@ private fun LevyraWordmark(fontSize: TextUnit = 30.sp, dotSize: Dp = 5.dp) {
 
 @Composable
 private fun GreetingBar(userName: String, isResolving: Boolean, onSettings: () -> Unit) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 2.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
+    Column(verticalArrangement = Arrangement.spacedBy(13.dp)) {
         Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(14.dp),
-            modifier = Modifier.weight(1f)
-        ) {
-            LevyraLogoMark(size = 56.dp)
-            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                LevyraWordmark(fontSize = 27.sp, dotSize = 5.dp)
-                Text(
-                    text = LocalLevyraStrings.current.formatGreeting(userName, java.util.Calendar.getInstance().get(java.util.Calendar.HOUR_OF_DAY)),
-                    color = LevyraMuted,
-                    fontSize = 12.5.sp,
-                    lineHeight = 15.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    letterSpacing = 0.15.sp,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
-        }
-        Surface(
-            color = if (LevyraIsLight) Color.White.copy(alpha = 0.90f) else Color(0xFF0C0D10),
-            border = BorderStroke(Dp.Hairline, LevyraAdaptiveSoftHairline),
-            shape = RoundedCornerShape(15.dp),
             modifier = Modifier
-                .size(48.dp)
-                .pressable(onClick = onSettings)
+                .fillMaxWidth()
+                .padding(top = 2.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            Box(contentAlignment = Alignment.Center) {
-                if (isResolving) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(18.dp),
-                        strokeWidth = 2.dp,
-                        color = LevyraCyan
-                    )
-                } else {
-                    Icon(
-                        imageVector = Icons.Rounded.Settings,
-                        contentDescription = LocalLevyraStrings.current.settings,
-                        tint = LevyraText,
-                        modifier = Modifier.size(22.dp)
-                    )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(11.dp),
+                modifier = Modifier.weight(1f)
+            ) {
+                LevyraLogoMark(size = 42.dp)
+                LevyraWordmark(fontSize = 20.sp, dotSize = 4.dp)
+            }
+            Surface(
+                color = if (LevyraIsLight) Color.White.copy(alpha = 0.90f) else Color(0xFF0C0D10),
+                border = BorderStroke(Dp.Hairline, LevyraAdaptiveSoftHairline),
+                shape = RoundedCornerShape(15.dp),
+                modifier = Modifier
+                    .size(48.dp)
+                    .pressable(onClick = onSettings)
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    if (isResolving) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(18.dp),
+                            strokeWidth = 2.dp,
+                            color = LevyraCyan
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Rounded.Settings,
+                            contentDescription = LocalLevyraStrings.current.settings,
+                            tint = LevyraText,
+                            modifier = Modifier.size(22.dp)
+                        )
+                    }
                 }
             }
         }
+        Text(
+            text = LocalLevyraStrings.current.formatGreeting(userName, java.util.Calendar.getInstance().get(java.util.Calendar.HOUR_OF_DAY)),
+            color = LevyraText,
+            fontSize = 24.sp,
+            lineHeight = 28.sp,
+            fontWeight = FontWeight.Black,
+            letterSpacing = (-0.6).sp,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
     }
 }
 
@@ -13116,30 +13179,26 @@ private fun MoodRow(moods: List<Mood>, selectedId: String?, onSelect: (Mood) -> 
             contentType = { "home-mood" }
         ) { mood ->
             val selected = mood.id == selectedId
-            Surface(
-                color = when {
-                    selected && LevyraIsLight -> LevyraText
-                    selected -> Color(0xFFF4F4F6)
-                    LevyraIsLight -> Color.White.copy(alpha = 0.82f)
-                    else -> Color(0xFF0C0D10)
-                },
-                border = BorderStroke(
-                    width = Dp.Hairline,
-                    color = when {
-                        selected -> Color.Transparent
-                        else -> LevyraAdaptiveSoftHairline
-                    }
-                ),
-                shape = CircleShape,
-                modifier = Modifier.pressable(onClick = { onSelect(mood) })
+            Box(
+                modifier = Modifier
+                    .clip(CircleShape)
+                    .background(
+                        if (selected) {
+                            Brush.linearGradient(listOf(LevyraCyan, LevyraViolet))
+                        } else {
+                            SolidColor(if (LevyraIsLight) Color.White.copy(alpha = 0.82f) else Color(0xFF0C0D10))
+                        },
+                        CircleShape
+                    )
+                    .then(
+                        if (selected) Modifier
+                        else Modifier.border(Dp.Hairline, LevyraAdaptiveSoftHairline, CircleShape)
+                    )
+                    .pressable(onClick = { onSelect(mood) })
             ) {
                 Text(
                     text = mood.title,
-                    color = when {
-                        selected && LevyraIsLight -> Color.White
-                        selected -> Color(0xFF090A0C)
-                        else -> LevyraText
-                    },
+                    color = if (selected) Color.White else LevyraText,
                     fontSize = 13.sp,
                     fontWeight = FontWeight.ExtraBold,
                     maxLines = 1,
@@ -13162,13 +13221,7 @@ private fun SectionHeaderAction(title: String, onPlayAll: () -> Unit) {
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(10.dp)
         ) {
-            Box(
-                modifier = Modifier
-                    .height(22.dp)
-                    .width(4.dp)
-                    .clip(RoundedCornerShape(99.dp))
-                    .background(Brush.verticalGradient(listOf(LevyraCyan, LevyraViolet)))
-            )
+            SectionAccentBar(height = 22.dp, width = 4.dp)
             Text(
                 text = title,
                 color = LevyraText,
@@ -13180,23 +13233,7 @@ private fun SectionHeaderAction(title: String, onPlayAll: () -> Unit) {
                 overflow = TextOverflow.Ellipsis
             )
         }
-        Surface(
-            color = LevyraAdaptiveChip,
-            border = BorderStroke(Dp.Hairline, LevyraAdaptiveHairline),
-            shape = CircleShape,
-            modifier = Modifier
-                .size(36.dp)
-                .pressable(onClick = onPlayAll)
-        ) {
-            Box(contentAlignment = Alignment.Center) {
-                Icon(
-                    imageVector = Icons.Rounded.PlayArrow,
-                    contentDescription = LocalLevyraStrings.current.play,
-                    tint = LevyraCyan,
-                    modifier = Modifier.size(18.dp)
-                )
-            }
-        }
+        HomePlayAllButton(onClick = onPlayAll)
     }
 }
 
@@ -13601,12 +13638,21 @@ private fun ChartRow(
             horizontalArrangement = Arrangement.spacedBy(10.dp)
         ) {
             Box(modifier = Modifier.width(26.dp), contentAlignment = Alignment.Center) {
-                Text(
-                    text = rank.toString(),
-                    color = if (rank <= 3) LevyraCyan else LevyraMuted,
-                    fontSize = if (rank <= 3) 20.sp else 16.sp,
-                    fontWeight = FontWeight.Black
-                )
+                if (rank <= 3) {
+                    Text(
+                        text = rank.toString(),
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Black,
+                        style = TextStyle(brush = Brush.verticalGradient(listOf(LevyraCyan, LevyraViolet)))
+                    )
+                } else {
+                    Text(
+                        text = rank.toString(),
+                        color = LevyraMuted,
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Black
+                    )
+                }
             }
             Box {
                 CoverImage(track, Modifier.size(52.dp).clip(RoundedCornerShape(12.dp)), zoom = 1.35f)


### PR DESCRIPTION
- Turn the greeting bar into an editorial header: compact brand row with
  a large time-based greeting headline below it
- Unify section headers with a shared gradient accent bar and a shared
  cyan-violet gradient play-all button (sections, Personal Orbit,
  Resonance, Artists shelves)
- Style the selected mood chip with the brand cyan-violet gradient
- Render top-3 chart ranks with a gradient text brush
- Round and thicken the continue-listening progress bar
- Add subtle depth halos to the background: a track-accent halo on the
  left in dark mode and a faint violet halo in light mode, keeping the
  existing background structure intact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added refreshed section headers with consistent accent bars and play controls.
  * Introduced featured quick-pick cards and updated album cards with vinyl disc visuals.

* **Style**
  * Refined Home screen shelves, mood chips, chart rankings, loading placeholders, and progress indicators.
  * Improved light and dark mode background effects with enhanced halo visuals.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->