### PR TITLE
fix: use Java 21 for F-Droid builds

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -104,6 +104,12 @@ jobs:
       - name: Release Compile
         run: ./gradlew --no-daemon --no-configuration-cache assembleRelease
 
+      - name: Setup Java 21 for F-Droid
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
       - name: F-Droid Release Compile
         shell: bash
         env:

--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -462,7 +462,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "21"
 
       - name: Setup Android SDK
         shell: bash

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -198,7 +198,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(if (isFdroidBuild) 21 else 17)
 }
 
 configurations.configureEach {


### PR DESCRIPTION
## Summary
- use Java 21 only when levyraFdroidBuild=true, matching the current F-Droid Debian runner
- keep regular Levyra builds on Java 17
- configure the F-Droid release job and PR verification accordingly

## Validation
- F-Droid ssembleRelease passed locally with Java 21
- regular compileDebugKotlin passed with Java 17
- version remains 2.3.15 / 2031500
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated F-Droid release builds to use Java 21.
  * Configured F-Droid builds to compile with Java 21 while preserving Java 17 for other builds.
  * Added Java 21 setup to the F-Droid release workflow for more consistent build execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->