### PR TITLE
fix: remove non-free Cronet dependency

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -14,6 +14,11 @@ on:
         required: false
         type: boolean
         default: false
+      fdroid_release_suffix:
+        description: "Optional suffix for a corrected F-Droid build of the same app version"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -394,6 +399,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          FDROID_RELEASE_SUFFIX: ${{ inputs.fdroid_release_suffix || '' }}
         run: |
           set -euo pipefail
 
@@ -406,7 +412,12 @@ jobs:
           VERSION_CODE="$(read_property levyraVersionCode)"
           printf '%s' "${VERSION}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)?$'
           printf '%s' "${VERSION_CODE}" | grep -Eq '^[1-9][0-9]*$'
-          FDROID_TAG="fdroid-${VERSION}"
+          if [[ -n "${FDROID_RELEASE_SUFFIX}" ]]; then
+            printf '%s' "${FDROID_RELEASE_SUFFIX}" | grep -Eq '^[0-9A-Za-z][0-9A-Za-z.-]*$'
+            FDROID_TAG="fdroid-${VERSION}-${FDROID_RELEASE_SUFFIX}"
+          else
+            FDROID_TAG="fdroid-${VERSION}"
+          fi
           FDROID_APK_NAME="LEVYRA-${VERSION}-fdroid.apk"
           FDROID_CHECKSUM_NAME="${FDROID_APK_NAME}.sha256"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -226,6 +226,7 @@ dependencies {
     implementation(libs.androidx.media3.datasource.okhttp)
     implementation(libs.androidx.media3.datasource.cronet) {
         exclude(group = "org.chromium.net", module = "cronet-api")
+        exclude(group = "com.google.android.gms", module = "play-services-cronet")
     }
     implementation(libs.chromium.cronet.embedded)
     implementation(libs.androidx.media3.datasource)


### PR DESCRIPTION
## Summary
- exclude Google Play Services Cronet pulled transitively by Media3
- keep the bundled open-source Cronet transport and OkHttp fallback unchanged
- allow a suffixed F-Droid prerelease tag for a corrected reproducible build of 2.3.15

## Validation
- :app:dependencyInsight confirms play-services-cronet is absent
- cronet-embedded:143.7445.0 remains present
- :app:assembleRelease -PlevyraFdroidBuild=true passed
- :app:lintRelease -PlevyraFdroidBuild=true passed
- git diff --check passed
- version remains 2.3.15 / 2031500

## Notes
The full local unit suite ran 283 tests with 7 unrelated existing failures; CI is the clean verification source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Management**
  - F-Droid releases can now be published under distinct tags for corrected builds, making updated release artifacts easier to identify and verify.

- **Bug Fixes**
  - Improved Android build compatibility by preventing conflicting Cronet components from being included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->