### PR TITLE
Presentazione artisti coerente in tutte le sezioni

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -316,6 +316,12 @@ import com.luc4n3x.levyra.domain.YoutubeCommentsState
 import com.luc4n3x.levyra.domain.YoutubeEngagementState
 import com.luc4n3x.levyra.LevyraLaunchActions
 import com.luc4n3x.levyra.feature.sharedmedia.SharedMediaPreview
+import com.luc4n3x.levyra.ui.components.LevyraArtistAvatarSize
+import com.luc4n3x.levyra.ui.components.LevyraArtistItemWidth
+import com.luc4n3x.levyra.ui.components.LevyraArtistNameSpacing
+import com.luc4n3x.levyra.ui.components.LevyraArtistShelfItem
+import com.luc4n3x.levyra.ui.components.LevyraArtistShelfSpacing
+import com.luc4n3x.levyra.ui.components.levyraArtistAccent
 import com.luc4n3x.levyra.ui.theme.LevyraBlack
 import com.luc4n3x.levyra.ui.theme.LevyraInk
 import com.luc4n3x.levyra.ui.theme.LevyraPanel
@@ -6390,14 +6396,17 @@ private fun pickHeroUpdate(state: LevyraUiState): HomeHeroUpdate? {
 }
 
 @Composable
-private fun StableRemoteArtwork(
+internal fun StableRemoteArtwork(
     url: String,
     contentDescription: String,
     modifier: Modifier,
-    contentScale: ContentScale
+    contentScale: ContentScale,
+    highRes: Boolean = false
 ) {
     val context = LocalContext.current
-    val resizedUrl = remember(url) { LevyraArtworkCache.small(url) }
+    val resizedUrl = remember(url, highRes) {
+        if (highRes) LevyraArtworkCache.large(url) else LevyraArtworkCache.small(url)
+    }
     val request = remember(context, resizedUrl) {
         ImageRequest.Builder(context)
             .data(resizedUrl)
@@ -6429,7 +6438,7 @@ private fun TrendingArtistsShelf(
         )
         LazyRow(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(18.dp),
+            horizontalArrangement = Arrangement.spacedBy(LevyraArtistShelfSpacing),
             contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
         ) {
             itemsIndexed(
@@ -6437,7 +6446,7 @@ private fun TrendingArtistsShelf(
                 key = { index, artist -> "trending-artist-$index-${artist.browseId.ifBlank { artist.name.trim().lowercase(Locale.ROOT) }}" },
                 contentType = { _, _ -> "trending-artist" }
             ) { _, artist ->
-                PremiumHomeArtistItem(
+                ArtistHitShelfItem(
                     artist = artist,
                     onClick = { onArtistClick(artist) }
                 )
@@ -6454,130 +6463,35 @@ private fun TrendingArtistsShelf(
 }
 
 @Composable
-private fun PremiumHomeArtistItem(
+private fun ArtistHitShelfItem(
     artist: ArtistHit,
     onClick: () -> Unit
 ) {
-    val accentStart = Color(artist.accentStart)
-    val accentEnd = Color(artist.accentEnd)
-    val interactionSource = remember { MutableInteractionSource() }
+    val accent = levyraArtistAccent(
+        key = artist.browseId.ifBlank { artist.name },
+        accentStart = artist.accentStart,
+        accentEnd = artist.accentEnd
+    )
 
-    Column(
-        modifier = Modifier
-            .width(122.dp)
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null,
-                onClick = onClick
-            ),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(11.dp)
-    ) {
-        Box(
-            modifier = Modifier
-                .size(114.dp)
-                .shadow(
-                    elevation = 16.dp,
-                    shape = CircleShape,
-                    clip = false,
-                    ambientColor = accentStart.copy(alpha = 0.18f),
-                    spotColor = accentEnd.copy(alpha = 0.22f)
-                )
-                .background(
-                    brush = Brush.sweepGradient(
-                        listOf(
-                            accentStart.copy(alpha = 0.94f),
-                            Color.White.copy(alpha = 0.42f),
-                            accentEnd.copy(alpha = 0.92f),
-                            accentStart.copy(alpha = 0.94f)
-                        )
-                    ),
-                    shape = CircleShape
-                )
-                .padding(1.5.dp)
-                .background(LevyraAdaptiveCardDeep.copy(alpha = 0.96f), CircleShape)
-                .padding(3.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            if (artist.thumbnailUrl.isNotBlank()) {
-                StableRemoteArtwork(
-                    url = artist.thumbnailUrl,
-                    contentDescription = artist.name,
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .clip(CircleShape)
-                        .background(CinematicGlassDeep)
-                )
-            } else {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .clip(CircleShape)
-                        .background(
-                            Brush.linearGradient(
-                                listOf(
-                                    accentStart.copy(alpha = 0.34f),
-                                    CinematicGlassDeep,
-                                    accentEnd.copy(alpha = 0.26f)
-                                )
-                            )
-                        ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(
-                        imageVector = Icons.Rounded.Person,
-                        contentDescription = artist.name,
-                        tint = Color.White.copy(alpha = 0.92f),
-                        modifier = Modifier.size(40.dp)
-                    )
-                }
-            }
-
-            Box(
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .padding(bottom = 7.dp)
-                    .width(34.dp)
-                    .height(3.dp)
-                    .clip(RoundedCornerShape(99.dp))
-                    .background(
-                        Brush.horizontalGradient(
-                            listOf(
-                                accentStart.copy(alpha = 0.84f),
-                                accentEnd.copy(alpha = 0.84f)
-                            )
-                        )
-                    )
-            )
-        }
-
-        Text(
-            text = artist.name,
-            color = LevyraText,
-            fontSize = 14.sp,
-            lineHeight = 17.sp,
-            fontWeight = FontWeight.SemiBold,
-            maxLines = 2,
-            minLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            textAlign = TextAlign.Center,
-            letterSpacing = (-0.2).sp,
-            modifier = Modifier.fillMaxWidth()
-        )
-    }
+    LevyraArtistShelfItem(
+        name = artist.name,
+        thumbnailUrl = artist.thumbnailUrl,
+        accentStart = accent.first,
+        accentEnd = accent.second,
+        onClick = onClick
+    )
 }
 
 @Composable
 private fun TrendingArtistLoadingItem() {
     Column(
-        modifier = Modifier.width(122.dp),
+        modifier = Modifier.width(LevyraArtistItemWidth),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(11.dp)
+        verticalArrangement = Arrangement.spacedBy(LevyraArtistNameSpacing)
     ) {
         Box(
             modifier = Modifier
-                .size(114.dp)
+                .size(LevyraArtistAvatarSize)
                 .clip(CircleShape)
                 .shimmer()
                 .background(CinematicGlassDeep)
@@ -9572,42 +9486,16 @@ private fun PulseArtistsRow(artists: List<PulseArtist>, label: String, minuteSho
 
 @Composable
 private fun FollowedArtistsRow(artists: List<FollowedArtist>, onOpen: (FollowedArtist) -> Unit) {
-    LazyRow(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+    LazyRow(horizontalArrangement = Arrangement.spacedBy(LevyraArtistShelfSpacing)) {
         items(artists, key = { "followed-${it.key}" }) { artist ->
-            Column(
-                modifier = Modifier.width(96.dp).clickable { onOpen(artist) },
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Box(
-                    modifier = Modifier
-                        .size(96.dp)
-                        .clip(CircleShape)
-                        .background(Brush.linearGradient(listOf(CinematicGold.copy(alpha = 0.3f), LevyraViolet.copy(alpha = 0.28f))))
-                        .border(1.dp, Color.White.copy(alpha = 0.1f), CircleShape),
-                    contentAlignment = Alignment.Center
-                ) {
-                    if (artist.thumbnailUrl.isNotBlank()) {
-                        AsyncImage(
-                            model = ImageRequest.Builder(LocalContext.current).data(artist.thumbnailUrl).crossfade(true).build(),
-                            contentDescription = artist.name,
-                            contentScale = ContentScale.Crop,
-                            modifier = Modifier.matchParentSize().clip(CircleShape)
-                        )
-                    } else {
-                        Icon(Icons.Rounded.Person, null, tint = LevyraText, modifier = Modifier.size(38.dp))
-                    }
-                }
-                Text(
-                    text = artist.name,
-                    color = LevyraText,
-                    fontSize = 12.sp,
-                    fontWeight = FontWeight.Bold,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    textAlign = TextAlign.Center
-                )
-            }
+            val accent = levyraArtistAccent(artist.key)
+            LevyraArtistShelfItem(
+                name = artist.name,
+                thumbnailUrl = artist.thumbnailUrl,
+                accentStart = accent.first,
+                accentEnd = accent.second,
+                onClick = { onOpen(artist) }
+            )
         }
     }
 }
@@ -15800,7 +15688,7 @@ private fun ArtistHitRow(
     onClick: (ArtistHit) -> Unit
 ) {
     LazyRow(
-        horizontalArrangement = Arrangement.spacedBy(14.dp),
+        horizontalArrangement = Arrangement.spacedBy(LevyraArtistShelfSpacing),
         contentPadding = contentPadding
     ) {
         itemsIndexed(
@@ -15808,75 +15696,10 @@ private fun ArtistHitRow(
             key = { index, hit -> "artist-hit-$index-${hit.browseId.ifBlank { hit.name.trim().lowercase(Locale.ROOT) }}" },
             contentType = { _, _ -> "artist-hit" }
         ) { _, hit ->
-            val accentStart = Color(hit.accentStart)
-            val accentEnd = Color(hit.accentEnd)
-            Surface(
-                color = LevyraAdaptiveCard,
-                border = BorderStroke(1.dp, LevyraAdaptiveSoftHairline),
-                shape = RoundedCornerShape(24.dp),
-                modifier = Modifier
-                    .width(136.dp)
-                    .clickable { onClick(hit) }
-            ) {
-                Column(
-                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(10.dp)
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .size(104.dp)
-                            .shadow(
-                                elevation = 18.dp,
-                                shape = CircleShape,
-                                clip = false,
-                                ambientColor = accentStart.copy(alpha = 0.22f),
-                                spotColor = accentEnd.copy(alpha = 0.24f)
-                            )
-                            .clip(CircleShape)
-                            .background(Brush.linearGradient(listOf(accentStart, accentEnd)))
-                            .padding(2.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        if (hit.thumbnailUrl.isNotBlank()) {
-                            StableRemoteArtwork(
-                                url = hit.thumbnailUrl,
-                                contentDescription = hit.name,
-                                contentScale = ContentScale.Crop,
-                                modifier = Modifier
-                                    .matchParentSize()
-                                    .clip(CircleShape)
-                            )
-                        } else {
-                            Icon(Icons.Rounded.Person, null, tint = Color.White, modifier = Modifier.size(40.dp))
-                        }
-                    }
-                    Text(
-                        text = hit.name,
-                        color = LevyraText,
-                        fontSize = 13.5.sp,
-                        lineHeight = 16.sp,
-                        fontWeight = FontWeight.Bold,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                        textAlign = TextAlign.Center,
-                        minLines = 2
-                    )
-                    Surface(
-                        color = accentStart.copy(alpha = 0.14f),
-                        shape = RoundedCornerShape(999.dp)
-                    ) {
-                        Text(
-                            text = LocalLevyraStrings.current.artistLabel.uppercase(Locale.ROOT),
-                            color = accentStart.playerAdjustBackgroundFor(Color.White, PlayerStrongContrast).color.copy(alpha = 0.96f),
-                            fontSize = 10.sp,
-                            fontWeight = FontWeight.Black,
-                            letterSpacing = 1.sp,
-                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)
-                        )
-                    }
-                }
-            }
+            ArtistHitShelfItem(
+                artist = hit,
+                onClick = { onClick(hit) }
+            )
         }
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/LevyraArtistPresentation.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/LevyraArtistPresentation.kt
@@ -1,0 +1,198 @@
+package com.luc4n3x.levyra.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.luc4n3x.levyra.ui.StableRemoteArtwork
+import com.luc4n3x.levyra.ui.theme.LevyraActivePalette
+import com.luc4n3x.levyra.ui.theme.LevyraText
+import java.util.Locale
+import kotlin.math.absoluteValue
+
+internal val LevyraArtistItemWidth = 122.dp
+internal val LevyraArtistAvatarSize = 114.dp
+internal val LevyraArtistShelfSpacing = 18.dp
+internal val LevyraArtistNameSpacing = 11.dp
+
+private val LevyraArtistHighResThreshold = 128.dp
+private val LevyraArtistAvatarSurface = Color(0xFF0B0A14)
+
+private val LevyraArtistAccentPalette = listOf(
+    Color(0xFF00E5FF) to Color(0xFF7B42FF),
+    Color(0xFF1B5CFF) to Color(0xFFFF4FD8),
+    Color(0xFFFF7A18) to Color(0xFF8E57FF),
+    Color(0xFF00D4A6) to Color(0xFFFF3B5C),
+    Color(0xFFFFB000) to Color(0xFF00E5FF)
+)
+
+internal fun levyraArtistAccent(
+    key: String,
+    accentStart: Int = 0,
+    accentEnd: Int = 0
+): Pair<Color, Color> {
+    if (accentStart != 0 && accentEnd != 0) return Color(accentStart) to Color(accentEnd)
+    val normalized = key.trim().lowercase(Locale.ROOT)
+    if (normalized.isEmpty()) return LevyraArtistAccentPalette.first()
+    val index = (normalized.hashCode().toLong().absoluteValue % LevyraArtistAccentPalette.size).toInt()
+    return LevyraArtistAccentPalette[index]
+}
+
+@Composable
+internal fun LevyraArtistAvatar(
+    name: String,
+    thumbnailUrl: String,
+    accentStart: Color,
+    accentEnd: Color,
+    modifier: Modifier = Modifier,
+    size: Dp = LevyraArtistAvatarSize,
+    ringOverride: Color? = null
+) {
+    val ringBrush = if (ringOverride != null) {
+        SolidColor(ringOverride)
+    } else {
+        Brush.sweepGradient(
+            listOf(
+                accentStart.copy(alpha = 0.94f),
+                Color.White.copy(alpha = 0.42f),
+                accentEnd.copy(alpha = 0.92f),
+                accentStart.copy(alpha = 0.94f)
+            )
+        )
+    }
+    val innerSurface = if (LevyraActivePalette.isLight) {
+        Color.White.copy(alpha = 0.86f)
+    } else {
+        LevyraArtistAvatarSurface.copy(alpha = 0.74f)
+    }
+
+    val ringWidth = (size * 0.013f).coerceAtLeast(1.dp)
+    val ringGap = (size * 0.026f).coerceAtLeast(1.5.dp)
+    val glowElevation = (size * 0.14f).coerceAtMost(22.dp)
+
+    Box(
+        modifier = modifier
+            .size(size)
+            .shadow(
+                elevation = glowElevation,
+                shape = CircleShape,
+                clip = false,
+                ambientColor = accentStart.copy(alpha = 0.18f),
+                spotColor = accentEnd.copy(alpha = 0.22f)
+            )
+            .background(brush = ringBrush, shape = CircleShape)
+            .padding(ringWidth)
+            .background(innerSurface, CircleShape)
+            .padding(ringGap),
+        contentAlignment = Alignment.Center
+    ) {
+        if (thumbnailUrl.isNotBlank()) {
+            StableRemoteArtwork(
+                url = thumbnailUrl,
+                contentDescription = name,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(CircleShape)
+                    .background(LevyraArtistAvatarSurface),
+                highRes = size >= LevyraArtistHighResThreshold
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(CircleShape)
+                    .background(
+                        Brush.linearGradient(
+                            listOf(
+                                accentStart.copy(alpha = 0.34f),
+                                LevyraArtistAvatarSurface,
+                                accentEnd.copy(alpha = 0.26f)
+                            )
+                        )
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Person,
+                    contentDescription = name,
+                    tint = Color.White.copy(alpha = 0.92f),
+                    modifier = Modifier.size(size * 0.35f)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun LevyraArtistShelfItem(
+    name: String,
+    thumbnailUrl: String,
+    accentStart: Color,
+    accentEnd: Color,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+
+    Column(
+        modifier = modifier
+            .width(LevyraArtistItemWidth)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick
+            ),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(LevyraArtistNameSpacing)
+    ) {
+        LevyraArtistAvatar(
+            name = name,
+            thumbnailUrl = thumbnailUrl,
+            accentStart = accentStart,
+            accentEnd = accentEnd,
+            size = LevyraArtistAvatarSize
+        )
+        Text(
+            text = name,
+            color = LevyraText,
+            fontSize = 14.sp,
+            lineHeight = 17.sp,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 2,
+            minLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center,
+            letterSpacing = (-0.2).sp,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
@@ -102,6 +102,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
@@ -111,6 +112,8 @@ import com.luc4n3x.levyra.domain.OfflineDownloadTask
 import com.luc4n3x.levyra.domain.ListeningPulse
 import com.luc4n3x.levyra.domain.Playlist
 import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.ui.components.LevyraArtistAvatar
+import com.luc4n3x.levyra.ui.components.levyraArtistAccent
 import com.luc4n3x.levyra.ui.i18n.LocalLevyraStrings
 import com.luc4n3x.levyra.ui.theme.LevyraCyan
 import com.luc4n3x.levyra.ui.theme.LevyraInk
@@ -2197,7 +2200,7 @@ private fun LibraryArtistRow(
         modifier = Modifier.fillMaxWidth().combinedClickable(onClick = onClick, onLongClick = onLongClick)
     ) {
         Row(modifier = Modifier.padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
-            LibraryArtwork(artist.artworkUrl, artist.name, Modifier.size(64.dp), CircleShape, selected)
+            LibraryArtistAvatar(artist = artist, size = 64.dp, selected = selected)
             Spacer(Modifier.width(13.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Text(artist.name, color = LevyraText, fontSize = 15.sp, fontWeight = FontWeight.Black, maxLines = 1, overflow = TextOverflow.Ellipsis)
@@ -2370,7 +2373,7 @@ private fun LibraryArtistGridCard(
 ) {
     Column(modifier = modifier.combinedClickable(onClick = onClick, onLongClick = onLongClick), horizontalAlignment = Alignment.CenterHorizontally) {
         Box {
-            LibraryArtwork(artist.artworkUrl, artist.name, Modifier.size(152.dp), CircleShape, selected)
+            LibraryArtistAvatar(artist = artist, size = 152.dp, selected = selected)
             if (selectionActive) {
                 Icon(if (selected) Icons.Rounded.CheckCircle else Icons.Rounded.RadioButtonUnchecked, contentDescription = null, tint = if (selected) LevyraCyan else Color.White.copy(alpha = 0.55f), modifier = Modifier.align(Alignment.TopEnd).padding(8.dp))
             }
@@ -2379,6 +2382,23 @@ private fun LibraryArtistGridCard(
         Text(artist.name, color = LevyraText, fontSize = 14.sp, fontWeight = FontWeight.Black, maxLines = 1, overflow = TextOverflow.Ellipsis)
         Text(if (isItalian) "${artist.tracks.size} brani" else "${artist.tracks.size} tracks", color = LevyraMuted, fontSize = 11.sp)
     }
+}
+
+@Composable
+private fun LibraryArtistAvatar(
+    artist: LibraryArtist,
+    size: Dp,
+    selected: Boolean
+) {
+    val accent = levyraArtistAccent(artist.browseId.ifBlank { artist.key })
+    LevyraArtistAvatar(
+        name = artist.name,
+        thumbnailUrl = artist.artworkUrl,
+        accentStart = accent.first,
+        accentEnd = accent.second,
+        size = size,
+        ringOverride = if (selected) LevyraCyan else null
+    )
 }
 
 @Composable


### PR DESCRIPTION
## Summary

- Gli artisti ora hanno una sola presentazione dell'immagine in tutta l'app: quella della Home (avatar circolare con anello accento e nome sotto).
- Rimossa la strisciolina sfumata sovrapposta alla foto dell'artista nella shelf "Artisti" della Home.
- Eliminata la seconda variante (card con badge `ARTISTA`) che compariva in "Artisti simili", nei risultati di ricerca e in "Simili a chi segui".

## Scope

- [x] UI / Compose

## What changed

- Nuovo file `ui/components/LevyraArtistPresentation.kt` con la presentazione condivisa:
  - `LevyraArtistAvatar`: avatar circolare con anello accento sfumato, glow e fallback icona/gradiente.
  - `LevyraArtistShelfItem`: item completo (avatar + nome su due righe) usato dalle shelf orizzontali.
  - `levyraArtistAccent`: accento stabile per artista, con fallback deterministico quando il modello non porta colori.
- `LevyraApp.kt`:
  - `PremiumHomeArtistItem` sostituito da `ArtistHitShelfItem`, che delega alla presentazione condivisa; la strisciolina sopra la foto non esiste più.
  - `ArtistHitRow` (ricerca, "Artisti simili" nella pagina artista, "Simili a chi segui" in Home) usa lo stesso item, senza card né badge.
  - `FollowedArtistsRow` allineata alla stessa presentazione.
  - Spaziature della shelf e placeholder di caricamento agganciati alle costanti condivise.
  - `StableRemoteArtwork` ora accetta `highRes` (default invariato) per gli avatar grandi.
- `LevyraLibraryScreen.kt`: gli avatar artista di lista e griglia usano lo stesso anello accento, mantenendo conteggi brani e indicatori di selezione (anello ciano quando selezionato).
- Anello, spazio interno e glow sono proporzionali alla dimensione dell'avatar, così il look resta identico a 64dp, 114dp e 152dp.

## Testing

- [ ] `gradle --no-daemon :app:lintRelease`
- [ ] `gradle --no-daemon testReleaseUnitTest`
- [ ] `gradle --no-daemon assembleRelease`
- [ ] APK installed on device
- [ ] Playback tested
- [ ] Downloads tested
- [ ] Language switching tested

Nessuna verifica eseguita in questa sessione: l'ambiente non ha l'Android SDK e le repository Maven (incluso Google Maven) non sono raggiungibili, quindi Gradle si ferma già alla risoluzione del plugin `com.android.application`. Le caselle restano non spuntate.

## Release safety

- [x] `levyraVersionName` and `levyraVersionCode` are correct
- [x] No secrets, keystores, APKs or ZIPs committed
- [x] No duplicated release workflows
- [x] Credits and licenses updated when adding external components

## Related issues

-
