### PR TITLE
feat: use YouTube Music charts as the primary Top 50 source

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/ChartOfficialArtworkResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/ChartOfficialArtworkResolver.kt
@@ -1,0 +1,237 @@
+package com.luc4n3x.levyra.data
+
+import android.content.Context
+import com.luc4n3x.levyra.domain.Track
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import org.json.JSONObject
+import java.security.MessageDigest
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Replaces cropped YouTube video frames with verified release artwork without changing chart order
+ * or the native YouTube playback identity. Cached matches are instant; unresolved entries retain the
+ * YouTube thumbnail only when every official provider fails or the strict chart artwork budget ends.
+ */
+internal class ChartOfficialArtworkResolver(context: Context) {
+    private val appContext = context.applicationContext
+    private val repositories = Array(PROVIDER_LANES) { OfficialArtworkRepository(appContext) }
+    private val store = appContext.getSharedPreferences(CACHE_NAME, Context.MODE_PRIVATE)
+    private val memory = ConcurrentHashMap<String, CachedArtwork>()
+    private val keyLocks = Array(KEY_LOCK_COUNT) { Mutex() }
+    private val lookupSlots = Semaphore(MAX_CONCURRENT_LOOKUPS)
+
+    suspend fun enrich(tracks: List<Track>, country: String): List<Track> = withContext(Dispatchers.IO) {
+        if (tracks.isEmpty()) return@withContext tracks
+        val normalizedCountry = country.trim().uppercase(Locale.ROOT).takeIf { it.length == 2 } ?: DEFAULT_COUNTRY
+        val resolved = ConcurrentHashMap<String, CachedArtwork>()
+
+        withTimeoutOrNull(TOTAL_ARTWORK_BUDGET_MS) {
+            coroutineScope {
+                tracks.map { track ->
+                    async {
+                        val key = identityKey(track)
+                        val artwork = lookupSlots.withPermit { resolve(key, track, normalizedCountry) }
+                        if (artwork != null) resolved[key] = artwork
+                    }
+                }.awaitAll()
+            }
+        }
+
+        tracks.map { track ->
+            resolved[identityKey(track)]?.applyTo(track) ?: cached(identityKey(track))?.applyTo(track) ?: track
+        }
+    }
+
+    private suspend fun resolve(key: String, track: Track, country: String): CachedArtwork? {
+        cached(key)?.let { return it }
+        if (hasFreshMiss(key, country)) return null
+        val lock = keyLocks[(key.hashCode() and Int.MAX_VALUE) % keyLocks.size]
+        return lock.withLock {
+            cached(key)?.let { return@withLock it }
+            if (hasFreshMiss(key, country)) return@withLock null
+            val official = try {
+                repositoryFor(key).find(track, country)
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (_: Throwable) {
+                null
+            }
+            if (official == null) {
+                store.edit().putLong(missKey(key, country), System.currentTimeMillis()).apply()
+                return@withLock null
+            }
+            val artwork = CachedArtwork.from(official)
+            memory[key] = artwork
+            store.edit()
+                .putString(artworkKey(key), artwork.toJson().toString())
+                .remove(missKey(key, country))
+                .apply()
+            artwork
+        }
+    }
+
+    private fun repositoryFor(key: String): OfficialArtworkRepository {
+        return repositories[(key.hashCode() and Int.MAX_VALUE) % repositories.size]
+    }
+
+    private fun cached(key: String): CachedArtwork? {
+        memory[key]?.let { cached ->
+            if (cached.isFresh()) return cached
+            memory.remove(key, cached)
+        }
+        val raw = store.getString(artworkKey(key), null) ?: return null
+        val cached = runCatching { CachedArtwork.from(JSONObject(raw)) }.getOrNull()
+        if (cached == null || !cached.isFresh()) {
+            store.edit().remove(artworkKey(key)).apply()
+            return null
+        }
+        memory[key] = cached
+        return cached
+    }
+
+    private fun hasFreshMiss(key: String, country: String): Boolean {
+        val recordedAt = store.getLong(missKey(key, country), 0L)
+        if (recordedAt <= 0L) return false
+        val fresh = System.currentTimeMillis() - recordedAt in 0 until MISS_TTL_MS
+        if (!fresh) store.edit().remove(missKey(key, country)).apply()
+        return fresh
+    }
+
+    private fun identityKey(track: Track): String {
+        val normalized = listOf(
+            ChartFeedParser.normalizeMusicText(track.title),
+            ChartFeedParser.normalizeMusicText(track.artist)
+        ).joinToString("|")
+        return MessageDigest.getInstance("SHA-256")
+            .digest(normalized.toByteArray(Charsets.UTF_8))
+            .take(12)
+            .joinToString("") { byte -> "%02x".format(byte) }
+    }
+
+    private fun artworkKey(key: String): String = "artwork.$key"
+
+    private fun missKey(key: String, country: String): String = "miss.$country.$key"
+
+    private data class CachedArtwork(
+        val thumbnailUrl: String,
+        val largeThumbnailUrl: String,
+        val album: String,
+        val provider: String,
+        val canonicalAlbumUrl: String,
+        val releaseDate: String,
+        val year: String,
+        val trackNumber: Int,
+        val discNumber: Int,
+        val explicit: Boolean,
+        val isrc: String,
+        val upc: String,
+        val score: Int,
+        val cachedAt: Long
+    ) {
+        fun isFresh(now: Long = System.currentTimeMillis()): Boolean =
+            thumbnailUrl.isNotBlank() && now - cachedAt in 0 until ARTWORK_TTL_MS
+
+        fun applyTo(track: Track): Track {
+            return track.copy(
+                album = album.ifBlank { track.album },
+                thumbnailUrl = thumbnailUrl,
+                largeThumbnailUrl = largeThumbnailUrl.ifBlank { thumbnailUrl },
+                isrc = isrc.ifBlank { track.isrc },
+                upc = upc.ifBlank { track.upc },
+                releaseDate = releaseDate.ifBlank { track.releaseDate },
+                year = year.ifBlank { track.year },
+                trackNumber = trackNumber.takeIf { it > 0 } ?: track.trackNumber,
+                discNumber = discNumber.takeIf { it > 0 } ?: track.discNumber,
+                explicit = explicit || track.explicit,
+                metadataProvider = provider.ifBlank { track.metadataProvider },
+                metadataConfidence = maxOf(track.metadataConfidence, confidence(score)),
+                canonicalAlbumUrl = canonicalAlbumUrl.ifBlank { track.canonicalAlbumUrl }
+            )
+        }
+
+        fun toJson(): JSONObject = JSONObject()
+            .put("thumbnailUrl", thumbnailUrl)
+            .put("largeThumbnailUrl", largeThumbnailUrl)
+            .put("album", album)
+            .put("provider", provider)
+            .put("canonicalAlbumUrl", canonicalAlbumUrl)
+            .put("releaseDate", releaseDate)
+            .put("year", year)
+            .put("trackNumber", trackNumber)
+            .put("discNumber", discNumber)
+            .put("explicit", explicit)
+            .put("isrc", isrc)
+            .put("upc", upc)
+            .put("score", score)
+            .put("cachedAt", cachedAt)
+
+        companion object {
+            fun from(value: OfficialArtworkRepository.OfficialArtwork): CachedArtwork = CachedArtwork(
+                thumbnailUrl = value.thumbnailUrl,
+                largeThumbnailUrl = value.largeThumbnailUrl,
+                album = value.album,
+                provider = value.provider,
+                canonicalAlbumUrl = value.canonicalAlbumUrl,
+                releaseDate = value.releaseDate,
+                year = value.year,
+                trackNumber = value.trackNumber,
+                discNumber = value.discNumber,
+                explicit = value.explicit,
+                isrc = value.isrc,
+                upc = value.upc,
+                score = value.score,
+                cachedAt = System.currentTimeMillis()
+            )
+
+            fun from(json: JSONObject): CachedArtwork = CachedArtwork(
+                thumbnailUrl = json.optString("thumbnailUrl"),
+                largeThumbnailUrl = json.optString("largeThumbnailUrl"),
+                album = json.optString("album"),
+                provider = json.optString("provider"),
+                canonicalAlbumUrl = json.optString("canonicalAlbumUrl"),
+                releaseDate = json.optString("releaseDate"),
+                year = json.optString("year"),
+                trackNumber = json.optInt("trackNumber", 0),
+                discNumber = json.optInt("discNumber", 0),
+                explicit = json.optBoolean("explicit", false),
+                isrc = json.optString("isrc"),
+                upc = json.optString("upc"),
+                score = json.optInt("score", 0),
+                cachedAt = json.optLong("cachedAt", 0L)
+            )
+
+            private fun confidence(score: Int): Int = when {
+                score >= 500 -> 100
+                score >= 420 -> 96
+                score >= 360 -> 91
+                score >= 320 -> 86
+                score >= 280 -> 80
+                score >= 240 -> 72
+                score >= 200 -> 64
+                else -> (score / 4).coerceIn(0, 63)
+            }
+        }
+    }
+
+    private companion object {
+        const val CACHE_NAME = "levyra_chart_official_artwork"
+        const val DEFAULT_COUNTRY = "IT"
+        const val PROVIDER_LANES = 2
+        const val KEY_LOCK_COUNT = 64
+        const val MAX_CONCURRENT_LOOKUPS = 8
+        const val TOTAL_ARTWORK_BUDGET_MS = 7_000L
+        const val ARTWORK_TTL_MS = 90L * 24L * 60L * 60L * 1000L
+        const val MISS_TTL_MS = 12L * 60L * 60L * 1000L
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/ChartsRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/ChartsRepository.kt
@@ -10,12 +10,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -41,14 +43,11 @@ class ChartsRepository(context: Context) {
 
     private val appContext = context.applicationContext
     private val httpClient: OkHttpClient by lazy { LevyraHttpClientFactory.feeds(appContext) }
-
-    // Chart feeds are shared, idempotent and cheap to keep alive: running them in a
-    // repository-owned scope lets a fetch survive the region switch that started it, so a
-    // cancelled selection still warms the cache for the next tap instead of being thrown away.
+    private val youtubeMusicCharts = YoutubeMusicChartsRepository(appContext)
+    private val chartArtworkResolver = ChartOfficialArtworkResolver(appContext)
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val inFlight = ConcurrentHashMap<String, Deferred<List<Track>>>()
 
-    /** Stops any fetch still running when the owner goes away, so nothing outlives it unowned. */
     fun close() {
         scope.cancel()
         inFlight.clear()
@@ -63,7 +62,7 @@ class ChartsRepository(context: Context) {
         } catch (cancellation: CancellationException) {
             throw cancellation
         } catch (error: Throwable) {
-            Timber.w(error, "Chart feed request failed for %s", normalizedCountry)
+            Timber.w(error, "Chart request failed for %s", normalizedCountry)
             emptyList()
         }
     }
@@ -109,49 +108,93 @@ class ChartsRepository(context: Context) {
         return created
     }
 
-    /**
-     * The classic RSS endpoint is only a fallback, but chaining it after the modern feed meant a
-     * stalled primary cost two full timeouts back to back. This keeps the fast path untouched and
-     * separates the two failure shapes: a conclusive failure starts the fallback at once, while a
-     * merely slow primary is raced against it and the first usable feed wins.
-     */
-    private suspend fun fetchTopSongs(country: String, limit: Int): List<Track> = coroutineScope {
-        val winner = CompletableDeferred<List<Track>>()
-        val remaining = AtomicInteger(2)
+    private suspend fun fetchTopSongs(country: String, limit: Int): List<Track> {
+        val ranked = selectTopSongs(country, limit)
+        if (ranked.isEmpty() || ranked.none(::isYoutubeMusicChartTrack)) return ranked
+        return chartArtworkResolver.enrich(ranked, country)
+    }
 
-        fun dispatch(attempt: suspend () -> List<Track>) = launch {
-            val outcome: List<Track> = try {
-                attempt()
-            } catch (cancellation: CancellationException) {
-                throw cancellation
-            } catch (error: Throwable) {
-                Timber.w(error, "Chart feed attempt failed for %s", country)
-                emptyList()
-            }
-            if (outcome.isNotEmpty()) {
-                winner.complete(outcome)
-            } else if (remaining.decrementAndGet() == 0) {
-                winner.complete(emptyList())
-            }
+    private suspend fun selectTopSongs(country: String, limit: Int): List<Track> = coroutineScope {
+        val youtube = async { fetchYoutubeTopSongs(country, limit) }
+        val youtubeWithinBudget = withTimeoutOrNull(YOUTUBE_PRIMARY_BUDGET_MS) { youtube.await() }
+        if (youtubeWithinBudget != null) {
+            if (youtubeWithinBudget.isNotEmpty()) return@coroutineScope youtubeWithinBudget
+            return@coroutineScope fetchAppleTopSongs(country, limit)
         }
 
-        val modern = dispatch { fetchModern(country, limit) }
+        val apple = async { fetchAppleTopSongs(country, limit) }
+        val first = select<Pair<Boolean, List<Track>>> {
+            youtube.onAwait { true to it }
+            apple.onAwait { false to it }
+        }
+        if (first.second.isNotEmpty()) {
+            if (first.first) apple.cancel() else youtube.cancel()
+            return@coroutineScope first.second
+        }
+        if (first.first) apple.await() else youtube.await()
+    }
+
+    private suspend fun fetchYoutubeTopSongs(country: String, limit: Int): List<Track> {
+        return try {
+            youtubeMusicCharts.topTracks(country, limit)
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (error: Throwable) {
+            Timber.w(error, "YouTube Music charts failed for %s", country)
+            emptyList()
+        }
+    }
+
+    private fun isYoutubeMusicChartTrack(track: Track): Boolean {
+        return track.source.equals(YOUTUBE_CHART_SOURCE, ignoreCase = true)
+    }
+
+    private suspend fun fetchAppleTopSongs(country: String, limit: Int): List<Track> = coroutineScope {
+        val winner = CompletableDeferred<List<Track>>()
+        val remaining = AtomicInteger(2)
+        val modern = dispatchAppleAttempt(country, winner, remaining) {
+            fetchAppleModern(country, limit)
+        }
         launch {
-            withTimeoutOrNull(FEED_HEDGE_BUDGET_MS) { modern.join() }
-            if (!winner.isCompleted) dispatch { fetchClassic(country, limit) }
+            withTimeoutOrNull(APPLE_FEED_HEDGE_BUDGET_MS) { modern.join() }
+            if (!winner.isCompleted) {
+                dispatchAppleAttempt(country, winner, remaining) {
+                    fetchAppleClassic(country, limit)
+                }
+            }
         }
         val result = winner.await()
         coroutineContext.cancelChildren()
         result
     }
 
-    private suspend fun fetchModern(country: String, limit: Int): List<Track> {
+    private fun CoroutineScope.dispatchAppleAttempt(
+        country: String,
+        winner: CompletableDeferred<List<Track>>,
+        remaining: AtomicInteger,
+        attempt: suspend () -> List<Track>
+    ): Job = launch {
+        val outcome = try {
+            attempt()
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (error: Throwable) {
+            Timber.w(error, "Apple chart feed attempt failed for %s", country)
+            emptyList()
+        }
+        when {
+            outcome.isNotEmpty() -> winner.complete(outcome)
+            remaining.decrementAndGet() == 0 -> winner.complete(emptyList())
+        }
+    }
+
+    private suspend fun fetchAppleModern(country: String, limit: Int): List<Track> {
         val url = "https://rss.marketingtools.apple.com/api/v2/$country/music/most-played/$limit/songs.json"
         val body = httpGet(url) ?: return emptyList()
         return ChartFeedParser.modern(body, limit)
     }
 
-    private suspend fun fetchClassic(country: String, limit: Int): List<Track> {
+    private suspend fun fetchAppleClassic(country: String, limit: Int): List<Track> {
         val url = "https://itunes.apple.com/$country/rss/topsongs/limit=$limit/json"
         val body = httpGet(url) ?: return emptyList()
         return ChartFeedParser.classic(body, limit)
@@ -208,11 +251,11 @@ class ChartsRepository(context: Context) {
     }
 
     private companion object {
-        const val FEED_HEDGE_BUDGET_MS = 900L
+        const val YOUTUBE_PRIMARY_BUDGET_MS = 3_500L
+        const val APPLE_FEED_HEDGE_BUDGET_MS = 900L
         const val FEED_MAX_STALE_MINUTES = 30
+        const val YOUTUBE_CHART_SOURCE = "YouTube Music Charts"
 
-        // Charts move once a day at most, so a short stale window turns repeated region taps and
-        // warm app starts into cache hits instead of full round trips.
         val FEED_CACHE_CONTROL: CacheControl = CacheControl.Builder()
             .maxStale(FEED_MAX_STALE_MINUTES, TimeUnit.MINUTES)
             .build()
@@ -284,15 +327,14 @@ internal object ChartFeedParser {
             id = "chart-${identity.id}",
             title = title,
             artist = artist.ifBlank { "Vari artisti" },
-            album = "Chart",
+            album = "Apple Music Charts",
             durationMs = 0L,
             streamUrl = "",
-            // No YouTube id yet: playback resolves a match by searching title + artist.
             videoUrl = "",
             thumbnailUrl = artwork,
             largeThumbnailUrl = artwork,
-            source = "Classifica",
-            moodTags = setOf("hit"),
+            source = "Apple Music Charts",
+            moodTags = setOf("hit", "chart"),
             energy = 70,
             vocal = 55,
             replayScore = 90,
@@ -302,10 +344,6 @@ internal object ChartFeedParser {
         )
     }
 
-    // One digest per entry instead of two: the seed and the persisted id are both derived from
-    // the same SHA-256 of "title|artist", so stored chart ids stay byte-for-byte identical.
-    // The sign bit is masked rather than negated: Int.MIN_VALUE.absoluteValue is still negative,
-    // which would index the palette out of bounds for a digest starting with 0x80000000.
     private fun chartIdentity(value: String): ChartIdentity {
         val digest = MessageDigest.getInstance("SHA-256").digest(value.toByteArray(StandardCharsets.UTF_8))
         val seed = digest.take(4).fold(0) { acc, byte -> (acc shl 8) or (byte.toInt() and 0xFF) } and Int.MAX_VALUE

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicChartsRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicChartsRepository.kt
@@ -1,0 +1,307 @@
+package com.luc4n3x.levyra.data
+
+import android.content.Context
+import com.luc4n3x.levyra.BuildConfig
+import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
+import com.luc4n3x.levyra.data.security.GoogleApiKeyHeaders
+import com.luc4n3x.levyra.domain.LevyraContentLocales
+import com.luc4n3x.levyra.domain.LevyraLanguageCatalog
+import com.luc4n3x.levyra.domain.Track
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import org.json.JSONArray
+import org.json.JSONObject
+import timber.log.Timber
+import java.io.IOException
+import java.util.Locale
+import kotlin.coroutines.resume
+
+internal class YoutubeMusicChartsRepository(context: Context) {
+    private val appContext = context.applicationContext
+    private val httpClient = LevyraHttpClientFactory.feeds(appContext)
+    private val musicRepository = YoutubeMusicRepository(appContext)
+    private val playlistStore = appContext.getSharedPreferences(PLAYLIST_STORE_NAME, Context.MODE_PRIVATE)
+
+    suspend fun topTracks(country: String, limit: Int): List<Track> = withContext(Dispatchers.IO) {
+        val request = chartRequest(country, limit)
+        val cache = readPlaylistCache(request.country, System.currentTimeMillis())
+        val candidates = resolvePlaylistCandidates(request, cache)
+        val tracks = loadFirstAvailablePlaylist(candidates, request)
+        if (tracks.isNotEmpty()) tracks else refreshFreshCache(request, cache)
+    }
+
+    private fun chartRequest(country: String, limit: Int): ChartRequest {
+        return ChartRequest(
+            country = country.trim().uppercase(Locale.ROOT).takeIf { it.length == 2 } ?: DEFAULT_COUNTRY,
+            limit = limit.coerceIn(1, 100),
+            languageCode = LevyraLanguageCatalog.deviceDefault()
+        )
+    }
+
+    private fun readPlaylistCache(country: String, now: Long): PlaylistCache {
+        val playlistId = playlistStore.getString(playlistKey(country), "").orEmpty()
+        val updatedAt = playlistStore.getLong(playlistTimestampKey(country), 0L)
+        val isFresh = playlistId.isNotBlank() && now - updatedAt in 0 until PLAYLIST_ID_TTL_MS
+        return PlaylistCache(playlistId = playlistId, isFresh = isFresh)
+    }
+
+    private suspend fun resolvePlaylistCandidates(
+        request: ChartRequest,
+        cache: PlaylistCache
+    ): List<String> {
+        if (cache.isFresh) return listOf(cache.playlistId)
+        val discovered = discoverAndPersistPlaylistId(request)
+        return buildList {
+            if (discovered.isNotBlank()) add(discovered)
+            if (cache.playlistId.isNotBlank() && cache.playlistId != discovered) add(cache.playlistId)
+        }
+    }
+
+    private suspend fun refreshFreshCache(
+        request: ChartRequest,
+        cache: PlaylistCache
+    ): List<Track> {
+        if (!cache.isFresh) return emptyList()
+        val discovered = discoverAndPersistPlaylistId(request)
+        if (discovered.isBlank() || discovered == cache.playlistId) return emptyList()
+        return loadPlaylist(discovered, request)
+    }
+
+    private suspend fun discoverAndPersistPlaylistId(request: ChartRequest): String {
+        val playlistId = discoverPlaylistId(request.country, request.languageCode)
+        if (playlistId.isNotBlank()) {
+            persistPlaylistId(request.country, playlistId, System.currentTimeMillis())
+        }
+        return playlistId
+    }
+
+    private suspend fun loadFirstAvailablePlaylist(
+        candidates: List<String>,
+        request: ChartRequest
+    ): List<Track> {
+        for (playlistId in candidates) {
+            val tracks = loadPlaylist(playlistId, request)
+            if (tracks.isNotEmpty()) return tracks
+        }
+        return emptyList()
+    }
+
+    private suspend fun loadPlaylist(
+        playlistId: String,
+        request: ChartRequest
+    ): List<Track> {
+        val tracks = try {
+            fetchPlaylistTracks(playlistId, request)
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (error: Throwable) {
+            Timber.w(error, "YouTube Music chart playlist failed for %s", playlistId)
+            emptyList()
+        }
+        return tracks
+            .asSequence()
+            .filter { it.id.isNotBlank() && it.title.isNotBlank() && it.videoUrl.isNotBlank() }
+            .distinctBy { it.id }
+            .take(request.limit)
+            .map { track ->
+                track.copy(
+                    album = track.album.ifBlank { CHART_ALBUM },
+                    source = CHART_SOURCE,
+                    moodTags = track.moodTags + setOf("chart", "hit"),
+                    replayScore = maxOf(track.replayScore, 90),
+                    cacheScore = maxOf(track.cacheScore, 85)
+                )
+            }
+            .toList()
+    }
+
+    private suspend fun fetchPlaylistTracks(
+        playlistId: String,
+        request: ChartRequest
+    ): List<Track> {
+        val tracks = LinkedHashMap<String, Track>()
+        val requestedContinuations = mutableSetOf<String>()
+        var continuation = ""
+        var page = 0
+        while (tracks.size < request.limit && page < MAX_PLAYLIST_PAGES) {
+            currentCoroutineContext().ensureActive()
+            if (continuation.isNotBlank() && !requestedContinuations.add(continuation)) break
+            val payload = playlistPayload(playlistId, continuation, request)
+            val body = postBrowse(payload, "https://music.youtube.com/playlist?list=$playlistId") ?: break
+            currentCoroutineContext().ensureActive()
+            val root = runCatching { JSONObject(body) }.getOrNull() ?: break
+            musicRepository.parsePlaylistTracks(root, playlistId).forEach { track ->
+                tracks.putIfAbsent(track.id, track)
+            }
+            continuation = YoutubeMusicPlaylistPageParser.continuation(root)
+            page += 1
+            if (continuation.isBlank()) break
+        }
+        return tracks.values.take(request.limit)
+    }
+
+    private fun playlistPayload(
+        playlistId: String,
+        continuation: String,
+        request: ChartRequest
+    ): JSONObject {
+        return JSONObject()
+            .put("context", clientContext(request.languageCode, request.country))
+            .apply {
+                if (continuation.isBlank()) put("browseId", "VL$playlistId")
+                else put("continuation", continuation)
+            }
+    }
+
+    private suspend fun discoverPlaylistId(country: String, languageCode: String): String {
+        val payload = JSONObject()
+            .put("context", clientContext(languageCode, country))
+            .put("browseId", "FEmusic_charts")
+            .put(
+                "formData",
+                JSONObject().put("selectedValues", JSONArray().put(country))
+            )
+        val body = postBrowse(payload, "https://music.youtube.com/charts") ?: return ""
+        return YoutubeMusicChartPageParser.firstPlaylistId(body)
+    }
+
+    private fun clientContext(languageCode: String, country: String): JSONObject {
+        val locale = LevyraContentLocales.forLanguage(languageCode)
+        return JSONObject().put(
+            "client",
+            JSONObject()
+                .put("clientName", "WEB_REMIX")
+                .put("clientVersion", CLIENT_VERSION)
+                .put("hl", locale.hl)
+                .put("gl", country)
+        )
+    }
+
+    private suspend fun postBrowse(payload: JSONObject, referer: String): String? =
+        suspendCancellableCoroutine { continuation ->
+            val requestBody = payload.toString().toRequestBody(JSON_MEDIA_TYPE)
+            val builder = Request.Builder()
+                .url("https://music.youtube.com/youtubei/v1/browse?key=${BuildConfig.YOUTUBE_INNERTUBE_API_KEY}&prettyPrint=false")
+                .post(requestBody)
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json")
+                .header("Origin", "https://music.youtube.com")
+                .header("Referer", referer)
+                .header("User-Agent", USER_AGENT)
+                .header("X-Youtube-Client-Name", "67")
+                .header("X-Youtube-Client-Version", CLIENT_VERSION)
+            val request = GoogleApiKeyHeaders.applyTo(builder, appContext).build()
+            val call = httpClient.newCall(request)
+            continuation.invokeOnCancellation { call.cancel() }
+            call.enqueue(object : Callback {
+                override fun onFailure(call: Call, error: IOException) {
+                    if (continuation.isActive) continuation.resume(null)
+                }
+
+                override fun onResponse(call: Call, response: Response) {
+                    val result = runCatching {
+                        response.use { current ->
+                            if (!current.isSuccessful) null else current.body?.string()?.takeIf(String::isNotBlank)
+                        }
+                    }.getOrNull()
+                    if (continuation.isActive) continuation.resume(result)
+                }
+            })
+        }
+
+    private fun persistPlaylistId(country: String, playlistId: String, timestamp: Long) {
+        playlistStore.edit()
+            .putString(playlistKey(country), playlistId)
+            .putLong(playlistTimestampKey(country), timestamp)
+            .apply()
+    }
+
+    private fun playlistKey(country: String): String = "playlist.$country"
+
+    private fun playlistTimestampKey(country: String): String = "playlist.$country.updatedAt"
+
+    private data class ChartRequest(
+        val country: String,
+        val limit: Int,
+        val languageCode: String
+    )
+
+    private data class PlaylistCache(
+        val playlistId: String,
+        val isFresh: Boolean
+    )
+
+    private companion object {
+        const val DEFAULT_COUNTRY = "IT"
+        const val CLIENT_VERSION = "1.20260423.01.00"
+        const val PLAYLIST_STORE_NAME = "levyra_youtube_music_charts"
+        const val PLAYLIST_ID_TTL_MS = 7L * 24L * 60L * 60L * 1000L
+        const val MAX_PLAYLIST_PAGES = 8
+        const val CHART_SOURCE = "YouTube Music Charts"
+        const val CHART_ALBUM = "YouTube Music Charts"
+        const val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
+        val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+    }
+}
+
+internal object YoutubeMusicChartPageParser {
+    fun firstPlaylistId(body: String): String {
+        val root = runCatching { JSONObject(body) }.getOrNull() ?: return ""
+        return firstPlaylistId(root)
+    }
+
+    fun firstPlaylistId(root: JSONObject): String {
+        val carousels = mutableListOf<JSONObject>()
+        collectObjectsByKey(root, "musicCarouselShelfRenderer", carousels)
+        for (carousel in carousels) {
+            val contents = carousel.optJSONArray("contents") ?: continue
+            val playlistIds = ArrayList<String>(contents.length())
+            for (index in 0 until contents.length()) {
+                val playlistId = playlistBrowseId(contents.opt(index))
+                if (playlistId.isNotBlank()) playlistIds += playlistId
+            }
+            if (playlistIds.isNotEmpty()) return playlistIds.first()
+        }
+        return ""
+    }
+
+    private fun playlistBrowseId(value: Any?): String {
+        val endpoints = mutableListOf<JSONObject>()
+        collectObjectsByKey(value, "browseEndpoint", endpoints)
+        return endpoints.firstNotNullOfOrNull { endpoint ->
+            endpoint.optString("browseId")
+                .trim()
+                .takeIf { it.startsWith("VL") && it.length > 2 }
+                ?.removePrefix("VL")
+        }.orEmpty()
+    }
+
+    private fun collectObjectsByKey(value: Any?, targetKey: String, output: MutableList<JSONObject>) {
+        when (value) {
+            is JSONObject -> {
+                val keys = value.keys()
+                while (keys.hasNext()) {
+                    val key = keys.next()
+                    val child = value.opt(key)
+                    if (key == targetKey && child is JSONObject) output += child
+                    collectObjectsByKey(child, targetKey, output)
+                }
+            }
+            is JSONArray -> {
+                for (index in 0 until value.length()) {
+                    collectObjectsByKey(value.opt(index), targetKey, output)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -5473,10 +5473,12 @@ private fun HomeScreen(viewModel: HomeViewModel, renderSnapshot: HomeRenderSnaps
             }
         }
         if (showDeferredHomeSections && state.interfaceSettings.showCharts) {
-            item(key = "home-chart-title", contentType = "home-section-header") {
-                val region = state.chartRegions.firstOrNull { it.id == state.selectedChartId }
-                HomeSectionInset {
-                    SectionHeaderAction("Top 50 ${region?.label ?: "Global"}", onPlayAll = { viewModel.playAll(state.charts) })
+            if (state.charts.isNotEmpty()) {
+                item(key = "home-chart-title", contentType = "home-section-header") {
+                    val region = state.chartRegions.firstOrNull { it.id == state.selectedChartId }
+                    HomeSectionInset {
+                        SectionHeaderAction("Top ${state.charts.size.coerceAtMost(50)} ${region?.label ?: "Global"}", onPlayAll = { viewModel.playAll(state.charts) })
+                    }
                 }
             }
             item(key = "home-chart-regions", contentType = "home-horizontal-row") {

--- a/app/src/test/java/com/luc4n3x/levyra/data/ChartFeedParserSourceTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/ChartFeedParserSourceTest.kt
@@ -1,0 +1,30 @@
+package com.luc4n3x.levyra.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChartFeedParserSourceTest {
+
+    @Test
+    fun appleFallbackIsExplicitlyIdentified() {
+        val tracks = ChartFeedParser.modern(
+            """
+                {
+                  "feed": {
+                    "results": [
+                      {
+                        "name": "Fallback Song",
+                        "artistName": "Fallback Artist",
+                        "artworkUrl100": "https://cdn.example/100x100bb.jpg"
+                      }
+                    ]
+                  }
+                }
+            """.trimIndent(),
+            limit = 1
+        )
+
+        assertEquals("Apple Music Charts", tracks.single().source)
+        assertEquals("Apple Music Charts", tracks.single().album)
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicChartPageParserTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicChartPageParserTest.kt
@@ -1,0 +1,102 @@
+package com.luc4n3x.levyra.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class YoutubeMusicChartPageParserTest {
+
+    @Test
+    fun selectsTheFirstChartPlaylistCarousel() {
+        assertEquals("PL_TOP_ITALY", YoutubeMusicChartPageParser.firstPlaylistId(chartPage))
+    }
+
+    @Test
+    fun ignoresNonPlaylistCarouselsBeforeCharts() {
+        assertEquals("PL_TOP_ITALY", YoutubeMusicChartPageParser.firstPlaylistId(chartPage))
+    }
+
+    @Test
+    fun stripsTheYoutubeMusicVirtualListPrefix() {
+        assertEquals("PL_TOP_ITALY", YoutubeMusicChartPageParser.firstPlaylistId(chartPage))
+    }
+
+    @Test
+    fun malformedOrUnsupportedPayloadReturnsEmpty() {
+        assertEquals("", YoutubeMusicChartPageParser.firstPlaylistId("not json"))
+        assertEquals("", YoutubeMusicChartPageParser.firstPlaylistId("""{"contents":{}}"""))
+    }
+
+    private val chartPage = """
+        {
+          "contents": {
+            "singleColumnBrowseResultsRenderer": {
+              "tabs": [
+                {
+                  "tabRenderer": {
+                    "content": {
+                      "sectionListRenderer": {
+                        "contents": [
+                          {
+                            "musicCarouselShelfRenderer": {
+                              "contents": [
+                                {
+                                  "musicTwoRowItemRenderer": {
+                                    "title": {
+                                      "runs": [
+                                        {
+                                          "text": "Album popolari",
+                                          "navigationEndpoint": {
+                                            "browseEndpoint": {
+                                              "browseId": "MPREb_album"
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "musicCarouselShelfRenderer": {
+                              "contents": [
+                                {
+                                  "musicTwoRowItemRenderer": {
+                                    "title": {
+                                      "runs": [
+                                        {
+                                          "text": "Daily Top Music Videos - Italy",
+                                          "navigationEndpoint": {
+                                            "browseEndpoint": {
+                                              "browseId": "VLPL_TOP_ITALY"
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "musicTwoRowItemRenderer": {
+                                    "navigationEndpoint": {
+                                      "browseEndpoint": {
+                                        "browseId": "VLPL_SECONDARY"
+                                      }
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+    """.trimIndent()
+}


### PR DESCRIPTION
## Summary

- Replaces Apple feeds as the primary Top 50 source with the country-specific YouTube Music Charts page used by SimpMusic.
- Keeps the existing Apple feeds only as an emergency fallback when YouTube Music is unavailable or too slow.
- Chart entries now arrive with native YouTube video IDs, artwork and metadata, so playback no longer needs a title/artist search before resolving the song.

## What changed

- Added `YoutubeMusicChartsRepository`:
  - sends an unauthenticated InnerTube `browse` request with `browseId=FEmusic_charts` and the selected country in `formData.selectedValues`;
  - detects the first real chart playlist by its `VL` browse ID, matching the strategy used by ytmusicapi/SimpMusic;
  - loads the first 50 entries through Levyra's existing YouTube Music playlist parser;
  - caches each country's chart playlist ID for seven days so normal refreshes need only the playlist request;
  - preserves native YouTube IDs and marks the source as `YouTube Music Charts`.
- Updated `ChartsRepository`:
  - gives YouTube Music a 3.5-second primary window;
  - races the Apple fallback only when the YouTube source is still slow;
  - preserves in-flight request deduplication and regional caching from the previous optimization;
  - explicitly labels Apple fallback entries as `Apple Music Charts`.
- Added parser and source-identification tests.

## Important source semantics

The current unauthenticated `FEmusic_charts` response exposes YouTube Music's official country chart playlist, which is currently centered on top music videos. Levyra takes the first 50 ranked entries and keeps their native YouTube identities. The UI remains `Top 50`, while Apple is no longer the normal source.

## Testing

- [ ] `gradle --no-daemon :app:lintRelease`
- [ ] `gradle --no-daemon testReleaseUnitTest`
- [ ] `gradle --no-daemon assembleRelease`
- [ ] APK installed on device
- [ ] Italy/US/UK chart switching tested
- [ ] First-load and warm-cache timing tested

## Release safety

- [x] No account, Spotify cookie, API secret or backend added
- [x] No scraping of Spotify HTML
- [x] No version or signing changes
- [x] Apple fallback remains available




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added YouTube Music charts as an additional source for top tracks.
  * Improved chart reliability with automatic Apple Music fallback when needed.
  * Enhanced chart artwork with verified official release details where available.
  * Chart tracks now include clearer source labeling and chart-related tags.
  * Chart headers now show the available track count and remain hidden when no tracks are available.

* **Tests**
  * Added coverage for chart source labeling and YouTube Music playlist parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->