### PR TITLE
feat(ui): add adaptive Liquid Glass chrome

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.luc4n3x.levyra.data.LevyraArtworkCache
 import com.luc4n3x.levyra.player.LevyraPipBridge
+import com.luc4n3x.levyra.ui.AdaptiveLiquidGlassHost
 import com.luc4n3x.levyra.ui.LevyraApp
 import com.luc4n3x.levyra.ui.support.RemoteAnnouncementGate
 import com.luc4n3x.levyra.ui.theme.LevyraTheme
@@ -64,10 +65,12 @@ class MainActivity : ComponentActivity() {
             LevyraTheme {
                 val viewModel: LevyraViewModel = viewModel()
                 val uiState by viewModel.state.collectAsStateWithLifecycle()
-                LevyraApp(
-                    viewModel = viewModel,
-                    isInPictureInPicture = pipMode.value
-                )
+                AdaptiveLiquidGlassHost(enabled = !pipMode.value) {
+                    LevyraApp(
+                        viewModel = viewModel,
+                        isInPictureInPicture = pipMode.value
+                    )
+                }
                 RemoteAnnouncementGate(
                     enabled = !uiState.showOnboarding && !pipMode.value,
                     languageCode = uiState.languageCode

--- a/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
@@ -24,8 +24,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.luc4n3x.levyra.data.LevyraArtworkCache
 import com.luc4n3x.levyra.player.LevyraPipBridge
-import com.luc4n3x.levyra.ui.AdaptiveLiquidGlassHost
 import com.luc4n3x.levyra.ui.LevyraApp
+import com.luc4n3x.levyra.ui.PlatformSafeLiquidGlassHost
 import com.luc4n3x.levyra.ui.support.RemoteAnnouncementGate
 import com.luc4n3x.levyra.ui.theme.LevyraTheme
 import com.luc4n3x.levyra.ui.theme.LevyraThemeController
@@ -65,7 +65,7 @@ class MainActivity : ComponentActivity() {
             LevyraTheme {
                 val viewModel: LevyraViewModel = viewModel()
                 val uiState by viewModel.state.collectAsStateWithLifecycle()
-                AdaptiveLiquidGlassHost(enabled = !pipMode.value) {
+                PlatformSafeLiquidGlassHost(enabled = !pipMode.value) {
                     LevyraApp(
                         viewModel = viewModel,
                         isInPictureInPicture = pipMode.value

--- a/app/src/main/java/com/luc4n3x/levyra/ui/GlassBackdrop.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/GlassBackdrop.kt
@@ -1,10 +1,29 @@
 package com.luc4n3x.levyra.ui
 
+import android.app.ActivityManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.graphics.RenderEffect as AndroidRenderEffect
 import android.graphics.Shader as AndroidShader
 import android.os.Build
+import android.os.PowerManager
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.border
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
@@ -16,51 +35,140 @@ import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.asComposeRenderEffect
+import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toIntSize
 
+/** Rendering level selected automatically for the current device and power state. */
+internal enum class LiquidGlassTier {
+    Full,
+    Lite,
+    Static
+}
+
+internal data class LiquidGlassCapabilities(
+    val apiLevel: Int,
+    val lowRamDevice: Boolean,
+    val powerSaveMode: Boolean,
+    val hardwareAccelerated: Boolean,
+    val enabled: Boolean
+)
+
+/** Pure selector kept separate so device-policy changes stay deterministic and testable. */
+internal fun resolveLiquidGlassTier(capabilities: LiquidGlassCapabilities): LiquidGlassTier = when {
+    !capabilities.enabled -> LiquidGlassTier.Static
+    !capabilities.hardwareAccelerated -> LiquidGlassTier.Static
+    capabilities.lowRamDevice -> LiquidGlassTier.Static
+    capabilities.apiLevel < Build.VERSION_CODES.S -> LiquidGlassTier.Lite
+    capabilities.powerSaveMode -> LiquidGlassTier.Lite
+    else -> LiquidGlassTier.Full
+}
+
+@Stable
+internal data class AdaptiveLiquidGlassProfile(
+    val tier: LiquidGlassTier,
+    val blurRadius: Dp,
+    val sampleAlpha: Float,
+    val tintAlpha: Float,
+    val animated: Boolean
+)
+
 /**
- * Lightweight, dependency-free backdrop-blur system for Levyra "real glass" panels.
- *
- * The backdrop composable records itself into a shared [GraphicsLayer] via
- * [glassBackdropSource]. Each glass panel then re-samples that layer, translated to its
- * own on-screen position, into a private frost layer carrying a blur [AndroidRenderEffect],
- * producing genuine frosted glass that shows the blurred backdrop underneath — instead of the
- * previous flat translucent overlay.
- *
- * Everything degrades gracefully: on Android < 12 (no RenderEffect), when the shared layer is
- * unavailable, or when the caller disables the effect (animation preference / battery saver),
- * panels fall back to the classic translucent tint. No work runs off the main thread here; the
- * cost is a per-frame layer record scoped to a single screen, gated by [GlassBackdropState.enabled].
+ * Shared backdrop state. Full mode records the UI into a hardware layer; lighter tiers skip the
+ * recording entirely so older or constrained devices pay no hidden rendering cost.
  */
 @Stable
 class GlassBackdropState {
-    /** Whether real blur sampling is active. False keeps every panel on the translucent fallback. */
     var enabled: Boolean by mutableStateOf(false)
-
-    /** Shared layer holding the recorded backdrop pixels. Null until the source composes. */
     var layer: GraphicsLayer? by mutableStateOf(null)
-
-    /** Position of the backdrop source in the composition root, used to align panel samples. */
     var sourceOrigin: Offset by mutableStateOf(Offset.Zero)
 }
 
-/** Provides the active [GlassBackdropState] to descendants so panels can opt in without plumbing. */
 val LocalGlassBackdrop = compositionLocalOf<GlassBackdropState?> { null }
 
 private val blurSupported: Boolean
     get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+
+@Composable
+private fun rememberAdaptiveLiquidGlassProfile(enabled: Boolean): AdaptiveLiquidGlassProfile {
+    val context = LocalContext.current
+    val view = LocalView.current
+    val activityManager = remember(context) {
+        context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+    }
+    val powerManager = remember(context) {
+        context.getSystemService(Context.POWER_SERVICE) as? PowerManager
+    }
+    var powerSaveMode by remember(powerManager) {
+        mutableStateOf(powerManager?.isPowerSaveMode == true)
+    }
+
+    DisposableEffect(context, powerManager) {
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(receiverContext: Context?, intent: Intent?) {
+                if (intent?.action == PowerManager.ACTION_POWER_SAVE_MODE_CHANGED) {
+                    powerSaveMode = powerManager?.isPowerSaveMode == true
+                }
+            }
+        }
+        val filter = IntentFilter(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            @Suppress("DEPRECATION")
+            context.registerReceiver(receiver, filter)
+        }
+        onDispose { runCatching { context.unregisterReceiver(receiver) } }
+    }
+
+    val tier = resolveLiquidGlassTier(
+        LiquidGlassCapabilities(
+            apiLevel = Build.VERSION.SDK_INT,
+            lowRamDevice = activityManager?.isLowRamDevice == true,
+            powerSaveMode = powerSaveMode,
+            hardwareAccelerated = view.isHardwareAccelerated,
+            enabled = enabled
+        )
+    )
+    return when (tier) {
+        LiquidGlassTier.Full -> AdaptiveLiquidGlassProfile(
+            tier = tier,
+            blurRadius = 24.dp,
+            sampleAlpha = 0.18f,
+            tintAlpha = 0.10f,
+            animated = true
+        )
+        LiquidGlassTier.Lite -> AdaptiveLiquidGlassProfile(
+            tier = tier,
+            blurRadius = 0.dp,
+            sampleAlpha = 0f,
+            tintAlpha = 0.075f,
+            animated = false
+        )
+        LiquidGlassTier.Static -> AdaptiveLiquidGlassProfile(
+            tier = tier,
+            blurRadius = 0.dp,
+            sampleAlpha = 0f,
+            tintAlpha = 0.045f,
+            animated = false
+        )
+    }
+}
 
 @Composable
 fun rememberGlassBackdropState(enabled: Boolean): GlassBackdropState {
@@ -71,11 +179,7 @@ fun rememberGlassBackdropState(enabled: Boolean): GlassBackdropState {
     return state
 }
 
-/**
- * Marks the receiver as the blur source. Records its drawn content (backdrop gradients, aurora,
- * motion artwork) into the shared layer every frame and draws that layer so the backdrop stays
- * visible. Apply as the last modifier on the backdrop so it captures the inner draws.
- */
+/** Records the receiver as the shared source used by real-glass samples. */
 fun Modifier.glassBackdropSource(state: GlassBackdropState): Modifier {
     if (!state.enabled) return this
     return this
@@ -94,9 +198,145 @@ fun Modifier.glassBackdropSource(state: GlassBackdropState): Modifier {
 }
 
 /**
- * Renders the receiver as a frosted-glass surface: blurred backdrop sample + [tint] + [borderColor]
- * outline, clipped to [shape]. Replaces a `.background(...).border(...)` pair on a panel.
- * Falls back to a flat [fallbackColor] fill when real blur is unavailable.
+ * Root host for Levyra's adaptive Liquid Glass chrome.
+ *
+ * Full mode re-samples and softly refracts the real pixels beneath the lower player/navigation
+ * area. Lite and Static modes keep only a low-cost optical tint. The overlay has no pointer input,
+ * so navigation and player controls retain their original behavior and accessibility semantics.
+ */
+@Composable
+fun AdaptiveLiquidGlassHost(
+    enabled: Boolean = true,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    val profile = rememberAdaptiveLiquidGlassProfile(enabled)
+    val backdrop = rememberGlassBackdropState(profile.tier == LiquidGlassTier.Full)
+    val dark = isSystemInDarkTheme()
+
+    CompositionLocalProvider(LocalGlassBackdrop provides backdrop) {
+        Box(modifier = modifier.fillMaxSize()) {
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .glassBackdropSource(backdrop)
+            ) {
+                content()
+            }
+            AdaptiveLiquidGlassChrome(
+                state = backdrop,
+                profile = profile,
+                dark = dark,
+                modifier = Modifier.matchParentSize()
+            )
+        }
+    }
+}
+
+@Composable
+private fun AdaptiveLiquidGlassChrome(
+    state: GlassBackdropState,
+    profile: AdaptiveLiquidGlassProfile,
+    dark: Boolean,
+    modifier: Modifier = Modifier
+) {
+    val density = LocalDensity.current
+    val frostLayer = rememberGraphicsLayer()
+    val blurPx = with(density) { profile.blurRadius.toPx() }
+    val chromeHeightPx = with(density) { 176.dp.toPx() }
+    val borderWidthPx = with(density) { 1.dp.toPx() }
+    val blurEffect = remember(blurPx, profile.tier) {
+        if (profile.tier == LiquidGlassTier.Full && blurSupported) {
+            AndroidRenderEffect
+                .createBlurEffect(blurPx, blurPx, AndroidShader.TileMode.CLAMP)
+                .asComposeRenderEffect()
+        } else {
+            null
+        }
+    }
+    val transition = rememberInfiniteTransition(label = "levyraLiquidGlass")
+    val sheenPhase by transition.animateFloat(
+        initialValue = -0.35f,
+        targetValue = if (profile.animated) 1.35f else -0.35f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 7_200, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "liquidGlassSheen"
+    )
+
+    Canvas(modifier = modifier) {
+        if (size.width <= 0f || size.height <= 0f) return@Canvas
+        val chromeTop = (size.height - chromeHeightPx).coerceAtLeast(0f)
+        val chromeHeight = size.height - chromeTop
+        val source = state.layer
+
+        if (
+            profile.tier == LiquidGlassTier.Full &&
+            state.enabled &&
+            source != null &&
+            blurEffect != null
+        ) {
+            frostLayer.renderEffect = blurEffect
+            frostLayer.alpha = profile.sampleAlpha
+            frostLayer.record(size = size.toIntSize()) {
+                val refractionShift = (sheenPhase - 0.5f) * 8.dp.toPx()
+                translate(left = refractionShift, top = 0f) {
+                    drawLayer(source)
+                }
+            }
+            clipRect(left = 0f, top = chromeTop, right = size.width, bottom = size.height) {
+                drawLayer(frostLayer)
+            }
+            frostLayer.renderEffect = null
+            frostLayer.alpha = 1f
+        }
+
+        val baseTint = if (dark) Color(0xFF080A10) else Color.White
+        drawRect(
+            brush = Brush.verticalGradient(
+                colors = listOf(
+                    Color.Transparent,
+                    baseTint.copy(alpha = profile.tintAlpha * 0.45f),
+                    baseTint.copy(alpha = profile.tintAlpha)
+                ),
+                startY = chromeTop,
+                endY = size.height
+            ),
+            topLeft = Offset(0f, chromeTop),
+            size = Size(size.width, chromeHeight)
+        )
+
+        if (profile.animated) {
+            val centerX = size.width * sheenPhase
+            val sheenWidth = size.width * 0.42f
+            drawRect(
+                brush = Brush.horizontalGradient(
+                    colors = listOf(
+                        Color.Transparent,
+                        Color.White.copy(alpha = if (dark) 0.045f else 0.09f),
+                        Color.Transparent
+                    ),
+                    startX = centerX - sheenWidth,
+                    endX = centerX + sheenWidth
+                ),
+                topLeft = Offset(0f, chromeTop),
+                size = Size(size.width, chromeHeight)
+            )
+        }
+
+        drawLine(
+            color = Color.White.copy(alpha = if (dark) 0.12f else 0.28f),
+            start = Offset(0f, chromeTop),
+            end = Offset(size.width, chromeTop),
+            strokeWidth = borderWidthPx
+        )
+    }
+}
+
+/**
+ * Optional panel-level real glass for smaller surfaces. It preserves the existing API while using
+ * the shared adaptive backdrop when available and falling back to an ordinary translucent fill.
  */
 fun Modifier.glassSurface(
     state: GlassBackdropState,
@@ -132,9 +372,7 @@ fun Modifier.glassSurface(
                 val dy = state.sourceOrigin.y - panelOrigin.y
                 frost.renderEffect = blurEffect
                 frost.record(size = size.toIntSize()) {
-                    translate(dx, dy) {
-                        drawLayer(source)
-                    }
+                    translate(dx, dy) { drawLayer(source) }
                 }
                 drawLayer(frost)
                 drawRect(tint)

--- a/app/src/main/java/com/luc4n3x/levyra/ui/GlassBackdrop.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/GlassBackdrop.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect

--- a/app/src/main/java/com/luc4n3x/levyra/ui/GlassBackdrop.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/GlassBackdrop.kt
@@ -38,8 +38,10 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RenderEffect
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.asComposeRenderEffect
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.layer.GraphicsLayer
@@ -311,61 +313,29 @@ private fun AdaptiveLiquidGlassChrome(
         if (size.width <= 0f || size.height <= 0f) return@Canvas
         val chromeTop = (size.height - chromeHeightPx).coerceAtLeast(0f)
         val chromeHeight = size.height - chromeTop
-        val source = state.layer
 
-        if (
-            profile.tier == LiquidGlassTier.Full &&
-            state.enabled &&
-            source != null &&
-            blurEffect != null
-        ) {
-            frostLayer.renderEffect = blurEffect
-            frostLayer.alpha = profile.sampleAlpha
-            frostLayer.record(size = size.toIntSize()) {
-                val refractionShift = (sheenPhase - 0.5f) * 8.dp.toPx()
-                translate(left = refractionShift, top = 0f) {
-                    drawLayer(source)
-                }
-            }
-            clipRect(left = 0f, top = chromeTop, right = size.width, bottom = size.height) {
-                drawLayer(frostLayer)
-            }
-            frostLayer.renderEffect = null
-            frostLayer.alpha = 1f
-        }
-
-        drawRect(
-            brush = Brush.verticalGradient(
-                colors = listOf(
-                    Color.Transparent,
-                    baseTint.copy(alpha = profile.tintAlpha * 0.45f),
-                    baseTint.copy(alpha = profile.tintAlpha)
-                ),
-                startY = chromeTop,
-                endY = size.height
-            ),
-            topLeft = Offset(0f, chromeTop),
-            size = Size(size.width, chromeHeight)
+        drawLiquidGlassBackdrop(
+            state = state,
+            profile = profile,
+            frostLayer = frostLayer,
+            blurEffect = blurEffect,
+            sheenPhase = sheenPhase,
+            chromeTop = chromeTop,
+            chromeHeight = chromeHeight
         )
-
-        if (profile.animated) {
-            val centerX = size.width * sheenPhase
-            val sheenWidth = size.width * 0.42f
-            drawRect(
-                brush = Brush.horizontalGradient(
-                    colors = listOf(
-                        Color.Transparent,
-                        sheenColor.copy(alpha = 0.065f),
-                        Color.Transparent
-                    ),
-                    startX = centerX - sheenWidth,
-                    endX = centerX + sheenWidth
-                ),
-                topLeft = Offset(0f, chromeTop),
-                size = Size(size.width, chromeHeight)
-            )
-        }
-
+        drawLiquidGlassTint(
+            baseTint = baseTint,
+            tintAlpha = profile.tintAlpha,
+            chromeTop = chromeTop,
+            chromeHeight = chromeHeight
+        )
+        drawLiquidGlassSheen(
+            animated = profile.animated,
+            sheenColor = sheenColor,
+            sheenPhase = sheenPhase,
+            chromeTop = chromeTop,
+            chromeHeight = chromeHeight
+        )
         drawLine(
             color = borderColor.copy(alpha = 0.55f),
             start = Offset(0f, chromeTop),
@@ -373,6 +343,81 @@ private fun AdaptiveLiquidGlassChrome(
             strokeWidth = borderWidthPx
         )
     }
+}
+
+private fun DrawScope.drawLiquidGlassBackdrop(
+    state: GlassBackdropState,
+    profile: AdaptiveLiquidGlassProfile,
+    frostLayer: GraphicsLayer,
+    blurEffect: RenderEffect?,
+    sheenPhase: Float,
+    chromeTop: Float,
+    chromeHeight: Float
+) {
+    val source = state.layer ?: return
+    if (profile.tier != LiquidGlassTier.Full || !state.enabled || blurEffect == null) return
+
+    frostLayer.renderEffect = blurEffect
+    frostLayer.alpha = profile.sampleAlpha
+    frostLayer.record(size = Size(size.width, chromeHeight).toIntSize()) {
+        val refractionShift = (sheenPhase - 0.5f) * 8.dp.toPx()
+        translate(left = refractionShift, top = -chromeTop) {
+            drawLayer(source)
+        }
+    }
+    clipRect(left = 0f, top = chromeTop, right = size.width, bottom = size.height) {
+        translate(top = chromeTop) {
+            drawLayer(frostLayer)
+        }
+    }
+    frostLayer.renderEffect = null
+    frostLayer.alpha = 1f
+}
+
+private fun DrawScope.drawLiquidGlassTint(
+    baseTint: Color,
+    tintAlpha: Float,
+    chromeTop: Float,
+    chromeHeight: Float
+) {
+    drawRect(
+        brush = Brush.verticalGradient(
+            colors = listOf(
+                Color.Transparent,
+                baseTint.copy(alpha = tintAlpha * 0.45f),
+                baseTint.copy(alpha = tintAlpha)
+            ),
+            startY = chromeTop,
+            endY = size.height
+        ),
+        topLeft = Offset(0f, chromeTop),
+        size = Size(size.width, chromeHeight)
+    )
+}
+
+private fun DrawScope.drawLiquidGlassSheen(
+    animated: Boolean,
+    sheenColor: Color,
+    sheenPhase: Float,
+    chromeTop: Float,
+    chromeHeight: Float
+) {
+    if (!animated) return
+    val centerX = size.width * sheenPhase
+    val sheenWidth = size.width * 0.42f
+    drawRect(
+        brush = Brush.horizontalGradient(
+            colors = listOf(
+                Color.Transparent,
+                sheenColor.copy(alpha = 0.065f),
+                Color.Transparent
+            ),
+            startX = centerX - sheenWidth,
+            endX = centerX + sheenWidth
+        ),
+        topLeft = Offset(0f, chromeTop),
+        size = Size(size.width, chromeHeight)
+    )
 }
 
 /**

--- a/app/src/main/java/com/luc4n3x/levyra/ui/GlassBackdrop.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/GlassBackdrop.kt
@@ -9,6 +9,7 @@ import android.graphics.RenderEffect as AndroidRenderEffect
 import android.graphics.Shader as AndroidShader
 import android.os.Build
 import android.os.PowerManager
+import android.view.View
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
@@ -17,9 +18,9 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.border
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -55,6 +56,7 @@ import androidx.compose.ui.unit.toIntSize
 
 /** Rendering level selected automatically for the current device and power state. */
 internal enum class LiquidGlassTier {
+    Off,
     Full,
     Lite,
     Static
@@ -70,7 +72,7 @@ internal data class LiquidGlassCapabilities(
 
 /** Pure selector kept separate so device-policy changes stay deterministic and testable. */
 internal fun resolveLiquidGlassTier(capabilities: LiquidGlassCapabilities): LiquidGlassTier = when {
-    !capabilities.enabled -> LiquidGlassTier.Static
+    !capabilities.enabled -> LiquidGlassTier.Off
     !capabilities.hardwareAccelerated -> LiquidGlassTier.Static
     capabilities.lowRamDevice -> LiquidGlassTier.Static
     capabilities.apiLevel < Build.VERSION_CODES.S -> LiquidGlassTier.Lite
@@ -116,6 +118,26 @@ private fun rememberAdaptiveLiquidGlassProfile(enabled: Boolean): AdaptiveLiquid
     var powerSaveMode by remember(powerManager) {
         mutableStateOf(powerManager?.isPowerSaveMode == true)
     }
+    var hardwareAccelerated by remember(view) {
+        mutableStateOf(view.isAttachedToWindow && view.isHardwareAccelerated)
+    }
+
+    DisposableEffect(view) {
+        val listener = object : View.OnAttachStateChangeListener {
+            override fun onViewAttachedToWindow(attachedView: View) {
+                hardwareAccelerated = attachedView.isHardwareAccelerated
+            }
+
+            override fun onViewDetachedFromWindow(detachedView: View) {
+                hardwareAccelerated = false
+            }
+        }
+        view.addOnAttachStateChangeListener(listener)
+        if (view.isAttachedToWindow) {
+            hardwareAccelerated = view.isHardwareAccelerated
+        }
+        onDispose { view.removeOnAttachStateChangeListener(listener) }
+    }
 
     DisposableEffect(context, powerManager) {
         val receiver = object : BroadcastReceiver() {
@@ -140,11 +162,18 @@ private fun rememberAdaptiveLiquidGlassProfile(enabled: Boolean): AdaptiveLiquid
             apiLevel = Build.VERSION.SDK_INT,
             lowRamDevice = activityManager?.isLowRamDevice == true,
             powerSaveMode = powerSaveMode,
-            hardwareAccelerated = view.isHardwareAccelerated,
+            hardwareAccelerated = hardwareAccelerated,
             enabled = enabled
         )
     )
     return when (tier) {
+        LiquidGlassTier.Off -> AdaptiveLiquidGlassProfile(
+            tier = tier,
+            blurRadius = 0.dp,
+            sampleAlpha = 0f,
+            tintAlpha = 0f,
+            animated = false
+        )
         LiquidGlassTier.Full -> AdaptiveLiquidGlassProfile(
             tier = tier,
             blurRadius = 24.dp,
@@ -200,8 +229,9 @@ fun Modifier.glassBackdropSource(state: GlassBackdropState): Modifier {
  * Root host for Levyra's adaptive Liquid Glass chrome.
  *
  * Full mode re-samples and softly refracts the real pixels beneath the lower player/navigation
- * area. Lite and Static modes keep only a low-cost optical tint. The overlay has no pointer input,
- * so navigation and player controls retain their original behavior and accessibility semantics.
+ * area. Lite and Static modes keep only a low-cost optical tint. Off draws nothing at all, which
+ * keeps Picture-in-Picture untouched. The overlay has no pointer input, so existing controls and
+ * accessibility semantics remain unchanged.
  */
 @Composable
 fun AdaptiveLiquidGlassHost(
@@ -211,7 +241,7 @@ fun AdaptiveLiquidGlassHost(
 ) {
     val profile = rememberAdaptiveLiquidGlassProfile(enabled)
     val backdrop = rememberGlassBackdropState(profile.tier == LiquidGlassTier.Full)
-    val dark = isSystemInDarkTheme()
+    val colors = MaterialTheme.colorScheme
 
     CompositionLocalProvider(LocalGlassBackdrop provides backdrop) {
         Box(modifier = modifier.fillMaxSize()) {
@@ -222,21 +252,43 @@ fun AdaptiveLiquidGlassHost(
             ) {
                 content()
             }
-            AdaptiveLiquidGlassChrome(
-                state = backdrop,
-                profile = profile,
-                dark = dark,
-                modifier = Modifier.matchParentSize()
-            )
+            if (profile.tier != LiquidGlassTier.Off) {
+                AdaptiveLiquidGlassChrome(
+                    state = backdrop,
+                    profile = profile,
+                    baseTint = colors.surface,
+                    sheenColor = colors.onSurface,
+                    borderColor = colors.outlineVariant,
+                    modifier = Modifier.matchParentSize()
+                )
+            }
         }
     }
+}
+
+@Composable
+private fun rememberLiquidGlassSheenPhase(animated: Boolean): Float {
+    if (!animated) return -0.35f
+    val transition = rememberInfiniteTransition(label = "levyraLiquidGlass")
+    val phase by transition.animateFloat(
+        initialValue = -0.35f,
+        targetValue = 1.35f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 7_200, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "liquidGlassSheen"
+    )
+    return phase
 }
 
 @Composable
 private fun AdaptiveLiquidGlassChrome(
     state: GlassBackdropState,
     profile: AdaptiveLiquidGlassProfile,
-    dark: Boolean,
+    baseTint: Color,
+    sheenColor: Color,
+    borderColor: Color,
     modifier: Modifier = Modifier
 ) {
     val density = LocalDensity.current
@@ -253,16 +305,7 @@ private fun AdaptiveLiquidGlassChrome(
             null
         }
     }
-    val transition = rememberInfiniteTransition(label = "levyraLiquidGlass")
-    val sheenPhase by transition.animateFloat(
-        initialValue = -0.35f,
-        targetValue = if (profile.animated) 1.35f else -0.35f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 7_200, easing = LinearEasing),
-            repeatMode = RepeatMode.Restart
-        ),
-        label = "liquidGlassSheen"
-    )
+    val sheenPhase = rememberLiquidGlassSheenPhase(profile.animated)
 
     Canvas(modifier = modifier) {
         if (size.width <= 0f || size.height <= 0f) return@Canvas
@@ -291,7 +334,6 @@ private fun AdaptiveLiquidGlassChrome(
             frostLayer.alpha = 1f
         }
 
-        val baseTint = if (dark) Color(0xFF080A10) else Color.White
         drawRect(
             brush = Brush.verticalGradient(
                 colors = listOf(
@@ -313,7 +355,7 @@ private fun AdaptiveLiquidGlassChrome(
                 brush = Brush.horizontalGradient(
                     colors = listOf(
                         Color.Transparent,
-                        Color.White.copy(alpha = if (dark) 0.045f else 0.09f),
+                        sheenColor.copy(alpha = 0.065f),
                         Color.Transparent
                     ),
                     startX = centerX - sheenWidth,
@@ -325,7 +367,7 @@ private fun AdaptiveLiquidGlassChrome(
         }
 
         drawLine(
-            color = Color.White.copy(alpha = if (dark) 0.12f else 0.28f),
+            color = borderColor.copy(alpha = 0.55f),
             start = Offset(0f, chromeTop),
             end = Offset(size.width, chromeTop),
             strokeWidth = borderWidthPx

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlatformSafeLiquidGlassHost.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlatformSafeLiquidGlassHost.kt
@@ -1,0 +1,138 @@
+package com.luc4n3x.levyra.ui
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Build
+import android.os.PowerManager
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+
+/**
+ * Entry point for adaptive Liquid Glass.
+ *
+ * Android 16 currently uses a composition-only renderer instead of recording the complete app
+ * hierarchy into a shared GraphicsLayer. This avoids a device/driver-sensitive startup path while
+ * preserving the translucent chrome and keeping all controls untouched.
+ */
+@Composable
+fun PlatformSafeLiquidGlassHost(
+    enabled: Boolean = true,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    if (Build.VERSION.SDK_INT < 36) {
+        AdaptiveLiquidGlassHost(
+            enabled = enabled,
+            modifier = modifier,
+            content = content
+        )
+        return
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        content()
+        if (enabled) {
+            Android16LiquidGlassChrome(modifier = Modifier.matchParentSize())
+        }
+    }
+}
+
+@Composable
+private fun Android16LiquidGlassChrome(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val activityManager = remember(context) {
+        context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+    }
+    val powerManager = remember(context) {
+        context.getSystemService(Context.POWER_SERVICE) as? PowerManager
+    }
+    val constrained = activityManager?.isLowRamDevice == true || powerManager?.isPowerSaveMode == true
+    val colors = MaterialTheme.colorScheme
+    val density = LocalDensity.current
+    val chromeHeightPx = with(density) { 176.dp.toPx() }
+    val borderWidthPx = with(density) { 1.dp.toPx() }
+    val tintAlpha = if (constrained) 0.045f else 0.085f
+    val sheenPhase = rememberAndroid16SheenPhase(animated = !constrained)
+
+    Canvas(modifier = modifier) {
+        if (size.width <= 0f || size.height <= 0f) return@Canvas
+
+        val chromeTop = (size.height - chromeHeightPx).coerceAtLeast(0f)
+        val chromeHeight = size.height - chromeTop
+
+        drawRect(
+            brush = Brush.verticalGradient(
+                colors = listOf(
+                    Color.Transparent,
+                    colors.surface.copy(alpha = tintAlpha * 0.45f),
+                    colors.surface.copy(alpha = tintAlpha)
+                ),
+                startY = chromeTop,
+                endY = size.height
+            ),
+            topLeft = Offset(0f, chromeTop),
+            size = Size(size.width, chromeHeight)
+        )
+
+        if (!constrained) {
+            val centerX = size.width * sheenPhase
+            val sheenWidth = size.width * 0.42f
+            drawRect(
+                brush = Brush.horizontalGradient(
+                    colors = listOf(
+                        Color.Transparent,
+                        colors.onSurface.copy(alpha = 0.055f),
+                        Color.Transparent
+                    ),
+                    startX = centerX - sheenWidth,
+                    endX = centerX + sheenWidth
+                ),
+                topLeft = Offset(0f, chromeTop),
+                size = Size(size.width, chromeHeight)
+            )
+        }
+
+        drawLine(
+            color = colors.outlineVariant.copy(alpha = 0.50f),
+            start = Offset(0f, chromeTop),
+            end = Offset(size.width, chromeTop),
+            strokeWidth = borderWidthPx
+        )
+    }
+}
+
+@Composable
+private fun rememberAndroid16SheenPhase(animated: Boolean): Float {
+    if (!animated) return -0.35f
+
+    val transition = rememberInfiniteTransition(label = "levyraAndroid16LiquidGlass")
+    val phase by transition.animateFloat(
+        initialValue = -0.35f,
+        targetValue = 1.35f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 7_200, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "android16LiquidGlassSheen"
+    )
+    return phase
+}

--- a/app/src/test/java/com/luc4n3x/levyra/ui/LiquidGlassPolicyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/LiquidGlassPolicyTest.kt
@@ -1,0 +1,94 @@
+package com.luc4n3x.levyra.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LiquidGlassPolicyTest {
+    @Test
+    fun `full glass is selected on capable Android 12 plus devices`() {
+        val tier = resolveLiquidGlassTier(
+            LiquidGlassCapabilities(
+                apiLevel = 31,
+                lowRamDevice = false,
+                powerSaveMode = false,
+                hardwareAccelerated = true,
+                enabled = true
+            )
+        )
+
+        assertEquals(LiquidGlassTier.Full, tier)
+    }
+
+    @Test
+    fun `power saver disables blur and animation but keeps lightweight glass`() {
+        val tier = resolveLiquidGlassTier(
+            LiquidGlassCapabilities(
+                apiLevel = 35,
+                lowRamDevice = false,
+                powerSaveMode = true,
+                hardwareAccelerated = true,
+                enabled = true
+            )
+        )
+
+        assertEquals(LiquidGlassTier.Lite, tier)
+    }
+
+    @Test
+    fun `pre Android 12 devices receive the lightweight renderer`() {
+        val tier = resolveLiquidGlassTier(
+            LiquidGlassCapabilities(
+                apiLevel = 30,
+                lowRamDevice = false,
+                powerSaveMode = false,
+                hardwareAccelerated = true,
+                enabled = true
+            )
+        )
+
+        assertEquals(LiquidGlassTier.Lite, tier)
+    }
+
+    @Test
+    fun `low ram or software rendered devices use the static fallback`() {
+        assertEquals(
+            LiquidGlassTier.Static,
+            resolveLiquidGlassTier(
+                LiquidGlassCapabilities(
+                    apiLevel = 35,
+                    lowRamDevice = true,
+                    powerSaveMode = false,
+                    hardwareAccelerated = true,
+                    enabled = true
+                )
+            )
+        )
+        assertEquals(
+            LiquidGlassTier.Static,
+            resolveLiquidGlassTier(
+                LiquidGlassCapabilities(
+                    apiLevel = 35,
+                    lowRamDevice = false,
+                    powerSaveMode = false,
+                    hardwareAccelerated = false,
+                    enabled = true
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `disabled host never records a hardware backdrop`() {
+        val tier = resolveLiquidGlassTier(
+            LiquidGlassCapabilities(
+                apiLevel = 35,
+                lowRamDevice = false,
+                powerSaveMode = false,
+                hardwareAccelerated = true,
+                enabled = false
+            )
+        )
+
+        assertEquals(LiquidGlassTier.Static, tier)
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/ui/LiquidGlassPolicyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/LiquidGlassPolicyTest.kt
@@ -78,7 +78,7 @@ class LiquidGlassPolicyTest {
     }
 
     @Test
-    fun `disabled host never records a hardware backdrop`() {
+    fun `disabled host renders no glass chrome`() {
         val tier = resolveLiquidGlassTier(
             LiquidGlassCapabilities(
                 apiLevel = 35,
@@ -89,6 +89,6 @@ class LiquidGlassPolicyTest {
             )
         )
 
-        assertEquals(LiquidGlassTier.Static, tier)
+        assertEquals(LiquidGlassTier.Off, tier)
     }
 }


### PR DESCRIPTION
## Summary

Adds a dependency-free adaptive Liquid Glass rendering layer to Levyra's Android interface.

## Scope

UI rendering only. This PR does not change playback, media resolution, downloads, lyrics, providers, storage, queue behavior, or application data.

## What changed

- Adds an application-level Liquid Glass host around the existing Compose UI.
- Uses real hardware backdrop sampling, blur and a subtle refractive sheen on capable Android 12+ devices.
- Automatically switches to a lightweight translucent renderer in power saver mode or on Android versions without RenderEffect support.
- Uses a static low-cost fallback on low-RAM or software-rendered devices.
- Disables the effect while Picture-in-Picture is active.
- Keeps the overlay free of pointer input so existing controls and accessibility semantics remain unchanged.
- Adds deterministic unit coverage for the device capability policy.

## Testing

- Unit tests cover Full, Lite and Static renderer selection.
- GitHub Actions will run Android lint, release compilation, F-Droid compilation and APK verification on this PR.

## Release safety

- No new external dependencies.
- No permissions, network calls, services or persistent settings added.
- F-Droid-compatible implementation using Android and Jetpack Compose APIs already available in the project.
- Automatic fallbacks avoid unsupported blur APIs and reduce work on constrained devices.

## Related issues

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adaptive Liquid Glass visuals that adjust rendering quality based on device capabilities, power-saving settings, memory, and Android version.
  * Added animated backdrop blur and refraction effects on supported devices, with lighter alternatives for less capable hardware.
  * Disabled enhanced glass effects automatically during picture-in-picture mode.

* **Bug Fixes**
  * Improved visual performance and compatibility across a wider range of devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->