### PR TITLE
fix: keep playback alive through Doze and offline recovery

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -384,11 +384,6 @@ class PlaybackResolver private constructor(private val context: Context) {
             cached(cacheLookupTrack, isVideoMode, audioQuality)?.let { return@coroutineScope it }
         }
 
-        if (!hasValidatedInternet()) {
-            clearTransientClientPenalties()
-            throw PlaybackBlockedException("Connessione Internet non disponibile")
-        }
-
         val key = "${cacheKey(track, isVideoMode, audioQuality)}_$requestKind"
         Timber.d("resolver start kind=%s mode=%s id=%s quality=%s", requestKind, if (isVideoMode) "video" else "audio", track.id, audioQuality)
         val deferred = async(Dispatchers.IO, start = CoroutineStart.LAZY) {
@@ -418,7 +413,6 @@ class PlaybackResolver private constructor(private val context: Context) {
 
     suspend fun prefetch(track: Track, isVideoMode: Boolean = false): Track? {
         if (isLocalPlaybackTrack(track)) return track.takeIf { isLocalPlaybackUri(it.streamUrl) }
-        if (!hasValidatedInternet()) return null
         if (track.streamUrl.isNotBlank()) {
             if (!isVideoMode && !isPlayableAudioUrl(track.streamUrl)) return null
             if (streamStillFresh(track.streamUrl)) {
@@ -428,6 +422,7 @@ class PlaybackResolver private constructor(private val context: Context) {
             return null
         }
         cached(track, isVideoMode)?.let { return it }
+        if (!hasValidatedInternet()) return null
         return runCatching { resolve(track, isVideoMode) }.getOrNull()
     }
 
@@ -442,6 +437,11 @@ class PlaybackResolver private constructor(private val context: Context) {
         restorePersistentSource(track, isVideoMode, preferMp4Audio, audioQuality, errors)?.let { restored ->
             store(track, restored, isVideoMode, audioQuality)
             return@withContext restored
+        }
+
+        if (!hasValidatedInternet()) {
+            clearTransientClientPenalties()
+            throw PlaybackBlockedException("Connessione Internet non disponibile")
         }
 
         if (isVideoMode) {
@@ -633,6 +633,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 source = stored.entity.provider.ifBlank { "Persistent source match" }
             )
         }
+        if (!hasValidatedInternet()) return null
         val sourceVideoId = stored.entity.sourceVideoId
             .takeIf(youtubeVideoIdRegex::matches)
             ?: return null

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -1,6 +1,8 @@
 package com.luc4n3x.levyra.data
 
 import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import com.luc4n3x.levyra.BuildConfig
 import com.luc4n3x.levyra.data.security.GoogleApiKeyHeaders
 import com.luc4n3x.levyra.data.local.LevyraDatabase
@@ -71,6 +73,7 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     private val apiKey = BuildConfig.YOUTUBE_INNERTUBE_API_KEY
+    private val connectivityManager = context.getSystemService(ConnectivityManager::class.java)
     private val prefs = context.getSharedPreferences("levyra_stream_cache", Context.MODE_PRIVATE)
     private val clientHealthPrefs = context.getSharedPreferences("levyra_innertube_client_health", Context.MODE_PRIVATE)
     private val userPreferences = LevyraPreferences(context)
@@ -141,6 +144,7 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     fun warmNetwork() {
+        if (!hasValidatedInternet()) return
         val now = System.currentTimeMillis()
         if (now - lastNetworkWarmAt < 15_000L) return
         lastNetworkWarmAt = now
@@ -221,6 +225,15 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     fun reportPlaybackFailure(track: Track, isVideoMode: Boolean, reason: String) {
+        if (isLocalPlaybackTrack(track)) {
+            resilienceEngine.recordPlayerFailure(track.id, isVideoMode, reason)
+            return
+        }
+        if (!hasValidatedInternet() && isNetworkFailureReason(reason)) {
+            clearTransientClientPenalties()
+            resilienceEngine.recordPlayerFailure(track.id, isVideoMode, reason)
+            return
+        }
         invalidate(track, isVideoMode)
         resilienceEngine.recordPlayerFailure(track.id, isVideoMode, reason)
         val now = System.currentTimeMillis()
@@ -267,6 +280,48 @@ class PlaybackResolver private constructor(private val context: Context) {
         return resilienceEngine.diagnostics(health)
     }
 
+    private fun isLocalPlaybackTrack(track: Track): Boolean =
+        track.source.equals("Offline", ignoreCase = true) || isLocalPlaybackUri(track.streamUrl)
+
+    private fun isLocalPlaybackUri(value: String): Boolean {
+        val clean = value.trim()
+        return clean.startsWith("content://", ignoreCase = true) ||
+            clean.startsWith("file://", ignoreCase = true)
+    }
+
+    private fun hasValidatedInternet(): Boolean {
+        val manager = connectivityManager ?: return false
+        val network = manager.activeNetwork ?: return false
+        val capabilities = manager.getNetworkCapabilities(network) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+    }
+
+    private fun isNetworkFailureReason(reason: String): Boolean {
+        val value = reason.lowercase()
+        return value.contains("network") ||
+            value.contains("socket") ||
+            value.contains("dns") ||
+            value.contains("connection") ||
+            value.contains("host") ||
+            value.contains("rete")
+    }
+
+    private fun clearTransientClientPenalties() {
+        val now = System.currentTimeMillis()
+        clientHealth.replaceAll { name, health ->
+            if (health.consecutiveFailures == 0 && health.blockedUntilMs == 0L) {
+                health
+            } else {
+                health.copy(
+                    consecutiveFailures = 0,
+                    blockedUntilMs = 0L,
+                    updatedAtMs = now
+                ).also { persistClientHealth(name, it) }
+            }
+        }
+    }
+
     private fun isPlaybackUrlBlocked(url: String): Boolean {
         if (url.isBlank()) return true
         val until = failedPlaybackUrls[url] ?: return false
@@ -309,6 +364,12 @@ class PlaybackResolver private constructor(private val context: Context) {
         audioQuality: String,
         reuseProvidedStream: Boolean
     ): Track = coroutineScope {
+        if (isLocalPlaybackTrack(track)) {
+            if (!isLocalPlaybackUri(track.streamUrl)) {
+                throw PlaybackBlockedException("File offline non disponibile per ${track.title}")
+            }
+            return@coroutineScope track.copy(videoStreamUrl = "")
+        }
         track.streamUrl.takeIf {
             reuseProvidedStream &&
             it.isNotBlank() &&
@@ -321,6 +382,11 @@ class PlaybackResolver private constructor(private val context: Context) {
         if (!preferMp4Audio) {
             val cacheLookupTrack = if (reuseProvidedStream) track else track.copy(streamUrl = "", videoStreamUrl = "")
             cached(cacheLookupTrack, isVideoMode, audioQuality)?.let { return@coroutineScope it }
+        }
+
+        if (!hasValidatedInternet()) {
+            clearTransientClientPenalties()
+            throw PlaybackBlockedException("Connessione Internet non disponibile")
         }
 
         val key = "${cacheKey(track, isVideoMode, audioQuality)}_$requestKind"
@@ -351,6 +417,8 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     suspend fun prefetch(track: Track, isVideoMode: Boolean = false): Track? {
+        if (isLocalPlaybackTrack(track)) return track.takeIf { isLocalPlaybackUri(it.streamUrl) }
+        if (!hasValidatedInternet()) return null
         if (track.streamUrl.isNotBlank()) {
             if (!isVideoMode && !isPlayableAudioUrl(track.streamUrl)) return null
             if (streamStillFresh(track.streamUrl)) {
@@ -978,6 +1046,10 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     private fun recordClientFailure(profile: ClientProfile, latencyMs: Long?, error: Throwable) {
+        if (!hasValidatedInternet()) {
+            clearTransientClientPenalties()
+            return
+        }
         clientHealth.compute(profile.clientName) { name, current ->
             val previous = current ?: ClientHealth()
             val failures = (previous.failures + 1).coerceAtMost(10_000)
@@ -1010,10 +1082,11 @@ class PlaybackResolver private constructor(private val context: Context) {
     private fun elapsedMs(startedAt: Long): Long = ((System.nanoTime() - startedAt) / 1_000_000L).coerceAtLeast(1L)
 
     private fun restoreClientHealth() {
+        val now = System.currentTimeMillis()
         clientHealthPrefs.all.forEach { (name, rawValue) ->
             val raw = rawValue as? String ?: return@forEach
             val json = runCatching { JSONObject(raw) }.getOrNull() ?: return@forEach
-            clientHealth[name] = ClientHealth(
+            val restored = ClientHealth(
                 successes = json.optInt("successes", 0),
                 failures = json.optInt("failures", 0),
                 consecutiveFailures = json.optInt("consecutiveFailures", 0),
@@ -1021,6 +1094,13 @@ class PlaybackResolver private constructor(private val context: Context) {
                 blockedUntilMs = json.optLong("blockedUntilMs", 0L),
                 updatedAtMs = json.optLong("updatedAtMs", 0L)
             )
+            val normalized = if (restored.blockedUntilMs in 1L..now) {
+                restored.copy(consecutiveFailures = 0, blockedUntilMs = 0L, updatedAtMs = now)
+            } else {
+                restored
+            }
+            clientHealth[name] = normalized
+            if (normalized != restored) persistClientHealth(name, normalized)
         }
     }
 
@@ -1240,8 +1320,13 @@ class PlaybackResolver private constructor(private val context: Context) {
             stream
         } catch (error: Throwable) {
             val latency = elapsedMs(startedAt)
-            recordClientFailure(profile, latency, error)
-            resilienceEngine.recordFailure(profile.label, mode, latency, error)
+            if (hasValidatedInternet()) {
+                recordClientFailure(profile, latency, error)
+                resilienceEngine.recordFailure(profile.label, mode, latency, error)
+            } else {
+                clearTransientClientPenalties()
+                Timber.d(error, "resolver skipped client penalty while offline")
+            }
             throw error
         }
     }

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaItemFactory.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaItemFactory.kt
@@ -31,10 +31,13 @@ object LevyraMediaItemFactory {
             .build()
     }
 
-    internal fun mimeTypeFor(url: String, videoMode: Boolean): String {
+    internal fun mimeTypeFor(url: String, videoMode: Boolean): String? {
         val clean = url.substringBefore('#').lowercase()
         val path = clean.substringBefore('?')
+        val isContentUri = clean.startsWith("content://")
+        val isExtensionlessFileUri = clean.startsWith("file://") && !path.substringAfterLast('/').contains('.')
         return when {
+            isContentUri || isExtensionlessFileUri -> null
             path.endsWith(".m3u8") || path.contains("/hls_playlist") || path.contains("/manifest/hls") || clean.contains("mime=application%2fx-mpegurl") || clean.contains("mime=application/vnd.apple.mpegurl") || clean.contains("type=application%2fx-mpegurl") -> "application/x-mpegURL"
             path.endsWith(".mpd") || clean.contains("mime=application%2fdash+xml") || clean.contains("mime=application/dash+xml") -> "application/dash+xml"
             clean.contains("mime=video%2fwebm") || clean.contains("mime=video/webm") -> "video/webm"

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaItemFactory.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaItemFactory.kt
@@ -16,9 +16,8 @@ object LevyraMediaItemFactory {
 
     fun build(track: Track, videoMode: Boolean = false): MediaItem {
         val streamUrl = track.streamUrl
-        return MediaItem.Builder()
+        val builder = MediaItem.Builder()
             .setUri(streamUrl)
-            .setMimeType(mimeTypeFor(streamUrl, videoMode))
             .setCustomCacheKey(
                 if (videoMode && track.videoStreamUrl.isBlank()) {
                     LevyraPlaybackCacheKey.video(track)
@@ -28,7 +27,8 @@ object LevyraMediaItemFactory {
             )
             .setMediaId(mediaId(track))
             .setMediaMetadata(metadata(track, videoMode))
-            .build()
+        mimeTypeFor(streamUrl, videoMode)?.let { builder.setMimeType(it) }
+        return builder.build()
     }
 
     internal fun mimeTypeFor(url: String, videoMode: Boolean): String? {
@@ -68,7 +68,7 @@ object LevyraMediaItemFactory {
             if (videoMode && track.videoStreamUrl.isNotBlank()) {
                 putString(PlaybackService.EXTRA_VIDEO_URL, track.videoStreamUrl)
                 putString(PlaybackService.EXTRA_VIDEO_CACHE_KEY, LevyraPlaybackCacheKey.video(track))
-                putString(PlaybackService.EXTRA_VIDEO_MIME_TYPE, mimeTypeFor(track.videoStreamUrl, true))
+                mimeTypeFor(track.videoStreamUrl, true)?.let { putString(PlaybackService.EXTRA_VIDEO_MIME_TYPE, it) }
             }
         }
         return MediaMetadata.Builder()

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
@@ -82,6 +82,9 @@ class LevyraPlayer(context: Context) {
                         recoveryAttempts = 0
                         sponsorJob?.cancel()
                         sponsorJob = null
+                        clearLoadedState()
+                        connected.pause()
+                        onError?.invoke(message)
                         return
                     }
                     if (isRecoverable(error) && !recoveryInFlight && recoveryAttempts < 3 && onRecoverableStreamError != null) {

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
@@ -77,6 +77,13 @@ class LevyraPlayer(context: Context) {
                     if (ignoreEndedFromManualStop || connected.mediaItemCount == 0) return
                     val track = loadedTrack ?: return
                     val message = cleanError(error)
+                    if (isLocalPlayback(track)) {
+                        recoveryInFlight = false
+                        recoveryAttempts = 0
+                        sponsorJob?.cancel()
+                        sponsorJob = null
+                        return
+                    }
                     if (isRecoverable(error) && !recoveryInFlight && recoveryAttempts < 3 && onRecoverableStreamError != null) {
                         recoveryInFlight = true
                         recoveryAttempts++
@@ -298,6 +305,13 @@ class LevyraPlayer(context: Context) {
             append('|')
             append(videoMode)
         }
+    }
+
+    private fun isLocalPlayback(track: Track): Boolean {
+        val stream = track.streamUrl.trim()
+        return track.source.equals("Offline", ignoreCase = true) ||
+            stream.startsWith("content://", ignoreCase = true) ||
+            stream.startsWith("file://", ignoreCase = true)
     }
 
     private fun isRecoverable(error: PlaybackException): Boolean {

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -877,7 +877,7 @@ class PlaybackService : MediaLibraryService() {
                 ?.takeIf { it.streamUrl.isNotBlank() }
                 ?.let { LevyraMediaItemFactory.build(it, videoMode) }
         } ?: return false
-        updatePlayerWakeMode(player, mediaItem)
+        (player as? ExoPlayer)?.let { updatePlayerWakeMode(it, mediaItem) }
         acquirePlaybackWakeLock()
         player.setMediaItem(mediaItem, positionMs.coerceAtLeast(0L))
         player.prepare()

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -6,6 +6,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.media.AudioManager
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.os.Bundle
 import android.os.PowerManager
 import android.os.SystemClock
@@ -59,6 +61,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+import java.io.IOException
 
 @UnstableApi
 class PlaybackService : MediaLibraryService() {
@@ -84,6 +87,7 @@ class PlaybackService : MediaLibraryService() {
     private var watchdogAdvancedAtMs = 0L
     private var lastPlaybackExpected: Boolean? = null
     private var lastPlaybackHeartbeatAtMs = 0L
+    private var appliedPlayerWakeMode = C.WAKE_MODE_NETWORK
 
     companion object {
         private const val RUNNING_LOW_LEVEL = 10
@@ -100,10 +104,11 @@ class PlaybackService : MediaLibraryService() {
         private const val KEY_PLAYBACK_EXPECTED = "playbackExpected"
         private const val KEY_PLAYBACK_HEARTBEAT_AT = "playbackHeartbeatAt"
         private const val PLAYBACK_HEARTBEAT_INTERVAL_MS = 30_000L
-        private const val STICKY_RESTORE_MAX_AGE_MS = 30L * 60L * 1_000L
+        private const val STICKY_RESTORE_MAX_AGE_MS = 12L * 60L * 60L * 1_000L
         private const val WATCHDOG_INTERVAL_MS = 5_000L
         private const val WATCHDOG_STALL_TIMEOUT_MS = 15_000L
-        private val RECOVERY_DELAYS_MS = longArrayOf(500L, 2_000L, 5_000L, 10_000L)
+        private val ONLINE_RECOVERY_DELAYS_MS = longArrayOf(500L, 2_000L, 5_000L, 10_000L)
+        private val LOCAL_RECOVERY_DELAYS_MS = longArrayOf(250L, 750L, 1_500L, 3_000L, 5_000L, 10_000L)
 
         @Volatile
         var activePlayer: ExoPlayer? = null
@@ -253,6 +258,7 @@ class PlaybackService : MediaLibraryService() {
         activePlayer = player
         player.addListener(object : Player.Listener {
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+                updatePlayerWakeMode(player, mediaItem)
                 if (serviceRecoveryJob?.isActive != true && stickyRestoreJob?.isActive != true) {
                     serviceRecoveryExhausted = false
                     serviceRecoveryAttempts = 0
@@ -276,7 +282,7 @@ class PlaybackService : MediaLibraryService() {
 
             override fun onPlayerError(error: PlaybackException) {
                 updatePlaybackProtection(player)
-                if (!uiRecoveryAvailable) scheduleServiceRecovery(error)
+                scheduleServiceRecovery(error)
             }
 
             override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
@@ -342,13 +348,9 @@ class PlaybackService : MediaLibraryService() {
                         val snapshot = queueEngine.state.value
                         val track = snapshot.currentTrack ?: error("Nessun brano da ripristinare")
                         val item = if (isForPlayback) {
-                            val resolved = if (track.streamUrl.startsWith("content://") || track.streamUrl.startsWith("file://")) {
-                                track
-                            } else {
-                                resolveQueueTrack(track)
-                            }
+                            val resolved = resolveQueueTrack(track)
                             queueEngine.updateTrackAt(snapshot.currentIndex, resolved)
-                            prefetchServiceQueueNext()
+                            if (!isLocalPlaybackTrack(resolved)) prefetchServiceQueueNext()
                             LevyraMediaItemFactory.build(resolved)
                         } else {
                             LevyraMediaItemFactory.metadataOnly(track)
@@ -487,7 +489,7 @@ class PlaybackService : MediaLibraryService() {
                 var selected = if (forward) queueEngine.next(respectRepeatOne) else queueEngine.previous()
                 if (selected == null && forward && queueEngine.state.value.radioEnabled) {
                     val seed = queueEngine.state.value.currentTrack
-                    if (seed != null) {
+                    if (seed != null && !isLocalPlaybackTrack(seed) && hasValidatedInternet()) {
                         val additions = runCatching {
                             musicRepository.radio(seed, LevyraPreferences(this@PlaybackService).languageCode(), 20)
                         }.onFailure { Timber.w(it, "Background radio expansion failed") }
@@ -517,7 +519,7 @@ class PlaybackService : MediaLibraryService() {
                 resolved.largeThumbnailUrl.ifBlank { resolved.thumbnailUrl },
                 true
             )
-            prefetchServiceQueueNext()
+            if (!isLocalPlaybackTrack(resolved)) prefetchServiceQueueNext()
         }
     }
 
@@ -528,6 +530,7 @@ class PlaybackService : MediaLibraryService() {
             val target = withContext(Dispatchers.IO) {
                 queueEngine.upcoming(1).firstOrNull()
             } ?: return@launch
+            if (isLocalPlaybackTrack(target) || !hasValidatedInternet()) return@launch
             val resolved = withContext(Dispatchers.IO) {
                 runCatching { resolveQueueTrack(target) }
                     .onFailure { Timber.d(it, "Service queue prefetch skipped") }
@@ -539,7 +542,13 @@ class PlaybackService : MediaLibraryService() {
     }
 
     private suspend fun resolveQueueTrack(track: com.luc4n3x.levyra.domain.Track): com.luc4n3x.levyra.domain.Track {
-        if (track.streamUrl.startsWith("content://", true) || track.streamUrl.startsWith("file://", true)) return track
+        if (isLocalPlaybackTrack(track)) {
+            if (!isLocalPlaybackUri(track.streamUrl)) {
+                throw IOException("File offline non disponibile per ${track.title}")
+            }
+            return track.copy(videoStreamUrl = "")
+        }
+        if (!hasValidatedInternet()) throw IOException("Connessione Internet non disponibile")
         val hasYoutubeIdentity = track.videoUrl.contains("youtube.com", true) ||
             track.videoUrl.contains("youtu.be", true) ||
             Regex("^[A-Za-z0-9_-]{11}$").matches(track.id)
@@ -577,10 +586,11 @@ class PlaybackService : MediaLibraryService() {
 
     override fun onTaskRemoved(rootIntent: Intent?) {
         val player = mediaSession?.player
+        val playbackExpected = playbackStateStore.getBoolean(KEY_PLAYBACK_EXPECTED, false)
         val keepAlive = player != null &&
             player.mediaItemCount > 0 &&
-            player.playWhenReady &&
-            player.playbackState != Player.STATE_ENDED
+            player.playbackState != Player.STATE_ENDED &&
+            (player.playWhenReady || playbackExpected)
         if (!keepAlive) pauseAllPlayersAndStopSelf()
     }
 
@@ -606,6 +616,7 @@ class PlaybackService : MediaLibraryService() {
     }
 
     private fun updatePlaybackProtection(player: Player) {
+        (player as? ExoPlayer)?.let { updatePlayerWakeMode(it, it.currentMediaItem) }
         val playbackExpected = !serviceRecoveryExhausted &&
             player.mediaItemCount > 0 &&
             player.playWhenReady &&
@@ -649,31 +660,53 @@ class PlaybackService : MediaLibraryService() {
     private fun scheduleServiceRecovery(error: PlaybackException) {
         if (serviceRecoveryJob?.isActive == true) return
         if (!playbackStateStore.getBoolean(KEY_PLAYBACK_EXPECTED, false)) return
-        if (serviceRecoveryAttempts >= RECOVERY_DELAYS_MS.size) {
-            serviceRecoveryExhausted = true
-            mediaSession?.player?.pause()
-            markPlaybackExpected(false, force = true)
-            releasePlaybackWakeLock()
-            Timber.e(error, "Background playback recovery exhausted")
-            return
-        }
-        val attempt = serviceRecoveryAttempts++
+        val localPlayback = isCurrentPlaybackLocal()
+        val delays = if (localPlayback) LOCAL_RECOVERY_DELAYS_MS else ONLINE_RECOVERY_DELAYS_MS
         val positionMs = mediaSession?.player?.currentPosition?.coerceAtLeast(0L) ?: 0L
+        acquirePlaybackWakeLock()
         serviceRecoveryJob = serviceScope.launch {
-            delay(RECOVERY_DELAYS_MS[attempt])
-            val restored = restoreCurrentPlayback(positionMs, preferFreshResolution = true)
-            if (!restored) {
-                Timber.w(error, "Background playback recovery attempt %d failed", attempt + 1)
-                if (attempt == RECOVERY_DELAYS_MS.lastIndex) {
+            if (uiRecoveryAvailable && !localPlayback) {
+                delay(750L)
+                if (isPlaybackHealthy(mediaSession?.player)) return@launch
+            }
+            while (isActive && playbackStateStore.getBoolean(KEY_PLAYBACK_EXPECTED, false)) {
+                if (isPlaybackHealthy(mediaSession?.player)) {
+                    serviceRecoveryAttempts = 0
+                    serviceRecoveryExhausted = false
+                    return@launch
+                }
+                if (!localPlayback && !hasValidatedInternet()) {
+                    Timber.d("Background playback recovery waiting for validated network")
+                    delay(5_000L)
+                    continue
+                }
+                if (serviceRecoveryAttempts >= delays.size) {
                     serviceRecoveryExhausted = true
                     mediaSession?.player?.pause()
                     markPlaybackExpected(false, force = true)
                     releasePlaybackWakeLock()
                     Timber.e(error, "Background playback recovery exhausted")
+                    return@launch
                 }
+                val attempt = serviceRecoveryAttempts++
+                delay(delays[attempt])
+                val restored = restoreCurrentPlayback(
+                    positionMs = positionMs,
+                    preferFreshResolution = !localPlayback && hasValidatedInternet()
+                )
+                if (restored) {
+                    Timber.i("Background playback recovery restored attempt=%d local=%s", attempt + 1, localPlayback)
+                    return@launch
+                }
+                Timber.w(error, "Background playback recovery attempt %d failed", attempt + 1)
             }
         }
     }
+
+    private fun isPlaybackHealthy(player: Player?): Boolean = player != null &&
+        player.mediaItemCount > 0 &&
+        player.playWhenReady &&
+        player.playbackState == Player.STATE_READY
 
     private fun scheduleStickyPlaybackRestore(startId: Int): Boolean {
         if (!playbackStateStore.getBoolean(KEY_PLAYBACK_EXPECTED, false)) {
@@ -686,6 +719,7 @@ class PlaybackService : MediaLibraryService() {
             stopSelfResult(startId)
             return false
         }
+        acquirePlaybackWakeLock()
         stickyRestoreJob?.cancel()
         stickyRestoreJob = serviceScope.launch {
             delay(250L)
@@ -707,12 +741,16 @@ class PlaybackService : MediaLibraryService() {
                     queueEngine.state.value
                 }
             }
-            if (snapshot.currentTrack == null) {
+            val currentTrack = snapshot.currentTrack
+            if (currentTrack == null) {
                 markPlaybackExpected(false, force = true)
                 stopSelfResult(startId)
                 return@launch
             }
-            if (!restoreCurrentPlayback(snapshot.positionMs, preferFreshResolution = true)) {
+            if (!restoreCurrentPlayback(
+                    snapshot.positionMs,
+                    preferFreshResolution = !isLocalPlaybackTrack(currentTrack) && hasValidatedInternet()
+                )) {
                 Timber.w("Sticky background playback restore failed")
                 markPlaybackExpected(false, force = true)
                 stopSelfResult(startId)
@@ -728,21 +766,34 @@ class PlaybackService : MediaLibraryService() {
         val queueSnapshot = queueEngine.state.value
         val queueTrack = queueSnapshot.currentTrack
         val videoMode = currentItem?.mediaMetadata?.extras?.getBoolean(EXTRA_VIDEO_MODE, false) ?: false
-        val mediaItem = if (preferFreshResolution && queueTrack != null) {
-            val resolved = withContext(Dispatchers.IO) {
-                runCatching { resolveQueueTrack(queueTrack) }
-                    .onFailure { Timber.w(it, "Fresh background stream resolution failed") }
-                    .getOrNull()
+        val mediaItem = when {
+            queueTrack != null && isLocalPlaybackTrack(queueTrack) -> {
+                when {
+                    isLocalPlaybackUri(queueTrack.streamUrl) -> LevyraMediaItemFactory.build(queueTrack, false)
+                    isLocalMediaItem(currentItem) -> currentItem
+                    else -> null
+                }
             }
-            if (resolved != null) {
-                queueEngine.updateTrackAt(queueSnapshot.currentIndex, resolved)
-                LevyraMediaItemFactory.build(resolved, videoMode)
-            } else {
-                currentItem
+            isLocalMediaItem(currentItem) -> currentItem
+            preferFreshResolution && queueTrack != null && hasValidatedInternet() -> {
+                val resolved = withContext(Dispatchers.IO) {
+                    runCatching { resolveQueueTrack(queueTrack) }
+                        .onFailure { Timber.w(it, "Fresh background stream resolution failed") }
+                        .getOrNull()
+                }
+                if (resolved != null) {
+                    queueEngine.updateTrackAt(queueSnapshot.currentIndex, resolved)
+                    LevyraMediaItemFactory.build(resolved, videoMode)
+                } else {
+                    currentItem
+                }
             }
-        } else {
-            currentItem
+            else -> currentItem ?: queueTrack
+                ?.takeIf { it.streamUrl.isNotBlank() }
+                ?.let { LevyraMediaItemFactory.build(it, videoMode) }
         } ?: return false
+        updatePlayerWakeMode(player, mediaItem)
+        acquirePlaybackWakeLock()
         player.setMediaItem(mediaItem, positionMs.coerceAtLeast(0L))
         player.prepare()
         player.play()
@@ -793,7 +844,7 @@ class PlaybackService : MediaLibraryService() {
     private fun isPlayerActivelyPlaying(player: ExoPlayer): Boolean = player.mediaItemCount > 0 &&
         player.playWhenReady &&
         player.playbackSuppressionReason == Player.PLAYBACK_SUPPRESSION_REASON_NONE &&
-        player.playbackState == Player.STATE_READY
+        (player.playbackState == Player.STATE_BUFFERING || player.playbackState == Player.STATE_READY)
 
     private fun resetWatchdogProgress(now: Long) {
         watchdogPositionMs = C.TIME_UNSET
@@ -819,9 +870,50 @@ class PlaybackService : MediaLibraryService() {
         if (serviceRecoveryJob?.isActive == true) return
         Timber.w("Playback watchdog detected a stalled player at %d ms", positionMs)
         serviceRecoveryJob = serviceScope.launch {
-            val restored = restoreCurrentPlayback(positionMs, preferFreshResolution = true)
+            val restored = restoreCurrentPlayback(
+                positionMs,
+                preferFreshResolution = !isCurrentPlaybackLocal() && hasValidatedInternet()
+            )
             if (!restored) Timber.w("Playback watchdog recovery failed")
         }
+    }
+
+    private fun isCurrentPlaybackLocal(): Boolean {
+        val player = mediaSession?.player
+        return isLocalMediaItem(player?.currentMediaItem) ||
+            queueEngine.state.value.currentTrack?.let(::isLocalPlaybackTrack) == true
+    }
+
+    private fun isLocalPlaybackTrack(track: com.luc4n3x.levyra.domain.Track): Boolean =
+        track.source.equals("Offline", ignoreCase = true) || isLocalPlaybackUri(track.streamUrl)
+
+    private fun isLocalPlaybackUri(value: String): Boolean {
+        val clean = value.trim()
+        return clean.startsWith("content://", ignoreCase = true) ||
+            clean.startsWith("file://", ignoreCase = true)
+    }
+
+    private fun isLocalMediaItem(mediaItem: MediaItem?): Boolean {
+        val scheme = mediaItem?.localConfiguration?.uri?.scheme.orEmpty()
+        if (scheme.equals("content", ignoreCase = true) || scheme.equals("file", ignoreCase = true)) return true
+        return mediaItem?.mediaMetadata?.extras
+            ?.getString("levyra.source")
+            ?.equals("Offline", ignoreCase = true) == true
+    }
+
+    private fun updatePlayerWakeMode(player: ExoPlayer, mediaItem: MediaItem?) {
+        val wakeMode = if (isLocalMediaItem(mediaItem)) C.WAKE_MODE_LOCAL else C.WAKE_MODE_NETWORK
+        if (wakeMode == appliedPlayerWakeMode) return
+        player.setWakeMode(wakeMode)
+        appliedPlayerWakeMode = wakeMode
+    }
+
+    private fun hasValidatedInternet(): Boolean {
+        val connectivity = getSystemService(ConnectivityManager::class.java) ?: return false
+        val network = connectivity.activeNetwork ?: return false
+        val capabilities = connectivity.getNetworkCapabilities(network) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
     }
 
     private fun libraryItemFuture(

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -49,6 +49,7 @@ import com.luc4n3x.levyra.data.PlaybackResolver
 import com.luc4n3x.levyra.data.YoutubeMusicRepository
 import com.luc4n3x.levyra.domain.LevyraAudioSettings
 import com.luc4n3x.levyra.player.queue.PersistentQueueEngine
+import com.luc4n3x.levyra.player.queue.PlaybackQueueSnapshot
 import com.luc4n3x.levyra.widget.LevyraWidgetBridge
 import com.luc4n3x.levyra.widget.LevyraWidgetCenter
 import kotlinx.coroutines.CoroutineScope
@@ -657,50 +658,101 @@ class PlaybackService : MediaLibraryService() {
         }
     }
 
+    private data class ServiceRecoveryPlan(
+        val localPlayback: Boolean,
+        val delaysMs: LongArray,
+        val positionMs: Long
+    )
+
     private fun scheduleServiceRecovery(error: PlaybackException) {
-        if (serviceRecoveryJob?.isActive == true) return
-        if (!playbackStateStore.getBoolean(KEY_PLAYBACK_EXPECTED, false)) return
-        val localPlayback = isCurrentPlaybackLocal()
-        val delays = if (localPlayback) LOCAL_RECOVERY_DELAYS_MS else ONLINE_RECOVERY_DELAYS_MS
-        val positionMs = mediaSession?.player?.currentPosition?.coerceAtLeast(0L) ?: 0L
-        acquirePlaybackWakeLock()
+        val plan = serviceRecoveryPlan() ?: return
         serviceRecoveryJob = serviceScope.launch {
-            if (uiRecoveryAvailable && !localPlayback) {
-                delay(750L)
-                if (isPlaybackHealthy(mediaSession?.player)) return@launch
-            }
-            while (isActive && playbackStateStore.getBoolean(KEY_PLAYBACK_EXPECTED, false)) {
-                if (isPlaybackHealthy(mediaSession?.player)) {
-                    serviceRecoveryAttempts = 0
-                    serviceRecoveryExhausted = false
-                    return@launch
-                }
-                if (!localPlayback && !hasValidatedInternet()) {
-                    Timber.d("Background playback recovery waiting for validated network")
-                    delay(5_000L)
-                    continue
-                }
-                if (serviceRecoveryAttempts >= delays.size) {
-                    serviceRecoveryExhausted = true
-                    mediaSession?.player?.pause()
-                    markPlaybackExpected(false, force = true)
-                    releasePlaybackWakeLock()
-                    Timber.e(error, "Background playback recovery exhausted")
-                    return@launch
-                }
-                val attempt = serviceRecoveryAttempts++
-                delay(delays[attempt])
-                val restored = restoreCurrentPlayback(
-                    positionMs = positionMs,
-                    preferFreshResolution = !localPlayback && hasValidatedInternet()
-                )
-                if (restored) {
-                    Timber.i("Background playback recovery restored attempt=%d local=%s", attempt + 1, localPlayback)
-                    return@launch
-                }
-                Timber.w(error, "Background playback recovery attempt %d failed", attempt + 1)
-            }
+            runServiceRecovery(error, plan)
         }
+    }
+
+    private fun serviceRecoveryPlan(): ServiceRecoveryPlan? {
+        if (serviceRecoveryJob?.isActive == true) return null
+        if (!isPlaybackRecoveryExpected()) return null
+        val localPlayback = isCurrentPlaybackLocal()
+        return ServiceRecoveryPlan(
+            localPlayback = localPlayback,
+            delaysMs = if (localPlayback) LOCAL_RECOVERY_DELAYS_MS else ONLINE_RECOVERY_DELAYS_MS,
+            positionMs = mediaSession?.player?.currentPosition?.coerceAtLeast(0L) ?: 0L
+        )
+    }
+
+    private suspend fun runServiceRecovery(error: PlaybackException, plan: ServiceRecoveryPlan) {
+        if (awaitUiRecovery(plan.localPlayback)) return
+        while (isPlaybackRecoveryExpected()) {
+            if (finishHealthyServiceRecovery()) return
+            if (awaitRecoveryConnectivity(plan.localPlayback)) continue
+            if (finishExhaustedServiceRecovery(error, plan.delaysMs)) return
+            if (attemptServiceRecovery(error, plan)) return
+        }
+        releasePlaybackWakeLock()
+    }
+
+    private fun isPlaybackRecoveryExpected(): Boolean =
+        playbackStateStore.getBoolean(KEY_PLAYBACK_EXPECTED, false)
+
+    private suspend fun awaitUiRecovery(localPlayback: Boolean): Boolean {
+        if (!uiRecoveryAvailable || localPlayback) return false
+        releasePlaybackWakeLock()
+        delay(750L)
+        return finishHealthyServiceRecovery()
+    }
+
+    private fun finishHealthyServiceRecovery(): Boolean {
+        if (!isPlaybackHealthy(mediaSession?.player)) return false
+        serviceRecoveryAttempts = 0
+        serviceRecoveryExhausted = false
+        mediaSession?.player?.let(::updatePlaybackProtection)
+        return true
+    }
+
+    private suspend fun awaitRecoveryConnectivity(localPlayback: Boolean): Boolean {
+        if (localPlayback || hasValidatedInternet()) return false
+        releasePlaybackWakeLock()
+        Timber.d("Background playback recovery waiting for validated network")
+        delay(5_000L)
+        return true
+    }
+
+    private fun finishExhaustedServiceRecovery(
+        error: PlaybackException,
+        delaysMs: LongArray
+    ): Boolean {
+        if (serviceRecoveryAttempts < delaysMs.size) return false
+        serviceRecoveryExhausted = true
+        mediaSession?.player?.pause()
+        markPlaybackExpected(false, force = true)
+        releasePlaybackWakeLock()
+        Timber.e(error, "Background playback recovery exhausted")
+        return true
+    }
+
+    private suspend fun attemptServiceRecovery(
+        error: PlaybackException,
+        plan: ServiceRecoveryPlan
+    ): Boolean {
+        val attempt = serviceRecoveryAttempts++
+        acquirePlaybackWakeLock()
+        delay(plan.delaysMs[attempt])
+        val restored = restoreCurrentPlayback(
+            positionMs = plan.positionMs,
+            preferFreshResolution = !plan.localPlayback && hasValidatedInternet()
+        )
+        if (restored) {
+            Timber.i(
+                "Background playback recovery restored attempt=%d local=%s",
+                attempt + 1,
+                plan.localPlayback
+            )
+            return true
+        }
+        Timber.w(error, "Background playback recovery attempt %d failed", attempt + 1)
+        return false
     }
 
     private fun isPlaybackHealthy(player: Player?): Boolean = player != null &&
@@ -709,54 +761,87 @@ class PlaybackService : MediaLibraryService() {
         player.playbackState == Player.STATE_READY
 
     private fun scheduleStickyPlaybackRestore(startId: Int): Boolean {
-        if (!playbackStateStore.getBoolean(KEY_PLAYBACK_EXPECTED, false)) {
+        if (!isPlaybackRecoveryExpected()) {
             stopSelfResult(startId)
             return false
         }
-        val heartbeatAt = playbackStateStore.getLong(KEY_PLAYBACK_HEARTBEAT_AT, 0L)
-        if (heartbeatAt <= 0L || System.currentTimeMillis() - heartbeatAt > STICKY_RESTORE_MAX_AGE_MS) {
-            markPlaybackExpected(false, force = true)
-            stopSelfResult(startId)
+        if (isStickyRestoreExpired()) {
+            stopStickyRestore(startId)
             return false
         }
         acquirePlaybackWakeLock()
         stickyRestoreJob?.cancel()
         stickyRestoreJob = serviceScope.launch {
-            delay(250L)
-            val player = mediaSession?.player ?: run {
-                markPlaybackExpected(false, force = true)
-                stopSelfResult(startId)
-                return@launch
-            }
-            if (player.mediaItemCount > 0 || player.playWhenReady) return@launch
-            val snapshot = withContext(Dispatchers.IO) {
-                if (queueEngine.state.value.tracks.isEmpty()) {
-                    queueEngine.restore(
-                        fallbackTracks = emptyList(),
-                        fallbackIndex = -1,
-                        fallbackPositionMs = 0L,
-                        fallbackRadioEnabled = true
-                    )
-                } else {
-                    queueEngine.state.value
-                }
-            }
-            val currentTrack = snapshot.currentTrack
-            if (currentTrack == null) {
-                markPlaybackExpected(false, force = true)
-                stopSelfResult(startId)
-                return@launch
-            }
-            if (!restoreCurrentPlayback(
-                    snapshot.positionMs,
-                    preferFreshResolution = !isLocalPlaybackTrack(currentTrack) && hasValidatedInternet()
-                )) {
-                Timber.w("Sticky background playback restore failed")
-                markPlaybackExpected(false, force = true)
-                stopSelfResult(startId)
-            }
+            restoreStickyPlayback(startId)
         }
         return true
+    }
+
+    private suspend fun restoreStickyPlayback(startId: Int) {
+        delay(250L)
+        val player = mediaSession?.player ?: run {
+            stopStickyRestore(startId)
+            return
+        }
+        if (player.mediaItemCount > 0 || player.playWhenReady) return
+        val snapshot = restoreQueueSnapshot()
+        val currentTrack = snapshot.currentTrack ?: run {
+            stopStickyRestore(startId)
+            return
+        }
+        if (!awaitStickyRestoreConnectivity(currentTrack)) {
+            if (isStickyRestoreExpired()) stopStickyRestore(startId)
+            return
+        }
+        val restored = restoreCurrentPlayback(
+            snapshot.positionMs,
+            preferFreshResolution = !isLocalPlaybackTrack(currentTrack)
+        )
+        if (!restored) {
+            Timber.w("Sticky background playback restore failed")
+            stopStickyRestore(startId)
+        }
+    }
+
+    private suspend fun restoreQueueSnapshot(): PlaybackQueueSnapshot = withContext(Dispatchers.IO) {
+        if (queueEngine.state.value.tracks.isEmpty()) {
+            queueEngine.restore(
+                fallbackTracks = emptyList(),
+                fallbackIndex = -1,
+                fallbackPositionMs = 0L,
+                fallbackRadioEnabled = true
+            )
+        } else {
+            queueEngine.state.value
+        }
+    }
+
+    private suspend fun awaitStickyRestoreConnectivity(
+        track: com.luc4n3x.levyra.domain.Track
+    ): Boolean {
+        if (isLocalPlaybackTrack(track)) return true
+        while (isPlaybackRecoveryExpected() && !isStickyRestoreExpired()) {
+            if (hasValidatedInternet()) {
+                acquirePlaybackWakeLock()
+                return true
+            }
+            releasePlaybackWakeLock()
+            Timber.d("Sticky playback restore waiting for validated network")
+            delay(5_000L)
+        }
+        return false
+    }
+
+    private fun isStickyRestoreExpired(): Boolean {
+        val heartbeatAt = playbackStateStore.getLong(KEY_PLAYBACK_HEARTBEAT_AT, 0L)
+        return heartbeatAt <= 0L ||
+            System.currentTimeMillis() - heartbeatAt > STICKY_RESTORE_MAX_AGE_MS
+    }
+
+    private fun stopStickyRestore(startId: Int) {
+        markPlaybackExpected(false, force = true)
+        releasePlaybackWakeLock()
+        stopSelfResult(startId)
     }
 
     private suspend fun restoreCurrentPlayback(positionMs: Long, preferFreshResolution: Boolean): Boolean {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -657,7 +657,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             recoverPlaybackStream(track, positionMs, videoMode, playWhenReady, errorMessage)
         }
         player.onError = { errorMsg ->
-            _state.value.currentTrack?.let { resolver.invalidate(it, _state.value.isVideoMode) }
+            _state.value.currentTrack
+                ?.takeUnless(::isLocalPlaybackTrack)
+                ?.let { resolver.invalidate(it, _state.value.isVideoMode) }
             _state.update { it.copy(playerError = cleanUserError(errorMsg), isPlaying = false, isResolving = false) }
         }
         applyFollowedArtists(followedArtistsStore.load())
@@ -1445,6 +1447,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         playWhenReady: Boolean,
         errorMessage: String
     ) {
+        if (isLocalPlaybackTrack(failedTrack)) return
         val transitionId = ++streamTransitionId
         modeSwitchJob?.cancel()
         streamRecoveryJob?.cancel()
@@ -3945,13 +3948,17 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     fun playDownloaded(download: DownloadedTrack) {
+        if (download.uri.isBlank()) {
+            _state.update { it.copy(playerError = "File offline non disponibile") }
+            return
+        }
         val track = Track(
-            id = download.trackId,
+            id = download.trackId.ifBlank { "offline-${download.id}" },
             title = download.title,
             artist = download.artist,
             album = download.album,
             durationMs = download.durationMs,
-            streamUrl = "",
+            streamUrl = download.uri,
             videoUrl = "",
             thumbnailUrl = "",
             largeThumbnailUrl = "",
@@ -3964,10 +3971,19 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             accentStart = 0,
             accentEnd = 0
         )
+        playRequestId++
+        streamTransitionId++
+        playJob?.cancel()
+        modeSwitchJob?.cancel()
+        streamRecoveryJob?.cancel()
+        crossfadeJob?.cancel()
+        crossfadeInProgress = false
+        cancelBackgroundWarmups(cancelList = true)
+        _state.update { it.copy(isVideoMode = false, playerError = null, isResolving = false) }
         loopCurrentQueueOnCompletion = false
         queueEngine.replace(listOf(track), 0, keepPlaybackModes = true, radioEnabled = false)
         queueIndex = 0
-        startResolve(track)
+        startPlayback(track)
     }
 
     private fun startPlayback(playable: Track) {
@@ -4369,7 +4385,12 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private fun fetchSponsorSegments(track: Track) {
         sponsorJob?.cancel()
         sponsorSegments = emptyList()
-        if (!_state.value.sponsorBlockEnabled || track.id.isBlank() || track.id.startsWith("chart-")) return
+        if (
+            !_state.value.sponsorBlockEnabled ||
+            isLocalPlaybackTrack(track) ||
+            track.id.isBlank() ||
+            track.id.startsWith("chart-")
+        ) return
         sponsorJob = viewModelScope.launch {
             val result = runCatching { sponsorBlockRepository.segments(track.id) }.getOrDefault(emptyList())
             if (_state.value.currentTrack?.id == track.id) sponsorSegments = result
@@ -4485,9 +4506,14 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         prefetchJob?.cancel()
         PlaybackService.clearPreparedQueueNext()
         val current = _state.value.currentTrack
-        if (current != null) prefetchLyricsAround(current)
-        if (current != null) prefetchNextMotionArtwork(current)
-        if (_state.value.isPlaying && current != null && current.streamUrl.isNotBlank()) prefetchAround(current)
+        if (current != null && !isLocalPlaybackTrack(current)) prefetchLyricsAround(current)
+        if (current != null && !isLocalPlaybackTrack(current)) prefetchNextMotionArtwork(current)
+        if (
+            _state.value.isPlaying &&
+            current != null &&
+            current.streamUrl.isNotBlank() &&
+            !isLocalPlaybackTrack(current)
+        ) prefetchAround(current)
     }
 
     private fun refreshMotionArtworkAround(current: Track) {
@@ -4611,6 +4637,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private fun prefetchAround(playable: Track) {
         prefetchJob?.cancel()
         PlaybackService.clearPreparedQueueNext()
+        if (isLocalPlaybackTrack(playable) || !lyricsNetworkProfile().connected) return
         val generation = queueEngine.state.value.generation
         prefetchJob = viewModelScope.launch(Dispatchers.IO) {
             val plan = adaptivePlaybackPolicy.current(_state.value.isVideoMode)
@@ -4661,6 +4688,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         if (!force && queueEngine.upcoming(3).size >= 3) return
         if (radioJob?.isActive == true) return
         val seed = queueSnapshot.currentTrack ?: return
+        if (isLocalPlaybackTrack(seed) || !lyricsNetworkProfile().connected) return
         val generation = queueSnapshot.generation
         radioJob = viewModelScope.launch(Dispatchers.IO) {
             val radioTracks = runCatching {
@@ -5157,6 +5185,13 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             throw IllegalStateException("YouTube non ha fornito uno stream audio riproducibile per ${track.title}")
         }
         return resolved
+    }
+
+    private fun isLocalPlaybackTrack(track: Track): Boolean {
+        val stream = track.streamUrl.trim()
+        return track.source.equals("Offline", ignoreCase = true) ||
+            stream.startsWith("content://", ignoreCase = true) ||
+            stream.startsWith("file://", ignoreCase = true)
     }
 
     private fun effectiveDuration(track: Track): Long {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -4682,30 +4682,49 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         }
     }
 
+    private data class RadioTailRequest(
+        val seed: Track,
+        val generation: Long
+    )
+
     private fun ensureRadioTail(force: Boolean, playWhenReady: Boolean = false) {
-        val queueSnapshot = queueEngine.state.value
-        if (!queueSnapshot.radioEnabled || queueSnapshot.currentTrack == null) return
-        if (!force && queueEngine.upcoming(3).size >= 3) return
-        if (radioJob?.isActive == true) return
-        val seed = queueSnapshot.currentTrack ?: return
-        if (isLocalPlaybackTrack(seed) || !lyricsNetworkProfile().connected) return
-        val generation = queueSnapshot.generation
+        val request = radioTailRequest(force) ?: return
         radioJob = viewModelScope.launch(Dispatchers.IO) {
-            val radioTracks = runCatching {
-                repository.radio(seed, _state.value.languageCode, 20)
-            }.getOrDefault(emptyList())
-            if (!isActive || radioTracks.isEmpty()) return@launch
-            val before = queueEngine.state.value
-            val sameSeed = before.currentTrack?.let { playbackQueueIdentity(it) } == playbackQueueIdentity(seed)
-            if (!sameSeed || (before.generation != generation && !force)) return@launch
-            queueEngine.appendRadioTracks(radioTracks)
-            if (playWhenReady) {
-                withContext(Dispatchers.Main) {
-                    queueEngine.next(respectRepeatOne = false)?.let(::startResolve)
-                }
-            }
+            appendRadioTail(request, force, playWhenReady)
         }
     }
+
+    private fun radioTailRequest(force: Boolean): RadioTailRequest? {
+        val snapshot = queueEngine.state.value
+        val seed = snapshot.currentTrack ?: return null
+        if (!snapshot.radioEnabled) return null
+        if (!force && queueEngine.upcoming(3).size >= 3) return null
+        if (radioJob?.isActive == true) return null
+        if (isLocalPlaybackTrack(seed) || !lyricsNetworkProfile().connected) return null
+        return RadioTailRequest(seed = seed, generation = snapshot.generation)
+    }
+
+    private suspend fun appendRadioTail(
+        request: RadioTailRequest,
+        force: Boolean,
+        playWhenReady: Boolean
+    ) {
+        val radioTracks = runCatching {
+            repository.radio(request.seed, _state.value.languageCode, 20)
+        }.getOrDefault(emptyList())
+        if (radioTracks.isEmpty()) return
+        val current = queueEngine.state.value
+        if (!isSameRadioSeed(current.currentTrack, request.seed)) return
+        if (current.generation != request.generation && !force) return
+        queueEngine.appendRadioTracks(radioTracks)
+        if (!playWhenReady) return
+        withContext(Dispatchers.Main) {
+            queueEngine.next(respectRepeatOne = false)?.let(::startResolve)
+        }
+    }
+
+    private fun isSameRadioSeed(current: Track?, seed: Track): Boolean =
+        current?.let { playbackQueueIdentity(it) } == playbackQueueIdentity(seed)
 
     private fun prefetchTop(tracks: List<Track>, count: Int = 8, respectHomeScroll: Boolean = false) {
         val plan = adaptivePlaybackPolicy.current(videoMode = false)

--- a/app/src/test/java/com/luc4n3x/levyra/player/LevyraMediaItemFactoryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/LevyraMediaItemFactoryTest.kt
@@ -1,6 +1,7 @@
 package com.luc4n3x.levyra.player
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class LevyraMediaItemFactoryTest {
@@ -16,5 +17,11 @@ class LevyraMediaItemFactoryTest {
         assertEquals("application/dash+xml", LevyraMediaItemFactory.mimeTypeFor("https://example.com/manifest.mpd", true))
         assertEquals("video/webm", LevyraMediaItemFactory.mimeTypeFor("https://example.com/videoplayback?mime=video%2Fwebm", true))
         assertEquals("video/mp4", LevyraMediaItemFactory.mimeTypeFor("https://example.com/videoplayback?mime=video%2Fmp4", true))
+    }
+
+    @Test
+    fun localContentUriUsesExtractorSniffing() {
+        assertNull(LevyraMediaItemFactory.mimeTypeFor("content://media/external/audio/media/42", false))
+        assertNull(LevyraMediaItemFactory.mimeTypeFor("file:///storage/emulated/0/Music/download", false))
     }
 }


### PR DESCRIPTION
## Summary

- Fixes playback stopping after extended periods with the screen off or the device idle.
- Improves playback continuity for both online streams and downloaded offline tracks.
- Prevents offline playback from unnecessarily invoking YouTube resolution and network recovery paths.

## Scope

- [x] Player / audio
- [ ] Stream extraction
- [ ] Downloads
- [ ] UI / Compose
- [ ] Localization
- [ ] Android Auto / media session
- [ ] CI / release
- [ ] Documentation

## What changed

- Extended sticky playback restoration beyond the previous 30-minute limit.
- Improved foreground playback service persistence during Doze and screen-off playback.
- Added the appropriate Media3 wake mode for local and network sources.
- Kept the playback wake lock active during buffering and recovery.
- Improved watchdog detection for playback stuck in the buffering state.
- Allowed `PlaybackService` to recover playback independently from the UI lifecycle.
- Restored the current track from the same playback position after a detected stall.
- Prevented temporary network loss from immediately exhausting all recovery attempts.
- Routed downloaded tracks directly through their local `content://` or `file://` URI.
- Disabled online resolving, prefetching, radio expansion, and SponsorBlock processing for local tracks.
- Prevented offline DNS failures from reducing YouTube client health scores.
- Cleared expired provider penalties when playback infrastructure is initialized.
- Improved local media type detection for files without a recognizable extension.
- Forced downloaded tracks to start in audio mode.
- Cancelled stale online resolution jobs before starting local playback.
- Added regression tests for local media-item creation and offline URI handling.

## Testing

- [ ] `gradle --no-daemon :app:lintRelease`
- [ ] `gradle --no-daemon testReleaseUnitTest`
- [ ] `gradle --no-daemon assembleRelease`
- [ ] APK installed on device
- [ ] Playback tested
- [ ] Downloads tested
- [ ] Language switching tested

Additional checks completed:

- Verified local and network wake-mode selection.
- Verified offline tracks bypass the online resolver path.
- Verified stale resolution jobs are cancelled before local playback.
- Verified watchdog and sticky-restoration logic structurally.
- Verified the generated patch with `git diff --check`.
- Full Gradle and physical-device validation remain pending GitHub Actions and device testing.

## Release safety

- [x] `levyraVersionName` and `levyraVersionCode` are correct
- [x] No secrets, keystores, APKs or ZIPs committed
- [x] No duplicated release workflows
- [x] Credits and licenses updated when adding external components

No external components or third-party code were added.

## Related issues

- Closes #
- Related to #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved offline playback for downloaded and local media.
  * Playback recovery, queue prefetching, radio expansion, and sponsor fetching now adapt to offline playback and network availability.
  * Local media with unknown formats can now be detected automatically.

* **Bug Fixes**
  * Prevented unnecessary online recovery attempts when internet access is unavailable.
  * Improved handling of local playback errors and unavailable offline files.
  * Expired connection penalties are now cleared correctly.

* **Tests**
  * Added coverage for local content and file URI format detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->