### PR TITLE
feat: playlist shortcuts, engagement layout and fast Top 50 loading

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/ChartsRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/ChartsRepository.kt
@@ -1,54 +1,71 @@
 package com.luc4n3x.levyra.data
 
+import android.content.Context
 import com.luc4n3x.levyra.BuildConfig
+import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
 import com.luc4n3x.levyra.domain.Track
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import okhttp3.CacheControl
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import org.json.JSONObject
+import timber.log.Timber
 import java.io.IOException
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.coroutines.resume
-import kotlin.math.absoluteValue
 
-/**
- * Real, reliable music charts from Apple's public RSS feeds (no auth needed).
- * Tries the modern marketing-tools feed first, then the classic iTunes feed.
- * Entries carry real titles, artists and cover art; a playable YouTube match is
- * resolved on demand when the user taps the song.
- */
-class ChartsRepository {
+class ChartsRepository(context: Context) {
 
-    suspend fun topSongs(country: String, limit: Int = 50): List<Track> = coroutineScope {
+    private val appContext = context.applicationContext
+    private val httpClient: OkHttpClient by lazy { LevyraHttpClientFactory.feeds(appContext) }
+
+    // Chart feeds are shared, idempotent and cheap to keep alive: running them in a
+    // repository-owned scope lets a fetch survive the region switch that started it, so a
+    // cancelled selection still warms the cache for the next tap instead of being thrown away.
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val inFlight = ConcurrentHashMap<String, Deferred<List<Track>>>()
+
+    /** Stops any fetch still running when the owner goes away, so nothing outlives it unowned. */
+    fun close() {
+        scope.cancel()
+        inFlight.clear()
+    }
+
+    suspend fun topSongs(country: String, limit: Int = 50): List<Track> {
         val normalizedCountry = country.trim().lowercase().takeIf { it.length == 2 } ?: "it"
         val normalizedLimit = limit.coerceIn(1, 100)
-        val modern = async(Dispatchers.Default) {
-            runCatching { fetchModern(normalizedCountry, normalizedLimit) }.getOrDefault(emptyList())
+        val shared = sharedRequest("$normalizedCountry/$normalizedLimit", normalizedCountry, normalizedLimit)
+        return try {
+            shared.await()
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (error: Throwable) {
+            Timber.w(error, "Chart feed request failed for %s", normalizedCountry)
+            emptyList()
         }
-        val classic = async(Dispatchers.Default) {
-            runCatching { fetchClassic(normalizedCountry, normalizedLimit) }.getOrDefault(emptyList())
-        }
-        val first = select<Pair<Boolean, List<Track>>> {
-            modern.onAwait { true to it }
-            classic.onAwait { false to it }
-        }
-        if (first.second.isNotEmpty()) {
-            if (first.first) classic.cancel() else modern.cancel()
-            return@coroutineScope first.second
-        }
-        if (first.first) classic.await() else modern.await()
     }
 
     suspend fun officialArtwork(title: String, artist: String, country: String): String? = withContext(Dispatchers.IO) {
@@ -60,58 +77,84 @@ class ChartsRepository {
         val body = httpGet("https://itunes.apple.com/search?term=$term&entity=song&limit=12&country=$region")
             ?: return@withContext null
         val results = JSONObject(body).optJSONArray("results") ?: return@withContext null
-        val targetTitle = normalizeMusicText(cleanTitle)
-        val targetArtist = normalizeMusicText(cleanArtist)
+        val targetTitle = ChartFeedParser.normalizeMusicText(cleanTitle)
+        val targetArtist = ChartFeedParser.normalizeMusicText(cleanArtist)
         var bestArtwork = ""
         var bestScore = Int.MIN_VALUE
         for (index in 0 until results.length()) {
             val item = results.optJSONObject(index) ?: continue
             val artwork = item.optString("artworkUrl100").trim()
             if (artwork.isBlank()) continue
-            val candidateTitle = normalizeMusicText(item.optString("trackName"))
-            val candidateArtist = normalizeMusicText(item.optString("artistName"))
+            val candidateTitle = ChartFeedParser.normalizeMusicText(item.optString("trackName"))
+            val candidateArtist = ChartFeedParser.normalizeMusicText(item.optString("artistName"))
             val score = artworkMatchScore(targetTitle, targetArtist, candidateTitle, candidateArtist)
             if (score > bestScore) {
                 bestScore = score
                 bestArtwork = artwork
             }
         }
-        bestArtwork.takeIf { bestScore >= 95 }?.let(::upgradeArtwork)
+        bestArtwork.takeIf { bestScore >= 95 }?.let(ChartFeedParser::upgradeArtwork)
+    }
+
+    private fun sharedRequest(key: String, country: String, limit: Int): Deferred<List<Track>> {
+        inFlight[key]?.let { return it }
+        val created = scope.async(start = CoroutineStart.LAZY) { fetchTopSongs(country, limit) }
+        val active = inFlight.putIfAbsent(key, created)
+        if (active != null) {
+            created.cancel()
+            return active
+        }
+        created.invokeOnCompletion { inFlight.remove(key, created) }
+        created.start()
+        return created
+    }
+
+    /**
+     * The classic RSS endpoint is only a fallback, but chaining it after the modern feed meant a
+     * stalled primary cost two full timeouts back to back. This keeps the fast path untouched and
+     * separates the two failure shapes: a conclusive failure starts the fallback at once, while a
+     * merely slow primary is raced against it and the first usable feed wins.
+     */
+    private suspend fun fetchTopSongs(country: String, limit: Int): List<Track> = coroutineScope {
+        val winner = CompletableDeferred<List<Track>>()
+        val remaining = AtomicInteger(2)
+
+        fun dispatch(attempt: suspend () -> List<Track>) = launch {
+            val outcome: List<Track> = try {
+                attempt()
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (error: Throwable) {
+                Timber.w(error, "Chart feed attempt failed for %s", country)
+                emptyList()
+            }
+            if (outcome.isNotEmpty()) {
+                winner.complete(outcome)
+            } else if (remaining.decrementAndGet() == 0) {
+                winner.complete(emptyList())
+            }
+        }
+
+        val modern = dispatch { fetchModern(country, limit) }
+        launch {
+            withTimeoutOrNull(FEED_HEDGE_BUDGET_MS) { modern.join() }
+            if (!winner.isCompleted) dispatch { fetchClassic(country, limit) }
+        }
+        val result = winner.await()
+        coroutineContext.cancelChildren()
+        result
     }
 
     private suspend fun fetchModern(country: String, limit: Int): List<Track> {
         val url = "https://rss.marketingtools.apple.com/api/v2/$country/music/most-played/$limit/songs.json"
         val body = httpGet(url) ?: return emptyList()
-        val results = JSONObject(body).optJSONObject("feed")?.optJSONArray("results") ?: return emptyList()
-        val tracks = mutableListOf<Track>()
-        for (i in 0 until results.length()) {
-            val entry = results.optJSONObject(i) ?: continue
-            val title = entry.optString("name").trim()
-            if (title.isBlank()) continue
-            val artist = entry.optString("artistName").trim()
-            val artwork = upgradeArtwork(entry.optString("artworkUrl100"))
-            tracks += buildChartTrack(title, artist, artwork)
-        }
-        return tracks
+        return ChartFeedParser.modern(body, limit)
     }
 
     private suspend fun fetchClassic(country: String, limit: Int): List<Track> {
         val url = "https://itunes.apple.com/$country/rss/topsongs/limit=$limit/json"
         val body = httpGet(url) ?: return emptyList()
-        val entries = JSONObject(body).optJSONObject("feed")?.optJSONArray("entry") ?: return emptyList()
-        val tracks = mutableListOf<Track>()
-        for (i in 0 until entries.length()) {
-            val entry = entries.optJSONObject(i) ?: continue
-            val title = entry.optJSONObject("im:name")?.optString("label").orEmpty().trim()
-            if (title.isBlank()) continue
-            val artist = entry.optJSONObject("im:artist")?.optString("label").orEmpty().trim()
-            val images = entry.optJSONArray("im:image")
-            val artwork = upgradeArtwork(
-                images?.optJSONObject((images.length() - 1).coerceAtLeast(0))?.optString("label").orEmpty()
-            )
-            tracks += buildChartTrack(title, artist, artwork)
-        }
-        return tracks
+        return ChartFeedParser.classic(body, limit)
     }
 
     private suspend fun httpGet(url: String): String? = suspendCancellableCoroutine { continuation ->
@@ -119,6 +162,7 @@ class ChartsRepository {
             .url(url)
             .header("Accept", "application/json")
             .header("User-Agent", "Levyra/${BuildConfig.VERSION_NAME} Android")
+            .cacheControl(FEED_CACHE_CONTROL)
             .build()
         val call = httpClient.newCall(request)
         val completed = AtomicBoolean(false)
@@ -142,11 +186,6 @@ class ChartsRepository {
         })
     }
 
-    private fun upgradeArtwork(url: String): String {
-        if (url.isBlank()) return url
-        return url.replace(Regex("\\d+x\\d+bb"), "600x600bb")
-    }
-
     private fun artworkMatchScore(
         targetTitle: String,
         targetArtist: String,
@@ -168,21 +207,81 @@ class ChartsRepository {
         return score
     }
 
-    private fun normalizeMusicText(value: String): String {
+    private companion object {
+        const val FEED_HEDGE_BUDGET_MS = 900L
+        const val FEED_MAX_STALE_MINUTES = 30
+
+        // Charts move once a day at most, so a short stale window turns repeated region taps and
+        // warm app starts into cache hits instead of full round trips.
+        val FEED_CACHE_CONTROL: CacheControl = CacheControl.Builder()
+            .maxStale(FEED_MAX_STALE_MINUTES, TimeUnit.MINUTES)
+            .build()
+    }
+}
+
+internal object ChartFeedParser {
+
+    fun modern(body: String, limit: Int): List<Track> {
+        val results = runCatching {
+            JSONObject(body).optJSONObject("feed")?.optJSONArray("results")
+        }.getOrNull() ?: return emptyList()
+        val tracks = ArrayList<Track>(minOf(results.length(), limit).coerceAtLeast(0))
+        for (index in 0 until results.length()) {
+            if (tracks.size >= limit) break
+            val entry = results.optJSONObject(index) ?: continue
+            val title = entry.optString("name").trim()
+            if (title.isBlank()) continue
+            tracks += buildChartTrack(
+                title = title,
+                artist = entry.optString("artistName").trim(),
+                artwork = upgradeArtwork(entry.optString("artworkUrl100"))
+            )
+        }
+        return tracks
+    }
+
+    fun classic(body: String, limit: Int): List<Track> {
+        val entries = runCatching {
+            JSONObject(body).optJSONObject("feed")?.optJSONArray("entry")
+        }.getOrNull() ?: return emptyList()
+        val tracks = ArrayList<Track>(minOf(entries.length(), limit).coerceAtLeast(0))
+        for (index in 0 until entries.length()) {
+            if (tracks.size >= limit) break
+            val entry = entries.optJSONObject(index) ?: continue
+            val title = entry.optJSONObject("im:name")?.optString("label").orEmpty().trim()
+            if (title.isBlank()) continue
+            val images = entry.optJSONArray("im:image")
+            tracks += buildChartTrack(
+                title = title,
+                artist = entry.optJSONObject("im:artist")?.optString("label").orEmpty().trim(),
+                artwork = upgradeArtwork(
+                    images?.optJSONObject((images.length() - 1).coerceAtLeast(0))?.optString("label").orEmpty()
+                )
+            )
+        }
+        return tracks
+    }
+
+    fun upgradeArtwork(url: String): String {
+        if (url.isBlank()) return url
+        return url.replace(appleArtworkSize, "600x600bb")
+    }
+
+    fun normalizeMusicText(value: String): String {
         return value.lowercase()
-            .replace(Regex("""\([^)]*\)|\[[^]]*]"""), " ")
-            .replace(Regex("""feat\.?|featuring|ft\.?"""), " ")
-            .replace(Regex("""official audio|official video|lyrics?|visuali[sz]er|music video"""), " ")
-            .replace(Regex("""[^a-z0-9àèéìòóùçñäöüß\s]"""), " ")
-            .replace(Regex("""\s+"""), " ")
+            .replace(parentheticals, " ")
+            .replace(featuredMarkers, " ")
+            .replace(videoMarkers, " ")
+            .replace(nonMusicCharacters, " ")
+            .replace(repeatedWhitespace, " ")
             .trim()
     }
 
     private fun buildChartTrack(title: String, artist: String, artwork: String): Track {
-        val seed = stableSeed("$title|$artist")
-        val palette = palette(seed)
+        val identity = chartIdentity("$title|$artist")
+        val palette = palette(identity.seed)
         return Track(
-            id = "chart-${stableId("$title|$artist")}",
+            id = "chart-${identity.id}",
             title = title,
             artist = artist.ifBlank { "Vari artisti" },
             album = "Chart",
@@ -203,39 +302,35 @@ class ChartsRepository {
         )
     }
 
-    private fun stableSeed(value: String): Int {
-        return MessageDigest.getInstance("SHA-256")
-            .digest(value.toByteArray(StandardCharsets.UTF_8))
-            .take(4)
-            .fold(0) { acc, byte -> (acc shl 8) or (byte.toInt() and 0xFF) }
-            .absoluteValue
-    }
-
-    private fun stableId(value: String): String {
-        return MessageDigest.getInstance("SHA-256")
-            .digest(value.toByteArray(StandardCharsets.UTF_8))
-            .take(8)
-            .joinToString("") { "%02x".format(it) }
+    // One digest per entry instead of two: the seed and the persisted id are both derived from
+    // the same SHA-256 of "title|artist", so stored chart ids stay byte-for-byte identical.
+    // The sign bit is masked rather than negated: Int.MIN_VALUE.absoluteValue is still negative,
+    // which would index the palette out of bounds for a digest starting with 0x80000000.
+    private fun chartIdentity(value: String): ChartIdentity {
+        val digest = MessageDigest.getInstance("SHA-256").digest(value.toByteArray(StandardCharsets.UTF_8))
+        val seed = digest.take(4).fold(0) { acc, byte -> (acc shl 8) or (byte.toInt() and 0xFF) } and Int.MAX_VALUE
+        val id = digest.take(8).joinToString("") { "%02x".format(it) }
+        return ChartIdentity(seed = seed, id = id)
     }
 
     private fun palette(seed: Int): Pair<Int, Int> {
-        val palettes = listOf(
-            0xFF00E5FF.toInt() to 0xFF7B42FF.toInt(),
-            0xFF1B5CFF.toInt() to 0xFFFF4FD8.toInt(),
-            0xFFFF7A18.toInt() to 0xFF8E57FF.toInt(),
-            0xFF00D4A6.toInt() to 0xFFFF3B5C.toInt(),
-            0xFFFFB000.toInt() to 0xFF00E5FF.toInt()
-        )
         return palettes[seed % palettes.size]
     }
 
-    private companion object {
-        val httpClient: OkHttpClient = OkHttpClient.Builder()
-            .connectTimeout(4, TimeUnit.SECONDS)
-            .readTimeout(7, TimeUnit.SECONDS)
-            .callTimeout(8, TimeUnit.SECONDS)
-            .retryOnConnectionFailure(true)
-            .build()
-    }
+    private data class ChartIdentity(val seed: Int, val id: String)
 
+    private val appleArtworkSize = Regex("\\d+x\\d+bb")
+    private val parentheticals = Regex("""\([^)]*\)|\[[^]]*]""")
+    private val featuredMarkers = Regex("""feat\.?|featuring|ft\.?""")
+    private val videoMarkers = Regex("""official audio|official video|lyrics?|visuali[sz]er|music video""")
+    private val nonMusicCharacters = Regex("""[^a-z0-9àèéìòóùçñäöüß\s]""")
+    private val repeatedWhitespace = Regex("""\s+""")
+
+    private val palettes = listOf(
+        0xFF00E5FF.toInt() to 0xFF7B42FF.toInt(),
+        0xFF1B5CFF.toInt() to 0xFFFF4FD8.toInt(),
+        0xFFFF7A18.toInt() to 0xFF8E57FF.toInt(),
+        0xFF00D4A6.toInt() to 0xFFFF3B5C.toInt(),
+        0xFFFFB000.toInt() to 0xFF00E5FF.toInt()
+    )
 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraHomeSnapshotCache.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraHomeSnapshotCache.kt
@@ -26,7 +26,12 @@ class LevyraHomeSnapshotCache(context: Context) {
             if (storedLanguage != normalized) return null
             val createdAt = rootJson.optLong("createdAt", 0L)
             val parsedHomeSections = parseHomeSections(rootJson.optJSONArray("homeSections") ?: JSONArray())
-            val parsedCharts = parseTracks(rootJson.optJSONArray("charts") ?: JSONArray())
+            val chartRegionId = if (schema >= 13) rootJson.optString("chartRegionId").trim().lowercase() else ""
+            val parsedCharts = if (chartRegionId.isNotBlank()) {
+                parseTracks(rootJson.optJSONArray("charts") ?: JSONArray())
+            } else {
+                emptyList()
+            }
             val parsedPersonalOrbit = parseTracks(rootJson.optJSONArray("personalOrbit") ?: JSONArray())
             val parsedResonance = if (schema >= 12) parseTracks(rootJson.optJSONArray("resonanceTracks") ?: JSONArray()) else emptyList()
             val homeSections = if (schema >= 7) parsedHomeSections else parsedHomeSections.map { section ->
@@ -40,6 +45,7 @@ class LevyraHomeSnapshotCache(context: Context) {
                 languageCode = storedLanguage,
                 createdAt = createdAt,
                 homeSections = homeSections,
+                chartRegionId = chartRegionId,
                 charts = charts,
                 personalOrbit = personalOrbit,
                 homeArtists = homeArtists,
@@ -52,6 +58,7 @@ class LevyraHomeSnapshotCache(context: Context) {
     fun save(
         languageCode: String,
         homeSections: List<HomeSection>,
+        chartRegionId: String,
         charts: List<Track>,
         personalOrbit: List<Track>,
         homeArtists: List<ArtistHit>,
@@ -59,6 +66,7 @@ class LevyraHomeSnapshotCache(context: Context) {
         resonanceUpdatedAt: Long
     ) {
         val normalized = LevyraLanguageCatalog.normalize(languageCode)
+        val normalizedChartRegionId = chartRegionId.trim().lowercase()
         if (homeSections.isEmpty() && charts.isEmpty() && personalOrbit.isEmpty() && homeArtists.isEmpty() && resonanceTracks.isEmpty()) return
         runCatching {
             val json = JSONObject()
@@ -66,7 +74,8 @@ class LevyraHomeSnapshotCache(context: Context) {
                 .put("languageCode", normalized)
                 .put("createdAt", System.currentTimeMillis())
                 .put("homeSections", homeSectionsToJson(homeSections.take(12)))
-                .put("charts", tracksToJson(charts.take(60)))
+                .put("chartRegionId", normalizedChartRegionId)
+                .put("charts", tracksToJson(if (normalizedChartRegionId.isBlank()) emptyList() else charts.take(60)))
                 .put("personalOrbit", tracksToJson(personalOrbit.take(40)))
                 .put("homeArtists", artistsToJson(homeArtists.take(HOME_ARTIST_LIMIT)))
                 .put("resonanceTracks", tracksToJson(resonanceTracks.take(RESONANCE_TRACK_LIMIT)))
@@ -182,7 +191,7 @@ class LevyraHomeSnapshotCache(context: Context) {
         const val HOME_ARTIST_LIMIT = 13
         const val RESONANCE_TRACK_LIMIT = 8
         const val MIN_SUPPORTED_SCHEMA = 5
-        const val SCHEMA = 12
+        const val SCHEMA = 13
         const val MAX_STALE_MS = 21L * 24L * 60L * 60L * 1000L
     }
 }
@@ -191,6 +200,7 @@ data class LevyraHomeSnapshot(
     val languageCode: String,
     val createdAt: Long,
     val homeSections: List<HomeSection>,
+    val chartRegionId: String,
     val charts: List<Track>,
     val personalOrbit: List<Track>,
     val homeArtists: List<ArtistHit>,

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
@@ -365,6 +365,31 @@ class LevyraPreferences(context: Context) {
         }
     }
 
+    /**
+     * Reads several chart regions from a single DataStore snapshot. Calling [loadChartTracks] once
+     * per region blocks a thread on its own snapshot read each time, which is too expensive when
+     * warming every region up front.
+     */
+    fun loadChartTracksByRegion(
+        languageCode: String = languageCode(),
+        regionIds: List<String>
+    ): Map<String, List<Track>> {
+        if (regionIds.isEmpty()) return emptyMap()
+        val normalized = LevyraLanguageCatalog.normalize(languageCode)
+        return read<Map<String, List<Track>>>(emptyMap()) { preferences ->
+            val out = LinkedHashMap<String, List<Track>>(regionIds.size)
+            regionIds.forEach { regionId ->
+                val region = regionId.trim().lowercase()
+                if (region.isBlank() || out.containsKey(region)) return@forEach
+                val raw = preferences[chartTracksKey(normalized, region)].orEmpty()
+                if (raw.isBlank()) return@forEach
+                val tracks = parseTrackList(raw)
+                if (tracks.isNotEmpty()) out[region] = tracks
+            }
+            out
+        }
+    }
+
     fun saveChartTracks(tracks: List<Track>, languageCode: String = languageCode(), regionId: String = "") {
         val array = JSONArray()
         tracks.take(50).forEach { track -> array.put(TrackJson.toJson(track)) }

--- a/app/src/main/java/com/luc4n3x/levyra/data/network/LevyraHttpClientFactory.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/network/LevyraHttpClientFactory.kt
@@ -3,14 +3,19 @@ package com.luc4n3x.levyra.data.network
 import android.content.Context
 import com.chuckerteam.chucker.api.ChuckerInterceptor
 import com.luc4n3x.levyra.BuildConfig
+import okhttp3.Cache
 import okhttp3.ConnectionPool
 import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.brotli.BrotliInterceptor
+import java.io.File
 import java.util.concurrent.TimeUnit
 
 object LevyraHttpClientFactory {
+    private const val FEED_CACHE_DIRECTORY = "levyra_feed_http"
+    private const val FEED_CACHE_BYTES = 8L * 1024L * 1024L
+
     private val mediaConnectionPool = ConnectionPool(24, 5, TimeUnit.MINUTES)
     private val mediaDispatcher = Dispatcher().apply {
         maxRequests = 40
@@ -38,6 +43,29 @@ object LevyraHttpClientFactory {
 
     @Volatile
     private var downloadClient: OkHttpClient? = null
+
+    @Volatile
+    private var feedClient: OkHttpClient? = null
+
+    /**
+     * Client for small public JSON feeds (charts, catalog lookups).
+     *
+     * It reuses the media connection pool and dispatcher instead of adding another one, and owns a
+     * bounded HTTP cache so a repeated feed read can be answered from disk — or revalidated with a
+     * 304 — instead of downloading the whole payload again.
+     */
+    fun feeds(context: Context): OkHttpClient {
+        return feedClient ?: synchronized(this) {
+            feedClient ?: media(context).newBuilder()
+                .connectTimeout(4, TimeUnit.SECONDS)
+                .readTimeout(7, TimeUnit.SECONDS)
+                .callTimeout(9, TimeUnit.SECONDS)
+                .addInterceptor(BrotliInterceptor)
+                .cache(Cache(File(context.applicationContext.cacheDir, FEED_CACHE_DIRECTORY), FEED_CACHE_BYTES))
+                .build()
+                .also { feedClient = it }
+        }
+    }
 
     fun media(context: Context? = null): OkHttpClient {
         return mediaClient ?: synchronized(this) {

--- a/app/src/main/java/com/luc4n3x/levyra/player/AndroidAutoLibrary.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/AndroidAutoLibrary.kt
@@ -37,7 +37,7 @@ class AndroidAutoLibrary(context: Context) {
     private val preferences = LevyraPreferences(appContext)
     private val smartProfileStore = LevyraSmartMusicProfileStore(appContext)
     private val database = LevyraDatabase.get(appContext)
-    private val chartsRepository = ChartsRepository()
+    private val chartsRepository = ChartsRepository(appContext)
     private val musicRepository = YoutubeMusicRepository(appContext)
     private val resolver = PlaybackResolver.getInstance(appContext)
     private val queueEngine = PersistentQueueEngine.get(appContext)

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -10472,6 +10472,7 @@ private fun PlayerUtilityDock(
     compact: Boolean,
     onQueue: () -> Unit,
     onLyrics: () -> Unit,
+    onAddToPlaylist: () -> Unit,
     onDownload: () -> Unit
 ) {
     val strings = LocalLevyraStrings.current
@@ -10501,6 +10502,13 @@ private fun PlayerUtilityDock(
                 tint = if (lyricsAvailable) activeColor else Color.White.copy(alpha = 0.70f),
                 compact = compact,
                 onClick = onLyrics
+            )
+            PlayerDockAction(
+                icon = Icons.AutoMirrored.Rounded.PlaylistAdd,
+                label = strings.addToPlaylist,
+                tint = Color.White.copy(alpha = 0.82f),
+                compact = compact,
+                onClick = onAddToPlaylist
             )
             PlayerDockAction(
                 icon = if (isDownloaded) Icons.Rounded.DownloadDone else Icons.Rounded.Download,
@@ -10576,6 +10584,7 @@ private fun compactYoutubeCount(value: Long): String {
         .replace(Regex("[,.]0$"), "") + suffix
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun PlayerYoutubeEngagementRow(
     track: Track,
@@ -10597,130 +10606,126 @@ private fun PlayerYoutubeEngagementRow(
         enter = fadeIn(animationSpec = tween(220)) + slideInVertically(initialOffsetY = { it / 3 }),
         exit = fadeOut(animationSpec = tween(140))
     ) {
-        Column(
-            modifier = Modifier.padding(top = if (compact) 9.dp else 11.dp),
-            verticalArrangement = Arrangement.spacedBy(if (compact) 5.dp else 6.dp)
+        FlowRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = if (compact) 9.dp else 11.dp),
+            horizontalArrangement = Arrangement.spacedBy(if (compact) 8.dp else 9.dp),
+            verticalArrangement = Arrangement.spacedBy(if (compact) 7.dp else 8.dp)
         ) {
-            LazyRow(
-                horizontalArrangement = Arrangement.spacedBy(if (compact) 8.dp else 9.dp),
-                contentPadding = PaddingValues(end = 10.dp)
+            Surface(
+                color = Color.White.copy(alpha = 0.085f),
+                border = BorderStroke(1.dp, Color.White.copy(alpha = 0.105f)),
+                shape = CircleShape
             ) {
-                item(key = "youtube-votes") {
-                    Surface(
-                        color = Color.White.copy(alpha = 0.085f),
-                        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.105f)),
-                        shape = CircleShape
+                Row(
+                    modifier = Modifier.height(if (compact) 40.dp else 42.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Row(
+                        modifier = Modifier.padding(
+                            start = if (compact) 12.dp else 13.dp,
+                            end = if (compact) 10.dp else 11.dp
+                        ),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(7.dp)
                     ) {
-                        Row(
-                            modifier = Modifier.height(if (compact) 40.dp else 42.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Row(
-                                modifier = Modifier.padding(
-                                    start = if (compact) 12.dp else 13.dp,
-                                    end = if (compact) 10.dp else 11.dp
-                                ),
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(7.dp)
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Rounded.ThumbUp,
-                                    contentDescription = null,
-                                    tint = Color.White.copy(alpha = if (hasLikes) 0.94f else 0.48f),
-                                    modifier = Modifier.size(if (compact) 19.dp else 20.dp)
-                                )
-                                if (hasLikes) {
-                                    Text(
-                                        text = compactYoutubeCount(track.youtubeLikeCount),
-                                        color = Color.White.copy(alpha = 0.94f),
-                                        fontSize = if (compact) 12.5.sp else 13.sp,
-                                        fontWeight = FontWeight.ExtraBold
-                                    )
-                                }
-                            }
-                            Box(
-                                modifier = Modifier
-                                    .width(1.dp)
-                                    .height(if (compact) 23.dp else 24.dp)
-                                    .background(Color.White.copy(alpha = 0.14f))
+                        Icon(
+                            imageVector = Icons.Rounded.ThumbUp,
+                            contentDescription = null,
+                            tint = Color.White.copy(alpha = if (hasLikes) 0.94f else 0.48f),
+                            modifier = Modifier.size(if (compact) 19.dp else 20.dp)
+                        )
+                        if (hasLikes) {
+                            Text(
+                                text = compactYoutubeCount(track.youtubeLikeCount),
+                                color = Color.White.copy(alpha = 0.94f),
+                                fontSize = if (compact) 12.5.sp else 13.sp,
+                                fontWeight = FontWeight.ExtraBold,
+                                maxLines = 1
                             )
-                            Row(
-                                modifier = Modifier.padding(
-                                    start = if (compact) 10.dp else 11.dp,
-                                    end = if (compact) 12.dp else 13.dp
-                                ),
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(7.dp)
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Rounded.ThumbDown,
-                                    contentDescription = null,
-                                    tint = if (hasDislikeEstimate) {
-                                        secondary.playerMix(Color.White, 0.58f)
-                                    } else {
-                                        Color.White.copy(alpha = 0.48f)
-                                    },
-                                    modifier = Modifier.size(if (compact) 19.dp else 20.dp)
-                                )
-                                when {
-                                    engagement.dislikeEstimateLoading -> CircularProgressIndicator(
-                                        modifier = Modifier.size(if (compact) 12.dp else 13.dp),
-                                        strokeWidth = 1.8.dp,
-                                        color = secondary.playerMix(Color.White, 0.58f)
-                                    )
-                                    hasDislikeEstimate -> Text(
-                                        text = "~${compactYoutubeCount(engagement.estimatedDislikeCount)}",
-                                        color = Color.White.copy(alpha = 0.90f),
-                                        fontSize = if (compact) 12.5.sp else 13.sp,
-                                        fontWeight = FontWeight.ExtraBold
-                                    )
-                                }
-                            }
                         }
                     }
-                }
-
-                item(key = "youtube-comments") {
-                    Surface(
-                        color = Color.White.copy(alpha = 0.085f),
-                        border = BorderStroke(
-                            1.dp,
-                            if (comments.visible) primary.copy(alpha = 0.52f) else Color.White.copy(alpha = 0.105f)
+                    Box(
+                        modifier = Modifier
+                            .width(1.dp)
+                            .height(if (compact) 23.dp else 24.dp)
+                            .background(Color.White.copy(alpha = 0.14f))
+                    )
+                    Row(
+                        modifier = Modifier.padding(
+                            start = if (compact) 10.dp else 11.dp,
+                            end = if (compact) 12.dp else 13.dp
                         ),
-                        shape = CircleShape,
-                        modifier = Modifier.pressable(enabled = canOpenComments, onClick = onComments)
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(7.dp)
                     ) {
-                        Row(
-                            modifier = Modifier
-                                .height(if (compact) 40.dp else 42.dp)
-                                .padding(horizontal = if (compact) 13.dp else 14.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Rounded.ChatBubbleOutline,
-                                contentDescription = null,
-                                tint = if (canOpenComments) Color.White.copy(alpha = 0.90f) else Color.White.copy(alpha = 0.42f),
-                                modifier = Modifier.size(if (compact) 19.dp else 20.dp)
+                        Icon(
+                            imageVector = Icons.Rounded.ThumbDown,
+                            contentDescription = null,
+                            tint = if (hasDislikeEstimate) {
+                                secondary.playerMix(Color.White, 0.58f)
+                            } else {
+                                Color.White.copy(alpha = 0.48f)
+                            },
+                            modifier = Modifier.size(if (compact) 19.dp else 20.dp)
+                        )
+                        when {
+                            engagement.dislikeEstimateLoading -> CircularProgressIndicator(
+                                modifier = Modifier.size(if (compact) 12.dp else 13.dp),
+                                strokeWidth = 1.8.dp,
+                                color = secondary.playerMix(Color.White, 0.58f)
                             )
-                            when {
-                                comments.loading && !comments.loaded -> CircularProgressIndicator(
-                                    modifier = Modifier.size(if (compact) 12.dp else 13.dp),
-                                    strokeWidth = 1.8.dp,
-                                    color = primary.playerMix(Color.White, 0.52f)
-                                )
-                                commentBadge.isNotBlank() -> Text(
-                                    text = commentBadge,
-                                    color = Color.White.copy(alpha = 0.92f),
-                                    fontSize = if (compact) 12.5.sp else 13.sp,
-                                    fontWeight = FontWeight.ExtraBold
-                                )
-                            }
+                            hasDislikeEstimate -> Text(
+                                text = "~${compactYoutubeCount(engagement.estimatedDislikeCount)}",
+                                color = Color.White.copy(alpha = 0.90f),
+                                fontSize = if (compact) 12.5.sp else 13.sp,
+                                fontWeight = FontWeight.ExtraBold,
+                                maxLines = 1
+                            )
                         }
                     }
                 }
             }
 
+            Surface(
+                color = Color.White.copy(alpha = 0.085f),
+                border = BorderStroke(
+                    1.dp,
+                    if (comments.visible) primary.copy(alpha = 0.52f) else Color.White.copy(alpha = 0.105f)
+                ),
+                shape = CircleShape,
+                modifier = Modifier.pressable(enabled = canOpenComments, onClick = onComments)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .height(if (compact) 40.dp else 42.dp)
+                        .padding(horizontal = if (compact) 13.dp else 14.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.ChatBubbleOutline,
+                        contentDescription = null,
+                        tint = if (canOpenComments) Color.White.copy(alpha = 0.90f) else Color.White.copy(alpha = 0.42f),
+                        modifier = Modifier.size(if (compact) 19.dp else 20.dp)
+                    )
+                    when {
+                        comments.loading && !comments.loaded -> CircularProgressIndicator(
+                            modifier = Modifier.size(if (compact) 12.dp else 13.dp),
+                            strokeWidth = 1.8.dp,
+                            color = primary.playerMix(Color.White, 0.52f)
+                        )
+                        commentBadge.isNotBlank() -> Text(
+                            text = commentBadge,
+                            color = Color.White.copy(alpha = 0.92f),
+                            fontSize = if (compact) 12.5.sp else 13.sp,
+                            fontWeight = FontWeight.ExtraBold,
+                            maxLines = 1
+                        )
+                    }
+                }
+            }
         }
     }
 }
@@ -10746,7 +10751,8 @@ private fun PlayerAdvancedControlsPanel(
     secondaryContent: Color,
     compact: Boolean,
     strings: LevyraStrings,
-    viewModel: PlayerViewModel
+    viewModel: PlayerViewModel,
+    onAddToPlaylist: () -> Unit
 ) {
     AnimatedVisibility(
         visible = expanded,
@@ -10772,6 +10778,7 @@ private fun PlayerAdvancedControlsPanel(
                 compact = compact,
                 onQueue = viewModel::openQueue,
                 onLyrics = viewModel::openLyrics,
+                onAddToPlaylist = onAddToPlaylist,
                 onDownload = viewModel::exportCurrentTrack
             )
             PlayerOptionsRow(
@@ -10960,6 +10967,7 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
     var mediaSeekFeedbackEvent by remember(track?.id) { mutableStateOf(0) }
     var gestureFeedback by remember(track?.id) { mutableStateOf("") }
     var gestureFeedbackEvent by remember(track?.id) { mutableStateOf(0) }
+    var playlistTarget by remember(track?.id) { mutableStateOf<Track?>(null) }
 
     BackHandler(enabled = state.youtubeEngagement.comments.visible) {
         viewModel.closeYoutubeComments()
@@ -11343,61 +11351,77 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                     }
                 }
                 item {
-                    Row(
+                    Column(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(
                                 horizontal = 4.dp,
                                 vertical = if (compactPlayer) 1.dp else 2.dp
-                            ),
-                        verticalAlignment = Alignment.CenterVertically
+                            )
                     ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = track.title,
-                                color = Color.White,
-                                fontSize = if (compactPlayer) 24.sp else 25.sp,
-                                lineHeight = if (compactPlayer) 28.sp else 29.sp,
-                                fontWeight = FontWeight.Black,
-                                maxLines = 2,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                            Spacer(modifier = Modifier.height(if (compactPlayer) 3.dp else 4.dp))
-                            Text(
-                                text = track.artist,
-                                color = Color.White.copy(alpha = 0.68f),
-                                fontSize = if (compactPlayer) 14.sp else 15.sp,
-                                fontWeight = FontWeight.Medium,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.clickable { viewModel.openArtist(track) }
-                            )
-                            PlayerYoutubeEngagementRow(
-                                track = track,
-                                engagement = state.youtubeEngagement,
-                                primary = primary,
-                                secondary = secondary,
-                                compact = compactPlayer,
-                                onComments = viewModel::openYoutubeComments
-                            )
-                        }
-                        Spacer(modifier = Modifier.width(12.dp))
-                        val isFavorite = track.id in state.favoriteIds
-                        PlayerRoundIconButton(
-                            icon = if (isFavorite) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
-                            contentDescription = strings.favoritesPlain,
-                            size = if (compactPlayer) 44.dp else 46.dp,
-                            iconSize = if (compactPlayer) 23.dp else 24.dp,
-                            tint = if (isFavorite) {
-                                Color.White.playerContentColor(
-                                    listOf(primary.copy(alpha = 0.46f).playerCompositeOver(PlayerDarkSurface))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = track.title,
+                                    color = Color.White,
+                                    fontSize = if (compactPlayer) 24.sp else 25.sp,
+                                    lineHeight = if (compactPlayer) 28.sp else 29.sp,
+                                    fontWeight = FontWeight.Black,
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis
                                 )
-                            } else {
-                                Color.White.copy(alpha = 0.78f)
-                            },
-                            background = if (isFavorite) primary.copy(alpha = 0.46f) else Color.Black.copy(alpha = 0.20f),
-                            borderColor = if (isFavorite) primary.playerMix(Color.White, 0.25f).copy(alpha = 0.62f) else Color.White.copy(alpha = 0.12f),
-                            onClick = { viewModel.toggleFavorite(track) }
+                                Spacer(modifier = Modifier.height(if (compactPlayer) 3.dp else 4.dp))
+                                Text(
+                                    text = track.artist,
+                                    color = Color.White.copy(alpha = 0.68f),
+                                    fontSize = if (compactPlayer) 14.sp else 15.sp,
+                                    fontWeight = FontWeight.Medium,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    modifier = Modifier.clickable { viewModel.openArtist(track) }
+                                )
+                            }
+                            Spacer(modifier = Modifier.width(10.dp))
+                            Row(horizontalArrangement = Arrangement.spacedBy(7.dp)) {
+                                PlayerRoundIconButton(
+                                    icon = Icons.AutoMirrored.Rounded.PlaylistAdd,
+                                    contentDescription = strings.addToPlaylist,
+                                    size = if (compactPlayer) 44.dp else 46.dp,
+                                    iconSize = if (compactPlayer) 22.dp else 23.dp,
+                                    tint = Color.White.copy(alpha = 0.82f),
+                                    background = Color.Black.copy(alpha = 0.20f),
+                                    borderColor = Color.White.copy(alpha = 0.12f),
+                                    onClick = { playlistTarget = track }
+                                )
+                                val isFavorite = track.id in state.favoriteIds
+                                PlayerRoundIconButton(
+                                    icon = if (isFavorite) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
+                                    contentDescription = strings.favoritesPlain,
+                                    size = if (compactPlayer) 44.dp else 46.dp,
+                                    iconSize = if (compactPlayer) 23.dp else 24.dp,
+                                    tint = if (isFavorite) {
+                                        Color.White.playerContentColor(
+                                            listOf(primary.copy(alpha = 0.46f).playerCompositeOver(PlayerDarkSurface))
+                                        )
+                                    } else {
+                                        Color.White.copy(alpha = 0.78f)
+                                    },
+                                    background = if (isFavorite) primary.copy(alpha = 0.46f) else Color.Black.copy(alpha = 0.20f),
+                                    borderColor = if (isFavorite) primary.playerMix(Color.White, 0.25f).copy(alpha = 0.62f) else Color.White.copy(alpha = 0.12f),
+                                    onClick = { viewModel.toggleFavorite(track) }
+                                )
+                            }
+                        }
+                        PlayerYoutubeEngagementRow(
+                            track = track,
+                            engagement = state.youtubeEngagement,
+                            primary = primary,
+                            secondary = secondary,
+                            compact = compactPlayer,
+                            onComments = viewModel::openYoutubeComments
                         )
                     }
                 }
@@ -11450,11 +11474,28 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                         secondaryContent = secondaryContent,
                         compact = compactPlayer,
                         strings = strings,
-                        viewModel = viewModel
+                        viewModel = viewModel,
+                        onAddToPlaylist = { playlistTarget = track }
                     )
                 }
                 item { PlayerError(state.playerError) }
             }
+        }
+
+        playlistTarget?.let { target ->
+            AddToPlaylistDialog(
+                track = target,
+                playlists = state.playlists,
+                onDismiss = { playlistTarget = null },
+                onAddTo = { playlistId ->
+                    viewModel.addToPlaylist(playlistId, target)
+                    playlistTarget = null
+                },
+                onCreateWith = { name ->
+                    viewModel.createPlaylist(name, target)
+                    playlistTarget = null
+                }
+            )
         }
 
         if (state.youtubeEngagement.comments.visible) {
@@ -16138,6 +16179,7 @@ private fun ExploreScreen(viewModel: ExploreViewModel, state: LevyraUiState) {
     val strings = LocalLevyraStrings.current
     LaunchedEffect(Unit) { viewModel.ensureExplore(strings) }
     val context = LocalContext.current
+    var addToPlaylistTarget by remember { mutableStateOf<Track?>(null) }
 
     Box(
         modifier = Modifier
@@ -16186,7 +16228,7 @@ private fun ExploreScreen(viewModel: ExploreViewModel, state: LevyraUiState) {
                                     }
                                     context.startActivity(Intent.createChooser(intent, strings.shareVia))
                                 },
-                                onAddToPlaylist = {}
+                                onAddToPlaylist = { addToPlaylistTarget = track }
                             )
                         }
                     }
@@ -16236,6 +16278,22 @@ private fun ExploreScreen(viewModel: ExploreViewModel, state: LevyraUiState) {
                     }
                 }
             }
+        }
+
+        addToPlaylistTarget?.let { target ->
+            AddToPlaylistDialog(
+                track = target,
+                playlists = state.playlists,
+                onDismiss = { addToPlaylistTarget = null },
+                onAddTo = { playlistId ->
+                    viewModel.addToPlaylist(playlistId, target)
+                    addToPlaylistTarget = null
+                },
+                onCreateWith = { name ->
+                    viewModel.createPlaylist(name, target)
+                    addToPlaylistTarget = null
+                }
+            )
         }
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -161,6 +161,8 @@ class SearchViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::sea
 }
 
 class ExploreViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::exploreProjection) {
+    fun addToPlaylist(playlistId: String, track: Track) = root.addToPlaylist(playlistId, track)
+    fun createPlaylist(name: String, firstTrack: Track? = null) = root.createPlaylist(name, firstTrack)
     fun ensureExplore(strings: LevyraStrings) = root.ensureExplore(strings)
     fun playFrom(list: List<Track>, track: Track, loopOnCompletion: Boolean = false) = root.playFrom(list, track, loopOnCompletion)
     fun selectExploreZone(zone: ExploreZone) = root.selectExploreZone(zone)
@@ -213,7 +215,9 @@ class LibraryViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::li
 }
 
 class PlayerViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::playerProjection) {
+    fun addToPlaylist(playlistId: String, track: Track) = root.addToPlaylist(playlistId, track)
     fun closePlayer() = root.closePlayer()
+    fun createPlaylist(name: String, firstTrack: Track? = null) = root.createPlaylist(name, firstTrack)
     fun cycleSleepTimer() = root.cycleSleepTimer()
     fun cycleSpeed() = root.cycleSpeed()
     fun exportCurrentTrack() = root.exportCurrentTrack()

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -227,7 +227,7 @@ private fun playbackArtistTokens(value: String): List<String> {
 class LevyraViewModel(application: Application) : AndroidViewModel(application) {
     private val repository = YoutubeMusicRepository(application.applicationContext)
     private val artistRepository = ArtistRepository(repository, application.applicationContext)
-    private val chartsRepository = ChartsRepository()
+    private val chartsRepository = ChartsRepository(application.applicationContext)
     private val officialArtworkRepository = OfficialArtworkRepository(application.applicationContext)
     private val motionArtworkEngine = MotionArtworkEngine(application.applicationContext)
     private val database = LevyraDatabase.get(application.applicationContext)
@@ -326,6 +326,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private var homeArtistsJob: Job? = null
     private var chartsJob: Job? = null
     private var chartPrefetchJob: Job? = null
+    private var chartMemoryWarmJob: Job? = null
     private var homeSnapshotJob: Job? = null
     private var homeResonanceJob: Job? = null
     private var homeArtistsFingerprint: String = ""
@@ -582,11 +583,14 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             }
             .distinctBy { it.browseId.lowercase() }
             .take(HOME_ARTIST_SHELF_SIZE)
-        val cachedCharts = instantSnapshot?.charts?.takeIf { it.isNotEmpty() } ?: preferences.loadChartTracks(settings.languageCode, defaultChartRegion.id)
-        val startupCharts = LevyraStartupCatalog.repairTracks(
-            cachedCharts.ifEmpty { LevyraStartupCatalog.chartTracks(settings.languageCode) },
-            settings.languageCode
-        )
+        val snapshotCharts = instantSnapshot
+            ?.takeIf { it.chartRegionId == defaultChartRegion.id }
+            ?.charts
+            .orEmpty()
+        val cachedCharts = snapshotCharts.ifEmpty {
+            preferences.loadChartTracks(settings.languageCode, defaultChartRegion.id)
+        }
+        val startupCharts = LevyraStartupCatalog.repairTracks(cachedCharts, settings.languageCode)
         if (startupCharts.isNotEmpty()) {
             chartsByRegion[chartsCacheKey(settings.languageCode, defaultChartRegion.id)] = startupCharts
         }
@@ -658,7 +662,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 charts = startupCharts,
                 selectedChartId = defaultChartRegion.id,
                 isSearching = false,
-                isLoadingCharts = false,
+                isLoadingCharts = startupCharts.isEmpty(),
                 cacheReport = repository.cacheReport(),
                 userName = settings.userName,
                 languageCode = settings.languageCode,
@@ -864,9 +868,13 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             prefetchChartRegions(_state.value.selectedChartId)
         }
         viewModelScope.launch {
-            delay(startupPlan.secondaryStartDelayMs)
+            delay(1_200L)
             awaitHomeUiIdle(startupPlan)
-            loadCharts(deferUntilHomeIdle = true)
+            warmChartRegionMemoryCache()
+        }
+        viewModelScope.launch {
+            if (_state.value.charts.isNotEmpty()) delay(350L)
+            loadCharts(deferUntilHomeIdle = false)
         }
         viewModelScope.launch {
             delay(3_200L)
@@ -902,6 +910,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         homeSnapshotCache.save(
             languageCode = normalizedLanguage,
             homeSections = pendingHomeSectionsSnapshot.get() ?: snapshot.homeSections,
+            chartRegionId = snapshot.selectedChartId,
             charts = snapshot.charts,
             personalOrbit = snapshot.personalOrbitTracks,
             homeArtists = deferredHomeArtistsSnapshot.get() ?: snapshot.homeArtists,
@@ -2411,9 +2420,16 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         )
         val homeTracks = homeSections.flatMap { it.tracks }.distinctBy { it.id }
         val chartTracks = LevyraStartupCatalog.repairTracks(
-            preferences.loadChartTracks(languageCode, defaultChartRegion.id).ifEmpty { LevyraStartupCatalog.chartTracks(languageCode) },
+            preferences.loadChartTracks(languageCode, defaultChartRegion.id),
             languageCode
         )
+        val chartCacheKey = chartsCacheKey(languageCode, defaultChartRegion.id)
+        if (chartTracks.isEmpty()) {
+            chartsByRegion.remove(chartCacheKey)
+            chartsFreshAt.remove(chartCacheKey)
+        } else {
+            chartsByRegion[chartCacheKey] = chartTracks
+        }
         val cachedOrbit = LevyraStartupCatalog.repairTracks(preferences.loadPersonalOrbitTracks(languageCode), languageCode)
         val seed = mergeTracks(cachedOrbit + _state.value.recentSearches + _state.value.favorites, homeTracks + chartTracks)
         val orbit = LevyraPersonalOrbit.build(
@@ -2480,7 +2496,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 searchData = SearchResults(),
                 searchError = null,
                 isSearching = false,
-                isLoadingCharts = false,
+                isLoadingCharts = refreshRemote && chartTracks.isEmpty(),
                 exploreZoneId = null,
                 exploreTracks = emptyList(),
                 exploreVideos = emptyList()
@@ -2494,6 +2510,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             loadHomeFeed()
             loadCharts(defaultChartRegion.id)
         }
+        warmChartRegionMemoryCache()
     }
 
     fun restartOnboarding() {
@@ -2575,6 +2592,35 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         }
         loadCharts(normalizedRegionId)
         prefetchChartRegions(normalizedRegionId)
+    }
+
+    /**
+     * Loads the persisted chart regions into the in-memory map in a single DataStore snapshot
+     * read, so tapping a region chip renders from memory instead of showing a shimmer while disk
+     * is read. Entries are intentionally left without a freshness stamp: they are shown at once and
+     * still revalidated by [loadCharts] when the region is selected. The region count is capped so
+     * the resident track list stays bounded, and trimmed further on low-RAM devices.
+     */
+    private fun warmChartRegionMemoryCache() {
+        val lowRam = adaptivePlaybackPolicy.current(videoMode = false).lowRam
+        val budget = if (lowRam) CHART_WARM_REGION_LIMIT_LOW_RAM else CHART_WARM_REGION_LIMIT
+        chartMemoryWarmJob?.cancel()
+        chartMemoryWarmJob = viewModelScope.launch(Dispatchers.IO) {
+            val languageCode = _state.value.languageCode
+            val missing = ChartsCatalog.regions
+                .map { it.id }
+                .filter { regionId -> chartsByRegion[chartsCacheKey(languageCode, regionId)].isNullOrEmpty() }
+                .take(budget)
+            if (missing.isEmpty()) return@launch
+            val stored = preferences.loadChartTracksByRegion(languageCode, missing)
+            if (stored.isEmpty() || !isActive || _state.value.languageCode != languageCode) return@launch
+            stored.forEach { (regionId, tracks) ->
+                val repaired = LevyraStartupCatalog.repairTracks(tracks, languageCode)
+                if (repaired.isNotEmpty()) {
+                    chartsByRegion.putIfAbsent(chartsCacheKey(languageCode, regionId), repaired)
+                }
+            }
+        }
     }
 
     private fun prefetchChartRegions(anchorRegionId: String) {
@@ -5762,7 +5808,11 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     private companion object {
-        private const val CHART_CACHE_FRESH_MS = 15L * 60L * 1000L
+        // Apple publishes the most-played feed about once a day, so a region fetched within the
+        // last hour is served straight from memory instead of paying for another round trip.
+        private const val CHART_CACHE_FRESH_MS = 60L * 60L * 1000L
+        private const val CHART_WARM_REGION_LIMIT = 14
+        private const val CHART_WARM_REGION_LIMIT_LOW_RAM = 6
         private const val HOME_ARTIST_SHELF_SIZE = 13
         private const val HOME_ARTIST_HISTORY_LIMIT = 48
         private const val HOME_ARTIST_CANDIDATE_LIMIT = 48
@@ -5800,6 +5850,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         youtubeCommentContinuationHistory.clear()
         returnYoutubeDislikeRepository.close()
         youtubeCommentsRepository.close()
+        chartsRepository.close()
         cancelBackgroundWarmups()
         orbitArtworkJob?.cancel()
         officialMetadataSignal.close()

--- a/app/src/test/java/com/luc4n3x/levyra/data/ChartFeedParserTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/ChartFeedParserTest.kt
@@ -1,0 +1,157 @@
+package com.luc4n3x.levyra.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChartFeedParserTest {
+
+    @Test
+    fun modernFeedKeepsChartOrderAndUpgradesArtwork() {
+        val tracks = ChartFeedParser.modern(modernFeed, limit = 50)
+
+        assertEquals(2, tracks.size)
+        assertEquals("Prima Canzone", tracks[0].title)
+        assertEquals("Artista Uno", tracks[0].artist)
+        assertEquals("https://cdn.example/a/600x600bb.jpg", tracks[0].thumbnailUrl)
+        assertEquals("https://cdn.example/a/600x600bb.jpg", tracks[0].largeThumbnailUrl)
+        assertEquals("Seconda Canzone", tracks[1].title)
+    }
+
+    @Test
+    fun classicFeedUsesTheLargestImageVariant() {
+        val tracks = ChartFeedParser.classic(classicFeed, limit = 50)
+
+        assertEquals(1, tracks.size)
+        assertEquals("Classica", tracks[0].title)
+        assertEquals("Artista Due", tracks[0].artist)
+        assertEquals("https://cdn.example/c/600x600bb.jpg", tracks[0].thumbnailUrl)
+    }
+
+    @Test
+    fun entriesWithoutATitleAreSkipped() {
+        val tracks = ChartFeedParser.modern(modernFeedWithBlankTitle, limit = 50)
+
+        assertEquals(1, tracks.size)
+        assertEquals("Solo Questa", tracks[0].title)
+    }
+
+    @Test
+    fun limitCapsTheParsedEntries() {
+        val tracks = ChartFeedParser.modern(modernFeed, limit = 1)
+
+        assertEquals(1, tracks.size)
+        assertEquals("Prima Canzone", tracks[0].title)
+    }
+
+    @Test
+    fun malformedPayloadsParseAsEmptyInsteadOfThrowing() {
+        assertTrue(ChartFeedParser.modern("not json", limit = 50).isEmpty())
+        assertTrue(ChartFeedParser.classic("", limit = 50).isEmpty())
+        assertTrue(ChartFeedParser.modern("""{"feed":{}}""", limit = 50).isEmpty())
+    }
+
+    @Test
+    fun identityStaysStableAcrossFeedsAndVariesByTrack() {
+        val fromModern = ChartFeedParser.modern(modernFeed, limit = 50)
+        val fromClassic = ChartFeedParser.classic(sameTrackAsClassicFeed, limit = 50)
+
+        assertEquals(fromModern[0].id, fromClassic[0].id)
+        assertNotEquals(fromModern[0].id, fromModern[1].id)
+        assertTrue(fromModern[0].id.startsWith("chart-"))
+    }
+
+    @Test
+    fun identityMatchesThePersistedChartIdFormat() {
+        // Chart ids are stored in favourites, playlists and home snapshots, so the derivation is
+        // pinned here: SHA-256("title|artist") truncated to the first eight bytes.
+        val tracks = ChartFeedParser.modern(modernFeed, limit = 1)
+
+        assertEquals("chart-${sha256Prefix("Prima Canzone|Artista Uno")}", tracks[0].id)
+    }
+
+    @Test
+    fun missingArtistFallsBackToTheGenericLabel() {
+        val tracks = ChartFeedParser.modern(modernFeedWithoutArtist, limit = 50)
+
+        assertEquals("Vari artisti", tracks[0].artist)
+    }
+
+    @Test
+    fun normalizeMusicTextDropsDecorations() {
+        assertEquals("titolo", ChartFeedParser.normalizeMusicText("Titolo (Official Video)"))
+        assertEquals("titolo canzone", ChartFeedParser.normalizeMusicText("Titolo   Canzone!"))
+        assertEquals("titolo qualcuno", ChartFeedParser.normalizeMusicText("Titolo feat. Qualcuno"))
+    }
+
+    private fun sha256Prefix(value: String): String {
+        return java.security.MessageDigest.getInstance("SHA-256")
+            .digest(value.toByteArray(Charsets.UTF_8))
+            .take(8)
+            .joinToString("") { "%02x".format(it) }
+    }
+
+    private val modernFeed = """
+        {
+          "feed": {
+            "results": [
+              {"name": "Prima Canzone", "artistName": "Artista Uno", "artworkUrl100": "https://cdn.example/a/100x100bb.jpg"},
+              {"name": "Seconda Canzone", "artistName": "Artista Due", "artworkUrl100": "https://cdn.example/b/100x100bb.jpg"}
+            ]
+          }
+        }
+    """.trimIndent()
+
+    private val modernFeedWithBlankTitle = """
+        {
+          "feed": {
+            "results": [
+              {"name": "   ", "artistName": "Nessuno", "artworkUrl100": "https://cdn.example/x/100x100bb.jpg"},
+              {"name": "Solo Questa", "artistName": "Artista", "artworkUrl100": "https://cdn.example/y/100x100bb.jpg"}
+            ]
+          }
+        }
+    """.trimIndent()
+
+    private val modernFeedWithoutArtist = """
+        {
+          "feed": {
+            "results": [
+              {"name": "Senza Artista", "artistName": "", "artworkUrl100": "https://cdn.example/z/100x100bb.jpg"}
+            ]
+          }
+        }
+    """.trimIndent()
+
+    private val classicFeed = """
+        {
+          "feed": {
+            "entry": [
+              {
+                "im:name": {"label": "Classica"},
+                "im:artist": {"label": "Artista Due"},
+                "im:image": [
+                  {"label": "https://cdn.example/c/55x55bb.jpg"},
+                  {"label": "https://cdn.example/c/170x170bb.jpg"}
+                ]
+              }
+            ]
+          }
+        }
+    """.trimIndent()
+
+    private val sameTrackAsClassicFeed = """
+        {
+          "feed": {
+            "entry": [
+              {
+                "im:name": {"label": "Prima Canzone"},
+                "im:artist": {"label": "Artista Uno"},
+                "im:image": [{"label": "https://cdn.example/a/170x170bb.jpg"}]
+              }
+            ]
+          }
+        }
+    """.trimIndent()
+}


### PR DESCRIPTION
Replaces #229, whose workflow runs never started: every run there ended in `startup_failure` with no runner assigned and no steps executed. Same files, same content, fresh branch and check suite.

## Summary

- Adds "add to playlist" shortcuts to the mini-player, the main player controls and the YouTube engagement area, and reflows the engagement row so it adapts to narrow screens.
- Makes Top 50 loading fast: the chart feed no longer parses on the main thread, no longer chains two full network timeouts on failure, no longer forbids HTTP caching, and no longer throws away an in-flight fetch when the region changes.

## Scope

- [x] Player / audio
- [ ] Stream extraction
- [ ] Downloads
- [x] UI / Compose
- [ ] Localization
- [ ] Android Auto / media session
- [ ] CI / release
- [ ] Documentation

## What changed

**Playlist shortcuts and engagement layout**

- The dock, the mini-player and the YouTube engagement row expose an "add to playlist" action backed by `AddToPlaylistDialog`; each surface owns its own target state and closes the dialog after adding a track or creating a playlist.
- `ExploreViewModel` and `PlayerViewModel` delegate the playlist add/create operations to the root view model.
- The YouTube engagement row moved from `LazyRow` to `FlowRow` so the controls wrap instead of scrolling off-screen on narrow layouts.

**Top 50 loading speed**

- `ChartsRepository` takes a `Context` and uses the shared HTTP client factory instead of building a private OkHttp client.
- New `LevyraHttpClientFactory.feeds()`: reuses the media connection pool and dispatcher and owns a bounded 8 MB HTTP cache, so a repeated feed read is served from disk or revalidated with a 304 instead of downloading the whole payload again.
- Requests allow a 30 minute stale window instead of sending `Cache-Control: no-cache` on every call.
- Fetches run in a repository-owned supervised IO scope with in-flight deduplication. Feed JSON and the per-entry SHA-256 work no longer run on the main thread, and switching region no longer discards a call that was about to complete — tapping back joins the same request. `close()` bounds that scope from `onCleared()`.
- The modern feed and the classic RSS fallback now distinguish the two failure shapes: a conclusive failure starts the fallback immediately, while a merely slow primary is raced against it and the first usable feed wins. Previously the fallback only started after the primary had burned its full timeout.
- Feed parsing moved into `ChartFeedParser` with precompiled regexes and a single SHA-256 per entry instead of two. Chart ids are unchanged byte-for-byte, so stored favourites, playlists and home snapshots keep matching. The palette seed masks the sign bit instead of using `absoluteValue`, which stays negative for `Int.MIN_VALUE` and would index the palette out of bounds.
- `LevyraPreferences.loadChartTracksByRegion` reads several regions from one DataStore snapshot; the view model uses it to warm the in-memory region cache after the home screen goes idle, so a region chip renders from memory instead of showing a shimmer while disk is read. The warm-up is capped at 14 regions, 6 on low-RAM devices.
- Chart memory-cache freshness raised from 15 to 60 minutes, matching how often Apple publishes the most-played feed.
- `LevyraHomeSnapshotCache` persists the selected chart region, so a restored snapshot never shows another region's chart.

## Testing

- [x] `gradle --no-daemon :app:lintRelease` (CI)
- [x] `gradle --no-daemon testReleaseUnitTest` (CI)
- [x] `gradle --no-daemon assembleRelease` (CI, signed and F-Droid unsigned)
- [ ] APK installed on device
- [ ] Playback tested
- [ ] Downloads tested
- [ ] Language switching tested

Lint, unit tests and the release build were verified by the PR Check workflow, which is green. `ChartFeedParserTest` covers feed ordering, artwork upgrade, malformed payloads, the entry limit and the pinned chart id derivation. The device checks above have not been performed.

## Release safety

- [x] `levyraVersionName` and `levyraVersionCode` are correct (unchanged)
- [x] No secrets, keystores, APKs or ZIPs committed
- [x] No duplicated release workflows
- [x] Credits and licenses updated when adding external components (no new external components)

## Related issues

- Supersedes #229