### PR TITLE
fix(release): write APK basename in checksum

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -260,7 +260,7 @@ jobs:
           "${ANDROID_HOME}/build-tools/36.0.0/apksigner" verify --verbose --print-certs "${SOURCE_APK}"
 
           cp "${SOURCE_APK}" "${APK_PATH}"
-          sha256sum "${APK_PATH}" > "${CHECKSUM_PATH}"
+          (cd release-assets && sha256sum "${APK_NAME}" > "${CHECKSUM_NAME}")
 
           {
             echo "APK_PATH=${APK_PATH}"


### PR DESCRIPTION
## Summary

- Generate the SHA-256 file from inside `release-assets`.
- Store only `LEVYRA-<version>.apk` in the checksum instead of the `release-assets/` path.

## Why

Downloaded release assets are placed side by side. Recording the directory prefix caused `sha256sum -c` to look for a missing `release-assets` subdirectory.

## Validation

- Diff contains one addition and one deletion in `.github/workflows/release-apk.yml`.
- No release, versioning, signing, build, or publishing behavior was otherwise changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release APK checksum generation to ensure the checksum file is created correctly in the release assets directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->