### PR TITLE
fix: automate stable F-Droid release tags

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -15,10 +15,10 @@ on:
         type: boolean
         default: false
       fdroid_release_suffix:
-        description: "Optional suffix for a corrected F-Droid build of the same app version"
+        description: "F-Droid release suffix; keep r5 for the automatic update channel"
         required: false
         type: string
-        default: ""
+        default: "r5"
 
 permissions:
   contents: write
@@ -399,7 +399,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          FDROID_RELEASE_SUFFIX: ${{ inputs.fdroid_release_suffix || '' }}
+          FDROID_RELEASE_SUFFIX: ${{ inputs.fdroid_release_suffix || 'r5' }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary
- default F-Droid release suffix to the stable 5 channel
- make version-bump pushes publish the exact droid-%v-r5 URL expected by fdroiddata
- keep manual correction suffixes available

## Verification
- workflow YAML parsed successfully
- automatic workflow suffix matches the fdroiddata Binaries URL
- push-trigger condition still requires a newly published canonical release
- version remains 2.3.15 / 2031500
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the F-Droid release workflow to use the `r5` release suffix by default.
  * Improved automatic release and verification behavior when no suffix is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->