### PR TITLE
Persist playback sources and improve startup performance

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.licensee)
     alias(libs.plugins.ruler)
+    alias(libs.plugins.androidx.baselineprofile)
 }
 
 val localProperties = Properties().apply {
@@ -36,8 +37,13 @@ fun buildConfigString(value: String): String {
     return "\"$escaped\""
 }
 
-fun isReleaseTaskRequested(): Boolean =
+fun isPerformanceTaskRequested(): Boolean =
     gradle.startParameter.taskNames.any { task ->
+        task.contains("baselineprofile", ignoreCase = true) || task.contains("benchmark", ignoreCase = true)
+    }
+
+fun isReleaseTaskRequested(): Boolean =
+    !isPerformanceTaskRequested() && gradle.startParameter.taskNames.any { task ->
         task.contains("Release", ignoreCase = true) || task.equals("bundle", ignoreCase = true) || task.equals("assemble", ignoreCase = true)
     }
 
@@ -47,12 +53,13 @@ val releaseStorePassword = envOrProperty("LEVYRA_KEYSTORE_PASSWORD", "levyraStor
 val releaseKeyAlias = envOrProperty("LEVYRA_KEY_ALIAS", "levyraKeyAlias")
 val releaseKeyPassword = envOrProperty("LEVYRA_KEY_PASSWORD", "levyraKeyPassword")
 val releaseStoreFile = rootProject.file(releaseStoreFilePath)
+val releaseSigningAvailable = releaseStoreFile.isFile && releaseStorePassword.isNotBlank() && releaseKeyAlias.isNotBlank() && releaseKeyPassword.isNotBlank()
 
 if (isReleaseTaskRequested() && youtubeInnertubeApiKey.isBlank()) {
     throw GradleException("Missing YOUTUBE_INNERTUBE_API_KEY. Set it as a GitHub Actions secret or in local.properties as youtubeInnertubeApiKey.")
 }
 
-if (isReleaseTaskRequested() && (!releaseStoreFile.isFile || releaseStorePassword.isBlank() || releaseKeyAlias.isBlank() || releaseKeyPassword.isBlank())) {
+if (isReleaseTaskRequested() && !releaseSigningAvailable) {
     throw GradleException("Missing release signing config. Set LEVYRA_KEYSTORE_BASE64, LEVYRA_KEYSTORE_PASSWORD, LEVYRA_KEY_ALIAS and LEVYRA_KEY_PASSWORD in GitHub Actions secrets.")
 }
 
@@ -118,10 +125,14 @@ android {
     signingConfigs {
         getByName("debug")
         create("release") {
-            storeFile = releaseStoreFile
-            storePassword = releaseStorePassword
-            keyAlias = releaseKeyAlias
-            keyPassword = releaseKeyPassword
+            if (releaseSigningAvailable) {
+                storeFile = releaseStoreFile
+                storePassword = releaseStorePassword
+                keyAlias = releaseKeyAlias
+                keyPassword = releaseKeyPassword
+            } else {
+                initWith(getByName("debug"))
+            }
         }
     }
 
@@ -216,6 +227,7 @@ dependencies {
     implementation(libs.androidx.room.ktx)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.work.runtime.ktx)
+    implementation(libs.androidx.profileinstaller)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.timber)
     implementation(libs.shimmer)
@@ -225,4 +237,5 @@ dependencies {
     coreLibraryDesugaring(libs.desugar.jdk.libs.nio)
     testImplementation(libs.junit)
     testImplementation(libs.json)
+    baselineProfile(project(":baselineprofile"))
 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackManifestCodec.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackManifestCodec.kt
@@ -1,0 +1,106 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.domain.PlaybackDeliveryMethod
+import com.luc4n3x.levyra.domain.PlaybackStreamDescriptor
+import com.luc4n3x.levyra.domain.PlaybackStreamKind
+import com.luc4n3x.levyra.domain.ResolvedPlaybackManifest
+import org.json.JSONArray
+import org.json.JSONObject
+
+object PlaybackManifestCodec {
+    fun encode(manifest: ResolvedPlaybackManifest): String {
+        val streams = JSONArray()
+        manifest.compact().streams.forEach { stream ->
+            streams.put(
+                JSONObject()
+                    .put("url", stream.url)
+                    .put("kind", stream.kind.name)
+                    .put("deliveryMethod", stream.deliveryMethod.name)
+                    .put("container", stream.container)
+                    .put("mimeType", stream.mimeType)
+                    .put("codec", stream.codec)
+                    .put("bitrate", stream.bitrate)
+                    .put("averageBitrate", stream.averageBitrate)
+                    .put("sampleRate", stream.sampleRate)
+                    .put("bitDepth", stream.bitDepth)
+                    .put("width", stream.width)
+                    .put("height", stream.height)
+                    .put("fps", stream.fps)
+                    .put("itag", stream.itag)
+                    .put("qualityLabel", stream.qualityLabel)
+                    .put("expiresAtMs", stream.expiresAtMs)
+                    .put("selected", stream.selected)
+            )
+        }
+        return JSONObject()
+            .put("schemaVersion", 1)
+            .put("sourceVideoId", manifest.sourceVideoId)
+            .put("provider", manifest.provider)
+            .put("resolvedAtMs", manifest.resolvedAtMs)
+            .put("expiresAtMs", manifest.expiresAtMs)
+            .put("durationMs", manifest.durationMs)
+            .put("selectedAudioUrl", manifest.selectedAudioUrl)
+            .put("selectedVideoUrl", manifest.selectedVideoUrl)
+            .put("loudnessDb", manifest.loudnessDb)
+            .put("perceptualLoudnessDb", manifest.perceptualLoudnessDb)
+            .put("streams", streams)
+            .toString()
+    }
+
+    fun decode(raw: String): ResolvedPlaybackManifest? = runCatching {
+        val root = JSONObject(raw)
+        if (root.optInt("schemaVersion", 0) != 1) return@runCatching null
+        val streamArray = root.optJSONArray("streams") ?: JSONArray()
+        val streams = buildList {
+            for (index in 0 until streamArray.length()) {
+                val json = streamArray.optJSONObject(index) ?: continue
+                val url = json.optString("url")
+                if (url.isBlank()) continue
+                add(
+                    PlaybackStreamDescriptor(
+                        url = url,
+                        kind = json.optEnum("kind", PlaybackStreamKind.AUDIO),
+                        deliveryMethod = json.optEnum("deliveryMethod", PlaybackDeliveryMethod.UNKNOWN),
+                        container = json.optString("container"),
+                        mimeType = json.optString("mimeType"),
+                        codec = json.optString("codec"),
+                        bitrate = json.optInt("bitrate", 0),
+                        averageBitrate = json.optInt("averageBitrate", 0),
+                        sampleRate = json.optInt("sampleRate", 0),
+                        bitDepth = json.optInt("bitDepth", 0),
+                        width = json.optInt("width", 0),
+                        height = json.optInt("height", 0),
+                        fps = json.optInt("fps", 0),
+                        itag = json.optInt("itag", -1),
+                        qualityLabel = json.optString("qualityLabel"),
+                        expiresAtMs = json.optLong("expiresAtMs", 0L),
+                        selected = json.optBoolean("selected", false)
+                    )
+                )
+            }
+        }
+        val selectedAudioUrl = root.optString("selectedAudioUrl")
+        if (selectedAudioUrl.isBlank()) return@runCatching null
+        ResolvedPlaybackManifest(
+            sourceVideoId = root.optString("sourceVideoId"),
+            provider = root.optString("provider"),
+            resolvedAtMs = root.optLong("resolvedAtMs", 0L),
+            expiresAtMs = root.optLong("expiresAtMs", 0L),
+            durationMs = root.optLong("durationMs", 0L),
+            selectedAudioUrl = selectedAudioUrl,
+            selectedVideoUrl = root.optString("selectedVideoUrl"),
+            streams = streams,
+            loudnessDb = root.optNullableFloat("loudnessDb"),
+            perceptualLoudnessDb = root.optNullableFloat("perceptualLoudnessDb")
+        )
+    }.getOrNull()
+}
+
+private inline fun <reified T : Enum<T>> JSONObject.optEnum(key: String, fallback: T): T {
+    return enumValues<T>().firstOrNull { it.name == optString(key) } ?: fallback
+}
+
+private fun JSONObject.optNullableFloat(key: String): Float? {
+    if (!has(key) || isNull(key)) return null
+    return optDouble(key, Double.NaN).takeIf { it.isFinite() }?.toFloat()
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -53,6 +53,13 @@ import java.util.concurrent.atomic.AtomicReference
 
 class PlaybackResolver private constructor(private val context: Context) {
     companion object {
+        private const val YOUTUBE_VIDEO_ID_PATTERN = "[A-Za-z0-9_-]{11}"
+        private const val LEVYRA_EXTRACTOR_PROVIDER = "LevyraExtractor"
+        private const val LEVYRA_EXTRACTOR_HLS_PROVIDER = "LevyraExtractor HLS"
+        private val youtubeVideoIdRegex = Regex(YOUTUBE_VIDEO_ID_PATTERN)
+        private val youtubeVideoUrlRegex = Regex("(?:v=|/shorts/|/embed/|/live/|youtu\\.be/)($YOUTUBE_VIDEO_ID_PATTERN)")
+        private val youtubeSearchResultVideoIdRegex = Regex("""\\?["]videoId\\?["]\s*:\s*\\?["]($YOUTUBE_VIDEO_ID_PATTERN)\\?["]""")
+
         @Volatile
         private var instance: PlaybackResolver? = null
 
@@ -162,7 +169,7 @@ class PlaybackResolver private constructor(private val context: Context) {
     suspend fun enrichYoutubeEngagement(track: Track): Track {
         if (track.source.equals("Offline", ignoreCase = true)) return track
         if (track.youtubeLikeCount >= 0L && track.youtubeViewCount >= 0L) return track
-        val videoId = extractVideoId(track.videoUrl).ifBlank { track.id.takeIf { it.matches(Regex("[A-Za-z0-9_-]{11}")) }.orEmpty() }
+        val videoId = extractVideoId(track.videoUrl).ifBlank { track.id.takeIf(youtubeVideoIdRegex::matches).orEmpty() }
         if (videoId.isBlank()) return track
         val now = System.currentTimeMillis()
         youtubeEngagementCache[videoId]?.let { cached ->
@@ -308,7 +315,8 @@ class PlaybackResolver private constructor(private val context: Context) {
                 !isPlaybackUrlBlocked(it) &&
                 (track.videoStreamUrl.isBlank() || !isPlaybackUrlBlocked(track.videoStreamUrl)) &&
                 streamStillFresh(it) &&
-                (isVideoMode || isPlayableAudioUrl(it))
+                (isVideoMode || isPlayableAudioUrl(it)) &&
+                (!preferMp4Audio || track.playbackManifest?.supportsMp4AudioExport() == true || isMp4AudioUrl(it))
         }?.let { return@coroutineScope track }
         if (!preferMp4Audio) {
             val cacheLookupTrack = if (reuseProvidedStream) track else track.copy(streamUrl = "", videoStreamUrl = "")
@@ -399,7 +407,7 @@ class PlaybackResolver private constructor(private val context: Context) {
             }
             if (resolved != null) {
                 store(track, resolved, isVideoMode, audioQuality)
-                persistResolvedSource(track, resolved, isVideoMode, audioQuality, 92)
+                persistResolvedSource(track, resolved, isVideoMode, audioQuality, 92, preferMp4Audio)
                 return@withContext resolved
             }
             val reason = errors.firstOrNull { it.contains("age", true) || it.contains("login", true) }
@@ -411,14 +419,14 @@ class PlaybackResolver private constructor(private val context: Context) {
         val resolved = resolveAudioFast(track, errors, preferMp4Audio, audioQuality)
         if (resolved != null) {
             store(track, resolved, isVideoMode, audioQuality)
-            persistResolvedSource(track, resolved, isVideoMode, audioQuality, 96)
+            persistResolvedSource(track, resolved, isVideoMode, audioQuality, 96, preferMp4Audio)
             return@withContext resolved
         }
 
         val alternate = resolveAudioWithSearchFallback(track, errors, preferMp4Audio, audioQuality)
         if (alternate != null) {
             store(track, alternate, isVideoMode, audioQuality)
-            persistResolvedSource(track, alternate, isVideoMode, audioQuality, 84)
+            persistResolvedSource(track, alternate, isVideoMode, audioQuality, 84, preferMp4Audio)
             return@withContext alternate
         }
 
@@ -506,7 +514,13 @@ class PlaybackResolver private constructor(private val context: Context) {
         for (candidate in candidates) {
             val localErrors = Collections.synchronizedList(mutableListOf<String>())
             val resolved = runCatching { resolveAudioFast(candidate, localErrors, preferMp4Audio, audioQuality) }.getOrNull()
-            if (resolved != null && resolved.streamUrl.isNotBlank() && streamStillFresh(resolved.streamUrl) && isPlayableAudioUrl(resolved.streamUrl)) {
+            if (
+                resolved != null &&
+                resolved.streamUrl.isNotBlank() &&
+                streamStillFresh(resolved.streamUrl) &&
+                isPlayableAudioUrl(resolved.streamUrl) &&
+                (!preferMp4Audio || resolved.playbackManifest?.supportsMp4AudioExport() == true || isMp4AudioUrl(resolved.streamUrl))
+            ) {
                 return track.copy(
                     streamUrl = resolved.streamUrl,
                     videoUrl = resolved.videoUrl.ifBlank { candidate.videoUrl },
@@ -534,7 +548,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         audioQuality: String,
         errors: MutableList<String>
     ): Track? {
-        val stored = runCatching { sourceMatchStore.load(track, isVideoMode, audioQuality) }
+        val stored = runCatching { sourceMatchStore.load(track, isVideoMode, audioQuality, preferMp4Audio) }
             .onFailure { error ->
                 if (error is CancellationException) throw error
                 Timber.w(error, "persistent source match load failed")
@@ -543,8 +557,8 @@ class PlaybackResolver private constructor(private val context: Context) {
         val now = System.currentTimeMillis()
         if (stored.entity.blockedUntil > now) return null
         val manifest = stored.manifest
-        if (manifest != null && manifest.isFresh(now) && manifestUrlsUsable(manifest, isVideoMode)) {
-            recordSourceMatchSuccess(track, isVideoMode, audioQuality)
+        if (manifest != null && manifest.isFresh(now) && manifestUrlsUsable(manifest, isVideoMode, preferMp4Audio)) {
+            recordSourceMatchSuccess(track, isVideoMode, audioQuality, preferMp4Audio)
             return track.applyManifest(
                 manifest = manifest,
                 sourceVideoUrl = stored.entity.sourceVideoUrl,
@@ -552,7 +566,7 @@ class PlaybackResolver private constructor(private val context: Context) {
             )
         }
         val sourceVideoId = stored.entity.sourceVideoId
-            .takeIf { it.matches(Regex("[A-Za-z0-9_-]{11}")) }
+            .takeIf(youtubeVideoIdRegex::matches)
             ?: return null
         val sourceVideoUrl = stored.entity.sourceVideoUrl.ifBlank { "https://www.youtube.com/watch?v=$sourceVideoId" }
         val sourceTrack = track.copy(
@@ -571,11 +585,18 @@ class PlaybackResolver private constructor(private val context: Context) {
             null
         }
         if (refreshed == null) {
-            recordSourceMatchFailure(track, isVideoMode, audioQuality, 90_000L)
+            recordSourceMatchFailure(track, isVideoMode, audioQuality, 90_000L, preferMp4Audio)
             return null
         }
         val rebased = rebaseResolvedTrack(track, refreshed)
-        persistResolvedSource(track, rebased, isVideoMode, audioQuality, stored.entity.confidence.coerceAtLeast(88))
+        persistResolvedSource(
+            track,
+            rebased,
+            isVideoMode,
+            audioQuality,
+            stored.entity.confidence.coerceAtLeast(88),
+            preferMp4Audio
+        )
         return rebased
     }
 
@@ -596,7 +617,7 @@ class PlaybackResolver private constructor(private val context: Context) {
             if (error is CancellationException) throw error
             errors += "Persistent LevyraExtractor: ${error.playbackDiagnostic()}"
         }.getOrNull()
-        if (extractor != null && manifestUrlsUsable(extractor.playbackManifest, isVideoMode)) return extractor
+        if (extractor != null && manifestUrlsUsable(extractor.playbackManifest, isVideoMode, preferMp4Audio)) return extractor
         val direct = runCatching {
             if (preferMp4Audio) {
                 raceInnerTube(sourceTrack, errors, isVideoMode, true, audioQuality)
@@ -607,13 +628,19 @@ class PlaybackResolver private constructor(private val context: Context) {
             if (error is CancellationException) throw error
             errors += "Persistent InnerTube: ${error.playbackDiagnostic()}"
         }.getOrNull() ?: return null
-        return sourceTrack.withDirectStream(direct)
+        val resolved = sourceTrack.withDirectStream(direct)
+        return resolved.takeIf { manifestUrlsUsable(it.playbackManifest, isVideoMode, preferMp4Audio) }
     }
 
-    private fun manifestUrlsUsable(manifest: ResolvedPlaybackManifest?, isVideoMode: Boolean): Boolean {
+    private fun manifestUrlsUsable(
+        manifest: ResolvedPlaybackManifest?,
+        isVideoMode: Boolean,
+        preferMp4Audio: Boolean = false
+    ): Boolean {
         if (manifest == null || manifest.selectedAudioUrl.isBlank()) return false
         if (isPlaybackUrlBlocked(manifest.selectedAudioUrl) || !streamStillFresh(manifest.selectedAudioUrl)) return false
         if (!isVideoMode && !isPlayableAudioUrl(manifest.selectedAudioUrl)) return false
+        if (preferMp4Audio && !manifest.supportsMp4AudioExport()) return false
         val videoUrl = manifest.selectedVideoUrl
         if (videoUrl.isNotBlank() && (isPlaybackUrlBlocked(videoUrl) || !streamStillFresh(videoUrl))) return false
         return true
@@ -655,10 +682,11 @@ class PlaybackResolver private constructor(private val context: Context) {
     private suspend fun recordSourceMatchSuccess(
         track: Track,
         isVideoMode: Boolean,
-        audioQuality: String
+        audioQuality: String,
+        preferMp4Audio: Boolean = false
     ) {
         try {
-            sourceMatchStore.recordSuccess(track, isVideoMode, audioQuality)
+            sourceMatchStore.recordSuccess(track, isVideoMode, audioQuality, preferMp4Audio)
         } catch (error: CancellationException) {
             throw error
         } catch (error: Throwable) {
@@ -670,10 +698,11 @@ class PlaybackResolver private constructor(private val context: Context) {
         track: Track,
         isVideoMode: Boolean,
         audioQuality: String,
-        quarantineMs: Long
+        quarantineMs: Long,
+        preferMp4Audio: Boolean = false
     ) {
         try {
-            sourceMatchStore.recordFailure(track, isVideoMode, audioQuality, quarantineMs)
+            sourceMatchStore.recordFailure(track, isVideoMode, audioQuality, quarantineMs, preferMp4Audio)
         } catch (error: CancellationException) {
             throw error
         } catch (error: Throwable) {
@@ -686,11 +715,13 @@ class PlaybackResolver private constructor(private val context: Context) {
         resolved: Track,
         isVideoMode: Boolean,
         audioQuality: String,
-        confidence: Int
+        confidence: Int,
+        preferMp4Audio: Boolean = false
     ) {
-        if (resolved.playbackManifest == null) return
+        val manifest = resolved.playbackManifest ?: return
+        if (preferMp4Audio && !manifest.supportsMp4AudioExport()) return
         try {
-            sourceMatchStore.save(original, resolved, isVideoMode, audioQuality, confidence)
+            sourceMatchStore.save(original, resolved, isVideoMode, audioQuality, confidence, preferMp4Audio)
         } catch (error: CancellationException) {
             throw error
         } catch (error: Throwable) {
@@ -751,7 +782,7 @@ class PlaybackResolver private constructor(private val context: Context) {
             searchFallbackClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) return@use emptyList()
                 val html = response.body.string()
-                Regex("""\\?["]videoId\\?["]\s*:\s*\\?["]([A-Za-z0-9_-]{11})\\?["]""")
+                youtubeSearchResultVideoIdRegex
                     .findAll(html)
                     .mapNotNull { match -> match.groupValues.getOrNull(1) }
                     .distinct()
@@ -781,8 +812,8 @@ class PlaybackResolver private constructor(private val context: Context) {
 
     private fun extractVideoId(url: String): String {
         if (url.isBlank()) return ""
-        Regex("(?:v=|/shorts/|/embed/|/live/|youtu\\.be/)([A-Za-z0-9_-]{11})").find(url)?.groupValues?.getOrNull(1)?.let { return it }
-        return url.takeIf { it.matches(Regex("[A-Za-z0-9_-]{11}")) }.orEmpty()
+        youtubeVideoUrlRegex.find(url)?.groupValues?.getOrNull(1)?.let { return it }
+        return url.takeIf(youtubeVideoIdRegex::matches).orEmpty()
     }
 
     private fun scoreAlternativeCandidate(original: Track, candidate: Track): Int {
@@ -1390,8 +1421,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                             selectedAudioUrl = selection.candidate.url,
                             selectedVideoUrl = "",
                             streams = listOf(videoDescriptor(selection.candidate, true)),
-                            loudnessDb = loudnessDb,
-                            perceptualLoudnessDb = perceptualLoudnessDb
+                            loudness = PlaybackLoudness(loudnessDb, perceptualLoudnessDb)
                         )
                         DirectStream(
                             url = selection.candidate.url,
@@ -1415,8 +1445,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                                 innerTubeAudioDescriptor(bestAudioFormat, bestAudioUrl, true),
                                 videoDescriptor(selection.candidate, true)
                             ),
-                            loudnessDb = loudnessDb,
-                            perceptualLoudnessDb = perceptualLoudnessDb
+                            loudness = PlaybackLoudness(loudnessDb, perceptualLoudnessDb)
                         )
                         DirectStream(
                             url = bestAudioUrl,
@@ -1437,8 +1466,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                             selectedAudioUrl = hlsUrl,
                             selectedVideoUrl = "",
                             streams = listOf(hlsDescriptor(hlsUrl)),
-                            loudnessDb = loudnessDb,
-                            perceptualLoudnessDb = perceptualLoudnessDb
+                            loudness = PlaybackLoudness(loudnessDb, perceptualLoudnessDb)
                         )
                         DirectStream(
                             url = hlsUrl,
@@ -1466,8 +1494,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 selectedAudioUrl = bestAudioUrl,
                 selectedVideoUrl = "",
                 streams = listOf(innerTubeAudioDescriptor(bestAudioFormat, bestAudioUrl, true)),
-                loudnessDb = loudnessDb,
-                perceptualLoudnessDb = perceptualLoudnessDb
+                loudness = PlaybackLoudness(loudnessDb, perceptualLoudnessDb)
             )
             DirectStream(
                 url = bestAudioUrl,
@@ -1558,7 +1585,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         )
         val durationMs = if (info.duration > 0L) info.duration * 1000L else track.durationMs
         val sourceVideoId = extractVideoId(track.videoUrl).ifBlank { track.id }
-        val provider = if (audio != null) "LevyraExtractor" else "LevyraExtractor HLS"
+        val provider = if (audio != null) LEVYRA_EXTRACTOR_PROVIDER else LEVYRA_EXTRACTOR_HLS_PROVIDER
         val descriptors = if (audio != null) {
             info.audioStreams
                 .asSequence()
@@ -1583,7 +1610,7 @@ class PlaybackResolver private constructor(private val context: Context) {
             source = if (audio != null) {
                 "LevyraExtractor${label.takeIf { it.isNotBlank() }?.let { " · $it" }.orEmpty()}"
             } else {
-                "LevyraExtractor HLS"
+                LEVYRA_EXTRACTOR_HLS_PROVIDER
             },
             playbackManifest = manifest
         ).withYoutubeEngagement(info.likeCount, info.viewCount).also {
@@ -1634,7 +1661,7 @@ class PlaybackResolver private constructor(private val context: Context) {
             }
             val manifest = buildManifest(
                 sourceVideoId = sourceVideoId,
-                provider = "LevyraExtractor",
+                provider = LEVYRA_EXTRACTOR_PROVIDER,
                 durationMs = durationMs,
                 selectedAudioUrl = selectedAudioUrl,
                 selectedVideoUrl = selectedVideoUrl,
@@ -1652,7 +1679,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         if (hls != null) {
             val manifest = buildManifest(
                 sourceVideoId = sourceVideoId,
-                provider = "LevyraExtractor HLS",
+                provider = LEVYRA_EXTRACTOR_HLS_PROVIDER,
                 durationMs = durationMs,
                 selectedAudioUrl = hls,
                 selectedVideoUrl = "",
@@ -1662,7 +1689,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 streamUrl = hls,
                 videoStreamUrl = "",
                 durationMs = durationMs,
-                source = "LevyraExtractor HLS",
+                source = LEVYRA_EXTRACTOR_HLS_PROVIDER,
                 playbackManifest = manifest
             )
         }
@@ -1729,8 +1756,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         selectedAudioUrl: String,
         selectedVideoUrl: String,
         streams: List<PlaybackStreamDescriptor>,
-        loudnessDb: Float? = null,
-        perceptualLoudnessDb: Float? = null
+        loudness: PlaybackLoudness = PlaybackLoudness()
     ): ResolvedPlaybackManifest {
         val selectedUrls = setOf(selectedAudioUrl, selectedVideoUrl).filter { it.isNotBlank() }.toSet()
         val normalizedStreams = streams
@@ -1751,8 +1777,8 @@ class PlaybackResolver private constructor(private val context: Context) {
             selectedAudioUrl = selectedAudioUrl,
             selectedVideoUrl = selectedVideoUrl,
             streams = normalizedStreams,
-            loudnessDb = loudnessDb,
-            perceptualLoudnessDb = perceptualLoudnessDb
+            loudnessDb = loudness.loudnessDb,
+            perceptualLoudnessDb = loudness.perceptualLoudnessDb
         ).compact()
     }
 
@@ -2125,6 +2151,11 @@ private data class ClientHealth(
             return reliability * 100.0 + latencyBonus - consecutiveFailures * 12.0
         }
 }
+
+private data class PlaybackLoudness(
+    val loudnessDb: Float? = null,
+    val perceptualLoudnessDb: Float? = null
+)
 
 private data class DirectStream(
     val url: String,

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -3,11 +3,18 @@ package com.luc4n3x.levyra.data
 import android.content.Context
 import com.luc4n3x.levyra.BuildConfig
 import com.luc4n3x.levyra.data.security.GoogleApiKeyHeaders
+import com.luc4n3x.levyra.data.local.LevyraDatabase
 import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
 import com.luc4n3x.levyra.domain.LevyraContentLocales
+import com.luc4n3x.levyra.domain.PlaybackDeliveryMethod
+import com.luc4n3x.levyra.domain.PlaybackStreamDescriptor
+import com.luc4n3x.levyra.domain.PlaybackStreamKind
+import com.luc4n3x.levyra.domain.ResolvedPlaybackManifest
 import com.luc4n3x.levyra.domain.LevyraPersonalOrbit
 import com.luc4n3x.levyra.domain.Track
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
@@ -18,6 +25,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
 import org.json.JSONArray
@@ -69,6 +77,8 @@ class PlaybackResolver private constructor(private val context: Context) {
     private val jsonMediaType = "application/json; charset=utf-8".toMediaType()
     private val playbackSecurity = YoutubePlaybackSecurity(context, youtubeHttpClient, apiKey, userPreferences)
     private val resilienceEngine = PlaybackResilienceEngine(context)
+    private val sourceMatchStore = PlaybackSourceMatchStore(LevyraDatabase.get(context).playbackSourceMatchDao())
+    private val sourceMatchScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val fallbackTtlMs = 90L * 60L * 1000L
     private val maxTtlMs = 5L * 60L * 60L * 1000L
     private val youtubeEngagementTtlMs = 12L * 60L * 60L * 1000L
@@ -223,6 +233,18 @@ class PlaybackResolver private constructor(private val context: Context) {
         if (recovery.rotateCodec) {
             videoSelector.reportPlaybackFailure(track.videoStreamUrl.ifBlank { track.streamUrl }, lower)
         }
+        val sourceMatchQuarantineMs = when {
+            lower.contains("403") || lower.contains("410") || lower.contains("expired") || lower.contains("scadut") || lower.contains("signature") -> 0L
+            lower.contains("decoder") || lower.contains("codec") -> recovery.quarantineMs
+            else -> minOf(recovery.quarantineMs, 20_000L)
+        }
+        sourceMatchScope.launch {
+            runCatching {
+                sourceMatchStore.recordFailure(track, isVideoMode, selectedAudioQuality, sourceMatchQuarantineMs)
+            }.onFailure { error ->
+                Timber.w(error, "persistent source match failure update failed")
+            }
+        }
     }
 
     fun playbackDiagnostics(): String {
@@ -324,7 +346,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         if (track.streamUrl.isNotBlank()) {
             if (!isVideoMode && !isPlayableAudioUrl(track.streamUrl)) return null
             if (streamStillFresh(track.streamUrl)) {
-                store(track, isVideoMode)
+                store(track, track, isVideoMode)
                 return track
             }
             return null
@@ -340,6 +362,11 @@ class PlaybackResolver private constructor(private val context: Context) {
         audioQuality: String = selectedAudioQuality
     ): Track = withContext(Dispatchers.IO) {
         val errors = Collections.synchronizedList(mutableListOf<String>())
+
+        restorePersistentSource(track, isVideoMode, preferMp4Audio, audioQuality, errors)?.let { restored ->
+            store(track, restored, isVideoMode, audioQuality)
+            return@withContext restored
+        }
 
         if (isVideoMode) {
             val resolved = coroutineScope {
@@ -371,7 +398,8 @@ class PlaybackResolver private constructor(private val context: Context) {
                 result
             }
             if (resolved != null) {
-                store(resolved, isVideoMode, audioQuality)
+                store(track, resolved, isVideoMode, audioQuality)
+                persistResolvedSource(track, resolved, isVideoMode, audioQuality, 92)
                 return@withContext resolved
             }
             val reason = errors.firstOrNull { it.contains("age", true) || it.contains("login", true) }
@@ -382,13 +410,15 @@ class PlaybackResolver private constructor(private val context: Context) {
 
         val resolved = resolveAudioFast(track, errors, preferMp4Audio, audioQuality)
         if (resolved != null) {
-            store(resolved, isVideoMode, audioQuality)
+            store(track, resolved, isVideoMode, audioQuality)
+            persistResolvedSource(track, resolved, isVideoMode, audioQuality, 96)
             return@withContext resolved
         }
 
         val alternate = resolveAudioWithSearchFallback(track, errors, preferMp4Audio, audioQuality)
         if (alternate != null) {
-            store(alternate, isVideoMode, audioQuality)
+            store(track, alternate, isVideoMode, audioQuality)
+            persistResolvedSource(track, alternate, isVideoMode, audioQuality, 84)
             return@withContext alternate
         }
 
@@ -488,12 +518,184 @@ class PlaybackResolver private constructor(private val context: Context) {
                     youtubeLoudnessDb = resolved.youtubeLoudnessDb,
                     youtubePerceptualLoudnessDb = resolved.youtubePerceptualLoudnessDb,
                     youtubeLikeCount = resolved.youtubeLikeCount,
-                    youtubeViewCount = resolved.youtubeViewCount
+                    youtubeViewCount = resolved.youtubeViewCount,
+                    playbackManifest = resolved.playbackManifest
                 )
             }
             localErrors.firstOrNull()?.takeIf { it.isNotBlank() }?.let { errors += "Fallback ${candidate.id}: $it" }
         }
         return null
+    }
+
+    private suspend fun restorePersistentSource(
+        track: Track,
+        isVideoMode: Boolean,
+        preferMp4Audio: Boolean,
+        audioQuality: String,
+        errors: MutableList<String>
+    ): Track? {
+        val stored = runCatching { sourceMatchStore.load(track, isVideoMode, audioQuality) }
+            .onFailure { error ->
+                if (error is CancellationException) throw error
+                Timber.w(error, "persistent source match load failed")
+            }
+            .getOrNull() ?: return null
+        val now = System.currentTimeMillis()
+        if (stored.entity.blockedUntil > now) return null
+        val manifest = stored.manifest
+        if (manifest != null && manifest.isFresh(now) && manifestUrlsUsable(manifest, isVideoMode)) {
+            recordSourceMatchSuccess(track, isVideoMode, audioQuality)
+            return track.applyManifest(
+                manifest = manifest,
+                sourceVideoUrl = stored.entity.sourceVideoUrl,
+                source = stored.entity.provider.ifBlank { "Persistent source match" }
+            )
+        }
+        val sourceVideoId = stored.entity.sourceVideoId
+            .takeIf { it.matches(Regex("[A-Za-z0-9_-]{11}")) }
+            ?: return null
+        val sourceVideoUrl = stored.entity.sourceVideoUrl.ifBlank { "https://www.youtube.com/watch?v=$sourceVideoId" }
+        val sourceTrack = track.copy(
+            id = sourceVideoId,
+            videoUrl = sourceVideoUrl,
+            streamUrl = "",
+            videoStreamUrl = "",
+            playbackManifest = null
+        )
+        val refreshed = try {
+            refreshExactPersistentSource(sourceTrack, isVideoMode, preferMp4Audio, audioQuality, errors)
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            errors += "Persistent source $sourceVideoId: ${error.playbackDiagnostic()}"
+            null
+        }
+        if (refreshed == null) {
+            recordSourceMatchFailure(track, isVideoMode, audioQuality, 90_000L)
+            return null
+        }
+        val rebased = rebaseResolvedTrack(track, refreshed)
+        persistResolvedSource(track, rebased, isVideoMode, audioQuality, stored.entity.confidence.coerceAtLeast(88))
+        return rebased
+    }
+
+    private suspend fun refreshExactPersistentSource(
+        sourceTrack: Track,
+        isVideoMode: Boolean,
+        preferMp4Audio: Boolean,
+        audioQuality: String,
+        errors: MutableList<String>
+    ): Track? {
+        val extractor = runCatching {
+            if (isVideoMode) {
+                resolveVideoWithLevyraExtractor(sourceTrack, audioQuality)
+            } else {
+                resolveWithLevyraExtractor(sourceTrack, preferMp4Audio, audioQuality)
+            }
+        }.onFailure { error ->
+            if (error is CancellationException) throw error
+            errors += "Persistent LevyraExtractor: ${error.playbackDiagnostic()}"
+        }.getOrNull()
+        if (extractor != null && manifestUrlsUsable(extractor.playbackManifest, isVideoMode)) return extractor
+        val direct = runCatching {
+            if (preferMp4Audio) {
+                raceInnerTube(sourceTrack, errors, isVideoMode, true, audioQuality)
+            } else {
+                hedgedInnerTube(sourceTrack, errors, isVideoMode, audioQuality)
+            }
+        }.onFailure { error ->
+            if (error is CancellationException) throw error
+            errors += "Persistent InnerTube: ${error.playbackDiagnostic()}"
+        }.getOrNull() ?: return null
+        return sourceTrack.withDirectStream(direct)
+    }
+
+    private fun manifestUrlsUsable(manifest: ResolvedPlaybackManifest?, isVideoMode: Boolean): Boolean {
+        if (manifest == null || manifest.selectedAudioUrl.isBlank()) return false
+        if (isPlaybackUrlBlocked(manifest.selectedAudioUrl) || !streamStillFresh(manifest.selectedAudioUrl)) return false
+        if (!isVideoMode && !isPlayableAudioUrl(manifest.selectedAudioUrl)) return false
+        val videoUrl = manifest.selectedVideoUrl
+        if (videoUrl.isNotBlank() && (isPlaybackUrlBlocked(videoUrl) || !streamStillFresh(videoUrl))) return false
+        return true
+    }
+
+    private fun Track.applyManifest(
+        manifest: ResolvedPlaybackManifest,
+        sourceVideoUrl: String,
+        source: String
+    ): Track {
+        return copy(
+            streamUrl = manifest.selectedAudioUrl,
+            videoStreamUrl = manifest.selectedVideoUrl,
+            videoUrl = sourceVideoUrl.ifBlank { videoUrl },
+            durationMs = manifest.durationMs.takeIf { it > 0L } ?: durationMs,
+            source = source,
+            youtubeLoudnessDb = manifest.loudnessDb ?: youtubeLoudnessDb,
+            youtubePerceptualLoudnessDb = manifest.perceptualLoudnessDb ?: youtubePerceptualLoudnessDb,
+            playbackManifest = manifest
+        )
+    }
+
+    private fun rebaseResolvedTrack(original: Track, resolved: Track): Track {
+        val artworkSafe = LevyraPersonalOrbit.preferAlbumArtwork(original, resolved)
+        return artworkSafe.copy(
+            streamUrl = resolved.streamUrl,
+            videoStreamUrl = resolved.videoStreamUrl,
+            videoUrl = resolved.videoUrl.ifBlank { original.videoUrl },
+            durationMs = resolved.durationMs.takeIf { it > 0L } ?: original.durationMs,
+            source = resolved.source,
+            youtubeLoudnessDb = resolved.youtubeLoudnessDb ?: original.youtubeLoudnessDb,
+            youtubePerceptualLoudnessDb = resolved.youtubePerceptualLoudnessDb ?: original.youtubePerceptualLoudnessDb,
+            youtubeLikeCount = resolved.youtubeLikeCount.takeIf { it >= 0L } ?: original.youtubeLikeCount,
+            youtubeViewCount = resolved.youtubeViewCount.takeIf { it >= 0L } ?: original.youtubeViewCount,
+            playbackManifest = resolved.playbackManifest
+        )
+    }
+
+    private suspend fun recordSourceMatchSuccess(
+        track: Track,
+        isVideoMode: Boolean,
+        audioQuality: String
+    ) {
+        try {
+            sourceMatchStore.recordSuccess(track, isVideoMode, audioQuality)
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            Timber.w(error, "persistent source match success update failed")
+        }
+    }
+
+    private suspend fun recordSourceMatchFailure(
+        track: Track,
+        isVideoMode: Boolean,
+        audioQuality: String,
+        quarantineMs: Long
+    ) {
+        try {
+            sourceMatchStore.recordFailure(track, isVideoMode, audioQuality, quarantineMs)
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            Timber.w(error, "persistent source match failure update failed")
+        }
+    }
+
+    private suspend fun persistResolvedSource(
+        original: Track,
+        resolved: Track,
+        isVideoMode: Boolean,
+        audioQuality: String,
+        confidence: Int
+    ) {
+        if (resolved.playbackManifest == null) return
+        try {
+            sourceMatchStore.save(original, resolved, isVideoMode, audioQuality, confidence)
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            Timber.w(error, "persistent source match save failed")
+        }
     }
 
     private suspend fun findAlternativeAudioCandidates(track: Track): List<Track> = withContext(Dispatchers.IO) {
@@ -579,7 +781,7 @@ class PlaybackResolver private constructor(private val context: Context) {
 
     private fun extractVideoId(url: String): String {
         if (url.isBlank()) return ""
-        Regex("(?:v=|/shorts/|/embed/|youtu\\.be/)([A-Za-z0-9_-]{11})").find(url)?.groupValues?.getOrNull(1)?.let { return it }
+        Regex("(?:v=|/shorts/|/embed/|/live/|youtu\\.be/)([A-Za-z0-9_-]{11})").find(url)?.groupValues?.getOrNull(1)?.let { return it }
         return url.takeIf { it.matches(Regex("[A-Za-z0-9_-]{11}")) }.orEmpty()
     }
 
@@ -655,7 +857,8 @@ class PlaybackResolver private constructor(private val context: Context) {
             durationMs = stream.durationMs.takeIf { it > 0L } ?: durationMs,
             source = stream.source,
             youtubeLoudnessDb = stream.loudnessDb ?: youtubeLoudnessDb,
-            youtubePerceptualLoudnessDb = stream.perceptualLoudnessDb ?: youtubePerceptualLoudnessDb
+            youtubePerceptualLoudnessDb = stream.perceptualLoudnessDb ?: youtubePerceptualLoudnessDb,
+            playbackManifest = stream.manifest
         )
     }
 
@@ -811,7 +1014,11 @@ class PlaybackResolver private constructor(private val context: Context) {
                 val json = runCatching { JSONObject(raw) }.getOrNull() ?: return@forEach
                 val streamUrl = json.optString("streamUrl")
                 val expiresAt = json.optLong("expiresAt", json.optLong("at", 0L) + fallbackTtlMs)
-                val track = json.optJSONObject("track")?.let(TrackJson::fromJson)?.copy(streamUrl = streamUrl)
+                val manifest = PlaybackManifestCodec.decode(json.optString("manifestJson"))
+                val track = json.optJSONObject("track")?.let(TrackJson::fromJson)?.copy(
+                    streamUrl = streamUrl,
+                    playbackManifest = manifest
+                )
                 val audioCache = key.contains("_audio_", ignoreCase = true)
                 if (track != null && streamUrl.isNotBlank() && now < expiresAt && streamStillFresh(streamUrl) && (!audioCache || isPlayableAudioUrl(streamUrl))) {
                     streamCache[key] = CachedStream(track, expiresAt)
@@ -825,20 +1032,25 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     private fun store(
-        track: Track,
+        requestedTrack: Track,
+        resolvedTrack: Track,
         isVideoMode: Boolean = false,
         audioQuality: String = selectedAudioQuality
     ) {
-        if (track.streamUrl.isBlank() || !streamStillFresh(track.streamUrl)) return
-        if (!isVideoMode && !isPlayableAudioUrl(track.streamUrl)) return
-        val key = cacheKey(track, isVideoMode, audioQuality)
-        val expiresAt = expiresAtFor(track.streamUrl)
-        streamCache[key] = CachedStream(track, expiresAt)
-        if (isVideoMode || track.videoStreamUrl.isNotBlank()) return
+        if (resolvedTrack.streamUrl.isBlank() || !streamStillFresh(resolvedTrack.streamUrl)) return
+        if (!isVideoMode && !isPlayableAudioUrl(resolvedTrack.streamUrl)) return
+        val key = cacheKey(requestedTrack, isVideoMode, audioQuality)
+        val expiresAt = resolvedTrack.playbackManifest?.expiresAtMs
+            ?.takeIf { it > System.currentTimeMillis() }
+            ?.let { minOf(it, expiresAtFor(resolvedTrack.streamUrl)) }
+            ?: expiresAtFor(resolvedTrack.streamUrl)
+        streamCache[key] = CachedStream(resolvedTrack, expiresAt)
+        if (isVideoMode || resolvedTrack.videoStreamUrl.isNotBlank()) return
         val json = JSONObject()
             .put("expiresAt", expiresAt)
-            .put("streamUrl", track.streamUrl)
-            .put("track", TrackJson.toJson(track.copy(streamUrl = "")))
+            .put("streamUrl", resolvedTrack.streamUrl)
+            .put("manifestJson", resolvedTrack.playbackManifest?.let(PlaybackManifestCodec::encode).orEmpty())
+            .put("track", TrackJson.toJson(resolvedTrack.copy(streamUrl = "", playbackManifest = null)))
         prefs.edit().putString(key, json.toString()).apply()
     }
 
@@ -967,7 +1179,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         isVideoMode: Boolean = false,
         audioQuality: String = selectedAudioQuality
     ): String {
-        val base = track.id.trim().ifBlank { track.videoUrl.trim() }
+        val base = PlaybackSourceIdentity.canonicalKey(track)
         val quality = normalizeAudioQuality(audioQuality).lowercase()
         return if (isVideoMode) "${base}_video_$quality" else "${base}_audio_$quality"
     }
@@ -1092,6 +1304,7 @@ class PlaybackResolver private constructor(private val context: Context) {
 
             var bestAudioUrl = ""
             var bestAudioLabel = ""
+            var bestAudioFormat: JSONObject? = null
             for ((format, _, label) in audioCandidates) {
                 val url = format.resolveFormatUrl(
                     videoId = track.id,
@@ -1101,6 +1314,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 if (url.isBlank() || isPlaybackUrlBlocked(url)) continue
                 bestAudioUrl = url
                 bestAudioLabel = label
+                bestAudioFormat = format
                 break
             }
 
@@ -1168,33 +1382,75 @@ class PlaybackResolver private constructor(private val context: Context) {
                 val duration = details?.optString("lengthSeconds")?.toLongOrNull()?.times(1000L) ?: 0L
                 val thumbnail = details?.optJSONObject("thumbnail")?.optJSONArray("thumbnails")?.bestThumbnail().orEmpty()
                 return@responseUse when {
-                    selection?.candidate?.muxed == true -> DirectStream(
-                        url = selection.candidate.url,
-                        videoUrl = "",
-                        durationMs = duration,
-                        thumbnailUrl = thumbnail,
-                        source = "YouTube ${profile.label} · ${selection.reason}",
-                        loudnessDb = loudnessDb,
-                        perceptualLoudnessDb = perceptualLoudnessDb
-                    )
-                    selection != null && bestAudioUrl.isNotBlank() -> DirectStream(
-                        url = bestAudioUrl,
-                        videoUrl = selection.candidate.url,
-                        durationMs = duration,
-                        thumbnailUrl = thumbnail,
-                        source = "YouTube ${profile.label} · ${selection.reason}",
-                        loudnessDb = loudnessDb,
-                        perceptualLoudnessDb = perceptualLoudnessDb
-                    )
-                    hlsUrl.isNotBlank() -> DirectStream(
-                        url = hlsUrl,
-                        videoUrl = "",
-                        durationMs = duration,
-                        thumbnailUrl = thumbnail,
-                        source = "YouTube HLS ${profile.label}",
-                        loudnessDb = loudnessDb,
-                        perceptualLoudnessDb = perceptualLoudnessDb
-                    )
+                    selection?.candidate?.muxed == true -> {
+                        val manifest = buildManifest(
+                            sourceVideoId = track.id,
+                            provider = "YouTube ${profile.label}",
+                            durationMs = duration,
+                            selectedAudioUrl = selection.candidate.url,
+                            selectedVideoUrl = "",
+                            streams = listOf(videoDescriptor(selection.candidate, true)),
+                            loudnessDb = loudnessDb,
+                            perceptualLoudnessDb = perceptualLoudnessDb
+                        )
+                        DirectStream(
+                            url = selection.candidate.url,
+                            videoUrl = "",
+                            durationMs = duration,
+                            thumbnailUrl = thumbnail,
+                            source = "YouTube ${profile.label} · ${selection.reason}",
+                            manifest = manifest,
+                            loudnessDb = loudnessDb,
+                            perceptualLoudnessDb = perceptualLoudnessDb
+                        )
+                    }
+                    selection != null && bestAudioUrl.isNotBlank() -> {
+                        val manifest = buildManifest(
+                            sourceVideoId = track.id,
+                            provider = "YouTube ${profile.label}",
+                            durationMs = duration,
+                            selectedAudioUrl = bestAudioUrl,
+                            selectedVideoUrl = selection.candidate.url,
+                            streams = listOf(
+                                innerTubeAudioDescriptor(bestAudioFormat, bestAudioUrl, true),
+                                videoDescriptor(selection.candidate, true)
+                            ),
+                            loudnessDb = loudnessDb,
+                            perceptualLoudnessDb = perceptualLoudnessDb
+                        )
+                        DirectStream(
+                            url = bestAudioUrl,
+                            videoUrl = selection.candidate.url,
+                            durationMs = duration,
+                            thumbnailUrl = thumbnail,
+                            source = "YouTube ${profile.label} · ${selection.reason}",
+                            manifest = manifest,
+                            loudnessDb = loudnessDb,
+                            perceptualLoudnessDb = perceptualLoudnessDb
+                        )
+                    }
+                    hlsUrl.isNotBlank() -> {
+                        val manifest = buildManifest(
+                            sourceVideoId = track.id,
+                            provider = "YouTube HLS ${profile.label}",
+                            durationMs = duration,
+                            selectedAudioUrl = hlsUrl,
+                            selectedVideoUrl = "",
+                            streams = listOf(hlsDescriptor(hlsUrl)),
+                            loudnessDb = loudnessDb,
+                            perceptualLoudnessDb = perceptualLoudnessDb
+                        )
+                        DirectStream(
+                            url = hlsUrl,
+                            videoUrl = "",
+                            durationMs = duration,
+                            thumbnailUrl = thumbnail,
+                            source = "YouTube HLS ${profile.label}",
+                            manifest = manifest,
+                            loudnessDb = loudnessDb,
+                            perceptualLoudnessDb = perceptualLoudnessDb
+                        )
+                    }
                     else -> throw YoutubePlayerRequestException(null, "Nessuno stream video compatibile disponibile")
                 }
             }
@@ -1203,12 +1459,23 @@ class PlaybackResolver private constructor(private val context: Context) {
             val details = root.optJSONObject("videoDetails")
             val duration = details?.optString("lengthSeconds")?.toLongOrNull()?.times(1000L) ?: 0L
             val thumbnail = details?.optJSONObject("thumbnail")?.optJSONArray("thumbnails")?.bestThumbnail().orEmpty()
+            val manifest = buildManifest(
+                sourceVideoId = track.id,
+                provider = "YouTube ${profile.label}",
+                durationMs = duration,
+                selectedAudioUrl = bestAudioUrl,
+                selectedVideoUrl = "",
+                streams = listOf(innerTubeAudioDescriptor(bestAudioFormat, bestAudioUrl, true)),
+                loudnessDb = loudnessDb,
+                perceptualLoudnessDb = perceptualLoudnessDb
+            )
             DirectStream(
                 url = bestAudioUrl,
                 videoUrl = "",
                 durationMs = duration,
                 thumbnailUrl = thumbnail,
                 source = "YouTube ${profile.label}${bestAudioLabel.takeIf { it.isNotBlank() }?.let { " · $it" }.orEmpty()}",
+                manifest = manifest,
                 loudnessDb = loudnessDb,
                 perceptualLoudnessDb = perceptualLoudnessDb
             )
@@ -1289,17 +1556,38 @@ class PlaybackResolver private constructor(private val context: Context) {
             primary = track,
             donor = track.copy(thumbnailUrl = bestThumb, largeThumbnailUrl = bestThumb)
         )
+        val durationMs = if (info.duration > 0L) info.duration * 1000L else track.durationMs
+        val sourceVideoId = extractVideoId(track.videoUrl).ifBlank { track.id }
+        val provider = if (audio != null) "LevyraExtractor" else "LevyraExtractor HLS"
+        val descriptors = if (audio != null) {
+            info.audioStreams
+                .asSequence()
+                .filter { it.isUrl && it.content.isNotBlank() && streamStillFresh(it.content) }
+                .map { audioDescriptor(it, it.content == url) }
+                .toList()
+        } else {
+            listOf(hlsDescriptor(url))
+        }
+        val manifest = buildManifest(
+            sourceVideoId = sourceVideoId,
+            provider = provider,
+            durationMs = durationMs,
+            selectedAudioUrl = url,
+            selectedVideoUrl = "",
+            streams = descriptors
+        )
         return artworkSafe.copy(
             streamUrl = url,
-            videoStreamUrl = if (audio == null) "" else artworkSafe.videoStreamUrl,
-            durationMs = if (info.duration > 0L) info.duration * 1000L else track.durationMs,
+            videoStreamUrl = "",
+            durationMs = durationMs,
             source = if (audio != null) {
                 "LevyraExtractor${label.takeIf { it.isNotBlank() }?.let { " · $it" }.orEmpty()}"
             } else {
                 "LevyraExtractor HLS"
-            }
+            },
+            playbackManifest = manifest
         ).withYoutubeEngagement(info.likeCount, info.viewCount).also {
-            cacheYoutubeEngagement(extractVideoId(track.videoUrl).ifBlank { track.id }, info.likeCount, info.viewCount)
+            cacheYoutubeEngagement(sourceVideoId, info.likeCount, info.viewCount)
         }
     }
 
@@ -1316,9 +1604,11 @@ class PlaybackResolver private constructor(private val context: Context) {
             primary = track,
             donor = track.copy(thumbnailUrl = bestThumb, largeThumbnailUrl = bestThumb)
         ).withYoutubeEngagement(info.likeCount, info.viewCount)
-        cacheYoutubeEngagement(extractVideoId(track.videoUrl).ifBlank { track.id }, info.likeCount, info.viewCount)
+        val sourceVideoId = extractVideoId(track.videoUrl).ifBlank { track.id }
+        cacheYoutubeEngagement(sourceVideoId, info.likeCount, info.viewCount)
         val durationMs = if (info.duration > 0L) info.duration * 1000L else track.durationMs
-        val bestAudio = selectAudioStream(info.audioStreams, preferMp4Audio = false, audioQuality = audioQuality)?.content
+        val selectedAudio = selectAudioStream(info.audioStreams, preferMp4Audio = false, audioQuality = audioQuality)
+        val bestAudio = selectedAudio?.content.orEmpty()
         val muxedCandidates = info.videoStreams
             .filter { it.isUrl && it.content.isNotBlank() && streamStillFresh(it.content) }
             .map(::extractorVideoCandidate)
@@ -1328,33 +1618,52 @@ class PlaybackResolver private constructor(private val context: Context) {
         val selection = videoSelector.select(
             muxedCandidates = muxedCandidates,
             videoOnlyCandidates = videoOnlyCandidates,
-            hasSeparateAudio = !bestAudio.isNullOrBlank(),
+            hasSeparateAudio = bestAudio.isNotBlank(),
             blocked = ::isPlaybackUrlBlocked
         )
         if (selection != null) {
-            return if (selection.candidate.muxed) {
-                artworkSafe.copy(
-                    streamUrl = selection.candidate.url,
-                    videoStreamUrl = "",
-                    durationMs = durationMs,
-                    source = "LevyraExtractor · ${selection.reason}"
-                )
-            } else {
-                artworkSafe.copy(
-                    streamUrl = bestAudio.orEmpty(),
-                    videoStreamUrl = selection.candidate.url,
-                    durationMs = durationMs,
-                    source = "LevyraExtractor · ${selection.reason}"
-                )
+            val selectedAudioUrl = if (selection.candidate.muxed) selection.candidate.url else bestAudio
+            val selectedVideoUrl = if (selection.candidate.muxed) "" else selection.candidate.url
+            val descriptors = buildList {
+                info.audioStreams
+                    .asSequence()
+                    .filter { it.isUrl && it.content.isNotBlank() && streamStillFresh(it.content) }
+                    .mapTo(this) { audioDescriptor(it, it.content == selectedAudioUrl) }
+                muxedCandidates.mapTo(this) { videoDescriptor(it, it.url == selection.candidate.url) }
+                videoOnlyCandidates.mapTo(this) { videoDescriptor(it, it.url == selection.candidate.url) }
             }
+            val manifest = buildManifest(
+                sourceVideoId = sourceVideoId,
+                provider = "LevyraExtractor",
+                durationMs = durationMs,
+                selectedAudioUrl = selectedAudioUrl,
+                selectedVideoUrl = selectedVideoUrl,
+                streams = descriptors
+            )
+            return artworkSafe.copy(
+                streamUrl = selectedAudioUrl,
+                videoStreamUrl = selectedVideoUrl,
+                durationMs = durationMs,
+                source = "LevyraExtractor · ${selection.reason}",
+                playbackManifest = manifest
+            )
         }
         val hls = info.hlsUrl.takeIf { it.isNotBlank() && !isPlaybackUrlBlocked(it) && isVerifiedHlsManifest(it) }
         if (hls != null) {
+            val manifest = buildManifest(
+                sourceVideoId = sourceVideoId,
+                provider = "LevyraExtractor HLS",
+                durationMs = durationMs,
+                selectedAudioUrl = hls,
+                selectedVideoUrl = "",
+                streams = listOf(hlsDescriptor(hls))
+            )
             return artworkSafe.copy(
                 streamUrl = hls,
                 videoStreamUrl = "",
                 durationMs = durationMs,
-                source = "LevyraExtractor HLS"
+                source = "LevyraExtractor HLS",
+                playbackManifest = manifest
             )
         }
         throw IllegalStateException("Nessuno stream video compatibile per ${track.title}")
@@ -1411,6 +1720,108 @@ class PlaybackResolver private constructor(private val context: Context) {
             ?.groupValues
             ?.getOrNull(1)
             .orEmpty()
+    }
+
+    private fun buildManifest(
+        sourceVideoId: String,
+        provider: String,
+        durationMs: Long,
+        selectedAudioUrl: String,
+        selectedVideoUrl: String,
+        streams: List<PlaybackStreamDescriptor>,
+        loudnessDb: Float? = null,
+        perceptualLoudnessDb: Float? = null
+    ): ResolvedPlaybackManifest {
+        val selectedUrls = setOf(selectedAudioUrl, selectedVideoUrl).filter { it.isNotBlank() }.toSet()
+        val normalizedStreams = streams
+            .filter { it.url.isNotBlank() }
+            .map { descriptor -> descriptor.copy(selected = descriptor.url in selectedUrls) }
+            .distinctBy { descriptor -> listOf(descriptor.kind.name, descriptor.itag.toString(), descriptor.url).joinToString("|") }
+        val selectedExpiry = normalizedStreams
+            .filter { it.selected }
+            .mapNotNull { it.expiresAtMs.takeIf { expiry -> expiry > 0L } }
+            .minOrNull()
+            ?: expiresAtFor(selectedAudioUrl)
+        return ResolvedPlaybackManifest(
+            sourceVideoId = sourceVideoId,
+            provider = provider,
+            resolvedAtMs = System.currentTimeMillis(),
+            expiresAtMs = selectedExpiry,
+            durationMs = durationMs,
+            selectedAudioUrl = selectedAudioUrl,
+            selectedVideoUrl = selectedVideoUrl,
+            streams = normalizedStreams,
+            loudnessDb = loudnessDb,
+            perceptualLoudnessDb = perceptualLoudnessDb
+        ).compact()
+    }
+
+    private fun audioDescriptor(stream: AudioStream, selected: Boolean = false): PlaybackStreamDescriptor {
+        val format = stream.getFormat()
+        return PlaybackStreamDescriptor(
+            url = stream.content,
+            kind = PlaybackStreamKind.AUDIO,
+            deliveryMethod = if (isHlsManifestUrl(stream.content)) PlaybackDeliveryMethod.HLS else PlaybackDeliveryMethod.PROGRESSIVE,
+            container = format?.suffix.orEmpty(),
+            mimeType = format?.mimeType.orEmpty(),
+            codec = stream.codec.orEmpty(),
+            bitrate = stream.bitrate.coerceAtLeast(0),
+            averageBitrate = stream.averageBitrate.coerceAtLeast(0),
+            itag = stream.itag,
+            qualityLabel = stream.quality.orEmpty(),
+            expiresAtMs = expiresAtFor(stream.content),
+            selected = selected
+        )
+    }
+
+    private fun videoDescriptor(candidate: LevyraVideoCandidate, selected: Boolean = false): PlaybackStreamDescriptor {
+        return PlaybackStreamDescriptor(
+            url = candidate.url,
+            kind = if (candidate.muxed) PlaybackStreamKind.MUXED else PlaybackStreamKind.VIDEO,
+            deliveryMethod = PlaybackDeliveryMethod.PROGRESSIVE,
+            container = candidate.mimeType.substringAfter('/', "").substringBefore(';'),
+            mimeType = candidate.mimeType.substringBefore(';'),
+            codec = candidate.codec,
+            bitrate = candidate.bitrate.coerceAtLeast(0),
+            width = candidate.width.coerceAtLeast(0),
+            height = candidate.height.coerceAtLeast(0),
+            fps = candidate.fps.coerceAtLeast(0),
+            itag = candidate.itag,
+            qualityLabel = candidate.label,
+            expiresAtMs = expiresAtFor(candidate.url),
+            selected = selected
+        )
+    }
+
+    private fun hlsDescriptor(url: String, selected: Boolean = true): PlaybackStreamDescriptor {
+        return PlaybackStreamDescriptor(
+            url = url,
+            kind = PlaybackStreamKind.HLS,
+            deliveryMethod = PlaybackDeliveryMethod.HLS,
+            container = "m3u8",
+            mimeType = "application/x-mpegURL",
+            expiresAtMs = expiresAtFor(url),
+            selected = selected
+        )
+    }
+
+    private fun innerTubeAudioDescriptor(format: JSONObject?, url: String, selected: Boolean = true): PlaybackStreamDescriptor {
+        val mime = format?.optString("mimeType").orEmpty()
+        return PlaybackStreamDescriptor(
+            url = url,
+            kind = PlaybackStreamKind.AUDIO,
+            deliveryMethod = PlaybackDeliveryMethod.PROGRESSIVE,
+            container = mime.substringBefore(';').substringAfter('/', ""),
+            mimeType = mime.substringBefore(';'),
+            codec = codecFromMimeType(mime),
+            bitrate = format?.optInt("bitrate", 0) ?: 0,
+            averageBitrate = format?.optInt("averageBitrate", 0) ?: 0,
+            sampleRate = format?.optString("audioSampleRate")?.toIntOrNull() ?: 0,
+            itag = format?.optInt("itag", -1) ?: -1,
+            qualityLabel = format?.optString("audioQuality").orEmpty(),
+            expiresAtMs = expiresAtFor(url),
+            selected = selected
+        )
     }
 
     private fun streamLabel(stream: AudioStream): String {
@@ -1721,6 +2132,7 @@ private data class DirectStream(
     val durationMs: Long,
     val thumbnailUrl: String,
     val source: String,
+    val manifest: ResolvedPlaybackManifest,
     val loudnessDb: Float? = null,
     val perceptualLoudnessDb: Float? = null
 )

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSourceIdentity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSourceIdentity.kt
@@ -6,8 +6,9 @@ import java.security.MessageDigest
 import java.util.Locale
 
 object PlaybackSourceIdentity {
-    private val youtubeIdPattern = Regex("[A-Za-z0-9_-]{11}")
-    private val youtubeUrlPattern = Regex("(?:v=|/shorts/|/embed/|/live/|youtu\\.be/)([A-Za-z0-9_-]{11})")
+    private const val YOUTUBE_VIDEO_ID_PATTERN = "[A-Za-z0-9_-]{11}"
+    private val youtubeIdPattern = Regex(YOUTUBE_VIDEO_ID_PATTERN)
+    private val youtubeUrlPattern = Regex("(?:v=|/shorts/|/embed/|/live/|youtu\\.be/)($YOUTUBE_VIDEO_ID_PATTERN)")
 
     fun canonicalKey(track: Track): String {
         val isrc = track.isrc.trim().lowercase(Locale.ROOT)
@@ -20,7 +21,12 @@ object PlaybackSourceIdentity {
             normalize(track.title),
             normalize(track.artist),
             normalize(track.album),
-            durationBucket.toString()
+            durationBucket.toString(),
+            if (track.explicit) "explicit" else "clean",
+            track.discNumber.coerceAtLeast(0).toString(),
+            track.trackNumber.coerceAtLeast(0).toString(),
+            normalizeIdentifier(track.upc),
+            recordingDiscriminator(track)
         ).joinToString("|")
         return "track:${sha256(payload).take(32)}"
     }
@@ -38,9 +44,29 @@ object PlaybackSourceIdentity {
         return youtubeUrlPattern.find(clean)?.groupValues?.getOrNull(1).orEmpty()
     }
 
-    fun matchKey(track: Track, videoMode: Boolean, audioQuality: String): String {
-        val mode = if (videoMode) "video" else "audio"
+    fun matchKey(
+        track: Track,
+        videoMode: Boolean,
+        audioQuality: String,
+        preferMp4Audio: Boolean = false
+    ): String {
+        val mode = when {
+            videoMode -> "video"
+            preferMp4Audio -> "audio-mp4"
+            else -> "audio"
+        }
         return "${canonicalKey(track)}|$mode|${audioQuality.trim().lowercase(Locale.ROOT)}"
+    }
+
+    private fun recordingDiscriminator(track: Track): String {
+        normalizeIdentifier(track.id).takeIf { it.isNotBlank() }?.let { return "id:$it" }
+        normalizeIdentifier(track.counterpartVideoId).takeIf { it.isNotBlank() }?.let { return "counterpart:$it" }
+        extractYoutubeVideoId(track.videoUrl).lowercase(Locale.ROOT).takeIf { it.isNotBlank() }?.let { return "youtube:$it" }
+        return "metadata-only"
+    }
+
+    private fun normalizeIdentifier(value: String): String {
+        return value.trim().lowercase(Locale.ROOT)
     }
 
     private fun normalize(value: String): String {

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSourceIdentity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSourceIdentity.kt
@@ -1,0 +1,60 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.domain.Track
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.Locale
+
+object PlaybackSourceIdentity {
+    private val youtubeIdPattern = Regex("[A-Za-z0-9_-]{11}")
+    private val youtubeUrlPattern = Regex("(?:v=|/shorts/|/embed/|/live/|youtu\\.be/)([A-Za-z0-9_-]{11})")
+
+    fun canonicalKey(track: Track): String {
+        val isrc = track.isrc.trim().lowercase(Locale.ROOT)
+        if (isrc.isNotBlank()) return "isrc:$isrc"
+        val durationBucket = when {
+            track.durationMs <= 0L -> 0L
+            else -> (track.durationMs + 1_000L) / 2_000L
+        }
+        val payload = listOf(
+            normalize(track.title),
+            normalize(track.artist),
+            normalize(track.album),
+            durationBucket.toString()
+        ).joinToString("|")
+        return "track:${sha256(payload).take(32)}"
+    }
+
+    fun sourceVideoId(track: Track): String {
+        extractYoutubeVideoId(track.videoUrl).takeIf { it.isNotBlank() }?.let { return it }
+        track.id.trim().takeIf { youtubeIdPattern.matches(it) }?.let { return it }
+        track.counterpartVideoId.trim().takeIf { youtubeIdPattern.matches(it) }?.let { return it }
+        return ""
+    }
+
+    fun extractYoutubeVideoId(value: String): String {
+        val clean = value.trim()
+        if (youtubeIdPattern.matches(clean)) return clean
+        return youtubeUrlPattern.find(clean)?.groupValues?.getOrNull(1).orEmpty()
+    }
+
+    fun matchKey(track: Track, videoMode: Boolean, audioQuality: String): String {
+        val mode = if (videoMode) "video" else "audio"
+        return "${canonicalKey(track)}|$mode|${audioQuality.trim().lowercase(Locale.ROOT)}"
+    }
+
+    private fun normalize(value: String): String {
+        return value
+            .lowercase(Locale.ROOT)
+            .replace(Regex("\\([^)]*(official|audio|video|lyrics?|visuali[sz]er|remaster)[^)]*\\)", RegexOption.IGNORE_CASE), " ")
+            .replace(Regex("\\[[^]]*(official|audio|video|lyrics?|visuali[sz]er|remaster)[^]]*]", RegexOption.IGNORE_CASE), " ")
+            .replace(Regex("[^\\p{L}\\p{N}]+"), " ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+    }
+
+    private fun sha256(value: String): String {
+        val bytes = MessageDigest.getInstance("SHA-256").digest(value.toByteArray(StandardCharsets.UTF_8))
+        return bytes.joinToString("") { byte -> "%02x".format(byte) }
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSourceMatchStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSourceMatchStore.kt
@@ -1,0 +1,71 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.data.local.PlaybackSourceMatchDao
+import com.luc4n3x.levyra.data.local.PlaybackSourceMatchEntity
+import com.luc4n3x.levyra.domain.ResolvedPlaybackManifest
+import com.luc4n3x.levyra.domain.Track
+
+internal data class StoredPlaybackSourceMatch(
+    val entity: PlaybackSourceMatchEntity,
+    val manifest: ResolvedPlaybackManifest?
+)
+
+internal class PlaybackSourceMatchStore(
+    private val dao: PlaybackSourceMatchDao
+) {
+    suspend fun load(track: Track, videoMode: Boolean, audioQuality: String): StoredPlaybackSourceMatch? {
+        val entity = dao.get(PlaybackSourceIdentity.matchKey(track, videoMode, audioQuality)) ?: return null
+        return StoredPlaybackSourceMatch(entity, PlaybackManifestCodec.decode(entity.manifestJson))
+    }
+
+    suspend fun save(
+        original: Track,
+        resolved: Track,
+        videoMode: Boolean,
+        audioQuality: String,
+        confidence: Int
+    ) {
+        val manifest = resolved.playbackManifest ?: return
+        val sourceVideoId = manifest.sourceVideoId.ifBlank { PlaybackSourceIdentity.sourceVideoId(resolved) }
+        if (sourceVideoId.isBlank()) return
+        val now = System.currentTimeMillis()
+        val matchKey = PlaybackSourceIdentity.matchKey(original, videoMode, audioQuality)
+        val previous = dao.get(matchKey)
+        dao.upsert(
+            PlaybackSourceMatchEntity(
+                matchKey = matchKey,
+                canonicalKey = PlaybackSourceIdentity.canonicalKey(original),
+                mode = if (videoMode) "video" else "audio",
+                audioQuality = audioQuality,
+                sourceVideoId = sourceVideoId,
+                sourceVideoUrl = resolved.videoUrl.ifBlank { "https://www.youtube.com/watch?v=$sourceVideoId" },
+                provider = manifest.provider,
+                manifestJson = PlaybackManifestCodec.encode(manifest.compact()),
+                confidence = confidence.coerceIn(0, 100),
+                successCount = (previous?.successCount ?: 0) + 1,
+                failureCount = previous?.failureCount?.let { (it - 1).coerceAtLeast(0) } ?: 0,
+                blockedUntil = 0L,
+                createdAt = previous?.createdAt ?: now,
+                updatedAt = now,
+                lastValidatedAt = now
+            )
+        )
+    }
+
+    suspend fun recordSuccess(track: Track, videoMode: Boolean, audioQuality: String) {
+        dao.recordSuccess(PlaybackSourceIdentity.matchKey(track, videoMode, audioQuality), System.currentTimeMillis())
+    }
+
+    suspend fun recordFailure(track: Track, videoMode: Boolean, audioQuality: String, quarantineMs: Long) {
+        val now = System.currentTimeMillis()
+        dao.recordFailure(
+            PlaybackSourceIdentity.matchKey(track, videoMode, audioQuality),
+            now + quarantineMs.coerceAtLeast(0L),
+            now
+        )
+    }
+
+    suspend fun delete(track: Track, videoMode: Boolean, audioQuality: String) {
+        dao.delete(PlaybackSourceIdentity.matchKey(track, videoMode, audioQuality))
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSourceMatchStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSourceMatchStore.kt
@@ -13,8 +13,14 @@ internal data class StoredPlaybackSourceMatch(
 internal class PlaybackSourceMatchStore(
     private val dao: PlaybackSourceMatchDao
 ) {
-    suspend fun load(track: Track, videoMode: Boolean, audioQuality: String): StoredPlaybackSourceMatch? {
-        val entity = dao.get(PlaybackSourceIdentity.matchKey(track, videoMode, audioQuality)) ?: return null
+    suspend fun load(
+        track: Track,
+        videoMode: Boolean,
+        audioQuality: String,
+        preferMp4Audio: Boolean = false
+    ): StoredPlaybackSourceMatch? {
+        val matchKey = PlaybackSourceIdentity.matchKey(track, videoMode, audioQuality, preferMp4Audio)
+        val entity = dao.get(matchKey) ?: return null
         return StoredPlaybackSourceMatch(entity, PlaybackManifestCodec.decode(entity.manifestJson))
     }
 
@@ -23,19 +29,24 @@ internal class PlaybackSourceMatchStore(
         resolved: Track,
         videoMode: Boolean,
         audioQuality: String,
-        confidence: Int
+        confidence: Int,
+        preferMp4Audio: Boolean = false
     ) {
         val manifest = resolved.playbackManifest ?: return
         val sourceVideoId = manifest.sourceVideoId.ifBlank { PlaybackSourceIdentity.sourceVideoId(resolved) }
         if (sourceVideoId.isBlank()) return
         val now = System.currentTimeMillis()
-        val matchKey = PlaybackSourceIdentity.matchKey(original, videoMode, audioQuality)
+        val matchKey = PlaybackSourceIdentity.matchKey(original, videoMode, audioQuality, preferMp4Audio)
         val previous = dao.get(matchKey)
         dao.upsert(
             PlaybackSourceMatchEntity(
                 matchKey = matchKey,
                 canonicalKey = PlaybackSourceIdentity.canonicalKey(original),
-                mode = if (videoMode) "video" else "audio",
+                mode = when {
+                    videoMode -> "video"
+                    preferMp4Audio -> "audio-mp4"
+                    else -> "audio"
+                },
                 audioQuality = audioQuality,
                 sourceVideoId = sourceVideoId,
                 sourceVideoUrl = resolved.videoUrl.ifBlank { "https://www.youtube.com/watch?v=$sourceVideoId" },
@@ -52,20 +63,37 @@ internal class PlaybackSourceMatchStore(
         )
     }
 
-    suspend fun recordSuccess(track: Track, videoMode: Boolean, audioQuality: String) {
-        dao.recordSuccess(PlaybackSourceIdentity.matchKey(track, videoMode, audioQuality), System.currentTimeMillis())
+    suspend fun recordSuccess(
+        track: Track,
+        videoMode: Boolean,
+        audioQuality: String,
+        preferMp4Audio: Boolean = false
+    ) {
+        val matchKey = PlaybackSourceIdentity.matchKey(track, videoMode, audioQuality, preferMp4Audio)
+        dao.recordSuccess(matchKey, System.currentTimeMillis())
     }
 
-    suspend fun recordFailure(track: Track, videoMode: Boolean, audioQuality: String, quarantineMs: Long) {
+    suspend fun recordFailure(
+        track: Track,
+        videoMode: Boolean,
+        audioQuality: String,
+        quarantineMs: Long,
+        preferMp4Audio: Boolean = false
+    ) {
         val now = System.currentTimeMillis()
         dao.recordFailure(
-            PlaybackSourceIdentity.matchKey(track, videoMode, audioQuality),
+            PlaybackSourceIdentity.matchKey(track, videoMode, audioQuality, preferMp4Audio),
             now + quarantineMs.coerceAtLeast(0L),
             now
         )
     }
 
-    suspend fun delete(track: Track, videoMode: Boolean, audioQuality: String) {
-        dao.delete(PlaybackSourceIdentity.matchKey(track, videoMode, audioQuality))
+    suspend fun delete(
+        track: Track,
+        videoMode: Boolean,
+        audioQuality: String,
+        preferMp4Audio: Boolean = false
+    ) {
+        dao.delete(PlaybackSourceIdentity.matchKey(track, videoMode, audioQuality, preferMp4Audio))
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/local/LevyraDatabase.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/local/LevyraDatabase.kt
@@ -18,9 +18,10 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         PlaybackQueueStateEntity::class,
         OfflineDownloadTaskEntity::class,
         LyricsCacheEntity::class,
-        MotionArtworkEntity::class
+        MotionArtworkEntity::class,
+        PlaybackSourceMatchEntity::class
     ],
-    version = 10,
+    version = 11,
     exportSchema = false
 )
 abstract class LevyraDatabase : RoomDatabase() {
@@ -32,6 +33,7 @@ abstract class LevyraDatabase : RoomDatabase() {
     abstract fun offlineDownloadTasksDao(): OfflineDownloadTasksDao
     abstract fun lyricsCacheDao(): LyricsCacheDao
     abstract fun motionArtworkDao(): MotionArtworkDao
+    abstract fun playbackSourceMatchDao(): PlaybackSourceMatchDao
 
     companion object {
         @Volatile private var instance: LevyraDatabase? = null
@@ -354,6 +356,35 @@ abstract class LevyraDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_10_11 = object : Migration(10, 11) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS playback_source_matches (
+                        matchKey TEXT NOT NULL PRIMARY KEY,
+                        canonicalKey TEXT NOT NULL,
+                        mode TEXT NOT NULL,
+                        audioQuality TEXT NOT NULL,
+                        sourceVideoId TEXT NOT NULL,
+                        sourceVideoUrl TEXT NOT NULL,
+                        provider TEXT NOT NULL,
+                        manifestJson TEXT NOT NULL,
+                        confidence INTEGER NOT NULL,
+                        successCount INTEGER NOT NULL,
+                        failureCount INTEGER NOT NULL,
+                        blockedUntil INTEGER NOT NULL,
+                        createdAt INTEGER NOT NULL,
+                        updatedAt INTEGER NOT NULL,
+                        lastValidatedAt INTEGER NOT NULL
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_playback_source_matches_canonicalKey ON playback_source_matches(canonicalKey)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_playback_source_matches_sourceVideoId ON playback_source_matches(sourceVideoId)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_playback_source_matches_updatedAt ON playback_source_matches(updatedAt)")
+            }
+        }
+
         fun get(context: Context): LevyraDatabase {
             return instance ?: synchronized(this) {
                 instance ?: Room.databaseBuilder(
@@ -371,7 +402,8 @@ abstract class LevyraDatabase : RoomDatabase() {
                         MIGRATION_6_7,
                         MIGRATION_7_8,
                         MIGRATION_8_9,
-                        MIGRATION_9_10
+                        MIGRATION_9_10,
+                        MIGRATION_10_11
                     )
                     .build()
                     .also { instance = it }

--- a/app/src/main/java/com/luc4n3x/levyra/data/local/PlaybackSourceMatchEntity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/local/PlaybackSourceMatchEntity.kt
@@ -1,0 +1,59 @@
+package com.luc4n3x.levyra.data.local
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Entity(
+    tableName = "playback_source_matches",
+    indices = [
+        Index(value = ["canonicalKey"]),
+        Index(value = ["sourceVideoId"]),
+        Index(value = ["updatedAt"])
+    ]
+)
+data class PlaybackSourceMatchEntity(
+    @androidx.room.PrimaryKey val matchKey: String,
+    val canonicalKey: String,
+    val mode: String,
+    val audioQuality: String,
+    val sourceVideoId: String,
+    val sourceVideoUrl: String,
+    val provider: String,
+    val manifestJson: String,
+    val confidence: Int,
+    val successCount: Int,
+    val failureCount: Int,
+    val blockedUntil: Long,
+    val createdAt: Long,
+    val updatedAt: Long,
+    val lastValidatedAt: Long
+)
+
+@Dao
+interface PlaybackSourceMatchDao {
+    @Query("SELECT * FROM playback_source_matches WHERE matchKey = :matchKey LIMIT 1")
+    suspend fun get(matchKey: String): PlaybackSourceMatchEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: PlaybackSourceMatchEntity)
+
+    @Query(
+        "UPDATE playback_source_matches SET successCount = successCount + 1, failureCount = CASE WHEN failureCount > 0 THEN failureCount - 1 ELSE 0 END, blockedUntil = 0, updatedAt = :now, lastValidatedAt = :now WHERE matchKey = :matchKey"
+    )
+    suspend fun recordSuccess(matchKey: String, now: Long)
+
+    @Query(
+        "UPDATE playback_source_matches SET failureCount = failureCount + 1, blockedUntil = :blockedUntil, updatedAt = :now WHERE matchKey = :matchKey"
+    )
+    suspend fun recordFailure(matchKey: String, blockedUntil: Long, now: Long)
+
+    @Query("DELETE FROM playback_source_matches WHERE matchKey = :matchKey")
+    suspend fun delete(matchKey: String)
+
+    @Query("DELETE FROM playback_source_matches WHERE updatedAt < :olderThan AND successCount = 0")
+    suspend fun deleteUnusedOlderThan(olderThan: Long): Int
+}

--- a/app/src/main/java/com/luc4n3x/levyra/domain/Models.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/Models.kt
@@ -40,7 +40,8 @@ data class Track(
     val metadataConfidence: Int = 0,
     val canonicalAlbumUrl: String = "",
     val youtubeLikeCount: Long = -1L,
-    val youtubeViewCount: Long = -1L
+    val youtubeViewCount: Long = -1L,
+    val playbackManifest: ResolvedPlaybackManifest? = null
 ) {
     val hasPlayableStream: Boolean
         get() = streamUrl.isNotBlank()

--- a/app/src/main/java/com/luc4n3x/levyra/domain/PlaybackManifest.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/PlaybackManifest.kt
@@ -38,6 +38,21 @@ data class PlaybackStreamDescriptor(
         if (expiresAtMs <= 0L) return true
         return nowMs + refreshAheadMs < expiresAtMs
     }
+
+    fun isMp4Audio(): Boolean {
+        if (kind != PlaybackStreamKind.AUDIO || deliveryMethod == PlaybackDeliveryMethod.HLS) return false
+        val normalizedContainer = container.trim().lowercase()
+        val normalizedMimeType = mimeType.substringBefore(';').trim().lowercase()
+        val normalizedUrl = url.lowercase()
+        val path = normalizedUrl.substringBefore('?').substringBefore('#')
+        return normalizedContainer == "m4a" ||
+            normalizedContainer == "mp4" ||
+            normalizedMimeType == "audio/mp4" ||
+            normalizedUrl.contains("mime=audio%2fmp4") ||
+            normalizedUrl.contains("mime=audio/mp4") ||
+            path.endsWith(".m4a") ||
+            path.endsWith(".mp4")
+    }
 }
 
 data class ResolvedPlaybackManifest(
@@ -61,6 +76,13 @@ data class ResolvedPlaybackManifest(
         if (expiresAtMs > 0L && nowMs + refreshAheadMs >= expiresAtMs) return false
         val selectedStreams = streams.filter { it.selected }
         return selectedStreams.isNotEmpty() && selectedStreams.all { it.isFresh(nowMs, refreshAheadMs) }
+    }
+
+    fun supportsMp4AudioExport(): Boolean {
+        if (selectedAudioUrl.isBlank() || selectedVideoUrl.isNotBlank()) return false
+        return streams.firstOrNull { descriptor ->
+            descriptor.selected && descriptor.url == selectedAudioUrl
+        }?.isMp4Audio() == true
     }
 
     fun compact(maxStreams: Int = 10): ResolvedPlaybackManifest {

--- a/app/src/main/java/com/luc4n3x/levyra/domain/PlaybackManifest.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/PlaybackManifest.kt
@@ -1,0 +1,82 @@
+package com.luc4n3x.levyra.domain
+
+enum class PlaybackStreamKind {
+    AUDIO,
+    VIDEO,
+    MUXED,
+    HLS
+}
+
+enum class PlaybackDeliveryMethod {
+    PROGRESSIVE,
+    HLS,
+    DASH,
+    UNKNOWN
+}
+
+data class PlaybackStreamDescriptor(
+    val url: String,
+    val kind: PlaybackStreamKind,
+    val deliveryMethod: PlaybackDeliveryMethod,
+    val container: String = "",
+    val mimeType: String = "",
+    val codec: String = "",
+    val bitrate: Int = 0,
+    val averageBitrate: Int = 0,
+    val sampleRate: Int = 0,
+    val bitDepth: Int = 0,
+    val width: Int = 0,
+    val height: Int = 0,
+    val fps: Int = 0,
+    val itag: Int = -1,
+    val qualityLabel: String = "",
+    val expiresAtMs: Long = 0L,
+    val selected: Boolean = false
+) {
+    fun isFresh(nowMs: Long = System.currentTimeMillis(), refreshAheadMs: Long = 90_000L): Boolean {
+        if (url.isBlank()) return false
+        if (expiresAtMs <= 0L) return true
+        return nowMs + refreshAheadMs < expiresAtMs
+    }
+}
+
+data class ResolvedPlaybackManifest(
+    val sourceVideoId: String,
+    val provider: String,
+    val resolvedAtMs: Long,
+    val expiresAtMs: Long,
+    val durationMs: Long,
+    val selectedAudioUrl: String,
+    val selectedVideoUrl: String,
+    val streams: List<PlaybackStreamDescriptor>,
+    val loudnessDb: Float? = null,
+    val perceptualLoudnessDb: Float? = null
+) {
+    val isMuxed: Boolean
+        get() = selectedAudioUrl.isNotBlank() && selectedVideoUrl.isBlank() &&
+            streams.any { it.selected && it.kind == PlaybackStreamKind.MUXED }
+
+    fun isFresh(nowMs: Long = System.currentTimeMillis(), refreshAheadMs: Long = 90_000L): Boolean {
+        if (selectedAudioUrl.isBlank()) return false
+        if (expiresAtMs > 0L && nowMs + refreshAheadMs >= expiresAtMs) return false
+        val selectedStreams = streams.filter { it.selected }
+        return selectedStreams.isNotEmpty() && selectedStreams.all { it.isFresh(nowMs, refreshAheadMs) }
+    }
+
+    fun compact(maxStreams: Int = 10): ResolvedPlaybackManifest {
+        val selected = streams.filter { it.selected }
+        val alternatives = streams
+            .asSequence()
+            .filterNot { it.selected }
+            .sortedWith(
+                compareByDescending<PlaybackStreamDescriptor> { it.kind == PlaybackStreamKind.AUDIO }
+                    .thenByDescending { it.averageBitrate.coerceAtLeast(it.bitrate) }
+                    .thenByDescending { it.height }
+            )
+            .take((maxStreams - selected.size).coerceAtLeast(0))
+            .toList()
+        return copy(streams = (selected + alternatives).distinctBy { descriptor ->
+            listOf(descriptor.kind.name, descriptor.itag.toString(), descriptor.url).joinToString("|")
+        })
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackManifestCodecTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackManifestCodecTest.kt
@@ -1,0 +1,94 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.domain.PlaybackDeliveryMethod
+import com.luc4n3x.levyra.domain.PlaybackStreamDescriptor
+import com.luc4n3x.levyra.domain.PlaybackStreamKind
+import com.luc4n3x.levyra.domain.ResolvedPlaybackManifest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaybackManifestCodecTest {
+    @Test
+    fun roundTripPreservesSelectedStreamsAndTechnicalMetadata() {
+        val now = System.currentTimeMillis()
+        val manifest = ResolvedPlaybackManifest(
+            sourceVideoId = "dQw4w9WgXcQ",
+            provider = "LevyraExtractor",
+            resolvedAtMs = now,
+            expiresAtMs = now + 3_600_000L,
+            durationMs = 212_000L,
+            selectedAudioUrl = "https://r1.googlevideo.com/videoplayback?expire=9999999999&mime=audio%2Fwebm",
+            selectedVideoUrl = "https://r1.googlevideo.com/videoplayback?expire=9999999999&mime=video%2Fwebm",
+            streams = listOf(
+                PlaybackStreamDescriptor(
+                    url = "https://r1.googlevideo.com/videoplayback?expire=9999999999&mime=audio%2Fwebm",
+                    kind = PlaybackStreamKind.AUDIO,
+                    deliveryMethod = PlaybackDeliveryMethod.PROGRESSIVE,
+                    container = "webm",
+                    mimeType = "audio/webm",
+                    codec = "opus",
+                    bitrate = 160_000,
+                    averageBitrate = 158_000,
+                    sampleRate = 48_000,
+                    itag = 251,
+                    qualityLabel = "AUDIO_QUALITY_HIGH",
+                    expiresAtMs = now + 3_600_000L,
+                    selected = true
+                ),
+                PlaybackStreamDescriptor(
+                    url = "https://r1.googlevideo.com/videoplayback?expire=9999999999&mime=video%2Fwebm",
+                    kind = PlaybackStreamKind.VIDEO,
+                    deliveryMethod = PlaybackDeliveryMethod.PROGRESSIVE,
+                    container = "webm",
+                    mimeType = "video/webm",
+                    codec = "vp9",
+                    bitrate = 2_000_000,
+                    width = 1920,
+                    height = 1080,
+                    fps = 30,
+                    itag = 248,
+                    expiresAtMs = now + 3_600_000L,
+                    selected = true
+                )
+            )
+        )
+
+        val decoded = PlaybackManifestCodec.decode(PlaybackManifestCodec.encode(manifest))
+
+        requireNotNull(decoded)
+        assertEquals(manifest.sourceVideoId, decoded.sourceVideoId)
+        assertEquals(manifest.selectedAudioUrl, decoded.selectedAudioUrl)
+        assertEquals(manifest.selectedVideoUrl, decoded.selectedVideoUrl)
+        assertEquals("opus", decoded.streams.first { it.kind == PlaybackStreamKind.AUDIO }.codec)
+        assertEquals(1080, decoded.streams.first { it.kind == PlaybackStreamKind.VIDEO }.height)
+        assertTrue(decoded.isFresh(now))
+    }
+
+    @Test
+    fun freshnessRejectsManifestNearExpiration() {
+        val now = System.currentTimeMillis()
+        val url = "https://r1.googlevideo.com/videoplayback"
+        val manifest = ResolvedPlaybackManifest(
+            sourceVideoId = "dQw4w9WgXcQ",
+            provider = "YouTube",
+            resolvedAtMs = now,
+            expiresAtMs = now + 30_000L,
+            durationMs = 1L,
+            selectedAudioUrl = url,
+            selectedVideoUrl = "",
+            streams = listOf(
+                PlaybackStreamDescriptor(
+                    url = url,
+                    kind = PlaybackStreamKind.AUDIO,
+                    deliveryMethod = PlaybackDeliveryMethod.PROGRESSIVE,
+                    expiresAtMs = now + 30_000L,
+                    selected = true
+                )
+            )
+        )
+
+        assertFalse(manifest.isFresh(now))
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackManifestCodecTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackManifestCodecTest.kt
@@ -91,4 +91,62 @@ class PlaybackManifestCodecTest {
 
         assertFalse(manifest.isFresh(now))
     }
+
+    @Test
+    fun mp4ExportRequirementRejectsWebmAndAcceptsM4a() {
+        val now = System.currentTimeMillis()
+        val webmUrl = "https://r1.googlevideo.com/videoplayback?expire=9999999999&mime=audio%2Fwebm"
+        val mp4Url = "https://r1.googlevideo.com/videoplayback?expire=9999999999&mime=audio%2Fmp4"
+        val webm = ResolvedPlaybackManifest(
+            sourceVideoId = "dQw4w9WgXcQ",
+            provider = "YouTube",
+            resolvedAtMs = now,
+            expiresAtMs = now + 3_600_000L,
+            durationMs = 1L,
+            selectedAudioUrl = webmUrl,
+            selectedVideoUrl = "",
+            streams = listOf(
+                PlaybackStreamDescriptor(
+                    url = webmUrl,
+                    kind = PlaybackStreamKind.AUDIO,
+                    deliveryMethod = PlaybackDeliveryMethod.PROGRESSIVE,
+                    container = "webm",
+                    mimeType = "audio/webm",
+                    selected = true
+                )
+            )
+        )
+        val mp4 = webm.copy(
+            selectedAudioUrl = mp4Url,
+            streams = listOf(
+                PlaybackStreamDescriptor(
+                    url = mp4Url,
+                    kind = PlaybackStreamKind.AUDIO,
+                    deliveryMethod = PlaybackDeliveryMethod.PROGRESSIVE,
+                    container = "m4a",
+                    mimeType = "audio/mp4",
+                    selected = true
+                )
+            )
+        )
+
+        val muxed = webm.copy(
+            selectedAudioUrl = mp4Url,
+            streams = listOf(
+                PlaybackStreamDescriptor(
+                    url = mp4Url,
+                    kind = PlaybackStreamKind.MUXED,
+                    deliveryMethod = PlaybackDeliveryMethod.PROGRESSIVE,
+                    container = "mp4",
+                    mimeType = "video/mp4",
+                    selected = true
+                )
+            )
+        )
+
+        assertFalse(webm.supportsMp4AudioExport())
+        assertFalse(muxed.supportsMp4AudioExport())
+        assertTrue(mp4.supportsMp4AudioExport())
+    }
+
 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackSourceIdentityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackSourceIdentityTest.kt
@@ -7,21 +7,21 @@ import org.junit.Test
 
 class PlaybackSourceIdentityTest {
     @Test
-    fun canonicalKeyIgnoresResolvedYoutubeSource() {
+    fun canonicalKeyIgnoresResolvedStreamState() {
         val original = track(
-            id = "original123",
+            id = "catalog-recording-1",
             title = "Song Title (Official Audio)",
             artist = "Artist Name",
             videoUrl = "https://www.youtube.com/watch?v=abcdefghijk"
         )
-        val fallback = original.copy(
-            id = "ZYXWVUTSRQP",
-            title = "Song Title",
-            videoUrl = "https://youtu.be/ZYXWVUTSRQP",
+        val resolved = original.copy(
+            streamUrl = "https://r1.googlevideo.com/videoplayback?expire=9999999999",
+            videoStreamUrl = "https://r1.googlevideo.com/videoplayback?expire=9999999999&video=1",
+            videoUrl = "https://www.youtube.com/watch?v=ZYXWVUTSRQP",
             source = "fallback"
         )
 
-        assertEquals(PlaybackSourceIdentity.canonicalKey(original), PlaybackSourceIdentity.canonicalKey(fallback))
+        assertEquals(PlaybackSourceIdentity.canonicalKey(original), PlaybackSourceIdentity.canonicalKey(resolved))
     }
 
     @Test
@@ -30,6 +30,38 @@ class PlaybackSourceIdentityTest {
         val long = track(durationMs = 240_000L)
 
         assertNotEquals(PlaybackSourceIdentity.canonicalKey(short), PlaybackSourceIdentity.canonicalKey(long))
+    }
+
+    @Test
+    fun canonicalKeySeparatesExplicitAndCleanRecordings() {
+        val clean = track(id = "recording-1", explicit = false)
+        val explicit = track(id = "recording-1", explicit = true)
+
+        assertNotEquals(PlaybackSourceIdentity.canonicalKey(clean), PlaybackSourceIdentity.canonicalKey(explicit))
+    }
+
+    @Test
+    fun canonicalKeySeparatesDifferentStableRecordingsWithEqualMetadata() {
+        val first = track(
+            id = "recording-1",
+            videoUrl = "https://www.youtube.com/watch?v=abcdefghijk"
+        )
+        val second = track(
+            id = "recording-2",
+            videoUrl = "https://www.youtube.com/watch?v=ZYXWVUTSRQP"
+        )
+
+        assertNotEquals(PlaybackSourceIdentity.canonicalKey(first), PlaybackSourceIdentity.canonicalKey(second))
+    }
+
+    @Test
+    fun offlineMp4MatchesUseASeparatePersistentKey() {
+        val track = track()
+
+        val playback = PlaybackSourceIdentity.matchKey(track, videoMode = false, audioQuality = "High")
+        val offline = PlaybackSourceIdentity.matchKey(track, videoMode = false, audioQuality = "High", preferMp4Audio = true)
+
+        assertNotEquals(playback, offline)
     }
 
     @Test
@@ -45,7 +77,8 @@ class PlaybackSourceIdentityTest {
         title: String = "Song Title",
         artist: String = "Artist Name",
         videoUrl: String = "",
-        durationMs: Long = 180_000L
+        durationMs: Long = 180_000L,
+        explicit: Boolean = false
     ) = Track(
         id = id,
         title = title,
@@ -63,6 +96,7 @@ class PlaybackSourceIdentityTest {
         replayScore = 0,
         cacheScore = 0,
         accentStart = 0,
-        accentEnd = 0
+        accentEnd = 0,
+        explicit = explicit
     )
 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackSourceIdentityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackSourceIdentityTest.kt
@@ -1,0 +1,68 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.domain.Track
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class PlaybackSourceIdentityTest {
+    @Test
+    fun canonicalKeyIgnoresResolvedYoutubeSource() {
+        val original = track(
+            id = "original123",
+            title = "Song Title (Official Audio)",
+            artist = "Artist Name",
+            videoUrl = "https://www.youtube.com/watch?v=abcdefghijk"
+        )
+        val fallback = original.copy(
+            id = "ZYXWVUTSRQP",
+            title = "Song Title",
+            videoUrl = "https://youtu.be/ZYXWVUTSRQP",
+            source = "fallback"
+        )
+
+        assertEquals(PlaybackSourceIdentity.canonicalKey(original), PlaybackSourceIdentity.canonicalKey(fallback))
+    }
+
+    @Test
+    fun canonicalKeySeparatesDifferentDurations() {
+        val short = track(durationMs = 180_000L)
+        val long = track(durationMs = 240_000L)
+
+        assertNotEquals(PlaybackSourceIdentity.canonicalKey(short), PlaybackSourceIdentity.canonicalKey(long))
+    }
+
+    @Test
+    fun extractsWatchShortLiveAndYoutuBeIds() {
+        assertEquals("abcdefghijk", PlaybackSourceIdentity.extractYoutubeVideoId("https://www.youtube.com/watch?v=abcdefghijk"))
+        assertEquals("abcdefghijk", PlaybackSourceIdentity.extractYoutubeVideoId("https://youtube.com/shorts/abcdefghijk"))
+        assertEquals("abcdefghijk", PlaybackSourceIdentity.extractYoutubeVideoId("https://youtube.com/live/abcdefghijk"))
+        assertEquals("abcdefghijk", PlaybackSourceIdentity.extractYoutubeVideoId("https://youtu.be/abcdefghijk"))
+    }
+
+    private fun track(
+        id: String = "track-id",
+        title: String = "Song Title",
+        artist: String = "Artist Name",
+        videoUrl: String = "",
+        durationMs: Long = 180_000L
+    ) = Track(
+        id = id,
+        title = title,
+        artist = artist,
+        album = "Album",
+        durationMs = durationMs,
+        streamUrl = "",
+        videoUrl = videoUrl,
+        thumbnailUrl = "",
+        largeThumbnailUrl = "",
+        source = "test",
+        moodTags = emptySet(),
+        energy = 0,
+        vocal = 0,
+        replayScore = 0,
+        cacheScore = 0,
+        accentStart = 0,
+        accentEnd = 0
+    )
+}

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -17,8 +17,8 @@ android {
 
     testOptions {
         managedDevices {
-            devices {
-                create<com.android.build.api.dsl.ManagedVirtualDevice>("pixel6Api35").apply {
+            localDevices {
+                create("pixel6Api35") {
                     device = "Pixel 6"
                     apiLevel = 35
                     systemImageSource = "aosp"

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -1,0 +1,40 @@
+plugins {
+    alias(libs.plugins.android.test)
+    alias(libs.plugins.androidx.baselineprofile)
+}
+
+android {
+    namespace = "com.luc4n3x.levyra.baselineprofile"
+    compileSdk = 37
+
+    defaultConfig {
+        minSdk = 26
+        targetSdk = 37
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    targetProjectPath = ":app"
+
+    testOptions {
+        managedDevices {
+            devices {
+                create<com.android.build.api.dsl.ManagedVirtualDevice>("pixel6Api35").apply {
+                    device = "Pixel 6"
+                    apiLevel = 35
+                    systemImageSource = "aosp"
+                }
+            }
+        }
+    }
+}
+
+baselineProfile {
+    managedDevices += "pixel6Api35"
+    useConnectedDevices = false
+}
+
+dependencies {
+    implementation(libs.androidx.benchmark.macro.junit4)
+    implementation(libs.androidx.test.ext.junit)
+    implementation(libs.androidx.test.uiautomator)
+}

--- a/baselineprofile/src/main/AndroidManifest.xml
+++ b/baselineprofile/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/baselineprofile/src/main/java/com/luc4n3x/levyra/baselineprofile/BaselineProfileGenerator.kt
+++ b/baselineprofile/src/main/java/com/luc4n3x/levyra/baselineprofile/BaselineProfileGenerator.kt
@@ -1,0 +1,25 @@
+package com.luc4n3x.levyra.baselineprofile
+
+import androidx.benchmark.macro.junit4.BaselineProfileRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class BaselineProfileGenerator {
+    @get:Rule
+    val rule = BaselineProfileRule()
+
+    @Test
+    fun generate() {
+        rule.collect(
+            packageName = "com.luc4n3x.levyra",
+            includeInStartupProfile = true
+        ) {
+            launchAndExerciseLevyra()
+        }
+    }
+}

--- a/baselineprofile/src/main/java/com/luc4n3x/levyra/baselineprofile/LevyraCriticalUserJourneys.kt
+++ b/baselineprofile/src/main/java/com/luc4n3x/levyra/baselineprofile/LevyraCriticalUserJourneys.kt
@@ -1,0 +1,44 @@
+package com.luc4n3x.levyra.baselineprofile
+
+import androidx.benchmark.macro.MacrobenchmarkScope
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Direction
+import androidx.test.uiautomator.Until
+
+internal fun MacrobenchmarkScope.launchAndExerciseLevyra() {
+    pressHome()
+    startActivityAndWait()
+    device.waitForIdle()
+    dismissOnboardingIfPresent()
+    device.waitForIdle()
+    repeat(3) {
+        device.swipe(
+            device.displayWidth / 2,
+            device.displayHeight * 4 / 5,
+            device.displayWidth / 2,
+            device.displayHeight / 3,
+            12
+        )
+        device.waitForIdle()
+    }
+    device.findObject(By.descContains("Libr"))?.click()
+        ?: device.findObject(By.textContains("Libr"))?.click()
+        ?: device.findObject(By.descContains("Library"))?.click()
+        ?: device.findObject(By.textContains("Library"))?.click()
+    device.waitForIdle()
+    device.findObject(By.scrollable(true))?.scroll(Direction.DOWN, 0.6f)
+    device.waitForIdle()
+}
+
+private fun MacrobenchmarkScope.dismissOnboardingIfPresent() {
+    val labels = listOf("Continua", "Avanti", "Inizia", "Fatto", "Continue", "Next", "Start", "Done", "Salta", "Skip")
+    repeat(6) {
+        val button = labels.asSequence()
+            .mapNotNull { label -> device.findObject(By.textContains(label)) }
+            .firstOrNull()
+            ?: return
+        button.click()
+        device.wait(Until.gone(By.text(button.text.orEmpty())), 1_000L)
+        device.waitForIdle()
+    }
+}

--- a/baselineprofile/src/main/java/com/luc4n3x/levyra/baselineprofile/StartupBenchmark.kt
+++ b/baselineprofile/src/main/java/com/luc4n3x/levyra/baselineprofile/StartupBenchmark.kt
@@ -1,0 +1,33 @@
+package com.luc4n3x.levyra.baselineprofile
+
+import androidx.benchmark.macro.BaselineProfileMode
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.StartupTimingMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class StartupBenchmark {
+    @get:Rule
+    val rule = MacrobenchmarkRule()
+
+    @Test
+    fun startupWithBaselineProfile() {
+        rule.measureRepeated(
+            packageName = "com.luc4n3x.levyra",
+            metrics = listOf(StartupTimingMetric()),
+            compilationMode = CompilationMode.Partial(baselineProfileMode = BaselineProfileMode.Require),
+            startupMode = StartupMode.COLD,
+            iterations = 10,
+            setupBlock = { pressHome() }
+        ) {
+            startActivityAndWait()
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
 plugins {
     alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.test) apply false
+    alias(libs.plugins.androidx.baselineprofile) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ksp) apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,3 @@ android.enableR8.fullMode=true
 kotlin.code.style=official
 levyraVersionName=2.3.13
 levyraVersionCode=2031300
-android.newDsl=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,4 @@ android.enableR8.fullMode=true
 kotlin.code.style=official
 levyraVersionName=2.3.13
 levyraVersionCode=2031300
+android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,10 +25,10 @@ shimmer = "1.5.0"
 chucker = "4.3.1"
 leakcanary = "2.14"
 ruler = "2.0.0-beta-3"
-baselineProfile = "1.4.1"
+baselineProfile = "1.5.0-alpha07"
 profileInstaller = "1.4.1"
 androidxTestExt = "1.3.0"
-uiautomator = "2.3.0"
+uiautomator = "2.4.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,10 @@ shimmer = "1.5.0"
 chucker = "4.3.1"
 leakcanary = "2.14"
 ruler = "2.0.0-beta-3"
+baselineProfile = "1.4.1"
+profileInstaller = "1.4.1"
+androidxTestExt = "1.3.0"
+uiautomator = "2.3.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -70,9 +74,15 @@ shimmer = { group = "com.valentinilk.shimmer", name = "compose-shimmer", version
 chucker = { group = "com.github.chuckerteam.chucker", name = "library", version.ref = "chucker" }
 chucker-no-op = { group = "com.github.chuckerteam.chucker", name = "library-no-op", version.ref = "chucker" }
 leakcanary-android = { group = "com.squareup.leakcanary", name = "leakcanary-android", version.ref = "leakcanary" }
+androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileInstaller" }
+androidx-benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "baselineProfile" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExt" }
+androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
+android-test = { id = "com.android.test", version.ref = "agp" }
+androidx-baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineProfile" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,3 +30,4 @@ includeBuild("third_party/LevyraExtractor") {
 
 rootProject.name = "Levyra"
 include(":app")
+include(":baselineprofile")


### PR DESCRIPTION
## Summary

- add typed playback manifests for resolved audio and video streams
- persist canonical playback source matches in Room
- renew expired or rejected stream URLs without repeating source searches
- preserve the selected YouTube source across retries and application restarts
- add Baseline Profile generation and startup Macrobenchmarks
- cover playback manifest serialization and source identity with unit tests

## Database

- upgrade the Room database from version 10 to version 11
- add persistent playback source match storage
- add indexes for canonical track and source lookup
- keep persistence failures outside the critical playback path

## Playback reliability

- reuse previously validated source identities
- refresh temporary stream URLs when required
- deduplicate simultaneous refresh operations
- avoid treating coroutine cancellation as a source failure
- prioritize dedicated audio streams over muxed video streams

## Performance

- add Baseline Profile infrastructure
- optimize application startup
- cover Home, Library and player critical journeys
- add startup Macrobenchmark coverage




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent playback source matching to improve stream reuse and playback recovery.
  * Added playback manifest handling, including stream metadata, freshness checks, and MP4 audio export support.
  * Added baseline profiles and startup performance benchmarking to improve app launch performance.
  * Added YouTube source identification across common URL formats.

* **Bug Fixes**
  * Improved fallback validation and handling of unavailable or temporarily failing playback sources.
  * Added database migration support for persisted playback matches.

* **Tests**
  * Added coverage for manifest handling, source matching, freshness, and MP4 compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->