### PR TITLE
Improve home scroll smoothness without visual changes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -131,8 +131,8 @@ android {
             versionNameSuffix = "-debug"
         }
         release {
-            isMinifyEnabled = false
-            isShrinkResources = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             isDebuggable = false
             signingConfig = signingConfigs.getByName("release")
             proguardFiles(

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -7,3 +7,25 @@
 -dontwarn org.mozilla.javascript.**
 -dontwarn org.schabi.newpipe.extractor.**
 -dontwarn javax.annotation.**
+
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault
+
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    static <1>$Companion Companion;
+}
+
+-if @kotlinx.serialization.Serializable class ** {
+    static **$* *;
+}
+-keepclassmembers class <2>$<3> {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+-if @kotlinx.serialization.Serializable class ** {
+    public static ** INSTANCE;
+}
+-keepclassmembers class <1> {
+    public static <1> INSTANCE;
+    kotlinx.serialization.KSerializer serializer(...);
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraArtworkCache.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraArtworkCache.kt
@@ -15,6 +15,7 @@ import com.luc4n3x.levyra.domain.LevyraPersonalOrbit
 import com.luc4n3x.levyra.domain.Track
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -72,6 +73,7 @@ object LevyraArtworkCache {
     private val indexScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val localIndex: MutableSet<String> = java.util.concurrent.ConcurrentHashMap.newKeySet()
     @Volatile private var localIndexPrimed = false
+    @Volatile private var primeJob: Job? = null
 
     fun configure(context: Context) {
         if (configured) return
@@ -162,7 +164,7 @@ object LevyraArtworkCache {
     }
 
     private fun primeLocalIndex(context: Context) {
-        indexScope.launch {
+        primeJob = indexScope.launch {
             runCatching {
                 persistentDirectory(context)
                     .listFiles()
@@ -208,6 +210,7 @@ object LevyraArtworkCache {
             if (smallTargets.isEmpty() && largeTargets.isEmpty()) return@withContext
             cacheTargets(smallTargets, 3)
             cacheTargets(largeTargets, 2)
+            primeJob?.join()
             trimPersistentDirectory(appContext)
         }
     }

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraArtworkCache.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraArtworkCache.kt
@@ -13,10 +13,13 @@ import coil3.request.crossfade
 import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
 import com.luc4n3x.levyra.domain.LevyraPersonalOrbit
 import com.luc4n3x.levyra.domain.Track
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
@@ -66,11 +69,15 @@ object LevyraArtworkCache {
     private val youtubeSquare = Regex("=s\\d+[^?&]*")
     private val appleArtwork = Regex("\\d+x\\d+bb")
     @Volatile private var configured = false
+    private val indexScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val localIndex: MutableSet<String> = java.util.concurrent.ConcurrentHashMap.newKeySet()
+    @Volatile private var localIndexPrimed = false
 
     fun configure(context: Context) {
         if (configured) return
         synchronized(this) {
             if (configured) return
+            primeLocalIndex(context.applicationContext)
             SingletonImageLoader.setSafe { appContext ->
                 val memoryProfile = memoryDeviceProfile(appContext)
                 val memoryCacheBytes = ArtworkMemoryCachePolicy.maxSizeBytes(memoryProfile)
@@ -141,12 +148,29 @@ object LevyraArtworkCache {
     fun localFile(context: Context, track: Track, highRes: Boolean = false): File? {
         if (artworkUrlCandidates(track, highRes).isEmpty()) return null
         val file = persistentFile(context.applicationContext, track, if (highRes) LARGE_SIZE else SMALL_SIZE)
+        if (localIndexPrimed) {
+            return if (localIndex.contains(file.name)) file else null
+        }
         if (!file.isFile || file.length() <= 512L) return null
         if (!isLikelyArtworkFile(file)) {
             runCatching { file.delete() }
+            localIndex.remove(file.name)
             return null
         }
+        localIndex.add(file.name)
         return file
+    }
+
+    private fun primeLocalIndex(context: Context) {
+        indexScope.launch {
+            runCatching {
+                persistentDirectory(context)
+                    .listFiles()
+                    ?.filter { it.isFile && it.length() > 512L && isLikelyArtworkFile(it) }
+                    ?.forEach { localIndex.add(it.name) }
+            }.onFailure { Timber.d(it, "Artwork index priming failed") }
+            localIndexPrimed = true
+        }
     }
 
     fun preloadHome(context: Context, tracks: List<Track>, limit: Int = 36) {
@@ -232,9 +256,13 @@ object LevyraArtworkCache {
         val file = target.file
         if (file.isFile && file.length() > 512L && isLikelyArtworkFile(file)) {
             file.setLastModified(System.currentTimeMillis())
+            localIndex.add(file.name)
             return
         }
-        if (file.exists()) runCatching { file.delete() }
+        if (file.exists()) {
+            runCatching { file.delete() }
+            localIndex.remove(file.name)
+        }
         target.urls.forEach { url ->
             repeat(2) { attempt ->
                 val saved = runCatching {
@@ -264,7 +292,10 @@ object LevyraArtworkCache {
                 }.onFailure { error ->
                     if (attempt == 1) Timber.d(error, "Artwork persistent cache miss")
                 }.getOrDefault(false)
-                if (saved || file.isFile && file.length() > 512L && isLikelyArtworkFile(file)) return
+                if (saved || file.isFile && file.length() > 512L && isLikelyArtworkFile(file)) {
+                    localIndex.add(file.name)
+                    return
+                }
             }
         }
     }
@@ -328,7 +359,11 @@ object LevyraArtworkCache {
         files
             .sortedBy { it.lastModified() }
             .take(files.size - MAX_PERSISTENT_FILES)
-            .forEach { runCatching { it.delete() } }
+            .forEach { file ->
+                if (runCatching { file.delete() }.getOrDefault(false)) {
+                    localIndex.remove(file.name)
+                }
+            }
     }
 
     private fun resize(url: String, size: Int): String {

--- a/app/src/main/java/com/luc4n3x/levyra/data/ReturnYoutubeDislikeRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/ReturnYoutubeDislikeRepository.kt
@@ -125,7 +125,7 @@ internal class ReturnYoutubeDislikeRepository {
                 } else {
                     when (response.code) {
                         200 -> {
-                            val body = response.body?.string().orEmpty()
+                            val body = response.body.string()
                             val estimate = parseReturnYoutubeDislikeResponse(body, videoId)
                             if (estimate == null) {
                                 ReturnYoutubeDislikeResult.Failed(IOException("Invalid RYD response"))
@@ -229,6 +229,7 @@ internal fun parseReturnYoutubeDislikeResponse(
 private fun JSONObject.optLongStrict(name: String): Long? {
     if (!has(name) || isNull(name)) return null
     return when (val value = opt(name)) {
+        null -> null
         is Number -> value.toLong()
         is String -> value.trim().toLongOrNull()
         else -> null

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -155,7 +155,7 @@ import androidx.compose.material.icons.rounded.ThumbUp
 import androidx.compose.material.icons.rounded.ThumbDown
 import androidx.compose.material.icons.rounded.ChatBubbleOutline
 import androidx.compose.material.icons.rounded.PushPin
-import androidx.compose.material.icons.rounded.Reply
+import androidx.compose.material.icons.automirrored.rounded.Reply
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.OpenInNew
 import androidx.compose.material.icons.rounded.Visibility
@@ -10704,7 +10704,7 @@ private fun YoutubeCommentCard(
                         horizontalArrangement = Arrangement.spacedBy(5.dp)
                     ) {
                         Icon(
-                            imageVector = Icons.Rounded.Reply,
+                            imageVector = Icons.AutoMirrored.Rounded.Reply,
                             contentDescription = null,
                             tint = secondary.playerMix(Color.White, 0.58f),
                             modifier = Modifier.size(15.dp)

--- a/app/src/main/java/com/luc4n3x/levyra/ui/MotionArtworkLayer.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/MotionArtworkLayer.kt
@@ -93,7 +93,6 @@ private fun rememberMotionArtworkEnvironmentAllowed(observe: Boolean): Boolean {
         val mainHandler = Handler(Looper.getMainLooper())
         val refresh: () -> Unit = {
             mainHandler.post { revision++ }
-            Unit
         }
         val receiver = object : BroadcastReceiver() {
             override fun onReceive(context: Context?, intent: Intent?) {


### PR DESCRIPTION
## Summary

- Removes main-thread disk I/O from home cell composition: every `CoverImage` cell was doing `File.isFile`/`length()` plus an open-and-read of the artwork file header during LazyColumn scroll composition. Artwork lookups now go through an in-memory index primed off the main thread at startup, so scrolling no longer touches the filesystem.
- Enables R8 minification and resource shrinking for release builds (rules for the extractor/Rhino were already in place; adds the official kotlinx.serialization keep rules). Sideloaded release APKs run optimized bytecode, which directly improves Compose scroll performance and reduces APK size.
- Zero visual changes: same layouts, same artwork sources, same fallback order (index fallback probes disk exactly like before until priming completes, so cold-start artwork behavior is unchanged).

## Scope

- [ ] Player / audio
- [ ] Stream extraction
- [ ] Downloads
- [x] UI / Compose
- [ ] Localization
- [ ] Android Auto / media session
- [x] CI / release
- [ ] Documentation

## What changed

- `LevyraArtworkCache`: new thread-safe index of validated persistent artwork files, primed on an IO-dispatcher scope from `configure()`. `localFile()` consults the index once primed; writes (`ensurePersistent`), validation failures, and `trimPersistentDirectory` keep the index consistent. Until priming completes the previous synchronous path is used, so startup behavior is identical.
- `app/build.gradle.kts`: `isMinifyEnabled = true`, `isShrinkResources = true` for release (`android.enableR8.fullMode=true` was already set).
- `app/proguard-rules.pro`: official kotlinx.serialization R8 rules added.

## Testing

- [ ] `gradle --no-daemon :app:lintRelease`
- [ ] `gradle --no-daemon testReleaseUnitTest`
- [ ] `gradle --no-daemon assembleRelease`
- [ ] APK installed on device
- [ ] Playback tested
- [ ] Downloads tested
- [ ] Language switching tested

Local Gradle validation was not possible in this environment (no Android SDK and the network policy blocks `dl.google.com`), so the checks above are intentionally unchecked. CI on this PR runs `assembleRelease`, which exercises the R8 configuration at build level. Before tagging a release, please smoke-test the minified APK on a device: playback (audio + video mode), downloads, backup restore, widget, and the JS extractor path.

## Release safety

- [x] `levyraVersionName` and `levyraVersionCode` are correct
- [x] No secrets, keystores, APKs or ZIPs committed
- [x] No duplicated release workflows
- [x] Credits and licenses updated when adding external components

## Related issues

- Related to home scroll fluidity reported by the maintainer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved release builds through code and resource shrinking.
  * Accelerated artwork cache validation and startup indexing.
  * Added concurrent cache processing for faster artwork access.

* **Reliability**
  * Preserved required serialization metadata during release optimization.
  * Improved cache consistency when validating, downloading, or removing artwork files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->