### PR TITLE
Make home mood-aware with adaptive artwork background and progressive rendering

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/HomeEditorialEngine.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/HomeEditorialEngine.kt
@@ -47,6 +47,7 @@ object HomeEditorialEngine {
         quickPickTracks: List<Track>,
         fallbackSections: List<List<Track>>,
         chartTracks: List<Track>,
+        preferenceScore: (Track) -> Int = { 0 },
         nowMillis: Long = System.currentTimeMillis()
     ): List<HomeSpotlightCandidate> {
         val sourcePriority = LinkedHashMap<String, Int>()
@@ -105,11 +106,12 @@ object HomeEditorialEngine {
             }
             val metadataScore = track.metadataConfidence.coerceIn(0, 100) * 2
             val engagementScore = (track.replayScore + track.cacheScore + track.energy / 2).coerceIn(0, 260)
+            val preferenceBoost = preferenceScore(track).coerceIn(0, 6_000)
             val stableDailyJitter = stableHash("$daySeed|${track.id}|${track.title}|${track.artist}") % 97
             HomeSpotlightCandidate(
                 track = track,
                 kind = kind,
-                score = freshnessScore + sourcePriority.getValue(key) + artworkScore + metadataScore + engagementScore + stableDailyJitter,
+                score = freshnessScore + sourcePriority.getValue(key) + artworkScore + metadataScore + engagementScore + preferenceBoost + stableDailyJitter,
                 releaseAgeDays = ageDays
             )
         }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -5192,6 +5192,18 @@ private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnaps
         }
     }
     val spotlightTracks = remember(spotlightCandidates) { spotlightCandidates.map { it.track } }
+    var homeAccentStart by remember { mutableStateOf(Color(0xFF071019)) }
+    var homeAccentEnd by remember { mutableStateOf(Color(0xFF160E24)) }
+    val animatedHomeAccentStart by animateColorAsState(
+        targetValue = homeAccentStart,
+        animationSpec = tween(520, easing = FastOutSlowInEasing),
+        label = "homeAccentStart"
+    )
+    val animatedHomeAccentEnd by animateColorAsState(
+        targetValue = homeAccentEnd,
+        animationSpec = tween(520, easing = FastOutSlowInEasing),
+        label = "homeAccentEnd"
+    )
     val visiblePersonalTracks = remember(personalTracks, spotlightCandidate?.track?.id) {
         personalTracks.filterNot { it.id == spotlightCandidate?.track?.id }
     }
@@ -5204,6 +5216,12 @@ private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnaps
     val chartChunks = homeDerivedState.chartChunks
     val homeContent = homeDerivedState.contentAvailability
     val homeFingerprint = homeDerivedState.contentFingerprint
+    var showDeferredHomeSections by remember(homeFingerprint) { mutableStateOf(false) }
+    LaunchedEffect(homeFingerprint) {
+        showDeferredHomeSections = false
+        delay(180L)
+        showDeferredHomeSections = true
+    }
     val showHomeAlbumShimmer = HomeLoadingPolicy.showAlbumShimmer(homeContent, state.homeAlbumsLoading)
     val showChartShimmer = HomeLoadingPolicy.showChartShimmer(homeContent, state.isLoadingCharts)
     LaunchedEffect(homeFingerprint) {
@@ -5236,7 +5254,22 @@ private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnaps
             }
         }
     }
-    LazyColumn(
+    Box(modifier = Modifier.fillMaxSize()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(430.dp)
+                .background(
+                    Brush.verticalGradient(
+                        listOf(
+                            animatedHomeAccentStart.copy(alpha = 0.28f),
+                            animatedHomeAccentEnd.copy(alpha = 0.14f),
+                            Color.Transparent
+                        )
+                    )
+                )
+        )
+        LazyColumn(
         state = homeListState,
         modifier = Modifier.fillMaxSize().statusBarsPadding(),
         contentPadding = PaddingValues(top = 8.dp, bottom = if (state.currentTrack != null) 188.dp else 104.dp),
@@ -5260,6 +5293,10 @@ private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnaps
                         isPlaying = state.isPlaying && heroTrack.id == state.currentTrack?.id,
                         isResolving = state.isResolving && heroTrack.id == state.currentTrack?.id,
                         animationsEnabled = state.animationsEnabled,
+                        onPaletteChanged = { start, end ->
+                            homeAccentStart = start
+                            homeAccentEnd = end
+                        },
                         onOpen = {
                             stableSpotlightId = heroTrack.id
                             viewModel.playFrom(spotlightTracks, heroTrack)
@@ -5297,7 +5334,7 @@ private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnaps
                 )
             }
         }
