### PR TITLE
fix: omit dependency metadata from F-Droid APK

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -177,6 +177,11 @@ android {
         buildConfig = true
     }
 
+    dependenciesInfo {
+        includeInApk = !isFdroidBuild
+        includeInBundle = !isFdroidBuild
+    }
+
     lint {
         // The whole player layer is built on media3, whose APIs are annotated
         // @UnstableApi. UnsafeOptInUsageError targets library authors who expose


### PR DESCRIPTION
## Summary
- omit AGP dependency metadata from the F-Droid APK only
- satisfy F-Droid's APK scanner without changing version, signer, or normal releases

## Verification
- Java 21 F-Droid assembleRelease passed
- previous F-Droid source build and reproducibility verification passed; the only remaining CI finding was the dependency metadata signing block
- git diff --check passed