### PR TITLE
fix: use available Android SDK in F-Droid release

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -460,7 +460,7 @@ jobs:
           yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses >/dev/null || true
           "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" \
             "platform-tools" \
-            "platforms;android-37" \
+            "platforms;android-36" \
             "build-tools;36.0.0"
 
       - name: Setup Gradle


### PR DESCRIPTION
## Summary

Use the same available Android 36 SDK package installation as the validated release and PR workflows. The Ubuntu runner already provides the compile SDK used by the project; explicitly requesting `platforms;android-37` fails because that package is not exposed by the runner's sdkmanager repository.

## Evidence

The manual F-Droid release run `29948073751` stopped in `Setup Android SDK` with `Failed to find package 'platforms;android-37'`, before Gradle or signing material were reached. YAML parsing, actionlint 1.7.12, and `git diff --check` pass after this one-line fix.

Version remains `2.3.15` (`2031500`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Android build environment to use Android platform version 36 for release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->