### PR TITLE
docs: align README with current Android build

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Levyra ships two native clients from one repository. Android uses strict unidire
 ```text
 📦 Android Application Specifications
 ├── Package Name      com.luc4n3x.levyra
-├── Target SDK        35 (Android 15)
+├── Target SDK        37
 ├── Min SDK           26 (Android 8.0)
 ├── Primary Language  100% Kotlin
 ├── UI Framework      Jetpack Compose + Material 3 (M3)
@@ -217,7 +217,7 @@ Levyra is built natively for Android and Windows, with platform-specific playbac
 
 ```yaml
 system:
-  language: "Kotlin 2.4.0"
+  language: "Kotlin 2.4.10"
   interface: "Jetpack Compose (Material 3)"
   state: "Mobius MVI"
 audio:
@@ -239,7 +239,7 @@ desktop:
 ```
 
 ### 📱 Core and UI
-* **Kotlin 2.4.0**: A 100% native codebase built with coroutines and flow APIs for asynchronous streaming.
+* **Kotlin 2.4.10**: A 100% native codebase built with coroutines and flow APIs for asynchronous streaming.
 * **Jetpack Compose** (via Compose BOM): Declarative layouts with Material 3 components and system-wide dynamic color adaptation.
 * **Mobius architecture**: A unidirectional data flow design (Model-Event-Effect-Update) for reliable player state transitions.
 * **Compose Multiplatform Desktop**: Native Windows layouts, lifecycle, onboarding, library and player surfaces.
@@ -266,9 +266,9 @@ desktop:
 ## ✦ Building from Source
 
 ### Android prerequisites
-* Android Studio Jellyfish (or newer)
+* Android Studio with Android Gradle Plugin 9.3.1 support
 * Java Development Kit (JDK) 17
-* Android SDK Platform 37 (`compileSdk = 37`, `targetSdk = 35`)
+* Android SDK Platform 37 (`compileSdk = 37`, `targetSdk = 37`)
 * Gradle 9.6.1 through the repository Gradle Wrapper
 
 ### Android build and install
@@ -316,7 +316,7 @@ compatibility with GitHub installations:
 ./gradlew --no-daemon -PlevyraFdroidBuild=true :app:assembleRelease
 ```
 
-Architecture and size-control notes live in `docs/APK_SIZE_RULER.md` and `docs/PLAYER_MOBIUS_SAMPLE_ARCHITECTURE.md`.
+Architecture and size-control details are summarized in the sections above and enforced by the Gradle and CI configuration.
 
 ### Versioning & CI
 


### PR DESCRIPTION
## Causa

Il README non era allineato alla configurazione Android corrente: riportava Kotlin 2.4.0 e target SDK 35, mentre la build usa Kotlin 2.4.10 e target SDK 37. Inoltre rimandava a due file sotto `docs/` che non esistono nel repository.

## Impatto

Le istruzioni di sviluppo e la panoramica tecnica potevano indurre a predisporre un ambiente non coerente con la build reale; i due riferimenti documentali risultavano non navigabili.

## Modifica

- allineati target SDK, Kotlin e prerequisiti Android ai valori della build;
- sostituiti i riferimenti ai documenti assenti con un rinvio alle sezioni e ai controlli già presenti nel repository;
- nessuna modifica a codice, dipendenze, workflow o release.

## File

- `README.md`

## Verifiche

- `/usr/local/bin/levyra-worker verify` — superato;
- controllo diretto contro `app/build.gradle.kts`, `gradle/libs.versions.toml` e `gradle/wrapper/gradle-wrapper.properties`.

## Rischi

Bassi: modifica esclusivamente documentale. Il requisito Android Studio è espresso in termini di supporto ad AGP 9.3.1 per evitare di fissare un nome di release IDE non verificato.

## Comportamento precedente

Il README dichiarava `targetSdk = 35`, Kotlin 2.4.0 e Android Studio Jellyfish, e collegava `docs/APK_SIZE_RULER.md` e `docs/PLAYER_MOBIUS_SAMPLE_ARCHITECTURE.md`, entrambi assenti.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Android SDK and target requirements.
  * Clarified Kotlin and Android Studio prerequisites.
  * Added updated Android Gradle Plugin support details.
  * Refined F-Droid and build architecture guidance, including references to architecture and app size controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->