### PR TITLE
ci(release): build and publish signed APK automatically

### DIFF
--- a/.github/workflows/apk-artifact-check.yml
+++ b/.github/workflows/apk-artifact-check.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
       - master
-  push:
-    branches:
-      - main
-      - master
   workflow_dispatch:
 
 permissions:
@@ -48,7 +44,7 @@ jobs:
           yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses >/dev/null || true
           "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" \
             "platform-tools" \
-            "platforms;android-36" \
+            "platforms;android-37" \
             "build-tools;36.0.0"
 
       - name: Setup Gradle
@@ -73,7 +69,7 @@ jobs:
           VERSION_CODE="$(grep -E '^levyraVersionCode=' gradle.properties | head -n 1 | cut -d '=' -f 2- | tr -d '\r' | xargs)"
           test -n "${VERSION}"
           test -n "${VERSION_CODE}"
-          printf "%s" "${VERSION_CODE}" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "${VERSION_CODE}" | grep -Eq '^[1-9][0-9]*$'
           {
             echo "VERSION=${VERSION}"
             echo "VERSION_CODE=${VERSION_CODE}"
@@ -92,7 +88,7 @@ jobs:
           test -n "${LEVYRA_KEY_ALIAS}"
           test -n "${LEVYRA_KEY_PASSWORD}"
           rm -f "${LEVYRA_KEYSTORE_FILE}"
-          printf "%s" "${LEVYRA_KEYSTORE_BASE64}" | tr -d '\r\n' | base64 --decode > "${LEVYRA_KEYSTORE_FILE}"
+          printf '%s' "${LEVYRA_KEYSTORE_BASE64}" | tr -d '\r\n' | base64 --decode > "${LEVYRA_KEYSTORE_FILE}"
           keytool -list \
             -keystore "${LEVYRA_KEYSTORE_FILE}" \
             -storepass "${LEVYRA_KEYSTORE_PASSWORD}" \
@@ -117,9 +113,9 @@ jobs:
           SIZE_BYTES="$(stat -c%s "${APK}")"
           test "${SIZE_BYTES}" -gt 1048576
           BADGING="$("${ANDROID_HOME}/build-tools/36.0.0/aapt" dump badging "${APK}")"
-          printf "%s\n" "${BADGING}" > artifacts/apk-badging.txt
-          printf "%s\n" "${BADGING}" | grep -F "versionName='${VERSION}'"
-          printf "%s\n" "${BADGING}" | grep -F "versionCode='${VERSION_CODE}'"
+          printf '%s\n' "${BADGING}" > artifacts/apk-badging.txt
+          printf '%s\n' "${BADGING}" | grep -F "versionName='${VERSION}'"
+          printf '%s\n' "${BADGING}" | grep -F "versionCode='${VERSION_CODE}'"
           "${ANDROID_HOME}/build-tools/36.0.0/apksigner" verify --verbose --print-certs "${APK}" > artifacts/apk-signing-certs.txt
           cp "${APK}" "artifacts/LEVYRA-${VERSION}.apk"
           sha256sum "artifacts/LEVYRA-${VERSION}.apk" > "artifacts/LEVYRA-${VERSION}.apk.sha256"
@@ -143,3 +139,8 @@ jobs:
           name: levyra-release-${{ env.VERSION }}-run-${{ github.run_number }}
           path: artifacts
           if-no-files-found: error
+
+      - name: Cleanup Signing Material
+        if: always()
+        shell: bash
+        run: rm -f "${LEVYRA_KEYSTORE_FILE}"

--- a/.github/workflows/apk-artifact-check.yml
+++ b/.github/workflows/apk-artifact-check.yml
@@ -44,7 +44,7 @@ jobs:
           yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses >/dev/null || true
           "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" \
             "platform-tools" \
-            "platforms;android-37" \
+            "platforms;android-36" \
             "build-tools;36.0.0"
 
       - name: Setup Gradle

--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -1,162 +1,337 @@
-name: Release APK Asset
+name: Publish Release APK
 
 on:
-  release:
-    types:
-      - published
+  push:
+    branches:
+      - main
+    paths:
+      - gradle.properties
+      - RELEASE_NOTES.md
   workflow_dispatch:
-    inputs:
-      tag:
-        description: "Existing GitHub Release tag"
-        required: true
-        type: string
 
 permissions:
-  actions: read
   contents: write
 
 concurrency:
-  group: release-apk-${{ github.event.release.tag_name || inputs.tag }}
+  group: publish-release-apk-${{ github.ref }}
   cancel-in-progress: false
 
 env:
   GH_TOKEN: ${{ github.token }}
-  RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
-  RELEASE_EVENT_ID: ${{ github.event.release.id || '' }}
+  YOUTUBE_INNERTUBE_API_KEY: ${{ secrets.YOUTUBE_INNERTUBE_API_KEY }}
+  LEVYRA_KEYSTORE_FILE: app/levyra-release.jks
+  LEVYRA_KEYSTORE_PASSWORD: ${{ secrets.LEVYRA_KEYSTORE_PASSWORD }}
+  LEVYRA_KEY_ALIAS: ${{ secrets.LEVYRA_KEY_ALIAS }}
+  LEVYRA_KEY_PASSWORD: ${{ secrets.LEVYRA_KEY_PASSWORD }}
 
 jobs:
-  publish:
-    name: Attach APK Artifact to Existing Release
+  release:
+    name: Validate, Build and Publish Signed APK
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
 
     steps:
-      - name: Checkout Release Tag
+      - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Validate Release and Version
+      - name: Resolve Release Version
+        id: version
         shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before || '' }}
         run: |
           set -euo pipefail
