### PR TITLE
feat(canvas): mirror and harden the community canvas catalog

### DIFF
--- a/.github/workflows/community-canvas-mirror.yml
+++ b/.github/workflows/community-canvas-mirror.yml
@@ -1,0 +1,110 @@
+name: Community Canvas Mirror
+
+on:
+  pull_request:
+    paths:
+      - "scripts/sync_community_canvas.py"
+      - "app/src/main/java/com/luc4n3x/levyra/feature/motion/CommunityCanvasProvider.kt"
+      - ".github/workflows/community-canvas-mirror.yml"
+  schedule:
+    - cron: "37 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: community-canvas-mirror-${{ github.event_name == 'pull_request' && github.ref || 'publisher' }}
+  cancel-in-progress: true
+
+env:
+  CANVAS_MIN_ENTRIES: "150"
+
+jobs:
+  normalize:
+    name: Normalize Upstream Catalog
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Normalize Catalog
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/sync_community_canvas.py \
+            --output build/canvas/community-canvas.json \
+            --min-entries "${CANVAS_MIN_ENTRIES}"
+          jq -e '.version == 1 and (.items | length) > 0' build/canvas/community-canvas.json >/dev/null
+
+      - name: Upload Normalized Catalog
+        uses: actions/upload-artifact@v7
+        with:
+          name: community-canvas-${{ github.run_number }}
+          path: build/canvas/community-canvas.json
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish Mirror Branch
+    if: github.event_name != 'pull_request'
+    needs: normalize
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Publish Validated Snapshot
+        shell: bash
+        run: |
+          set -euo pipefail
+          branch="canvas-data"
+          source_ref="$(git rev-parse HEAD)"
+          python3 scripts/sync_community_canvas.py \
+            --output /tmp/community-canvas.json \
+            --min-entries "${CANVAS_MIN_ENTRIES}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git ls-remote --exit-code origin "refs/heads/${branch}" >/dev/null 2>&1; then
+            git fetch origin "refs/heads/${branch}:refs/remotes/origin/${branch}"
+            git switch --force-create "${branch}" "origin/${branch}"
+            if [ -f catalog/community-canvas.json ]; then
+              jq -S 'del(.generatedAt)' catalog/community-canvas.json > /tmp/current-canvas-content.json
+              jq -S 'del(.generatedAt)' /tmp/community-canvas.json > /tmp/new-canvas-content.json
+              if cmp -s /tmp/current-canvas-content.json /tmp/new-canvas-content.json; then
+                echo "Community canvas catalog is unchanged; publication skipped."
+                git switch --detach "${source_ref}"
+                exit 0
+              fi
+            fi
+          else
+            git switch --orphan "${branch}"
+            git rm -rf --ignore-unmatch .
+          fi
+
+          mkdir -p catalog
+          cp /tmp/community-canvas.json catalog/community-canvas.json
+          git add catalog/community-canvas.json
+          git commit -m "chore(canvas): refresh community catalog from run ${GITHUB_RUN_NUMBER}"
+          git push origin "HEAD:refs/heads/${branch}"
+          git switch --detach "${source_ref}"
+          echo "Published catalog to ${branch}/catalog/community-canvas.json"

--- a/app/src/main/java/com/luc4n3x/levyra/feature/motion/CommunityCanvasProvider.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/motion/CommunityCanvasProvider.kt
@@ -3,20 +3,25 @@ package com.luc4n3x.levyra.feature.motion
 import android.content.Context
 import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import okhttp3.Call