-        if (state.interfaceSettings.showResonance && resonanceTracks.isNotEmpty()) {
+        if (showDeferredHomeSections && state.interfaceSettings.showResonance && resonanceTracks.isNotEmpty()) {
             item(key = "home-resonance", contentType = "home-shelf") {
                 ResonanceShelf(
                     tracks = resonanceTracks,
@@ -5309,7 +5346,7 @@ private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnaps
                 )
             }
         }
-        if (quickPicks != null && quickPicks.tracks.isNotEmpty()) {
+        if (showDeferredHomeSections && quickPicks != null && quickPicks.tracks.isNotEmpty()) {
             item(key = "home-quick-picks", contentType = "home-dense-shelf") {
                 HomeQuickPicksShelf(
                     title = quickPicks.title.ifBlank { strings.quickPicks },
@@ -5335,7 +5372,7 @@ private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnaps
                 )
             }
         }
-        if (state.interfaceSettings.showTrendingArtists && state.similarArtists.isNotEmpty()) {
+        if (showDeferredHomeSections && state.interfaceSettings.showTrendingArtists && state.similarArtists.isNotEmpty()) {
             item(key = "sec-similar-artists-header", contentType = "home-section-header") {
                 HomeSectionInset { HomeSectionHeader(strings.similarToFollowed) }
             }
@@ -5347,7 +5384,7 @@ private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnaps
                 )
             }
         }
-        if (state.interfaceSettings.showNewReleases && newReleases != null && newReleases.tracks.isNotEmpty()) {
+        if (showDeferredHomeSections && state.interfaceSettings.showNewReleases && newReleases != null && newReleases.tracks.isNotEmpty()) {
             item(key = "sec-new-releases-header", contentType = "home-section-header") {
                 HomeSectionInset { SectionHeaderAction(strings.newReleases, onPlayAll = { viewModel.playAll(newReleases.tracks) }) }
             }
@@ -5360,7 +5397,7 @@ private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnaps
                 )
             }
         }
-        if (state.interfaceSettings.showAlbumsForYou && (homeAlbums.isNotEmpty() || showHomeAlbumShimmer)) {
+        if (showDeferredHomeSections && state.interfaceSettings.showAlbumsForYou && (homeAlbums.isNotEmpty() || showHomeAlbumShimmer)) {
             item(key = "sec-home-albums-header", contentType = "home-section-header") {
                 HomeSectionInset { SectionHeaderAction(strings.albumsForYou, onPlayAll = { viewModel.playAlbumRecommendations(homeAlbums) }) }
             }
@@ -5377,7 +5414,7 @@ private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnaps
             }
         }
         if (
-            state.interfaceSettings.showTrendingArtists &&
+            showDeferredHomeSections && state.interfaceSettings.showTrendingArtists &&
             (state.homeArtists.isNotEmpty() || state.homeArtistsLoading)
         ) {
             item(key = "home-trending-artists", contentType = "home-shelf") {
@@ -5388,7 +5425,7 @@ private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnaps
                 )
             }
         }