-          test -n "${RELEASE_TAG}"
-          if [ -n "${RELEASE_EVENT_ID}" ]; then
-            RELEASE_ID="${RELEASE_EVENT_ID}"
-          else
-            gh api --paginate "/repos/${GITHUB_REPOSITORY}/releases?per_page=100" > release-pages.jsonl
-            RELEASE_ID="$(jq -sr --arg tag "${RELEASE_TAG}" '[.[][] | select(.tag_name == $tag)] | first | .id // empty' release-pages.jsonl)"
+
+          read_property() {
+            local file="$1"
+            local key="$2"
+            grep -E "^${key}=" "${file}" | head -n 1 | cut -d '=' -f 2- | tr -d '\r' | xargs
+          }
+
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "Release publishing is allowed only from main."
+            exit 1
           fi
-          test -n "${RELEASE_ID}"
-          gh api "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" > release-before.json
-          test "$(jq -r '.tag_name' release-before.json)" = "${RELEASE_TAG}"
-          VERSION="$(grep -E '^levyraVersionName=' gradle.properties | head -n 1 | cut -d '=' -f 2- | tr -d '\r' | xargs)"
-          VERSION_CODE="$(grep -E '^levyraVersionCode=' gradle.properties | head -n 1 | cut -d '=' -f 2- | tr -d '\r' | xargs)"
+
+          VERSION="$(read_property gradle.properties levyraVersionName)"
+          VERSION_CODE="$(read_property gradle.properties levyraVersionCode)"
           test -n "${VERSION}"
           test -n "${VERSION_CODE}"
-          test "${RELEASE_TAG}" = "v${VERSION}"
-          RELEASE_SHA="$(git rev-parse HEAD)"
-          ARTIFACT_PREFIX="levyra-release-${VERSION}-run-"
+          printf '%s' "${VERSION}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)?$'
+          printf '%s' "${VERSION_CODE}" | grep -Eq '^[1-9][0-9]*$'
+
+          if [ "${GITHUB_EVENT_NAME}" = "push" ] && [ -n "${BEFORE_SHA}" ] && ! printf '%s' "${BEFORE_SHA}" | grep -Eq '^0+$'; then
+            if git cat-file -e "${BEFORE_SHA}:gradle.properties" 2>/dev/null; then
+              git show "${BEFORE_SHA}:gradle.properties" > previous-gradle.properties
+              PREVIOUS_VERSION="$(read_property previous-gradle.properties levyraVersionName)"
+              PREVIOUS_VERSION_CODE="$(read_property previous-gradle.properties levyraVersionCode)"
+
+              if [ "${VERSION}" != "${PREVIOUS_VERSION}" ] && [ "${VERSION_CODE}" = "${PREVIOUS_VERSION_CODE}" ]; then
+                echo "levyraVersionCode must change together with levyraVersionName."
+                exit 1
+              fi
+
+              if [ "${VERSION}" = "${PREVIOUS_VERSION}" ] && [ "${VERSION_CODE}" != "${PREVIOUS_VERSION_CODE}" ]; then
+                echo "levyraVersionName must change together with levyraVersionCode."
+                exit 1
+              fi
+            fi
+          fi
+
+          TAG="v${VERSION}"
           APK_NAME="LEVYRA-${VERSION}.apk"
-          jq -S '{name: (.name // ""), body: (.body // "")}' release-before.json > release-message-before.json
+          CHECKSUM_NAME="${APK_NAME}.sha256"
+          PUBLISH="true"
+
+          if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            PUBLISH="false"
+          else
+            git fetch --tags --force "https://github.com/${GITHUB_REPOSITORY}.git"
+            if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
+              TAG_SHA="$(git rev-list -n 1 "${TAG}")"
+              if [ "${TAG_SHA}" != "${GITHUB_SHA}" ]; then
+                echo "Tag ${TAG} already points to ${TAG_SHA}, not ${GITHUB_SHA}."
+                exit 1
+              fi
+            fi
+          fi
+
           {
             echo "VERSION=${VERSION}"
             echo "VERSION_CODE=${VERSION_CODE}"
-            echo "RELEASE_ID=${RELEASE_ID}"
-            echo "RELEASE_SHA=${RELEASE_SHA}"
-            echo "ARTIFACT_PREFIX=${ARTIFACT_PREFIX}"
+            echo "TAG=${TAG}"
             echo "APK_NAME=${APK_NAME}"
+            echo "CHECKSUM_NAME=${CHECKSUM_NAME}"
           } >> "${GITHUB_ENV}"
 
-      - name: Wait for Matching APK Artifact
+          echo "publish=${PUBLISH}" >> "${GITHUB_OUTPUT}"
+
+      - name: Validate Release Notes
+        if: steps.version.outputs.publish == 'true'
         shell: bash
         run: |
           set -euo pipefail
