### PR TITLE
fix: keep background playback alive through Doze, battery kills and offline recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Architecture and size-control notes live in `docs/APK_SIZE_RULER.md` and `docs/P
 Version numbering is centralized in `gradle.properties`:
 
 ```properties
-levyraVersionName=2.3.13
+levyraVersionName=2.3.15
 levyraVersionCode=2031300
 ```
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Version numbering is centralized in `gradle.properties`:
 
 ```properties
 levyraVersionName=2.3.15
-levyraVersionCode=2031300
+levyraVersionCode=2031500
 ```
 
 `versionCode = major * 1_000_000 + minor * 10_000 + patch * 100 + build` — calculated sequentially so no two deployments ever collide. The APK Artifact workflow parses this schema, verifies target versions with `aapt`, checks structural integrity, compiles the signed binary and publishes it as `LEVYRA-<version>.apk`.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,7 +66,7 @@ if (isReleaseTaskRequested() && !releaseSigningAvailable) {
 fun normalizedVersionName(value: String): String {
     val clean = value.trim().removePrefix("v").removePrefix("V")
     val match = Regex("\\d+(?:\\.\\d+){0,3}(?:[-+][0-9A-Za-z.-]+)?").find(clean)?.value
-    return match ?: clean.ifBlank { "2.3.13" }
+    return match ?: clean.ifBlank { "2.3.15" }
 }
 
 fun generatedVersionCode(versionName: String): Int {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -97,7 +97,7 @@ val levyraVersionName = normalizedVersionName(
     (findProperty("levyraVersionName") as? String)
         ?: System.getenv("LEVYRA_VERSION_NAME")
         ?: githubTagVersionName()
-        ?: "2.3.13"
+        ?: "2.3.15"
 )
 
 val levyraVersionCode = ((findProperty("levyraVersionCode") as? String)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
 

--- a/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
@@ -38,7 +38,6 @@ class MainActivity : ComponentActivity() {
         configureFastImageLoader()
         requestNotificationPermission()
         requestLegacyStoragePermission()
-        requestUnrestrictedBatteryUsage()
         val startPalette = LevyraThemes.byId(LevyraThemes.APPLE_MUSIC)
         LevyraThemeController.apply(startPalette.id)
         WindowCompat.enableEdgeToEdge(window)
@@ -97,20 +96,6 @@ class MainActivity : ComponentActivity() {
     override fun onDestroy() {
         LevyraPipBridge.unbind()
         super.onDestroy()
-    }
-
-    private fun requestUnrestrictedBatteryUsage() {
-        val powerManager = getSystemService(android.os.PowerManager::class.java) ?: return
-        if (powerManager.isIgnoringBatteryOptimizations(packageName)) return
-        val prefs = getSharedPreferences("levyra_battery_guard", MODE_PRIVATE)
-        if (prefs.getBoolean("requested", false)) return
-        prefs.edit().putBoolean("requested", true).apply()
-        runCatching {
-            startActivity(
-                Intent(android.provider.Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
-                    .setData(android.net.Uri.parse("package:$packageName"))
-            )
-        }
     }
 
     private fun enterPictureInPicture(): Boolean {

--- a/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
@@ -38,6 +38,7 @@ class MainActivity : ComponentActivity() {
         configureFastImageLoader()
         requestNotificationPermission()
         requestLegacyStoragePermission()
+        requestUnrestrictedBatteryUsage()
         val startPalette = LevyraThemes.byId(LevyraThemes.APPLE_MUSIC)
         LevyraThemeController.apply(startPalette.id)
         WindowCompat.enableEdgeToEdge(window)
@@ -96,6 +97,20 @@ class MainActivity : ComponentActivity() {
     override fun onDestroy() {
         LevyraPipBridge.unbind()
         super.onDestroy()
+    }
+
+    private fun requestUnrestrictedBatteryUsage() {
+        val powerManager = getSystemService(android.os.PowerManager::class.java) ?: return
+        if (powerManager.isIgnoringBatteryOptimizations(packageName)) return
+        val prefs = getSharedPreferences("levyra_battery_guard", MODE_PRIVATE)
+        if (prefs.getBoolean("requested", false)) return
+        prefs.edit().putBoolean("requested", true).apply()
+        runCatching {
+            startActivity(
+                Intent(android.provider.Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+                    .setData(android.net.Uri.parse("package:$packageName"))
+            )
+        }
     }
 
     private fun enterPictureInPicture(): Boolean {

--- a/app/src/main/java/com/luc4n3x/levyra/data/OfficialArtworkRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/OfficialArtworkRepository.kt
@@ -624,7 +624,7 @@ class OfficialArtworkRepository(context: Context) {
         const val APPLE_SEARCH_URL = "https://itunes.apple.com/search"
         const val DEEZER_SEARCH_URL = "https://api.deezer.com/search/track"
         const val DEEZER_ALBUM_URL = "https://api.deezer.com/album"
-        const val USER_AGENT = "Levyra/2.3.13 Android"
+        const val USER_AGENT = "Levyra/2.3.15 Android"
         const val MIN_ACCEPTED_SCORE = 200
         const val DECISIVE_MATCH_SCORE = 350
         const val MIN_ARTIST_MATCH_SCORE = 45

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -393,6 +393,18 @@ class PlaybackResolver private constructor(private val context: Context) {
 
         if (!hasInternetCapableNetwork()) {
             clearTransientClientPenalties()
+            val offlineTrack = track.copy(streamUrl = "", videoStreamUrl = "")
+            val restored = withContext(Dispatchers.IO) {
+                restorePersistentSource(
+                    track = offlineTrack,
+                    isVideoMode = isVideoMode,
+                    preferMp4Audio = preferMp4Audio,
+                    audioQuality = audioQuality,
+                    errors = mutableListOf(),
+                    allowNetworkRefresh = false
+                )?.also { store(offlineTrack, it, isVideoMode, audioQuality) }
+            }
+            restored?.let { return@coroutineScope it }
             throw PlaybackBlockedException("Connessione Internet non disponibile")
         }
 
@@ -425,7 +437,6 @@ class PlaybackResolver private constructor(private val context: Context) {
 
     suspend fun prefetch(track: Track, isVideoMode: Boolean = false): Track? {
         if (isLocalPlaybackTrack(track)) return track.takeIf { isLocalPlaybackUri(it.streamUrl) }
-        if (!hasInternetCapableNetwork()) return null
         if (track.streamUrl.isNotBlank()) {
             if (!isVideoMode && !isPlayableAudioUrl(track.streamUrl)) return null
             if (streamStillFresh(track.streamUrl)) {
@@ -435,6 +446,7 @@ class PlaybackResolver private constructor(private val context: Context) {
             return null
         }
         cached(track, isVideoMode)?.let { return it }
+        if (!hasInternetCapableNetwork()) return null
         return runCatching { resolve(track, isVideoMode) }.getOrNull()
     }
 
@@ -621,7 +633,8 @@ class PlaybackResolver private constructor(private val context: Context) {
         isVideoMode: Boolean,
         preferMp4Audio: Boolean,
         audioQuality: String,
-        errors: MutableList<String>
+        errors: MutableList<String>,
+        allowNetworkRefresh: Boolean = true
     ): Track? {
         val stored = runCatching { sourceMatchStore.load(track, isVideoMode, audioQuality, preferMp4Audio) }
             .onFailure { error ->
@@ -640,6 +653,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 source = stored.entity.provider.ifBlank { "Persistent source match" }
             )
         }
+        if (!allowNetworkRefresh) return null
         val sourceVideoId = stored.entity.sourceVideoId
             .takeIf(youtubeVideoIdRegex::matches)
             ?: return null

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -144,7 +144,7 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     fun warmNetwork() {
-        if (!hasValidatedInternet()) return
+        if (!hasInternetCapableNetwork()) return
         val now = System.currentTimeMillis()
         if (now - lastNetworkWarmAt < 15_000L) return
         lastNetworkWarmAt = now
@@ -297,6 +297,13 @@ class PlaybackResolver private constructor(private val context: Context) {
             capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
     }
 
+    private fun hasInternetCapableNetwork(): Boolean {
+        val manager = connectivityManager ?: return false
+        val network = manager.activeNetwork ?: return false
+        val capabilities = manager.getNetworkCapabilities(network) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+
     private fun isNetworkFailureReason(reason: String): Boolean {
         val value = reason.lowercase()
         return value.contains("network") ||
@@ -384,7 +391,7 @@ class PlaybackResolver private constructor(private val context: Context) {
             cached(cacheLookupTrack, isVideoMode, audioQuality)?.let { return@coroutineScope it }
         }
 
-        if (!hasValidatedInternet()) {
+        if (!hasInternetCapableNetwork()) {
             clearTransientClientPenalties()
             throw PlaybackBlockedException("Connessione Internet non disponibile")
         }
@@ -418,7 +425,7 @@ class PlaybackResolver private constructor(private val context: Context) {
 
     suspend fun prefetch(track: Track, isVideoMode: Boolean = false): Track? {
         if (isLocalPlaybackTrack(track)) return track.takeIf { isLocalPlaybackUri(it.streamUrl) }
-        if (!hasValidatedInternet()) return null
+        if (!hasInternetCapableNetwork()) return null
         if (track.streamUrl.isNotBlank()) {
             if (!isVideoMode && !isPlayableAudioUrl(track.streamUrl)) return null
             if (streamStillFresh(track.streamUrl)) {

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -1,6 +1,8 @@
 package com.luc4n3x.levyra.data
 
 import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import com.luc4n3x.levyra.BuildConfig
 import com.luc4n3x.levyra.data.security.GoogleApiKeyHeaders
 import com.luc4n3x.levyra.data.local.LevyraDatabase
@@ -71,6 +73,7 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     private val apiKey = BuildConfig.YOUTUBE_INNERTUBE_API_KEY
+    private val connectivityManager = context.getSystemService(ConnectivityManager::class.java)
     private val prefs = context.getSharedPreferences("levyra_stream_cache", Context.MODE_PRIVATE)
     private val clientHealthPrefs = context.getSharedPreferences("levyra_innertube_client_health", Context.MODE_PRIVATE)
     private val userPreferences = LevyraPreferences(context)
@@ -141,6 +144,7 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     fun warmNetwork() {
+        if (!hasValidatedInternet()) return
         val now = System.currentTimeMillis()
         if (now - lastNetworkWarmAt < 15_000L) return
         lastNetworkWarmAt = now
@@ -221,6 +225,15 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     fun reportPlaybackFailure(track: Track, isVideoMode: Boolean, reason: String) {
+        if (isLocalPlaybackTrack(track)) {
+            resilienceEngine.recordPlayerFailure(track.id, isVideoMode, reason)
+            return
+        }
+        if (!hasValidatedInternet() && isNetworkFailureReason(reason)) {
+            clearTransientClientPenalties()
+            resilienceEngine.recordPlayerFailure(track.id, isVideoMode, reason)
+            return
+        }
         invalidate(track, isVideoMode)
         resilienceEngine.recordPlayerFailure(track.id, isVideoMode, reason)
         val now = System.currentTimeMillis()
@@ -267,6 +280,48 @@ class PlaybackResolver private constructor(private val context: Context) {
         return resilienceEngine.diagnostics(health)
     }
 
+    private fun isLocalPlaybackTrack(track: Track): Boolean =
+        track.source.equals("Offline", ignoreCase = true) || isLocalPlaybackUri(track.streamUrl)
+
+    private fun isLocalPlaybackUri(value: String): Boolean {
+        val clean = value.trim()
+        return clean.startsWith("content://", ignoreCase = true) ||
+            clean.startsWith("file://", ignoreCase = true)
+    }
+
+    private fun hasValidatedInternet(): Boolean {
+        val manager = connectivityManager ?: return false
+        val network = manager.activeNetwork ?: return false
+        val capabilities = manager.getNetworkCapabilities(network) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+    }
+
+    private fun isNetworkFailureReason(reason: String): Boolean {
+        val value = reason.lowercase()
+        return value.contains("network") ||
+            value.contains("socket") ||
+            value.contains("dns") ||
+            value.contains("connection") ||
+            value.contains("host") ||
+            value.contains("rete")
+    }
+
+    private fun clearTransientClientPenalties() {
+        val now = System.currentTimeMillis()
+        clientHealth.replaceAll { name, health ->
+            if (health.consecutiveFailures == 0 && health.blockedUntilMs == 0L) {
+                health
+            } else {
+                health.copy(
+                    consecutiveFailures = 0,
+                    blockedUntilMs = 0L,
+                    updatedAtMs = now
+                ).also { persistClientHealth(name, it) }
+            }
+        }
+    }
+
     private fun isPlaybackUrlBlocked(url: String): Boolean {
         if (url.isBlank()) return true
         val until = failedPlaybackUrls[url] ?: return false
@@ -309,6 +364,12 @@ class PlaybackResolver private constructor(private val context: Context) {
         audioQuality: String,
         reuseProvidedStream: Boolean
     ): Track = coroutineScope {
+        if (isLocalPlaybackTrack(track)) {
+            if (!isLocalPlaybackUri(track.streamUrl)) {
+                throw PlaybackBlockedException("File offline non disponibile per ${track.title}")
+            }
+            return@coroutineScope track.copy(videoStreamUrl = "")
+        }
         track.streamUrl.takeIf {
             reuseProvidedStream &&
             it.isNotBlank() &&
@@ -321,6 +382,11 @@ class PlaybackResolver private constructor(private val context: Context) {
         if (!preferMp4Audio) {
             val cacheLookupTrack = if (reuseProvidedStream) track else track.copy(streamUrl = "", videoStreamUrl = "")
             cached(cacheLookupTrack, isVideoMode, audioQuality)?.let { return@coroutineScope it }
+        }
+
+        if (!hasValidatedInternet()) {
+            clearTransientClientPenalties()
+            throw PlaybackBlockedException("Connessione Internet non disponibile")
         }
 
         val key = "${cacheKey(track, isVideoMode, audioQuality)}_$requestKind"
@@ -351,6 +417,8 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     suspend fun prefetch(track: Track, isVideoMode: Boolean = false): Track? {
+        if (isLocalPlaybackTrack(track)) return track.takeIf { isLocalPlaybackUri(it.streamUrl) }
+        if (!hasValidatedInternet()) return null
         if (track.streamUrl.isNotBlank()) {
             if (!isVideoMode && !isPlayableAudioUrl(track.streamUrl)) return null
             if (streamStillFresh(track.streamUrl)) {
@@ -978,6 +1046,10 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     private fun recordClientFailure(profile: ClientProfile, latencyMs: Long?, error: Throwable) {
+        if (!hasValidatedInternet()) {
+            clearTransientClientPenalties()
+            return
+        }
         clientHealth.compute(profile.clientName) { name, current ->
             val previous = current ?: ClientHealth()
             val failures = (previous.failures + 1).coerceAtMost(10_000)
@@ -1010,10 +1082,11 @@ class PlaybackResolver private constructor(private val context: Context) {
     private fun elapsedMs(startedAt: Long): Long = ((System.nanoTime() - startedAt) / 1_000_000L).coerceAtLeast(1L)
 
     private fun restoreClientHealth() {
+        val now = System.currentTimeMillis()
         clientHealthPrefs.all.forEach { (name, rawValue) ->
             val raw = rawValue as? String ?: return@forEach
             val json = runCatching { JSONObject(raw) }.getOrNull() ?: return@forEach
-            clientHealth[name] = ClientHealth(
+            val restored = ClientHealth(
                 successes = json.optInt("successes", 0),
                 failures = json.optInt("failures", 0),
                 consecutiveFailures = json.optInt("consecutiveFailures", 0),
@@ -1021,6 +1094,13 @@ class PlaybackResolver private constructor(private val context: Context) {
                 blockedUntilMs = json.optLong("blockedUntilMs", 0L),
                 updatedAtMs = json.optLong("updatedAtMs", 0L)
             )
+            val normalized = if (restored.blockedUntilMs in 1L..now) {
+                restored.copy(consecutiveFailures = 0, blockedUntilMs = 0L, updatedAtMs = now)
+            } else {
+                restored
+            }
+            clientHealth[name] = normalized
+            if (normalized != restored) persistClientHealth(name, normalized)
         }
     }
 
@@ -1240,8 +1320,13 @@ class PlaybackResolver private constructor(private val context: Context) {
             stream
         } catch (error: Throwable) {
             val latency = elapsedMs(startedAt)
-            recordClientFailure(profile, latency, error)
-            resilienceEngine.recordFailure(profile.label, mode, latency, error)
+            if (hasValidatedInternet()) {
+                recordClientFailure(profile, latency, error)
+                resilienceEngine.recordFailure(profile.label, mode, latency, error)
+            } else {
+                clearTransientClientPenalties()
+                Timber.d(error, "resolver skipped client penalty while offline")
+            }
             throw error
         }
     }

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
@@ -804,7 +804,7 @@ internal class YoutubePlayerConfigStore(
     companion object {
         private const val BUNDLED_CONFIG_ASSET = "player_configs.json"
         private const val REMOTE_CONFIG_URL = "https://raw.githubusercontent.com/ZemerTeam/zemer-cipher/master/library/src/main/assets/player_configs.json"
-        private const val USER_AGENT = "Levyra/2.3.13 Android local-decoder"
+        private const val USER_AGENT = "Levyra/2.3.15 Android local-decoder"
         private const val CONFIG_TTL_MS = 6L * 60L * 60L * 1000L
         private const val UNKNOWN_REFRESH_COOLDOWN_MS = 60_000L
         private const val REJECTION_REFRESH_COOLDOWN_MS = 5L * 60L * 1000L

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaItemFactory.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaItemFactory.kt
@@ -31,10 +31,13 @@ object LevyraMediaItemFactory {
             .build()
     }
 
-    internal fun mimeTypeFor(url: String, videoMode: Boolean): String {
+    internal fun mimeTypeFor(url: String, videoMode: Boolean): String? {
         val clean = url.substringBefore('#').lowercase()
         val path = clean.substringBefore('?')
+        val isContentUri = clean.startsWith("content://")
+        val isExtensionlessFileUri = clean.startsWith("file://") && !path.substringAfterLast('/').contains('.')
         return when {
+            isContentUri || isExtensionlessFileUri -> null
             path.endsWith(".m3u8") || path.contains("/hls_playlist") || path.contains("/manifest/hls") || clean.contains("mime=application%2fx-mpegurl") || clean.contains("mime=application/vnd.apple.mpegurl") || clean.contains("type=application%2fx-mpegurl") -> "application/x-mpegURL"
             path.endsWith(".mpd") || clean.contains("mime=application%2fdash+xml") || clean.contains("mime=application/dash+xml") -> "application/dash+xml"
             clean.contains("mime=video%2fwebm") || clean.contains("mime=video/webm") -> "video/webm"

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaItemFactory.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaItemFactory.kt
@@ -16,9 +16,8 @@ object LevyraMediaItemFactory {
 
     fun build(track: Track, videoMode: Boolean = false): MediaItem {
         val streamUrl = track.streamUrl
-        return MediaItem.Builder()
+        val builder = MediaItem.Builder()
             .setUri(streamUrl)
-            .setMimeType(mimeTypeFor(streamUrl, videoMode))
             .setCustomCacheKey(
                 if (videoMode && track.videoStreamUrl.isBlank()) {
                     LevyraPlaybackCacheKey.video(track)
@@ -28,7 +27,8 @@ object LevyraMediaItemFactory {
             )
             .setMediaId(mediaId(track))
             .setMediaMetadata(metadata(track, videoMode))
-            .build()
+        mimeTypeFor(streamUrl, videoMode)?.let { builder.setMimeType(it) }
+        return builder.build()
     }
 
     internal fun mimeTypeFor(url: String, videoMode: Boolean): String? {
@@ -68,7 +68,7 @@ object LevyraMediaItemFactory {
             if (videoMode && track.videoStreamUrl.isNotBlank()) {
                 putString(PlaybackService.EXTRA_VIDEO_URL, track.videoStreamUrl)
                 putString(PlaybackService.EXTRA_VIDEO_CACHE_KEY, LevyraPlaybackCacheKey.video(track))
-                putString(PlaybackService.EXTRA_VIDEO_MIME_TYPE, mimeTypeFor(track.videoStreamUrl, true))
+                mimeTypeFor(track.videoStreamUrl, true)?.let { putString(PlaybackService.EXTRA_VIDEO_MIME_TYPE, it) }
             }
         }
         return MediaMetadata.Builder()

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
@@ -82,6 +82,9 @@ class LevyraPlayer(context: Context) {
                         recoveryAttempts = 0
                         sponsorJob?.cancel()
                         sponsorJob = null
+                        clearLoadedState()
+                        connected.pause()
+                        onError?.invoke(message)
                         return
                     }
                     if (isRecoverable(error) && !recoveryInFlight && recoveryAttempts < 3 && onRecoverableStreamError != null) {

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
@@ -77,6 +77,13 @@ class LevyraPlayer(context: Context) {
                     if (ignoreEndedFromManualStop || connected.mediaItemCount == 0) return
                     val track = loadedTrack ?: return
                     val message = cleanError(error)
+                    if (isLocalPlayback(track)) {
+                        recoveryInFlight = false
+                        recoveryAttempts = 0
+                        sponsorJob?.cancel()
+                        sponsorJob = null
+                        return
+                    }
                     if (isRecoverable(error) && !recoveryInFlight && recoveryAttempts < 3 && onRecoverableStreamError != null) {
                         recoveryInFlight = true
                         recoveryAttempts++
@@ -298,6 +305,13 @@ class LevyraPlayer(context: Context) {
             append('|')
             append(videoMode)
         }
+    }
+
+    private fun isLocalPlayback(track: Track): Boolean {
+        val stream = track.streamUrl.trim()
+        return track.source.equals("Offline", ignoreCase = true) ||
+            stream.startsWith("content://", ignoreCase = true) ||
+            stream.startsWith("file://", ignoreCase = true)
     }
 
     private fun isRecoverable(error: PlaybackException): Boolean {

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -604,13 +604,13 @@ class PlaybackService : MediaLibraryService() {
             }
             return track.copy(videoStreamUrl = "")
         }
-        if (!hasInternetCapableNetwork()) throw IOException("Connessione Internet non disponibile")
         val hasYoutubeIdentity = track.videoUrl.contains("youtube.com", true) ||
             track.videoUrl.contains("youtu.be", true) ||
             Regex("^[A-Za-z0-9_-]{11}$").matches(track.id)
         val candidate = if (hasYoutubeIdentity) {
             track
         } else {
+            if (!hasInternetCapableNetwork()) throw IOException("Connessione Internet non disponibile")
             val query = listOf(track.title, track.artist).filter { it.isNotBlank() }.joinToString(" ")
             val match = musicRepository.searchOne(query, LevyraPreferences(this).languageCode())
             match?.copy(

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -490,7 +490,7 @@ class PlaybackService : MediaLibraryService() {
                 var selected = if (forward) queueEngine.next(respectRepeatOne) else queueEngine.previous()
                 if (selected == null && forward && queueEngine.state.value.radioEnabled) {
                     val seed = queueEngine.state.value.currentTrack
-                    if (seed != null && !isLocalPlaybackTrack(seed) && hasValidatedInternet()) {
+                    if (seed != null && !isLocalPlaybackTrack(seed) && hasInternetCapableNetwork()) {
                         val additions = runCatching {
                             musicRepository.radio(seed, LevyraPreferences(this@PlaybackService).languageCode(), 20)
                         }.onFailure { Timber.w(it, "Background radio expansion failed") }
@@ -531,7 +531,7 @@ class PlaybackService : MediaLibraryService() {
             val target = withContext(Dispatchers.IO) {
                 queueEngine.upcoming(1).firstOrNull()
             } ?: return@launch
-            if (isLocalPlaybackTrack(target) || !hasValidatedInternet()) return@launch
+            if (isLocalPlaybackTrack(target) || !hasInternetCapableNetwork()) return@launch
             val resolved = withContext(Dispatchers.IO) {
                 runCatching { resolveQueueTrack(target) }
                     .onFailure { Timber.d(it, "Service queue prefetch skipped") }
@@ -549,7 +549,7 @@ class PlaybackService : MediaLibraryService() {
             }
             return track.copy(videoStreamUrl = "")
         }
-        if (!hasValidatedInternet()) throw IOException("Connessione Internet non disponibile")
+        if (!hasInternetCapableNetwork()) throw IOException("Connessione Internet non disponibile")
         val hasYoutubeIdentity = track.videoUrl.contains("youtube.com", true) ||
             track.videoUrl.contains("youtu.be", true) ||
             Regex("^[A-Za-z0-9_-]{11}$").matches(track.id)
@@ -684,9 +684,17 @@ class PlaybackService : MediaLibraryService() {
 
     private suspend fun runServiceRecovery(error: PlaybackException, plan: ServiceRecoveryPlan) {
         if (awaitUiRecovery(plan.localPlayback)) return
+        var awaitedConnectivity = false
         while (isPlaybackRecoveryExpected()) {
             if (finishHealthyServiceRecovery()) return
-            if (awaitRecoveryConnectivity(plan.localPlayback)) continue
+            if (awaitRecoveryConnectivity(plan.localPlayback)) {
+                awaitedConnectivity = true
+                continue
+            }
+            if (awaitedConnectivity) {
+                awaitedConnectivity = false
+                serviceRecoveryAttempts = 0
+            }
             if (finishExhaustedServiceRecovery(error, plan.delaysMs)) return
             if (attemptServiceRecovery(error, plan)) return
         }
@@ -699,8 +707,14 @@ class PlaybackService : MediaLibraryService() {
     private suspend fun awaitUiRecovery(localPlayback: Boolean): Boolean {
         if (!uiRecoveryAvailable || localPlayback) return false
         releasePlaybackWakeLock()
-        delay(750L)
-        return finishHealthyServiceRecovery()
+        repeat(8) {
+            delay(750L)
+            if (finishHealthyServiceRecovery()) return true
+        }
+        val player = mediaSession?.player
+        return player != null &&
+            player.playWhenReady &&
+            player.playbackState == Player.STATE_BUFFERING
     }
 
     private fun finishHealthyServiceRecovery(): Boolean {
@@ -712,9 +726,9 @@ class PlaybackService : MediaLibraryService() {
     }
 
     private suspend fun awaitRecoveryConnectivity(localPlayback: Boolean): Boolean {
-        if (localPlayback || hasValidatedInternet()) return false
+        if (localPlayback || hasInternetCapableNetwork()) return false
         releasePlaybackWakeLock()
-        Timber.d("Background playback recovery waiting for validated network")
+        Timber.d("Background playback recovery waiting for network")
         delay(5_000L)
         return true
     }
@@ -741,7 +755,7 @@ class PlaybackService : MediaLibraryService() {
         delay(plan.delaysMs[attempt])
         val restored = restoreCurrentPlayback(
             positionMs = plan.positionMs,
-            preferFreshResolution = !plan.localPlayback && hasValidatedInternet()
+            preferFreshResolution = !plan.localPlayback && hasInternetCapableNetwork()
         )
         if (restored) {
             Timber.i(
@@ -821,12 +835,12 @@ class PlaybackService : MediaLibraryService() {
     ): Boolean {
         if (isLocalPlaybackTrack(track)) return true
         while (isPlaybackRecoveryExpected() && !isStickyRestoreExpired()) {
-            if (hasValidatedInternet()) {
+            if (hasInternetCapableNetwork()) {
                 acquirePlaybackWakeLock()
                 return true
             }
             releasePlaybackWakeLock()
-            Timber.d("Sticky playback restore waiting for validated network")
+            Timber.d("Sticky playback restore waiting for network")
             delay(5_000L)
         }
         return false
@@ -860,7 +874,7 @@ class PlaybackService : MediaLibraryService() {
                 }
             }
             isLocalMediaItem(currentItem) -> currentItem
-            preferFreshResolution && queueTrack != null && hasValidatedInternet() -> {
+            preferFreshResolution && queueTrack != null && hasInternetCapableNetwork() -> {
                 val resolved = withContext(Dispatchers.IO) {
                     runCatching { resolveQueueTrack(queueTrack) }
                         .onFailure { Timber.w(it, "Fresh background stream resolution failed") }
@@ -957,7 +971,7 @@ class PlaybackService : MediaLibraryService() {
         serviceRecoveryJob = serviceScope.launch {
             val restored = restoreCurrentPlayback(
                 positionMs,
-                preferFreshResolution = !isCurrentPlaybackLocal() && hasValidatedInternet()
+                preferFreshResolution = !isCurrentPlaybackLocal() && hasInternetCapableNetwork()
             )
             if (!restored) Timber.w("Playback watchdog recovery failed")
         }
@@ -993,12 +1007,11 @@ class PlaybackService : MediaLibraryService() {
         appliedPlayerWakeMode = wakeMode
     }
 
-    private fun hasValidatedInternet(): Boolean {
+    private fun hasInternetCapableNetwork(): Boolean {
         val connectivity = getSystemService(ConnectivityManager::class.java) ?: return false
         val network = connectivity.activeNetwork ?: return false
         val capabilities = connectivity.getNetworkCapabilities(network) ?: return false
-        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
-            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
     }
 
     private fun libraryItemFuture(

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -6,6 +6,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.media.AudioManager
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.os.Bundle
 import android.os.PowerManager
 import android.os.SystemClock
@@ -59,6 +61,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+import java.io.IOException
 
 @UnstableApi
 class PlaybackService : MediaLibraryService() {
@@ -84,6 +87,7 @@ class PlaybackService : MediaLibraryService() {
     private var watchdogAdvancedAtMs = 0L
     private var lastPlaybackExpected: Boolean? = null
     private var lastPlaybackHeartbeatAtMs = 0L
+    private var appliedPlayerWakeMode = C.WAKE_MODE_NETWORK
 
     companion object {
         private const val RUNNING_LOW_LEVEL = 10
@@ -100,10 +104,11 @@ class PlaybackService : MediaLibraryService() {
         private const val KEY_PLAYBACK_EXPECTED = "playbackExpected"
         private const val KEY_PLAYBACK_HEARTBEAT_AT = "playbackHeartbeatAt"
         private const val PLAYBACK_HEARTBEAT_INTERVAL_MS = 30_000L
-        private const val STICKY_RESTORE_MAX_AGE_MS = 30L * 60L * 1_000L
+        private const val STICKY_RESTORE_MAX_AGE_MS = 12L * 60L * 60L * 1_000L
         private const val WATCHDOG_INTERVAL_MS = 5_000L
         private const val WATCHDOG_STALL_TIMEOUT_MS = 15_000L
-        private val RECOVERY_DELAYS_MS = longArrayOf(500L, 2_000L, 5_000L, 10_000L)
+        private val ONLINE_RECOVERY_DELAYS_MS = longArrayOf(500L, 2_000L, 5_000L, 10_000L)
+        private val LOCAL_RECOVERY_DELAYS_MS = longArrayOf(250L, 750L, 1_500L, 3_000L, 5_000L, 10_000L)
 
         @Volatile
         var activePlayer: ExoPlayer? = null
@@ -253,6 +258,7 @@ class PlaybackService : MediaLibraryService() {
         activePlayer = player
         player.addListener(object : Player.Listener {
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+                updatePlayerWakeMode(player, mediaItem)
                 if (serviceRecoveryJob?.isActive != true && stickyRestoreJob?.isActive != true) {
                     serviceRecoveryExhausted = false
                     serviceRecoveryAttempts = 0
@@ -276,7 +282,7 @@ class PlaybackService : MediaLibraryService() {
 
             override fun onPlayerError(error: PlaybackException) {
                 updatePlaybackProtection(player)
-                if (!uiRecoveryAvailable) scheduleServiceRecovery(error)
+                scheduleServiceRecovery(error)
             }
 
             override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
@@ -342,13 +348,9 @@ class PlaybackService : MediaLibraryService() {
                         val snapshot = queueEngine.state.value
                         val track = snapshot.currentTrack ?: error("Nessun brano da ripristinare")
                         val item = if (isForPlayback) {
-                            val resolved = if (track.streamUrl.startsWith("content://") || track.streamUrl.startsWith("file://")) {
-                                track
-                            } else {
-                                resolveQueueTrack(track)
-                            }
+                            val resolved = resolveQueueTrack(track)
                             queueEngine.updateTrackAt(snapshot.currentIndex, resolved)
-                            prefetchServiceQueueNext()
+                            if (!isLocalPlaybackTrack(resolved)) prefetchServiceQueueNext()
                             LevyraMediaItemFactory.build(resolved)
                         } else {
                             LevyraMediaItemFactory.metadataOnly(track)
@@ -487,7 +489,7 @@ class PlaybackService : MediaLibraryService() {
                 var selected = if (forward) queueEngine.next(respectRepeatOne) else queueEngine.previous()
                 if (selected == null && forward && queueEngine.state.value.radioEnabled) {
                     val seed = queueEngine.state.value.currentTrack
-                    if (seed != null) {
+                    if (seed != null && !isLocalPlaybackTrack(seed) && hasValidatedInternet()) {
                         val additions = runCatching {
                             musicRepository.radio(seed, LevyraPreferences(this@PlaybackService).languageCode(), 20)
                         }.onFailure { Timber.w(it, "Background radio expansion failed") }
@@ -517,7 +519,7 @@ class PlaybackService : MediaLibraryService() {
                 resolved.largeThumbnailUrl.ifBlank { resolved.thumbnailUrl },
                 true
             )
-            prefetchServiceQueueNext()
+            if (!isLocalPlaybackTrack(resolved)) prefetchServiceQueueNext()
         }
     }
 
@@ -528,6 +530,7 @@ class PlaybackService : MediaLibraryService() {
             val target = withContext(Dispatchers.IO) {
                 queueEngine.upcoming(1).firstOrNull()
             } ?: return@launch
+            if (isLocalPlaybackTrack(target) || !hasValidatedInternet()) return@launch
             val resolved = withContext(Dispatchers.IO) {
                 runCatching { resolveQueueTrack(target) }
                     .onFailure { Timber.d(it, "Service queue prefetch skipped") }
@@ -539,7 +542,13 @@ class PlaybackService : MediaLibraryService() {
     }
 
     private suspend fun resolveQueueTrack(track: com.luc4n3x.levyra.domain.Track): com.luc4n3x.levyra.domain.Track {
-        if (track.streamUrl.startsWith("content://", true) || track.streamUrl.startsWith("file://", true)) return track
+        if (isLocalPlaybackTrack(track)) {
+            if (!isLocalPlaybackUri(track.streamUrl)) {
+                throw IOException("File offline non disponibile per ${track.title}")
+            }
+            return track.copy(videoStreamUrl = "")
+        }
+        if (!hasValidatedInternet()) throw IOException("Connessione Internet non disponibile")
         val hasYoutubeIdentity = track.videoUrl.contains("youtube.com", true) ||
             track.videoUrl.contains("youtu.be", true) ||
             Regex("^[A-Za-z0-9_-]{11}$").matches(track.id)
@@ -577,10 +586,11 @@ class PlaybackService : MediaLibraryService() {
 
     override fun onTaskRemoved(rootIntent: Intent?) {
         val player = mediaSession?.player
+        val playbackExpected = playbackStateStore.getBoolean(KEY_PLAYBACK_EXPECTED, false)
         val keepAlive = player != null &&
             player.mediaItemCount > 0 &&
-            player.playWhenReady &&
-            player.playbackState != Player.STATE_ENDED
+            player.playbackState != Player.STATE_ENDED &&
+            (player.playWhenReady || playbackExpected)
         if (!keepAlive) pauseAllPlayersAndStopSelf()
     }
 
@@ -606,6 +616,7 @@ class PlaybackService : MediaLibraryService() {
     }
 
     private fun updatePlaybackProtection(player: Player) {
+        (player as? ExoPlayer)?.let { updatePlayerWakeMode(it, it.currentMediaItem) }
         val playbackExpected = !serviceRecoveryExhausted &&
             player.mediaItemCount > 0 &&
             player.playWhenReady &&
@@ -649,31 +660,53 @@ class PlaybackService : MediaLibraryService() {
     private fun scheduleServiceRecovery(error: PlaybackException) {
         if (serviceRecoveryJob?.isActive == true) return
         if (!playbackStateStore.getBoolean(KEY_PLAYBACK_EXPECTED, false)) return
-        if (serviceRecoveryAttempts >= RECOVERY_DELAYS_MS.size) {
-            serviceRecoveryExhausted = true
-            mediaSession?.player?.pause()
-            markPlaybackExpected(false, force = true)
-            releasePlaybackWakeLock()
-            Timber.e(error, "Background playback recovery exhausted")
-            return
-        }
-        val attempt = serviceRecoveryAttempts++
+        val localPlayback = isCurrentPlaybackLocal()
+        val delays = if (localPlayback) LOCAL_RECOVERY_DELAYS_MS else ONLINE_RECOVERY_DELAYS_MS
         val positionMs = mediaSession?.player?.currentPosition?.coerceAtLeast(0L) ?: 0L
+        acquirePlaybackWakeLock()
         serviceRecoveryJob = serviceScope.launch {
-            delay(RECOVERY_DELAYS_MS[attempt])
-            val restored = restoreCurrentPlayback(positionMs, preferFreshResolution = true)
-            if (!restored) {
-                Timber.w(error, "Background playback recovery attempt %d failed", attempt + 1)
-                if (attempt == RECOVERY_DELAYS_MS.lastIndex) {
+            if (uiRecoveryAvailable && !localPlayback) {
+                delay(750L)
+                if (isPlaybackHealthy(mediaSession?.player)) return@launch
+            }
+            while (isActive && playbackStateStore.getBoolean(KEY_PLAYBACK_EXPECTED, false)) {
+                if (isPlaybackHealthy(mediaSession?.player)) {
+                    serviceRecoveryAttempts = 0
+                    serviceRecoveryExhausted = false
+                    return@launch
+                }
+                if (!localPlayback && !hasValidatedInternet()) {
+                    Timber.d("Background playback recovery waiting for validated network")
+                    delay(5_000L)
+                    continue
+                }
+                if (serviceRecoveryAttempts >= delays.size) {
                     serviceRecoveryExhausted = true
                     mediaSession?.player?.pause()
                     markPlaybackExpected(false, force = true)
                     releasePlaybackWakeLock()
                     Timber.e(error, "Background playback recovery exhausted")
+                    return@launch
                 }
+                val attempt = serviceRecoveryAttempts++
+                delay(delays[attempt])
+                val restored = restoreCurrentPlayback(
+                    positionMs = positionMs,
+                    preferFreshResolution = !localPlayback && hasValidatedInternet()
+                )
+                if (restored) {
+                    Timber.i("Background playback recovery restored attempt=%d local=%s", attempt + 1, localPlayback)
+                    return@launch
+                }
+                Timber.w(error, "Background playback recovery attempt %d failed", attempt + 1)
             }
         }
     }
+
+    private fun isPlaybackHealthy(player: Player?): Boolean = player != null &&
+        player.mediaItemCount > 0 &&
+        player.playWhenReady &&
+        player.playbackState == Player.STATE_READY
 
     private fun scheduleStickyPlaybackRestore(startId: Int): Boolean {
         if (!playbackStateStore.getBoolean(KEY_PLAYBACK_EXPECTED, false)) {
@@ -686,6 +719,7 @@ class PlaybackService : MediaLibraryService() {
             stopSelfResult(startId)
             return false
         }
+        acquirePlaybackWakeLock()
         stickyRestoreJob?.cancel()
         stickyRestoreJob = serviceScope.launch {
             delay(250L)
@@ -707,12 +741,16 @@ class PlaybackService : MediaLibraryService() {
                     queueEngine.state.value
                 }
             }
-            if (snapshot.currentTrack == null) {
+            val currentTrack = snapshot.currentTrack
+            if (currentTrack == null) {
                 markPlaybackExpected(false, force = true)
                 stopSelfResult(startId)
                 return@launch
             }
-            if (!restoreCurrentPlayback(snapshot.positionMs, preferFreshResolution = true)) {
+            if (!restoreCurrentPlayback(
+                    snapshot.positionMs,
+                    preferFreshResolution = !isLocalPlaybackTrack(currentTrack) && hasValidatedInternet()
+                )) {
                 Timber.w("Sticky background playback restore failed")
                 markPlaybackExpected(false, force = true)
                 stopSelfResult(startId)
@@ -728,21 +766,34 @@ class PlaybackService : MediaLibraryService() {
         val queueSnapshot = queueEngine.state.value
         val queueTrack = queueSnapshot.currentTrack
         val videoMode = currentItem?.mediaMetadata?.extras?.getBoolean(EXTRA_VIDEO_MODE, false) ?: false
-        val mediaItem = if (preferFreshResolution && queueTrack != null) {
-            val resolved = withContext(Dispatchers.IO) {
-                runCatching { resolveQueueTrack(queueTrack) }
-                    .onFailure { Timber.w(it, "Fresh background stream resolution failed") }
-                    .getOrNull()
+        val mediaItem = when {
+            queueTrack != null && isLocalPlaybackTrack(queueTrack) -> {
+                when {
+                    isLocalPlaybackUri(queueTrack.streamUrl) -> LevyraMediaItemFactory.build(queueTrack, false)
+                    isLocalMediaItem(currentItem) -> currentItem
+                    else -> null
+                }
             }
-            if (resolved != null) {
-                queueEngine.updateTrackAt(queueSnapshot.currentIndex, resolved)
-                LevyraMediaItemFactory.build(resolved, videoMode)
-            } else {
-                currentItem
+            isLocalMediaItem(currentItem) -> currentItem
+            preferFreshResolution && queueTrack != null && hasValidatedInternet() -> {
+                val resolved = withContext(Dispatchers.IO) {
+                    runCatching { resolveQueueTrack(queueTrack) }
+                        .onFailure { Timber.w(it, "Fresh background stream resolution failed") }
+                        .getOrNull()
+                }
+                if (resolved != null) {
+                    queueEngine.updateTrackAt(queueSnapshot.currentIndex, resolved)
+                    LevyraMediaItemFactory.build(resolved, videoMode)
+                } else {
+                    currentItem
+                }
             }
-        } else {
-            currentItem
+            else -> currentItem ?: queueTrack
+                ?.takeIf { it.streamUrl.isNotBlank() }
+                ?.let { LevyraMediaItemFactory.build(it, videoMode) }
         } ?: return false
+        updatePlayerWakeMode(player, mediaItem)
+        acquirePlaybackWakeLock()
         player.setMediaItem(mediaItem, positionMs.coerceAtLeast(0L))
         player.prepare()
         player.play()
@@ -793,7 +844,7 @@ class PlaybackService : MediaLibraryService() {
     private fun isPlayerActivelyPlaying(player: ExoPlayer): Boolean = player.mediaItemCount > 0 &&
         player.playWhenReady &&
         player.playbackSuppressionReason == Player.PLAYBACK_SUPPRESSION_REASON_NONE &&
-        player.playbackState == Player.STATE_READY
+        (player.playbackState == Player.STATE_BUFFERING || player.playbackState == Player.STATE_READY)
 
     private fun resetWatchdogProgress(now: Long) {
         watchdogPositionMs = C.TIME_UNSET
@@ -819,9 +870,50 @@ class PlaybackService : MediaLibraryService() {
         if (serviceRecoveryJob?.isActive == true) return
         Timber.w("Playback watchdog detected a stalled player at %d ms", positionMs)
         serviceRecoveryJob = serviceScope.launch {
-            val restored = restoreCurrentPlayback(positionMs, preferFreshResolution = true)
+            val restored = restoreCurrentPlayback(
+                positionMs,
+                preferFreshResolution = !isCurrentPlaybackLocal() && hasValidatedInternet()
+            )
             if (!restored) Timber.w("Playback watchdog recovery failed")
         }
+    }
+
+    private fun isCurrentPlaybackLocal(): Boolean {
+        val player = mediaSession?.player
+        return isLocalMediaItem(player?.currentMediaItem) ||
+            queueEngine.state.value.currentTrack?.let(::isLocalPlaybackTrack) == true
+    }
+
+    private fun isLocalPlaybackTrack(track: com.luc4n3x.levyra.domain.Track): Boolean =
+        track.source.equals("Offline", ignoreCase = true) || isLocalPlaybackUri(track.streamUrl)
+
+    private fun isLocalPlaybackUri(value: String): Boolean {
+        val clean = value.trim()
+        return clean.startsWith("content://", ignoreCase = true) ||
+            clean.startsWith("file://", ignoreCase = true)
+    }
+
+    private fun isLocalMediaItem(mediaItem: MediaItem?): Boolean {
+        val scheme = mediaItem?.localConfiguration?.uri?.scheme.orEmpty()
+        if (scheme.equals("content", ignoreCase = true) || scheme.equals("file", ignoreCase = true)) return true
+        return mediaItem?.mediaMetadata?.extras
+            ?.getString("levyra.source")
+            ?.equals("Offline", ignoreCase = true) == true
+    }
+
+    private fun updatePlayerWakeMode(player: ExoPlayer, mediaItem: MediaItem?) {
+        val wakeMode = if (isLocalMediaItem(mediaItem)) C.WAKE_MODE_LOCAL else C.WAKE_MODE_NETWORK
+        if (wakeMode == appliedPlayerWakeMode) return
+        player.setWakeMode(wakeMode)
+        appliedPlayerWakeMode = wakeMode
+    }
+
+    private fun hasValidatedInternet(): Boolean {
+        val connectivity = getSystemService(ConnectivityManager::class.java) ?: return false
+        val network = connectivity.activeNetwork ?: return false
+        val capabilities = connectivity.getNetworkCapabilities(network) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
     }
 
     private fun libraryItemFuture(

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -473,66 +473,86 @@ class PlaybackService : MediaLibraryService() {
         servicePrefetchJob?.cancel()
         queueSkipJob = serviceScope.launch {
             val player = activePlayer ?: return@launch
-            if (!forward && player.currentPosition > 5_000L) {
-                player.seekTo(0L)
-                queueEngine.updatePosition(0L)
-                return@launch
-            }
+            if (rewindInsteadOfSkip(player, forward)) return@launch
             val target = withContext(Dispatchers.IO) {
-                if (queueEngine.state.value.tracks.isEmpty()) {
-                    queueEngine.restore(
-                        fallbackTracks = emptyList(),
-                        fallbackIndex = -1,
-                        fallbackPositionMs = 0L,
-                        fallbackRadioEnabled = true
-                    )
-                }
-                var selected = if (forward) queueEngine.next(respectRepeatOne) else queueEngine.previous()
-                if (selected == null && forward && queueEngine.state.value.radioEnabled) {
-                    val seed = queueEngine.state.value.currentTrack
-                    if (seed != null && !isLocalPlaybackTrack(seed) && hasInternetCapableNetwork()) {
-                        val additions = runCatching {
-                            musicRepository.radio(seed, LevyraPreferences(this@PlaybackService).languageCode(), 20)
-                        }.onFailure { Timber.w(it, "Background radio expansion failed") }
-                            .getOrDefault(emptyList())
-                        if (additions.isNotEmpty()) {
-                            queueEngine.appendRadioTracks(additions)
-                            selected = queueEngine.next(respectRepeatOne = false)
-                        }
-                    }
-                }
-                selected
+                selectSkipTarget(forward, respectRepeatOne)
             } ?: return@launch
             val resolved = withContext(Dispatchers.IO) {
-                if (autoAdvance) {
-                    resolveQueueTrackPersistently(target)
-                } else {
-                    runCatching { resolveQueueTrack(target) }
-                        .onFailure { Timber.w(it, "Background queue resolution failed") }
-                        .getOrNull()
-                }
+                resolveSkipTarget(target, autoAdvance)
             } ?: run {
-                if (autoAdvance) {
-                    Timber.e("Background queue auto-advance gave up for %s", target.title)
-                    markPlaybackExpected(false, force = true)
-                    releasePlaybackWakeLock()
-                }
+                abandonAutoAdvance(target, autoAdvance)
                 return@launch
             }
-            queueEngine.updateTrackAt(queueEngine.state.value.currentIndex, resolved)
-            player.setMediaItem(LevyraMediaItemFactory.build(resolved))
-            player.prepare()
-            player.play()
-            queueEngine.updatePosition(0L)
-            LevyraWidgetCenter.update(
-                this@PlaybackService,
-                resolved.title,
-                resolved.artist,
-                resolved.largeThumbnailUrl.ifBlank { resolved.thumbnailUrl },
-                true
-            )
-            if (!isLocalPlaybackTrack(resolved)) prefetchServiceQueueNext()
+            playSkipTarget(player, resolved)
         }
+    }
+
+    private fun rewindInsteadOfSkip(player: ExoPlayer, forward: Boolean): Boolean {
+        if (forward || player.currentPosition <= 5_000L) return false
+        player.seekTo(0L)
+        queueEngine.updatePosition(0L)
+        return true
+    }
+
+    private suspend fun selectSkipTarget(forward: Boolean, respectRepeatOne: Boolean): com.luc4n3x.levyra.domain.Track? {
+        if (queueEngine.state.value.tracks.isEmpty()) {
+            queueEngine.restore(
+                fallbackTracks = emptyList(),
+                fallbackIndex = -1,
+                fallbackPositionMs = 0L,
+                fallbackRadioEnabled = true
+            )
+        }
+        val selected = if (forward) queueEngine.next(respectRepeatOne) else queueEngine.previous()
+        if (selected != null || !forward) return selected
+        return expandRadioForSkip()
+    }
+
+    private suspend fun expandRadioForSkip(): com.luc4n3x.levyra.domain.Track? {
+        if (!queueEngine.state.value.radioEnabled) return null
+        val seed = queueEngine.state.value.currentTrack ?: return null
+        if (isLocalPlaybackTrack(seed) || !hasInternetCapableNetwork()) return null
+        val additions = runCatching {
+            musicRepository.radio(seed, LevyraPreferences(this).languageCode(), 20)
+        }.onFailure { Timber.w(it, "Background radio expansion failed") }
+            .getOrDefault(emptyList())
+        if (additions.isEmpty()) return null
+        queueEngine.appendRadioTracks(additions)
+        return queueEngine.next(respectRepeatOne = false)
+    }
+
+    private suspend fun resolveSkipTarget(
+        target: com.luc4n3x.levyra.domain.Track,
+        autoAdvance: Boolean
+    ): com.luc4n3x.levyra.domain.Track? = if (autoAdvance) {
+        resolveQueueTrackPersistently(target)
+    } else {
+        runCatching { resolveQueueTrack(target) }
+            .onFailure { Timber.w(it, "Background queue resolution failed") }
+            .getOrNull()
+    }
+
+    private fun abandonAutoAdvance(target: com.luc4n3x.levyra.domain.Track, autoAdvance: Boolean) {
+        if (!autoAdvance) return
+        Timber.e("Background queue auto-advance gave up for %s", target.title)
+        markPlaybackExpected(false, force = true)
+        releasePlaybackWakeLock()
+    }
+
+    private fun playSkipTarget(player: ExoPlayer, resolved: com.luc4n3x.levyra.domain.Track) {
+        queueEngine.updateTrackAt(queueEngine.state.value.currentIndex, resolved)
+        player.setMediaItem(LevyraMediaItemFactory.build(resolved))
+        player.prepare()
+        player.play()
+        queueEngine.updatePosition(0L)
+        LevyraWidgetCenter.update(
+            this,
+            resolved.title,
+            resolved.artist,
+            resolved.largeThumbnailUrl.ifBlank { resolved.thumbnailUrl },
+            true
+        )
+        if (!isLocalPlaybackTrack(resolved)) prefetchServiceQueueNext()
     }
 
     private fun prefetchServiceQueueNext() {

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -277,7 +277,7 @@ class PlaybackService : MediaLibraryService() {
             override fun onPlaybackStateChanged(playbackState: Int) {
                 if (playbackState == Player.STATE_READY) scheduleRecoveryReset(player)
                 if (playbackState == Player.STATE_ENDED && LevyraWidgetBridge.onNext == null) {
-                    skipQueue(forward = true, respectRepeatOne = true)
+                    skipQueue(forward = true, respectRepeatOne = true, autoAdvance = true)
                 }
             }
 
@@ -468,7 +468,7 @@ class PlaybackService : MediaLibraryService() {
         return START_STICKY
     }
 
-    private fun skipQueue(forward: Boolean, respectRepeatOne: Boolean) {
+    private fun skipQueue(forward: Boolean, respectRepeatOne: Boolean, autoAdvance: Boolean = false) {
         queueSkipJob?.cancel()
         servicePrefetchJob?.cancel()
         queueSkipJob = serviceScope.launch {
@@ -504,10 +504,21 @@ class PlaybackService : MediaLibraryService() {
                 selected
             } ?: return@launch
             val resolved = withContext(Dispatchers.IO) {
-                runCatching { resolveQueueTrack(target) }
-                    .onFailure { Timber.w(it, "Background queue resolution failed") }
-                    .getOrNull()
-            } ?: return@launch
+                if (autoAdvance) {
+                    resolveQueueTrackPersistently(target)
+                } else {
+                    runCatching { resolveQueueTrack(target) }
+                        .onFailure { Timber.w(it, "Background queue resolution failed") }
+                        .getOrNull()
+                }
+            } ?: run {
+                if (autoAdvance) {
+                    Timber.e("Background queue auto-advance gave up for %s", target.title)
+                    markPlaybackExpected(false, force = true)
+                    releasePlaybackWakeLock()
+                }
+                return@launch
+            }
             queueEngine.updateTrackAt(queueEngine.state.value.currentIndex, resolved)
             player.setMediaItem(LevyraMediaItemFactory.build(resolved))
             player.prepare()
@@ -540,6 +551,30 @@ class PlaybackService : MediaLibraryService() {
             if (queueEngine.state.value.generation != generation) return@launch
             withContext(Dispatchers.IO) { runCatching { playbackWarmup.prime(resolved, 256L * 1024L) } }
         }
+    }
+
+    private suspend fun resolveQueueTrackPersistently(
+        track: com.luc4n3x.levyra.domain.Track
+    ): com.luc4n3x.levyra.domain.Track? {
+        var attempts = 0
+        while (isPlaybackRecoveryExpected() && !isStickyRestoreExpired()) {
+            if (!isLocalPlaybackTrack(track) && !hasInternetCapableNetwork()) {
+                releasePlaybackWakeLock()
+                Timber.d("Background queue auto-advance waiting for network")
+                delay(5_000L)
+                attempts = 0
+                continue
+            }
+            acquirePlaybackWakeLock()
+            val resolved = runCatching { resolveQueueTrack(track) }
+                .onFailure { Timber.w(it, "Background queue resolution failed") }
+                .getOrNull()
+            if (resolved != null) return resolved
+            if (attempts >= ONLINE_RECOVERY_DELAYS_MS.lastIndex) return null
+            delay(ONLINE_RECOVERY_DELAYS_MS[attempts])
+            attempts++
+        }
+        return null
     }
 
     private suspend fun resolveQueueTrack(track: com.luc4n3x.levyra.domain.Track): com.luc4n3x.levyra.domain.Track {
@@ -622,9 +657,25 @@ class PlaybackService : MediaLibraryService() {
             player.mediaItemCount > 0 &&
             player.playWhenReady &&
             player.playbackState != Player.STATE_ENDED
-        if (playbackExpected) acquirePlaybackWakeLock() else releasePlaybackWakeLock()
-        markPlaybackExpected(playbackExpected)
+        if (playbackExpected) {
+            acquirePlaybackWakeLock()
+            markPlaybackExpected(true)
+        } else if (!shouldPreservePlaybackExpectation(player)) {
+            releasePlaybackWakeLock()
+            markPlaybackExpected(false)
+        }
     }
+
+    private fun isPlaybackRecoveryInFlight(): Boolean =
+        serviceRecoveryJob?.isActive == true ||
+            stickyRestoreJob?.isActive == true ||
+            queueSkipJob?.isActive == true
+
+    private fun shouldPreservePlaybackExpectation(player: Player): Boolean =
+        isPlaybackRecoveryInFlight() &&
+            (player.mediaItemCount == 0 ||
+                player.playbackState == Player.STATE_ENDED ||
+                player.playbackState == Player.STATE_IDLE)
 
     @SuppressLint("WakelockTimeout")
     private fun acquirePlaybackWakeLock() {
@@ -891,7 +942,7 @@ class PlaybackService : MediaLibraryService() {
                 ?.takeIf { it.streamUrl.isNotBlank() }
                 ?.let { LevyraMediaItemFactory.build(it, videoMode) }
         } ?: return false
-        updatePlayerWakeMode(player, mediaItem)
+        (player as? ExoPlayer)?.let { updatePlayerWakeMode(it, mediaItem) }
         acquirePlaybackWakeLock()
         player.setMediaItem(mediaItem, positionMs.coerceAtLeast(0L))
         player.prepare()
@@ -913,7 +964,7 @@ class PlaybackService : MediaLibraryService() {
 
     private fun inspectPlaybackWatchdog(player: ExoPlayer) {
         val now = SystemClock.elapsedRealtime()
-        markPlaybackExpected(isPlaybackExpected(player))
+        if (!shouldPreservePlaybackExpectation(player)) markPlaybackExpected(isPlaybackExpected(player))
         if (resetWatchdogForExhaustedRecovery(now)) return
         if (resetWatchdogForInactivePlayer(player, now)) return
         val positionMs = player.currentPosition.coerceAtLeast(0L)

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -49,6 +49,7 @@ import com.luc4n3x.levyra.data.PlaybackResolver
 import com.luc4n3x.levyra.data.YoutubeMusicRepository
 import com.luc4n3x.levyra.domain.LevyraAudioSettings
 import com.luc4n3x.levyra.player.queue.PersistentQueueEngine
+import com.luc4n3x.levyra.player.queue.PlaybackQueueSnapshot
 import com.luc4n3x.levyra.widget.LevyraWidgetBridge
 import com.luc4n3x.levyra.widget.LevyraWidgetCenter
 import kotlinx.coroutines.CoroutineScope
@@ -657,50 +658,101 @@ class PlaybackService : MediaLibraryService() {
         }
     }
 
+    private data class ServiceRecoveryPlan(
+        val localPlayback: Boolean,
+        val delaysMs: LongArray,
+        val positionMs: Long
+    )
+
     private fun scheduleServiceRecovery(error: PlaybackException) {
-        if (serviceRecoveryJob?.isActive == true) return
-        if (!playbackStateStore.getBoolean(KEY_PLAYBACK_EXPECTED, false)) return
-        val localPlayback = isCurrentPlaybackLocal()
-        val delays = if (localPlayback) LOCAL_RECOVERY_DELAYS_MS else ONLINE_RECOVERY_DELAYS_MS
-        val positionMs = mediaSession?.player?.currentPosition?.coerceAtLeast(0L) ?: 0L
-        acquirePlaybackWakeLock()
+        val plan = serviceRecoveryPlan() ?: return
         serviceRecoveryJob = serviceScope.launch {
-            if (uiRecoveryAvailable && !localPlayback) {
-                delay(750L)
-                if (isPlaybackHealthy(mediaSession?.player)) return@launch
-            }
-            while (isActive && playbackStateStore.getBoolean(KEY_PLAYBACK_EXPECTED, false)) {
-                if (isPlaybackHealthy(mediaSession?.player)) {
-                    serviceRecoveryAttempts = 0
-                    serviceRecoveryExhausted = false
-                    return@launch
-                }
-                if (!localPlayback && !hasValidatedInternet()) {
-                    Timber.d("Background playback recovery waiting for validated network")
-                    delay(5_000L)
-                    continue
-                }
-                if (serviceRecoveryAttempts >= delays.size) {
-                    serviceRecoveryExhausted = true
-                    mediaSession?.player?.pause()
-                    markPlaybackExpected(false, force = true)
-                    releasePlaybackWakeLock()
-                    Timber.e(error, "Background playback recovery exhausted")
-                    return@launch
-                }
-                val attempt = serviceRecoveryAttempts++
-                delay(delays[attempt])
-                val restored = restoreCurrentPlayback(
-                    positionMs = positionMs,
-                    preferFreshResolution = !localPlayback && hasValidatedInternet()
-                )
-                if (restored) {
-                    Timber.i("Background playback recovery restored attempt=%d local=%s", attempt + 1, localPlayback)
-                    return@launch
-                }
-                Timber.w(error, "Background playback recovery attempt %d failed", attempt + 1)
-            }
+            runServiceRecovery(error, plan)
         }
+    }
+
+    private fun serviceRecoveryPlan(): ServiceRecoveryPlan? {
+        if (serviceRecoveryJob?.isActive == true) return null
+        if (!isPlaybackRecoveryExpected()) return null
+        val localPlayback = isCurrentPlaybackLocal()
+        return ServiceRecoveryPlan(
+            localPlayback = localPlayback,
+            delaysMs = if (localPlayback) LOCAL_RECOVERY_DELAYS_MS else ONLINE_RECOVERY_DELAYS_MS,
+            positionMs = mediaSession?.player?.currentPosition?.coerceAtLeast(0L) ?: 0L
+        )
+    }
+
+    private suspend fun runServiceRecovery(error: PlaybackException, plan: ServiceRecoveryPlan) {
+        if (awaitUiRecovery(plan.localPlayback)) return
+        while (isPlaybackRecoveryExpected()) {
+            if (finishHealthyServiceRecovery()) return
+            if (awaitRecoveryConnectivity(plan.localPlayback)) continue
+            if (finishExhaustedServiceRecovery(error, plan.delaysMs)) return
+            if (attemptServiceRecovery(error, plan)) return
+        }
+        releasePlaybackWakeLock()
+    }
+
+    private fun isPlaybackRecoveryExpected(): Boolean =
+        playbackStateStore.getBoolean(KEY_PLAYBACK_EXPECTED, false)
+
+    private suspend fun awaitUiRecovery(localPlayback: Boolean): Boolean {
+        if (!uiRecoveryAvailable || localPlayback) return false
+        releasePlaybackWakeLock()
+        delay(750L)
+        return finishHealthyServiceRecovery()
+    }
+
+    private fun finishHealthyServiceRecovery(): Boolean {
+        if (!isPlaybackHealthy(mediaSession?.player)) return false
+        serviceRecoveryAttempts = 0
+        serviceRecoveryExhausted = false
+        mediaSession?.player?.let(::updatePlaybackProtection)
+        return true
+    }
+
+    private suspend fun awaitRecoveryConnectivity(localPlayback: Boolean): Boolean {
+        if (localPlayback || hasValidatedInternet()) return false
+        releasePlaybackWakeLock()
+        Timber.d("Background playback recovery waiting for validated network")
+        delay(5_000L)
+        return true
+    }
+
+    private fun finishExhaustedServiceRecovery(
+        error: PlaybackException,
+        delaysMs: LongArray
+    ): Boolean {
+        if (serviceRecoveryAttempts < delaysMs.size) return false
+        serviceRecoveryExhausted = true
+        mediaSession?.player?.pause()
+        markPlaybackExpected(false, force = true)
+        releasePlaybackWakeLock()
+        Timber.e(error, "Background playback recovery exhausted")
+        return true
+    }
+
+    private suspend fun attemptServiceRecovery(
+        error: PlaybackException,
+        plan: ServiceRecoveryPlan
+    ): Boolean {
+        val attempt = serviceRecoveryAttempts++
+        acquirePlaybackWakeLock()
+        delay(plan.delaysMs[attempt])
+        val restored = restoreCurrentPlayback(
+            positionMs = plan.positionMs,
+            preferFreshResolution = !plan.localPlayback && hasValidatedInternet()
+        )
+        if (restored) {
+            Timber.i(
+                "Background playback recovery restored attempt=%d local=%s",
+                attempt + 1,
+                plan.localPlayback
+            )
+            return true
+        }
+        Timber.w(error, "Background playback recovery attempt %d failed", attempt + 1)
+        return false
     }
 
     private fun isPlaybackHealthy(player: Player?): Boolean = player != null &&
@@ -709,54 +761,87 @@ class PlaybackService : MediaLibraryService() {
         player.playbackState == Player.STATE_READY
 
     private fun scheduleStickyPlaybackRestore(startId: Int): Boolean {
-        if (!playbackStateStore.getBoolean(KEY_PLAYBACK_EXPECTED, false)) {
+        if (!isPlaybackRecoveryExpected()) {
             stopSelfResult(startId)
             return false
         }
-        val heartbeatAt = playbackStateStore.getLong(KEY_PLAYBACK_HEARTBEAT_AT, 0L)
-        if (heartbeatAt <= 0L || System.currentTimeMillis() - heartbeatAt > STICKY_RESTORE_MAX_AGE_MS) {
-            markPlaybackExpected(false, force = true)
-            stopSelfResult(startId)
+        if (isStickyRestoreExpired()) {
+            stopStickyRestore(startId)
             return false
         }
         acquirePlaybackWakeLock()
         stickyRestoreJob?.cancel()
         stickyRestoreJob = serviceScope.launch {
-            delay(250L)
-            val player = mediaSession?.player ?: run {
-                markPlaybackExpected(false, force = true)
-                stopSelfResult(startId)
-                return@launch
-            }
-            if (player.mediaItemCount > 0 || player.playWhenReady) return@launch
-            val snapshot = withContext(Dispatchers.IO) {
-                if (queueEngine.state.value.tracks.isEmpty()) {
-                    queueEngine.restore(
-                        fallbackTracks = emptyList(),
-                        fallbackIndex = -1,
-                        fallbackPositionMs = 0L,
-                        fallbackRadioEnabled = true
-                    )
-                } else {
-                    queueEngine.state.value
-                }
-            }
-            val currentTrack = snapshot.currentTrack
-            if (currentTrack == null) {
-                markPlaybackExpected(false, force = true)
-                stopSelfResult(startId)
-                return@launch
-            }
-            if (!restoreCurrentPlayback(
-                    snapshot.positionMs,
-                    preferFreshResolution = !isLocalPlaybackTrack(currentTrack) && hasValidatedInternet()
-                )) {
-                Timber.w("Sticky background playback restore failed")
-                markPlaybackExpected(false, force = true)
-                stopSelfResult(startId)
-            }
+            restoreStickyPlayback(startId)
         }
         return true
+    }
+
+    private suspend fun restoreStickyPlayback(startId: Int) {
+        delay(250L)
+        val player = mediaSession?.player ?: run {
+            stopStickyRestore(startId)
+            return
+        }
+        if (player.mediaItemCount > 0 || player.playWhenReady) return
+        val snapshot = restoreQueueSnapshot()
+        val currentTrack = snapshot.currentTrack ?: run {
+            stopStickyRestore(startId)
+            return
+        }
+        if (!awaitStickyRestoreConnectivity(currentTrack)) {
+            if (isStickyRestoreExpired()) stopStickyRestore(startId)
+            return
+        }
+        val restored = restoreCurrentPlayback(
+            snapshot.positionMs,
+            preferFreshResolution = !isLocalPlaybackTrack(currentTrack)
+        )
+        if (!restored) {
+            Timber.w("Sticky background playback restore failed")
+            stopStickyRestore(startId)
+        }
+    }
+
+    private suspend fun restoreQueueSnapshot(): PlaybackQueueSnapshot = withContext(Dispatchers.IO) {
+        if (queueEngine.state.value.tracks.isEmpty()) {
+            queueEngine.restore(
+                fallbackTracks = emptyList(),
+                fallbackIndex = -1,
+                fallbackPositionMs = 0L,
+                fallbackRadioEnabled = true
+            )
+        } else {
+            queueEngine.state.value
+        }
+    }
+
+    private suspend fun awaitStickyRestoreConnectivity(
+        track: com.luc4n3x.levyra.domain.Track
+    ): Boolean {
+        if (isLocalPlaybackTrack(track)) return true
+        while (isPlaybackRecoveryExpected() && !isStickyRestoreExpired()) {
+            if (hasValidatedInternet()) {
+                acquirePlaybackWakeLock()
+                return true
+            }
+            releasePlaybackWakeLock()
+            Timber.d("Sticky playback restore waiting for validated network")
+            delay(5_000L)
+        }
+        return false
+    }
+
+    private fun isStickyRestoreExpired(): Boolean {
+        val heartbeatAt = playbackStateStore.getLong(KEY_PLAYBACK_HEARTBEAT_AT, 0L)
+        return heartbeatAt <= 0L ||
+            System.currentTimeMillis() - heartbeatAt > STICKY_RESTORE_MAX_AGE_MS
+    }
+
+    private fun stopStickyRestore(startId: Int) {
+        markPlaybackExpected(false, force = true)
+        releasePlaybackWakeLock()
+        stopSelfResult(startId)
     }
 
     private suspend fun restoreCurrentPlayback(positionMs: Long, preferFreshResolution: Boolean): Boolean {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -15,6 +15,7 @@ import android.app.Activity
 import android.media.AudioManager
 import android.content.Intent
 import android.net.Uri
+import android.os.PowerManager
 import android.widget.Toast
 import android.speech.RecognizerIntent
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -195,6 +196,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel as composeViewModel
 import androidx.compose.runtime.setValue
@@ -11916,6 +11920,20 @@ private fun SettingsOverlay(
     val strings = LocalLevyraStrings.current
     var languageExpanded by remember { mutableStateOf(false) }
     val blocker = remember { MutableInteractionSource() }
+    val batteryContext = LocalContext.current
+    val batteryLifecycleOwner = LocalLifecycleOwner.current
+    var batteryCheckToken by remember { mutableStateOf(0) }
+    val batteryUnrestricted = remember(batteryCheckToken) {
+        batteryContext.getSystemService(PowerManager::class.java)
+            ?.isIgnoringBatteryOptimizations(batteryContext.packageName) == true
+    }
+    DisposableEffect(batteryLifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) batteryCheckToken++
+        }
+        batteryLifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { batteryLifecycleOwner.lifecycle.removeObserver(observer) }
+    }
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -12249,6 +12267,26 @@ private fun SettingsOverlay(
                 )
             }
             item { SettingsSectionLabel(strings.playbackResilienceSection) }
+            item {
+                SettingsButton(
+                    icon = Icons.Rounded.Bolt,
+                    title = strings.batteryUnrestricted,
+                    subtitle = if (batteryUnrestricted) strings.batteryUnrestrictedActive else strings.batteryUnrestrictedSubtitle,
+                    onClick = {
+                        if (!batteryUnrestricted) {
+                            val request = Intent(android.provider.Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+                                .setData(Uri.parse("package:${batteryContext.packageName}"))
+                            runCatching { batteryContext.startActivity(request) }.onFailure {
+                                runCatching {
+                                    batteryContext.startActivity(
+                                        Intent(android.provider.Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                )
+            }
             item {
                 SettingsButton(
                     icon = Icons.Rounded.Share,

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraAdditionalStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraAdditionalStrings.kt
@@ -348,7 +348,10 @@ internal fun jaLocalizationEntries(): Map<String, String> = mapOf(
     "normalizationShort" to "音量正規化",
     "coverAndTags" to "カバーとタグ",
     "madeWithBy" to "❤️を込めて制作：",
-    "activeIndicator" to "オン"
+    "activeIndicator" to "オン",
+    "batteryUnrestricted" to "バックグラウンド再生を制限しない",
+    "batteryUnrestrictedSubtitle" to "電池の最適化から Levyra を除外し、画面オフでも音楽を再生し続けます",
+    "batteryUnrestrictedActive" to "有効 — システムは再生を停止しません"
 )
 
 internal fun koLocalizationEntries(): Map<String, String> = mapOf(
@@ -699,7 +702,10 @@ internal fun koLocalizationEntries(): Map<String, String> = mapOf(
     "normalizationShort" to "음량 정규화",
     "coverAndTags" to "커버 및 태그",
     "madeWithBy" to "❤️를 담아 제작：",
-    "activeIndicator" to "켜짐"
+    "activeIndicator" to "켜짐",
+    "batteryUnrestricted" to "무제한 백그라운드 재생",
+    "batteryUnrestrictedSubtitle" to "배터리 최적화에서 Levyra를 제외하여 화면이 꺼져도 음악이 계속 재생됩니다",
+    "batteryUnrestrictedActive" to "활성 — 시스템이 재생을 중지하지 않습니다"
 )
 
 internal fun hiLocalizationEntries(): Map<String, String> = mapOf(
@@ -1050,7 +1056,10 @@ internal fun hiLocalizationEntries(): Map<String, String> = mapOf(
     "normalizationShort" to "वॉल्यूम सामान्यीकरण",
     "coverAndTags" to "कवर और टैग",
     "madeWithBy" to "❤️ से बनाया गया:",
-    "activeIndicator" to "चालू"
+    "activeIndicator" to "चालू",
+    "batteryUnrestricted" to "असीमित बैकग्राउंड प्लेबैक",
+    "batteryUnrestrictedSubtitle" to "बैटरी ऑप्टिमाइज़ेशन से Levyra को बाहर रखें ताकि स्क्रीन बंद होने पर भी संगीत चलता रहे",
+    "batteryUnrestrictedActive" to "सक्रिय — सिस्टम प्लेबैक नहीं रोकेगा"
 )
 
 internal fun idLocalizationEntries(): Map<String, String> = mapOf(
@@ -1401,7 +1410,10 @@ internal fun idLocalizationEntries(): Map<String, String> = mapOf(
     "normalizationShort" to "Normalisasi",
     "coverAndTags" to "Sampul dan tag",
     "madeWithBy" to "Dibuat dengan ❤️ oleh",
-    "activeIndicator" to "AKTIF"
+    "activeIndicator" to "AKTIF",
+    "batteryUnrestricted" to "Pemutaran latar belakang tanpa batas",
+    "batteryUnrestrictedSubtitle" to "Kecualikan Levyra dari optimasi baterai agar musik terus diputar saat layar mati",
+    "batteryUnrestrictedActive" to "Aktif — sistem tidak akan menghentikan pemutaran"
 )
 
 internal fun viLocalizationEntries(): Map<String, String> = mapOf(
@@ -1752,7 +1764,10 @@ internal fun viLocalizationEntries(): Map<String, String> = mapOf(
     "normalizationShort" to "Chuẩn hóa",
     "coverAndTags" to "Ảnh bìa và thẻ",
     "madeWithBy" to "Được tạo bằng ❤️ bởi",
-    "activeIndicator" to "BẬT"
+    "activeIndicator" to "BẬT",
+    "batteryUnrestricted" to "Phát trong nền không giới hạn",
+    "batteryUnrestrictedSubtitle" to "Loại Levyra khỏi tối ưu hóa pin để nhạc tiếp tục phát khi tắt màn hình",
+    "batteryUnrestrictedActive" to "Đang bật — hệ thống sẽ không dừng phát"
 )
 
 internal fun thLocalizationEntries(): Map<String, String> = mapOf(
@@ -2103,5 +2118,8 @@ internal fun thLocalizationEntries(): Map<String, String> = mapOf(
     "normalizationShort" to "ปรับระดับเสียง",
     "coverAndTags" to "ปกและแท็ก",
     "madeWithBy" to "สร้างด้วย ❤️ โดย",
-    "activeIndicator" to "เปิด"
+    "activeIndicator" to "เปิด",
+    "batteryUnrestricted" to "เล่นเบื้องหลังแบบไม่จำกัด",
+    "batteryUnrestrictedSubtitle" to "ยกเว้น Levyra จากการปรับแต่งแบตเตอรี่เพื่อให้เพลงเล่นต่อเมื่อปิดหน้าจอ",
+    "batteryUnrestrictedActive" to "เปิดใช้งาน — ระบบจะไม่หยุดการเล่น"
 )

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraFilipinoStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraFilipinoStrings.kt
@@ -348,5 +348,8 @@ internal fun filLocalizationEntries(): Map<String, String> = mapOf(
     "normalizationShort" to "Norm",
     "coverAndTags" to "cover at tags",
     "madeWithBy" to "Ginawa nang may ❤️ ni",
-    "activeIndicator" to "ON"
+    "activeIndicator" to "ON",
+    "batteryUnrestricted" to "Walang limitasyong pag-play sa background",
+    "batteryUnrestrictedSubtitle" to "Ibukod ang Levyra sa battery optimization para tuloy ang musika kahit nakapatay ang screen",
+    "batteryUnrestrictedActive" to "Aktibo — hindi ihihinto ng system ang pag-play"
 )

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraHebrewStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraHebrewStrings.kt
@@ -348,5 +348,8 @@ internal fun heLocalizationEntries(): Map<String, String> = mapOf(
     "normalizationShort" to "נרמול",
     "coverAndTags" to "עטיפה ותגיות",
     "madeWithBy" to "נוצר באהבה ❤️ על ידי",
-    "activeIndicator" to "פעיל"
+    "activeIndicator" to "פעיל",
+    "batteryUnrestricted" to "ניגון ברקע ללא הגבלה",
+    "batteryUnrestrictedSubtitle" to "החרג את Levyra מאופטימיזציית הסוללה כדי שהמוזיקה תמשיך גם כשהמסך כבוי",
+    "batteryUnrestrictedActive" to "פעיל — המערכת לא תעצור את הניגון"
 )

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
@@ -306,6 +306,9 @@ class LevyraStrings private constructor(
     val restoreBackupSubtitle: String get() = value("restoreBackupSubtitle")
     val playbackResilienceSection: String get() = value("playbackResilienceSection")
     val exportSafeDiagnostics: String get() = value("exportSafeDiagnostics")
+    val batteryUnrestricted: String get() = value("batteryUnrestricted")
+    val batteryUnrestrictedSubtitle: String get() = value("batteryUnrestrictedSubtitle")
+    val batteryUnrestrictedActive: String get() = value("batteryUnrestrictedActive")
     val generateResolverTrace: String get() = value("generateResolverTrace")
     val safeDiagnosticsSubtitle: String get() = value("safeDiagnosticsSubtitle")
     val check: String get() = value("check")
@@ -682,7 +685,7 @@ class LevyraStrings private constructor(
     fun formatPauseDownload(title: String): String = "$pauseDownload ${directionalValue(title)}"
 
     companion object {
-        private val requiredKeys = setOf("welcomeBadge", "welcomeTitle", "languageQuestion", "nameQuestion", "namePlaceholder", "tasteQuestion", "skipAndContinue", "startListening", "settings", "settingsSubtitle", "design", "playback", "preferences", "app", "animations", "animationsSubtitle", "dynamicColor", "dynamicColorSubtitle", "sponsorBlock", "sponsorBlockSubtitle", "skipSilence", "skipSilenceSubtitle", "redoQuestionnaire", "redoQuestionnaireSubtitle", "language", "languageSubtitle", "home", "search", "library", "player", "queue", "lyrics", "related", "song", "video", "nowPlaying", "emptyPlayer", "phoneSpeaker", "connected", "volume", "audioQuality", "done", "queueEmpty", "lyricsUnavailable", "synced", "libraryTitle", "librarySubtitle", "playlists", "newItem", "downloads", "favorites", "recent", "quickPicks", "play", "newReleases", "albumsForYou", "top50Unavailable", "artists", "albumsAndSingles", "songs", "searchPlaceholder", "back", "clear", "voice", "createPlaylistHint", "selectLanguagePrompt", "explore", "exploreTitle", "exploreSubtitle", "exploreZones", "exploreFresh", "exploreNewVideos", "exploreEmpty", "localWaveName", "localWaveEmoji", "localWaveQuery", "exploreNewReleases", "exploreRapDrill", "exploreElectronic", "explorePopGlobal", "exploreRnbSoul", "exploreRockAlt", "exploreLatino", "exploreLofiChill", "exploreJpopAnime", "followArtist", "followingArtist", "releaseRadar", "similarArtists", "similarToFollowed", "theme", "themeSubtitle", "personalOrbitTitle", "personalOrbitSubtitle", "voicesTitle", "voicesSubtitle", "totalComments", "engagement", "audioEngine", "audioEngineSubtitle", "equalizer", "equalizerSubtitle", "preset", "bassBoost", "virtualizer", "crossfade", "djSoft", "replayGain", "tempo", "pitch", "gapless", "restartRequiredTitle", "restartRequiredBody", "restartNow", "later", "audioQualityAuto", "audioQualityHigh", "audioQualityLow", "pulseSectionBand", "pulseTitle", "pulseSubtitle", "followedArtistsTitle", "followedArtistsSubtitle", "listeningHistoryEmptyTitle", "listeningHistoryEmptyDetail", "pulseMinutes", "pulseMinuteShort", "pulsePlays", "pulseStreak", "pulseCompletion", "pulseTopArtists", "pulseWeek", "pulsePeakHour", "pulseEmpty", "listeningHistory", "listeningHistorySubtitle", "listeningPrompt", "voiceSearchUnsupported", "musicFiltersComingSoon", "recentSearches", "actions", "removeFromFavorites", "addToFavorites", "playNext", "addToQueue", "addToPlaylist", "alreadyOffline", "download", "openArtist", "share", "shareSong", "removeFromRecentSearches", "songOptions", "goToPlayer", "saveOffline", "favorite", "downloaded", "remove", "youMightAlsoLike", "topResult", "currentlyPlaying", "artistLabel", "playNow", "biography", "newUpdate", "updateDescription", "whatsNew", "update", "updateLinkUnavailable", "cannotOpenDownload", "externalLinkUnavailable", "cannotOpenExternalLink", "continuousRadio", "continuousRadioSubtitle", "artistsLabelPlural", "albumMood", "openLyricsAnalysis", "closeLyrics", "lyricsDuet", "lyricsCinema", "lyricsPage", "lyricsRomanization", "lyricsCompact", "lyricsSections", "lyricsSectionIntro", "lyricsSectionVerse", "lyricsSectionPreChorus", "lyricsSectionChorus", "lyricsSectionBridge", "lyricsSectionInstrumental", "lyricsSectionOutro", "automaticTranslation", "automaticTranslationSubtitle", "atmosphere", "themes", "chorusDetected", "goToChorus", "close", "complete", "delete", "newPlaylist", "playlistName", "create", "cancel", "newPlaylistName", "createNewPlaylist", "createAndAdd", "downloadPlaylist", "playAll", "playingFrom", "closePlayer", "options", "showLyrics", "shuffle", "previous", "next", "repeat", "persistentQueue", "continueListening", "favoritesPlain", "offline", "more", "mixForYou", "genres", "smartMusicProfile", "flow", "pictureInPicture", "discoveryFlow", "shareDiagnostics", "albumUnavailable", "albumTracksUnavailable", "showLess", "playing", "artistProfileUnavailable", "popularTracks", "showAll", "versionLabel", "generalImprovements", "historyLabel", "undoRemoval", "lyricsAnalysis", "linesLabel", "wordsLabel", "localAnalysis", "open", "newRelease", "newReleaseSubtitle", "saved", "save", "noOfflineDownloads", "createFirstPlaylist", "createFirstPlaylistSubtitle", "downloadTrackHint", "savedTracks", "favoritesEmpty", "playlistEmpty", "showPersonalListening", "showRecentReleases", "showRecommendedAlbums", "showDiscoveredArtists", "showChartsCountry", "partialDownloadResume", "lyricsAnalysisSection", "lyricsAnalysisCompact", "lyricsAnalysisCompactSubtitle", "createDataBackup", "createDataBackupSubtitle", "updateAvailable", "updates", "checkingLatestVersion", "latestVersionReady", "latestInstalled", "checkNewVersions", "releasePageReady", "installedVersion", "openPlayer", "searchSongsArtists", "songsPlain", "shareVia", "emptySearchPrompt", "cancelDownload", "readAll", "singlesAndEps", "tapHeartToAdd", "all", "automaticResume", "simultaneousDownloads", "simultaneousDownloadsSubtitle", "backupRestoreSection", "restoreBackup", "restoreBackupSubtitle", "playbackResilienceSection", "exportSafeDiagnostics", "generateResolverTrace", "safeDiagnosticsSubtitle", "check", "checking", "dragToReorder", "homeInterfaceSection", "compactHome", "compactHomeSubtitle", "yourOrbitSetting", "voicesSetting", "voicesSettingSubtitle", "newReleasesSetting", "albumsForYouSetting", "trendingArtists", "top50Charts", "mobilePlayerSection", "advancedGestures", "advancedGesturesSubtitle", "doubleTapSeek", "doubleTapSeekSubtitle", "longPress", "longPressSubtitle", "downloadEngineSection", "wifiOnly", "wifiOnlySubtitle", "chargingOnly", "chargingOnlySubtitle", "resumeDownload", "pauseDownload", "signedApkReady", "downloadsInProgress", "downloadInProgress", "newAlbums", "newSingles", "newAlbum", "downloadsFolder", "offlineDownloadsPlain", "personalPlaylists", "searchingYouTubeMusic", "searchingLyrics", "pause", "newSingle", "albumsPlain", "albumPlain", "singlePlain", "playlistsPlain", "profileActive", "profileLearning", "newBadge", "brightness", "timer", "normalizationShort", "coverAndTags", "madeWithBy", "activeIndicator")
+        private val requiredKeys = setOf("welcomeBadge", "welcomeTitle", "languageQuestion", "nameQuestion", "namePlaceholder", "tasteQuestion", "skipAndContinue", "startListening", "settings", "settingsSubtitle", "design", "playback", "preferences", "app", "animations", "animationsSubtitle", "dynamicColor", "dynamicColorSubtitle", "sponsorBlock", "sponsorBlockSubtitle", "skipSilence", "skipSilenceSubtitle", "redoQuestionnaire", "redoQuestionnaireSubtitle", "language", "languageSubtitle", "home", "search", "library", "player", "queue", "lyrics", "related", "song", "video", "nowPlaying", "emptyPlayer", "phoneSpeaker", "connected", "volume", "audioQuality", "done", "queueEmpty", "lyricsUnavailable", "synced", "libraryTitle", "librarySubtitle", "playlists", "newItem", "downloads", "favorites", "recent", "quickPicks", "play", "newReleases", "albumsForYou", "top50Unavailable", "artists", "albumsAndSingles", "songs", "searchPlaceholder", "back", "clear", "voice", "createPlaylistHint", "selectLanguagePrompt", "explore", "exploreTitle", "exploreSubtitle", "exploreZones", "exploreFresh", "exploreNewVideos", "exploreEmpty", "localWaveName", "localWaveEmoji", "localWaveQuery", "exploreNewReleases", "exploreRapDrill", "exploreElectronic", "explorePopGlobal", "exploreRnbSoul", "exploreRockAlt", "exploreLatino", "exploreLofiChill", "exploreJpopAnime", "followArtist", "followingArtist", "releaseRadar", "similarArtists", "similarToFollowed", "theme", "themeSubtitle", "personalOrbitTitle", "personalOrbitSubtitle", "voicesTitle", "voicesSubtitle", "totalComments", "engagement", "audioEngine", "audioEngineSubtitle", "equalizer", "equalizerSubtitle", "preset", "bassBoost", "virtualizer", "crossfade", "djSoft", "replayGain", "tempo", "pitch", "gapless", "restartRequiredTitle", "restartRequiredBody", "restartNow", "later", "audioQualityAuto", "audioQualityHigh", "audioQualityLow", "pulseSectionBand", "pulseTitle", "pulseSubtitle", "followedArtistsTitle", "followedArtistsSubtitle", "listeningHistoryEmptyTitle", "listeningHistoryEmptyDetail", "pulseMinutes", "pulseMinuteShort", "pulsePlays", "pulseStreak", "pulseCompletion", "pulseTopArtists", "pulseWeek", "pulsePeakHour", "pulseEmpty", "listeningHistory", "listeningHistorySubtitle", "listeningPrompt", "voiceSearchUnsupported", "musicFiltersComingSoon", "recentSearches", "actions", "removeFromFavorites", "addToFavorites", "playNext", "addToQueue", "addToPlaylist", "alreadyOffline", "download", "openArtist", "share", "shareSong", "removeFromRecentSearches", "songOptions", "goToPlayer", "saveOffline", "favorite", "downloaded", "remove", "youMightAlsoLike", "topResult", "currentlyPlaying", "artistLabel", "playNow", "biography", "newUpdate", "updateDescription", "whatsNew", "update", "updateLinkUnavailable", "cannotOpenDownload", "externalLinkUnavailable", "cannotOpenExternalLink", "continuousRadio", "continuousRadioSubtitle", "artistsLabelPlural", "albumMood", "openLyricsAnalysis", "closeLyrics", "lyricsDuet", "lyricsCinema", "lyricsPage", "lyricsRomanization", "lyricsCompact", "lyricsSections", "lyricsSectionIntro", "lyricsSectionVerse", "lyricsSectionPreChorus", "lyricsSectionChorus", "lyricsSectionBridge", "lyricsSectionInstrumental", "lyricsSectionOutro", "automaticTranslation", "automaticTranslationSubtitle", "atmosphere", "themes", "chorusDetected", "goToChorus", "close", "complete", "delete", "newPlaylist", "playlistName", "create", "cancel", "newPlaylistName", "createNewPlaylist", "createAndAdd", "downloadPlaylist", "playAll", "playingFrom", "closePlayer", "options", "showLyrics", "shuffle", "previous", "next", "repeat", "persistentQueue", "continueListening", "favoritesPlain", "offline", "more", "mixForYou", "genres", "smartMusicProfile", "flow", "pictureInPicture", "discoveryFlow", "shareDiagnostics", "albumUnavailable", "albumTracksUnavailable", "showLess", "playing", "artistProfileUnavailable", "popularTracks", "showAll", "versionLabel", "generalImprovements", "historyLabel", "undoRemoval", "lyricsAnalysis", "linesLabel", "wordsLabel", "localAnalysis", "open", "newRelease", "newReleaseSubtitle", "saved", "save", "noOfflineDownloads", "createFirstPlaylist", "createFirstPlaylistSubtitle", "downloadTrackHint", "savedTracks", "favoritesEmpty", "playlistEmpty", "showPersonalListening", "showRecentReleases", "showRecommendedAlbums", "showDiscoveredArtists", "showChartsCountry", "partialDownloadResume", "lyricsAnalysisSection", "lyricsAnalysisCompact", "lyricsAnalysisCompactSubtitle", "createDataBackup", "createDataBackupSubtitle", "updateAvailable", "updates", "checkingLatestVersion", "latestVersionReady", "latestInstalled", "checkNewVersions", "releasePageReady", "installedVersion", "openPlayer", "searchSongsArtists", "songsPlain", "shareVia", "emptySearchPrompt", "cancelDownload", "readAll", "singlesAndEps", "tapHeartToAdd", "all", "automaticResume", "simultaneousDownloads", "simultaneousDownloadsSubtitle", "backupRestoreSection", "restoreBackup", "restoreBackupSubtitle", "playbackResilienceSection", "exportSafeDiagnostics", "generateResolverTrace", "safeDiagnosticsSubtitle", "check", "checking", "dragToReorder", "homeInterfaceSection", "compactHome", "compactHomeSubtitle", "yourOrbitSetting", "voicesSetting", "voicesSettingSubtitle", "newReleasesSetting", "albumsForYouSetting", "trendingArtists", "top50Charts", "mobilePlayerSection", "advancedGestures", "advancedGesturesSubtitle", "doubleTapSeek", "doubleTapSeekSubtitle", "longPress", "longPressSubtitle", "downloadEngineSection", "wifiOnly", "wifiOnlySubtitle", "chargingOnly", "chargingOnlySubtitle", "resumeDownload", "pauseDownload", "signedApkReady", "downloadsInProgress", "downloadInProgress", "newAlbums", "newSingles", "newAlbum", "downloadsFolder", "offlineDownloadsPlain", "personalPlaylists", "searchingYouTubeMusic", "searchingLyrics", "pause", "newSingle", "albumsPlain", "albumPlain", "singlePlain", "playlistsPlain", "profileActive", "profileLearning", "newBadge", "brightness", "timer", "normalizationShort", "coverAndTags", "madeWithBy", "activeIndicator", "batteryUnrestricted", "batteryUnrestrictedSubtitle", "batteryUnrestrictedActive")
 
         private val values: Map<String, LevyraStrings> by lazy(LazyThreadSafetyMode.PUBLICATION) {
             mapOf(
@@ -1076,7 +1079,10 @@ class LevyraStrings private constructor(
             "normalizationShort" to "Norm",
             "coverAndTags" to "cover and tags",
             "madeWithBy" to "Made with ❤️ by",
-            "activeIndicator" to "ON"
+            "activeIndicator" to "ON",
+            "batteryUnrestricted" to "Unrestricted background playback",
+            "batteryUnrestrictedSubtitle" to "Exclude Levyra from battery optimization so music keeps playing with the screen off",
+            "batteryUnrestrictedActive" to "Active — the system will not stop playback"
         )
 
         private fun itEntries(): Map<String, String> = mapOf(
@@ -1427,7 +1433,10 @@ class LevyraStrings private constructor(
             "normalizationShort" to "Norm.",
             "coverAndTags" to "cover e tag",
             "madeWithBy" to "Creato con ❤️ da",
-            "activeIndicator" to "ATTIVO"
+            "activeIndicator" to "ATTIVO",
+            "batteryUnrestricted" to "Riproduzione in background senza limiti",
+            "batteryUnrestrictedSubtitle" to "Escludi Levyra dall'ottimizzazione batteria così la musica continua a schermo spento",
+            "batteryUnrestrictedActive" to "Attivo — il sistema non fermerà la riproduzione"
         )
 
         private fun esEntries(): Map<String, String> = mapOf(
@@ -1778,7 +1787,10 @@ class LevyraStrings private constructor(
             "normalizationShort" to "Norm.",
             "coverAndTags" to "carátula y etiquetas",
             "madeWithBy" to "Creado con ❤️ por",
-            "activeIndicator" to "ACTIVO"
+            "activeIndicator" to "ACTIVO",
+            "batteryUnrestricted" to "Reproducción en segundo plano sin límites",
+            "batteryUnrestrictedSubtitle" to "Excluye Levyra de la optimización de batería para que la música siga sonando con la pantalla apagada",
+            "batteryUnrestrictedActive" to "Activo — el sistema no detendrá la reproducción"
         )
 
         private fun frEntries(): Map<String, String> = mapOf(
@@ -2129,7 +2141,10 @@ class LevyraStrings private constructor(
             "normalizationShort" to "Norm.",
             "coverAndTags" to "pochette et tags",
             "madeWithBy" to "Créé avec ❤️ par",
-            "activeIndicator" to "ACTIF"
+            "activeIndicator" to "ACTIF",
+            "batteryUnrestricted" to "Lecture en arrière-plan sans limites",
+            "batteryUnrestrictedSubtitle" to "Exclure Levyra de l'optimisation de la batterie pour que la musique continue écran éteint",
+            "batteryUnrestrictedActive" to "Actif — le système n'arrêtera pas la lecture"
         )
 
         private fun deEntries(): Map<String, String> = mapOf(
@@ -2480,7 +2495,10 @@ class LevyraStrings private constructor(
             "normalizationShort" to "Norm.",
             "coverAndTags" to "Cover und Tags",
             "madeWithBy" to "Mit ❤️ erstellt von",
-            "activeIndicator" to "AKTIV"
+            "activeIndicator" to "AKTIV",
+            "batteryUnrestricted" to "Uneingeschränkte Hintergrundwiedergabe",
+            "batteryUnrestrictedSubtitle" to "Levyra von der Akku-Optimierung ausschließen, damit die Musik bei ausgeschaltetem Bildschirm weiterläuft",
+            "batteryUnrestrictedActive" to "Aktiv — das System stoppt die Wiedergabe nicht"
         )
 
         private fun ptEntries(): Map<String, String> = mapOf(
@@ -2831,7 +2849,10 @@ class LevyraStrings private constructor(
             "normalizationShort" to "Norm.",
             "coverAndTags" to "capa e etiquetas",
             "madeWithBy" to "Criado com ❤️ por",
-            "activeIndicator" to "ATIVO"
+            "activeIndicator" to "ATIVO",
+            "batteryUnrestricted" to "Reprodução em segundo plano sem limites",
+            "batteryUnrestrictedSubtitle" to "Exclua o Levyra da otimização de bateria para a música continuar com a tela desligada",
+            "batteryUnrestrictedActive" to "Ativo — o sistema não interromperá a reprodução"
         )
 
         private fun nlEntries(): Map<String, String> = mapOf(
@@ -3182,7 +3203,10 @@ class LevyraStrings private constructor(
             "normalizationShort" to "Norm.",
             "coverAndTags" to "hoes en tags",
             "madeWithBy" to "Gemaakt met ❤️ door",
-            "activeIndicator" to "ACTIEF"
+            "activeIndicator" to "ACTIEF",
+            "batteryUnrestricted" to "Onbeperkt afspelen op de achtergrond",
+            "batteryUnrestrictedSubtitle" to "Sluit Levyra uit van batterijoptimalisatie zodat muziek blijft spelen met het scherm uit",
+            "batteryUnrestrictedActive" to "Actief — het systeem stopt het afspelen niet"
         )
 
         private fun plEntries(): Map<String, String> = mapOf(
@@ -3533,7 +3557,10 @@ class LevyraStrings private constructor(
             "normalizationShort" to "Norm.",
             "coverAndTags" to "okładka i tagi",
             "madeWithBy" to "Stworzone z ❤️ przez",
-            "activeIndicator" to "AKTYWNE"
+            "activeIndicator" to "AKTYWNE",
+            "batteryUnrestricted" to "Nieograniczone odtwarzanie w tle",
+            "batteryUnrestrictedSubtitle" to "Wyklucz Levyra z optymalizacji baterii, aby muzyka grała przy wyłączonym ekranie",
+            "batteryUnrestrictedActive" to "Aktywne — system nie zatrzyma odtwarzania"
         )
 
         private fun roEntries(): Map<String, String> = mapOf(
@@ -3884,7 +3911,10 @@ class LevyraStrings private constructor(
             "normalizationShort" to "Norm.",
             "coverAndTags" to "copertă și etichete",
             "madeWithBy" to "Creat cu ❤️ de",
-            "activeIndicator" to "ACTIV"
+            "activeIndicator" to "ACTIV",
+            "batteryUnrestricted" to "Redare în fundal fără limite",
+            "batteryUnrestrictedSubtitle" to "Exclude Levyra din optimizarea bateriei pentru ca muzica să continue cu ecranul stins",
+            "batteryUnrestrictedActive" to "Activ — sistemul nu va opri redarea"
         )
 
         private fun elEntries(): Map<String, String> = mapOf(
@@ -4235,7 +4265,10 @@ class LevyraStrings private constructor(
             "normalizationShort" to "Κανον.",
             "coverAndTags" to "εξώφυλλο και ετικέτες",
             "madeWithBy" to "Δημιουργήθηκε με ❤️ από",
-            "activeIndicator" to "ΕΝΕΡΓΟ"
+            "activeIndicator" to "ΕΝΕΡΓΟ",
+            "batteryUnrestricted" to "Απεριόριστη αναπαραγωγή στο παρασκήνιο",
+            "batteryUnrestrictedSubtitle" to "Εξαιρέστε το Levyra από τη βελτιστοποίηση μπαταρίας ώστε η μουσική να συνεχίζει με σβηστή οθόνη",
+            "batteryUnrestrictedActive" to "Ενεργό — το σύστημα δεν θα σταματήσει την αναπαραγωγή"
         )
 
         private fun svEntries(): Map<String, String> = mapOf(
@@ -4586,7 +4619,10 @@ class LevyraStrings private constructor(
             "normalizationShort" to "Norm.",
             "coverAndTags" to "omslag och taggar",
             "madeWithBy" to "Skapad med ❤️ av",
-            "activeIndicator" to "AKTIV"
+            "activeIndicator" to "AKTIV",
+            "batteryUnrestricted" to "Obegränsad bakgrundsuppspelning",
+            "batteryUnrestrictedSubtitle" to "Undanta Levyra från batterioptimering så att musiken fortsätter med släckt skärm",
+            "batteryUnrestrictedActive" to "Aktiv — systemet stoppar inte uppspelningen"
         )
 
         private fun daEntries(): Map<String, String> = mapOf(
@@ -4937,7 +4973,10 @@ class LevyraStrings private constructor(
             "normalizationShort" to "Norm.",
             "coverAndTags" to "cover og tags",
             "madeWithBy" to "Skabt med ❤️ af",
-            "activeIndicator" to "AKTIV"
+            "activeIndicator" to "AKTIV",
+            "batteryUnrestricted" to "Ubegrænset baggrundsafspilning",
+            "batteryUnrestrictedSubtitle" to "Undtag Levyra fra batterioptimering, så musikken fortsætter med slukket skærm",
+            "batteryUnrestrictedActive" to "Aktiv — systemet stopper ikke afspilningen"
         )
 
         private fun csEntries(): Map<String, String> = mapOf(
@@ -5288,7 +5327,10 @@ class LevyraStrings private constructor(
             "normalizationShort" to "Norm.",
             "coverAndTags" to "obal a tagy",
             "madeWithBy" to "Vytvořeno s ❤️ od",
-            "activeIndicator" to "AKTIVNÍ"
+            "activeIndicator" to "AKTIVNÍ",
+            "batteryUnrestricted" to "Neomezené přehrávání na pozadí",
+            "batteryUnrestrictedSubtitle" to "Vyjměte Levyra z optimalizace baterie, aby hudba hrála i s vypnutou obrazovkou",
+            "batteryUnrestrictedActive" to "Aktivní — systém přehrávání nezastaví"
         )
 
         private fun ukEntries(): Map<String, String> = mapOf(
@@ -5639,7 +5681,10 @@ class LevyraStrings private constructor(
             "normalizationShort" to "Норм.",
             "coverAndTags" to "обкладинка й теги",
             "madeWithBy" to "Створено з ❤️ автором",
-            "activeIndicator" to "АКТИВНО"
+            "activeIndicator" to "АКТИВНО",
+            "batteryUnrestricted" to "Необмежене відтворення у фоні",
+            "batteryUnrestrictedSubtitle" to "Виключіть Levyra з оптимізації батареї, щоб музика грала з вимкненим екраном",
+            "batteryUnrestrictedActive" to "Активно — система не зупинить відтворення"
         )
 
         private fun ruEntries(): Map<String, String> = mapOf(
@@ -5990,7 +6035,10 @@ class LevyraStrings private constructor(
             "normalizationShort" to "Норм.",
             "coverAndTags" to "обложка и теги",
             "madeWithBy" to "Создано с ❤️ автором",
-            "activeIndicator" to "АКТИВНО"
+            "activeIndicator" to "АКТИВНО",
+            "batteryUnrestricted" to "Фоновое воспроизведение без ограничений",
+            "batteryUnrestrictedSubtitle" to "Исключите Levyra из оптимизации батареи, чтобы музыка играла при выключенном экране",
+            "batteryUnrestrictedActive" to "Активно — система не остановит воспроизведение"
         )
 
         private fun trEntries(): Map<String, String> = mapOf(
@@ -6341,7 +6389,10 @@ class LevyraStrings private constructor(
             "normalizationShort" to "Norm.",
             "coverAndTags" to "kapak ve etiketler",
             "madeWithBy" to "❤️ ile hazırlayan",
-            "activeIndicator" to "ETKİN"
+            "activeIndicator" to "ETKİN",
+            "batteryUnrestricted" to "Sınırsız arka plan oynatma",
+            "batteryUnrestrictedSubtitle" to "Ekran kapalıyken müziğin devam etmesi için Levyra'yı pil optimizasyonundan hariç tutun",
+            "batteryUnrestrictedActive" to "Etkin — sistem oynatmayı durdurmayacak"
         )
 
         private fun arEntries(): Map<String, String> = mapOf(
@@ -6692,7 +6743,10 @@ class LevyraStrings private constructor(
             "normalizationShort" to "تسوية",
             "coverAndTags" to "الغلاف والوسوم",
             "madeWithBy" to "صُنع بـ ❤️ بواسطة",
-            "activeIndicator" to "مفعّل"
+            "activeIndicator" to "مفعّل",
+            "batteryUnrestricted" to "تشغيل غير مقيد في الخلفية",
+            "batteryUnrestrictedSubtitle" to "استثنِ Levyra من تحسين البطارية ليستمر تشغيل الموسيقى مع إطفاء الشاشة",
+            "batteryUnrestrictedActive" to "مفعّل — لن يوقف النظام التشغيل"
         )
 
         private fun zhEntries(): Map<String, String> = mapOf(
@@ -7043,7 +7097,10 @@ class LevyraStrings private constructor(
             "normalizationShort" to "标准化",
             "coverAndTags" to "封面和标签",
             "madeWithBy" to "由 ❤️ 倾心打造",
-            "activeIndicator" to "已启用"
+            "activeIndicator" to "已启用",
+            "batteryUnrestricted" to "不受限制的后台播放",
+            "batteryUnrestrictedSubtitle" to "将 Levyra 排除在电池优化之外，熄屏时音乐继续播放",
+            "batteryUnrestrictedActive" to "已启用 — 系统不会停止播放"
         )
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
@@ -162,6 +162,7 @@ internal fun LevyraLibraryScreen(
     var addToPlaylistTracks by remember { mutableStateOf<List<Track>>(emptyList()) }
     var confirmDelete by remember { mutableStateOf(false) }
     var showCreatePlaylist by remember { mutableStateOf(false) }
+    var openSmartCollectionName by rememberSaveable { mutableStateOf<String?>(null) }
     val listState = rememberLazyListState()
     val scrollPositions = remember { mutableStateMapOf<String, Pair<Int, Int>>() }
 
@@ -222,6 +223,10 @@ internal fun LevyraLibraryScreen(
     }
     val selectionActive = selectedKeys.isNotEmpty()
 
+    BackHandler(enabled = !selectionActive && openSmartCollectionName == null && category != LibraryCategory.Overview) {
+        switchCategory(LibraryCategory.Overview)
+    }
+    BackHandler(enabled = !selectionActive && openSmartCollectionName != null) { openSmartCollectionName = null }
     BackHandler(enabled = selectionActive) { selectedKeys = emptySet() }
 
     Box(
@@ -360,7 +365,7 @@ internal fun LevyraLibraryScreen(
                             downloads = catalog.offlineTracks,
                             recent = catalog.recent,
                             mostPlayed = catalog.mostPlayed,
-                            onPlay = { tracks -> tracks.firstOrNull()?.let { viewModel.playFrom(tracks, it) } },
+                            onOpenCollection = { openSmartCollectionName = it },
                             onOpenOffline = { switchCategory(LibraryCategory.Offline) },
                             isItalian = isItalian
                         )
@@ -715,6 +720,19 @@ internal fun LevyraLibraryScreen(
             ) {
                 Icon(Icons.Rounded.PlaylistAdd, contentDescription = null)
             }
+        }
+
+        openSmartCollectionName?.let { collectionId ->
+            SmartCollectionDetail(
+                collectionId = collectionId,
+                state = state,
+                favorites = state.favorites,
+                recent = catalog.recent,
+                mostPlayed = catalog.mostPlayed,
+                viewModel = viewModel,
+                isItalian = isItalian,
+                onClose = { openSmartCollectionName = null }
+            )
         }
     }
 
@@ -1225,7 +1243,7 @@ private fun SmartCollectionGrid(
     downloads: List<Track>,
     recent: List<Track>,
     mostPlayed: List<Track>,
-    onPlay: (List<Track>) -> Unit,
+    onOpenCollection: (String) -> Unit,
     onOpenOffline: () -> Unit,
     isItalian: Boolean
 ) {
@@ -1242,7 +1260,7 @@ private fun SmartCollectionGrid(
             icon = Icons.Rounded.Favorite,
             accent = LevyraPink,
             tracks = favorites,
-            onClick = { onPlay(favorites) }
+            onClick = { onOpenCollection(SMART_COLLECTION_FAVORITES) }
         ),
         SmartCollection(
             title = if (isItalian) "Offline" else "Offline",
@@ -1259,7 +1277,7 @@ private fun SmartCollectionGrid(
             icon = Icons.Rounded.History,
             accent = LevyraViolet,
             tracks = recent,
-            onClick = { onPlay(recent) }
+            onClick = { onOpenCollection(SMART_COLLECTION_RECENT) }
         ),
         SmartCollection(
             title = if (isItalian) "Più ascoltati" else "Most played",
@@ -1267,7 +1285,7 @@ private fun SmartCollectionGrid(
             icon = Icons.Rounded.Replay,
             accent = Color(0xFFFFC857),
             tracks = mostPlayed,
-            onClick = { onPlay(mostPlayed) }
+            onClick = { onOpenCollection(SMART_COLLECTION_MOST_PLAYED) }
         )
     )
 
@@ -1295,6 +1313,202 @@ private data class SmartCollection(
     val enabledWhenEmpty: Boolean = false,
     val onClick: () -> Unit
 )
+
+private const val SMART_COLLECTION_FAVORITES = "favorites"
+private const val SMART_COLLECTION_RECENT = "recent"
+private const val SMART_COLLECTION_MOST_PLAYED = "mostPlayed"
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun SmartCollectionDetail(
+    collectionId: String,
+    state: LevyraUiState,
+    favorites: List<Track>,
+    recent: List<Track>,
+    mostPlayed: List<Track>,
+    viewModel: LibraryViewModel,
+    isItalian: Boolean,
+    onClose: () -> Unit
+) {
+    val tracks = when (collectionId) {
+        SMART_COLLECTION_RECENT -> recent
+        SMART_COLLECTION_MOST_PLAYED -> mostPlayed
+        else -> favorites
+    }
+    val title = when (collectionId) {
+        SMART_COLLECTION_RECENT -> if (isItalian) "Ascoltati di recente" else "Recently played"
+        SMART_COLLECTION_MOST_PLAYED -> if (isItalian) "Più ascoltati" else "Most played"
+        else -> if (isItalian) "Preferiti" else "Favorites"
+    }
+    val subtitle = when (collectionId) {
+        SMART_COLLECTION_RECENT -> if (isItalian) "I brani che hai riprodotto per ultimi" else "The tracks you played last"
+        SMART_COLLECTION_MOST_PLAYED -> if (isItalian) "I brani che riascolti più spesso" else "The tracks you replay the most"
+        else -> if (isItalian) "La musica che hai salvato con il cuore" else "The music you saved with a heart"
+    }
+    val accent = when (collectionId) {
+        SMART_COLLECTION_RECENT -> LevyraViolet
+        SMART_COLLECTION_MOST_PLAYED -> Color(0xFFFFC857)
+        else -> LevyraPink
+    }
+    val icon = when (collectionId) {
+        SMART_COLLECTION_RECENT -> Icons.Rounded.History
+        SMART_COLLECTION_MOST_PLAYED -> Icons.Rounded.Replay
+        else -> Icons.Rounded.Favorite
+    }
+    val countLabel = if (isItalian) {
+        "${tracks.size} ${if (tracks.size == 1) "brano" else "brani"}"
+    } else {
+        "${tracks.size} ${if (tracks.size == 1) "track" else "tracks"}"
+    }
+
+    Surface(color = LevyraInk, modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .statusBarsPadding(),
+            contentPadding = PaddingValues(
+                start = 16.dp,
+                end = 16.dp,
+                top = 12.dp,
+                bottom = if (state.currentTrack != null) 230.dp else 116.dp
+            ),
+            verticalArrangement = Arrangement.spacedBy(14.dp)
+        ) {
+            item(key = "smart-hero") {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(26.dp))
+                        .background(
+                            Brush.linearGradient(
+                                listOf(
+                                    accent.copy(alpha = 0.30f),
+                                    LevyraPanel.copy(alpha = 0.92f)
+                                )
+                            )
+                        )
+                        .padding(20.dp)
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(14.dp),
+                        modifier = Modifier.padding(end = 40.dp)
+                    ) {
+                        Surface(
+                            shape = RoundedCornerShape(18.dp),
+                            color = accent.copy(alpha = 0.22f)
+                        ) {
+                            Icon(
+                                icon,
+                                contentDescription = null,
+                                tint = accent,
+                                modifier = Modifier
+                                    .padding(13.dp)
+                                    .size(28.dp)
+                            )
+                        }
+                        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            Text(title, color = LevyraText, fontSize = 23.sp, fontWeight = FontWeight.Black)
+                            Text(subtitle, color = LevyraMuted, fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
+                            Text(countLabel, color = accent, fontSize = 12.sp, fontWeight = FontWeight.Bold)
+                        }
+                    }
+                    IconButton(
+                        onClick = onClose,
+                        modifier = Modifier.align(Alignment.TopEnd)
+                    ) {
+                        Icon(Icons.Rounded.Close, contentDescription = null, tint = LevyraMuted)
+                    }
+                }
+            }
+            item(key = "smart-actions") {
+                Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                    SmartCollectionAction(
+                        label = if (isItalian) "Riproduci" else "Play",
+                        icon = Icons.Rounded.PlayArrow,
+                        accent = accent,
+                        filled = true,
+                        enabled = tracks.isNotEmpty(),
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        tracks.firstOrNull()?.let { viewModel.playFrom(tracks, it) }
+                    }
+                    SmartCollectionAction(
+                        label = if (isItalian) "Casuale" else "Shuffle",
+                        icon = Icons.Rounded.Shuffle,
+                        accent = accent,
+                        filled = false,
+                        enabled = tracks.isNotEmpty(),
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        val shuffled = tracks.shuffled()
+                        shuffled.firstOrNull()?.let { viewModel.playFrom(shuffled, it) }
+                    }
+                }
+            }
+            if (tracks.isEmpty()) {
+                item(key = "smart-empty") {
+                    LibraryEmpty(icon, if (isItalian) "Ancora nessun brano qui" else "No tracks here yet")
+                }
+            } else {
+                items(tracks, key = { "smart-$collectionId-${libraryTrackKey(it)}" }) { track ->
+                    LibraryTrackRow(
+                        track = track,
+                        selected = false,
+                        selectionActive = false,
+                        isCurrent = track.id == state.currentTrack?.id,
+                        isPlaying = state.isPlaying && track.id == state.currentTrack?.id,
+                        isFavorite = track.id in state.favoriteIds,
+                        isDownloaded = libraryDownloadForTrack(track, state.downloads) != null,
+                        downloadProgress = downloadProgressFor(track, state),
+                        onClick = { viewModel.playFrom(tracks, track) },
+                        onLongClick = {},
+                        onFavorite = { viewModel.toggleFavorite(track) },
+                        onDownload = { viewModel.exportTrack(track) },
+                        isItalian = isItalian
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun SmartCollectionAction(
+    label: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    accent: Color,
+    filled: Boolean,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    Surface(
+        color = if (filled) accent.copy(alpha = if (enabled) 0.92f else 0.35f) else LevyraPanel.copy(alpha = 0.85f),
+        shape = RoundedCornerShape(18.dp),
+        border = if (filled) null else BorderStroke(1.dp, accent.copy(alpha = 0.35f)),
+        modifier = modifier
+            .height(46.dp)
+            .clip(RoundedCornerShape(18.dp))
+            .combinedClickable(enabled = enabled, onClick = onClick)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxSize(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                icon,
+                contentDescription = null,
+                tint = if (filled) Color.Black else accent,
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(label, color = if (filled) Color.Black else LevyraText, fontSize = 14.sp, fontWeight = FontWeight.Bold)
+        }
+    }
+}
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable

--- a/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
@@ -57,8 +57,8 @@ import androidx.compose.material.icons.rounded.OfflinePin
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.icons.rounded.PlayArrow
-import androidx.compose.material.icons.rounded.PlaylistAdd
-import androidx.compose.material.icons.rounded.QueueMusic
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Replay
 import androidx.compose.material.icons.rounded.Insights
@@ -66,9 +66,9 @@ import androidx.compose.material.icons.rounded.Schedule
 import androidx.compose.material.icons.rounded.RadioButtonUnchecked
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Shuffle
-import androidx.compose.material.icons.rounded.Sort
+import androidx.compose.material.icons.automirrored.rounded.Sort
 import androidx.compose.material.icons.rounded.Storage
-import androidx.compose.material.icons.rounded.ViewList
+import androidx.compose.material.icons.automirrored.rounded.ViewList
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -442,7 +442,7 @@ internal fun LevyraLibraryScreen(
                         )
                     }
                     if (visiblePlaylists.isEmpty()) {
-                        item { LibraryEmpty(Icons.Rounded.QueueMusic, if (isItalian) "Nessuna playlist trovata" else "No playlists found") }
+                        item { LibraryEmpty(Icons.AutoMirrored.Rounded.QueueMusic, if (isItalian) "Nessuna playlist trovata" else "No playlists found") }
                     } else if (layout == LibraryLayout.List) {
                         items(visiblePlaylists, key = { "playlist-${it.id}" }) { playlist ->
                             val key = "playlist:${playlist.id}"
@@ -718,7 +718,7 @@ internal fun LevyraLibraryScreen(
                     .navigationBarsPadding()
                     .padding(end = 18.dp, bottom = if (state.currentTrack != null) 94.dp else 24.dp)
             ) {
-                Icon(Icons.Rounded.PlaylistAdd, contentDescription = null)
+                Icon(Icons.AutoMirrored.Rounded.PlaylistAdd, contentDescription = null)
             }
         }
 
@@ -909,7 +909,7 @@ internal fun LevyraPlaylistDetailScreen(
             }
 
             if (orderedTracks.isEmpty()) {
-                item { LibraryEmpty(Icons.Rounded.QueueMusic, if (isItalian) "Questa playlist è vuota" else "This playlist is empty") }
+                item { LibraryEmpty(Icons.AutoMirrored.Rounded.QueueMusic, if (isItalian) "Questa playlist è vuota" else "This playlist is empty") }
             } else if (reorderMode) {
                 items(orderedTracks, key = { "reorder-${playlistEntryKey(it)}" }) { track ->
                     val entryKey = playlistEntryKey(track)
@@ -1158,7 +1158,7 @@ private fun LibraryToolbar(
                 contentPadding = PaddingValues(horizontal = 4.dp, vertical = 2.dp)
             ) {
                 Icon(
-                    Icons.Rounded.Sort,
+                    Icons.AutoMirrored.Rounded.Sort,
                     contentDescription = null,
                     tint = LevyraCyan,
                     modifier = Modifier.size(18.dp)
@@ -1207,7 +1207,7 @@ private fun LibraryToolbar(
             if (category != LibraryCategory.Offline && category != LibraryCategory.Songs) {
                 IconButton(onClick = onLayout) {
                     Icon(
-                        if (layout == LibraryLayout.List) Icons.Rounded.GridView else Icons.Rounded.ViewList,
+                        if (layout == LibraryLayout.List) Icons.Rounded.GridView else Icons.AutoMirrored.Rounded.ViewList,
                         contentDescription = null,
                         tint = LevyraMuted
                     )
@@ -1757,7 +1757,7 @@ private fun LibraryListeningDashboard(
                     ) {
                         LibraryInsightMetric(
                             modifier = Modifier.weight(1f),
-                            icon = Icons.Rounded.QueueMusic,
+                            icon = Icons.AutoMirrored.Rounded.QueueMusic,
                             value = playlistCount.toString(),
                             label = "Playlist",
                             accent = LevyraCyan
@@ -2549,8 +2549,8 @@ private fun LibrarySelectionBar(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 LibrarySelectionAction(Icons.Rounded.PlayArrow, if (isItalian) "Riproduci" else "Play", canOperateTracks, onPlay, LevyraCyan)
-                LibrarySelectionAction(Icons.Rounded.QueueMusic, if (isItalian) "Coda" else "Queue", canOperateTracks, onQueue, LevyraText)
-                LibrarySelectionAction(Icons.Rounded.PlaylistAdd, if (isItalian) "Playlist" else "Playlist", canOperateTracks, onAddToPlaylist, LevyraText)
+                LibrarySelectionAction(Icons.AutoMirrored.Rounded.QueueMusic, if (isItalian) "Coda" else "Queue", canOperateTracks, onQueue, LevyraText)
+                LibrarySelectionAction(Icons.AutoMirrored.Rounded.PlaylistAdd, if (isItalian) "Playlist" else "Playlist", canOperateTracks, onAddToPlaylist, LevyraText)
                 LibrarySelectionAction(Icons.Rounded.Download, if (isItalian) "Offline" else "Offline", canOperateTracks, onDownload, LevyraText)
                 LibrarySelectionAction(Icons.Rounded.Delete, if (isItalian) "Elimina" else "Delete", canDelete, onDelete, LevyraPink)
             }
@@ -2607,7 +2607,7 @@ private fun AddTracksToPlaylistDialog(
                     OutlinedTextField(value = name, onValueChange = { name = it }, singleLine = true, label = { Text(if (isItalian) "Nome playlist" else "Playlist name") })
                 } else {
                     TextButton(onClick = { creating = true }) {
-                        Icon(Icons.Rounded.PlaylistAdd, contentDescription = null)
+                        Icon(Icons.AutoMirrored.Rounded.PlaylistAdd, contentDescription = null)
                         Spacer(Modifier.width(7.dp))
                         Text(if (isItalian) "Crea nuova playlist" else "Create new playlist")
                     }
@@ -2618,7 +2618,7 @@ private fun AddTracksToPlaylistDialog(
                             modifier = Modifier.fillMaxWidth().combinedClickable(onClick = { onAdd(playlist.id) })
                         ) {
                             Row(modifier = Modifier.padding(10.dp), verticalAlignment = Alignment.CenterVertically) {
-                                Icon(Icons.Rounded.QueueMusic, contentDescription = null, tint = LevyraMuted)
+                                Icon(Icons.AutoMirrored.Rounded.QueueMusic, contentDescription = null, tint = LevyraMuted)
                                 Spacer(Modifier.width(10.dp))
                                 Text(playlist.name, color = LevyraText, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
                             }
@@ -2696,7 +2696,7 @@ private fun PlaylistDetailHeader(
                     IconButton(onClick = { menuExpanded = true }) { Icon(Icons.Rounded.MoreVert, contentDescription = null, tint = LevyraText) }
                     DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
                         DropdownMenuItem(text = { Text(if (isItalian) "Rinomina" else "Rename") }, leadingIcon = { Icon(Icons.Rounded.Edit, null) }, onClick = { menuExpanded = false; onRename() })
-                        DropdownMenuItem(text = { Text(if (isItalian) "Riordina" else "Reorder") }, leadingIcon = { Icon(Icons.Rounded.Sort, null) }, onClick = { menuExpanded = false; onReorder() })
+                        DropdownMenuItem(text = { Text(if (isItalian) "Riordina" else "Reorder") }, leadingIcon = { Icon(Icons.AutoMirrored.Rounded.Sort, null) }, onClick = { menuExpanded = false; onReorder() })
                     }
                 }
             }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
@@ -726,9 +726,11 @@ internal fun LevyraLibraryScreen(
             SmartCollectionDetail(
                 collectionId = collectionId,
                 state = state,
-                favorites = state.favorites,
-                recent = catalog.recent,
-                mostPlayed = catalog.mostPlayed,
+                tracks = when (collectionId) {
+                    SMART_COLLECTION_RECENT -> catalog.recent
+                    SMART_COLLECTION_MOST_PLAYED -> catalog.mostPlayed
+                    else -> state.favorites
+                },
                 viewModel = viewModel,
                 isItalian = isItalian,
                 onClose = { openSmartCollectionName = null }
@@ -1318,43 +1320,44 @@ private const val SMART_COLLECTION_FAVORITES = "favorites"
 private const val SMART_COLLECTION_RECENT = "recent"
 private const val SMART_COLLECTION_MOST_PLAYED = "mostPlayed"
 
-@OptIn(ExperimentalFoundationApi::class)
+private data class SmartCollectionStyle(
+    val title: String,
+    val subtitle: String,
+    val accent: Color,
+    val icon: androidx.compose.ui.graphics.vector.ImageVector
+)
+
+private fun smartCollectionStyle(collectionId: String, isItalian: Boolean): SmartCollectionStyle = when (collectionId) {
+    SMART_COLLECTION_RECENT -> SmartCollectionStyle(
+        title = if (isItalian) "Ascoltati di recente" else "Recently played",
+        subtitle = if (isItalian) "I brani che hai riprodotto per ultimi" else "The tracks you played last",
+        accent = LevyraViolet,
+        icon = Icons.Rounded.History
+    )
+    SMART_COLLECTION_MOST_PLAYED -> SmartCollectionStyle(
+        title = if (isItalian) "Più ascoltati" else "Most played",
+        subtitle = if (isItalian) "I brani che riascolti più spesso" else "The tracks you replay the most",
+        accent = Color(0xFFFFC857),
+        icon = Icons.Rounded.Replay
+    )
+    else -> SmartCollectionStyle(
+        title = if (isItalian) "Preferiti" else "Favorites",
+        subtitle = if (isItalian) "La musica che hai salvato con il cuore" else "The music you saved with a heart",
+        accent = LevyraPink,
+        icon = Icons.Rounded.Favorite
+    )
+}
+
 @Composable
 private fun SmartCollectionDetail(
     collectionId: String,
     state: LevyraUiState,
-    favorites: List<Track>,
-    recent: List<Track>,
-    mostPlayed: List<Track>,
+    tracks: List<Track>,
     viewModel: LibraryViewModel,
     isItalian: Boolean,
     onClose: () -> Unit
 ) {
-    val tracks = when (collectionId) {
-        SMART_COLLECTION_RECENT -> recent
-        SMART_COLLECTION_MOST_PLAYED -> mostPlayed
-        else -> favorites
-    }
-    val title = when (collectionId) {
-        SMART_COLLECTION_RECENT -> if (isItalian) "Ascoltati di recente" else "Recently played"
-        SMART_COLLECTION_MOST_PLAYED -> if (isItalian) "Più ascoltati" else "Most played"
-        else -> if (isItalian) "Preferiti" else "Favorites"
-    }
-    val subtitle = when (collectionId) {
-        SMART_COLLECTION_RECENT -> if (isItalian) "I brani che hai riprodotto per ultimi" else "The tracks you played last"
-        SMART_COLLECTION_MOST_PLAYED -> if (isItalian) "I brani che riascolti più spesso" else "The tracks you replay the most"
-        else -> if (isItalian) "La musica che hai salvato con il cuore" else "The music you saved with a heart"
-    }
-    val accent = when (collectionId) {
-        SMART_COLLECTION_RECENT -> LevyraViolet
-        SMART_COLLECTION_MOST_PLAYED -> Color(0xFFFFC857)
-        else -> LevyraPink
-    }
-    val icon = when (collectionId) {
-        SMART_COLLECTION_RECENT -> Icons.Rounded.History
-        SMART_COLLECTION_MOST_PLAYED -> Icons.Rounded.Replay
-        else -> Icons.Rounded.Favorite
-    }
+    val style = smartCollectionStyle(collectionId, isItalian)
     val countLabel = if (isItalian) {
         "${tracks.size} ${if (tracks.size == 1) "brano" else "brani"}"
     } else {
@@ -1375,102 +1378,139 @@ private fun SmartCollectionDetail(
             verticalArrangement = Arrangement.spacedBy(14.dp)
         ) {
             item(key = "smart-hero") {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(26.dp))
-                        .background(
-                            Brush.linearGradient(
-                                listOf(
-                                    accent.copy(alpha = 0.30f),
-                                    LevyraPanel.copy(alpha = 0.92f)
-                                )
-                            )
-                        )
-                        .padding(20.dp)
-                ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(14.dp),
-                        modifier = Modifier.padding(end = 40.dp)
-                    ) {
-                        Surface(
-                            shape = RoundedCornerShape(18.dp),
-                            color = accent.copy(alpha = 0.22f)
-                        ) {
-                            Icon(
-                                icon,
-                                contentDescription = null,
-                                tint = accent,
-                                modifier = Modifier
-                                    .padding(13.dp)
-                                    .size(28.dp)
-                            )
-                        }
-                        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                            Text(title, color = LevyraText, fontSize = 23.sp, fontWeight = FontWeight.Black)
-                            Text(subtitle, color = LevyraMuted, fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
-                            Text(countLabel, color = accent, fontSize = 12.sp, fontWeight = FontWeight.Bold)
-                        }
-                    }
-                    IconButton(
-                        onClick = onClose,
-                        modifier = Modifier.align(Alignment.TopEnd)
-                    ) {
-                        Icon(Icons.Rounded.Close, contentDescription = null, tint = LevyraMuted)
-                    }
-                }
+                SmartCollectionHero(style, countLabel, onClose)
             }
             item(key = "smart-actions") {
-                Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                    SmartCollectionAction(
-                        label = if (isItalian) "Riproduci" else "Play",
-                        icon = Icons.Rounded.PlayArrow,
-                        accent = accent,
-                        filled = true,
-                        enabled = tracks.isNotEmpty(),
-                        modifier = Modifier.weight(1f)
-                    ) {
-                        tracks.firstOrNull()?.let { viewModel.playFrom(tracks, it) }
-                    }
-                    SmartCollectionAction(
-                        label = if (isItalian) "Casuale" else "Shuffle",
-                        icon = Icons.Rounded.Shuffle,
-                        accent = accent,
-                        filled = false,
-                        enabled = tracks.isNotEmpty(),
-                        modifier = Modifier.weight(1f)
-                    ) {
+                SmartCollectionActions(
+                    accent = style.accent,
+                    enabled = tracks.isNotEmpty(),
+                    isItalian = isItalian,
+                    onPlay = { tracks.firstOrNull()?.let { viewModel.playFrom(tracks, it) } },
+                    onShuffle = {
                         val shuffled = tracks.shuffled()
                         shuffled.firstOrNull()?.let { viewModel.playFrom(shuffled, it) }
                     }
-                }
+                )
             }
             if (tracks.isEmpty()) {
                 item(key = "smart-empty") {
-                    LibraryEmpty(icon, if (isItalian) "Ancora nessun brano qui" else "No tracks here yet")
+                    LibraryEmpty(style.icon, if (isItalian) "Ancora nessun brano qui" else "No tracks here yet")
                 }
             } else {
                 items(tracks, key = { "smart-$collectionId-${libraryTrackKey(it)}" }) { track ->
-                    LibraryTrackRow(
-                        track = track,
-                        selected = false,
-                        selectionActive = false,
-                        isCurrent = track.id == state.currentTrack?.id,
-                        isPlaying = state.isPlaying && track.id == state.currentTrack?.id,
-                        isFavorite = track.id in state.favoriteIds,
-                        isDownloaded = libraryDownloadForTrack(track, state.downloads) != null,
-                        downloadProgress = downloadProgressFor(track, state),
-                        onClick = { viewModel.playFrom(tracks, track) },
-                        onLongClick = {},
-                        onFavorite = { viewModel.toggleFavorite(track) },
-                        onDownload = { viewModel.exportTrack(track) },
-                        isItalian = isItalian
-                    )
+                    SmartCollectionTrackRow(state, tracks, track, viewModel, isItalian)
                 }
             }
         }
     }
+}
+
+@Composable
+private fun SmartCollectionHero(
+    style: SmartCollectionStyle,
+    countLabel: String,
+    onClose: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(26.dp))
+            .background(
+                Brush.linearGradient(
+                    listOf(
+                        style.accent.copy(alpha = 0.30f),
+                        LevyraPanel.copy(alpha = 0.92f)
+                    )
+                )
+            )
+            .padding(20.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            modifier = Modifier.padding(end = 40.dp)
+        ) {
+            Surface(
+                shape = RoundedCornerShape(18.dp),
+                color = style.accent.copy(alpha = 0.22f)
+            ) {
+                Icon(
+                    style.icon,
+                    contentDescription = null,
+                    tint = style.accent,
+                    modifier = Modifier
+                        .padding(13.dp)
+                        .size(28.dp)
+                )
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(style.title, color = LevyraText, fontSize = 23.sp, fontWeight = FontWeight.Black)
+                Text(style.subtitle, color = LevyraMuted, fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
+                Text(countLabel, color = style.accent, fontSize = 12.sp, fontWeight = FontWeight.Bold)
+            }
+        }
+        IconButton(
+            onClick = onClose,
+            modifier = Modifier.align(Alignment.TopEnd)
+        ) {
+            Icon(Icons.Rounded.Close, contentDescription = null, tint = LevyraMuted)
+        }
+    }
+}
+
+@Composable
+private fun SmartCollectionActions(
+    accent: Color,
+    enabled: Boolean,
+    isItalian: Boolean,
+    onPlay: () -> Unit,
+    onShuffle: () -> Unit
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+        SmartCollectionAction(
+            label = if (isItalian) "Riproduci" else "Play",
+            icon = Icons.Rounded.PlayArrow,
+            accent = accent,
+            filled = true,
+            enabled = enabled,
+            modifier = Modifier.weight(1f),
+            onClick = onPlay
+        )
+        SmartCollectionAction(
+            label = if (isItalian) "Casuale" else "Shuffle",
+            icon = Icons.Rounded.Shuffle,
+            accent = accent,
+            filled = false,
+            enabled = enabled,
+            modifier = Modifier.weight(1f),
+            onClick = onShuffle
+        )
+    }
+}
+
+@Composable
+private fun SmartCollectionTrackRow(
+    state: LevyraUiState,
+    tracks: List<Track>,
+    track: Track,
+    viewModel: LibraryViewModel,
+    isItalian: Boolean
+) {
+    LibraryTrackRow(
+        track = track,
+        selected = false,
+        selectionActive = false,
+        isCurrent = track.id == state.currentTrack?.id,
+        isPlaying = state.isPlaying && track.id == state.currentTrack?.id,
+        isFavorite = track.id in state.favoriteIds,
+        isDownloaded = libraryDownloadForTrack(track, state.downloads) != null,
+        downloadProgress = downloadProgressFor(track, state),
+        onClick = { viewModel.playFrom(tracks, track) },
+        onLongClick = {},
+        onFavorite = { viewModel.toggleFavorite(track) },
+        onDownload = { viewModel.exportTrack(track) },
+        isItalian = isItalian
+    )
 }
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -657,7 +657,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             recoverPlaybackStream(track, positionMs, videoMode, playWhenReady, errorMessage)
         }
         player.onError = { errorMsg ->
-            _state.value.currentTrack?.let { resolver.invalidate(it, _state.value.isVideoMode) }
+            _state.value.currentTrack
+                ?.takeUnless(::isLocalPlaybackTrack)
+                ?.let { resolver.invalidate(it, _state.value.isVideoMode) }
             _state.update { it.copy(playerError = cleanUserError(errorMsg), isPlaying = false, isResolving = false) }
         }
         applyFollowedArtists(followedArtistsStore.load())
@@ -1445,6 +1447,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         playWhenReady: Boolean,
         errorMessage: String
     ) {
+        if (isLocalPlaybackTrack(failedTrack)) return
         val transitionId = ++streamTransitionId
         modeSwitchJob?.cancel()
         streamRecoveryJob?.cancel()
@@ -3945,13 +3948,17 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     fun playDownloaded(download: DownloadedTrack) {
+        if (download.uri.isBlank()) {
+            _state.update { it.copy(playerError = "File offline non disponibile") }
+            return
+        }
         val track = Track(
-            id = download.trackId,
+            id = download.trackId.ifBlank { "offline-${download.id}" },
             title = download.title,
             artist = download.artist,
             album = download.album,
             durationMs = download.durationMs,
-            streamUrl = "",
+            streamUrl = download.uri,
             videoUrl = "",
             thumbnailUrl = "",
             largeThumbnailUrl = "",
@@ -3964,10 +3971,19 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             accentStart = 0,
             accentEnd = 0
         )
+        playRequestId++
+        streamTransitionId++
+        playJob?.cancel()
+        modeSwitchJob?.cancel()
+        streamRecoveryJob?.cancel()
+        crossfadeJob?.cancel()
+        crossfadeInProgress = false
+        cancelBackgroundWarmups(cancelList = true)
+        _state.update { it.copy(isVideoMode = false, playerError = null, isResolving = false) }
         loopCurrentQueueOnCompletion = false
         queueEngine.replace(listOf(track), 0, keepPlaybackModes = true, radioEnabled = false)
         queueIndex = 0
-        startResolve(track)
+        startPlayback(track)
     }
 
     private fun startPlayback(playable: Track) {
@@ -4369,7 +4385,12 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private fun fetchSponsorSegments(track: Track) {
         sponsorJob?.cancel()
         sponsorSegments = emptyList()
-        if (!_state.value.sponsorBlockEnabled || track.id.isBlank() || track.id.startsWith("chart-")) return
+        if (
+            !_state.value.sponsorBlockEnabled ||
+            isLocalPlaybackTrack(track) ||
+            track.id.isBlank() ||
+            track.id.startsWith("chart-")
+        ) return
         sponsorJob = viewModelScope.launch {
             val result = runCatching { sponsorBlockRepository.segments(track.id) }.getOrDefault(emptyList())
             if (_state.value.currentTrack?.id == track.id) sponsorSegments = result
@@ -4485,9 +4506,14 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         prefetchJob?.cancel()
         PlaybackService.clearPreparedQueueNext()
         val current = _state.value.currentTrack
-        if (current != null) prefetchLyricsAround(current)
-        if (current != null) prefetchNextMotionArtwork(current)
-        if (_state.value.isPlaying && current != null && current.streamUrl.isNotBlank()) prefetchAround(current)
+        if (current != null && !isLocalPlaybackTrack(current)) prefetchLyricsAround(current)
+        if (current != null && !isLocalPlaybackTrack(current)) prefetchNextMotionArtwork(current)
+        if (
+            _state.value.isPlaying &&
+            current != null &&
+            current.streamUrl.isNotBlank() &&
+            !isLocalPlaybackTrack(current)
+        ) prefetchAround(current)
     }
 
     private fun refreshMotionArtworkAround(current: Track) {
@@ -4611,6 +4637,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private fun prefetchAround(playable: Track) {
         prefetchJob?.cancel()
         PlaybackService.clearPreparedQueueNext()
+        if (isLocalPlaybackTrack(playable) || !lyricsNetworkProfile().connected) return
         val generation = queueEngine.state.value.generation
         prefetchJob = viewModelScope.launch(Dispatchers.IO) {
             val plan = adaptivePlaybackPolicy.current(_state.value.isVideoMode)
@@ -4661,6 +4688,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         if (!force && queueEngine.upcoming(3).size >= 3) return
         if (radioJob?.isActive == true) return
         val seed = queueSnapshot.currentTrack ?: return
+        if (isLocalPlaybackTrack(seed) || !lyricsNetworkProfile().connected) return
         val generation = queueSnapshot.generation
         radioJob = viewModelScope.launch(Dispatchers.IO) {
             val radioTracks = runCatching {
@@ -5157,6 +5185,13 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             throw IllegalStateException("YouTube non ha fornito uno stream audio riproducibile per ${track.title}")
         }
         return resolved
+    }
+
+    private fun isLocalPlaybackTrack(track: Track): Boolean {
+        val stream = track.streamUrl.trim()
+        return track.source.equals("Offline", ignoreCase = true) ||
+            stream.startsWith("content://", ignoreCase = true) ||
+            stream.startsWith("file://", ignoreCase = true)
     }
 
     private fun effectiveDuration(track: Track): Long {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -1356,7 +1356,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         recordSmartCompletion(current)
         val nextTrack = queueEngine.next()
         when {
-            nextTrack != null -> startResolve(nextTrack)
+            nextTrack != null -> startResolve(nextTrack, autoRetryWhenOffline = true)
             queueEngine.state.value.radioEnabled -> ensureRadioTail(force = true, playWhenReady = true)
             loopCurrentQueueOnCompletion && queueEngine.state.value.tracks.isNotEmpty() -> {
                 val first = queueEngine.select(0, rememberCurrent = true)
@@ -3799,7 +3799,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         startResolve(list.getOrElse(index) { track })
     }
 
-    private fun startResolve(track: Track, preserveCrossfade: Boolean = false) {
+    private fun startResolve(track: Track, preserveCrossfade: Boolean = false, autoRetryWhenOffline: Boolean = false) {
         streamTransitionId++
         modeSwitchJob?.cancel()
         streamRecoveryJob?.cancel()
@@ -3868,6 +3868,21 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             } catch (error: Throwable) {
                 if (error is CancellationException) throw error
                 if (!isActive || requestId != playRequestId) return@launch
+                if (autoRetryWhenOffline && !hasInternetCapableNetwork()) {
+                    player.stop()
+                    _state.update {
+                        it.copy(
+                            isResolving = false,
+                            isPlaying = false,
+                            positionMs = 0L,
+                            durationMs = track.durationMs,
+                            currentTrack = track.copy(streamUrl = ""),
+                            playerError = null
+                        )
+                    }
+                    scheduleOfflineAutoAdvanceRetry(track, requestId)
+                    return@launch
+                }
                 player.stop()
                 _state.update {
                     it.copy(
@@ -3880,6 +3895,25 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                     )
                 }
             }
+        }
+    }
+
+    private fun hasInternetCapableNetwork(): Boolean {
+        val connectivity = getApplication<Application>().getSystemService(ConnectivityManager::class.java)
+            ?: return false
+        val network = connectivity.activeNetwork ?: return false
+        val capabilities = connectivity.getNetworkCapabilities(network) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+
+    private fun scheduleOfflineAutoAdvanceRetry(track: Track, requestId: Long) {
+        streamRecoveryJob?.cancel()
+        streamRecoveryJob = viewModelScope.launch {
+            while (isActive && requestId == playRequestId && !hasInternetCapableNetwork()) {
+                delay(5_000L)
+            }
+            if (!isActive || requestId != playRequestId) return@launch
+            startResolve(track, autoRetryWhenOffline = true)
         }
     }
 
@@ -3971,19 +4005,11 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             accentStart = 0,
             accentEnd = 0
         )
-        playRequestId++
-        streamTransitionId++
-        playJob?.cancel()
-        modeSwitchJob?.cancel()
-        streamRecoveryJob?.cancel()
-        crossfadeJob?.cancel()
-        crossfadeInProgress = false
-        cancelBackgroundWarmups(cancelList = true)
-        _state.update { it.copy(isVideoMode = false, playerError = null, isResolving = false) }
+        _state.update { it.copy(isVideoMode = false) }
         loopCurrentQueueOnCompletion = false
         queueEngine.replace(listOf(track), 0, keepPlaybackModes = true, radioEnabled = false)
         queueIndex = 0
-        startPlayback(track)
+        startResolve(track)
     }
 
     private fun startPlayback(playable: Track) {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -4682,30 +4682,49 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         }
     }
 
+    private data class RadioTailRequest(
+        val seed: Track,
+        val generation: Long
+    )
+
     private fun ensureRadioTail(force: Boolean, playWhenReady: Boolean = false) {
-        val queueSnapshot = queueEngine.state.value
-        if (!queueSnapshot.radioEnabled || queueSnapshot.currentTrack == null) return
-        if (!force && queueEngine.upcoming(3).size >= 3) return
-        if (radioJob?.isActive == true) return
-        val seed = queueSnapshot.currentTrack ?: return
-        if (isLocalPlaybackTrack(seed) || !lyricsNetworkProfile().connected) return
-        val generation = queueSnapshot.generation
+        val request = radioTailRequest(force) ?: return
         radioJob = viewModelScope.launch(Dispatchers.IO) {
-            val radioTracks = runCatching {
-                repository.radio(seed, _state.value.languageCode, 20)
-            }.getOrDefault(emptyList())
-            if (!isActive || radioTracks.isEmpty()) return@launch
-            val before = queueEngine.state.value
-            val sameSeed = before.currentTrack?.let { playbackQueueIdentity(it) } == playbackQueueIdentity(seed)
-            if (!sameSeed || (before.generation != generation && !force)) return@launch
-            queueEngine.appendRadioTracks(radioTracks)
-            if (playWhenReady) {
-                withContext(Dispatchers.Main) {
-                    queueEngine.next(respectRepeatOne = false)?.let(::startResolve)
-                }
-            }
+            appendRadioTail(request, force, playWhenReady)
         }
     }
+
+    private fun radioTailRequest(force: Boolean): RadioTailRequest? {
+        val snapshot = queueEngine.state.value
+        val seed = snapshot.currentTrack ?: return null
+        if (!snapshot.radioEnabled) return null
+        if (!force && queueEngine.upcoming(3).size >= 3) return null
+        if (radioJob?.isActive == true) return null
+        if (isLocalPlaybackTrack(seed) || !lyricsNetworkProfile().connected) return null
+        return RadioTailRequest(seed = seed, generation = snapshot.generation)
+    }
+
+    private suspend fun appendRadioTail(
+        request: RadioTailRequest,
+        force: Boolean,
+        playWhenReady: Boolean
+    ) {
+        val radioTracks = runCatching {
+            repository.radio(request.seed, _state.value.languageCode, 20)
+        }.getOrDefault(emptyList())
+        if (radioTracks.isEmpty()) return
+        val current = queueEngine.state.value
+        if (!isSameRadioSeed(current.currentTrack, request.seed)) return
+        if (current.generation != request.generation && !force) return
+        queueEngine.appendRadioTracks(radioTracks)
+        if (!playWhenReady) return
+        withContext(Dispatchers.Main) {
+            queueEngine.next(respectRepeatOne = false)?.let(::startResolve)
+        }
+    }
+
+    private fun isSameRadioSeed(current: Track?, seed: Track): Boolean =
+        current?.let { playbackQueueIdentity(it) } == playbackQueueIdentity(seed)
 
     private fun prefetchTop(tracks: List<Track>, count: Int = 8, respectHomeScroll: Boolean = false) {
         val plan = adaptivePlaybackPolicy.current(videoMode = false)

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -328,6 +328,51 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private var radioJob: Job? = null
     private var sponsorSegments: List<SponsorSegment> = emptyList()
     private val tabBackStack = ArrayDeque<LevyraTab>()
+
+    private sealed interface DetailPage {
+        data class AlbumPage(val detail: AlbumDetail) : DetailPage
+        data class ArtistPage(val profile: ArtistProfile) : DetailPage
+    }
+
+    private val detailBackStack = ArrayDeque<DetailPage>()
+
+    private fun pushDetailPage(page: DetailPage) {
+        detailBackStack.addLast(page)
+        while (detailBackStack.size > 12) {
+            detailBackStack.removeFirst()
+        }
+    }
+
+    private fun restoreDetailPage(): Boolean {
+        val page = detailBackStack.removeLastOrNull() ?: return false
+        when (page) {
+            is DetailPage.AlbumPage -> _state.update {
+                it.copy(
+                    showAlbum = true,
+                    albumLoading = false,
+                    albumError = null,
+                    albumDetail = page.detail,
+                    showArtist = false,
+                    artistLoading = false,
+                    artistError = null,
+                    detailReturnTarget = DetailReturnTarget.None
+                )
+            }
+            is DetailPage.ArtistPage -> _state.update {
+                it.copy(
+                    showArtist = true,
+                    artistLoading = false,
+                    artistError = null,
+                    artistProfile = page.profile,
+                    showAlbum = false,
+                    albumLoading = false,
+                    albumError = null,
+                    detailReturnTarget = DetailReturnTarget.None
+                )
+            }
+        }
+        return true
+    }
     private var playRequestId: Long = 0L
     private var streamTransitionId: Long = 0L
     private var pendingSeekMs: Long = 0L
@@ -2702,6 +2747,21 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         val normalizedBrowseId = browseId.trim()
         if (clean.length < 2 || clean.equals("YouTube Music", ignoreCase = true) || clean.equals("YouTube", ignoreCase = true)) return
         artistJob?.cancel()
+        val previous = _state.value
+        val previousProfileMatches = previous.artistProfile?.let { profile ->
+            if (normalizedBrowseId.isNotBlank()) {
+                profile.browseId.equals(normalizedBrowseId, ignoreCase = true)
+            } else {
+                profile.name.equals(clean, ignoreCase = true)
+            }
+        } == true
+        val previousAlbum = previous.albumDetail
+        val previousProfile = previous.artistProfile
+        if (previous.showAlbum && previousAlbum != null) {
+            pushDetailPage(DetailPage.AlbumPage(previousAlbum))
+        } else if (previous.showArtist && previousProfile != null && !previousProfileMatches) {
+            pushDetailPage(DetailPage.ArtistPage(previousProfile))
+        }
         _state.update { current ->
             val sameProfile = current.artistProfile?.let { profile ->
                 if (normalizedBrowseId.isNotBlank()) {
@@ -2717,11 +2777,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 artistError = null,
                 artistProfile = if (sameProfile) current.artistProfile else null,
                 openPlaylist = null,
-                detailReturnTarget = if (returnTarget == DetailReturnTarget.Album && current.albumDetail != null) {
-                    DetailReturnTarget.Album
-                } else {
-                    DetailReturnTarget.None
-                }
+                detailReturnTarget = DetailReturnTarget.None
             )
         }
         artistJob = viewModelScope.launch {
@@ -2753,13 +2809,13 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     fun closeArtist() {
         artistJob?.cancel()
-        _state.update { current ->
-            val returnToAlbum = current.detailReturnTarget == DetailReturnTarget.Album && current.albumDetail != null
-            current.copy(
+        if (restoreDetailPage()) return
+        _state.update {
+            it.copy(
                 showArtist = false,
                 artistLoading = false,
                 artistError = null,
-                showAlbum = returnToAlbum,
+                showAlbum = false,
                 detailReturnTarget = DetailReturnTarget.None
             )
         }
@@ -2772,8 +2828,15 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private fun openAlbumInternal(album: AlbumHit, returnTarget: DetailReturnTarget) {
         albumJob?.cancel()
         if (returnTarget != DetailReturnTarget.Artist) artistJob?.cancel()
-        val current = _state.value.albumDetail
+        val previous = _state.value
+        val current = previous.albumDetail
         val sameAlbum = current != null && current.album.title.equals(album.title, ignoreCase = true) && current.album.artist.equals(album.artist, ignoreCase = true)
+        val keepsArtistParent = returnTarget == DetailReturnTarget.Artist && previous.showArtist
+        if (previous.showAlbum && current != null && !sameAlbum) {
+            pushDetailPage(DetailPage.AlbumPage(current))
+        } else if (!keepsArtistParent && previous.showArtist && previous.artistProfile != null) {
+            pushDetailPage(DetailPage.ArtistPage(previous.artistProfile))
+        }
         _state.update { state ->
             val keepArtistParent = returnTarget == DetailReturnTarget.Artist && state.showArtist
             state.copy(
@@ -2820,13 +2883,26 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     fun closeAlbum() {
         albumJob?.cancel()
-        _state.update { current ->
-            val returnToArtist = current.detailReturnTarget == DetailReturnTarget.Artist && current.showArtist
-            current.copy(
+        val current = _state.value
+        if (current.detailReturnTarget == DetailReturnTarget.Artist && current.showArtist) {
+            _state.update {
+                it.copy(
+                    showAlbum = false,
+                    albumLoading = false,
+                    albumError = null,
+                    showArtist = true,
+                    detailReturnTarget = DetailReturnTarget.None
+                )
+            }
+            return
+        }
+        if (restoreDetailPage()) return
+        _state.update {
+            it.copy(
                 showAlbum = false,
                 albumLoading = false,
                 albumError = null,
-                showArtist = returnToArtist,
+                showArtist = false,
                 detailReturnTarget = DetailReturnTarget.None
             )
         }
@@ -2835,6 +2911,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     fun openPlayerScreen() {
         albumJob?.cancel()
         artistJob?.cancel()
+        detailBackStack.clear()
         _state.update {
             it.copy(
                 showAlbum = false,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -2701,11 +2701,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         val artistName = primaryArtistSegment(track.artist).ifBlank { track.artist.trim() }
         val browseId = track.artistBrowseIds.firstOrNull().orEmpty()
         if (browseId.isNotBlank()) {
-            openArtistReference(
-                name = artistName,
-                browseId = browseId,
-                returnTarget = DetailReturnTarget.None
-            )
+            openArtistReference(name = artistName, browseId = browseId)
         } else {
             openArtistByName(artistName)
         }
@@ -2713,11 +2709,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     fun openArtistFromAlbum() {
         val album = _state.value.albumDetail?.album ?: return
-        openArtistReference(
-            name = album.artist,
-            browseId = album.artistBrowseId,
-            returnTarget = DetailReturnTarget.Album
-        )
+        openArtistReference(name = album.artist, browseId = album.artistBrowseId)
     }
 
     fun openArtistRelease(release: ArtistRelease, artistName: String) {
@@ -2735,14 +2727,10 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     fun openArtistByName(name: String) {
-        openArtistByNameInternal(name, DetailReturnTarget.None)
+        openArtistReference(name = name, browseId = "")
     }
 
-    private fun openArtistByNameInternal(name: String, returnTarget: DetailReturnTarget) {
-        openArtistReference(name = name, browseId = "", returnTarget = returnTarget)
-    }
-
-    private fun openArtistReference(name: String, browseId: String, returnTarget: DetailReturnTarget) {
+    private fun openArtistReference(name: String, browseId: String) {
         val clean = name.trim()
         val normalizedBrowseId = browseId.trim()
         if (clean.length < 2 || clean.equals("YouTube Music", ignoreCase = true) || clean.equals("YouTube", ignoreCase = true)) return
@@ -3441,11 +3429,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     fun openArtistFromHit(hit: ArtistHit) {
-        openArtistReference(
-            name = hit.name,
-            browseId = hit.browseId,
-            returnTarget = DetailReturnTarget.None
-        )
+        openArtistReference(name = hit.name, browseId = hit.browseId)
     }
 
     private fun recordPlaybackHistory(track: Track) {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -106,6 +106,7 @@ import com.luc4n3x.levyra.player.queue.playbackQueueIdentity
 import com.luc4n3x.levyra.player.offline.OfflineAudioExporter
 import com.luc4n3x.levyra.player.offline.work.OfflineExportWorker
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.TimeoutCancellationException
@@ -3801,20 +3802,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     private fun startResolve(track: Track, preserveCrossfade: Boolean = false, autoRetryWhenOffline: Boolean = false) {
         streamTransitionId++
-        modeSwitchJob?.cancel()
-        streamRecoveryJob?.cancel()
-        alternateModePrefetchJob?.cancel()
-        youtubeEngagementJob?.cancel()
-        motionArtworkJob?.cancel()
-        motionArtworkRequestKey = null
-        motionArtworkPrefetchJob?.cancel()
-        youtubeDislikeJob?.cancel()
-        youtubeCommentsJob?.cancel()
-        youtubeCommentsPageJob?.cancel()
-        youtubeCommentReplyJobs.values.forEach { it.cancel() }
-        youtubeCommentReplyJobs.clear()
-        youtubeCommentContinuationHistory.clear()
-        youtubeEngagementGeneration.incrementAndGet()
+        cancelResolutionSideJobs()
         val engagementVideoId = youtubeEngagementVideoId(track)
         if (!preserveCrossfade) {
             crossfadeJob?.cancel()
@@ -3841,61 +3829,73 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         fetchLyrics(track)
         prefetchLyricsAround(track)
         refreshMotionArtworkAround(track)
-
-        val playableTrack = youtubePlayableTrack(track) ?: track
         playJob = viewModelScope.launch {
-            val local = localDownloadedTrack(track)
-            if (local != null) {
-                if (!isActive || requestId != playRequestId) return@launch
-                startPlayback(local)
-                prefetchAround(local)
-                return@launch
-            }
-            val instant = resolver.cached(playableTrack, _state.value.isVideoMode)
-            if (instant != null) {
-                if (!isActive || requestId != playRequestId) return@launch
-                startPlayback(instant)
-                prefetchAround(instant)
-                return@launch
-            }
-
-            player.stop()
-            try {
-                val playable = resolveForPlayback(track)
-                if (!isActive || requestId != playRequestId) return@launch
-                startPlayback(playable)
-                prefetchAround(playable)
-            } catch (error: Throwable) {
-                if (error is CancellationException) throw error
-                if (!isActive || requestId != playRequestId) return@launch
-                if (autoRetryWhenOffline && !hasInternetCapableNetwork()) {
-                    player.stop()
-                    _state.update {
-                        it.copy(
-                            isResolving = false,
-                            isPlaying = false,
-                            positionMs = 0L,
-                            durationMs = track.durationMs,
-                            currentTrack = track.copy(streamUrl = ""),
-                            playerError = null
-                        )
-                    }
-                    scheduleOfflineAutoAdvanceRetry(track, requestId)
-                    return@launch
-                }
-                player.stop()
-                _state.update {
-                    it.copy(
-                        isResolving = false,
-                        isPlaying = false,
-                        positionMs = 0L,
-                        durationMs = track.durationMs,
-                        currentTrack = track.copy(streamUrl = ""),
-                        playerError = cleanUserError(error)
-                    )
-                }
-            }
+            resolveAndStartPlayback(track, requestId, autoRetryWhenOffline)
         }
+    }
+
+    private fun cancelResolutionSideJobs() {
+        modeSwitchJob?.cancel()
+        streamRecoveryJob?.cancel()
+        alternateModePrefetchJob?.cancel()
+        youtubeEngagementJob?.cancel()
+        motionArtworkJob?.cancel()
+        motionArtworkRequestKey = null
+        motionArtworkPrefetchJob?.cancel()
+        youtubeDislikeJob?.cancel()
+        youtubeCommentsJob?.cancel()
+        youtubeCommentsPageJob?.cancel()
+        youtubeCommentReplyJobs.values.forEach { it.cancel() }
+        youtubeCommentReplyJobs.clear()
+        youtubeCommentContinuationHistory.clear()
+        youtubeEngagementGeneration.incrementAndGet()
+    }
+
+    private suspend fun CoroutineScope.resolveAndStartPlayback(
+        track: Track,
+        requestId: Long,
+        autoRetryWhenOffline: Boolean
+    ) {
+        val playableTrack = youtubePlayableTrack(track) ?: track
+        val instant = localDownloadedTrack(track) ?: resolver.cached(playableTrack, _state.value.isVideoMode)
+        if (instant != null) {
+            if (!isActive || requestId != playRequestId) return
+            startPlayback(instant)
+            prefetchAround(instant)
+            return
+        }
+        player.stop()
+        try {
+            val playable = resolveForPlayback(track)
+            if (!isActive || requestId != playRequestId) return
+            startPlayback(playable)
+            prefetchAround(playable)
+        } catch (error: Throwable) {
+            if (error is CancellationException) throw error
+            if (!isActive || requestId != playRequestId) return
+            publishResolveFailure(track, error, requestId, autoRetryWhenOffline)
+        }
+    }
+
+    private fun publishResolveFailure(
+        track: Track,
+        error: Throwable,
+        requestId: Long,
+        autoRetryWhenOffline: Boolean
+    ) {
+        val retryWhenOnline = autoRetryWhenOffline && !hasInternetCapableNetwork()
+        player.stop()
+        _state.update {
+            it.copy(
+                isResolving = false,
+                isPlaying = false,
+                positionMs = 0L,
+                durationMs = track.durationMs,
+                currentTrack = track.copy(streamUrl = ""),
+                playerError = if (retryWhenOnline) null else cleanUserError(error)
+            )
+        }
+        if (retryWhenOnline) scheduleOfflineAutoAdvanceRetry(track, requestId)
     }
 
     private fun hasInternetCapableNetwork(): Boolean {

--- a/app/src/test/java/com/luc4n3x/levyra/player/LevyraMediaItemFactoryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/LevyraMediaItemFactoryTest.kt
@@ -1,6 +1,7 @@
 package com.luc4n3x.levyra.player
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class LevyraMediaItemFactoryTest {
@@ -16,5 +17,11 @@ class LevyraMediaItemFactoryTest {
         assertEquals("application/dash+xml", LevyraMediaItemFactory.mimeTypeFor("https://example.com/manifest.mpd", true))
         assertEquals("video/webm", LevyraMediaItemFactory.mimeTypeFor("https://example.com/videoplayback?mime=video%2Fwebm", true))
         assertEquals("video/mp4", LevyraMediaItemFactory.mimeTypeFor("https://example.com/videoplayback?mime=video%2Fmp4", true))
+    }
+
+    @Test
+    fun localContentUriUsesExtractorSniffing() {
+        assertNull(LevyraMediaItemFactory.mimeTypeFor("content://media/external/audio/media/42", false))
+        assertNull(LevyraMediaItemFactory.mimeTypeFor("file:///storage/emulated/0/Music/download", false))
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Levyra Architecture
  
-**Current application version:** 2.3.13
+**Current application version:** 2.3.15
 **Platform:** Android 8.0 and newer  
 **Primary stack:** Kotlin, Jetpack Compose, AndroidX Media3, Room, WorkManager, OkHttp, Coil
  

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ android.uniquePackageNames=false
 android.enableR8.fullMode=true
 kotlin.code.style=official
 levyraVersionName=2.3.15
-levyraVersionCode=2031300
+levyraVersionCode=2031500

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ android.nonTransitiveRClass=true
 android.uniquePackageNames=false
 android.enableR8.fullMode=true
 kotlin.code.style=official
-levyraVersionName=2.3.13
+levyraVersionName=2.3.15
 levyraVersionCode=2031300


### PR DESCRIPTION
## Summary

- Fixes playback stopping after roughly 30 minutes of screen-off background listening, both online and in offline mode.
- Includes all the offline/Doze recovery work from #200 plus additional hardening on top of it, so this PR supersedes #200.
- Adds a user-facing battery optimization exemption so vendor battery managers stop killing the playback service.

## Scope

- [x] Player / audio
- [ ] Stream extraction
- [ ] Downloads
- [x] UI / Compose
- [x] Localization
- [ ] Android Auto / media session
- [ ] CI / release
- [ ] Documentation

## What changed

- Included the full offline/Doze recovery work from the `Test` branch (#200): local `content://`/`file://` playback bypasses the online resolver, offline DNS failures no longer poison YouTube client health scores, expired client blocks are cleared on restore, sticky playback restore extended to 12 hours, Media3 wake mode switches between local and network sources, and the watchdog treats buffering as active playback.
- Relaxed the network gate from `VALIDATED` to `INTERNET`-capable for stream resolution, prefetch, background queue advancement, radio expansion and recovery paths, so playback keeps working on VPNs and networks that fail the validation probe; client health penalties remain guarded by the stricter `VALIDATED` check.
- Extended the UI recovery grace window in `PlaybackService` from a single 750 ms wait to polling for up to 6 seconds, and deferring to the UI while the player is actively buffering, preventing the service and the ViewModel from restoring the same track concurrently.
- Reset background recovery attempts once connectivity returns after an offline wait, so a temporary network loss can no longer permanently exhaust recovery and leave playback paused forever.
- Added an "Unrestricted background playback" entry in the Playback Resilience settings section that checks `PowerManager.isIgnoringBatteryOptimizations` and launches the system exemption request, refreshing its state on resume.
- Added the `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` permission to the manifest.
- Added the three new settings strings to all 26 localization bundles.

