### PR TITLE
fix: preserve reproducible F-Droid native library

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -187,6 +187,14 @@ android {
     }
 
     packaging {
+        jniLibs {
+            if (isFdroidBuild) {
+                // F-Droid's build server has no NDK strip tool, while GitHub's
+                // runner does. Preserve this prebuilt library in both builds so
+                // the upstream-signed and F-Droid-rebuilt APKs are identical.
+                keepDebugSymbols += "**/libdatastore_shared_counter.so"
+            }
+        }
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
             excludes += "/META-INF/versions/**"


### PR DESCRIPTION
## Summary
- keep AndroidX DataStore's prebuilt native library unstripped for F-Droid builds
- make GitHub's signed APK byte-compatible with the F-Droid build server, which has no NDK strip tool
- leave normal builds, version 2.3.15, and signing configuration unchanged

## Verification
- F-Droid assembleRelease on Java 21: passed
- normal compileDebugKotlin on Java 17: passed
- corrected native-library SHA-256 values match the F-Droid runner artifact for all four ABIs
- git diff --check: passed