### PR TITLE
fix: install compile SDK 37 for releases

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -152,7 +152,7 @@ jobs:
           yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses >/dev/null || true
           "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" \
             "platform-tools" \
-            "platforms;android-36" \
+            "platforms;android-37.0" \
             "build-tools;36.0.0"
 
       - name: Setup Gradle
@@ -460,7 +460,7 @@ jobs:
           yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses >/dev/null || true
           "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" \
             "platform-tools" \
-            "platforms;android-36" \
+            "platforms;android-37.0" \
             "build-tools;36.0.0"
 
       - name: Setup Gradle


### PR DESCRIPTION
## Summary
- install the exact Android 37.0 platform package required by compileSdk 37
- apply the fix to both canonical and F-Droid release jobs

## Validation
- actionlint
- YAML parse
- git diff --check

This does not change Levyra 2.3.15 or its versionCode.