### PR TITLE
chore(release): bump version to 2.3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,8 @@ Architecture and size-control notes live in `docs/APK_SIZE_RULER.md` and `docs/P
 Version numbering is centralized in `gradle.properties`:
 
 ```properties
-levyraVersionName=2.3.12
-levyraVersionCode=2031200
+levyraVersionName=2.3.13
+levyraVersionCode=2031300
 ```
 
 `versionCode = major * 1_000_000 + minor * 10_000 + patch * 100 + build` — calculated sequentially so no two deployments ever collide. The APK Artifact workflow parses this schema, verifies target versions with `aapt`, checks structural integrity, compiles the signed binary and publishes it as `LEVYRA-<version>.apk`.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,7 +59,7 @@ if (isReleaseTaskRequested() && (!releaseStoreFile.isFile || releaseStorePasswor
 fun normalizedVersionName(value: String): String {
     val clean = value.trim().removePrefix("v").removePrefix("V")
     val match = Regex("\\d+(?:\\.\\d+){0,3}(?:[-+][0-9A-Za-z.-]+)?").find(clean)?.value
-    return match ?: clean.ifBlank { "2.3.12" }
+    return match ?: clean.ifBlank { "2.3.13" }
 }
 
 fun generatedVersionCode(versionName: String): Int {
@@ -90,7 +90,7 @@ val levyraVersionName = normalizedVersionName(
     (findProperty("levyraVersionName") as? String)
         ?: System.getenv("LEVYRA_VERSION_NAME")
         ?: githubTagVersionName()
-        ?: "2.3.12"
+        ?: "2.3.13"
 )
 
 val levyraVersionCode = ((findProperty("levyraVersionCode") as? String)

--- a/app/src/main/java/com/luc4n3x/levyra/data/OfficialArtworkRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/OfficialArtworkRepository.kt
@@ -624,7 +624,7 @@ class OfficialArtworkRepository(context: Context) {
         const val APPLE_SEARCH_URL = "https://itunes.apple.com/search"
         const val DEEZER_SEARCH_URL = "https://api.deezer.com/search/track"
         const val DEEZER_ALBUM_URL = "https://api.deezer.com/album"
-        const val USER_AGENT = "Levyra/2.3.12 Android"
+        const val USER_AGENT = "Levyra/2.3.13 Android"
         const val MIN_ACCEPTED_SCORE = 200
         const val DECISIVE_MATCH_SCORE = 350
         const val MIN_ARTIST_MATCH_SCORE = 45

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
@@ -804,7 +804,7 @@ internal class YoutubePlayerConfigStore(
     companion object {
         private const val BUNDLED_CONFIG_ASSET = "player_configs.json"
         private const val REMOTE_CONFIG_URL = "https://raw.githubusercontent.com/ZemerTeam/zemer-cipher/master/library/src/main/assets/player_configs.json"
-        private const val USER_AGENT = "Levyra/2.3.12 Android local-decoder"
+        private const val USER_AGENT = "Levyra/2.3.13 Android local-decoder"
         private const val CONFIG_TTL_MS = 6L * 60L * 60L * 1000L
         private const val UNKNOWN_REFRESH_COOLDOWN_MS = 60_000L
         private const val REJECTION_REFRESH_COOLDOWN_MS = 5L * 60L * 1000L

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Levyra Architecture
  
-**Current application version:** 2.3.12
+**Current application version:** 2.3.13
 **Platform:** Android 8.0 and newer  
 **Primary stack:** Kotlin, Jetpack Compose, AndroidX Media3, Room, WorkManager, OkHttp, Coil
  

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ android.nonTransitiveRClass=true
 android.uniquePackageNames=false
 android.enableR8.fullMode=true
 kotlin.code.style=official
-levyraVersionName=2.3.12
-levyraVersionCode=2031200
+levyraVersionName=2.3.13
+levyraVersionCode=2031300


### PR DESCRIPTION
## Summary

Bump the app release from **2.3.12** to **2.3.13**.

- `levyraVersionName` → `2.3.13`
- `levyraVersionCode` → `2031300` (`2 * 1_000_000 + 3 * 10_000 + 13 * 100`)

## Changes

All version references that track the app release were updated:

- `gradle.properties` — canonical `levyraVersionName` / `levyraVersionCode`
- `app/build.gradle.kts` — fallback default version names
- `app/src/main/java/com/luc4n3x/levyra/data/OfficialArtworkRepository.kt` — HTTP `User-Agent`
- `app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt` — local-decoder HTTP `User-Agent`
- `docs/ARCHITECTURE.md` — documented current application version
- `README.md` — version numbering example

The auto-generated release badge (`docs/assets/levyra-release.svg`) is left untouched as it is regenerated by the badge workflow.

## Notes

No functional or behavioral changes — this is a version-only release bump.