+import okhttp3.Callback
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.Response
 import org.json.JSONObject
 import timber.log.Timber
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.util.Locale
 import java.util.concurrent.TimeUnit
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * Curated community canvases are an optional, read-only motion-artwork source.
@@ -30,7 +35,7 @@ class CommunityCanvasProvider(context: Context) : MotionArtworkProvider {
     private val client: OkHttpClient = LevyraHttpClientFactory.media(context).newBuilder()
         .connectTimeout(3, TimeUnit.SECONDS)
         .readTimeout(4, TimeUnit.SECONDS)
-        .callTimeout(4_500, TimeUnit.MILLISECONDS)
+        .callTimeout(5, TimeUnit.SECONDS)
         .build()
     private val catalogMutex = Mutex()
 
@@ -72,60 +77,95 @@ class CommunityCanvasProvider(context: Context) : MotionArtworkProvider {
 
     private suspend fun loadFirstUsableCatalog(): List<CommunityCanvasEntry> {
         var lastError: Throwable? = null
-        for (source in CATALOG_URLS) {
-            val parsed = try {
-                parseCommunityCanvasCatalog(fetchCatalog(source))
+        val deadlineMs = System.currentTimeMillis() + CATALOG_BUDGET_MS
+        for ((index, source) in CATALOG_URLS.withIndex()) {
+            val remainingMs = deadlineMs - System.currentTimeMillis()
+            if (remainingMs <= 0L) break
+            val sliceMs = (remainingMs / (CATALOG_URLS.size - index))
+                .coerceAtLeast(MIN_SOURCE_BUDGET_MS)
+            val payload = try {
+                withTimeoutOrNull(sliceMs) { fetchCatalog(source) }
             } catch (error: CancellationException) {
                 throw error
             } catch (error: Throwable) {
                 lastError = error
                 continue
             }
-            if (parsed.isNotEmpty()) return parsed
-            lastError = CommunityCanvasException("Community canvas catalog is empty")
+            if (payload == null) {
+                lastError = CommunityCanvasException("Community canvas source timed out")
+                continue
+            }
+            val document = parseCommunityCanvasDocument(payload)
+            if (isUsableCatalog(source, document)) return document.entries
+            lastError = CommunityCanvasException("Community canvas catalog is not usable")
         }
         throw lastError ?: CommunityCanvasException("Community canvas catalog is unavailable")
     }
 
-    private suspend fun fetchCatalog(source: String): String = withContext(Dispatchers.IO) {
+    private fun isUsableCatalog(source: String, catalog: CommunityCanvasCatalog): Boolean =
+        if (source == MIRROR_CATALOG_URL) {
+            catalog.version == MIRROR_CATALOG_VERSION &&
+                catalog.entries.size >= MIN_MIRROR_CATALOG_ENTRIES
+        } else {
+            catalog.entries.isNotEmpty()
+        }
+
+    private suspend fun fetchCatalog(source: String): String = suspendCancellableCoroutine { continuation ->
         val request = Request.Builder()
             .url(source)
             .header("Accept", "application/json")
             .header("User-Agent", USER_AGENT)
             .build()
-        try {
-            client.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) {
-                    throw CommunityCanvasException("Community canvas HTTP ${response.code}")
+        val call = client.newCall(request)
+        continuation.invokeOnCancellation { call.cancel() }
+        call.enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {
+                if (continuation.isActive) {
+                    continuation.resumeWithException(
+                        CommunityCanvasException("Unable to load community canvas catalog", e)
+                    )
                 }
-                val body = response.body
-                val declaredLength = body.contentLength()
-                if (declaredLength > MAX_CATALOG_BYTES) {
-                    throw CommunityCanvasException("Community canvas catalog is too large")
-                }
-                val input = body.byteStream()
-                val output = ByteArrayOutputStream()
-                val buffer = ByteArray(8 * 1024)
-                var total = 0
-                while (true) {
-                    val read = input.read(buffer)
-                    if (read < 0) break
-                    total += read
-                    if (total > MAX_CATALOG_BYTES) {
-                        throw CommunityCanvasException("Community canvas catalog is too large")
-                    }
-                    output.write(buffer, 0, read)
-                }
-                output.toString(Charsets.UTF_8.name()).takeIf { it.isNotBlank() }
-                    ?: throw CommunityCanvasException("Community canvas catalog is empty")
             }
-        } catch (error: CancellationException) {
-            throw error
-        } catch (error: CommunityCanvasException) {
-            throw error
-        } catch (error: Exception) {
-            throw CommunityCanvasException("Unable to load community canvas catalog", error)
+
+            override fun onResponse(call: Call, response: Response) {
+                val payload = runCatching { readCatalogPayload(response) }
+                if (!continuation.isActive) return
+                payload.fold(
+                    onSuccess = { body -> continuation.resume(body) },
+                    onFailure = { error ->
+                        continuation.resumeWithException(
+                            error as? CommunityCanvasException
+                                ?: CommunityCanvasException("Unable to load community canvas catalog", error)
+                        )
+                    }
+                )
+            }
+        })
+    }
+
+    private fun readCatalogPayload(response: Response): String = response.use { current ->
+        if (!current.isSuccessful) {
+            throw CommunityCanvasException("Community canvas HTTP ${current.code}")
         }
+        val body = current.body
+        if (body.contentLength() > MAX_CATALOG_BYTES) {
+            throw CommunityCanvasException("Community canvas catalog is too large")
+        }
+        val input = body.byteStream()
+        val output = ByteArrayOutputStream()
+        val buffer = ByteArray(8 * 1024)
+        var total = 0
+        while (true) {
+            val read = input.read(buffer)
+            if (read < 0) break
+            total += read
+            if (total > MAX_CATALOG_BYTES) {
+                throw CommunityCanvasException("Community canvas catalog is too large")
+            }
+            output.write(buffer, 0, read)
+        }
+        output.toString(Charsets.UTF_8.name()).takeIf { it.isNotBlank() }
+            ?: throw CommunityCanvasException("Community canvas catalog is empty")
     }
 
     companion object {
@@ -139,6 +179,10 @@ class CommunityCanvasProvider(context: Context) : MotionArtworkProvider {
             "Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 Chrome/142 Mobile Safari/537.36 Levyra/CommunityCanvas"
         const val MAX_CATALOG_BYTES = 1024 * 1024
         const val CATALOG_TTL_MS = 6L * 60L * 60L * 1000L
+        const val CATALOG_BUDGET_MS = 6_000L
+        const val MIN_SOURCE_BUDGET_MS = 2_000L
+        const val MIRROR_CATALOG_VERSION = 1
+        const val MIN_MIRROR_CATALOG_ENTRIES = 100
     }
 }
 
@@ -154,9 +198,19 @@ internal data class CommunityCanvasEntry(
     val height: Int? = null
 )
 
-internal fun parseCommunityCanvasCatalog(payload: String): List<CommunityCanvasEntry> {
-    val root = runCatching { JSONObject(payload) }.getOrNull() ?: return emptyList()
-    val items = root.optJSONArray("items") ?: return emptyList()
+internal data class CommunityCanvasCatalog(
+    val version: Int,
+    val entries: List<CommunityCanvasEntry>
+)
+
+internal fun parseCommunityCanvasCatalog(payload: String): List<CommunityCanvasEntry> =
+    parseCommunityCanvasDocument(payload).entries
+
+internal fun parseCommunityCanvasDocument(payload: String): CommunityCanvasCatalog {
+    val root = runCatching { JSONObject(payload) }.getOrNull()
+        ?: return CommunityCanvasCatalog(0, emptyList())
+    val version = root.optInt("version")
+    val items = root.optJSONArray("items") ?: return CommunityCanvasCatalog(version, emptyList())
     val output = ArrayList<CommunityCanvasEntry>(items.length())
     val seen = HashSet<String>()
     for (index in 0 until items.length()) {
@@ -199,7 +253,7 @@ internal fun parseCommunityCanvasCatalog(payload: String): List<CommunityCanvasE
             height = item.optInt("height").takeIf { it > 0 }
         )
     }
-    return output
+    return CommunityCanvasCatalog(version, output)
 }
 
 private fun communityCanvasScopeFromPath(url: HttpUrl): MotionArtworkScope? {
@@ -248,7 +302,7 @@ internal fun communityCanvasCandidates(
         .map { entry -> entry to communityCanvasQuickScore(identity, entry) }
         .filter { (_, score) -> score >= MIN_COMMUNITY_QUICK_SCORE }
         .sortedByDescending { (_, score) -> score }
-        .distinctBy { (entry, _) -> "${entry.scope}|${entry.url}|${normalizeMotionText(entry.song)}" }
+        .distinctBy { (entry, _) -> communityCanvasCandidateKey(entry) }
         .take(MAX_COMMUNITY_CANDIDATES)
         .map { (entry, _) ->
             MotionArtworkCandidate(
@@ -259,7 +313,7 @@ internal fun communityCanvasCandidates(
                     artists = splitArtists(entry.artist),
                     album = entry.album,
                     durationMs = 0L,
-                    isrc = entry.isrc,
+                    isrc = if (entry.scope == MotionArtworkScope.TRACK) entry.isrc else "",
                     upc = "",
                     year = "",
                     trackId = "",
@@ -279,13 +333,31 @@ internal fun communityCanvasCandidates(
         .toList()
 }
 
+private fun communityCanvasCandidateKey(entry: CommunityCanvasEntry): String = when (entry.scope) {
+    MotionArtworkScope.ALBUM -> listOf(
+        MotionArtworkScope.ALBUM.name,
+        normalizeMotionText(entry.artist),
+        normalizeMotionText(entry.album),
+        entry.url
+    ).joinToString("|")
+    MotionArtworkScope.TRACK -> listOf(
+        MotionArtworkScope.TRACK.name,
+        entry.url,
+        normalizeMotionText(entry.song)
+    ).joinToString("|")
+}
+
 private fun communityCanvasQuickScore(
     identity: MotionTrackIdentity,
     entry: CommunityCanvasEntry
 ): Int {
     val entryArtists = splitArtists(entry.artist)
     if (!primaryMotionArtistMatches(identity.artists, entryArtists)) return Int.MIN_VALUE
-    if (identity.isrc.isNotBlank() && entry.isrc.isNotBlank()) {
+    if (
+        entry.scope == MotionArtworkScope.TRACK &&
+        identity.isrc.isNotBlank() &&
+        entry.isrc.isNotBlank()
+    ) {
         return if (identity.isrc == entry.isrc) 100 else Int.MIN_VALUE
     }
     val titleScore = communityTextSimilarity(identity.title, entry.song)

--- a/app/src/main/java/com/luc4n3x/levyra/feature/motion/CommunityCanvasProvider.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/motion/CommunityCanvasProvider.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -28,8 +29,8 @@ class CommunityCanvasProvider(context: Context) : MotionArtworkProvider {
 
     private val client: OkHttpClient = LevyraHttpClientFactory.media(context).newBuilder()
         .connectTimeout(3, TimeUnit.SECONDS)
-        .readTimeout(5, TimeUnit.SECONDS)
-        .callTimeout(7, TimeUnit.SECONDS)
+        .readTimeout(4, TimeUnit.SECONDS)
+        .callTimeout(4_500, TimeUnit.MILLISECONDS)
         .build()
     private val catalogMutex = Mutex()
 
@@ -62,18 +63,33 @@ class CommunityCanvasProvider(context: Context) : MotionArtworkProvider {
             cachedEntries.takeIf { it.isNotEmpty() && refreshedAt < catalogExpiresAtMs }?.let {
                 return@withLock it
             }
-            val payload = fetchCatalog()
-            val parsed = parseCommunityCanvasCatalog(payload)
-            if (parsed.isEmpty()) throw CommunityCanvasException("Community canvas catalog is empty")
+            val parsed = loadFirstUsableCatalog()
             cachedEntries = parsed
             catalogExpiresAtMs = refreshedAt + CATALOG_TTL_MS
             parsed
         }
     }
 
-    private suspend fun fetchCatalog(): String = withContext(Dispatchers.IO) {
+    private suspend fun loadFirstUsableCatalog(): List<CommunityCanvasEntry> {
+        var lastError: Throwable? = null
+        for (source in CATALOG_URLS) {
+            val parsed = try {
+                parseCommunityCanvasCatalog(fetchCatalog(source))
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                lastError = error
+                continue
+            }
+            if (parsed.isNotEmpty()) return parsed
+            lastError = CommunityCanvasException("Community canvas catalog is empty")
+        }
+        throw lastError ?: CommunityCanvasException("Community canvas catalog is unavailable")
+    }
+
+    private suspend fun fetchCatalog(source: String): String = withContext(Dispatchers.IO) {
         val request = Request.Builder()
-            .url(CATALOG_URL)
+            .url(source)
             .header("Accept", "application/json")
             .header("User-Agent", USER_AGENT)
             .build()
@@ -114,8 +130,11 @@ class CommunityCanvasProvider(context: Context) : MotionArtworkProvider {
 
     companion object {
         const val PROVIDER_ID = "community-canvas"
-        const val CATALOG_URL =
+        const val MIRROR_CATALOG_URL =
+            "https://raw.githubusercontent.com/LUC4N3X/Levyra-deepsound/canvas-data/catalog/community-canvas.json"
+        const val UPSTREAM_CATALOG_URL =
             "https://raw.githubusercontent.com/vivizzz007/vivimusicanvas/main/canvas.json"
+        val CATALOG_URLS = listOf(MIRROR_CATALOG_URL, UPSTREAM_CATALOG_URL)
         const val USER_AGENT =
             "Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 Chrome/142 Mobile Safari/537.36 Levyra/CommunityCanvas"
         const val MAX_CATALOG_BYTES = 1024 * 1024
@@ -129,6 +148,7 @@ internal data class CommunityCanvasEntry(
     val album: String,
     val url: String,
     val scope: MotionArtworkScope,
+    val pathScope: MotionArtworkScope? = null,
     val isrc: String = "",
     val width: Int? = null,
     val height: Int? = null
@@ -152,10 +172,13 @@ internal fun parseCommunityCanvasCatalog(payload: String): List<CommunityCanvasE
         }
         val extension = url.encodedPath.substringAfterLast('.', "").lowercase(Locale.ROOT)
         if (extension !in COMMUNITY_MEDIA_EXTENSIONS) continue
-        val scope = when (item.optString("scope").trim().lowercase(Locale.ROOT)) {
+        val declaredScope = when (item.optString("scope").trim().lowercase(Locale.ROOT)) {
             "album" -> MotionArtworkScope.ALBUM
-            else -> MotionArtworkScope.TRACK
+            "track", "song" -> MotionArtworkScope.TRACK
+            else -> null
         }
+        val scope = declaredScope ?: MotionArtworkScope.TRACK
+        val pathScope = if (declaredScope == null) communityCanvasScopeFromPath(url) else null
         val key = listOf(
             normalizeMotionText(song),
             normalizeMotionText(artist),
@@ -170,12 +193,27 @@ internal fun parseCommunityCanvasCatalog(payload: String): List<CommunityCanvasE
             album = album,
             url = rawUrl,
             scope = scope,
-            isrc = item.optString("isrc").trim().uppercase(Locale.ROOT),
+            pathScope = pathScope,
+            isrc = communityCanvasIsrc(item.optString("isrc")),
             width = item.optInt("width").takeIf { it > 0 },
             height = item.optInt("height").takeIf { it > 0 }
         )
     }
     return output
+}
+
+private fun communityCanvasScopeFromPath(url: HttpUrl): MotionArtworkScope? {
+    val marker = url.pathSegments
+        .dropLast(1)
+        .map { segment -> segment.lowercase(Locale.ROOT) }
+        .lastOrNull { segment -> segment == "album" || segment == "song" }
+        ?: return null
+    return if (marker == "album") MotionArtworkScope.ALBUM else MotionArtworkScope.TRACK
+}
+
+private fun communityCanvasIsrc(value: String): String {
+    val normalized = value.trim().uppercase(Locale.ROOT)
+    return if (COMMUNITY_ISRC_PATTERN.matches(normalized)) normalized else ""
 }
 
 internal fun communityCanvasCandidates(
@@ -195,7 +233,11 @@ internal fun communityCanvasCandidates(
         .values
         .mapNotNull { group ->
             val first = group.firstOrNull() ?: return@mapNotNull null
-            if (first.scope == MotionArtworkScope.ALBUM || group.map { it.song }.distinct().size >= 2) {
+            if (
+                first.scope == MotionArtworkScope.ALBUM ||
+                first.pathScope == MotionArtworkScope.ALBUM ||
+                group.map { it.song }.distinct().size >= 2
+            ) {
                 first.copy(scope = MotionArtworkScope.ALBUM)
             } else {
                 null
@@ -273,6 +315,7 @@ internal val COMMUNITY_MEDIA_HOSTS = setOf(
 )
 
 private val COMMUNITY_MEDIA_EXTENSIONS = setOf("mp4", "m3u8")
+private val COMMUNITY_ISRC_PATTERN = Regex("^[A-Z]{2}[A-Z0-9]{3}[0-9]{7}$")
 private const val MIN_COMMUNITY_QUICK_SCORE = 70
 private const val MAX_COMMUNITY_CANDIDATES = 8
 

--- a/app/src/main/java/com/luc4n3x/levyra/ui/MotionArtworkLayer.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/MotionArtworkLayer.kt
@@ -147,9 +147,11 @@ private fun MotionArtworkVideo(
     modifier: Modifier
 ) {
     val context = LocalContext.current
-    var firstFrameRendered by remember(artwork.identityKey, artwork.url) { mutableStateOf(false) }
-    var failed by remember(artwork.identityKey, artwork.url) { mutableStateOf(false) }
-    val player = remember(artwork.identityKey, artwork.url) {
+    var firstFrameRendered by remember(artwork.identityKey, artwork.url, artwork.mimeType) {
+        mutableStateOf(false)
+    }
+    var failed by remember(artwork.identityKey, artwork.url, artwork.mimeType) { mutableStateOf(false) }
+    val player = remember(artwork.identityKey, artwork.url, artwork.mimeType) {
         ExoPlayer.Builder(context).build().apply {
             repeatMode = Player.REPEAT_MODE_ONE
             volume = 0f

--- a/app/src/main/java/com/luc4n3x/levyra/ui/MotionArtworkLayer.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/MotionArtworkLayer.kt
@@ -180,7 +180,12 @@ private fun MotionArtworkVideo(
         }
         player.addListener(listener)
         player.setVideoTextureView(textureView)
-        player.setMediaItem(MediaItem.fromUri(artwork.url))
+        player.setMediaItem(
+            MediaItem.Builder()
+                .setUri(artwork.url)
+                .setMimeType(artwork.mimeType.takeIf { it.isNotBlank() })
+                .build()
+        )
         player.prepare()
         onDispose {
             player.removeListener(listener)

--- a/app/src/test/java/com/luc4n3x/levyra/feature/motion/CommunityCanvasProviderTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/feature/motion/CommunityCanvasProviderTest.kt
@@ -152,6 +152,117 @@ class CommunityCanvasProviderTest {
     }
 
     @Test
+    fun albumCanvasIgnoresTheIsrcOfTheListedTrack() {
+        val albumUrl = "https://vivimusicanvas.mkmdevilmi.workers.dev/Album/dawn.m3u8"
+        val entries = parseCommunityCanvasCatalog(
+            """
+            {
+              "items": [
+                {
+                  "song": "Track A",
+                  "artist": "Exact Artist",
+                  "album": "Exact Album",
+                  "url": "$albumUrl",
+                  "isrc": "USUM71703861"
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+        val identity = MotionTrackIdentity(
+            title = "Track B",
+            artists = listOf("Exact Artist"),
+            album = "Exact Album",
+            durationMs = 195_000L,
+            isrc = "GBAYE0601498",
+            upc = "",
+            year = "",
+            trackId = "track-b",
+            albumId = "exact-album"
+        )
+
+        val candidate = communityCanvasCandidates(identity, entries, nowMs = 1_000L)
+            .single { it.scope == MotionArtworkScope.ALBUM }
+
+        assertEquals(albumUrl, candidate.url)
+        assertEquals("", candidate.identity.isrc)
+        assertTrue(CanonicalTrackMatcher.match(identity, candidate).accepted)
+    }
+
+    @Test
+    fun repeatedAlbumScopeEntriesCollapseIntoOneCandidate() {
+        val albumUrl = "https://vivimusicanvas.mkmdevilmi.workers.dev/Album/dawn.m3u8"
+        val entries = parseCommunityCanvasCatalog(
+            """
+            {
+              "items": [
+                {
+                  "song": "One",
+                  "artist": "Exact Artist",
+                  "album": "Exact Album",
+                  "url": "$albumUrl",
+                  "scope": "album"
+                },
+                {
+                  "song": "Two",
+                  "artist": "Exact Artist",
+                  "album": "Exact Album",
+                  "url": "$albumUrl",
+                  "scope": "album"
+                },
+                {
+                  "song": "Three",
+                  "artist": "Exact Artist",
+                  "album": "Exact Album",
+                  "url": "$albumUrl",
+                  "scope": "album"
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+        val identity = MotionTrackIdentity(
+            title = "Four",
+            artists = listOf("Exact Artist"),
+            album = "Exact Album",
+            durationMs = 195_000L,
+            isrc = "",
+            upc = "",
+            year = "",
+            trackId = "four",
+            albumId = "exact-album"
+        )
+
+        assertEquals(3, entries.size)
+        assertEquals(1, communityCanvasCandidates(identity, entries, nowMs = 1_000L).count { it.url == albumUrl })
+    }
+
+    @Test
+    fun mirrorCatalogVersionIsExposedForUsabilityChecks() {
+        val document = parseCommunityCanvasDocument(
+            """
+            {
+              "version": 1,
+              "generatedAt": "2026-07-31T04:37:00Z",
+              "items": [
+                {
+                  "song": "Exact Song",
+                  "artist": "Exact Artist",
+                  "album": "Exact Album",
+                  "url": "https://vivimusicanvas.mkmdevilmi.workers.dev/Song/1.mp4"
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        assertEquals(1, document.version)
+        assertEquals(1, document.entries.size)
+        assertEquals(0, parseCommunityCanvasDocument("{\"items\":[]}").version)
+        assertEquals(0, parseCommunityCanvasDocument("{ truncated").version)
+    }
+
+    @Test
     fun conflictingIsrcStillRejectsTheEntry() {
         val entries = listOf(
             CommunityCanvasEntry(

--- a/app/src/test/java/com/luc4n3x/levyra/feature/motion/CommunityCanvasProviderTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/feature/motion/CommunityCanvasProviderTest.kt
@@ -1,6 +1,8 @@
 package com.luc4n3x.levyra.feature.motion
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -36,6 +38,144 @@ class CommunityCanvasProviderTest {
 
         assertEquals(1, entries.size)
         assertEquals("Exact Song", entries.single().song)
+    }
+
+    @Test
+    fun albumDirectoryEntryAlsoCoversTheRestOfTheAlbum() {
+        val albumUrl = "https://vivimusicanvas.mkmdevilmi.workers.dev/Album/dawn.m3u8"
+        val entries = parseCommunityCanvasCatalog(
+            """
+            {
+              "items": [
+                {
+                  "song": "Listed Song",
+                  "artist": "Exact Artist",
+                  "album": "Exact Album",
+                  "url": "$albumUrl"
+                },
+                {
+                  "song": "Other Song",
+                  "artist": "Exact Artist",
+                  "album": "Other Album",
+                  "url": "https://vivimusicanvas.mkmdevilmi.workers.dev/Song/7.mp4"
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+        val identity = MotionTrackIdentity(
+            title = "Unlisted Song",
+            artists = listOf("Exact Artist"),
+            album = "Exact Album",
+            durationMs = 180_000L,
+            isrc = "",
+            upc = "",
+            year = "",
+            trackId = "unlisted-song",
+            albumId = "exact-album"
+        )
+
+        assertEquals(MotionArtworkScope.TRACK, entries.single { it.song == "Listed Song" }.scope)
+        assertEquals(
+            MotionArtworkScope.ALBUM,
+            entries.single { it.song == "Listed Song" }.pathScope
+        )
+
+        val candidates = communityCanvasCandidates(identity, entries, nowMs = 1_000L)
+
+        assertTrue(candidates.any { it.scope == MotionArtworkScope.ALBUM && it.url == albumUrl })
+        assertTrue(candidates.none { it.url.contains("/Song/7.mp4") })
+    }
+
+    @Test
+    fun declaredScopeWinsOverThePathDirectory() {
+        val entries = parseCommunityCanvasCatalog(
+            """
+            {
+              "version": 1,
+              "generatedAt": "2026-07-31T00:00:00Z",
+              "items": [
+                {
+                  "song": "Album Canvas",
+                  "artist": "Exact Artist",
+                  "album": "Exact Album",
+                  "url": "https://vivimusicanvas.mkmdevilmi.workers.dev/Song/9.mp4",
+                  "scope": "album",
+                  "isrc": "USUM71703861",
+                  "width": 1080,
+                  "height": 1920
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        val entry = entries.single()
+        assertEquals(MotionArtworkScope.ALBUM, entry.scope)
+        assertNull(entry.pathScope)
+        assertEquals("USUM71703861", entry.isrc)
+        assertEquals(1080, entry.width)
+        assertEquals(1920, entry.height)
+    }
+
+    @Test
+    fun malformedIsrcIsDiscardedInsteadOfBlockingTheMatch() {
+        val entries = parseCommunityCanvasCatalog(
+            """
+            {
+              "items": [
+                {
+                  "song": "Exact Song",
+                  "artist": "Exact Artist",
+                  "album": "Exact Album",
+                  "url": "https://vivimusicanvas.mkmdevilmi.workers.dev/Song/1.mp4",
+                  "isrc": "not-an-isrc"
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+        val identity = MotionTrackIdentity(
+            title = "Exact Song",
+            artists = listOf("Exact Artist"),
+            album = "Exact Album",
+            durationMs = 210_000L,
+            isrc = "USUM71703861",
+            upc = "",
+            year = "",
+            trackId = "exact-song",
+            albumId = "exact-album"
+        )
+
+        assertEquals("", entries.single().isrc)
+        assertNotNull(communityCanvasCandidates(identity, entries, nowMs = 1_000L).firstOrNull())
+    }
+
+    @Test
+    fun conflictingIsrcStillRejectsTheEntry() {
+        val entries = listOf(
+            CommunityCanvasEntry(
+                song = "Exact Song",
+                artist = "Exact Artist",
+                album = "Exact Album",
+                url = "https://vivimusicanvas.mkmdevilmi.workers.dev/Song/1.mp4",
+                scope = MotionArtworkScope.TRACK,
+                isrc = "GBAYE0601498"
+            )
+        )
+        val identity = MotionTrackIdentity(
+            title = "Exact Song",
+            artists = listOf("Exact Artist"),
+            album = "Exact Album",
+            durationMs = 210_000L,
+            isrc = "USUM71703861",
+            upc = "",
+            year = "",
+            trackId = "exact-song",
+            albumId = "exact-album"
+        )
+
+        assertNull(communityCanvasCandidates(identity, entries, nowMs = 1_000L).firstOrNull())
     }
 
     @Test

--- a/docs/COMMUNITY_CANVAS_CATALOG.md
+++ b/docs/COMMUNITY_CANVAS_CATALOG.md
@@ -20,10 +20,14 @@ The mirror is the pinned copy Levyra controls. Upstream stays as a fallback so t
 working when the mirror branch is missing, unreachable or structurally unusable. Each response is
 capped at 1 MiB. The first usable parsed catalog is cached in memory for six hours.
 
-The mirror is only accepted when it declares `version: 1` and yields at least 100 usable entries,
-which is below the 150-entry floor the publishing pipeline enforces. A truncated or gutted mirror
-therefore falls through to upstream instead of being cached for six hours. Upstream itself is
+The mirror is only accepted when it declares exactly `version: 1` and yields at least 100 usable
+entries, which is below the 150-entry floor the publishing pipeline enforces. A truncated or gutted
+mirror therefore falls through to upstream instead of being cached for six hours. Upstream itself is
 accepted whenever it yields at least one usable entry, because nothing else backs it up.
+
+The version match is exact on purpose. Optional fields can be added without a bump, because the
+parser ignores what it does not know, so a bump is reserved for a schema an older client would read
+incorrectly. Rejecting it sends those clients to the upstream fallback instead.
 
 There is no freshness check: neither `generatedAt` nor the branch commit date is compared against
 the clock, and a mirror that stops being refreshed keeps being served. That is deliberate — the
@@ -72,10 +76,10 @@ keys, so the upstream shape (`items` alone) is accepted unchanged.
 | `isrc` | no | Must match `^[A-Z]{2}[A-Z0-9]{3}[0-9]{7}$`; malformed values are discarded instead of blocking the match. |
 | `width` / `height` | no | Positive integers, published together. |
 
-`scope`, `isrc`, `width` and `height` are optional extensions. Upstream does not emit them yet, and
-the mirror only passes through what upstream publishes, so today every mirrored entry carries the
-four required fields alone. The parser and the mirror already accept the extended form so the
-catalog can adopt it without an app release.
+`scope`, `isrc`, `width` and `height` are optional extensions. The mirror only passes through what
+upstream publishes, and in the 2026-07-31 snapshot upstream emitted none of them, so every mirrored
+entry carried the four required fields alone. The parser and the mirror already accept the extended
+form so the catalog can adopt it without an app release.
 
 ## Scope resolution
 
@@ -85,15 +89,18 @@ and rejected below 0.82, while a track-scope candidate is scored mostly on title
 
 Levyra resolves the scope in this order:
 
-1. A recognized `scope` field wins and is authoritative.
-2. Otherwise the URL directory is used as a hint: upstream stores album canvases under `/Album/`
-   and track canvases under `/Song/`, and their PR validator enforces that layout.
-3. Otherwise the entry is treated as a track canvas.
+1. A recognized `scope` field wins and is authoritative. It is used as declared and no path-derived
+   variant is added, so `scope: "track"` on a `/Album/` URL yields a track candidate only.
+2. When the field is absent or unrecognized, the URL directory becomes a hint: upstream stores album
+   canvases under `/Album/` and track canvases under `/Song/`, and their PR validator enforces that
+   layout.
+3. Failing both, the entry is treated as a track canvas.
 
-The directory hint is additive. An entry under `/Album/` keeps its track-scope form *and* gains an
-album-scope variant, so a canvas listed once can also cover the rest of the release without losing
-the exact-title match it already had. The older heuristic — the same URL repeated across two or
-more songs implies an album canvas — still applies on top of both.
+That directory hint is additive. An entry under `/Album/` **with no declared scope** keeps its
+track-scope form *and* gains an album-scope variant, so a canvas listed once can also cover the rest
+of the release without losing the exact-title match it already had. The older heuristic — the same
+URL repeated across two or more songs implies an album canvas — is evaluated per group and still
+applies regardless of how the scope was resolved.
 
 ## Mirror pipeline
 
@@ -105,7 +112,8 @@ skipping the commit when only `generatedAt` changed.
 The normalizer refuses to publish when:
 
 * upstream is unreachable, oversized or not valid JSON;
-* fewer than `--min-entries` usable entries survive (150 in CI, against 187 upstream entries today);
+* fewer than `--min-entries` usable entries survive (150 in CI, against the 187 upstream entries of
+  the 2026-07-31 snapshot);
 * any entry points at a host outside the allowlist.
 
 The last point is the drift alarm. A new upstream host fails the run and leaves the previous

--- a/docs/COMMUNITY_CANVAS_CATALOG.md
+++ b/docs/COMMUNITY_CANVAS_CATALOG.md
@@ -17,8 +17,8 @@ usable entry:
 | 2 | `vivizzz007/vivimusicanvas@main:canvas.json` | Upstream community catalog |
 
 The mirror is the pinned copy Levyra controls. Upstream stays as a fallback so the feature keeps
-working when the mirror branch is missing, unreachable or structurally unusable. Both responses are
-capped at 1 MiB and cached in memory for six hours.
+working when the mirror branch is missing, unreachable or structurally unusable. Each response is
+capped at 1 MiB. The first usable parsed catalog is cached in memory for six hours.
 
 The mirror is only accepted when it declares `version: 1` and yields at least 100 usable entries,
 which is below the 150-entry floor the publishing pipeline enforces. A truncated or gutted mirror
@@ -33,8 +33,9 @@ pipeline skips the commit when only `generatedAt` changed, so the timestamp does
 The whole two-source attempt is bounded by a 6 s budget that sits inside the motion-artwork engine's
 `MotionArtworkConfig.requestTimeoutMs` (6.5 s by default). Each source gets the remaining budget
 divided by the number of sources left, with a 2 s floor, so a slow mirror cannot starve the upstream
-fallback. Fetches run on `Call.enqueue` inside `suspendCancellableCoroutine`, so cancelling the
-coroutine cancels the HTTP call instead of leaving a blocked thread holding the catalog lock.
+fallback. Fetches run on `Call.enqueue` inside `suspendCancellableCoroutine`; cancelling the
+coroutine cancels the HTTP call, and the catalog mutex is released when the cancellable suspension
+exits.
 
 ## Entry schema
 

--- a/docs/COMMUNITY_CANVAS_CATALOG.md
+++ b/docs/COMMUNITY_CANVAS_CATALOG.md
@@ -1,0 +1,116 @@
+# Community canvas catalog
+
+Levyra's `community-canvas` provider is an optional, read-only motion-artwork source. It reads a
+JSON catalog that maps a recording to a short looping video, then hands the winning URL to the
+shared motion-artwork verifier before anything is rendered. The catalog never controls playback,
+never carries audio, and never selects a destination on its own: every media URL must survive the
+host allowlist, the MIME probe and the redirect checks in `MotionArtworkUrlVerifier`.
+
+## Sources
+
+The provider tries two catalogs in order and keeps the first one that parses into at least one
+usable entry:
+
+| Order | Source | Purpose |
+|:--|:--|:--|
+| 1 | `LUC4N3X/Levyra-deepsound@canvas-data:catalog/community-canvas.json` | Validated Levyra mirror |
+| 2 | `vivizzz007/vivimusicanvas@main:canvas.json` | Upstream community catalog |
+
+The mirror is the pinned copy Levyra controls. Upstream stays as a fallback so the feature keeps
+working when the mirror branch is missing, stale or unreachable. Both responses are capped at
+1 MiB and cached in memory for six hours.
+
+Per-source network timeouts are deliberately short (4.5 s call budget) because the motion-artwork
+engine caps the whole provider call at `MotionArtworkConfig.requestTimeoutMs` (6.5 s by default).
+A fast failure on the first source is what leaves room for the second one.
+
+## Entry schema
+
+```json
+{
+  "version": 1,
+  "generatedAt": "2026-07-31T04:37:00Z",
+  "source": "https://raw.githubusercontent.com/vivizzz007/vivimusicanvas/main/canvas.json",
+  "items": [
+    {
+      "song": "Dracula",
+      "artist": "Tame Impala",
+      "album": "Deadbeat",
+      "url": "https://vivimusicanvas.mkmdevilmi.workers.dev/Song/1.mp4",
+      "scope": "track",
+      "isrc": "AUUM72500123",
+      "width": 720,
+      "height": 1280
+    }
+  ]
+}
+```
+
+Top-level `version`, `generatedAt` and `source` are mirror-only metadata. The parser ignores unknown
+keys, so the upstream shape (`items` alone) is accepted unchanged.
+
+| Field | Required | Notes |
+|:--|:--|:--|
+| `song` | yes | Recording title. Blank entries are dropped. |
+| `artist` | yes | Split on the usual separators before matching. |
+| `album` | yes | Blank entries are dropped. |
+| `url` | yes | HTTPS, port 443, allowlisted host, `.mp4` or `.m3u8`. |
+| `scope` | no | `track`, `song` or `album`. Anything else is treated as absent. |
+| `isrc` | no | Must match `^[A-Z]{2}[A-Z0-9]{3}[0-9]{7}$`; malformed values are discarded instead of blocking the match. |
+| `width` / `height` | no | Positive integers, published together. |
+
+`scope`, `isrc`, `width` and `height` are optional extensions. Upstream does not emit them yet, and
+the mirror only passes through what upstream publishes, so today every mirrored entry carries the
+four required fields alone. The parser and the mirror already accept the extended form so the
+catalog can adopt it without an app release.
+
+## Scope resolution
+
+An album canvas is one video shared by a whole release; a track canvas belongs to a single
+recording. The two are matched differently: an album-scope candidate is scored on album similarity
+and rejected below 0.82, while a track-scope candidate is scored mostly on title similarity.
+
+Levyra resolves the scope in this order:
+
+1. A recognized `scope` field wins and is authoritative.
+2. Otherwise the URL directory is used as a hint: upstream stores album canvases under `/Album/`
+   and track canvases under `/Song/`, and their PR validator enforces that layout.
+3. Otherwise the entry is treated as a track canvas.
+
+The directory hint is additive. An entry under `/Album/` keeps its track-scope form *and* gains an
+album-scope variant, so a canvas listed once can also cover the rest of the release without losing
+the exact-title match it already had. The older heuristic — the same URL repeated across two or
+more songs implies an album canvas — still applies on top of both.
+
+## Mirror pipeline
+
+`.github/workflows/community-canvas-mirror.yml` runs daily at 04:37 UTC (06:37 Europe/Rome in
+summer, 05:37 in winter) and on demand. It normalizes upstream with
+`scripts/sync_community_canvas.py` and publishes the result to the orphan `canvas-data` branch,
+skipping the commit when only `generatedAt` changed.
+
+The normalizer refuses to publish when:
+
+* upstream is unreachable, oversized or not valid JSON;
+* fewer than `--min-entries` usable entries survive (150 in CI, against 187 upstream entries today);
+* any entry points at a host outside the allowlist.
+
+The last point is the drift alarm. A new upstream host fails the run and leaves the previous
+snapshot in place, so the app keeps serving a known-good catalog until the host is reviewed and
+added to **both** allowlists:
+
+* `COMMUNITY_MEDIA_HOSTS` in `app/src/main/java/com/luc4n3x/levyra/feature/motion/CommunityCanvasProvider.kt`
+* `ALLOWED_HOSTS` in `scripts/sync_community_canvas.py`
+
+Adding a host to only one of them either breaks the sync or ships a catalog the app silently
+discards.
+
+## Running the normalizer locally
+
+```bash
+python3 scripts/sync_community_canvas.py --output build/canvas/community-canvas.json
+python3 scripts/sync_community_canvas.py --input canvas.json --output build/canvas/community-canvas.json
+```
+
+`--input` skips the network and normalizes a local copy, which is the fastest way to check a
+catalog change before it reaches upstream.

--- a/docs/COMMUNITY_CANVAS_CATALOG.md
+++ b/docs/COMMUNITY_CANVAS_CATALOG.md
@@ -17,12 +17,24 @@ usable entry:
 | 2 | `vivizzz007/vivimusicanvas@main:canvas.json` | Upstream community catalog |
 
 The mirror is the pinned copy Levyra controls. Upstream stays as a fallback so the feature keeps
-working when the mirror branch is missing, stale or unreachable. Both responses are capped at
-1 MiB and cached in memory for six hours.
+working when the mirror branch is missing, unreachable or structurally unusable. Both responses are
+capped at 1 MiB and cached in memory for six hours.
 
-Per-source network timeouts are deliberately short (4.5 s call budget) because the motion-artwork
-engine caps the whole provider call at `MotionArtworkConfig.requestTimeoutMs` (6.5 s by default).
-A fast failure on the first source is what leaves room for the second one.
+The mirror is only accepted when it declares `version: 1` and yields at least 100 usable entries,
+which is below the 150-entry floor the publishing pipeline enforces. A truncated or gutted mirror
+therefore falls through to upstream instead of being cached for six hours. Upstream itself is
+accepted whenever it yields at least one usable entry, because nothing else backs it up.
+
+There is no freshness check: neither `generatedAt` nor the branch commit date is compared against
+the clock, and a mirror that stops being refreshed keeps being served. That is deliberate — the
+pipeline skips the commit when only `generatedAt` changed, so the timestamp does not track staleness
+— but it means an abandoned mirror is served until it fails one of the structural checks above.
+
+The whole two-source attempt is bounded by a 6 s budget that sits inside the motion-artwork engine's
+`MotionArtworkConfig.requestTimeoutMs` (6.5 s by default). Each source gets the remaining budget
+divided by the number of sources left, with a 2 s floor, so a slow mirror cannot starve the upstream
+fallback. Fetches run on `Call.enqueue` inside `suspendCancellableCoroutine`, so cancelling the
+coroutine cancels the HTTP call instead of leaving a blocked thread holding the catalog lock.
 
 ## Entry schema
 

--- a/scripts/sync_community_canvas.py
+++ b/scripts/sync_community_canvas.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Normalize the upstream community canvas catalog into Levyra's mirrored schema."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+UPSTREAM_URL = "https://raw.githubusercontent.com/vivizzz007/vivimusicanvas/main/canvas.json"
+ALLOWED_HOSTS = ("vivimusicanvas.mkmdevilmi.workers.dev", "vivimusicanvas-mtih.vercel.app")
+ALLOWED_EXTENSIONS = (".mp4", ".m3u8")
+DECLARED_SCOPES = {"track": "track", "song": "track", "album": "album"}
+ISRC_PATTERN = re.compile(r"^[A-Z]{2}[A-Z0-9]{3}[0-9]{7}$")
+USER_AGENT = "Levyra-community-canvas-mirror/1.0 (+https://github.com/LUC4N3X/Levyra-deepsound)"
+MAX_PAYLOAD_BYTES = 1024 * 1024
+CATALOG_VERSION = 1
+MAX_REPORTED_REJECTS = 20
+
+
+class CatalogError(RuntimeError):
+    pass
+
+
+def fetch_payload(url: str, timeout: float) -> str:
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "application/json", "User-Agent": USER_AGENT},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read(MAX_PAYLOAD_BYTES + 1)
+    except (urllib.error.URLError, TimeoutError, OSError) as error:
+        raise CatalogError(f"Unable to download {url}: {error}") from error
+    if len(raw) > MAX_PAYLOAD_BYTES:
+        raise CatalogError(f"Catalog at {url} exceeds {MAX_PAYLOAD_BYTES} bytes")
+    return raw.decode("utf-8")
+
+
+def text_field(item: dict[str, Any], key: str) -> str:
+    value = item.get(key)
+    return value.strip() if isinstance(value, str) else ""
+
+
+def positive_dimension(item: dict[str, Any], key: str) -> int | None:
+    value = item.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if value > 0 else None
+
+
+def media_url_problem(raw_url: str) -> str | None:
+    try:
+        parts = urlsplit(raw_url)
+        port = parts.port
+    except ValueError:
+        return "malformed url"
+    if parts.scheme != "https":
+        return "non-https url"
+    if parts.username or parts.password:
+        return "url with credentials"
+    if port not in (None, 443):
+        return "non-standard port"
+    host = (parts.hostname or "").lower()
+    if not host:
+        return "missing host"
+    if host not in ALLOWED_HOSTS:
+        return f"unapproved host {host}"
+    if not parts.path.lower().endswith(ALLOWED_EXTENSIONS):
+        return "unsupported media type"
+    return None
+
+
+def normalize_item(item: Any) -> tuple[dict[str, Any] | None, str | None]:
+    if not isinstance(item, dict):
+        return None, "entry is not an object"
+    song = text_field(item, "song")
+    artist = text_field(item, "artist")
+    album = text_field(item, "album")
+    raw_url = text_field(item, "url")
+    if not song or not artist or not album or not raw_url:
+        return None, "missing required field"
+    problem = media_url_problem(raw_url)
+    if problem is not None:
+        return None, problem
+
+    normalized: dict[str, Any] = {
+        "song": song,
+        "artist": artist,
+        "album": album,
+        "url": raw_url,
+    }
+    scope = DECLARED_SCOPES.get(text_field(item, "scope").lower())
+    if scope is not None:
+        normalized["scope"] = scope
+    isrc = text_field(item, "isrc").upper()
+    if ISRC_PATTERN.match(isrc):
+        normalized["isrc"] = isrc
+    width = positive_dimension(item, "width")
+    height = positive_dimension(item, "height")
+    if width is not None and height is not None:
+        normalized["width"] = width
+        normalized["height"] = height
+    return normalized, None
+
+
+def normalize_catalog(payload: str) -> tuple[list[dict[str, Any]], list[str], list[str]]:
+    try:
+        root = json.loads(payload)
+    except json.JSONDecodeError as error:
+        raise CatalogError(f"Upstream catalog is not valid JSON: {error}") from error
+    if not isinstance(root, dict) or not isinstance(root.get("items"), list):
+        raise CatalogError("Upstream catalog does not contain an items array")
+
+    items: list[dict[str, Any]] = []
+    rejects: list[str] = []
+    blocked_hosts: list[str] = []
+    seen: set[tuple[str, ...]] = set()
+    for index, raw_item in enumerate(root["items"]):
+        normalized, problem = normalize_item(raw_item)
+        if normalized is None:
+            rejects.append(f"item {index}: {problem}")
+            if problem is not None and problem.startswith("unapproved host"):
+                blocked_hosts.append(problem.removeprefix("unapproved host "))
+            continue
+        key = (
+            normalized["song"].casefold(),
+            normalized["artist"].casefold(),
+            normalized["album"].casefold(),
+            normalized["url"],
+            normalized.get("scope", ""),
+        )
+        if key in seen:
+            rejects.append(f"item {index}: duplicate entry")
+            continue
+        seen.add(key)
+        items.append(normalized)
+
+    items.sort(key=lambda entry: (
+        entry["artist"].casefold(),
+        entry["album"].casefold(),
+        entry["song"].casefold(),
+        entry["url"],
+    ))
+    return items, rejects, sorted(set(blocked_hosts))
+
+
+def write_catalog(path: Path, source: str, items: list[dict[str, Any]]) -> None:
+    document = {
+        "version": CATALOG_VERSION,
+        "generatedAt": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "source": source,
+        "items": items,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-url", default=UPSTREAM_URL)
+    parser.add_argument("--input", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--min-entries", type=int, default=150)
+    parser.add_argument("--timeout", type=float, default=30.0)
+    return parser.parse_args()
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    try:
+        payload = (
+            arguments.input.read_text(encoding="utf-8")
+            if arguments.input is not None
+            else fetch_payload(arguments.source_url, arguments.timeout)
+        )
+        items, rejects, blocked_hosts = normalize_catalog(payload)
+    except (CatalogError, OSError, UnicodeDecodeError) as error:
+        print(f"Community canvas sync failed: {error}", file=sys.stderr)
+        return 1
+
+    for reject in rejects[:MAX_REPORTED_REJECTS]:
+        print(f"Rejected {reject}")
+    if len(rejects) > MAX_REPORTED_REJECTS:
+        print(f"Rejected {len(rejects) - MAX_REPORTED_REJECTS} more entries")
+
+    if blocked_hosts:
+        print(
+            "Community canvas sync failed: upstream published media on hosts Levyra does not allow: "
+            + ", ".join(blocked_hosts),
+            file=sys.stderr,
+        )
+        return 1
+
+    if len(items) < arguments.min_entries:
+        print(
+            f"Community canvas sync failed: only {len(items)} usable entries, "
+            f"expected at least {arguments.min_entries}",
+            file=sys.stderr,
+        )
+        return 1
+
+    source = arguments.source_url if arguments.input is None else arguments.input.as_posix()
+    write_catalog(arguments.output, source, items)
+    album_scoped = sum(1 for entry in items if entry.get("scope") == "album")
+    with_isrc = sum(1 for entry in items if "isrc" in entry)
+    print(
+        f"Normalized {len(items)} entries "
+        f"({album_scoped} album-scoped, {with_isrc} with ISRC, {len(rejects)} rejected) "
+        f"into {arguments.output}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Levyra no longer hot-links a third-party repository's `main` branch for community canvases: it reads a validated mirror published from this repository and keeps upstream as the fallback.
- The catalog parser now understands the optional fields it already read (`scope`, `isrc`, `width`, `height`), uses the upstream `/Song/` and `/Album/` directory convention as an additive album hint, and discards malformed ISRC values.
- The decorative motion-artwork player is told the resolved MIME type instead of relying on URL extension inference.

## Scope

- [x] Player / audio
- [ ] Stream extraction
- [ ] Downloads
- [x] UI / Compose
- [ ] Localization
- [ ] Android Auto / media session
- [x] CI / release
- [x] Documentation

## What changed

**`CommunityCanvasProvider`**

- `CATALOG_URLS` replaces `CATALOG_URL`: `canvas-data/catalog/community-canvas.json` from this repository first, `vivizzz007/vivimusicanvas@main/canvas.json` second. The first source that parses into at least one usable entry wins; an empty or failing source falls through to the next one.
- Per-source timeouts drop from 7 s to a 4.5 s call budget. The engine caps the whole provider call at `MotionArtworkConfig.requestTimeoutMs` (6.5 s), so a fast failure on the first source is what leaves room for the second.
- A recognized `scope` field (`track`, `song`, `album`) is authoritative. When it is absent, the URL directory is recorded as `pathScope` and an `/Album/` entry additionally produces an album-scope candidate, keeping its track-scope form. The existing "same URL across two or more songs" heuristic is unchanged.
- `isrc` is only kept when it matches `^[A-Z]{2}[A-Z0-9]{3}[0-9]{7}$`. A malformed value used to be treated as a real identifier and could veto an otherwise good match.
- The media host allowlist, the HTTPS/port checks and the shared `MotionArtworkUrlVerifier` path are untouched: the mirror changes where the *catalog* comes from, never where media may come from.

**`MotionArtworkLayer`**

- `MediaItem.Builder().setUri(...).setMimeType(...)` replaces `MediaItem.fromUri(...)`. The MIME type was already computed, stored in Room and carried through the engine, then dropped at the player; a `.m3u8` URL with a query string would have been prepared as progressive media.

**Mirror pipeline**

- `scripts/sync_community_canvas.py` normalizes upstream: required fields, HTTPS + port 443 + allowlisted host + `.mp4`/`.m3u8`, no credentials in the URL, optional-field validation, dedupe, deterministic ordering.
- `.github/workflows/community-canvas-mirror.yml` validates on relevant pull requests and, daily at 04:37 UTC (06:37 Europe/Rome in summer, 05:37 in winter) plus on demand, publishes to the orphan `canvas-data` branch, skipping the commit when only `generatedAt` changed. It refuses to publish when upstream is unreachable, when fewer than 150 entries survive (187 upstream today) or when any entry points at a host outside the allowlist — that last case is the drift alarm for the two `workers.dev` / `vercel.app` hosts baked into the app.
- `docs/COMMUNITY_CANVAS_CATALOG.md` documents the schema, the scope rules and the fact that the host allowlist lives in two places that must move together.

**Measured effect on today's catalog**

Upstream currently holds 187 entries (all valid, no duplicates, both hosts allowlisted), of which 14 sit under `/Album/` forming 3 groups — and all 3 already had two or more listed songs, so the existing heuristic covered them. The directory hint therefore changes no match today; it makes the signal explicit and covers an album canvas listed only once. Likewise no upstream entry publishes `scope`, `isrc`, `width` or `height` yet, so that part is enabling work plus documentation. The immediately observable changes are the mirror/fallback chain and the MIME type.

## Testing

- [ ] `gradle --no-daemon :app:lintRelease`
- [ ] `gradle --no-daemon testReleaseUnitTest`
- [ ] `gradle --no-daemon assembleRelease`
- [ ] APK installed on device
- [ ] Playback tested
- [ ] Downloads tested
- [ ] Language switching tested

No Gradle task was run: this environment has no Android SDK, and no workflow currently runs the unit tests, so the four new cases in `CommunityCanvasProviderTest` are unverified and need a local `testReleaseUnitTest` before merge.

What was actually run here:

- `python3 scripts/check_android_regex_compatibility.py` — passed.
- `scripts/sync_community_canvas.py` against the live upstream catalog: 187 entries, 0 rejected, 0 duplicates.
- The same script against a crafted fixture: non-HTTPS, non-standard port, embedded credentials, wrong extension, missing field, non-object entry and duplicate are dropped; an unapproved host fails the run; `scope`, `isrc`, `width`/`height` normalization behaves as documented.
- YAML parse of the new workflow and a local replay of `workflow-duplicates-guard.yml` logic: no duplicated names or bodies.

## Release safety

- [x] `levyraVersionName` and `levyraVersionCode` are correct
- [x] No secrets, keystores, APKs or ZIPs committed
- [x] No duplicated release workflows
- [x] Credits and licenses updated when adding external components

The `canvas-data` branch does not exist yet. Until the workflow runs once (`workflow_dispatch`), the app's first source returns 404 and it falls back to upstream, which is the current behaviour.

## Related issues

- Closes #
- Related to #




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Community canvas catalogs now support source fallback, versioning, album and track scopes, and improved candidate matching.
  - Artwork playback now handles media types more reliably for compatible canvas artwork.

- **Bug Fixes**
  - Improved handling of malformed entries, duplicate canvases, conflicting identifiers, oversized responses, and unavailable sources.
  - Added cancellation and timeout safeguards for catalog loading.

- **Documentation**
  - Added guidance covering catalog validation, caching, security, mirroring, and local synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->