### PR TITLE
fix(desktop): harden releases, downloads and Windows distribution

### DIFF
--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -243,8 +243,13 @@ jobs:
 
           gh release view $tag --repo $repo *> $null
           $releaseExists = $LASTEXITCODE -eq 0
-          $remoteTag = git ls-remote --tags $remote "refs/tags/$tag"
-          $tagExists = -not [string]::IsNullOrWhiteSpace(($remoteTag | Out-String).Trim())
+          $remoteTag = git ls-remote --exit-code --tags $remote "refs/tags/$tag" 2>$null
+          $tagQueryExit = $LASTEXITCODE
+          $tagExists = switch ($tagQueryExit) {
+            0 { $true }
+            2 { $false }
+            default { throw "Impossibile verificare l'esistenza del tag remoto $tag (git ls-remote exit $tagQueryExit)" }
+          }
 
           if ($tagExists) {
             $tagCommit = Resolve-TagCommit $tag

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -176,6 +176,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $false
           $version = "${{ steps.version.outputs.version }}"
           $tag = "desktop-v$version"
           $repo = $env:GITHUB_REPOSITORY
@@ -185,6 +186,7 @@ jobs:
           $msiName = "LEVYRA-Windows-$version-x64.msi"
           $exeName = "LEVYRA-Windows-$version-x64.exe"
           $zipName = "LEVYRA-Windows-$version-portable-x64.zip"
+          $remoteAssetsByName = @{}
 
           function Resolve-TagCommit([string]$tagName) {
             git fetch --force $remote "refs/tags/$tagName:refs/tags/$tagName" *> $null
@@ -213,6 +215,10 @@ jobs:
           }
 
           function Download-ReleaseAsset([string]$assetName, [string]$directory) {
+            $metadata = $remoteAssetsByName[$assetName]
+            if ($null -eq $metadata) {
+              throw "Metadati GitHub mancanti per l'asset $assetName"
+            }
             New-Item -ItemType Directory -Force -Path $directory | Out-Null
             gh release download $tag --repo $repo --pattern $assetName --dir $directory
             if ($LASTEXITCODE -ne 0) {
@@ -221,6 +227,14 @@ jobs:
             $path = Join-Path $directory $assetName
             if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
               throw "GitHub non ha restituito l'asset esistente $assetName"
+            }
+            if ($null -eq $metadata.size) {
+              throw "Dimensione GitHub mancante per l'asset $assetName"
+            }
+            $declaredSize = [int64]$metadata.size
+            $downloadedSize = [int64](Get-Item -LiteralPath $path).Length
+            if ($downloadedSize -ne $declaredSize) {
+              throw "Asset $assetName incompleto: GitHub dichiara $declaredSize byte, scaricati $downloadedSize byte"
             }
             return $path
           }
@@ -245,7 +259,11 @@ jobs:
 
           $releaseJson = gh release view $tag --repo $repo --json assets
           if ($LASTEXITCODE -ne 0) { throw "Impossibile leggere gli asset esistenti di $tag" }
-          $existingNames = @((($releaseJson | ConvertFrom-Json).assets | ForEach-Object { $_.name }))
+          $remoteAssets = @((($releaseJson | ConvertFrom-Json).assets))
+          foreach ($remoteAsset in $remoteAssets) {
+            $remoteAssetsByName[[string]$remoteAsset.name] = $remoteAsset
+          }
+          $existingNames = @($remoteAssetsByName.Keys)
 
           $pairs = @(
             [pscustomobject]@{ Artifact = $msiName; Checksum = "$msiName.sha256" },

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          fetch-depth: 0
           persist-credentials: false
       - name: Setup Java
         uses: actions/setup-java@v5
@@ -148,6 +149,19 @@ jobs:
             $hash = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
             "$hash  $($_.Name)" | Set-Content -Path "$($_.FullName).sha256" -Encoding ascii -NoNewline
           }
+          $expected = @(
+            $msiName,
+            "$msiName.sha256",
+            $exeName,
+            "$exeName.sha256",
+            $zipName,
+            "$zipName.sha256"
+          )
+          foreach ($name in $expected) {
+            if (-not (Test-Path (Join-Path $output $name))) {
+              throw "Asset Windows obbligatorio non trovato: $name"
+            }
+          }
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -155,7 +169,7 @@ jobs:
           path: release-assets/*
           retention-days: 14
           if-no-files-found: error
-      - name: Publish independent desktop release
+      - name: Publish immutable desktop release
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         shell: pwsh
         env:
@@ -164,10 +178,51 @@ jobs:
           $version = "${{ steps.version.outputs.version }}"
           $tag = "desktop-v$version"
           $repo = $env:GITHUB_REPOSITORY
+          $remote = "https://github.com/$repo.git"
+
+          function Resolve-TagCommit([string]$tagName) {
+            git fetch --force $remote "refs/tags/$tagName:refs/tags/$tagName" *> $null
+            if ($LASTEXITCODE -ne 0) { return $null }
+            $resolved = (git rev-list -n 1 $tagName).Trim()
+            if ([string]::IsNullOrWhiteSpace($resolved)) { return $null }
+            return $resolved
+          }
+
           gh release view $tag --repo $repo *> $null
-          if ($LASTEXITCODE -ne 0) {
+          $releaseExists = $LASTEXITCODE -eq 0
+          $remoteTag = git ls-remote --tags $remote "refs/tags/$tag"
+          $tagExists = -not [string]::IsNullOrWhiteSpace(($remoteTag | Out-String).Trim())
+
+          if ($tagExists) {
+            $tagCommit = Resolve-TagCommit $tag
+            if (-not $tagCommit) { throw "Impossibile risolvere il commit del tag $tag" }
+            if ($tagCommit -ne $env:GITHUB_SHA) {
+              throw "La versione Desktop $version è già legata al commit $tagCommit. Incrementare desktop/version.properties prima di pubblicare un nuovo build."
+            }
+          }
+
+          if (-not $releaseExists) {
             gh release create $tag --repo $repo --target $env:GITHUB_SHA --title "Levyra Desktop $version" --notes "Release Windows indipendente. Android e Desktop mantengono versioni e release separate." --latest=false
             if ($LASTEXITCODE -ne 0) { throw "Impossibile creare la release desktop $tag" }
           }
-          gh release upload $tag "release-assets/*" --repo $repo --clobber
-          if ($LASTEXITCODE -ne 0) { throw "Upload degli asset desktop non riuscito" }
+
+          $existingNames = @()
+          if ($releaseExists) {
+            $releaseJson = gh release view $tag --repo $repo --json assets
+            if ($LASTEXITCODE -ne 0) { throw "Impossibile leggere gli asset esistenti di $tag" }
+            $existingNames = @((($releaseJson | ConvertFrom-Json).assets | ForEach-Object { $_.name }))
+          }
+
+          $assets = @(Get-ChildItem release-assets -File | Sort-Object Name)
+          $missingAssets = @($assets | Where-Object { $_.Name -notin $existingNames })
+          if ($missingAssets.Count -eq 0) {
+            Write-Host "La release $tag è già completa per il commit corrente; nessun asset è stato sostituito."
+            exit 0
+          }
+
+          foreach ($asset in $missingAssets) {
+            gh release upload $tag $asset.FullName --repo $repo
+            if ($LASTEXITCODE -ne 0) {
+              throw "Upload non riuscito per $($asset.Name). Gli asset esistenti non vengono mai sostituiti: incrementare la versione per un nuovo build."
+            }
+          }

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -175,10 +175,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          $ErrorActionPreference = "Stop"
           $version = "${{ steps.version.outputs.version }}"
           $tag = "desktop-v$version"
           $repo = $env:GITHUB_REPOSITORY
           $remote = "https://github.com/$repo.git"
+          $releaseAssets = Join-Path $PWD "release-assets"
+          $downloadRoot = Join-Path $env:RUNNER_TEMP "levyra-existing-release-$version"
+          $msiName = "LEVYRA-Windows-$version-x64.msi"
+          $exeName = "LEVYRA-Windows-$version-x64.exe"
+          $zipName = "LEVYRA-Windows-$version-portable-x64.zip"
 
           function Resolve-TagCommit([string]$tagName) {
             git fetch --force $remote "refs/tags/$tagName:refs/tags/$tagName" *> $null
@@ -186,6 +192,37 @@ jobs:
             $resolved = (git rev-list -n 1 $tagName).Trim()
             if ([string]::IsNullOrWhiteSpace($resolved)) { return $null }
             return $resolved
+          }
+
+          function Get-FileDigest([string]$path) {
+            if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+              throw "File non trovato per la verifica SHA-256: $path"
+            }
+            return (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash.ToLowerInvariant()
+          }
+
+          function Read-Checksum([string]$path) {
+            if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+              throw "Checksum non trovato: $path"
+            }
+            $value = ((Get-Content -LiteralPath $path -Raw).Trim() -split '\s+')[0].ToLowerInvariant()
+            if ($value -notmatch '^[0-9a-f]{64}$') {
+              throw "Checksum SHA-256 non valido in $path"
+            }
+            return $value
+          }
+
+          function Download-ReleaseAsset([string]$assetName, [string]$directory) {
+            New-Item -ItemType Directory -Force -Path $directory | Out-Null
+            gh release download $tag --repo $repo --pattern $assetName --dir $directory
+            if ($LASTEXITCODE -ne 0) {
+              throw "Impossibile scaricare l'asset esistente $assetName"
+            }
+            $path = Join-Path $directory $assetName
+            if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+              throw "GitHub non ha restituito l'asset esistente $assetName"
+            }
+            return $path
           }
 
           gh release view $tag --repo $repo *> $null
@@ -202,27 +239,85 @@ jobs:
           }
 
           if (-not $releaseExists) {
-            gh release create $tag --repo $repo --target $env:GITHUB_SHA --title "Levyra Desktop $version" --notes "Release Windows indipendente. Android e Desktop mantengono versioni e release separate." --latest=false
+            gh release create $tag --repo $repo --target $env:GITHUB_SHA --title "Levyra Desktop $version" --notes "Independent Windows release. Android and Desktop keep separate versions and release channels." --latest=false
             if ($LASTEXITCODE -ne 0) { throw "Impossibile creare la release desktop $tag" }
           }
 
-          $existingNames = @()
-          if ($releaseExists) {
-            $releaseJson = gh release view $tag --repo $repo --json assets
-            if ($LASTEXITCODE -ne 0) { throw "Impossibile leggere gli asset esistenti di $tag" }
-            $existingNames = @((($releaseJson | ConvertFrom-Json).assets | ForEach-Object { $_.name }))
-          }
+          $releaseJson = gh release view $tag --repo $repo --json assets
+          if ($LASTEXITCODE -ne 0) { throw "Impossibile leggere gli asset esistenti di $tag" }
+          $existingNames = @((($releaseJson | ConvertFrom-Json).assets | ForEach-Object { $_.name }))
 
-          $assets = @(Get-ChildItem release-assets -File | Sort-Object Name)
-          $missingAssets = @($assets | Where-Object { $_.Name -notin $existingNames })
-          if ($missingAssets.Count -eq 0) {
-            Write-Host "La release $tag è già completa per il commit corrente; nessun asset è stato sostituito."
-            exit 0
-          }
+          $pairs = @(
+            [pscustomobject]@{ Artifact = $msiName; Checksum = "$msiName.sha256" },
+            [pscustomobject]@{ Artifact = $exeName; Checksum = "$exeName.sha256" },
+            [pscustomobject]@{ Artifact = $zipName; Checksum = "$zipName.sha256" }
+          )
 
-          foreach ($asset in $missingAssets) {
-            gh release upload $tag $asset.FullName --repo $repo
+          foreach ($pair in $pairs) {
+            $localArtifact = Join-Path $releaseAssets $pair.Artifact
+            $localChecksum = Join-Path $releaseAssets $pair.Checksum
+            $localDigest = Get-FileDigest $localArtifact
+            $declaredLocalDigest = Read-Checksum $localChecksum
+            if ($localDigest -ne $declaredLocalDigest) {
+              throw "La coppia locale $($pair.Artifact) / $($pair.Checksum) non è coerente"
+            }
+
+            $artifactExists = $pair.Artifact -in $existingNames
+            $checksumExists = $pair.Checksum -in $existingNames
+            $pairDirectory = Join-Path $downloadRoot ([IO.Path]::GetFileNameWithoutExtension($pair.Artifact))
+
+            if ($artifactExists -and $checksumExists) {
+              $existingArtifact = Download-ReleaseAsset $pair.Artifact $pairDirectory
+              $existingChecksum = Download-ReleaseAsset $pair.Checksum $pairDirectory
+              $existingDigest = Get-FileDigest $existingArtifact
+              $declaredExistingDigest = Read-Checksum $existingChecksum
+              if ($existingDigest -ne $declaredExistingDigest) {
+                throw "La release $tag contiene una coppia non valida: $($pair.Artifact) / $($pair.Checksum). Gli asset pubblicati non vengono sostituiti."
+              }
+              Write-Host "Coppia già pubblicata e verificata: $($pair.Artifact)"
+              continue
+            }
+
+            if ($artifactExists -and -not $checksumExists) {
+              $existingArtifact = Download-ReleaseAsset $pair.Artifact $pairDirectory
+              $existingDigest = Get-FileDigest $existingArtifact
+              $recoveryChecksum = Join-Path $pairDirectory $pair.Checksum
+              "$existingDigest  $($pair.Artifact)" | Set-Content -LiteralPath $recoveryChecksum -Encoding ascii -NoNewline
+              gh release upload $tag $recoveryChecksum --repo $repo
+              if ($LASTEXITCODE -ne 0) {
+                throw "Impossibile completare la coppia pubblicata per $($pair.Artifact)"
+              }
+              Write-Host "Checksum ricostruito dall'asset già pubblicato: $($pair.Checksum)"
+              continue
+            }
+
+            if (-not $artifactExists -and $checksumExists) {
+              $existingChecksum = Download-ReleaseAsset $pair.Checksum $pairDirectory
+              $declaredExistingDigest = Read-Checksum $existingChecksum
+              if ($localDigest -ne $declaredExistingDigest) {
+                throw "La release $tag contiene $($pair.Checksum) per un build differente. Incrementare desktop/version.properties o rimuovere manualmente l'asset orfano."
+              }
+              gh release upload $tag $localArtifact --repo $repo
+              if ($LASTEXITCODE -ne 0) {
+                throw "Impossibile completare la coppia pubblicata per $($pair.Checksum)"
+              }
+              Write-Host "Artifact compatibile aggiunto al checksum esistente: $($pair.Artifact)"
+              continue
+            }
+
+            gh release upload $tag $localArtifact $localChecksum --repo $repo
             if ($LASTEXITCODE -ne 0) {
-              throw "Upload non riuscito per $($asset.Name). Gli asset esistenti non vengono mai sostituiti: incrementare la versione per un nuovo build."
+              throw "Upload non riuscito per la coppia $($pair.Artifact) / $($pair.Checksum)"
+            }
+            Write-Host "Coppia pubblicata: $($pair.Artifact) / $($pair.Checksum)"
+          }
+
+          $finalJson = gh release view $tag --repo $repo --json assets
+          if ($LASTEXITCODE -ne 0) { throw "Impossibile verificare la release finale $tag" }
+          $finalNames = @((($finalJson | ConvertFrom-Json).assets | ForEach-Object { $_.name }))
+          foreach ($pair in $pairs) {
+            if ($pair.Artifact -notin $finalNames -or $pair.Checksum -notin $finalNames) {
+              throw "Release incompleta: manca la coppia $($pair.Artifact) / $($pair.Checksum)"
             }
           }
+          Write-Host "Release immutabile $tag completa: tutte le coppie artifact/checksum sono presenti e coerenti."

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -220,11 +220,12 @@ jobs:
               throw "Metadati GitHub mancanti per l'asset $assetName"
             }
             New-Item -ItemType Directory -Force -Path $directory | Out-Null
+            $path = Join-Path $directory $assetName
+            Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
             gh release download $tag --repo $repo --pattern $assetName --dir $directory
             if ($LASTEXITCODE -ne 0) {
               throw "Impossibile scaricare l'asset esistente $assetName"
             }
-            $path = Join-Path $directory $assetName
             if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
               throw "GitHub non ha restituito l'asset esistente $assetName"
             }
@@ -300,6 +301,9 @@ jobs:
               $existingArtifact = Download-ReleaseAsset $pair.Artifact $pairDirectory
               $existingDigest = Get-FileDigest $existingArtifact
               $recoveryChecksum = Join-Path $pairDirectory $pair.Checksum
+              if ($existingDigest -ne $localDigest) {
+                Write-Host "::warning::L'asset pubblicato $($pair.Artifact) differisce dal build corrente; il checksum viene ricostruito dall'asset immutabile già pubblicato."
+              }
               "$existingDigest  $($pair.Artifact)" | Set-Content -LiteralPath $recoveryChecksum -Encoding ascii -NoNewline
               gh release upload $tag $recoveryChecksum --repo $repo
               if ($LASTEXITCODE -ne 0) {

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -174,10 +174,11 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          LEVYRA_DESKTOP_VERSION: ${{ steps.version.outputs.version }}
         run: |
           $ErrorActionPreference = "Stop"
           $PSNativeCommandUseErrorActionPreference = $false
-          $version = "${{ steps.version.outputs.version }}"
+          $version = $env:LEVYRA_DESKTOP_VERSION
           $tag = "desktop-v$version"
           $repo = $env:GITHUB_REPOSITORY
           $remote = "https://github.com/$repo.git"

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ data:
   client: "OkHttp 5 (Brotli)"
   image_cache: "Coil 3"
   database: "Room (SQLite) + DataStore"
-  downloads: "WorkManager Daemon"
+  downloads: "WorkManager background work scheduler"
 build:
   engine: "Gradle Kotlin DSL + KSP"
   size_audit: "Spotify Ruler"
@@ -291,7 +291,7 @@ desktop:
 * **Room Database and DataStore**: Local SQLite and key-value storage for Android player history and preferences.
 * **Desktop local stores**: JSON state, artwork cache and offline files under `%APPDATA%\Levyra`.
 * **Coil 3**: Asynchronous image loading optimized for Jetpack Compose.
-* **WorkManager**: A background daemon that schedules and runs Android offline audio downloads.
+* **WorkManager**: An OS-managed background work scheduler for Android offline audio downloads.
 
 ### 🛠️ Build and bundle tools
 * **Gradle Kotlin DSL**: Build configuration using version catalogs, KSP, and Kotlin script files.
@@ -370,7 +370,7 @@ levyraDesktopVersion=1.0.1
 
 Android publishes `v<version>` releases and remains the repository's **Latest** channel. Windows publishes immutable `desktop-v<version>` releases with MSI, EXE, portable ZIP and SHA-256 files. Increasing the Android version never starts or publishes the Desktop build, and increasing the Desktop version never modifies Android or F-Droid releases.
 
-`versionCode = major * 1_000_000 + minor * 10_000 + patch * 100 + build` — calculated sequentially so no two Android deployments ever collide. The APK Artifact workflow verifies the signed APK independently from the Desktop Windows workflow.
+`versionCode = major * 1_000_000 + minor * 10_000 + patch * 100 + build`, with every component bounded by the build logic and `build` restricted to `0–99`. The APK Artifact workflow verifies the signed APK independently from the Desktop Windows workflow.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 ### Stream everything. Keep what you love. Own every note.
 
-<a href="https://github.com/LUC4N3X/Levyra-deepsound/releases/latest"><img src="docs/assets/levyra-release.svg" alt="Latest Levyra release"></a>
+<a href="https://github.com/LUC4N3X/Levyra-deepsound/releases/latest"><img src="docs/assets/levyra-android-platform.svg" alt="Download Levyra for Android"></a>
+<a href="https://github.com/LUC4N3X/Levyra-deepsound/releases?q=desktop-v&expanded=true"><img src="docs/assets/levyra-windows-platform.svg" alt="Download Levyra for Windows"></a>
 <a href="https://github.com/LUC4N3X/Levyra-deepsound/releases"><img src="docs/assets/levyra-downloads.svg" alt="Total Levyra downloads"></a>
 <a href="LICENSE"><img src="docs/assets/levyra-license.svg" alt="GPL-3.0 License"></a>
 <a href="https://github.com/LUC4N3X/Levyra-deepsound/stargazers"><img src="docs/assets/levyra-stars.svg" alt="Star Levyra"></a>
@@ -14,10 +15,13 @@
 <br>
 
 <a href="https://github.com/LUC4N3X/Levyra-deepsound/releases/latest">
-  <img src="docs/assets/levyra-github-download.svg" alt="Download the latest signed Levyra APK from GitHub Releases" width="520" />
+  <img src="docs/assets/levyra-github-download.svg" alt="Download the latest signed Levyra APK from GitHub Releases" width="370" />
+</a>
+<a href="https://github.com/LUC4N3X/Levyra-deepsound/releases?q=desktop-v&expanded=true">
+  <img src="docs/assets/levyra-windows-download.svg" alt="Download Levyra Desktop for Windows from GitHub Releases" width="370" />
 </a>
 
-<sub>**One APK. No Play Store. No account. No ads.** · Official signed build · Android 8.0+</sub>
+<sub>**Android and Windows. No account. No ads.** · Signed APK · MSI / EXE / Portable ZIP</sub>
 
 </div>
 
@@ -28,12 +32,12 @@
 
 <div align="center">
 
-🎵 **Levyra** isn't another website wearing an app icon. It's a native Android music client,<br>
-written from the ground up in 100% Kotlin, for people who are tired of renting their own music library.
+🎵 **Levyra** isn't another website wearing an app icon. It is a native music client for **Android and Windows**,<br>
+built in Kotlin for people who want fast streaming, a private library and real offline playback.
 
-It streams instantly, plays flawlessly in the background, and when you hit download it gives you<br>
-something almost no app dares to anymore: a **real M4A file**, tagged and covered, sitting in<br>
-`Music/Levyra` where it belongs. **Yours. In any player. Forever.**
+On Android, downloads can become tagged **M4A files** in `Music/Levyra`. On Windows, Levyra keeps a persistent<br>
+offline library with resumable downloads and automatically prefers the verified local file during playback.
+**Your music experience stays on your device — whichever screen you use.**
 
 <sub>*Every screen, every animation, every retry-on-bad-wifi was built by one developer who actually uses this app every day — and it shows.*</sub>
 
@@ -41,15 +45,52 @@ something almost no app dares to anymore: a **real M4A file**, tagged and covere
 
 🛡️ &nbsp;**Privacy by Default** &nbsp;—&nbsp; <sub>Listening stats stay in a local database. No trackers, no telemetry, no analytics.</sub>
 
-📥 &nbsp;**Real Files, Really Yours** &nbsp;—&nbsp; <sub>Tagged M4A exports with embedded artwork, not cache blobs locked inside the app.</sub>
+📥 &nbsp;**Real Files, Really Yours** &nbsp;—&nbsp; <sub>Tagged Android exports and persistent Windows offline files, not disposable cache blobs.</sub>
 
-⚡ &nbsp;**Native Audio Engine** &nbsp;—&nbsp; <sub>Media3 / ExoPlayer foreground service. Screen off, pocket, music never stops.</sub>
+⚡ &nbsp;**Native Audio Engines** &nbsp;—&nbsp; <sub>Media3 / ExoPlayer on Android and libvlc on Windows.</sub>
 
 <br>
 
-`100% Kotlin` &nbsp;·&nbsp; `Jetpack Compose` &nbsp;·&nbsp; `Material 3`
+`Kotlin` &nbsp;·&nbsp; `Jetpack Compose` &nbsp;·&nbsp; `Compose Multiplatform` &nbsp;·&nbsp; `Media3` &nbsp;·&nbsp; `libvlc`
 
 </div>
+
+---
+
+## ✦ Available on Android and Windows
+
+<table width="100%">
+<tr>
+<td width="50%" valign="top">
+
+### 🤖 Android
+
+- Signed APK for Android 8.0+
+- Media3 / ExoPlayer background playback
+- Public tagged M4A exports
+- Pulse listening statistics
+- F-Droid reproducible-build support
+
+<a href="https://github.com/LUC4N3X/Levyra-deepsound/releases/latest"><strong>Download the latest Android APK →</strong></a>
+
+</td>
+<td width="50%" valign="top">
+
+### 🪟 Windows
+
+- Native Compose Desktop interface
+- libvlc audio engine and system tray controls
+- Persistent offline downloads with resume
+- Full player plus always-on-top mini player
+- MSI, EXE and portable ZIP packages
+
+<a href="https://github.com/LUC4N3X/Levyra-deepsound/releases?q=desktop-v&expanded=true"><strong>Download Levyra Desktop for Windows →</strong></a>
+
+</td>
+</tr>
+</table>
+
+> Android remains the repository's **Latest** release. Windows builds use independent `desktop-v*` releases and are always available through the dedicated Windows badge above.
 
 ---
 
@@ -63,15 +104,16 @@ something almost no app dares to anymore: a **real M4A file**, tagged and covere
 
 **Dark-First, OLED-True:** Deep blacks and high contrast, built dark from day one — not dimmed as an afterthought.
 **Fluid Navigation:** Home, Search, Library and Player tied together by custom micro-animations.
-**Dual-State Player:** A discreet mini-player one swipe away from an immersive fullscreen experience.
-**Dynamic Material 3:** Optional system-wide dynamic color so the app matches your phone, not the other way around.
+**Platform-Native Layouts:** Mobile-first navigation on Android and a full desktop sidebar, player dock and window lifecycle on Windows.
+**Dual-State Player:** Immersive mobile playback on Android and a separate always-on-top mini player on Windows.
+**Adaptive Styling:** Dynamic Material 3 on Android, coordinated light/dark surfaces and native title-bar styling on Windows.
 
 </td>
 <td width="50%" valign="top">
 
 ### ⚡ Rock-Solid Playback
 
-**True Background Service:** Media3 + MediaSession keep playing with the screen off and the app minimized.
+**Native Playback:** Media3 + MediaSession on Android; libvlc, tray controls and single-instance lifecycle on Windows.
 **Total Control:** Loop all/single, shuffle, playback speed tuning, sleep timers (15/30/60m).
 **Audio Tuning:** In-app normalization, silence skipping, quality selectors (Auto/High/Low).
 **SponsorBlock Built In:** Non-music and sponsored segments skipped automatically, in real time.
@@ -83,10 +125,10 @@ something almost no app dares to anymore: a **real M4A file**, tagged and covere
 
 ### 📥 Downloads Done Right
 
-**Real Media Files:** Exported straight to the public `Music/Levyra` directory. Move them, back them up, keep them.
-**Pure-Kotlin Tagging:** High-res covers, titles, albums and artists embedded on completion.
-**Unstoppable Pipeline:** WorkManager downloads survive reboots and network drops, then retry on their own.
-**Truncation Shield:** Strict Content-Length checks discard corrupted files and re-queue them automatically.
+**Android Exports:** Tagged M4A files written to the public `Music/Levyra` directory. Move them, back them up, keep them.
+**Windows Offline Library:** Persistent local files with progress, cancellation, retry and HTTP Range resume.
+**Reliable Completion:** Atomic finalization prevents half-written files from being treated as complete.
+**Local-First Playback:** Levyra automatically uses the verified offline copy when it is available.
 
 </td>
 <td width="50%" valign="top">
@@ -115,7 +157,7 @@ something almost no app dares to anymore: a **real M4A file**, tagged and covere
 ### 🎵 Synced Lyrics
 
 **LRCLIB Integration:** Synced and static lyrics fetched instantly from track metadata.
-**Live Tracker:** Karaoke-precise scrolling locked to the ExoPlayer position.
+**Live Tracker:** Karaoke-precise scrolling synchronized with the active Android or Windows player.
 **Graceful Fallback:** No timestamps? Clean static text. Never a blank screen.
 
 </td>
@@ -142,10 +184,10 @@ something almost no app dares to anymore: a **real M4A file**, tagged and covere
 
 ## ✦ Architecture
 
-Levyra runs on strict unidirectional data flow: Compose renders, a central ViewModel owns state, and decoupled repositories and services make sure no network call or database write ever touches the main thread.
+Levyra ships two native clients from one repository. Android uses strict unidirectional data flow around a central ViewModel, while Windows is isolated under `desktop/` with its own Kotlin/JVM modules, state controllers, persistence, packaging and release channel. Both clients reuse LevyraExtractor and the shared localization catalog.
 
 ```text
-📦 Application Specifications
+📦 Android Application Specifications
 ├── Package Name      com.luc4n3x.levyra
 ├── Target SDK        35 (Android 15)
 ├── Min SDK           26 (Android 8.0)
@@ -191,11 +233,24 @@ graph TD
 | **Background Exports** | WorkManager pipeline, metadata tagging, MediaStore registrations | [`player/offline/`](app/src/main/java/com/luc4n3x/levyra/player/offline) |
 | **Local Cache** | SQLite database, Room entities, and key-value preference stores | [`data/local/`](app/src/main/java/com/luc4n3x/levyra/data/local) |
 
+### Windows Desktop architecture
+
+```text
+desktop/
+├── core/       catalog, stream resolution, downloads and persistence
+├── player/     queue model and libvlc audio implementation
+├── app/        Compose UI, onboarding, library, updater and lifecycle
+├── packaging/  Windows icon and jpackage resources
+└── version.properties  independent Desktop version
+```
+
+The Windows client includes a persistent library, offline downloads, single-instance protection, `levyra://` deep links, crash reports, a mini player and verified in-place updates. See [`desktop/README.md`](desktop/README.md) for the complete Desktop documentation.
+
 ---
 
 ## ✦ Technical stack
 
-Levyra is built natively for Android, focusing on a light runtime footprint and direct local data ownership.
+Levyra is built natively for Android and Windows, with platform-specific playback engines and a shared focus on fast startup, local ownership and private listening data.
 
 ```yaml
 system:
@@ -213,38 +268,47 @@ data:
 build:
   engine: "Gradle Kotlin DSL + KSP"
   size_audit: "Spotify Ruler"
+desktop:
+  interface: "Compose Multiplatform"
+  audio: "libvlc"
+  storage: "%APPDATA%/Levyra"
+  packaging: "jpackage + WiX"
 ```
 
 ### 📱 Core and UI
 * **Kotlin 2.4.0**: A 100% native codebase built with coroutines and flow APIs for asynchronous streaming.
 * **Jetpack Compose** (via Compose BOM): Declarative layouts with Material 3 components and system-wide dynamic color adaptation.
 * **Mobius architecture**: A unidirectional data flow design (Model-Event-Effect-Update) for reliable player state transitions.
+* **Compose Multiplatform Desktop**: Native Windows layouts, lifecycle, onboarding, library and player surfaces.
 
 ### 🎧 Audio pipeline
-* **Media3 and ExoPlayer**: A foreground playback service that handles HTTP live streaming, ExoPlayer caching, and background controller sync.
+* **Media3 and ExoPlayer**: Android foreground playback with HTTP live streaming, caching and background controller sync.
+* **libvlc**: Windows playback, system tray controls and local-file-first offline playback.
 * **LevyraExtractor**: A custom resolver hosted on JitPack to parse playback streams from InnerTube endpoints.
 
 ### 📦 Storage and networking
 * **OkHttp 5**: The underlying network client, using Brotli compression to save mobile bandwidth.
-* **Room Database and DataStore**: Local SQLite and key-value storage for player history (Pulse metrics) and user preferences.
+* **Room Database and DataStore**: Local SQLite and key-value storage for Android player history and preferences.
+* **Desktop local stores**: JSON state, artwork cache and offline files under `%APPDATA%\Levyra`.
 * **Coil 3**: Asynchronous image loading optimized for Jetpack Compose.
-* **WorkManager**: A background daemon that schedules and runs offline audio downloads, resuming automatically if the device restarts.
+* **WorkManager**: A background daemon that schedules and runs Android offline audio downloads.
 
 ### 🛠️ Build and bundle tools
 * **Gradle Kotlin DSL**: Build configuration using version catalogs, KSP, and Kotlin script files.
 * **Spotify Ruler**: A build analyzer that runs size audits and tracks dependency weights to keep the APK compact.
+* **jpackage + WiX**: MSI, EXE and portable Windows distributions.
 
 ---
 
 ## ✦ Building from Source
 
-### Prerequisites
-*   Android Studio Jellyfish (or newer)
-*   Java Development Kit (JDK) 17
-*   Android SDK Platform 37 (`compileSdk = 37`, `targetSdk = 35`)
-*   Gradle 9.6.1 through the repository Gradle Wrapper
+### Android prerequisites
+* Android Studio Jellyfish (or newer)
+* Java Development Kit (JDK) 17
+* Android SDK Platform 37 (`compileSdk = 37`, `targetSdk = 35`)
+* Gradle 9.6.1 through the repository Gradle Wrapper
 
-### Build & Install
+### Android build and install
 
 ```bash
 # Clone the repository
@@ -263,6 +327,20 @@ cd Levyra-deepsound
 
 The release APK lands in `app/build/outputs/apk/release/app-release.apk`.
 
+### Windows build
+
+Requirements: JDK 21, Windows x64, VLC 3.0.x/libvlc and WiX Toolset 3.14 for installers.
+
+```powershell
+git clone https://github.com/LUC4N3X/Levyra-deepsound.git
+cd Levyra-deepsound\desktop
+.\gradlew.bat check
+.\gradlew.bat createReleaseDistributable
+.\gradlew.bat packageReleaseMsi packageReleaseExe
+```
+
+Desktop artifacts are written to `desktop/app/build/compose/binaries/main-release/`.
+
 For F-Droid reproducible-build verification, use the dedicated source-build
 switch. It keeps the standard application ID, produces the unsigned rebuild
 that F-Droid compares with Levyra's upstream-signed F-Droid APK, uses the
@@ -279,37 +357,43 @@ Architecture and size-control notes live in `docs/APK_SIZE_RULER.md` and `docs/P
 
 ### Versioning & CI
 
-Version numbering is centralized in `gradle.properties`:
+Android and Windows use independent version sources and release tags.
 
 ```properties
+# Android — gradle.properties
 levyraVersionName=2.3.16
 levyraVersionCode=2031600
+
+# Windows — desktop/version.properties
+levyraDesktopVersion=1.0.1
 ```
 
-`versionCode = major * 1_000_000 + minor * 10_000 + patch * 100 + build` — calculated sequentially so no two deployments ever collide. The APK Artifact workflow parses this schema, verifies target versions with `aapt`, checks structural integrity, compiles the signed binary and publishes it as `LEVYRA-<version>.apk`.
+Android publishes `v<version>` releases and remains the repository's **Latest** channel. Windows publishes immutable `desktop-v<version>` releases with MSI, EXE, portable ZIP and SHA-256 files. Increasing the Android version never starts or publishes the Desktop build, and increasing the Desktop version never modifies Android or F-Droid releases.
+
+`versionCode = major * 1_000_000 + minor * 10_000 + patch * 100 + build` — calculated sequentially so no two Android deployments ever collide. The APK Artifact workflow verifies the signed APK independently from the Desktop Windows workflow.
 
 ---
 
-## ✦  Privacy & data collection
+## ✦ Privacy & data collection
 
 Your listening habits are nobody's business, including mine.
 
 * **No analytics frameworks**: There are no tracking SDKs or developer-operated telemetry services.
-* **On-device statistics**: Every history entry and Pulse statistic is stored locally inside your Room database.
+* **On-device statistics**: History, Pulse data, preferences and Desktop library state stay on the user's device.
 * **Network interactions**: Actions like searching, loading artwork, showing SponsorBlock segments, fetching lyrics, or using account features contact third-party endpoints. These connections send standard client data, including your IP address, device headers, and cookies where applicable.
 
-### Declared manifest permissions
+### Declared Android manifest permissions
 
 ```text
 INTERNET & ACCESS_NETWORK_STATE       Streams music data and queries metadata.
 FOREGROUND_SERVICE_MEDIA_PLAYBACK     Keeps audio playing when the app is backgrounded.
-POST_NOTIFICATIONS                     Displays the playback controller notification.
-WAKE_LOCK                              Prevents playback stutter when the CPU goes to sleep.
+POST_NOTIFICATIONS                    Displays the playback controller notification.
+WAKE_LOCK                             Prevents playback stutter when the CPU goes to sleep.
 WRITE_EXTERNAL_STORAGE (≤ SDK 28)     Saves offline files on older Android versions.
 ```
 
 ---
-## ✦  Contributing
+## ✦ Contributing
 
 Contributions are welcome. If you want to report a bug, suggest a feature, or submit a pull request, follow these steps:
 
@@ -332,7 +416,7 @@ Contributions are welcome. If you want to report a bug, suggest a feature, or su
 
 If you build and distribute your own version of Levyra, please respect these rules:
 * **Signing keys**: Generate your own Android keystores. Do not reuse existing keys.
-* **Build names**: Follow the release naming schema `LEVYRA-<version>.apk` rather than standard Gradle outputs.
+* **Build names**: Follow the release naming schema `LEVYRA-<version>.apk` for Android and `LEVYRA-Windows-<version>-x64` for Windows.
 * **Execution dispatching**: Run all database, storage, and network requests on background thread pools (`Dispatchers.IO`), keeping the UI thread responsive.
 * **Resiliency**: Handle query timeouts gracefully with clear fallback routes.
 
@@ -351,7 +435,7 @@ If you build and distribute your own version of Levyra, please respect these rul
       <h3>LUC4N3X</h3>
       <strong>Creator · Lead Architect · Design Lead</strong>
       <br>
-      <sub>System architecture · ExoPlayer orchestration · WorkManager export pipeline · Automated release CI · UI/UX</sub>
+      <sub>Android and Desktop architecture · Media3 and libvlc orchestration · Offline pipelines · Automated release CI · UI/UX</sub>
       <br>
       <sub><em>One developer. No team, no shortcuts — every line, every pixel.</em></sub>
       <br><br>
@@ -382,6 +466,10 @@ If you build and distribute your own version of Levyra, please respect these rul
   <tr>
     <td><a href="https://github.com/InfinityLoop1308/PipePipeExtractor"><strong>PipePipeExtractor</strong></a></td>
     <td>Upstream extractor foundation from the NewPipe/PipePipe ecosystem</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/maxrave-dev/SimpMusic"><strong>SimpMusic</strong></a></td>
+    <td>Architectural reference for selected Desktop lifecycle patterns</td>
   </tr>
 </table>
 

--- a/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/DesktopUpdateController.kt
+++ b/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/DesktopUpdateController.kt
@@ -2,6 +2,7 @@ package com.luc4n3x.levyra.desktop.app.state
 
 import com.luc4n3x.levyra.desktop.app.AppInfo
 import com.luc4n3x.levyra.desktop.core.storage.AppPaths
+import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
@@ -86,7 +87,13 @@ internal class DesktopUpdateController(
         .followSslRedirects(true)
         .build()
 ) {
-    private val client = baseClient.newBuilder()
+    private val metadataClient = baseClient.newBuilder()
+        .connectTimeout(8, TimeUnit.SECONDS)
+        .readTimeout(20, TimeUnit.SECONDS)
+        .writeTimeout(15, TimeUnit.SECONDS)
+        .callTimeout(30, TimeUnit.SECONDS)
+        .build()
+    private val downloadClient = baseClient.newBuilder()
         .callTimeout(0L, TimeUnit.MILLISECONDS)
         .readTimeout(0L, TimeUnit.MILLISECONDS)
         .build()
@@ -156,23 +163,29 @@ internal class DesktopUpdateController(
         installJob?.cancel()
     }
 
-    private fun fetchLatestRelease(): DesktopRelease? {
+    private suspend fun fetchLatestRelease(): DesktopRelease? {
         val request = Request.Builder()
             .url(DESKTOP_RELEASES_URL)
             .header("Accept", "application/vnd.github+json")
             .header("X-GitHub-Api-Version", "2022-11-28")
             .header("User-Agent", "Levyra-Desktop/$currentVersion")
             .build()
-        client.newCall(request).execute().use { response ->
-            if (!response.isSuccessful) {
-                throw IllegalStateException("GitHub desktop release check failed: HTTP ${response.code}")
-            }
-            return Json.parseToJsonElement(response.body.string())
-                .jsonArray
-                .mapNotNull { parseDesktopRelease(it.jsonObject) }
-                .reduceOrNull { newest, candidate ->
-                    if (DesktopVersion.isNewer(candidate.version, newest.version)) candidate else newest
+        val call = metadataClient.newCall(request)
+        val cancellationHandle = currentCoroutineContext()[Job]?.invokeOnCompletion { call.cancel() }
+        return try {
+            call.execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IllegalStateException("GitHub desktop release check failed: HTTP ${response.code}")
                 }
+                Json.parseToJsonElement(response.body.string())
+                    .jsonArray
+                    .mapNotNull { parseDesktopRelease(it.jsonObject) }
+                    .reduceOrNull { newest, candidate ->
+                        if (DesktopVersion.isNewer(candidate.version, newest.version)) candidate else newest
+                    }
+            }
+        } finally {
+            cancellationHandle?.dispose()
         }
     }
 
@@ -193,8 +206,10 @@ internal class DesktopUpdateController(
         val assets = root["assets"]?.jsonArray.orEmpty().mapNotNull { element ->
             val asset = element.jsonObject
             val name = asset["name"]?.jsonPrimitive?.contentOrNull.orEmpty()
-            val url = asset["browser_download_url"]?.jsonPrimitive?.contentOrNull.orEmpty()
-            if (name.isBlank() || url.isBlank()) {
+            val url = trustedReleaseAssetUrl(
+                asset["browser_download_url"]?.jsonPrimitive?.contentOrNull.orEmpty()
+            )
+            if (name.isBlank() || url == null) {
                 null
             } else {
                 DesktopReleaseAsset(
@@ -234,51 +249,55 @@ internal class DesktopUpdateController(
             .header("Accept", "application/octet-stream")
             .header("User-Agent", "Levyra-Desktop/$currentVersion")
             .build()
-        val call = client.newCall(request)
-        currentCoroutineContext()[Job]?.invokeOnCompletion { call.cancel() }
-        call.execute().use { response ->
-            if (!response.isSuccessful) {
-                throw IllegalStateException("Download aggiornamento non disponibile: HTTP ${response.code}")
-            }
-            val body = response.body
-            val responseLength = body.contentLength().coerceAtLeast(0L)
-            val total = release.installer.size.takeIf { it > 0L } ?: responseLength
-            internalState.update { it.copy(totalBytes = total) }
-            body.byteStream().buffered(BUFFER_SIZE).use { input ->
-                Files.newOutputStream(
-                    temporary,
-                    StandardOpenOption.CREATE,
-                    StandardOpenOption.WRITE,
-                    StandardOpenOption.TRUNCATE_EXISTING
-                ).buffered(BUFFER_SIZE).use { output ->
-                    val buffer = ByteArray(BUFFER_SIZE)
-                    var downloaded = 0L
-                    var lastPublished = 0L
-                    while (true) {
-                        currentCoroutineContext().ensureActive()
-                        val read = input.read(buffer)
-                        if (read < 0) break
-                        output.write(buffer, 0, read)
-                        downloaded += read
-                        if (downloaded - lastPublished >= PROGRESS_INTERVAL_BYTES || downloaded == total) {
-                            internalState.update {
-                                it.copy(bytesDownloaded = downloaded, totalBytes = total)
+        val call = downloadClient.newCall(request)
+        val cancellationHandle = currentCoroutineContext()[Job]?.invokeOnCompletion { call.cancel() }
+        try {
+            call.execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IllegalStateException("Download aggiornamento non disponibile: HTTP ${response.code}")
+                }
+                val body = response.body
+                val responseLength = body.contentLength().coerceAtLeast(0L)
+                val total = release.installer.size.takeIf { it > 0L } ?: responseLength
+                internalState.update { it.copy(totalBytes = total) }
+                body.byteStream().buffered(BUFFER_SIZE).use { input ->
+                    Files.newOutputStream(
+                        temporary,
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.WRITE,
+                        StandardOpenOption.TRUNCATE_EXISTING
+                    ).buffered(BUFFER_SIZE).use { output ->
+                        val buffer = ByteArray(BUFFER_SIZE)
+                        var downloaded = 0L
+                        var lastPublished = 0L
+                        while (true) {
+                            currentCoroutineContext().ensureActive()
+                            val read = input.read(buffer)
+                            if (read < 0) break
+                            output.write(buffer, 0, read)
+                            downloaded += read
+                            if (downloaded - lastPublished >= PROGRESS_INTERVAL_BYTES || downloaded == total) {
+                                internalState.update {
+                                    it.copy(bytesDownloaded = downloaded, totalBytes = total)
+                                }
+                                lastPublished = downloaded
                             }
-                            lastPublished = downloaded
                         }
-                    }
-                    output.flush()
-                    if (total > 0L && downloaded != total) {
-                        throw IllegalStateException("Aggiornamento incompleto: $downloaded di $total byte")
-                    }
-                    internalState.update {
-                        it.copy(
-                            bytesDownloaded = downloaded,
-                            totalBytes = total.takeIf { value -> value > 0L } ?: downloaded
-                        )
+                        output.flush()
+                        if (total > 0L && downloaded != total) {
+                            throw IllegalStateException("Aggiornamento incompleto: $downloaded di $total byte")
+                        }
+                        internalState.update {
+                            it.copy(
+                                bytesDownloaded = downloaded,
+                                totalBytes = total.takeIf { value -> value > 0L } ?: downloaded
+                            )
+                        }
                     }
                 }
             }
+        } finally {
+            cancellationHandle?.dispose()
         }
 
         verifyChecksum(release, temporary)
@@ -286,18 +305,24 @@ internal class DesktopUpdateController(
         target
     }
 
-    private fun verifyChecksum(release: DesktopRelease, installer: Path) {
+    private suspend fun verifyChecksum(release: DesktopRelease, installer: Path) {
         try {
             val request = Request.Builder()
                 .url(release.checksum.url)
                 .header("Accept", "text/plain")
                 .header("User-Agent", "Levyra-Desktop/$currentVersion")
                 .build()
-            val expected = client.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) {
-                    throw IllegalStateException("Checksum aggiornamento non disponibile: HTTP ${response.code}")
+            val call = metadataClient.newCall(request)
+            val cancellationHandle = currentCoroutineContext()[Job]?.invokeOnCompletion { call.cancel() }
+            val expected = try {
+                call.execute().use { response ->
+                    if (!response.isSuccessful) {
+                        throw IllegalStateException("Checksum aggiornamento non disponibile: HTTP ${response.code}")
+                    }
+                    response.body.string().trim().substringBefore(' ').lowercase(Locale.ROOT)
                 }
-                response.body.string().trim().substringBefore(' ').lowercase(Locale.ROOT)
+            } finally {
+                cancellationHandle?.dispose()
             }
             if (!expected.matches(Regex("^[0-9a-f]{64}$"))) {
                 throw IllegalStateException("Checksum aggiornamento non valido")
@@ -306,6 +331,7 @@ internal class DesktopUpdateController(
             Files.newInputStream(installer).buffered(BUFFER_SIZE).use { input ->
                 val buffer = ByteArray(BUFFER_SIZE)
                 while (true) {
+                    currentCoroutineContext().ensureActive()
                     val read = input.read(buffer)
                     if (read < 0) break
                     digest.update(buffer, 0, read)
@@ -320,6 +346,17 @@ internal class DesktopUpdateController(
             throw error
         }
     }
+
+    private fun trustedReleaseAssetUrl(raw: String): String? = runCatching {
+        val uri = URI(raw.trim())
+        require(uri.scheme.equals("https", ignoreCase = true))
+        require(uri.host.equals("github.com", ignoreCase = true))
+        require(uri.rawUserInfo == null)
+        require(uri.port == -1 || uri.port == 443)
+        require(uri.rawQuery == null && uri.rawFragment == null)
+        require(uri.path.orEmpty().startsWith(RELEASE_ASSET_PATH_PREFIX))
+        uri.toASCIIString()
+    }.getOrNull()
 
     private fun launchInstaller(release: DesktopRelease, installer: Path) {
         val osName = System.getProperty("os.name").orEmpty().lowercase(Locale.ROOT)
@@ -408,6 +445,7 @@ exit ${'$'}process.ExitCode
         const val DESKTOP_RELEASES_URL =
             "https://api.github.com/repos/LUC4N3X/Levyra-deepsound/releases?per_page=50"
         const val DESKTOP_RELEASE_TAG_PREFIX = "desktop-v"
+        const val RELEASE_ASSET_PATH_PREFIX = "/LUC4N3X/Levyra-deepsound/releases/download/"
         const val UPDATE_DIRECTORY = "updates"
         const val BUFFER_SIZE = 64 * 1024
         const val PROGRESS_INTERVAL_BYTES = 256 * 1024L

--- a/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/DesktopUpdateController.kt
+++ b/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/DesktopUpdateController.kt
@@ -2,6 +2,7 @@ package com.luc4n3x.levyra.desktop.app.state
 
 import com.luc4n3x.levyra.desktop.app.AppInfo
 import com.luc4n3x.levyra.desktop.core.storage.AppPaths
+import java.io.IOException
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -22,6 +23,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.swing.Swing
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
@@ -32,8 +34,11 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
+import okhttp3.Call
+import okhttp3.Callback
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.Response
 
 internal enum class DesktopUpdatePhase {
     IDLE,
@@ -170,22 +175,16 @@ internal class DesktopUpdateController(
             .header("X-GitHub-Api-Version", "2022-11-28")
             .header("User-Agent", "Levyra-Desktop/$currentVersion")
             .build()
-        val call = metadataClient.newCall(request)
-        val cancellationHandle = currentCoroutineContext()[Job]?.invokeOnCompletion { call.cancel() }
-        return try {
-            call.execute().use { response ->
-                if (!response.isSuccessful) {
-                    throw IllegalStateException("GitHub desktop release check failed: HTTP ${response.code}")
-                }
-                Json.parseToJsonElement(response.body.string())
-                    .jsonArray
-                    .mapNotNull { parseDesktopRelease(it.jsonObject) }
-                    .reduceOrNull { newest, candidate ->
-                        if (DesktopVersion.isNewer(candidate.version, newest.version)) candidate else newest
-                    }
+        return metadataClient.newCall(request).awaitResponse().use { response ->
+            if (!response.isSuccessful) {
+                throw IllegalStateException("GitHub desktop release check failed: HTTP ${response.code}")
             }
-        } finally {
-            cancellationHandle?.dispose()
+            Json.parseToJsonElement(response.body.string())
+                .jsonArray
+                .mapNotNull { parseDesktopRelease(it.jsonObject) }
+                .reduceOrNull { newest, candidate ->
+                    if (DesktopVersion.isNewer(candidate.version, newest.version)) candidate else newest
+                }
         }
     }
 
@@ -249,55 +248,49 @@ internal class DesktopUpdateController(
             .header("Accept", "application/octet-stream")
             .header("User-Agent", "Levyra-Desktop/$currentVersion")
             .build()
-        val call = downloadClient.newCall(request)
-        val cancellationHandle = currentCoroutineContext()[Job]?.invokeOnCompletion { call.cancel() }
-        try {
-            call.execute().use { response ->
-                if (!response.isSuccessful) {
-                    throw IllegalStateException("Download aggiornamento non disponibile: HTTP ${response.code}")
-                }
-                val body = response.body
-                val responseLength = body.contentLength().coerceAtLeast(0L)
-                val total = release.installer.size.takeIf { it > 0L } ?: responseLength
-                internalState.update { it.copy(totalBytes = total) }
-                body.byteStream().buffered(BUFFER_SIZE).use { input ->
-                    Files.newOutputStream(
-                        temporary,
-                        StandardOpenOption.CREATE,
-                        StandardOpenOption.WRITE,
-                        StandardOpenOption.TRUNCATE_EXISTING
-                    ).buffered(BUFFER_SIZE).use { output ->
-                        val buffer = ByteArray(BUFFER_SIZE)
-                        var downloaded = 0L
-                        var lastPublished = 0L
-                        while (true) {
-                            currentCoroutineContext().ensureActive()
-                            val read = input.read(buffer)
-                            if (read < 0) break
-                            output.write(buffer, 0, read)
-                            downloaded += read
-                            if (downloaded - lastPublished >= PROGRESS_INTERVAL_BYTES || downloaded == total) {
-                                internalState.update {
-                                    it.copy(bytesDownloaded = downloaded, totalBytes = total)
-                                }
-                                lastPublished = downloaded
+        downloadClient.newCall(request).awaitResponse().use { response ->
+            if (!response.isSuccessful) {
+                throw IllegalStateException("Download aggiornamento non disponibile: HTTP ${response.code}")
+            }
+            val body = response.body
+            val responseLength = body.contentLength().coerceAtLeast(0L)
+            val total = release.installer.size.takeIf { it > 0L } ?: responseLength
+            internalState.update { it.copy(totalBytes = total) }
+            body.byteStream().buffered(BUFFER_SIZE).use { input ->
+                Files.newOutputStream(
+                    temporary,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.TRUNCATE_EXISTING
+                ).buffered(BUFFER_SIZE).use { output ->
+                    val buffer = ByteArray(BUFFER_SIZE)
+                    var downloaded = 0L
+                    var lastPublished = 0L
+                    while (true) {
+                        currentCoroutineContext().ensureActive()
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        output.write(buffer, 0, read)
+                        downloaded += read
+                        if (downloaded - lastPublished >= PROGRESS_INTERVAL_BYTES || downloaded == total) {
+                            internalState.update {
+                                it.copy(bytesDownloaded = downloaded, totalBytes = total)
                             }
+                            lastPublished = downloaded
                         }
-                        output.flush()
-                        if (total > 0L && downloaded != total) {
-                            throw IllegalStateException("Aggiornamento incompleto: $downloaded di $total byte")
-                        }
-                        internalState.update {
-                            it.copy(
-                                bytesDownloaded = downloaded,
-                                totalBytes = total.takeIf { value -> value > 0L } ?: downloaded
-                            )
-                        }
+                    }
+                    output.flush()
+                    if (total > 0L && downloaded != total) {
+                        throw IllegalStateException("Aggiornamento incompleto: $downloaded di $total byte")
+                    }
+                    internalState.update {
+                        it.copy(
+                            bytesDownloaded = downloaded,
+                            totalBytes = total.takeIf { value -> value > 0L } ?: downloaded
+                        )
                     }
                 }
             }
-        } finally {
-            cancellationHandle?.dispose()
         }
 
         verifyChecksum(release, temporary)
@@ -312,17 +305,11 @@ internal class DesktopUpdateController(
                 .header("Accept", "text/plain")
                 .header("User-Agent", "Levyra-Desktop/$currentVersion")
                 .build()
-            val call = metadataClient.newCall(request)
-            val cancellationHandle = currentCoroutineContext()[Job]?.invokeOnCompletion { call.cancel() }
-            val expected = try {
-                call.execute().use { response ->
-                    if (!response.isSuccessful) {
-                        throw IllegalStateException("Checksum aggiornamento non disponibile: HTTP ${response.code}")
-                    }
-                    response.body.string().trim().substringBefore(' ').lowercase(Locale.ROOT)
+            val expected = metadataClient.newCall(request).awaitResponse().use { response ->
+                if (!response.isSuccessful) {
+                    throw IllegalStateException("Checksum aggiornamento non disponibile: HTTP ${response.code}")
                 }
-            } finally {
-                cancellationHandle?.dispose()
+                response.body.string().trim().substringBefore(' ').lowercase(Locale.ROOT)
             }
             if (!expected.matches(Regex("^[0-9a-f]{64}$"))) {
                 throw IllegalStateException("Checksum aggiornamento non valido")
@@ -345,6 +332,19 @@ internal class DesktopUpdateController(
             Files.deleteIfExists(installer)
             throw error
         }
+    }
+
+    private suspend fun Call.awaitResponse(): Response = suspendCancellableCoroutine { continuation ->
+        continuation.invokeOnCancellation { cancel() }
+        enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {
+                continuation.resumeWith(Result.failure(e))
+            }
+
+            override fun onResponse(call: Call, response: Response) {
+                continuation.resume(response) { _, value, _ -> value.close() }
+            }
+        })
     }
 
     private fun trustedReleaseAssetUrl(raw: String): String? = runCatching {

--- a/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/DesktopUpdateController.kt
+++ b/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/DesktopUpdateController.kt
@@ -54,7 +54,7 @@ internal data class DesktopRelease(
     val name: String,
     val notes: String,
     val installer: DesktopReleaseAsset,
-    val checksum: DesktopReleaseAsset?
+    val checksum: DesktopReleaseAsset
 )
 
 internal data class DesktopUpdateUiState(
@@ -209,7 +209,7 @@ internal class DesktopUpdateController(
             ?: return null
         val checksum = assets.firstOrNull {
             it.name.equals("${installer.name}.sha256", ignoreCase = true)
-        }
+        } ?: return null
         return DesktopRelease(
             version = version,
             name = root["name"]?.jsonPrimitive?.contentOrNull.orEmpty().ifBlank {
@@ -281,40 +281,43 @@ internal class DesktopUpdateController(
             }
         }
 
+        verifyChecksum(release, temporary)
         moveAtomically(temporary, target)
-        verifyChecksum(release, target)
         target
     }
 
     private fun verifyChecksum(release: DesktopRelease, installer: Path) {
-        val checksumAsset = release.checksum ?: return
-        val request = Request.Builder()
-            .url(checksumAsset.url)
-            .header("Accept", "text/plain")
-            .header("User-Agent", "Levyra-Desktop/$currentVersion")
-            .build()
-        val expected = client.newCall(request).execute().use { response ->
-            if (!response.isSuccessful) {
-                throw IllegalStateException("Checksum aggiornamento non disponibile: HTTP ${response.code}")
+        try {
+            val request = Request.Builder()
+                .url(release.checksum.url)
+                .header("Accept", "text/plain")
+                .header("User-Agent", "Levyra-Desktop/$currentVersion")
+                .build()
+            val expected = client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IllegalStateException("Checksum aggiornamento non disponibile: HTTP ${response.code}")
+                }
+                response.body.string().trim().substringBefore(' ').lowercase(Locale.ROOT)
             }
-            response.body.string().trim().substringBefore(' ').lowercase(Locale.ROOT)
-        }
-        if (!expected.matches(Regex("^[0-9a-f]{64}$"))) {
-            throw IllegalStateException("Checksum aggiornamento non valido")
-        }
-        val digest = MessageDigest.getInstance("SHA-256")
-        Files.newInputStream(installer).buffered(BUFFER_SIZE).use { input ->
-            val buffer = ByteArray(BUFFER_SIZE)
-            while (true) {
-                val read = input.read(buffer)
-                if (read < 0) break
-                digest.update(buffer, 0, read)
+            if (!expected.matches(Regex("^[0-9a-f]{64}$"))) {
+                throw IllegalStateException("Checksum aggiornamento non valido")
             }
-        }
-        val actual = digest.digest().joinToString("") { byte -> "%02x".format(byte) }
-        if (!actual.equals(expected, ignoreCase = true)) {
+            val digest = MessageDigest.getInstance("SHA-256")
+            Files.newInputStream(installer).buffered(BUFFER_SIZE).use { input ->
+                val buffer = ByteArray(BUFFER_SIZE)
+                while (true) {
+                    val read = input.read(buffer)
+                    if (read < 0) break
+                    digest.update(buffer, 0, read)
+                }
+            }
+            val actual = digest.digest().joinToString("") { byte -> "%02x".format(byte) }
+            if (!actual.equals(expected, ignoreCase = true)) {
+                throw IllegalStateException("Verifica SHA-256 dell'aggiornamento non riuscita")
+            }
+        } catch (error: Throwable) {
             Files.deleteIfExists(installer)
-            throw IllegalStateException("Verifica SHA-256 dell'aggiornamento non riuscita")
+            throw error
         }
     }
 

--- a/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/DesktopUpdateController.kt
+++ b/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/DesktopUpdateController.kt
@@ -305,7 +305,7 @@ internal class DesktopUpdateController(
         target
     }
 
-    private suspend fun verifyChecksum(release: DesktopRelease, installer: Path) {
+    internal suspend fun verifyChecksum(release: DesktopRelease, installer: Path) {
         try {
             val request = Request.Builder()
                 .url(release.checksum.url)

--- a/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflineDownloadController.kt
+++ b/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflineDownloadController.kt
@@ -13,6 +13,7 @@ import com.luc4n3x.levyra.desktop.core.stream.ResolvedAudio
 import com.luc4n3x.levyra.desktop.core.stream.StreamResolver
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
@@ -28,11 +29,15 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
+import okhttp3.Call
+import okhttp3.Callback
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.Response
 
 class OfflineDownloadController(
     private val scope: CoroutineScope,
@@ -202,9 +207,7 @@ class OfflineDownloadController(
             )
         }
 
-        val call = client.newCall(requestBuilder.build())
-        kotlinx.coroutines.currentCoroutineContext()[Job]?.invokeOnCompletion { call.cancel() }
-        call.execute().use { response ->
+        client.newCall(requestBuilder.build()).awaitResponse().use { response ->
             if (!response.isSuccessful) {
                 throw IllegalStateException("Download non disponibile: HTTP ${response.code}")
             }
@@ -274,19 +277,6 @@ class OfflineDownloadController(
                 mediaLabel = resolved.label,
                 error = ""
             )
-        }
-    }
-
-    private fun moveAtomically(source: Path, target: Path) {
-        runCatching {
-            Files.move(
-                source,
-                target,
-                StandardCopyOption.REPLACE_EXISTING,
-                StandardCopyOption.ATOMIC_MOVE
-            )
-        }.getOrElse {
-            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING)
         }
     }
 
@@ -365,19 +355,6 @@ internal object OfflinePartialFileMigration {
             .lowercase(Locale.ROOT)
     }
 
-    private fun moveAtomically(source: Path, target: Path) {
-        runCatching {
-            Files.move(
-                source,
-                target,
-                StandardCopyOption.REPLACE_EXISTING,
-                StandardCopyOption.ATOMIC_MOVE
-            )
-        }.getOrElse {
-            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING)
-        }
-    }
-
     private const val PART_SUFFIX_LENGTH = 5
 }
 
@@ -424,4 +401,30 @@ internal object OfflineFileName {
         .trim()
         .trimEnd('.')
         .ifBlank { "track" }
+}
+
+private suspend fun Call.awaitResponse(): Response = suspendCancellableCoroutine { continuation ->
+    continuation.invokeOnCancellation { cancel() }
+    enqueue(object : Callback {
+        override fun onFailure(call: Call, e: IOException) {
+            continuation.resumeWith(Result.failure(e))
+        }
+
+        override fun onResponse(call: Call, response: Response) {
+            continuation.resume(response) { _, value, _ -> value.close() }
+        }
+    })
+}
+
+private fun moveAtomically(source: Path, target: Path) {
+    runCatching {
+        Files.move(
+            source,
+            target,
+            StandardCopyOption.REPLACE_EXISTING,
+            StandardCopyOption.ATOMIC_MOVE
+        )
+    }.getOrElse {
+        Files.move(source, target, StandardCopyOption.REPLACE_EXISTING)
+    }
 }

--- a/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflineDownloadController.kt
+++ b/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflineDownloadController.kt
@@ -17,6 +17,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.nio.file.StandardOpenOption
+import java.security.MessageDigest
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
@@ -170,7 +171,7 @@ class OfflineDownloadController(
         resolved: ResolvedAudio
     ) {
         val extension = extensionFor(resolved.label)
-        val baseName = fileBaseName(track)
+        val baseName = OfflineFileName.baseName(track)
         val target = paths.downloadsDirectory.resolve("$baseName.$extension")
         val temporary = paths.downloadsDirectory.resolve("$baseName.$extension.part")
         Files.createDirectories(paths.downloadsDirectory)
@@ -289,20 +290,6 @@ class OfflineDownloadController(
         }
     }
 
-    private fun fileBaseName(track: Track): String {
-        val artist = safeComponent(track.artist.ifBlank { "Levyra" })
-        val title = safeComponent(track.title.ifBlank { track.id })
-        val suffix = safeComponent(track.id).takeLast(10).ifBlank { track.hashCode().toUInt().toString(16) }
-        return "$artist - $title [$suffix]".take(MAX_FILE_NAME_LENGTH)
-    }
-
-    private fun safeComponent(value: String): String = value
-        .replace(Regex("[\\\\/:*?\"<>|\\p{Cntrl}]"), " ")
-        .replace(Regex("\\s+"), " ")
-        .trim()
-        .trimEnd('.')
-        .ifBlank { "track" }
-
     private fun extensionFor(label: String): String {
         val normalized = label.lowercase(Locale.ROOT)
         return when {
@@ -321,6 +308,49 @@ class OfflineDownloadController(
         private const val BUFFER_SIZE = 64 * 1024
         private const val PROGRESS_BYTES_INTERVAL = 512 * 1024L
         private const val PROGRESS_TIME_INTERVAL_NANOS = 250_000_000L
-        private const val MAX_FILE_NAME_LENGTH = 180
     }
+}
+
+internal object OfflineFileName {
+    private const val MAX_FILE_NAME_LENGTH = 180
+    private const val HASH_BYTES = 8
+
+    fun baseName(track: Track): String {
+        val artist = safeComponent(track.artist.ifBlank { "Levyra" })
+        val title = safeComponent(track.title.ifBlank { track.id })
+        val suffixBlock = " [${stableSuffix(track)}]"
+        val availableDescriptionLength =
+            (MAX_FILE_NAME_LENGTH - suffixBlock.length).coerceAtLeast(1)
+        val description = "$artist - $title"
+            .take(availableDescriptionLength)
+            .trimEnd(' ', '.', '-')
+            .ifBlank { "track" }
+        return description + suffixBlock
+    }
+
+    private fun stableSuffix(track: Track): String {
+        val identity = track.id.ifBlank {
+            buildString {
+                append(track.title.trim().lowercase(Locale.ROOT))
+                append('|')
+                append(track.artist.trim().lowercase(Locale.ROOT))
+                append('|')
+                append(track.videoUrl.trim())
+            }
+        }
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(identity.toByteArray(Charsets.UTF_8))
+        return digest
+            .take(HASH_BYTES)
+            .joinToString("") { byte ->
+                (byte.toInt() and 0xff).toString(16).padStart(2, '0')
+            }
+    }
+
+    private fun safeComponent(value: String): String = value
+        .replace(Regex("[\\/:*?\"<>|\\p{Cntrl}]"), " ")
+        .replace(Regex("\\s+"), " ")
+        .trim()
+        .trimEnd('.')
+        .ifBlank { "track" }
 }

--- a/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflineDownloadController.kt
+++ b/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflineDownloadController.kt
@@ -177,11 +177,11 @@ class OfflineDownloadController(
         Files.createDirectories(paths.downloadsDirectory)
 
         val existingRecord = store.record(id) ?: return
-        if (existingRecord.temporaryPath.isNotBlank() && existingRecord.temporaryPath != temporary.toString()) {
-            runCatching { Files.deleteIfExists(Path.of(existingRecord.temporaryPath)) }
-        }
-
-        var resumedBytes = runCatching { Files.size(temporary) }.getOrDefault(0L)
+        var resumedBytes = OfflinePartialFileMigration.prepare(
+            downloadsDirectory = paths.downloadsDirectory,
+            recordedPath = existingRecord.temporaryPath,
+            targetPath = temporary
+        )
         val requestBuilder = Request.Builder()
             .url(resolved.url)
             .header("User-Agent", ExtractorHttp.DESKTOP_USER_AGENT)
@@ -309,6 +309,76 @@ class OfflineDownloadController(
         private const val PROGRESS_BYTES_INTERVAL = 512 * 1024L
         private const val PROGRESS_TIME_INTERVAL_NANOS = 250_000_000L
     }
+}
+
+internal object OfflinePartialFileMigration {
+    fun prepare(downloadsDirectory: Path, recordedPath: String, targetPath: Path): Long {
+        val root = downloadsDirectory.toAbsolutePath().normalize()
+        val target = targetPath.toAbsolutePath().normalize()
+        require(target.startsWith(root)) { "Il file temporaneo deve restare nella cartella download" }
+        Files.createDirectories(target.parent)
+
+        val source = recordedPath
+            .takeIf { it.isNotBlank() }
+            ?.let { raw ->
+                runCatching {
+                    val parsed = Path.of(raw)
+                    (if (parsed.isAbsolute) parsed else root.resolve(parsed)).toAbsolutePath().normalize()
+                }.getOrNull()
+            }
+
+        if (
+            source != null &&
+            source != target &&
+            source.startsWith(root) &&
+            !Files.isSymbolicLink(source) &&
+            Files.isRegularFile(source)
+        ) {
+            if (partialExtension(source) == partialExtension(target) && partialExtension(target).isNotBlank()) {
+                migrateCompatiblePartial(source, target)
+            } else {
+                Files.deleteIfExists(source)
+            }
+        }
+
+        return runCatching { Files.size(target) }.getOrDefault(0L)
+    }
+
+    private fun migrateCompatiblePartial(source: Path, target: Path) {
+        if (Files.isRegularFile(target) && !Files.isSymbolicLink(target)) {
+            if (Files.size(source) > Files.size(target)) {
+                moveAtomically(source, target)
+            } else {
+                Files.deleteIfExists(source)
+            }
+        } else {
+            Files.deleteIfExists(target)
+            moveAtomically(source, target)
+        }
+    }
+
+    private fun partialExtension(path: Path): String {
+        val name = path.fileName.toString()
+        if (!name.endsWith(".part", ignoreCase = true)) return ""
+        return name.dropLast(PART_SUFFIX_LENGTH)
+            .substringAfterLast('.', "")
+            .lowercase(Locale.ROOT)
+    }
+
+    private fun moveAtomically(source: Path, target: Path) {
+        runCatching {
+            Files.move(
+                source,
+                target,
+                StandardCopyOption.REPLACE_EXISTING,
+                StandardCopyOption.ATOMIC_MOVE
+            )
+        }.getOrElse {
+            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
+
+    private const val PART_SUFFIX_LENGTH = 5
 }
 
 internal object OfflineFileName {

--- a/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflineDownloadController.kt
+++ b/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflineDownloadController.kt
@@ -14,6 +14,9 @@ import com.luc4n3x.levyra.desktop.core.stream.StreamResolver
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
 import java.io.IOException
+import java.net.URI
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
@@ -179,13 +182,16 @@ class OfflineDownloadController(
         val baseName = OfflineFileName.baseName(track)
         val target = paths.downloadsDirectory.resolve("$baseName.$extension")
         val temporary = paths.downloadsDirectory.resolve("$baseName.$extension.part")
+        val currentStreamIdentity = OfflineStreamIdentity.from(track, resolved)
         Files.createDirectories(paths.downloadsDirectory)
 
         val existingRecord = store.record(id) ?: return
         var resumedBytes = OfflinePartialFileMigration.prepare(
             downloadsDirectory = paths.downloadsDirectory,
             recordedPath = existingRecord.temporaryPath,
-            targetPath = temporary
+            targetPath = temporary,
+            recordedIdentity = existingRecord.streamIdentity,
+            currentIdentity = currentStreamIdentity
         )
         val requestBuilder = Request.Builder()
             .url(resolved.url)
@@ -203,6 +209,7 @@ class OfflineDownloadController(
                 filePath = "",
                 bytesDownloaded = resumedBytes,
                 mediaLabel = resolved.label,
+                streamIdentity = currentStreamIdentity,
                 error = ""
             )
         }
@@ -275,6 +282,7 @@ class OfflineDownloadController(
                 bytesDownloaded = completedSize,
                 totalBytes = completedSize,
                 mediaLabel = resolved.label,
+                streamIdentity = currentStreamIdentity,
                 error = ""
             )
         }
@@ -302,7 +310,13 @@ class OfflineDownloadController(
 }
 
 internal object OfflinePartialFileMigration {
-    fun prepare(downloadsDirectory: Path, recordedPath: String, targetPath: Path): Long {
+    fun prepare(
+        downloadsDirectory: Path,
+        recordedPath: String,
+        targetPath: Path,
+        recordedIdentity: String,
+        currentIdentity: String
+    ): Long {
         val root = downloadsDirectory.toAbsolutePath().normalize()
         val target = targetPath.toAbsolutePath().normalize()
         require(target.startsWith(root)) { "Il file temporaneo deve restare nella cartella download" }
@@ -317,6 +331,17 @@ internal object OfflinePartialFileMigration {
                 }.getOrNull()
             }
 
+        val identitiesMatch = recordedIdentity.isNotBlank() &&
+            currentIdentity.isNotBlank() &&
+            recordedIdentity == currentIdentity
+        if (!identitiesMatch) {
+            source
+                ?.takeIf { it.startsWith(root) }
+                ?.let { Files.deleteIfExists(it) }
+            Files.deleteIfExists(target)
+            return 0L
+        }
+
         if (
             source != null &&
             source != target &&
@@ -328,10 +353,14 @@ internal object OfflinePartialFileMigration {
                 migrateCompatiblePartial(source, target)
             } else {
                 Files.deleteIfExists(source)
+                Files.deleteIfExists(target)
             }
         }
 
-        return runCatching { Files.size(target) }.getOrDefault(0L)
+        return target
+            .takeIf { !Files.isSymbolicLink(it) && Files.isRegularFile(it) }
+            ?.let(Files::size)
+            ?: 0L
     }
 
     private fun migrateCompatiblePartial(source: Path, target: Path) {
@@ -356,6 +385,51 @@ internal object OfflinePartialFileMigration {
     }
 
     private const val PART_SUFFIX_LENGTH = 5
+}
+
+internal object OfflineStreamIdentity {
+    private val stableQueryKeys = listOf("itag", "clen", "dur", "lmt", "mime", "id")
+    private const val HASH_BYTES = 16
+
+    fun from(track: Track, resolved: ResolvedAudio): String {
+        val query = runCatching { URI(resolved.url).rawQuery }.getOrNull().orEmpty()
+        val parameters = query
+            .split('&')
+            .asSequence()
+            .filter { it.isNotBlank() }
+            .mapNotNull { entry ->
+                val key = decode(entry.substringBefore('=', "")).lowercase(Locale.ROOT)
+                val value = decode(entry.substringAfter('=', ""))
+                key.takeIf { it.isNotBlank() && value.isNotBlank() }?.let { it to value }
+            }
+            .toMap()
+        val itag = parameters["itag"].orEmpty()
+        val validator = parameters["clen"].orEmpty()
+            .ifBlank { parameters["lmt"].orEmpty() }
+            .ifBlank { parameters["id"].orEmpty() }
+        if (itag.isBlank() || validator.isBlank()) return ""
+
+        val stableQuery = stableQueryKeys.joinToString("&") { key ->
+            "$key=${parameters[key].orEmpty()}"
+        }
+        val payload = buildString {
+            append(track.id.ifBlank { track.videoUrl })
+            append('|')
+            append(resolved.label.trim().lowercase(Locale.ROOT))
+            append('|')
+            append(stableQuery)
+        }
+        return MessageDigest.getInstance("SHA-256")
+            .digest(payload.toByteArray(StandardCharsets.UTF_8))
+            .take(HASH_BYTES)
+            .joinToString("") { byte ->
+                (byte.toInt() and 0xff).toString(16).padStart(2, '0')
+            }
+    }
+
+    private fun decode(value: String): String = runCatching {
+        URLDecoder.decode(value, StandardCharsets.UTF_8)
+    }.getOrDefault(value)
 }
 
 internal object OfflineFileName {

--- a/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflineDownloadController.kt
+++ b/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflineDownloadController.kt
@@ -314,6 +314,7 @@ class OfflineDownloadController(
 internal object OfflineFileName {
     private const val MAX_FILE_NAME_LENGTH = 180
     private const val HASH_BYTES = 8
+    private val invalidFileNameChars = Regex("""[\\/:*?"<>|\p{Cntrl}]""")
 
     fun baseName(track: Track): String {
         val artist = safeComponent(track.artist.ifBlank { "Levyra" })
@@ -348,7 +349,7 @@ internal object OfflineFileName {
     }
 
     private fun safeComponent(value: String): String = value
-        .replace(Regex("[\\/:*?\"<>|\\p{Cntrl}]"), " ")
+        .replace(invalidFileNameChars, " ")
         .replace(Regex("\\s+"), " ")
         .trim()
         .trimEnd('.')

--- a/desktop/app/src/test/kotlin/com/luc4n3x/levyra/desktop/app/state/DesktopUpdateChecksumTest.kt
+++ b/desktop/app/src/test/kotlin/com/luc4n3x/levyra/desktop/app/state/DesktopUpdateChecksumTest.kt
@@ -1,0 +1,118 @@
+package com.luc4n3x.levyra.desktop.app.state
+
+import com.luc4n3x.levyra.desktop.core.storage.AppPaths
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class DesktopUpdateChecksumTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun validChecksumKeepsInstaller() = runTest {
+        val bytes = "verified installer".toByteArray()
+        val installer = installerFile(bytes)
+        val controller = controller(200, "${sha256(bytes)}  installer.msi")
+
+        controller.verifyChecksum(release(), installer)
+
+        assertTrue(Files.isRegularFile(installer))
+        controller.shutdown()
+    }
+
+    @Test
+    fun mismatchedChecksumDeletesInstaller() = runTest {
+        val installer = installerFile("installer".toByteArray())
+        val controller = controller(200, "0".repeat(64))
+
+        assertVerificationFailsAndDeletes(controller, installer)
+    }
+
+    @Test
+    fun malformedChecksumDeletesInstaller() = runTest {
+        val installer = installerFile("installer".toByteArray())
+        val controller = controller(200, "not-a-sha256")
+
+        assertVerificationFailsAndDeletes(controller, installer)
+    }
+
+    @Test
+    fun unsuccessfulChecksumResponseDeletesInstaller() = runTest {
+        val installer = installerFile("installer".toByteArray())
+        val controller = controller(503, "temporarily unavailable")
+
+        assertVerificationFailsAndDeletes(controller, installer)
+    }
+
+    private suspend fun assertVerificationFailsAndDeletes(
+        controller: DesktopUpdateController,
+        installer: Path
+    ) {
+        try {
+            controller.verifyChecksum(release(), installer)
+            fail("Checksum verification should fail")
+        } catch (_: IllegalStateException) {
+        } finally {
+            controller.shutdown()
+        }
+        assertFalse(Files.exists(installer))
+    }
+
+    private fun controller(code: Int, body: String): DesktopUpdateController {
+        val client = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                Response.Builder()
+                    .request(chain.request())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(code)
+                    .message("test")
+                    .body(body.toResponseBody("text/plain".toMediaType()))
+                    .build()
+            }
+            .build()
+        return DesktopUpdateController(
+            scope = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Unconfined),
+            paths = AppPaths(temporaryFolder.root.toPath()).prepare(),
+            currentVersion = "1.0.0",
+            baseClient = client
+        )
+    }
+
+    private fun installerFile(bytes: ByteArray): Path {
+        val path = temporaryFolder.newFile("installer-${System.nanoTime()}.msi").toPath()
+        return Files.write(path, bytes)
+    }
+
+    private fun release(): DesktopRelease = DesktopRelease(
+        version = "1.0.1",
+        name = "Levyra Desktop 1.0.1",
+        notes = "",
+        installer = DesktopReleaseAsset(
+            name = "LEVYRA-Windows-1.0.1-x64.msi",
+            url = "https://github.com/LUC4N3X/Levyra-deepsound/releases/download/desktop-v1.0.1/LEVYRA-Windows-1.0.1-x64.msi",
+            size = 0L
+        ),
+        checksum = DesktopReleaseAsset(
+            name = "LEVYRA-Windows-1.0.1-x64.msi.sha256",
+            url = "https://github.com/LUC4N3X/Levyra-deepsound/releases/download/desktop-v1.0.1/LEVYRA-Windows-1.0.1-x64.msi.sha256",
+            size = 0L
+        )
+    )
+
+    private fun sha256(bytes: ByteArray): String = MessageDigest.getInstance("SHA-256")
+        .digest(bytes)
+        .joinToString("") { byte -> "%02x".format(byte) }
+}

--- a/desktop/app/src/test/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflineFileNameTest.kt
+++ b/desktop/app/src/test/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflineFileNameTest.kt
@@ -1,6 +1,8 @@
 package com.luc4n3x.levyra.desktop.app.state
 
 import com.luc4n3x.levyra.desktop.core.model.Track
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -10,27 +12,42 @@ class OfflineFileNameTest {
     fun longMetadataKeepsDistinctStableSuffixes() {
         val longArtist = "Artist ".repeat(40)
         val longTitle = "Very long track title ".repeat(40)
-        val first = OfflineFileName.baseName(
-            Track(
-                id = "first-unique-video-id",
-                title = longTitle,
-                artist = longArtist,
-                videoUrl = "https://music.youtube.com/watch?v=first-unique-video-id"
-            )
+        val firstTrack = Track(
+            id = "first-unique-video-id",
+            title = longTitle,
+            artist = longArtist,
+            videoUrl = "https://music.youtube.com/watch?v=first-unique-video-id"
         )
-        val second = OfflineFileName.baseName(
-            Track(
-                id = "second-unique-video-id",
-                title = longTitle,
-                artist = longArtist,
-                videoUrl = "https://music.youtube.com/watch?v=second-unique-video-id"
-            )
+        val secondTrack = Track(
+            id = "second-unique-video-id",
+            title = longTitle,
+            artist = longArtist,
+            videoUrl = "https://music.youtube.com/watch?v=second-unique-video-id"
         )
+        val first = OfflineFileName.baseName(firstTrack)
+        val repeated = OfflineFileName.baseName(firstTrack)
+        val second = OfflineFileName.baseName(secondTrack)
 
+        assertEquals(first, repeated)
         assertTrue(first.length <= 180)
         assertTrue(second.length <= 180)
         assertTrue(first.matches(Regex(".* \\[[0-9a-f]{16}]$")))
         assertTrue(second.matches(Regex(".* \\[[0-9a-f]{16}]$")))
         assertNotEquals(first, second)
+    }
+
+    @Test
+    fun windowsPathSeparatorsAreRemoved() {
+        val name = OfflineFileName.baseName(
+            Track(
+                id = "acdc-track",
+                title = "Back\\In/Black",
+                artist = "AC\\DC",
+                videoUrl = "https://music.youtube.com/watch?v=acdc-track"
+            )
+        )
+
+        assertFalse(name.contains('\\'))
+        assertFalse(name.contains('/'))
     }
 }

--- a/desktop/app/src/test/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflineFileNameTest.kt
+++ b/desktop/app/src/test/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflineFileNameTest.kt
@@ -1,0 +1,36 @@
+package com.luc4n3x.levyra.desktop.app.state
+
+import com.luc4n3x.levyra.desktop.core.model.Track
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OfflineFileNameTest {
+    @Test
+    fun longMetadataKeepsDistinctStableSuffixes() {
+        val longArtist = "Artist ".repeat(40)
+        val longTitle = "Very long track title ".repeat(40)
+        val first = OfflineFileName.baseName(
+            Track(
+                id = "first-unique-video-id",
+                title = longTitle,
+                artist = longArtist,
+                videoUrl = "https://music.youtube.com/watch?v=first-unique-video-id"
+            )
+        )
+        val second = OfflineFileName.baseName(
+            Track(
+                id = "second-unique-video-id",
+                title = longTitle,
+                artist = longArtist,
+                videoUrl = "https://music.youtube.com/watch?v=second-unique-video-id"
+            )
+        )
+
+        assertTrue(first.length <= 180)
+        assertTrue(second.length <= 180)
+        assertTrue(first.matches(Regex(".* \\[[0-9a-f]{16}]$")))
+        assertTrue(second.matches(Regex(".* \\[[0-9a-f]{16}]$")))
+        assertNotEquals(first, second)
+    }
+}

--- a/desktop/app/src/test/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflinePartialFileMigrationTest.kt
+++ b/desktop/app/src/test/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflinePartialFileMigrationTest.kt
@@ -1,9 +1,12 @@
 package com.luc4n3x.levyra.desktop.app.state
 
+import com.luc4n3x.levyra.desktop.core.model.Track
+import com.luc4n3x.levyra.desktop.core.stream.ResolvedAudio
 import java.nio.file.Files
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -14,7 +17,7 @@ class OfflinePartialFileMigrationTest {
     val temporaryFolder = TemporaryFolder()
 
     @Test
-    fun legacyPartialIsMovedToHashedNameWithoutLosingProgress() {
+    fun matchingStreamIdentityMovesPartialWithoutLosingProgress() {
         val downloads = temporaryFolder.newFolder("offline").toPath()
         val legacy = downloads.resolve("Artist - Track [legacy].m4a.part")
         val target = downloads.resolve("Artist - Track [0123456789abcdef].m4a.part")
@@ -24,7 +27,9 @@ class OfflinePartialFileMigrationTest {
         val resumedBytes = OfflinePartialFileMigration.prepare(
             downloadsDirectory = downloads,
             recordedPath = legacy.toString(),
-            targetPath = target
+            targetPath = target,
+            recordedIdentity = "same-stream",
+            currentIdentity = "same-stream"
         )
 
         assertEquals(content.size.toLong(), resumedBytes)
@@ -34,7 +39,48 @@ class OfflinePartialFileMigrationTest {
     }
 
     @Test
-    fun largerLegacyPartialReplacesSmallerTarget() {
+    fun mismatchedStreamIdentityDiscardsEveryLocalPartial() {
+        val downloads = temporaryFolder.newFolder("offline-mismatch").toPath()
+        val legacy = downloads.resolve("old-name.m4a.part")
+        val target = downloads.resolve("new-name.m4a.part")
+        Files.write(legacy, ByteArray(8_192) { 7 })
+        Files.write(target, ByteArray(512) { 3 })
+
+        val resumedBytes = OfflinePartialFileMigration.prepare(
+            downloadsDirectory = downloads,
+            recordedPath = legacy.toString(),
+            targetPath = target,
+            recordedIdentity = "old-stream",
+            currentIdentity = "new-stream"
+        )
+
+        assertEquals(0L, resumedBytes)
+        assertFalse(Files.exists(legacy))
+        assertFalse(Files.exists(target))
+    }
+
+    @Test
+    fun missingLegacyIdentityCannotResume() {
+        val downloads = temporaryFolder.newFolder("offline-legacy").toPath()
+        val legacy = downloads.resolve("old-name.webm.part")
+        val target = downloads.resolve("new-name.webm.part")
+        Files.write(legacy, ByteArray(4_096) { 4 })
+
+        val resumedBytes = OfflinePartialFileMigration.prepare(
+            downloadsDirectory = downloads,
+            recordedPath = legacy.toString(),
+            targetPath = target,
+            recordedIdentity = "",
+            currentIdentity = "verified-stream"
+        )
+
+        assertEquals(0L, resumedBytes)
+        assertFalse(Files.exists(legacy))
+        assertFalse(Files.exists(target))
+    }
+
+    @Test
+    fun largerMatchingPartialReplacesSmallerTarget() {
         val downloads = temporaryFolder.newFolder("offline-conflict").toPath()
         val legacy = downloads.resolve("old-name.webm.part")
         val target = downloads.resolve("new-name.webm.part")
@@ -45,7 +91,9 @@ class OfflinePartialFileMigrationTest {
         val resumedBytes = OfflinePartialFileMigration.prepare(
             downloadsDirectory = downloads,
             recordedPath = legacy.toString(),
-            targetPath = target
+            targetPath = target,
+            recordedIdentity = "same-stream",
+            currentIdentity = "same-stream"
         )
 
         assertEquals(legacyContent.size.toLong(), resumedBytes)
@@ -63,11 +111,53 @@ class OfflinePartialFileMigrationTest {
         val resumedBytes = OfflinePartialFileMigration.prepare(
             downloadsDirectory = downloads,
             recordedPath = outside.toString(),
-            targetPath = target
+            targetPath = target,
+            recordedIdentity = "same-stream",
+            currentIdentity = "same-stream"
         )
 
         assertEquals(0L, resumedBytes)
         assertTrue(Files.isRegularFile(outside))
         assertFalse(Files.exists(target))
     }
+
+    @Test
+    fun streamIdentityIgnoresExpiringSignatureButTracksMediaVariant() {
+        val track = Track(id = "video-id", title = "Track", artist = "Artist")
+        val first = resolved(
+            "https://r1.googlevideo.com/videoplayback?itag=140&clen=123456&lmt=1710000000000000&dur=180.0&mime=audio%2Fmp4&expire=1&sig=first"
+        )
+        val refreshed = resolved(
+            "https://r2.googlevideo.com/videoplayback?sig=second&expire=2&mime=audio%2Fmp4&dur=180.0&lmt=1710000000000000&clen=123456&itag=140"
+        )
+        val differentItag = resolved(
+            "https://r1.googlevideo.com/videoplayback?itag=251&clen=123456&lmt=1710000000000000&dur=180.0&mime=audio%2Fwebm"
+        )
+
+        val firstIdentity = OfflineStreamIdentity.from(track, first)
+        val refreshedIdentity = OfflineStreamIdentity.from(track, refreshed)
+        val differentIdentity = OfflineStreamIdentity.from(track, differentItag)
+
+        assertTrue(firstIdentity.isNotBlank())
+        assertEquals(firstIdentity, refreshedIdentity)
+        assertNotEquals(firstIdentity, differentIdentity)
+    }
+
+    @Test
+    fun streamIdentityRequiresFormatAndContentValidator() {
+        val track = Track(id = "video-id", title = "Track", artist = "Artist")
+        val unresolved = resolved("https://example.com/audio?expire=1&sig=value")
+
+        assertEquals("", OfflineStreamIdentity.from(track, unresolved))
+    }
+
+    private fun resolved(url: String): ResolvedAudio = ResolvedAudio(
+        url = url,
+        label = "AAC · M4A",
+        expiresAtMillis = 0L,
+        durationMs = 180_000L,
+        artworkUrl = "",
+        title = "Track",
+        artist = "Artist"
+    )
 }

--- a/desktop/app/src/test/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflinePartialFileMigrationTest.kt
+++ b/desktop/app/src/test/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflinePartialFileMigrationTest.kt
@@ -1,0 +1,73 @@
+package com.luc4n3x.levyra.desktop.app.state
+
+import java.nio.file.Files
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class OfflinePartialFileMigrationTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun legacyPartialIsMovedToHashedNameWithoutLosingProgress() {
+        val downloads = temporaryFolder.newFolder("offline").toPath()
+        val legacy = downloads.resolve("Artist - Track [legacy].m4a.part")
+        val target = downloads.resolve("Artist - Track [0123456789abcdef].m4a.part")
+        val content = ByteArray(16_384) { index -> (index % 251).toByte() }
+        Files.write(legacy, content)
+
+        val resumedBytes = OfflinePartialFileMigration.prepare(
+            downloadsDirectory = downloads,
+            recordedPath = legacy.toString(),
+            targetPath = target
+        )
+
+        assertEquals(content.size.toLong(), resumedBytes)
+        assertFalse(Files.exists(legacy))
+        assertTrue(Files.isRegularFile(target))
+        assertArrayEquals(content, Files.readAllBytes(target))
+    }
+
+    @Test
+    fun largerLegacyPartialReplacesSmallerTarget() {
+        val downloads = temporaryFolder.newFolder("offline-conflict").toPath()
+        val legacy = downloads.resolve("old-name.webm.part")
+        val target = downloads.resolve("new-name.webm.part")
+        val legacyContent = ByteArray(8_192) { 7 }
+        Files.write(legacy, legacyContent)
+        Files.write(target, ByteArray(512) { 3 })
+
+        val resumedBytes = OfflinePartialFileMigration.prepare(
+            downloadsDirectory = downloads,
+            recordedPath = legacy.toString(),
+            targetPath = target
+        )
+
+        assertEquals(legacyContent.size.toLong(), resumedBytes)
+        assertFalse(Files.exists(legacy))
+        assertArrayEquals(legacyContent, Files.readAllBytes(target))
+    }
+
+    @Test
+    fun recordedPathOutsideDownloadDirectoryIsIgnored() {
+        val downloads = temporaryFolder.newFolder("offline-safe").toPath()
+        val outside = temporaryFolder.newFile("outside.m4a.part").toPath()
+        val target = downloads.resolve("safe-name.m4a.part")
+        Files.writeString(outside, "do not touch")
+
+        val resumedBytes = OfflinePartialFileMigration.prepare(
+            downloadsDirectory = downloads,
+            recordedPath = outside.toString(),
+            targetPath = target
+        )
+
+        assertEquals(0L, resumedBytes)
+        assertTrue(Files.isRegularFile(outside))
+        assertFalse(Files.exists(target))
+    }
+}

--- a/desktop/app/src/test/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflinePartialFileMigrationTest.kt
+++ b/desktop/app/src/test/kotlin/com/luc4n3x/levyra/desktop/app/state/OfflinePartialFileMigrationTest.kt
@@ -123,7 +123,7 @@ class OfflinePartialFileMigrationTest {
 
     @Test
     fun streamIdentityIgnoresExpiringSignatureButTracksMediaVariant() {
-        val track = Track(id = "video-id", title = "Track", artist = "Artist")
+        val track = Track(id = "video-id", title = "Track", artist = "Artist", videoUrl = "")
         val first = resolved(
             "https://r1.googlevideo.com/videoplayback?itag=140&clen=123456&lmt=1710000000000000&dur=180.0&mime=audio%2Fmp4&expire=1&sig=first"
         )
@@ -145,7 +145,7 @@ class OfflinePartialFileMigrationTest {
 
     @Test
     fun streamIdentityRequiresFormatAndContentValidator() {
-        val track = Track(id = "video-id", title = "Track", artist = "Artist")
+        val track = Track(id = "video-id", title = "Track", artist = "Artist", videoUrl = "")
         val unresolved = resolved("https://example.com/audio?expire=1&sig=value")
 
         assertEquals("", OfflineStreamIdentity.from(track, unresolved))

--- a/desktop/core/src/main/kotlin/com/luc4n3x/levyra/desktop/core/storage/DownloadModels.kt
+++ b/desktop/core/src/main/kotlin/com/luc4n3x/levyra/desktop/core/storage/DownloadModels.kt
@@ -23,6 +23,7 @@ data class DownloadRecord(
     val bytesDownloaded: Long = 0L,
     val totalBytes: Long = 0L,
     val mediaLabel: String = "",
+    val streamIdentity: String = "",
     val error: String = "",
     val createdAt: Long = 0L,
     val updatedAt: Long = 0L

--- a/desktop/version.properties
+++ b/desktop/version.properties
@@ -1,1 +1,1 @@
-levyraDesktopVersion=1.0.0
+levyraDesktopVersion=1.0.1

--- a/docs/assets/levyra-android-platform.svg
+++ b/docs/assets/levyra-android-platform.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="196" height="36" viewBox="0 0 196 36" role="img" aria-label="Android: signed APK">
+  <title>Android: signed APK</title>
+  <rect x="0.75" y="0.75" width="194.5" height="34.5" rx="8" fill="#0d1117" stroke="#303b4d"/>
+  <path d="M87 1h101a8 8 0 0 1 8 8v18a8 8 0 0 1-8 8H87Z" fill="#3ddc84"/>
+  <path d="M87 6v24" stroke="#ffffff" stroke-opacity=".16"/>
+  <g fill="#ffffff" transform="translate(12 9)">
+    <path d="M4.3 5.2 2.8 2.6l1-.6 1.6 2.7A8 8 0 0 1 9 4c1.3 0 2.5.3 3.6.7L14.2 2l1 .6-1.5 2.6A7.8 7.8 0 0 1 17 11H1a7.8 7.8 0 0 1 3.3-5.8ZM5 8a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm8 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"/>
+    <path d="M1 12h16v2.5A2.5 2.5 0 0 1 14.5 17h-11A2.5 2.5 0 0 1 1 14.5V12Z"/>
+  </g>
+  <text x="36" y="22.5" fill="#f8fafc" font-family="Segoe UI,Arial,sans-serif" font-size="11.5" font-weight="700">Android</text>
+  <text x="141" y="22.5" fill="#07160d" text-anchor="middle" font-family="Segoe UI,Arial,sans-serif" font-size="12" font-weight="800">Signed APK</text>
+</svg>

--- a/docs/assets/levyra-android-platform.svg
+++ b/docs/assets/levyra-android-platform.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="196" height="36" viewBox="0 0 196 36" role="img" aria-label="Android: signed APK">
-  <title>Android: signed APK</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="196" height="36" viewBox="0 0 196 36" role="img" aria-label="Android: v2.3.16">
+  <title>Android: v2.3.16</title>
   <rect x="0.75" y="0.75" width="194.5" height="34.5" rx="8" fill="#0d1117" stroke="#303b4d"/>
   <path d="M87 1h101a8 8 0 0 1 8 8v18a8 8 0 0 1-8 8H87Z" fill="#3ddc84"/>
   <path d="M87 6v24" stroke="#ffffff" stroke-opacity=".16"/>
@@ -8,5 +8,5 @@
     <path d="M1 12h16v2.5A2.5 2.5 0 0 1 14.5 17h-11A2.5 2.5 0 0 1 1 14.5V12Z"/>
   </g>
   <text x="36" y="22.5" fill="#f8fafc" font-family="Segoe UI,Arial,sans-serif" font-size="11.5" font-weight="700">Android</text>
-  <text x="141" y="22.5" fill="#07160d" text-anchor="middle" font-family="Segoe UI,Arial,sans-serif" font-size="12" font-weight="800">Signed APK</text>
+  <text x="141" y="22.5" fill="#07160d" text-anchor="middle" font-family="Segoe UI,Arial,sans-serif" font-size="12" font-weight="800">v2.3.16</text>
 </svg>

--- a/docs/assets/levyra-windows-download.svg
+++ b/docs/assets/levyra-windows-download.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="154" viewBox="0 0 760 154" role="img" aria-labelledby="title desc">
+  <title id="title">Download Levyra Desktop for Windows</title>
+  <desc id="desc">Official Levyra Windows release download button for MSI, EXE and portable ZIP packages</desc>
+  <defs>
+    <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#151b27"/>
+      <stop offset="55%" stop-color="#0d1117"/>
+      <stop offset="100%" stop-color="#090c12"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#55e7ff"/>
+      <stop offset="52%" stop-color="#18bde8"/>
+      <stop offset="100%" stop-color="#2f6df6"/>
+    </linearGradient>
+    <linearGradient id="button" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#27d9f5"/>
+      <stop offset="100%" stop-color="#2475ef"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-35%" width="140%" height="190%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#000000" flood-opacity="0.34"/>
+    </filter>
+    <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="0" stdDeviation="8" flood-color="#27d9f5" flood-opacity="0.32"/>
+    </filter>
+  </defs>
+  <g filter="url(#shadow)">
+    <rect x="8" y="8" width="744" height="138" rx="24" fill="url(#panel)" stroke="#30394a" stroke-width="2"/>
+    <rect x="9" y="9" width="742" height="136" rx="23" fill="none" stroke="#ffffff" stroke-opacity="0.05"/>
+  </g>
+  <rect x="31" y="31" width="92" height="92" rx="24" fill="url(#accent)" filter="url(#glow)"/>
+  <rect x="32" y="32" width="90" height="90" rx="23" fill="none" stroke="#ffffff" stroke-opacity="0.18"/>
+  <g fill="#ffffff">
+    <path d="M49 52.5 75 49v25H49z"/>
+    <path d="M79 48.5 107 45v29H79z"/>
+    <path d="M49 78h26v25l-26-3.5z"/>
+    <path d="M79 78h28v29l-28-3.5z"/>
+  </g>
+  <text x="148" y="49" fill="#76eaff" font-family="Segoe UI, Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.8">OFFICIAL GITHUB RELEASE</text>
+  <text x="146" y="83" fill="#ffffff" font-family="Segoe UI, Arial, sans-serif" font-size="30" font-weight="800">Levyra for Windows</text>
+  <text x="148" y="109" fill="#9aa7bc" font-family="Segoe UI, Arial, sans-serif" font-size="16" font-weight="600">MSI · EXE · Portable ZIP · Windows 10/11 x64</text>
+  <g transform="translate(576 49)">
+    <rect width="146" height="56" rx="17" fill="url(#button)"/>
+    <rect x="0.75" y="0.75" width="144.5" height="54.5" rx="16.25" fill="none" stroke="#ffffff" stroke-opacity="0.20"/>
+    <text x="57" y="35" text-anchor="middle" fill="#06131a" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="900">Get Windows</text>
+    <path d="M112 20.5 120 28l-8 7.5M119 28h-19" fill="none" stroke="#06131a" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <rect x="148" y="121" width="386" height="2" rx="1" fill="#27d9f5" fill-opacity="0.34"/>
+</svg>

--- a/docs/assets/levyra-windows-platform.svg
+++ b/docs/assets/levyra-windows-platform.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="206" height="36" viewBox="0 0 206 36" role="img" aria-label="Windows: MSI, EXE and portable ZIP">
+  <title>Windows: MSI, EXE and portable ZIP</title>
+  <rect x="0.75" y="0.75" width="204.5" height="34.5" rx="8" fill="#0d1117" stroke="#303b4d"/>
+  <path d="M91 1h107a8 8 0 0 1 8 8v18a8 8 0 0 1-8 8H91Z" fill="#27d9f5"/>
+  <path d="M91 6v24" stroke="#ffffff" stroke-opacity=".16"/>
+  <g fill="#ffffff" transform="translate(12 10)">
+    <path d="M0 1.8 7.2.8v6.7H0zM8.1.7 16 0v7.5H8.1zM0 8.4h7.2v6.8L0 14.2zM8.1 8.4H16V16l-7.9-.8z"/>
+  </g>
+  <text x="36" y="22.5" fill="#f8fafc" font-family="Segoe UI,Arial,sans-serif" font-size="11.5" font-weight="700">Windows</text>
+  <text x="148" y="22.5" fill="#06131a" text-anchor="middle" font-family="Segoe UI,Arial,sans-serif" font-size="12" font-weight="800">MSI · EXE · ZIP</text>
+</svg>

--- a/scripts/update-readme-badges.mjs
+++ b/scripts/update-readme-badges.mjs
@@ -57,30 +57,33 @@ const measure = value => {
 }
 
 const icons = {
+  android: 'M3.7 5.2 2.5 3.1l.9-.5 1.3 2.2A7.2 7.2 0 0 1 8 4c1.2 0 2.3.3 3.3.8l1.3-2.2.9.5-1.2 2.1A6.8 6.8 0 0 1 15 10H1a6.8 6.8 0 0 1 2.7-4.8ZM5 8a.8.8 0 1 0 0-1.6A.8.8 0 0 0 5 8Zm6 0a.8.8 0 1 0 0-1.6A.8.8 0 0 0 11 8ZM2 11h12v2a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2v-2Z',
   release: 'M7.73 2.5a1.5 1.5 0 0 0-1.06.44L2.44 7.17a1.5 1.5 0 0 0 0 2.12l4.27 4.27a1.5 1.5 0 0 0 2.12 0l4.23-4.23a1.5 1.5 0 0 0 .44-1.06V4A1.5 1.5 0 0 0 12 2.5H7.73Zm0 1.5H12v4.27L7.77 12.5 3.5 8.23 7.73 4ZM9 7a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z',
   downloads: 'M8 2.25a.75.75 0 0 1 .75.75v5.69l1.97-1.97a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.78a.75.75 0 0 1 1.06-1.06l1.97 1.97V3A.75.75 0 0 1 8 2.25Zm-4.75 10a.75.75 0 0 1 .75-.75h8a.75.75 0 0 1 0 1.5H4a.75.75 0 0 1-.75-.75Z',
   license: 'M8 1.25 2.5 3.2v4.16c0 3.42 2.29 6.55 5.5 7.39 3.21-.84 5.5-3.97 5.5-7.39V3.2L8 1.25Zm0 1.59 4 1.42v3.1c0 2.6-1.64 5.05-4 5.82-2.36-.77-4-3.22-4-5.82v-3.1l4-1.42Z',
   stars: 'M8 .75a.75.75 0 0 1 .673.418L10.52 4.9l4.12.599a.75.75 0 0 1 .416 1.279l-2.98 2.905.704 4.103a.75.75 0 0 1-1.088.79L8 12.61l-3.694 1.943a.75.75 0 0 1-1.088-.79l.704-4.103-2.98-2.905a.75.75 0 0 1 .416-1.279l4.12-.599L7.327 1.168A.75.75 0 0 1 8 .75Z'
 }
 
-const makeBadge = ({ label, value, color, icon }) => {
+const makeBadge = ({ label, value, color, icon, valueTextColor = '#ffffff' }) => {
   const labelWidth = Math.max(92, Math.ceil(measure(label) + 44))
   const valueWidth = Math.max(52, Math.ceil(measure(value) + 28))
   const totalWidth = labelWidth + valueWidth
   const valueCenter = labelWidth + valueWidth / 2
   const title = `${label}: ${value}`
 
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="${totalWidth}" height="36" role="img" aria-label="${escapeXml(title)}"><title>${escapeXml(title)}</title><rect x="0.75" y="0.75" width="${totalWidth - 1.5}" height="34.5" rx="8" fill="#0d1117" stroke="#303b4d"/><path d="M${labelWidth} 1h${valueWidth - 8}a8 8 0 0 1 8 8v18a8 8 0 0 1-8 8h-${valueWidth - 8}Z" fill="${color}"/><path d="M${labelWidth} 6v24" stroke="#ffffff" stroke-opacity=".16"/><svg x="12" y="10" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true"><path fill="#ffffff" d="${icon}"/></svg><text x="36" y="22.5" fill="#f8fafc" font-family="Segoe UI,Arial,sans-serif" font-size="11.5" font-weight="700" letter-spacing=".15">${escapeXml(label)}</text><text x="${valueCenter}" y="22.5" fill="#ffffff" text-anchor="middle" font-family="Segoe UI,Arial,sans-serif" font-size="12" font-weight="700">${escapeXml(value)}</text></svg>\n`
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${totalWidth}" height="36" role="img" aria-label="${escapeXml(title)}"><title>${escapeXml(title)}</title><rect x="0.75" y="0.75" width="${totalWidth - 1.5}" height="34.5" rx="8" fill="#0d1117" stroke="#303b4d"/><path d="M${labelWidth} 1h${valueWidth - 8}a8 8 0 0 1 8 8v18a8 8 0 0 1-8 8h-${valueWidth - 8}Z" fill="${color}"/><path d="M${labelWidth} 6v24" stroke="#ffffff" stroke-opacity=".16"/><svg x="12" y="10" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true"><path fill="#ffffff" d="${icon}"/></svg><text x="36" y="22.5" fill="#f8fafc" font-family="Segoe UI,Arial,sans-serif" font-size="11.5" font-weight="700" letter-spacing=".15">${escapeXml(label)}</text><text x="${valueCenter}" y="22.5" fill="${valueTextColor}" text-anchor="middle" font-family="Segoe UI,Arial,sans-serif" font-size="12" font-weight="700">${escapeXml(value)}</text></svg>\n`
 }
 
+const releaseTimestamp = release => new Date(release.published_at ?? release.created_at).getTime()
 const repositoryData = await requestJson(`https://api.github.com/repos/${repository}`)
 const releases = (await listReleases()).filter(release => !release.draft)
 const stableReleases = releases.filter(release => !release.prerelease)
-const latestRelease = [...stableReleases].sort((left, right) => {
-  const leftDate = new Date(left.published_at ?? left.created_at).getTime()
-  const rightDate = new Date(right.published_at ?? right.created_at).getTime()
-  return rightDate - leftDate
-})[0]
+const androidRelease = [...stableReleases]
+  .filter(release => {
+    const tag = String(release.tag_name ?? '')
+    return !tag.startsWith('desktop-v') && /^v?\d+\.\d+\.\d+(?:[-+].*)?$/.test(tag)
+  })
+  .sort((left, right) => releaseTimestamp(right) - releaseTimestamp(left))[0]
 const totalDownloads = releases.reduce((releaseTotal, release) => {
   const assetTotal = Array.isArray(release.assets)
     ? release.assets.reduce((sum, asset) => sum + Number(asset.download_count ?? 0), 0)
@@ -89,12 +92,13 @@ const totalDownloads = releases.reduce((releaseTotal, release) => {
 }, 0)
 
 const formatNumber = value => new Intl.NumberFormat('en-US').format(Number(value))
-const releaseValue = latestRelease?.tag_name ?? 'none'
+const releaseValue = androidRelease?.tag_name ?? 'none'
 const downloadsValue = formatNumber(totalDownloads)
 const starsValue = formatNumber(repositoryData.stargazers_count ?? 0)
 
 await mkdir('docs/assets', { recursive: true })
 await Promise.all([
+  writeFile('docs/assets/levyra-android-platform.svg', makeBadge({ label: 'Android', value: releaseValue, color: '#3DDC84', icon: icons.android, valueTextColor: '#07160d' }), 'utf8'),
   writeFile('docs/assets/levyra-release.svg', makeBadge({ label: 'Release', value: releaseValue, color: '#7C3AED', icon: icons.release }), 'utf8'),
   writeFile('docs/assets/levyra-downloads.svg', makeBadge({ label: 'Downloads', value: downloadsValue, color: '#1689E8', icon: icons.downloads }), 'utf8'),
   writeFile('docs/assets/levyra-license.svg', makeBadge({ label: 'License', value: 'GPL-3.0', color: '#22C776', icon: icons.license }), 'utf8'),

--- a/scripts/update-readme-badges.mjs
+++ b/scripts/update-readme-badges.mjs
@@ -101,15 +101,19 @@ await Promise.all([
   writeFile('docs/assets/levyra-stars.svg', makeBadge({ label: 'Stars', value: starsValue, color: '#F2A900', icon: icons.stars }), 'utf8')
 ])
 
-const badgeBlock = `<a href="https://github.com/LUC4N3X/Levyra-deepsound/releases/latest"><img src="docs/assets/levyra-release.svg" alt="Latest Levyra release"></a>
+const badgeBlock = `<a href="https://github.com/LUC4N3X/Levyra-deepsound/releases/latest"><img src="docs/assets/levyra-android-platform.svg" alt="Download Levyra for Android"></a>
+<a href="https://github.com/LUC4N3X/Levyra-deepsound/releases?q=desktop-v&expanded=true"><img src="docs/assets/levyra-windows-platform.svg" alt="Download Levyra for Windows"></a>
 <a href="https://github.com/LUC4N3X/Levyra-deepsound/releases"><img src="docs/assets/levyra-downloads.svg" alt="Total Levyra downloads"></a>
 <a href="LICENSE"><img src="docs/assets/levyra-license.svg" alt="GPL-3.0 License"></a>
 <a href="https://github.com/LUC4N3X/Levyra-deepsound/stargazers"><img src="docs/assets/levyra-stars.svg" alt="Star Levyra"></a>`
-const badgePattern = /<a href="https:\/\/github\.com\/LUC4N3X\/Levyra-deepsound\/releases\/latest"><img[^>]+><\/a>\n<a href="https:\/\/github\.com\/LUC4N3X\/Levyra-deepsound\/releases"><img[^>]+><\/a>\n<a href="LICENSE"><img[^>]+><\/a>\n<a href="https:\/\/github\.com\/LUC4N3X\/Levyra-deepsound(?:\/stargazers)?"><img[^>]+><\/a>/
+const badgePattern = /<a href="https:\/\/github\.com\/LUC4N3X\/Levyra-deepsound\/releases\/latest"><img[^>]+><\/a>\n(?:<a href="https:\/\/github\.com\/LUC4N3X\/Levyra-deepsound\/releases\?q=desktop-v&expanded=true"><img[^>]+><\/a>\n)?<a href="https:\/\/github\.com\/LUC4N3X\/Levyra-deepsound\/releases"><img[^>]+><\/a>\n<a href="LICENSE"><img[^>]+><\/a>\n<a href="https:\/\/github\.com\/LUC4N3X\/Levyra-deepsound(?:\/stargazers)?"><img[^>]+><\/a>/
 const downloadBlock = `<a href="https://github.com/LUC4N3X/Levyra-deepsound/releases/latest">
-  <img src="docs/assets/levyra-github-download.svg" alt="Download the latest signed Levyra APK from GitHub Releases" width="520" />
+  <img src="docs/assets/levyra-github-download.svg" alt="Download the latest signed Levyra APK from GitHub Releases" width="370" />
+</a>
+<a href="https://github.com/LUC4N3X/Levyra-deepsound/releases?q=desktop-v&expanded=true">
+  <img src="docs/assets/levyra-windows-download.svg" alt="Download Levyra Desktop for Windows from GitHub Releases" width="370" />
 </a>`
-const downloadPattern = /<a href="https:\/\/github\.com\/LUC4N3X\/Levyra-deepsound\/releases\/latest">\n\s*<img src="docs\/assets\/levyra-github-download\.svg"[^>]*>\n<\/a>/
+const downloadPattern = /<a href="https:\/\/github\.com\/LUC4N3X\/Levyra-deepsound\/releases\/latest">\n\s*<img src="docs\/assets\/levyra-github-download\.svg"[^>]*>\n<\/a>\n(?:<a href="https:\/\/github\.com\/LUC4N3X\/Levyra-deepsound\/releases\?q=desktop-v&expanded=true">\n\s*<img src="docs\/assets\/levyra-windows-download\.svg"[^>]*>\n<\/a>)?/
 const readme = await readFile('README.md', 'utf8')
 const badgesUpdated = readme.replace(badgePattern, badgeBlock)
 const updatedReadme = badgesUpdated.replace(downloadPattern, downloadBlock)


### PR DESCRIPTION
## Summary

Harden Levyra Desktop 1.0.1 before publication by making update verification mandatory and cancellable, preventing Windows offline-filename collisions without losing resumable download progress, keeping release artifacts immutable and correctly paired with their SHA-256 files, and presenting Android and Windows downloads clearly in the repository README.

## Scope

- [x] Desktop updater integrity
- [x] Windows offline-download filenames
- [x] Legacy partial-download migration
- [x] Immutable Desktop release publishing
- [x] Android and Windows README presentation
- [x] Independent Desktop version bump to `1.0.1`

## What changed

### Updater security and availability

- Require the MSI `.sha256` asset before a Desktop release is considered installable.
- Accept release download URLs only from the official HTTPS GitHub release path for this repository.
- Use bounded, cancellable metadata requests for release discovery and checksum retrieval.
- Keep the large MSI transfer on a separate download client while allowing shutdown to cancel every active request.
- Verify the temporary installer before moving it into the final update path.
- Delete every unverified installer when checksum retrieval, parsing or comparison fails.

### Offline downloads

- Preserve a deterministic 16-character SHA-256 suffix even when long artist/title metadata is truncated.
- Remove all Windows-invalid filename characters, including both `\` and `/` path separators.
- Migrate compatible `.part` files created with the previous naming scheme to the new hashed filename.
- Preserve the larger partial file if both legacy and new paths exist.
- Ignore recorded partial paths outside Levyra's offline directory.
- Add regression coverage for uniqueness, repeatability, maximum length, Windows-safe names and partial-download migration.

### Desktop release publishing

- Keep `desktop-v*` tags and published assets immutable.
- Refuse publication when the requested Desktop version already points to another commit.
- Validate MSI, EXE, portable ZIP and their SHA-256 files before publishing.
- Treat each artifact and checksum as one pair.
- Validate downloaded existing assets against GitHub's declared size before trusting them.
- On interrupted publication, reconstruct a missing checksum from the already-published artifact instead of pairing it with a rebuilt binary.
- Verify already-published pairs before accepting a same-commit rerun.
- Never use `--clobber` and never replace an existing release asset.

### README

- Present Android and Windows together at the top of the repository.
- Add dedicated Android and Windows platform badges.
- Add a premium Windows GitHub download badge for MSI, EXE and portable ZIP packages.
- Keep Android linked to `/releases/latest` and Windows linked to the independent `desktop-v*` release list.

## Testing

- [x] Desktop modules compile.
- [x] Existing Desktop tests pass.
- [x] Filename suffix uniqueness test added.
- [x] Filename repeatability test added.
- [x] Windows path-separator sanitization test added.
- [x] Legacy partial migration test added.
- [x] Larger-partial preservation test added.
- [x] Out-of-directory partial-path safety test added.
- [x] Updater checksum success test added.
- [x] Updater checksum mismatch cleanup test added.
- [x] Malformed-checksum cleanup test added.
- [x] Checksum HTTP-failure cleanup test added.
- [x] Workflow duplicate guard passes.
- [x] Final Desktop compile and test on the latest commit.
- [ ] Final MSI, EXE and portable ZIP packaging on the latest commit.
- [ ] Final post-merge publication of `desktop-v1.0.1`.

## Release safety

- [x] Android `versionName` and `versionCode` are unchanged.
- [x] F-Droid configuration and workflows are unchanged.
- [x] Android `v2.3.16` remains the repository's Latest release.
- [x] Windows uses only `desktop/version.properties` and `desktop-v*` tags.
- [x] Existing Desktop release assets are never overwritten.
- [x] The Desktop updater refuses releases without a matching SHA-256 asset.
- [x] Legacy partial files are migrated only inside Levyra's offline directory and only between matching media extensions.
- [x] No secrets, installers, APKs, ZIPs or signing material are committed.

## Related issues

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows desktop releases now include verified SHA-256 checksums for installation files.
  * Desktop updates verify downloads before installation and remove invalid or incomplete files.
  * Offline downloads now use stable, sanitized filenames that remain distinct and resume safely.

* **Bug Fixes**
  * Improved validation of desktop release download links and release assets.
  * Prevented incomplete or mismatched Windows release uploads.

* **Documentation**
  * Updated platform availability, features, build instructions, versioning, privacy, and architecture documentation.
  * Updated the desktop version to 1.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->