-        otherSections.forEachIndexed { sectionIndex, section ->
+        if (showDeferredHomeSections) otherSections.forEachIndexed { sectionIndex, section ->
             if (section.tracks.isNotEmpty()) {
                 val sectionKey = homeSectionLazyKey(
                     position = sectionIndex,
@@ -5408,7 +5445,7 @@ private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnaps
                 }
             }
         }
-        if (state.interfaceSettings.showCharts) {
+        if (showDeferredHomeSections && state.interfaceSettings.showCharts) {
             item(key = "home-chart-title", contentType = "home-section-header") {
                 val region = state.chartRegions.firstOrNull { it.id == state.selectedChartId }
                 HomeSectionInset {
@@ -5472,6 +5509,7 @@ private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnaps
             HomeSectionInset { StatusBlock(state) }
         }
     }
+    }
 
     addTarget?.let { track ->
         AddToPlaylistDialog(
@@ -5524,6 +5562,7 @@ private fun HomeEditorialSpotlight(
     isPlaying: Boolean,
     isResolving: Boolean,
     animationsEnabled: Boolean,
+    onPaletteChanged: (Color, Color) -> Unit,
     onOpen: () -> Unit
 ) {
     val track = candidate.track
@@ -5618,6 +5657,9 @@ private fun HomeEditorialSpotlight(
         animationSpec = tween(durationMillis = 420, easing = FastOutSlowInEasing),
         label = "homeSpotlightAccentEnd"
     )
+    LaunchedEffect(accentStart, accentEnd) {
+        onPaletteChanged(accentStart, accentEnd)
+    }
     val badge = homeSpotlightBadge(strings, candidate)
     val detail = homeSpotlightDetail(strings, candidate)
 

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -6483,7 +6483,7 @@ private fun PremiumHomeArtistItem(
                     shape = CircleShape
                 )
                 .padding(1.5.dp)
-                .background(LevyraBackground.copy(alpha = 0.96f), CircleShape)
+                .background(LevyraAdaptiveCardDeep.copy(alpha = 0.96f), CircleShape)
                 .padding(3.dp),
             contentAlignment = Alignment.Center
         ) {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -6416,7 +6416,8 @@ private fun TrendingArtistsShelf(
             modifier = Modifier.padding(horizontal = HomeHorizontalInset)
         )
         LazyRow(
-            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(18.dp),
             contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
         ) {
             itemsIndexed(
@@ -6424,99 +6425,10 @@ private fun TrendingArtistsShelf(
                 key = { index, artist -> "trending-artist-$index-${artist.browseId.ifBlank { artist.name.trim().lowercase(Locale.ROOT) }}" },
                 contentType = { _, _ -> "trending-artist" }
             ) { _, artist ->
-                val accentStart = Color(artist.accentStart)
-                val accentEnd = Color(artist.accentEnd)
-                Surface(
-                    color = LevyraAdaptiveCard,
-                    border = BorderStroke(1.dp, LevyraAdaptiveSoftHairline),
-                    shape = RoundedCornerShape(24.dp),
-                    shadowElevation = 8.dp,
-                    modifier = Modifier
-                        .width(132.dp)
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null,
-                            onClick = { onArtistClick(artist) }
-                        )
-                ) {
-                    Column(
-                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(10.dp)
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .size(98.dp)
-                                .shadow(
-                                    elevation = 18.dp,
-                                    shape = CircleShape,
-                                    clip = false,
-                                    ambientColor = accentStart.copy(alpha = 0.22f),
-                                    spotColor = accentEnd.copy(alpha = 0.24f)
-                                )
-                                .clip(CircleShape)
-                                .background(
-                                    Brush.linearGradient(
-                                        listOf(
-                                            accentStart.copy(alpha = 0.96f),
-                                            accentEnd.copy(alpha = 0.90f)
-                                        )
-                                    )
-                                )
-                                .padding(2.dp),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            if (artist.thumbnailUrl.isNotBlank()) {
-                                StableRemoteArtwork(
-                                    url = artist.thumbnailUrl,
-                                    contentDescription = artist.name,
-                                    contentScale = ContentScale.Crop,
-                                    modifier = Modifier
-                                        .fillMaxSize()
-                                        .clip(CircleShape)
-                                        .background(CinematicGlassDeep)
-                                )
-                            } else {
-                                Icon(
-                                    imageVector = Icons.Rounded.Person,
-                                    contentDescription = artist.name,
-                                    tint = Color.White,
-                                    modifier = Modifier.size(38.dp)
-                                )
-                            }
-                        }
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(4.dp)
-                        ) {
-                            Text(
-                                text = artist.name,
-                                color = LevyraText,
-                                fontSize = 13.5.sp,
-                                lineHeight = 16.sp,
-                                fontWeight = FontWeight.Bold,
-                                maxLines = 2,
-                                overflow = TextOverflow.Ellipsis,
-                                textAlign = TextAlign.Center,
-                                minLines = 2
-                            )
-                            Surface(
-                                color = accentStart.copy(alpha = 0.14f),
-                                shape = RoundedCornerShape(999.dp)
-                            ) {
-                                Text(
-                                    text = strings.artistLabel.uppercase(Locale.ROOT),
-                                    color = accentStart.playerAdjustBackgroundFor(Color.White, PlayerStrongContrast).color.copy(alpha = 0.96f),
-                                    fontSize = 10.sp,
-                                    lineHeight = 12.sp,
-                                    fontWeight = FontWeight.Black,
-                                    letterSpacing = 1.sp,
-                                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)
-                                )
-                            }
-                        }
-                    }
-                }
+                PremiumHomeArtistItem(
+                    artist = artist,
+                    onClick = { onArtistClick(artist) }
+                )
             }
             items(
                 count = loadingSlots,
@@ -6529,44 +6441,151 @@ private fun TrendingArtistsShelf(
     }
 }
 
+@Composable
+private fun PremiumHomeArtistItem(
+    artist: ArtistHit,
+    onClick: () -> Unit
+) {
+    val accentStart = Color(artist.accentStart)
+    val accentEnd = Color(artist.accentEnd)
+    val interactionSource = remember { MutableInteractionSource() }
+
+    Column(
+        modifier = Modifier
+            .width(122.dp)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick
+            ),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(11.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(114.dp)
+                .shadow(
+                    elevation = 16.dp,
+                    shape = CircleShape,
+                    clip = false,
+                    ambientColor = accentStart.copy(alpha = 0.18f),
+                    spotColor = accentEnd.copy(alpha = 0.22f)
+                )
+                .background(
+                    brush = Brush.sweepGradient(
+                        listOf(
+                            accentStart.copy(alpha = 0.94f),
+                            Color.White.copy(alpha = 0.42f),
+                            accentEnd.copy(alpha = 0.92f),
+                            accentStart.copy(alpha = 0.94f)
+                        )
+                    ),
+                    shape = CircleShape
+                )
+                .padding(1.5.dp)
+                .background(LevyraBackground.copy(alpha = 0.96f), CircleShape)
+                .padding(3.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            if (artist.thumbnailUrl.isNotBlank()) {
+                StableRemoteArtwork(
+                    url = artist.thumbnailUrl,
+                    contentDescription = artist.name,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(CircleShape)
+                        .background(CinematicGlassDeep)
+                )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(CircleShape)
+                        .background(
+                            Brush.linearGradient(
+                                listOf(
+                                    accentStart.copy(alpha = 0.34f),
+                                    CinematicGlassDeep,
+                                    accentEnd.copy(alpha = 0.26f)
+                                )
+                            )
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Person,
+                        contentDescription = artist.name,
+                        tint = Color.White.copy(alpha = 0.92f),
+                        modifier = Modifier.size(40.dp)
+                    )
+                }
+            }
+
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 7.dp)
+                    .width(34.dp)
+                    .height(3.dp)
+                    .clip(RoundedCornerShape(99.dp))
+                    .background(
+                        Brush.horizontalGradient(
+                            listOf(
+                                accentStart.copy(alpha = 0.84f),
+                                accentEnd.copy(alpha = 0.84f)
+                            )
+                        )
+                    )
+            )
+        }
+
+        Text(
+            text = artist.name,
+            color = LevyraText,
+            fontSize = 14.sp,
+            lineHeight = 17.sp,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 2,
+            minLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center,
+            letterSpacing = (-0.2).sp,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
 
 @Composable
 private fun TrendingArtistLoadingItem() {
-    Surface(
-        color = LevyraAdaptiveCard,
-        border = BorderStroke(1.dp, LevyraAdaptiveSoftHairline),
-        shape = RoundedCornerShape(24.dp),
-        modifier = Modifier.width(132.dp)
+    Column(
+        modifier = Modifier.width(122.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(11.dp)
     ) {
-        Column(
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(10.dp)
-        ) {
-            Box(
-                modifier = Modifier
-                    .size(98.dp)
-                    .clip(CircleShape)
-                    .shimmer()
-                    .background(CinematicGlassDeep)
-            )
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth(0.78f)
-                    .height(14.dp)
-                    .clip(RoundedCornerShape(99.dp))
-                    .shimmer()
-                    .background(CinematicGlassDeep)
-            )
-            Box(
-                modifier = Modifier
-                    .width(62.dp)
-                    .height(22.dp)
-                    .clip(RoundedCornerShape(99.dp))
-                    .shimmer()
-                    .background(CinematicGlassDeep)
-            )
-        }
+        Box(
+            modifier = Modifier
+                .size(114.dp)
+                .clip(CircleShape)
+                .shimmer()
+                .background(CinematicGlassDeep)
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(0.78f)
+                .height(15.dp)
+                .clip(RoundedCornerShape(99.dp))
+                .shimmer()
+                .background(CinematicGlassDeep)
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(0.58f)
+                .height(12.dp)
+                .clip(RoundedCornerShape(99.dp))
+                .shimmer()
+                .background(CinematicGlassDeep)
+        )
     }
 }
 

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -2,6 +2,7 @@
 package com.luc4n3x.levyra.ui
 
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.Spring
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.basicMarquee
@@ -5196,12 +5197,20 @@ private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnaps
     var homeAccentEnd by remember { mutableStateOf(Color(0xFF160E24)) }
     val animatedHomeAccentStart by animateColorAsState(
         targetValue = homeAccentStart,
-        animationSpec = tween(520, easing = FastOutSlowInEasing),
+        animationSpec = if (state.animationsEnabled) {
+            tween(520, easing = FastOutSlowInEasing)
+        } else {
+            snap()
+        },
         label = "homeAccentStart"
     )
     val animatedHomeAccentEnd by animateColorAsState(
         targetValue = homeAccentEnd,
-        animationSpec = tween(520, easing = FastOutSlowInEasing),
+        animationSpec = if (state.animationsEnabled) {
+            tween(520, easing = FastOutSlowInEasing)
+        } else {
+            snap()
+        },
         label = "homeAccentEnd"
     )
     val visiblePersonalTracks = remember(personalTracks, spotlightCandidate?.track?.id) {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -408,15 +408,21 @@ private fun LevyraUiState.toHomeDerivedInput(): HomeDerivedInput {
 
 private fun buildHomeDerivedState(input: HomeDerivedInput): HomeDerivedState {
     val mood = input.selectedMood
+    fun moodPreferenceScore(track: Track): Int {
+        if (mood == null) return 0
+        val tagMatches = track.moodTags.count { tag ->
+            mood.tags.any { moodTag -> moodTag.equals(tag, ignoreCase = true) }
+        }
+        val energyFit = 100 - kotlin.math.abs(track.energy - mood.energyTarget).coerceIn(0, 100)
+        return (
+            tagMatches * 900 +
+                energyFit * 28 +
+                track.replayScore.coerceIn(0, 100) * 3
+        ).coerceIn(0, 6_000)
+    }
     fun moodRank(tracks: List<Track>): List<Track> {
         if (mood == null || tracks.size < 2) return tracks
-        return tracks.sortedByDescending { track ->
-            val tagMatches = track.moodTags.count { tag ->
-                mood.tags.any { moodTag -> moodTag.equals(tag, ignoreCase = true) }
-            }
-            val energyFit = 100 - kotlin.math.abs(track.energy - mood.energyTarget).coerceIn(0, 100)
-            tagMatches * 220 + energyFit * 2 + track.replayScore.coerceIn(0, 100)
-        }
+        return tracks.sortedByDescending(::moodPreferenceScore)
     }
     val quickPicks = buildQuickPicks(input)?.let { it.copy(tracks = moodRank(it.tracks)) }
     val newReleases = input.homeSections.firstOrNull {
@@ -448,7 +454,8 @@ private fun buildHomeDerivedState(input: HomeDerivedInput): HomeDerivedState {
         resonanceTracks = moodRank(resonanceTracks),
         quickPickTracks = moodRank(quickPicks?.tracks.orEmpty()),
         fallbackSections = otherSections.map { moodRank(it.tracks) },
-        chartTracks = if (input.showCharts) moodRank(input.charts) else emptyList()
+        chartTracks = if (input.showCharts) moodRank(input.charts) else emptyList(),
+        preferenceScore = ::moodPreferenceScore
     )
     val visibleCollectionSections = input.homeSections.filter { section ->
         isHomeSectionVisible(section.title, input)

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -338,6 +338,7 @@ private data class HomeDerivedInput(
     val releaseRadar: List<ReleaseRadarEntry>,
     val similarArtists: List<ArtistHit>,
     val currentTrack: Track?,
+    val selectedMood: Mood?,
     val showNewReleases: Boolean,
     val showPersonalOrbit: Boolean,
     val showResonance: Boolean,
@@ -376,6 +377,7 @@ private fun sameHomeDerivedInputs(previous: LevyraUiState, current: LevyraUiStat
         previous.homeResonanceTracks === current.homeResonanceTracks &&
         previous.releaseRadar === current.releaseRadar &&
         previous.similarArtists === current.similarArtists &&
+        previous.selectedMood == current.selectedMood &&
         previous.interfaceSettings.showNewReleases == current.interfaceSettings.showNewReleases &&
         previous.interfaceSettings.showPersonalOrbit == current.interfaceSettings.showPersonalOrbit &&
         previous.interfaceSettings.showResonance == current.interfaceSettings.showResonance &&
@@ -396,6 +398,7 @@ private fun LevyraUiState.toHomeDerivedInput(): HomeDerivedInput {
         releaseRadar = releaseRadar,
         similarArtists = similarArtists,
         currentTrack = currentTrack,
+        selectedMood = selectedMood,
         showNewReleases = interfaceSettings.showNewReleases,
         showPersonalOrbit = interfaceSettings.showPersonalOrbit,
         showResonance = interfaceSettings.showResonance,
@@ -404,10 +407,21 @@ private fun LevyraUiState.toHomeDerivedInput(): HomeDerivedInput {
 }
 
 private fun buildHomeDerivedState(input: HomeDerivedInput): HomeDerivedState {
-    val quickPicks = buildQuickPicks(input)
+    val mood = input.selectedMood
+    fun moodRank(tracks: List<Track>): List<Track> {
+        if (mood == null || tracks.size < 2) return tracks
+        return tracks.sortedByDescending { track ->
+            val tagMatches = track.moodTags.count { tag ->
+                mood.tags.any { moodTag -> moodTag.equals(tag, ignoreCase = true) }
+            }
+            val energyFit = 100 - kotlin.math.abs(track.energy - mood.energyTarget).coerceIn(0, 100)
+            tagMatches * 220 + energyFit * 2 + track.replayScore.coerceIn(0, 100)
+        }
+    }
+    val quickPicks = buildQuickPicks(input)?.let { it.copy(tracks = moodRank(it.tracks)) }
     val newReleases = input.homeSections.firstOrNull {
         isVerifiedHomeReleaseSectionTitle(it.title, input.languageCode)
-    }
+    }?.let { it.copy(tracks = moodRank(it.tracks)) }
     val otherSections = input.homeSections.filter {
         !isVerifiedHomeReleaseSectionTitle(it.title, input.languageCode) &&
             !isHomeQuickPicksSectionTitle(it.title) &&
@@ -427,25 +441,25 @@ private fun buildHomeDerivedState(input: HomeDerivedInput): HomeDerivedState {
     val resonanceTracks = input.cachedResonanceTracks.ifEmpty { buildHomeResonanceTracks(input) }
     val spotlightCandidates = HomeEditorialEngine.buildSpotlightCandidates(
         showNewReleases = input.showNewReleases,
-        newReleaseTracks = newReleases?.tracks.orEmpty(),
+        newReleaseTracks = moodRank(newReleases?.tracks.orEmpty()),
         showPersonalOrbit = input.showPersonalOrbit,
-        personalTracks = input.personalOrbitTracks.take(LevyraPersonalOrbit.DISPLAY_LIMIT),
+        personalTracks = moodRank(input.personalOrbitTracks.take(LevyraPersonalOrbit.DISPLAY_LIMIT)),
         showResonance = input.showResonance,
-        resonanceTracks = resonanceTracks,
-        quickPickTracks = quickPicks?.tracks.orEmpty(),
-        fallbackSections = otherSections.map { it.tracks },
-        chartTracks = if (input.showCharts) input.charts else emptyList()
+        resonanceTracks = moodRank(resonanceTracks),
+        quickPickTracks = moodRank(quickPicks?.tracks.orEmpty()),
+        fallbackSections = otherSections.map { moodRank(it.tracks) },
+        chartTracks = if (input.showCharts) moodRank(input.charts) else emptyList()
     )
     val visibleCollectionSections = input.homeSections.filter { section ->
         isHomeSectionVisible(section.title, input)
     }
     val editorialCollections = HomeEditorialEngine.buildCollections(
         homeSections = visibleCollectionSections,
-        newReleaseTracks = if (input.showNewReleases) newReleases?.tracks.orEmpty() else emptyList(),
-        personalTracks = if (input.showPersonalOrbit) input.personalOrbitTracks else emptyList(),
-        resonanceTracks = if (input.showResonance) resonanceTracks else emptyList(),
-        quickPickTracks = quickPicks?.tracks.orEmpty(),
-        chartTracks = if (input.showCharts) input.charts else emptyList(),
+        newReleaseTracks = if (input.showNewReleases) moodRank(newReleases?.tracks.orEmpty()) else emptyList(),
+        personalTracks = if (input.showPersonalOrbit) moodRank(input.personalOrbitTracks) else emptyList(),
+        resonanceTracks = if (input.showResonance) moodRank(resonanceTracks) else emptyList(),
+        quickPickTracks = moodRank(quickPicks?.tracks.orEmpty()),
+        chartTracks = if (input.showCharts) moodRank(input.charts) else emptyList(),
         favorites = input.favorites,
         libraryTracks = input.tracks,
         includeFresh = input.showNewReleases

--- a/app/src/test/java/com/luc4n3x/levyra/data/HomeEditorialEngineTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/HomeEditorialEngineTest.kt
@@ -39,6 +39,30 @@ class HomeEditorialEngineTest {
     }
 
     @Test
+    fun moodPreferenceScoreChangesSpotlightSelection() {
+        val gym = track("gym", tags = setOf("gym"), energy = 96)
+        val chill = track("chill", tags = setOf("chill"), energy = 42)
+        val tracks = listOf(gym, chill)
+
+        fun candidates(preferredId: String) = HomeEditorialEngine.buildSpotlightCandidates(
+            showNewReleases = false,
+            newReleaseTracks = emptyList(),
+            showPersonalOrbit = false,
+            personalTracks = emptyList(),
+            showResonance = false,
+            resonanceTracks = emptyList(),
+            quickPickTracks = tracks,
+            fallbackSections = emptyList(),
+            chartTracks = emptyList(),
+            preferenceScore = { track -> if (track.id == preferredId) 6_000 else 0 },
+            nowMillis = 1_753_276_800_000L
+        )
+
+        assertEquals("gym", candidates("gym").first().track.id)
+        assertEquals("chill", candidates("chill").first().track.id)
+    }
+
+    @Test
     fun hiddenSectionsDoNotFeedSpotlight() {
         val candidates = HomeEditorialEngine.buildSpotlightCandidates(
             showNewReleases = false,


### PR DESCRIPTION
## Summary

-

## Scope

- [ ] Player / audio
- [ ] Stream extraction
- [ ] Downloads
- [ ] UI / Compose
- [ ] Localization
- [ ] Android Auto / media session
- [ ] CI / release
- [ ] Documentation

## What changed

-
## Testing

- [ ] `gradle --no-daemon :app:lintRelease`
- [ ] `gradle --no-daemon testReleaseUnitTest`
- [ ] `gradle --no-daemon assembleRelease`
- [ ] APK installed on device
- [ ] Playback tested
- [ ] Downloads tested
- [ ] Language switching tested

## Release safety

- [ ] `levyraVersionName` and `levyraVersionCode` are correct
- [ ] No secrets, keystores, APKs or ZIPs committed
- [ ] No duplicated release workflows
- [ ] Credits and licenses updated when adding external components

## Related issues

- Closes #
- Related to #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Home content now adapts to the selected mood, prioritizing tracks based on mood relevance, energy, and replay history.
  * Added an animated accent gradient that reflects the current home-screen palette.

* **Performance Improvements**
  * Deferred loading of several home sections to help the screen appear faster.

* **UI Enhancements**
  * Mood-aware ordering now applies across quick picks, new releases, spotlight content, collections, and charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->