## Testing

- [ ] `gradle --no-daemon :app:lintRelease`
- [ ] `gradle --no-daemon testReleaseUnitTest`
- [ ] `gradle --no-daemon assembleRelease`
- [ ] APK installed on device
- [ ] Playback tested
- [ ] Downloads tested
- [ ] Language switching tested

Gradle could not run in the working environment because the network policy blocks `dl.google.com` (Android Gradle Plugin and SDK downloads). All modified Kotlin files were parse-checked with the standalone Kotlin 2.1.0 compiler and contain no syntax errors; localization bundles were verified to contain the new keys in every language, which the runtime `requiredKeys` validation enforces at startup. Full Gradle and on-device validation remain pending CI and device testing.

## Release safety

- [x] `levyraVersionName` and `levyraVersionCode` are correct
- [x] No secrets, keystores, APKs or ZIPs committed
- [x] No duplicated release workflows
- [x] Credits and licenses updated when adding external components

No external components or third-party code were added.

## Related issues

- Closes #
- Related to #200


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Smart Collection detail views with improved navigation.
  * Added a Settings option to exempt the app from battery optimization restrictions.
  * Improved background playback recovery and offline auto-advance behavior.

* **Bug Fixes**
  * Improved reliability when switching between local and online playback.
  * Prevented unnecessary network requests for downloaded tracks.
  * Improved handling of local media errors and unavailable connections.

* **Style**
  * Improved right-to-left icon mirroring across library and playlist screens.

* **Release**
  * Updated the app version to 2.3.15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->