-          ARTIFACT_ID=""
-          ARTIFACT_NAME=""
-          for attempt in $(seq 1 180); do
-            rm -f artifact-pages.jsonl
-            gh api --paginate "/repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100" > artifact-pages.jsonl
-            RECORD="$(jq -sr --arg sha "${RELEASE_SHA}" --arg prefix "${ARTIFACT_PREFIX}" '[.[].artifacts[] | select(.expired == false and .workflow_run.head_sha == $sha and (.name | startswith($prefix)))] | sort_by(.created_at) | last // empty | [.id, .name] | @tsv' artifact-pages.jsonl)"
-            if [ -n "${RECORD}" ]; then
-              IFS=$'\t' read -r ARTIFACT_ID ARTIFACT_NAME <<< "${RECORD}"
-              break
-            fi
-            echo "Waiting for APK Artifact for ${RELEASE_TAG} at ${RELEASE_SHA} (${attempt}/180)"
-            sleep 20
-          done
-          test -n "${ARTIFACT_ID}"
-          test -n "${ARTIFACT_NAME}"
-          {
-            echo "ARTIFACT_ID=${ARTIFACT_ID}"
-            echo "ARTIFACT_NAME=${ARTIFACT_NAME}"
-          } >> "${GITHUB_ENV}"
 
-      - name: Download and Verify APK Artifact
+          NOTES_FILE="RELEASE_NOTES.md"
+          test -f "${NOTES_FILE}"
+          test "$(sed -n '/./{p;q;}' "${NOTES_FILE}")" = "# Levyra ${VERSION}"
+          grep -Fx -- "- Version name: \`${VERSION}\`" "${NOTES_FILE}"
+          grep -Fx -- "- Version code: \`${VERSION_CODE}\`" "${NOTES_FILE}"
+          grep -Fx -- "## Highlights" "${NOTES_FILE}"
+          grep -Fx -- "## Versioning" "${NOTES_FILE}"
+          grep -Fx -- "## Validation" "${NOTES_FILE}"
+          grep -Fx -- "## Upgrade notes" "${NOTES_FILE}"
+          grep -Fx -- "## Final note" "${NOTES_FILE}"
+
+          NOTES_BYTES="$(wc -c < "${NOTES_FILE}")"
+          test "${NOTES_BYTES}" -ge 2000
+
+          if grep -Eiq '\b(TODO|TBD|PLACEHOLDER)\b|Closes #[[:space:]]*$|Related to #[[:space:]]*$' "${NOTES_FILE}"; then
+            echo "Release notes contain unfinished placeholders."
+            exit 1
+          fi
+
+      - name: Setup Java
+        if: steps.version.outputs.publish == 'true'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Android SDK
+        if: steps.version.outputs.publish == 'true'
         shell: bash
         run: |
           set -euo pipefail
-          rm -rf downloaded-artifact artifact.zip
-          mkdir -p downloaded-artifact
-          curl --fail --location --retry 5 --retry-all-errors \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}/zip" \
-            --output artifact.zip
-          unzip -q artifact.zip -d downloaded-artifact
-          APK_PATH="$(find downloaded-artifact -type f -name "${APK_NAME}" -print -quit)"
-          CHECKSUM_PATH="$(find downloaded-artifact -type f -name "${APK_NAME}.sha256" -print -quit)"
-          test -f "${APK_PATH}"
-          test -f "${CHECKSUM_PATH}"
-          APK_SIZE="$(stat -c%s "${APK_PATH}")"
-          test "${APK_SIZE}" -gt 1048576
-          EXPECTED_SHA="$(awk 'NR == 1 {print $1}' "${CHECKSUM_PATH}")"
-          ACTUAL_SHA="$(sha256sum "${APK_PATH}" | awk '{print $1}')"
-          test -n "${EXPECTED_SHA}"
-          test "${EXPECTED_SHA}" = "${ACTUAL_SHA}"
+          yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses >/dev/null || true
+          "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" \
+            "platform-tools" \
+            "platforms;android-37" \
+            "build-tools;36.0.0"
+
+      - name: Setup Gradle
+        if: steps.version.outputs.publish == 'true'
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-disabled: true
+
+      - name: Validate Gradle Wrapper
+        if: steps.version.outputs.publish == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -x ./gradlew
+          test -f gradle/wrapper/gradle-wrapper.jar
+          test -f gradle/wrapper/gradle-wrapper.properties
+          ./gradlew --no-daemon --version
+
+      - name: Prepare Release Signing
+        if: steps.version.outputs.publish == 'true'
+        shell: bash
+        env:
+          LEVYRA_KEYSTORE_BASE64: ${{ secrets.LEVYRA_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          test -n "${YOUTUBE_INNERTUBE_API_KEY}"
+          test -n "${LEVYRA_KEYSTORE_BASE64}"
+          test -n "${LEVYRA_KEYSTORE_PASSWORD}"
+          test -n "${LEVYRA_KEY_ALIAS}"
+          test -n "${LEVYRA_KEY_PASSWORD}"
+          rm -f "${LEVYRA_KEYSTORE_FILE}"
+          printf '%s' "${LEVYRA_KEYSTORE_BASE64}" | tr -d '\r\n' | base64 --decode > "${LEVYRA_KEYSTORE_FILE}"
+          keytool -list \
+            -keystore "${LEVYRA_KEYSTORE_FILE}" \
+            -storepass "${LEVYRA_KEYSTORE_PASSWORD}" \
+            -alias "${LEVYRA_KEY_ALIAS}" \
+            >/dev/null
+
+      - name: Android Lint
+        if: steps.version.outputs.publish == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./gradlew \
+            --no-daemon \
+            --no-configuration-cache \
+            --stacktrace \
+            :app:lintRelease \
+            -PlevyraVersionName="${VERSION}" \
+            -PlevyraVersionCode="${VERSION_CODE}"
+
+      - name: Unit Tests
+        if: steps.version.outputs.publish == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          GRADLE_ARGS=(
+            --no-daemon
+            --no-configuration-cache
+            --stacktrace
+            -PlevyraVersionName="${VERSION}"
+            -PlevyraVersionCode="${VERSION_CODE}"
+          )
+
+          TASKS="$(./gradlew "${GRADLE_ARGS[@]}" :app:tasks --all)"
+          if grep -q '^testReleaseUnitTest ' <<< "${TASKS}"; then
+            ./gradlew "${GRADLE_ARGS[@]}" :app:testReleaseUnitTest
+          elif grep -q '^testDebugUnitTest ' <<< "${TASKS}"; then
+            ./gradlew "${GRADLE_ARGS[@]}" :app:testDebugUnitTest
+          elif grep -q '^test ' <<< "${TASKS}"; then
+            ./gradlew "${GRADLE_ARGS[@]}" :app:test
+          else
+            echo "No JVM unit test task is available for the app module."
+            exit 1
+          fi
+
+      - name: Build Signed Release APK
+        if: steps.version.outputs.publish == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./gradlew \
+            --no-daemon \
+            --no-configuration-cache \
+            --stacktrace \
+            :app:assembleRelease \
+            -PlevyraVersionName="${VERSION}" \
+            -PlevyraVersionCode="${VERSION_CODE}"
+
+      - name: Verify Release APK
+        if: steps.version.outputs.publish == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+          SOURCE_APK="app/build/outputs/apk/release/app-release.apk"
+          APK_PATH="release-assets/${APK_NAME}"
+          CHECKSUM_PATH="release-assets/${CHECKSUM_NAME}"
+          test -f "${SOURCE_APK}"
+
+          SIZE_BYTES="$(stat -c%s "${SOURCE_APK}")"
+          test "${SIZE_BYTES}" -gt 1048576
+
+          BADGING="$("${ANDROID_HOME}/build-tools/36.0.0/aapt" dump badging "${SOURCE_APK}")"
+          printf '%s\n' "${BADGING}" | grep -F "versionName='${VERSION}'"
+          printf '%s\n' "${BADGING}" | grep -F "versionCode='${VERSION_CODE}'"
+          "${ANDROID_HOME}/build-tools/36.0.0/apksigner" verify --verbose --print-certs "${SOURCE_APK}"
+
+          cp "${SOURCE_APK}" "${APK_PATH}"
+          sha256sum "${APK_PATH}" > "${CHECKSUM_PATH}"
+
           {
             echo "APK_PATH=${APK_PATH}"
-            echo "APK_SHA256=${ACTUAL_SHA}"
-            echo "APK_SIZE=${APK_SIZE}"
+            echo "CHECKSUM_PATH=${CHECKSUM_PATH}"
+            echo "APK_SHA256=$(sha256sum "${APK_PATH}" | awk '{print $1}')"
           } >> "${GITHUB_ENV}"
 
-      - name: Attach APK Without Changing Release Message
+      - name: Create GitHub Release and Upload APK
+        if: steps.version.outputs.publish == 'true'
         shell: bash
         run: |
           set -euo pipefail
 
-          verify_release_asset() {
-            local asset_id="$1"
-            local asset_digest="$2"
-            local expected_digest="sha256:${APK_SHA256}"
-            if [ -n "${asset_digest}" ]; then
-              test "${asset_digest}" = "${expected_digest}"
-              return
-            fi
-            rm -f existing-release-asset.apk
-            curl --fail --location --retry 5 --retry-all-errors \
-              -H "Accept: application/octet-stream" \
-              -H "Authorization: Bearer ${GH_TOKEN}" \
-              "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" \
-              --output existing-release-asset.apk
-            test "$(sha256sum existing-release-asset.apk | awk '{print $1}')" = "${APK_SHA256}"
-          }
+          RELEASE_FLAGS=(
+            --target "${GITHUB_SHA}"
+            --title "Levyra ${VERSION}"
+            --notes-file RELEASE_NOTES.md
+            --repo "${GITHUB_REPOSITORY}"
+          )
 
-          gh api "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" > release-current.json
-          EXISTING_ID="$(jq -r --arg name "${APK_NAME}" '.assets[]? | select(.name == $name) | .id' release-current.json | head -n 1)"
-          EXISTING_DIGEST="$(jq -r --arg name "${APK_NAME}" '.assets[]? | select(.name == $name) | .digest // empty' release-current.json | head -n 1)"
-          if [ -n "${EXISTING_ID}" ]; then
-            verify_release_asset "${EXISTING_ID}" "${EXISTING_DIGEST}"
+          if [[ "${VERSION}" == *-* ]]; then
+            RELEASE_FLAGS+=(--prerelease)
           else
-            gh release upload "${RELEASE_TAG}" "${APK_PATH}" --repo "${GITHUB_REPOSITORY}"
+            RELEASE_FLAGS+=(--latest)
           fi
-          gh api "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" > release-after.json
-          jq -S '{name: (.name // ""), body: (.body // "")}' release-after.json > release-message-after.json
-          cmp --silent release-message-before.json release-message-after.json
-          FINAL_ID="$(jq -r --arg name "${APK_NAME}" '.assets[]? | select(.name == $name) | .id' release-after.json | head -n 1)"
-          FINAL_DIGEST="$(jq -r --arg name "${APK_NAME}" '.assets[]? | select(.name == $name) | .digest // empty' release-after.json | head -n 1)"
-          test -n "${FINAL_ID}"
-          verify_release_asset "${FINAL_ID}" "${FINAL_DIGEST}"
-          echo "Attached ${APK_NAME} from ${ARTIFACT_NAME} to ${RELEASE_TAG} without modifying the release title or message."
+
+          gh release create "${TAG}" \
+            "${APK_PATH}#LEVYRA Android APK" \
+            "${CHECKSUM_PATH}#SHA-256 checksum" \
+            "${RELEASE_FLAGS[@]}"
+
+      - name: Verify Published Release
+        if: steps.version.outputs.publish == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf release-verification
+          mkdir -p release-verification
+
+          gh release download "${TAG}" \
+            --pattern "${APK_NAME}" \
+            --pattern "${CHECKSUM_NAME}" \
+            --dir release-verification \
+            --clobber \
+            --repo "${GITHUB_REPOSITORY}"
+
+          PUBLISHED_APK="release-verification/${APK_NAME}"
+          PUBLISHED_CHECKSUM="release-verification/${CHECKSUM_NAME}"
+          test -f "${PUBLISHED_APK}"
+          test -f "${PUBLISHED_CHECKSUM}"
+          test "$(sha256sum "${PUBLISHED_APK}" | awk '{print $1}')" = "${APK_SHA256}"
+          test "$(awk 'NR == 1 {print $1}' "${PUBLISHED_CHECKSUM}")" = "${APK_SHA256}"
+
+          gh release view "${TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --json body,isDraft,isPrerelease,name,tagName,url \
+            > published-release.json
+
+          test "$(jq -r '.tagName' published-release.json)" = "${TAG}"
+          test "$(jq -r '.name' published-release.json)" = "Levyra ${VERSION}"
+          test "$(jq -r '.isDraft' published-release.json)" = "false"
+          jq -r '.body' published-release.json | grep -Fx "# Levyra ${VERSION}"
+          jq -r '.body' published-release.json | grep -Fx -- "- Version code: \`${VERSION_CODE}\`"
+          jq -r '.url' published-release.json
+
+      - name: Skip Existing Release
+        if: steps.version.outputs.publish != 'true'
+        shell: bash
+        run: echo "Release ${TAG} already exists; no assets or release notes were overwritten."
+
+      - name: Cleanup Signing Material
+        if: always()
+        shell: bash
+        run: rm -f "${LEVYRA_KEYSTORE_FILE}"

--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -149,7 +149,7 @@ jobs:
           yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses >/dev/null || true
           "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" \
             "platform-tools" \
-            "platforms;android-37" \
+            "platforms;android-36" \
             "build-tools;36.0.0"
 
       - name: Setup Gradle

--- a/.github/workflows/release-guard.yml
+++ b/.github/workflows/release-guard.yml
@@ -9,6 +9,7 @@ on:
       - gradle.properties
       - app/build.gradle.kts
       - README.md
+      - RELEASE_NOTES.md
       - .github/workflows/apk-artifact-check.yml
       - .github/workflows/release-apk.yml
       - .github/workflows/release-guard.yml
@@ -48,7 +49,7 @@ jobs:
           VERSION="$(read_property levyraVersionName)"
           VERSION_CODE="$(read_property levyraVersionCode)"
 
-          if ! printf "%s" "${VERSION}" | grep -Eq '^[0-9]+(\.[0-9]+){0,3}([-+][0-9A-Za-z.-]+)?$'; then
+          if ! printf '%s' "${VERSION}" | grep -Eq '^[0-9]+(\.[0-9]+){0,3}([-+][0-9A-Za-z.-]+)?$'; then
             echo "Invalid levyraVersionName: ${VERSION}" >&2
             exit 1
           fi
@@ -86,13 +87,38 @@ jobs:
           grep -F "\"${VERSION}\"" app/build.gradle.kts >/dev/null
           grep -F "levyraVersionName=${VERSION}" README.md >/dev/null
           grep -F "levyraVersionCode=${VERSION_CODE}" README.md >/dev/null
-          test -f .github/workflows/release-apk.yml
-          grep -F "types:" .github/workflows/release-apk.yml >/dev/null
-          grep -F -- "- published" .github/workflows/release-apk.yml >/dev/null
-          grep -F "actions/artifacts" .github/workflows/release-apk.yml >/dev/null
-          grep -Eq 'gh[[:space:]]+release[[:space:]]+upload' .github/workflows/release-apk.yml
-          if grep -Eq 'gh[[:space:]]+release[[:space:]]+(create|edit)|generate[_-]release[_-]notes|generate-notes' .github/workflows/release-apk.yml; then
-            echo "release-apk.yml must not create releases or modify manually written release messages" >&2
+
+          NOTES_FILE="RELEASE_NOTES.md"
+          test -f "${NOTES_FILE}"
+          test "$(sed -n '/./{p;q;}' "${NOTES_FILE}")" = "# Levyra ${VERSION}"
+          grep -Fx -- "- Version name: \`${VERSION}\`" "${NOTES_FILE}" >/dev/null
+          grep -Fx -- "- Version code: \`${VERSION_CODE}\`" "${NOTES_FILE}" >/dev/null
+          grep -Fx "## Highlights" "${NOTES_FILE}" >/dev/null
+          grep -Fx "## Versioning" "${NOTES_FILE}" >/dev/null
+          grep -Fx "## Validation" "${NOTES_FILE}" >/dev/null
+          grep -Fx "## Upgrade notes" "${NOTES_FILE}" >/dev/null
+          grep -Fx "## Final note" "${NOTES_FILE}" >/dev/null
+          test "$(wc -c < "${NOTES_FILE}")" -ge 2000
+
+          RELEASE_WORKFLOW=".github/workflows/release-apk.yml"
+          test -f "${RELEASE_WORKFLOW}"
+          grep -F "gradle.properties" "${RELEASE_WORKFLOW}" >/dev/null
+          grep -F "RELEASE_NOTES.md" "${RELEASE_WORKFLOW}" >/dev/null
+          grep -F ":app:lintRelease" "${RELEASE_WORKFLOW}" >/dev/null
+          grep -F ":app:assembleRelease" "${RELEASE_WORKFLOW}" >/dev/null
+          grep -F "LEVYRA_KEYSTORE_BASE64" "${RELEASE_WORKFLOW}" >/dev/null
+          grep -F "apksigner" "${RELEASE_WORKFLOW}" >/dev/null
+          grep -F "sha256sum" "${RELEASE_WORKFLOW}" >/dev/null
+          grep -Eq 'gh[[:space:]]+release[[:space:]]+create' "${RELEASE_WORKFLOW}"
+          grep -F -- "--notes-file RELEASE_NOTES.md" "${RELEASE_WORKFLOW}" >/dev/null
+
+          if grep -Eq 'actions/artifacts|Wait for Matching APK Artifact|Download and Verify APK Artifact' "${RELEASE_WORKFLOW}"; then
+            echo "release-apk.yml must build the signed APK directly and must not consume workflow artifacts" >&2
+            exit 1
+          fi
+
+          if grep -Eq 'generate[_-]release[_-]notes|generate-notes' "${RELEASE_WORKFLOW}"; then
+            echo "release-apk.yml must use the curated RELEASE_NOTES.md body" >&2
             exit 1
           fi
 
@@ -101,6 +127,8 @@ jobs:
             echo "version=${VERSION}"
             echo "versionCode=${VERSION_CODE}"
             echo "tag=v${VERSION}"
+            echo "releaseNotes=${NOTES_FILE}"
+            echo "publisher=${RELEASE_WORKFLOW}"
           } | tee release-guard-result.txt
 
       - name: Upload Guard Result

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,326 @@
+# Levyra 2.3.15
+
+Levyra 2.3.15 is a stability-focused release built around one simple goal: music should keep playing, regardless of whether the screen is off, the device enters Doze, the connection drops, or the current track comes from local storage.
+
+This update also improves the Library experience with dedicated smart collection pages, more predictable back navigation, and a cleaner distinction between browsing music and starting playback.
+
+---
+
+## Highlights
+
+- More reliable background playback during screen-off sessions and Android Doze.
+- Stronger recovery after temporary network loss, service recreation, or a stalled player.
+- Correct offline playback for downloaded tracks using their real local URI.
+- Smart Library pages for Favorites, Recently Played, and Most Played.
+- Improved back navigation between Library sections, albums, artists, playlists, and overlays.
+- Optional battery optimization exemption available directly from Levyra settings.
+- Better resolver behavior when a cached or persisted source is already available offline.
+- Safer playback recovery without unnecessary CPU wake time or repeated network failures.
+
+---
+
+## Background playback that stays alive
+
+Long listening sessions are now significantly more resilient.
+
+The playback service has been hardened to survive the situations that commonly interrupt audio on modern Android devices:
+
+- the screen remains off for an extended period;
+- Android enters Doze or app standby;
+- the app process is recreated while playback was expected;
+- the current connection disappears and returns later;
+- the player becomes stuck in a buffering state;
+- the UI is no longer active while the playback service continues in the background.
+
+Sticky playback restoration now remains valid for a much longer recovery window instead of being abandoned after roughly 30 minutes.
+
+The service also preserves the expected playback state while a background restoration is still pending. This prevents the watchdog from incorrectly deciding that playback was intentionally stopped simply because the newly recreated player does not yet have a media item.
+
+---
+
+## Smarter recovery after connection loss
+
+Online playback recovery now waits for connectivity without permanently exhausting all retry attempts.
+
+When the network disappears:
+
+- recovery attempts are paused instead of wasted;
+- the playback wake lock is released while waiting;
+- the CPU is not kept awake throughout airplane mode or a prolonged outage;
+- retry counters are reset once connectivity returns;
+- the service resumes recovery from the previous playback position.
+
+This prevents a temporary connection problem from leaving Levyra permanently paused after the network becomes available again.
+
+The service also gives the UI recovery path more time to complete before attempting its own restoration. This reduces duplicate recovery operations and avoids the service and ViewModel trying to replace the same stream at the same time.
+
+---
+
+## Better support for VPNs and unusual networks
+
+Stream resolution, queue advancement, radio expansion, prefetching, and background recovery now accept networks that advertise Internet capability even when Android has not marked them as fully validated.
+
+This is useful for:
+
+- VPN connections;
+- private DNS configurations;
+- captive or partially validated networks;
+- devices where Android's validation probe is delayed or blocked.
+
+Strict validation is still used where appropriate for provider health accounting, so a questionable connection does not unfairly damage resolver client scores.
+
+---
+
+## Offline playback rebuilt around local media
+
+Downloaded tracks now play directly from their stored `content://` or `file://` URI.
+
+Local playback no longer depends on online YouTube resolution and no longer triggers unrelated network work such as:
+
+- stream re-resolution;
+- online prefetching;
+- radio expansion;
+- SponsorBlock requests;
+- motion artwork prefetch;
+- remote playback recovery.
+
+Levyra now automatically switches Media3 wake behavior between local and network playback sources.
+
+Local files without a recognizable extension are also handled more safely by allowing Media3 to inspect the actual container instead of forcing an incorrect MIME type.
+
+---
+
+## Clear errors for missing or damaged downloads
+
+Local playback failures are no longer silently swallowed.
+
+When a downloaded file has been removed, cannot be read, is corrupted, or uses an unsupported format, Levyra now:
+
+- stops the unsuccessful recovery loop;
+- pauses playback cleanly;
+- clears the loading state;
+- reports a visible error to the interface.
+
+This makes offline failures understandable instead of leaving the user with a player that simply stops without explanation.
+
+---
+
+## Cached playback remains available offline
+
+The playback resolver now checks every source that can work without a new network request before requiring connectivity.
+
+The resolution order is now effectively:
+
+1. local file;
+2. already resolved and still-valid stream URL;
+3. in-memory cache;
+4. persisted playback source or manifest;
+5. network availability;
+6. fresh online extraction.
+
+The same principle applies to prefetching: Levyra first checks an already resolved stream and existing cache before deciding that offline mode prevents the operation.
+
+This avoids blocking music that is already available locally or through a still-valid persisted source.
+
+---
+
+## Resolver health no longer degrades while offline
+
+Temporary DNS failures and connection loss no longer poison YouTube client health scores.
+
+When Android reports no validated connection, Levyra avoids treating network-level failures as provider failures. Expired client blocks are also normalized when resolver health is restored.
+
+This prevents all playback clients from becoming heavily penalized simply because the device spent time offline.
+
+---
+
+## More reliable queue continuation
+
+Automatic queue advancement now understands temporary offline conditions.
+
+When the current track finishes but the next online track cannot be resolved because connectivity is unavailable, Levyra can wait and retry once the network returns instead of immediately surfacing a permanent failure.
+
+Continuous radio also avoids running for local tracks or when there is no usable connection.
+
+---
+
+## Smart Library collections
+
+Favorites, Recently Played, and Most Played are now real Library destinations.
+
+Tapping one of these cards no longer starts the first track immediately. Each collection opens a dedicated page with:
+
+- a clear title and description;
+- track count;
+- artwork-led presentation;
+- full track list;
+- Play button;
+- Shuffle button;
+- favorite and download actions;
+- current-track and playback indicators.
+
+Playback starts only when the user explicitly selects a track or presses Play or Shuffle.
+
+This makes the Library feel more like a complete music app and less like a set of playback shortcuts.
+
+---
+
+## Improved back navigation
+
+Back navigation is now more predictable across the app.
+
+Inside the Library:
+
+- Back closes an active selection first;
+- Back closes an open smart collection and returns to the Library overview;
+- Back from another Library category returns to the overview instead of jumping to Home;
+- previous scroll positions are preserved when moving between Library sections.
+
+Album and artist navigation now keeps a lightweight history stack, allowing flows such as:
+
+- Artist → Album → Back to Artist;
+- Album → Artist → Back to Album;
+- Album → another Album → Back to the previous Album.
+
+The central back handler continues to close overlays, playlists, download folders, settings panels, lyrics, queues, and other temporary screens before leaving the current area.
+
+---
+
+## Battery optimization controls
+
+Levyra now includes an optional **Unrestricted background playback** entry in the Playback Resilience settings section.
+
+The setting:
+
+- checks whether Android is currently ignoring battery optimizations for Levyra;
+- opens the system exemption screen when requested;
+- refreshes its status when returning to the app;
+- remains user-initiated instead of forcing a battery prompt during startup.
+
+This is especially useful on devices with aggressive background limits, where the operating system may still stop a correctly implemented foreground playback service.
+
+---
+
+## Download playback cleanup
+
+Starting a downloaded track now uses the same playback initialization path as other tracks.
+
+This ensures that Levyra correctly resets:
+
+- stale lyrics;
+- YouTube engagement data;
+- comments and replies;
+- motion artwork;
+- previous recovery jobs;
+- old prefetch work;
+- active crossfade state.
+
+The player volume is also restored to full level when a previous crossfade is cancelled, preventing downloaded tracks from starting nearly silent.
+
+Downloaded tracks are always forced into audio mode.
+
+---
+
+## Player watchdog improvements
+
+The playback watchdog now treats both `READY` and `BUFFERING` as active playback states.
+
+If playback is expected but the position stops advancing for too long, Levyra can trigger a controlled restoration from the current position.
+
+The watchdog also respects active recovery operations and does not clear persisted playback state while restoration is still in progress.
+
+---
+
+## Media item handling
+
+Media item creation is more flexible for local sources.
+
+- `content://` URIs no longer receive a forced MIME type when the real type is unknown.
+- Extensionless `file://` sources can be inspected by Media3.
+- Video MIME metadata is only added when a valid value is available.
+- Local and online media continue to use the correct playback mode and wake behavior.
+
+Regression coverage has been added for local URI handling.
+
+---
+
+## Localization
+
+The new battery optimization setting has been added across all supported localization bundles.
+
+The release also keeps runtime localization validation intact, ensuring that required keys remain available for every supported language.
+
+---
+
+## Internal stability work
+
+This release includes several structural improvements intended to make future playback work safer:
+
+- background recovery logic split into smaller, clearer functions;
+- radio tail loading separated into request, validation, and append stages;
+- side-job cancellation consolidated before resolving a new track;
+- online and local recovery paths kept separate;
+- recovery state reset after healthy playback resumes;
+- foreground service state protected during task removal;
+- persistent queue restoration reused by sticky playback recovery.
+
+These changes reduce duplicated logic and make failure handling easier to reason about without changing the expected user-facing flow.
+
+---
+
+## Versioning
+
+- Version name: `2.3.15`
+- Version code: `2031500`
+
+The version code now correctly matches the 2.3.15 release line.
+
+---
+
+## Validation
+
+The release workflow is expected to validate:
+
+- Android Lint;
+- release unit tests;
+- release Kotlin compilation;
+- signed APK generation;
+- release metadata and version consistency;
+- duplicate workflow protection;
+- APK size reporting.
+
+On-device verification should cover:
+
+- at least 45–60 minutes of screen-off playback;
+- online playback through a temporary connection loss;
+- playback after Android recreates the service;
+- offline playback from downloaded tracks;
+- a missing or deleted local file;
+- queue advancement while offline and after reconnecting;
+- Library smart collection navigation;
+- Album → Artist → Album back navigation;
+- playback with battery optimization enabled and exempted.
+
+---
+
+## Upgrade notes
+
+No library migration or manual data reset is required.
+
+Existing favorites, playlists, listening history, downloads, queue state, and settings remain compatible with this release.
+
+For the most reliable long-running playback on devices with aggressive battery management, open:
+
+**Settings → Playback Resilience → Unrestricted background playback**
+
+and grant the system exemption when needed.
+
+---
+
+## Final note
+
+Levyra 2.3.15 is less about adding another flashy feature and more about making the features already there behave like they should.
+
+Music should not stop because the screen has been off for a while. A temporary outage should not destroy the playback session. Opening a Library collection should not unexpectedly start a song. Pressing Back should take you somewhere that makes sense.
+
+This release moves Levyra much closer to that standard.


### PR DESCRIPTION
## Summary

- Replace the artifact-dependent release publisher with a direct signed APK build and automatic GitHub Release publication.
- Use curated, version-validated release notes instead of autogenerated GitHub notes.

## Scope

- [ ] Player / audio
- [ ] Stream extraction
- [ ] Downloads
- [ ] UI / Compose
- [ ] Localization
- [ ] Android Auto / media session
- [x] CI / release
- [x] Documentation

## What changed

- Added `RELEASE_NOTES.md` with the complete Levyra 2.3.15 release message.
- Trigger release publishing when `levyraVersionName`, `levyraVersionCode`, or the release notes are updated on `main`.
- Require version name and version code to change together.
- Validate the release-note title, version metadata, required sections, minimum content length, and unfinished placeholders.
- Run Android Lint and the available app unit-test task before building.
- Build the signed release APK directly with the production keystore secrets.
- Verify APK size, version name, version code, signature, and SHA-256 checksum.
- Create the `v<version>` tag and GitHub Release automatically.
- Publish `LEVYRA-<version>.apk` and its checksum as release assets.
- Verify the uploaded APK and release metadata after publication.
- Never overwrite an existing release or its notes.
- Removed the `main` push trigger from the APK artifact workflow so release publishing no longer performs a duplicate artifact build.

## Testing

- [ ] GitHub Actions workflow syntax validated by CI
- [ ] `:app:lintRelease`
- [ ] App JVM unit tests
- [ ] `:app:assembleRelease`
- [ ] APK signature and version metadata verified
- [ ] GitHub Release asset checksum verified

## Release safety

- [x] Production signing remains secret-backed
- [x] Existing releases and release notes are never overwritten
- [x] Version name and version code must remain synchronized
- [x] Release body must match the version being published
- [x] No APK, keystore, or secret committed
- [x] Release publishing no longer depends on GitHub Actions artifacts

## Usage

For each release:

1. Update `levyraVersionName` and `levyraVersionCode` in `gradle.properties`.
2. Replace `RELEASE_NOTES.md` with the complete release text for that version.
3. Push or merge both changes into `main`.

The workflow validates, builds, signs, creates the release, uploads the APK, and verifies the published asset automatically.