### PR TITLE
feat(player): unify the player design language and rebuild the seekbar

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
@@ -130,6 +130,9 @@ class LevyraPlayer(context: Context) {
     val positionMs: Long
         get() = controller?.currentPosition?.coerceAtLeast(0L) ?: pendingPlayback?.positionMs ?: 0L
 
+    val bufferedPositionMs: Long
+        get() = controller?.bufferedPosition?.coerceAtLeast(0L) ?: 0L
+
     val durationMs: Long
         get() {
             val duration = controller?.duration ?: return 0L

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -2025,6 +2025,7 @@ private fun AlbumOverlay(
                 isPlaying = state.isPlaying,
                 isResolving = state.isResolving,
                 progress = progressOf(state.positionMs, state.durationMs),
+                animated = state.animationsEnabled,
                 onToggle = onTogglePlayback,
                 onOpenPlayer = onOpenPlayer,
                 modifier = Modifier
@@ -2310,6 +2311,7 @@ private fun AlbumNowPlayingDock(
     isPlaying: Boolean,
     isResolving: Boolean,
     progress: Float,
+    animated: Boolean,
     onToggle: () -> Unit,
     onOpenPlayer: () -> Unit,
     modifier: Modifier = Modifier
@@ -2361,6 +2363,7 @@ private fun AlbumNowPlayingDock(
                     isPlaying = isPlaying,
                     isResolving = isResolving,
                     buttonColor = if (LevyraIsLight) LevyraBlack else Color.White,
+                    animated = animated,
                     onToggle = onToggle
                 )
             }
@@ -10265,6 +10268,7 @@ private fun PlaylistDetailOverlay(viewModel: LevyraViewModel, state: LevyraUiSta
                 isPlaying = state.isPlaying,
                 isResolving = state.isResolving,
                 progress = progressOf(state.positionMs, state.durationMs),
+                animated = state.animationsEnabled,
                 onToggle = viewModel::togglePlay,
                 onOpenPlayer = viewModel::openPlayerScreen,
                 modifier = Modifier

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -1217,6 +1217,7 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
                             isPlaying = state.isPlaying,
                             isResolving = state.isResolving,
                             progress = progressOf(state.positionMs, state.durationMs),
+                            animated = state.animationsEnabled,
                             onOpen = { viewModel.selectTab(LevyraTab.Player) },
                             onToggle = viewModel::togglePlay,
                             onNext = viewModel::next,
@@ -11619,7 +11620,11 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                     }
                     val favoriteScale by animateFloatAsState(
                         targetValue = if (isFavorite) 1.08f else 1f,
-                        animationSpec = LevyraPlayerDesign.expressiveSpring(),
+                        animationSpec = if (state.animationsEnabled) {
+                            LevyraPlayerDesign.expressiveSpring()
+                        } else {
+                            snap()
+                        },
                         label = "player-favorite-scale"
                     )
                     val actionSize = if (compactPlayer) {
@@ -11752,6 +11757,7 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                         accent = primary,
                         accentSecondary = secondary,
                         compact = compactPlayer,
+                        animated = state.animationsEnabled,
                         labels = playerControlLabels,
                         onShuffle = viewModel::toggleShuffle,
                         onPrevious = viewModel::previous,
@@ -15850,6 +15856,7 @@ private fun MiniPlayer(
     isPlaying: Boolean,
     isResolving: Boolean,
     progress: Float,
+    animated: Boolean,
     onOpen: () -> Unit,
     onToggle: () -> Unit,
     onNext: () -> Unit,
@@ -15963,6 +15970,7 @@ private fun MiniPlayer(
                     isPlaying = isPlaying,
                     isResolving = isResolving,
                     buttonColor = miniPrimaryContent,
+                    animated = animated,
                     onToggle = onToggle
                 )
                 PlayerRoundIconButton(
@@ -16019,13 +16027,14 @@ private fun MiniPlayerToggleButton(
     isPlaying: Boolean,
     isResolving: Boolean,
     buttonColor: Color,
+    animated: Boolean,
     onToggle: () -> Unit
 ) {
     val playBg = buttonColor.copy(alpha = 1f)
     val playTint = Color.White.playerContentColor(listOf(playBg))
     val corner by animateDpAsState(
         targetValue = if (isPlaying) 14.dp else 20.dp,
-        animationSpec = LevyraPlayerDesign.expressiveSpring(),
+        animationSpec = if (animated) LevyraPlayerDesign.expressiveSpring() else snap(),
         label = "mini-play-corner"
     )
     Box(

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -1,11 +1,13 @@
 @file:androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 package com.luc4n3x.levyra.ui
 
+import com.luc4n3x.levyra.ui.components.PlayerAccentColors
 import com.luc4n3x.levyra.ui.components.PlayerControlLabels
 import com.luc4n3x.levyra.ui.components.PlayerGlassIconButton
 import com.luc4n3x.levyra.ui.components.PlayerTransportControls
 import com.luc4n3x.levyra.ui.components.PremiumSeekbar
 import com.luc4n3x.levyra.ui.components.SpringIconButton
+import com.luc4n3x.levyra.ui.components.formatSeekbarMillis
 import com.luc4n3x.levyra.ui.components.playerGlass
 import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
 import androidx.compose.material.icons.rounded.ChevronRight
@@ -256,6 +258,13 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.toggleableState
+import androidx.compose.ui.state.ToggleableState
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.ui.semantics.setProgress
 import androidx.core.view.WindowCompat
 import androidx.media3.common.Player
@@ -10498,17 +10507,19 @@ private fun PlayerArtworkCanvas(
 private fun PlayerModeSwitch(
     isVideoMode: Boolean,
     activeColor: Color,
+    activeColorTarget: Color,
     onSong: () -> Unit,
     onVideo: () -> Unit
 ) {
     val strings = LocalLevyraStrings.current
-    val selectedContent = remember(activeColor) {
+    val selectedContent = remember(activeColorTarget) {
         Color.White.playerContentColor(
-            listOf(activeColor.copy(alpha = 0.42f).playerCompositeOver(PlayerDarkSurface))
+            listOf(activeColorTarget.copy(alpha = 0.42f).playerCompositeOver(PlayerDarkSurface))
         )
     }
     Row(
         modifier = Modifier
+            .selectableGroup()
             .playerGlass(
                 shape = LevyraPlayerDesign.ShapePill,
                 fill = LevyraPlayerDesign.GlassFillSunken
@@ -10542,18 +10553,28 @@ private fun PlayerModeSwitchTab(
     selectedContent: Color,
     onClick: () -> Unit
 ) {
+    val isSelected = selected
+    val tabSpec: AnimationSpec<Color> = if (LocalAnimationsEnabled.current) {
+        LevyraPlayerDesign.standardTween(180)
+    } else {
+        snap()
+    }
     val background by animateColorAsState(
         targetValue = if (selected) activeColor.copy(alpha = 0.42f) else Color.Transparent,
-        animationSpec = LevyraPlayerDesign.standardTween(180),
+        animationSpec = tabSpec,
         label = "player-mode-tab-background"
     )
     val contentColor by animateColorAsState(
         targetValue = if (selected) selectedContent else LevyraPlayerDesign.TextSecondary,
-        animationSpec = LevyraPlayerDesign.standardTween(180),
+        animationSpec = tabSpec,
         label = "player-mode-tab-content"
     )
     Box(
         modifier = Modifier
+            .semantics {
+                this.selected = isSelected
+                role = Role.Tab
+            }
             .background(background, LevyraPlayerDesign.ShapePill)
             .pressable(enabled = !selected, onClick = onClick)
             .padding(horizontal = 14.dp, vertical = 7.dp)
@@ -11195,6 +11216,12 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
     val secondaryContent = remember(secondary) {
         secondary.playerContentColor(listOf(PlayerDarkSurface))
     }
+    val playerAccentColors = PlayerAccentColors(
+        primary = primary,
+        secondary = secondary,
+        primaryTarget = primaryTarget,
+        secondaryTarget = secondaryTarget
+    )
     val playerControlLabels = remember(strings) {
         PlayerControlLabels(
             shuffle = strings.shuffle,
@@ -11319,6 +11346,7 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                             PlayerModeSwitch(
                                 isVideoMode = state.isVideoMode,
                                 activeColor = primary,
+                                activeColorTarget = primaryTarget,
                                 onSong = viewModel::toggleVideoMode,
                                 onVideo = viewModel::toggleVideoMode
                             )
@@ -11619,8 +11647,10 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                 item {
                     val isFavorite = track.id in state.favoriteIds
                     val favoriteFill = primary.copy(alpha = 0.42f)
-                    val favoriteTint = remember(favoriteFill) {
-                        Color.White.playerContentColor(listOf(favoriteFill.playerCompositeOver(PlayerDarkSurface)))
+                    val favoriteTint = remember(primaryTarget) {
+                        Color.White.playerContentColor(
+                            listOf(primaryTarget.copy(alpha = 0.42f).playerCompositeOver(PlayerDarkSurface))
+                        )
                     }
                     val favoriteScale by animateFloatAsState(
                         targetValue = if (isFavorite) 1.08f else 1f,
@@ -11667,6 +11697,7 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                                 Spacer(modifier = Modifier.height(LevyraPlayerDesign.SpaceXs))
                                 Row(
                                     modifier = Modifier
+                                        .heightIn(min = LevyraPlayerDesign.MinimumTouchTarget)
                                         .clip(LevyraPlayerDesign.ShapePill)
                                         .clickable(
                                             onClickLabel = strings.openArtist,
@@ -11720,10 +11751,12 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                                     } else {
                                         LevyraPlayerDesign.GlassBorderBottom
                                     },
-                                    modifier = Modifier.graphicsLayer {
-                                        scaleX = favoriteScale
-                                        scaleY = favoriteScale
-                                    },
+                                    modifier = Modifier
+                                        .graphicsLayer {
+                                            scaleX = favoriteScale
+                                            scaleY = favoriteScale
+                                        }
+                                        .semantics { toggleableState = ToggleableState(isFavorite) },
                                     onClick = { viewModel.toggleFavorite(track) }
                                 )
                             }
@@ -11758,8 +11791,7 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                         shuffleOn = state.shuffleEnabled,
                         repeatOn = state.repeatMode != com.luc4n3x.levyra.domain.RepeatMode.Off,
                         repeatOne = state.repeatMode == com.luc4n3x.levyra.domain.RepeatMode.One,
-                        accent = primary,
-                        accentSecondary = secondary,
+                        accents = playerAccentColors,
                         compact = compactPlayer,
                         animated = state.animationsEnabled,
                         labels = playerControlLabels,
@@ -12477,14 +12509,14 @@ private fun PlayerTimeline(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = formatDuration(positionMs),
+                text = formatSeekbarMillis(positionMs),
                 color = LevyraPlayerDesign.TextSecondary,
                 fontSize = if (compact) 11.sp else 11.5.sp,
                 fontWeight = FontWeight.SemiBold,
                 letterSpacing = 0.2.sp
             )
             Text(
-                text = formatDuration(durationMs),
+                text = if (durationMs > 0L) formatSeekbarMillis(durationMs) else formatDuration(durationMs),
                 color = LevyraPlayerDesign.TextTertiary,
                 fontSize = if (compact) 11.sp else 11.5.sp,
                 fontWeight = FontWeight.Medium,
@@ -16035,7 +16067,7 @@ private fun MiniPlayerToggleButton(
     onToggle: () -> Unit
 ) {
     val playBg = buttonColor.copy(alpha = 1f)
-    val playTint = Color.White.playerContentColor(listOf(playBg))
+    val playTint = remember(playBg) { Color.White.playerContentColor(listOf(playBg)) }
     val corner by animateDpAsState(
         targetValue = if (isPlaying) 14.dp else 20.dp,
         animationSpec = if (animated) LevyraPlayerDesign.expressiveSpring() else snap(),

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -411,21 +411,7 @@ private val LevyraMiniPlayerHeight = 77.dp
 private val LevyraBottomContentGap = 16.dp
 private val LevyraNavigationBlue = Color(0xFF0A84FF)
 private val LevyraNavigationBlueDeep = Color(0xFF0066E6)
-private val LevyraSignalNodes = listOf(
-    0.08f to 0.16f,
-    0.20f to 0.09f,
-    0.34f to 0.20f,
-    0.52f to 0.12f,
-    0.69f to 0.23f,
-    0.86f to 0.14f,
-    0.14f to 0.38f,
-    0.42f to 0.33f,
-    0.76f to 0.41f,
-    0.93f to 0.31f,
-    0.27f to 0.58f,
-    0.61f to 0.53f,
-    0.84f to 0.66f
-)
+private val LevyraHomeGlowViolet = Color(0xFF6E5CF0)
 
 private val LevyraIsLight: Boolean get() = LevyraActivePalette.isLight
 private val LevyraReadableOnArtwork: Color get() = Color.White
@@ -1144,7 +1130,7 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
                 .fillMaxSize()
                 .background(LevyraBlack)
         ) {
-            LevyraBackground(accent?.accentStart, accent?.accentEnd)
+            LevyraBackground()
 
             val homeListState = rememberLazyListState()
             // Hoisted next to the list state: once the heavy home shelves are revealed they must stay
@@ -1886,7 +1872,7 @@ private fun AlbumOverlay(
             .fillMaxSize()
             .background(LevyraBlack)
     ) {
-        LevyraBackground(accentTrack?.accentStart, accentTrack?.accentEnd)
+        LevyraBackground()
         Box(
             modifier = Modifier
                 .matchParentSize()
@@ -4124,7 +4110,7 @@ private fun LyricsOverlay(
             .fillMaxSize()
             .consumeOverlayTouches()
     ) {
-        LevyraBackground(accentStart = track?.accentStart, accentEnd = track?.accentEnd)
+        LevyraBackground()
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -5052,30 +5038,18 @@ private fun LyricsStatusRow(provider: String, synced: Boolean, cached: Boolean, 
 }
 
 @Composable
-private fun LevyraBackground(accentStart: Int?, accentEnd: Int?) {
-    val sourceStart = accentStart?.let { Color(it) } ?: LevyraNavigationBlue
-    val sourceEnd = accentEnd?.let { Color(it) } ?: LevyraNavigationBlueDeep
-    val primaryAccent by animateColorAsState(
-        targetValue = sourceStart,
-        animationSpec = tween(900, easing = LinearOutSlowInEasing),
-        label = "levyra-background-primary"
-    )
-    val secondaryAccent by animateColorAsState(
-        targetValue = sourceEnd,
-        animationSpec = tween(900, easing = LinearOutSlowInEasing),
-        label = "levyra-background-secondary"
-    )
+private fun LevyraBackground() {
     val isLight = LevyraIsLight
 
     Box(
         modifier = Modifier
             .fillMaxSize()
             .drawWithCache {
+                val width = size.width
+                val height = size.height
                 if (size.minDimension <= 0f) {
                     onDrawBehind {}
                 } else if (isLight) {
-                    val width = size.width
-                    val height = size.height
                     val backgroundBrush = Brush.verticalGradient(
                         listOf(
                             Color(0xFFFFFFFF),
@@ -5083,230 +5057,104 @@ private fun LevyraBackground(accentStart: Int?, accentEnd: Int?) {
                             Color(0xFFF2F5FB)
                         )
                     )
-                    val haloCenter = androidx.compose.ui.geometry.Offset(width * 0.18f, height * 0.04f)
-                    val haloRadius = width * 0.92f
+                    val haloCenter = androidx.compose.ui.geometry.Offset(width * 0.16f, -height * 0.02f)
+                    val haloRadius = width * 1.10f
                     val haloBrush = Brush.radialGradient(
                         colors = listOf(
-                            LevyraNavigationBlue.copy(alpha = 0.09f),
-                            LevyraNavigationBlue.copy(alpha = 0.025f),
+                            LevyraNavigationBlue.copy(alpha = 0.10f),
+                            LevyraNavigationBlue.copy(alpha = 0.03f),
                             Color.Transparent
                         ),
                         center = haloCenter,
                         radius = haloRadius
                     )
-                    val violetHaloCenter = androidx.compose.ui.geometry.Offset(width * 0.94f, height * 0.12f)
-                    val violetHaloRadius = width * 0.64f
-                    val violetHaloBrush = Brush.radialGradient(
+                    val violetCenter = androidx.compose.ui.geometry.Offset(width * 1.02f, height * 0.16f)
+                    val violetRadius = width * 0.82f
+                    val violetBrush = Brush.radialGradient(
                         colors = listOf(
-                            LevyraViolet.copy(alpha = 0.05f),
-                            LevyraViolet.copy(alpha = 0.015f),
+                            LevyraHomeGlowViolet.copy(alpha = 0.07f),
+                            LevyraHomeGlowViolet.copy(alpha = 0.02f),
                             Color.Transparent
                         ),
-                        center = violetHaloCenter,
-                        radius = violetHaloRadius
+                        center = violetCenter,
+                        radius = violetRadius
                     )
                     onDrawBehind {
                         drawRect(backgroundBrush)
-                        drawCircle(
-                            brush = haloBrush,
-                            radius = haloRadius,
-                            center = haloCenter
-                        )
-                        drawCircle(
-                            brush = violetHaloBrush,
-                            radius = violetHaloRadius,
-                            center = violetHaloCenter
-                        )
+                        drawCircle(brush = haloBrush, radius = haloRadius, center = haloCenter)
+                        drawCircle(brush = violetBrush, radius = violetRadius, center = violetCenter)
                     }
                 } else {
-                    val width = size.width
-                    val height = size.height
                     val backgroundBrush = Brush.verticalGradient(
-                        listOf(
-                            Color.Black,
-                            Color(0xFF01040A),
-                            Color(0xFF02050B),
-                            Color.Black
+                        colorStops = arrayOf(
+                            0f to Color(0xFF10121A),
+                            0.28f to Color(0xFF0A0C13),
+                            0.62f to Color(0xFF05060A),
+                            1f to Color(0xFF000000)
                         )
                     )
-                    val topHalo = androidx.compose.ui.geometry.Offset(width * 0.18f, height * 0.02f)
-                    val topHaloRadius = width * 0.88f
-                    val topHaloBrush = Brush.radialGradient(
+                    val auroraCenter = androidx.compose.ui.geometry.Offset(width * 0.10f, -height * 0.04f)
+                    val auroraRadius = width * 1.25f
+                    val auroraBrush = Brush.radialGradient(
                         colors = listOf(
-                            LevyraNavigationBlue.copy(alpha = 0.17f),
-                            LevyraNavigationBlue.copy(alpha = 0.055f),
+                            LevyraNavigationBlue.copy(alpha = 0.26f),
+                            LevyraNavigationBlue.copy(alpha = 0.09f),
                             Color.Transparent
                         ),
-                        center = topHalo,
-                        radius = topHaloRadius
+                        center = auroraCenter,
+                        radius = auroraRadius
                     )
-                    val rightHalo = androidx.compose.ui.geometry.Offset(width * 1.04f, height * 0.34f)
-                    val rightHaloRadius = width * 0.76f
-                    val rightHaloBrush = Brush.radialGradient(
+                    val violetCenter = androidx.compose.ui.geometry.Offset(width * 1.06f, height * 0.14f)
+                    val violetRadius = width * 0.95f
+                    val violetBrush = Brush.radialGradient(
+                        colors = listOf(
+                            LevyraHomeGlowViolet.copy(alpha = 0.20f),
+                            LevyraHomeGlowViolet.copy(alpha = 0.06f),
+                            Color.Transparent
+                        ),
+                        center = violetCenter,
+                        radius = violetRadius
+                    )
+                    val emberCenter = androidx.compose.ui.geometry.Offset(width * 0.82f, height * 0.44f)
+                    val emberRadius = width * 0.70f
+                    val emberBrush = Brush.radialGradient(
                         colors = listOf(
                             LevyraNavigationBlueDeep.copy(alpha = 0.10f),
-                            primaryAccent.copy(alpha = 0.025f),
                             Color.Transparent
                         ),
-                        center = rightHalo,
-                        radius = rightHaloRadius
+                        center = emberCenter,
+                        radius = emberRadius
                     )
-                    val leftHalo = androidx.compose.ui.geometry.Offset(-width * 0.06f, height * 0.56f)
-                    val leftHaloRadius = width * 0.62f
-                    val leftHaloBrush = Brush.radialGradient(
+                    val sheenBrush = Brush.verticalGradient(
                         colors = listOf(
-                            primaryAccent.copy(alpha = 0.055f),
-                            primaryAccent.copy(alpha = 0.018f),
+                            Color.Transparent,
+                            Color.White.copy(alpha = 0.030f),
                             Color.Transparent
                         ),
-                        center = leftHalo,
-                        radius = leftHaloRadius
+                        startY = height * 0.04f,
+                        endY = height * 0.26f
                     )
-                    val signalPath = androidx.compose.ui.graphics.Path().apply {
-                        moveTo(-width * 0.10f, height * 0.27f)
-                        cubicTo(
-                            width * 0.18f,
-                            height * 0.17f,
-                            width * 0.34f,
-                            height * 0.39f,
-                            width * 0.56f,
-                            height * 0.25f
-                        )
-                        cubicTo(
-                            width * 0.72f,
-                            height * 0.15f,
-                            width * 0.88f,
-                            height * 0.32f,
-                            width * 1.10f,
-                            height * 0.20f
-                        )
-                    }
-                    val signalBrush = Brush.horizontalGradient(
-                        listOf(
-                            Color.Transparent,
-                            LevyraNavigationBlue.copy(alpha = 0.04f),
-                            LevyraNavigationBlue.copy(alpha = 0.12f),
-                            LevyraNavigationBlueDeep.copy(alpha = 0.055f),
-                            Color.Transparent
-                        )
-                    )
-                    val signalStroke = Stroke(width = 1.15.dp.toPx())
-                    val echoPath = androidx.compose.ui.graphics.Path().apply {
-                        moveTo(-width * 0.08f, height * 0.285f)
-                        cubicTo(
-                            width * 0.19f,
-                            height * 0.20f,
-                            width * 0.36f,
-                            height * 0.42f,
-                            width * 0.57f,
-                            height * 0.28f
-                        )
-                        cubicTo(
-                            width * 0.74f,
-                            height * 0.18f,
-                            width * 0.90f,
-                            height * 0.35f,
-                            width * 1.08f,
-                            height * 0.24f
-                        )
-                    }
-                    val echoStroke = Stroke(width = 0.75.dp.toPx())
-                    val firstArcTopLeft = androidx.compose.ui.geometry.Offset(width * 0.45f, -height * 0.075f)
-                    val firstArcSize = androidx.compose.ui.geometry.Size(width * 0.74f, height * 0.34f)
-                    val firstArcStroke = Stroke(width = 0.9.dp.toPx())
-                    val secondArcTopLeft = androidx.compose.ui.geometry.Offset(width * 0.38f, -height * 0.105f)
-                    val secondArcSize = androidx.compose.ui.geometry.Size(width * 0.90f, height * 0.41f)
-                    val secondArcStroke = Stroke(width = 0.65.dp.toPx())
-                    val signalNodes = LevyraSignalNodes.mapIndexed { index, node ->
-                        Triple(
-                            index,
-                            androidx.compose.ui.geometry.Offset(width * node.first, height * node.second),
-                            when (index % 3) {
-                                0 -> 0.13f
-                                1 -> 0.085f
-                                else -> 0.055f
-                            }
-                        )
-                    }
-                    val nodeRadiusLarge = 1.25.dp.toPx()
-                    val nodeRadiusSmall = 0.75.dp.toPx()
-                    val nodeHaloRadius = 8.dp.toPx()
-                    val bottomFadeTop = height * 0.50f
+                    val fadeTop = height * 0.40f
                     val bottomFadeBrush = Brush.verticalGradient(
                         colors = listOf(
                             Color.Transparent,
-                            Color.Black.copy(alpha = 0.24f),
-                            Color.Black.copy(alpha = 0.88f),
+                            Color.Black.copy(alpha = 0.55f),
                             Color.Black
                         ),
-                        startY = bottomFadeTop,
+                        startY = fadeTop,
                         endY = height
                     )
-                    val bottomFadeSize = androidx.compose.ui.geometry.Size(width, height - bottomFadeTop)
-
+                    val fadeSize = androidx.compose.ui.geometry.Size(width, height - fadeTop)
                     onDrawBehind {
                         drawRect(backgroundBrush)
-                        drawCircle(
-                            brush = topHaloBrush,
-                            radius = topHaloRadius,
-                            center = topHalo
-                        )
-                        drawCircle(
-                            brush = rightHaloBrush,
-                            radius = rightHaloRadius,
-                            center = rightHalo
-                        )
-                        drawCircle(
-                            brush = leftHaloBrush,
-                            radius = leftHaloRadius,
-                            center = leftHalo
-                        )
-                        drawPath(
-                            path = signalPath,
-                            brush = signalBrush,
-                            style = signalStroke
-                        )
-                        drawPath(
-                            path = echoPath,
-                            color = LevyraNavigationBlue.copy(alpha = 0.035f),
-                            style = echoStroke
-                        )
-                        drawArc(
-                            color = LevyraNavigationBlue.copy(alpha = 0.075f),
-                            startAngle = 202f,
-                            sweepAngle = 116f,
-                            useCenter = false,
-                            topLeft = firstArcTopLeft,
-                            size = firstArcSize,
-                            style = firstArcStroke
-                        )
-                        drawArc(
-                            color = secondaryAccent.copy(alpha = 0.035f),
-                            startAngle = 196f,
-                            sweepAngle = 128f,
-                            useCenter = false,
-                            topLeft = secondArcTopLeft,
-                            size = secondArcSize,
-                            style = secondArcStroke
-                        )
-                        signalNodes.forEach { (index, center, pulse) ->
-                            drawCircle(
-                                color = LevyraNavigationBlue.copy(alpha = pulse),
-                                radius = if (index % 4 == 0) nodeRadiusLarge else nodeRadiusSmall,
-                                center = center
-                            )
-                            if (index % 4 == 0) {
-                                drawCircle(
-                                    color = LevyraNavigationBlue.copy(alpha = 0.025f),
-                                    radius = nodeHaloRadius,
-                                    center = center
-                                )
-                            }
-                        }
+                        drawCircle(brush = auroraBrush, radius = auroraRadius, center = auroraCenter)
+                        drawCircle(brush = violetBrush, radius = violetRadius, center = violetCenter)
+                        drawCircle(brush = emberBrush, radius = emberRadius, center = emberCenter)
+                        drawRect(sheenBrush)
                         drawRect(
                             brush = bottomFadeBrush,
-                            topLeft = androidx.compose.ui.geometry.Offset(0f, bottomFadeTop),
-                            size = bottomFadeSize
+                            topLeft = androidx.compose.ui.geometry.Offset(0f, fadeTop),
+                            size = fadeSize
                         )
                     }
                 }
@@ -11680,7 +11528,7 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                                     text = track.title,
                                     color = LevyraPlayerDesign.TextPrimary,
                                     fontSize = if (compactPlayer) 24.sp else 26.sp,
-                                    lineHeight = if (compactPlayer) 28.sp else 30.sp,
+                                    lineHeight = if (compactPlayer) 26.sp else 28.sp,
                                     fontWeight = FontWeight.Black,
                                     letterSpacing = (-0.4).sp,
                                     maxLines = if (state.animationsEnabled) 1 else 2,
@@ -11694,10 +11542,9 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                                         Modifier
                                     }
                                 )
-                                Spacer(modifier = Modifier.height(LevyraPlayerDesign.SpaceXs))
                                 Row(
                                     modifier = Modifier
-                                        .heightIn(min = LevyraPlayerDesign.MinimumTouchTarget)
+                                        .heightIn(min = 34.dp)
                                         .clip(LevyraPlayerDesign.ShapePill)
                                         .clickable(
                                             onClickLabel = strings.openArtist,
@@ -14251,48 +14098,76 @@ private fun GreetingBar(userName: String, isResolving: Boolean, onSettings: () -
             modifier = Modifier.weight(1f),
             verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
-            Surface(
-                color = if (LevyraIsLight) Color.White.copy(alpha = 0.90f) else Color(0xFF0E1015),
-                border = BorderStroke(1.dp, LevyraAdaptiveSoftHairline),
-                shape = RoundedCornerShape(999.dp)
-            ) {
-                Row(
-                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .size(24.dp)
-                            .background(
-                                Brush.linearGradient(
-                                    listOf(
-                                        LevyraCyan.copy(alpha = 0.92f),
-                                        LevyraViolet.copy(alpha = 0.84f)
-                                    )
-                                ),
-                                CircleShape
+            val greetingShape = RoundedCornerShape(999.dp)
+            Row(
+                modifier = Modifier
+                    .clip(greetingShape)
+                    .background(
+                        if (LevyraIsLight) Color.White.copy(alpha = 0.90f) else Color(0xFF12141C)
+                    )
+                    .background(
+                        Brush.horizontalGradient(
+                            listOf(
+                                LevyraCyan.copy(alpha = if (LevyraIsLight) 0.10f else 0.16f),
+                                Color.Transparent
                             )
-                            .border(Dp.Hairline, Color.White.copy(alpha = 0.16f), CircleShape),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(
-                            imageVector = Icons.Rounded.Headphones,
-                            contentDescription = null,
-                            tint = Color.White,
-                            modifier = Modifier.size(13.dp)
                         )
-                    }
-                    Text(
-                        text = greeting,
-                        color = LevyraMuted,
-                        fontSize = 12.5.sp,
-                        lineHeight = 15.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
+                    )
+                    .border(
+                        BorderStroke(
+                            1.dp,
+                            Brush.horizontalGradient(
+                                listOf(
+                                    LevyraCyan.copy(alpha = if (LevyraIsLight) 0.34f else 0.42f),
+                                    Color.White.copy(alpha = if (LevyraIsLight) 0.06f else 0.08f)
+                                )
+                            )
+                        ),
+                        greetingShape
+                    )
+                    .padding(start = 5.dp, end = 14.dp, top = 5.dp, bottom = 5.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(9.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(28.dp)
+                        .shadow(
+                            elevation = 8.dp,
+                            shape = CircleShape,
+                            clip = false,
+                            ambientColor = LevyraCyan.copy(alpha = 0.55f),
+                            spotColor = LevyraViolet.copy(alpha = 0.65f)
+                        )
+                        .background(
+                            Brush.linearGradient(
+                                listOf(
+                                    LevyraCyan.copy(alpha = 0.95f),
+                                    LevyraViolet.copy(alpha = 0.90f)
+                                )
+                            ),
+                            CircleShape
+                        )
+                        .border(1.dp, Color.White.copy(alpha = 0.22f), CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Headphones,
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(15.dp)
                     )
                 }
+                Text(
+                    text = greeting,
+                    color = if (LevyraIsLight) LevyraText.copy(alpha = 0.82f) else Color.White.copy(alpha = 0.90f),
+                    fontSize = 13.sp,
+                    lineHeight = 15.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    letterSpacing = (-0.1).sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -14302,46 +14177,58 @@ private fun GreetingBar(userName: String, isResolving: Boolean, onSettings: () -
                 LevyraWordmark(fontSize = 31.sp, dotSize = 5.dp)
             }
         }
-        Surface(
-            color = if (LevyraIsLight) Color.White.copy(alpha = 0.92f) else Color(0xFF0C0F15),
-            border = BorderStroke(1.dp, LevyraAdaptiveSoftHairline),
-            shape = RoundedCornerShape(16.dp),
-            shadowElevation = if (LevyraIsLight) 2.dp else 6.dp,
+        Box(
             modifier = Modifier
                 .size(46.dp)
-                .pressable(onClick = onSettings)
-        ) {
-            Box(contentAlignment = Alignment.Center) {
-                Box(
-                    modifier = Modifier
-                        .size(30.dp)
-                        .clip(RoundedCornerShape(11.dp))
-                        .background(
-                            Brush.linearGradient(
-                                listOf(
-                                    Color.White.copy(alpha = if (LevyraIsLight) 0.0f else 0.08f),
-                                    LevyraCyan.copy(alpha = 0.14f),
-                                    LevyraViolet.copy(alpha = 0.10f)
-                                )
+                .shadow(
+                    elevation = if (LevyraIsLight) 3.dp else 10.dp,
+                    shape = CircleShape,
+                    clip = false,
+                    ambientColor = LevyraCyan.copy(alpha = 0.30f),
+                    spotColor = Color.Black.copy(alpha = 0.60f)
+                )
+                .background(
+                    if (LevyraIsLight) Color.White.copy(alpha = 0.94f) else Color(0xFF12141C),
+                    CircleShape
+                )
+                .background(
+                    Brush.linearGradient(
+                        listOf(
+                            LevyraCyan.copy(alpha = if (LevyraIsLight) 0.10f else 0.18f),
+                            Color.Transparent,
+                            LevyraViolet.copy(alpha = if (LevyraIsLight) 0.06f else 0.12f)
+                        )
+                    ),
+                    CircleShape
+                )
+                .border(
+                    BorderStroke(
+                        1.dp,
+                        Brush.verticalGradient(
+                            listOf(
+                                Color.White.copy(alpha = if (LevyraIsLight) 0.24f else 0.20f),
+                                Color.White.copy(alpha = if (LevyraIsLight) 0.06f else 0.05f)
                             )
-                        ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    if (isResolving) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(17.dp),
-                            strokeWidth = 2.dp,
-                            color = LevyraCyan
                         )
-                    } else {
-                        Icon(
-                            imageVector = Icons.Rounded.Settings,
-                            contentDescription = strings.settings,
-                            tint = LevyraText.copy(alpha = 0.90f),
-                            modifier = Modifier.size(20.dp)
-                        )
-                    }
-                }
+                    ),
+                    CircleShape
+                )
+                .pressable(onClick = onSettings),
+            contentAlignment = Alignment.Center
+        ) {
+            if (isResolving) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(18.dp),
+                    strokeWidth = 2.dp,
+                    color = LevyraCyan
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.Rounded.Settings,
+                    contentDescription = strings.settings,
+                    tint = if (LevyraIsLight) LevyraText.copy(alpha = 0.88f) else Color.White.copy(alpha = 0.92f),
+                    modifier = Modifier.size(21.dp)
+                )
             }
         }
     }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -660,16 +660,6 @@ private fun ActiveTrackEqualizer(
     }
 }
 @Composable
-private fun SectionAccentBar(height: Dp = 22.dp, width: Dp = 4.dp) {
-    Box(
-        modifier = Modifier
-            .width(width)
-            .height(height)
-            .background(Brush.verticalGradient(listOf(LevyraCyan, LevyraViolet)), RoundedCornerShape(99.dp))
-    )
-}
-
-@Composable
 private fun HomePlayAllButton(onClick: () -> Unit, size: Dp = 36.dp) {
     Box(
         modifier = Modifier
@@ -738,64 +728,39 @@ private fun HomeSectionHeader(
 ) {
     val displayTitle = remember(title) { cleanHomeSectionTitle(title) }
     val displaySubtitle = subtitle?.trim().orEmpty()
-    Column(
+    Row(
         modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(11.dp)
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(Dp.Hairline)
-                .background(
-                    Brush.horizontalGradient(
-                        listOf(
-                            Color.Transparent,
-                            LevyraAdaptiveSoftHairline,
-                            LevyraAdaptiveHairline.copy(alpha = 0.64f),
-                            LevyraAdaptiveSoftHairline,
-                            Color.Transparent
-                        )
-                    )
-                )
-        )
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = if (displaySubtitle.isBlank()) Alignment.CenterVertically else Alignment.Top,
-            horizontalArrangement = Arrangement.spacedBy(11.dp)
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp)
         ) {
-            SectionAccentBar(
-                height = if (displaySubtitle.isBlank()) 24.dp else 34.dp,
-                width = 4.dp
+            Text(
+                text = displayTitle,
+                color = LevyraText,
+                fontSize = 22.sp,
+                lineHeight = 26.sp,
+                letterSpacing = (-0.60).sp,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
+            if (displaySubtitle.isNotBlank()) {
                 Text(
-                    text = displayTitle,
-                    color = LevyraText,
-                    fontSize = 23.sp,
-                    lineHeight = 26.sp,
-                    letterSpacing = (-0.70).sp,
-                    fontWeight = FontWeight.Black,
+                    text = displaySubtitle,
+                    color = LevyraMuted,
+                    fontSize = 12.5.sp,
+                    lineHeight = 16.sp,
+                    fontWeight = FontWeight.Medium,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
-                if (displaySubtitle.isNotBlank()) {
-                    Text(
-                        text = displaySubtitle,
-                        color = LevyraMuted,
-                        fontSize = 12.5.sp,
-                        lineHeight = 16.sp,
-                        fontWeight = FontWeight.Medium,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
             }
-            onPlayAll?.let { action ->
-                HomePlayAllButton(onClick = action, size = 34.dp)
-            }
+        }
+        onPlayAll?.let { action ->
+            HomePlayAllButton(onClick = action, size = 34.dp)
         }
     }
 }
@@ -5087,70 +5052,37 @@ private fun LevyraBackground() {
                 } else {
                     val backgroundBrush = Brush.verticalGradient(
                         colorStops = arrayOf(
-                            0f to Color(0xFF10121A),
-                            0.28f to Color(0xFF0A0C13),
-                            0.62f to Color(0xFF05060A),
+                            0f to Color(0xFF0B0C10),
+                            0.16f to Color(0xFF05060A),
+                            0.34f to Color(0xFF000000),
                             1f to Color(0xFF000000)
                         )
                     )
-                    val auroraCenter = androidx.compose.ui.geometry.Offset(width * 0.10f, -height * 0.04f)
-                    val auroraRadius = width * 1.25f
-                    val auroraBrush = Brush.radialGradient(
+                    val washCenter = androidx.compose.ui.geometry.Offset(width * 0.24f, -height * 0.10f)
+                    val washRadius = width * 1.30f
+                    val washBrush = Brush.radialGradient(
                         colors = listOf(
-                            LevyraNavigationBlue.copy(alpha = 0.26f),
-                            LevyraNavigationBlue.copy(alpha = 0.09f),
+                            LevyraNavigationBlue.copy(alpha = 0.13f),
+                            LevyraNavigationBlue.copy(alpha = 0.04f),
                             Color.Transparent
                         ),
-                        center = auroraCenter,
-                        radius = auroraRadius
+                        center = washCenter,
+                        radius = washRadius
                     )
-                    val violetCenter = androidx.compose.ui.geometry.Offset(width * 1.06f, height * 0.14f)
-                    val violetRadius = width * 0.95f
-                    val violetBrush = Brush.radialGradient(
-                        colors = listOf(
-                            LevyraHomeGlowViolet.copy(alpha = 0.20f),
-                            LevyraHomeGlowViolet.copy(alpha = 0.06f),
-                            Color.Transparent
-                        ),
-                        center = violetCenter,
-                        radius = violetRadius
-                    )
-                    val emberCenter = androidx.compose.ui.geometry.Offset(width * 0.82f, height * 0.44f)
-                    val emberRadius = width * 0.70f
-                    val emberBrush = Brush.radialGradient(
-                        colors = listOf(
-                            LevyraNavigationBlueDeep.copy(alpha = 0.10f),
-                            Color.Transparent
-                        ),
-                        center = emberCenter,
-                        radius = emberRadius
-                    )
-                    val sheenBrush = Brush.verticalGradient(
-                        colors = listOf(
-                            Color.Transparent,
-                            Color.White.copy(alpha = 0.030f),
-                            Color.Transparent
-                        ),
-                        startY = height * 0.04f,
-                        endY = height * 0.26f
-                    )
-                    val fadeTop = height * 0.40f
+                    val fadeTop = height * 0.18f
                     val bottomFadeBrush = Brush.verticalGradient(
                         colors = listOf(
                             Color.Transparent,
-                            Color.Black.copy(alpha = 0.55f),
+                            Color.Black.copy(alpha = 0.85f),
                             Color.Black
                         ),
                         startY = fadeTop,
-                        endY = height
+                        endY = height * 0.46f
                     )
                     val fadeSize = androidx.compose.ui.geometry.Size(width, height - fadeTop)
                     onDrawBehind {
                         drawRect(backgroundBrush)
-                        drawCircle(brush = auroraBrush, radius = auroraRadius, center = auroraCenter)
-                        drawCircle(brush = violetBrush, radius = violetRadius, center = violetCenter)
-                        drawCircle(brush = emberBrush, radius = emberRadius, center = emberCenter)
-                        drawRect(sheenBrush)
+                        drawCircle(brush = washBrush, radius = washRadius, center = washCenter)
                         drawRect(
                             brush = bottomFadeBrush,
                             topLeft = androidx.compose.ui.geometry.Offset(0f, fadeTop),

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -5926,8 +5926,8 @@ private fun HomeEditorialSpotlight(
                 Brush.linearGradient(
                     listOf(
                         Color(0xFF07080A),
-                        accentStart.copy(alpha = 0.34f),
-                        accentEnd.copy(alpha = 0.18f),
+                        accentStart.copy(alpha = 0.10f),
+                        accentEnd.copy(alpha = 0.06f),
                         Color(0xFF0A0B0F)
                     )
                 )
@@ -5961,8 +5961,8 @@ private fun HomeEditorialSpotlight(
                     Brush.horizontalGradient(
                         listOf(
                             Color(0xFF07080A),
-                            Color(0xFF07080A).copy(alpha = 0.96f),
-                            accentStart.copy(alpha = 0.70f),
+                            Color(0xFF07080A).copy(alpha = 0.94f),
+                            Color(0xFF07080A).copy(alpha = 0.62f),
                             Color.Transparent
                         )
                     )
@@ -5989,7 +5989,7 @@ private fun HomeEditorialSpotlight(
                 .background(
                     Brush.radialGradient(
                         listOf(
-                            accentStart.copy(alpha = 0.18f),
+                            accentStart.copy(alpha = 0.07f),
                             Color.Transparent
                         )
                     ),

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -1,8 +1,14 @@
 @file:androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 package com.luc4n3x.levyra.ui
 
+import com.luc4n3x.levyra.ui.components.PlayerControlLabels
+import com.luc4n3x.levyra.ui.components.PlayerGlassIconButton
+import com.luc4n3x.levyra.ui.components.PlayerTransportControls
 import com.luc4n3x.levyra.ui.components.PremiumSeekbar
 import com.luc4n3x.levyra.ui.components.SpringIconButton
+import com.luc4n3x.levyra.ui.components.playerGlass
+import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
+import androidx.compose.material.icons.rounded.ChevronRight
 
 
 import androidx.compose.animation.core.spring
@@ -10269,166 +10275,6 @@ private fun PlaylistDetailOverlay(viewModel: LevyraViewModel, state: LevyraUiSta
     }
 }
 
-private fun Color.playerMix(other: Color, amount: Float): Color {
-    val fraction = amount.coerceIn(0f, 1f)
-    return Color(
-        red = red + (other.red - red) * fraction,
-        green = green + (other.green - green) * fraction,
-        blue = blue + (other.blue - blue) * fraction,
-        alpha = alpha + (other.alpha - alpha) * fraction
-    )
-}
-
-private val PlayerDarkSurface = Color(0xFF0B0B10)
-private const val PlayerMinimumContrast = 4.5f
-private const val PlayerStrongContrast = 7f
-
-private data class PlayerContrastAdjustment(
-    val color: Color,
-    val amount: Float,
-    val valid: Boolean
-)
-
-private data class PlayerContrastGradient(
-    val start: Color,
-    val end: Color,
-    val content: Color
-)
-
-private fun Color.playerCompositeOver(background: Color): Color {
-    val foregroundAlpha = alpha.coerceIn(0f, 1f)
-    val backgroundAlpha = background.alpha.coerceIn(0f, 1f)
-    val outputAlpha = foregroundAlpha + backgroundAlpha * (1f - foregroundAlpha)
-    if (outputAlpha <= 0f) return Color.Transparent
-    return Color(
-        red = (red * foregroundAlpha + background.red * backgroundAlpha * (1f - foregroundAlpha)) / outputAlpha,
-        green = (green * foregroundAlpha + background.green * backgroundAlpha * (1f - foregroundAlpha)) / outputAlpha,
-        blue = (blue * foregroundAlpha + background.blue * backgroundAlpha * (1f - foregroundAlpha)) / outputAlpha,
-        alpha = outputAlpha
-    )
-}
-
-private fun playerContrastRatio(foreground: Color, background: Color): Float {
-    val opaqueBackground = background.playerCompositeOver(Color.Black).copy(alpha = 1f)
-    val opaqueForeground = foreground.playerCompositeOver(opaqueBackground).copy(alpha = 1f)
-    val foregroundLuminance = opaqueForeground.luminance()
-    val backgroundLuminance = opaqueBackground.luminance()
-    val lighter = maxOf(foregroundLuminance, backgroundLuminance)
-    val darker = minOf(foregroundLuminance, backgroundLuminance)
-    return (lighter + 0.05f) / (darker + 0.05f)
-}
-
-private fun Color.playerAdjustForegroundToward(
-    target: Color,
-    backgrounds: List<Color>,
-    minimumContrast: Float
-): PlayerContrastAdjustment {
-    val source = copy(alpha = 1f)
-    val opaqueTarget = target.copy(alpha = 1f)
-    if (backgrounds.all { playerContrastRatio(source, it) >= minimumContrast }) {
-        return PlayerContrastAdjustment(source, 0f, true)
-    }
-    if (backgrounds.any { playerContrastRatio(opaqueTarget, it) < minimumContrast }) {
-        return PlayerContrastAdjustment(opaqueTarget, 1f, false)
-    }
-    var low = 0f
-    var high = 1f
-    repeat(24) {
-        val middle = (low + high) / 2f
-        val candidate = source.playerMix(opaqueTarget, middle).copy(alpha = 1f)
-        if (backgrounds.all { playerContrastRatio(candidate, it) >= minimumContrast }) {
-            high = middle
-        } else {
-            low = middle
-        }
-    }
-    return PlayerContrastAdjustment(source.playerMix(opaqueTarget, high).copy(alpha = 1f), high, true)
-}
-
-private fun Color.playerContentColor(
-    backgrounds: List<Color>,
-    minimumContrast: Float = PlayerMinimumContrast
-): Color {
-    val white = playerAdjustForegroundToward(Color.White, backgrounds, minimumContrast)
-    val black = playerAdjustForegroundToward(Color.Black, backgrounds, minimumContrast)
-    return when {
-        white.valid && black.valid -> if (white.amount <= black.amount) white.color else black.color
-        white.valid -> white.color
-        black.valid -> black.color
-        else -> if (backgrounds.sumOf { it.luminance().toDouble() } / backgrounds.size.coerceAtLeast(1) < 0.5) Color.White else Color.Black
-    }
-}
-
-private fun Color.playerAdjustBackgroundFor(
-    content: Color,
-    minimumContrast: Float
-): PlayerContrastAdjustment {
-    val source = copy(alpha = 1f)
-    if (playerContrastRatio(content, source) >= minimumContrast) {
-        return PlayerContrastAdjustment(source, 0f, true)
-    }
-    val target = if (content.luminance() >= 0.5f) Color.Black else Color.White
-    if (playerContrastRatio(content, target) < minimumContrast) {
-        return PlayerContrastAdjustment(target, 1f, false)
-    }
-    var low = 0f
-    var high = 1f
-    repeat(24) {
-        val middle = (low + high) / 2f
-        val candidate = source.playerMix(target, middle).copy(alpha = 1f)
-        if (playerContrastRatio(content, candidate) >= minimumContrast) {
-            high = middle
-        } else {
-            low = middle
-        }
-    }
-    return PlayerContrastAdjustment(source.playerMix(target, high).copy(alpha = 1f), high, true)
-}
-
-private fun playerContrastGradient(
-    start: Color,
-    end: Color,
-    minimumContrast: Float = PlayerMinimumContrast
-): PlayerContrastGradient {
-    fun candidate(content: Color): Pair<PlayerContrastGradient, Float>? {
-        val safeStart = start.playerAdjustBackgroundFor(content, minimumContrast)
-        val safeEnd = end.playerAdjustBackgroundFor(content, minimumContrast)
-        if (!safeStart.valid || !safeEnd.valid) return null
-        return PlayerContrastGradient(safeStart.color, safeEnd.color, content) to safeStart.amount + safeEnd.amount
-    }
-    val white = candidate(Color.White)
-    val black = candidate(Color.Black)
-    return when {
-        white != null && black != null -> if (white.second <= black.second) white.first else black.first
-        white != null -> white.first
-        black != null -> black.first
-        else -> PlayerContrastGradient(Color.Black, Color.Black, Color.White)
-    }
-}
-
-private fun Color.playerMutedContentColor(
-    backgrounds: List<Color>,
-    minimumContrast: Float = PlayerMinimumContrast
-): Color {
-    val source = copy(alpha = 1f)
-    if (backgrounds.any { playerContrastRatio(source, it) < minimumContrast }) return source
-    val averageBackground = backgrounds.fold(Color.Transparent) { accumulator, color ->
-        if (accumulator == Color.Transparent) color.copy(alpha = 1f) else accumulator.playerMix(color.copy(alpha = 1f), 0.5f)
-    }
-    var low = 0f
-    var high = 1f
-    repeat(24) {
-        val middle = (low + high) / 2f
-        val candidate = source.playerMix(averageBackground, middle).copy(alpha = 1f)
-        if (backgrounds.all { playerContrastRatio(candidate, it) >= minimumContrast }) {
-            low = middle
-        } else {
-            high = middle
-        }
-    }
-    return source.playerMix(averageBackground, low).copy(alpha = 1f)
-}
-
 @Composable
 private fun PlayerImmersiveBackdrop(
     primaryTarget: Color,
@@ -10651,54 +10497,70 @@ private fun PlayerModeSwitch(
     onVideo: () -> Unit
 ) {
     val strings = LocalLevyraStrings.current
+    val selectedContent = remember(activeColor) {
+        Color.White.playerContentColor(
+            listOf(activeColor.copy(alpha = 0.42f).playerCompositeOver(PlayerDarkSurface))
+        )
+    }
     Row(
         modifier = Modifier
-            .background(Color.Black.copy(alpha = 0.24f), RoundedCornerShape(500.dp))
-            .border(BorderStroke(1.dp, Color.White.copy(alpha = 0.12f)), RoundedCornerShape(500.dp))
+            .playerGlass(
+                shape = LevyraPlayerDesign.ShapePill,
+                fill = LevyraPlayerDesign.GlassFillSunken
+            )
             .padding(3.dp),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(2.dp)
     ) {
-        val songBackground by animateColorAsState(
-            targetValue = if (!isVideoMode) activeColor.copy(alpha = 0.42f) else Color.Transparent,
-            animationSpec = tween(180),
-            label = "player-mode-song"
+        PlayerModeSwitchTab(
+            label = strings.song,
+            selected = !isVideoMode,
+            activeColor = activeColor,
+            selectedContent = selectedContent,
+            onClick = onSong
         )
-        val videoBackground by animateColorAsState(
-            targetValue = if (isVideoMode) activeColor.copy(alpha = 0.42f) else Color.Transparent,
-            animationSpec = tween(180),
-            label = "player-mode-video"
+        PlayerModeSwitchTab(
+            label = strings.video,
+            selected = isVideoMode,
+            activeColor = activeColor,
+            selectedContent = selectedContent,
+            onClick = onVideo
         )
-        val selectedContent = remember(activeColor) {
-            Color.White.playerContentColor(
-                listOf(activeColor.copy(alpha = 0.42f).playerCompositeOver(PlayerDarkSurface))
-            )
-        }
-        Box(
-            modifier = Modifier
-                .background(songBackground, RoundedCornerShape(500.dp))
-                .pressable(enabled = isVideoMode, onClick = onSong)
-                .padding(horizontal = 13.dp, vertical = 6.dp)
-        ) {
-            Text(
-                text = strings.song,
-                color = if (!isVideoMode) selectedContent else Color.White.copy(alpha = 0.72f),
-                fontSize = 12.sp,
-                fontWeight = FontWeight.Bold
-            )
-        }
-        Box(
-            modifier = Modifier
-                .background(videoBackground, RoundedCornerShape(500.dp))
-                .pressable(enabled = !isVideoMode, onClick = onVideo)
-                .padding(horizontal = 13.dp, vertical = 6.dp)
-        ) {
-            Text(
-                text = strings.video,
-                color = if (isVideoMode) selectedContent else Color.White.copy(alpha = 0.72f),
-                fontSize = 12.sp,
-                fontWeight = FontWeight.Bold
-            )
-        }
+    }
+}
+
+@Composable
+private fun PlayerModeSwitchTab(
+    label: String,
+    selected: Boolean,
+    activeColor: Color,
+    selectedContent: Color,
+    onClick: () -> Unit
+) {
+    val background by animateColorAsState(
+        targetValue = if (selected) activeColor.copy(alpha = 0.42f) else Color.Transparent,
+        animationSpec = LevyraPlayerDesign.standardTween(180),
+        label = "player-mode-tab-background"
+    )
+    val contentColor by animateColorAsState(
+        targetValue = if (selected) selectedContent else LevyraPlayerDesign.TextSecondary,
+        animationSpec = LevyraPlayerDesign.standardTween(180),
+        label = "player-mode-tab-content"
+    )
+    Box(
+        modifier = Modifier
+            .background(background, LevyraPlayerDesign.ShapePill)
+            .pressable(enabled = !selected, onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 7.dp)
+    ) {
+        Text(
+            text = label,
+            color = contentColor,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
     }
 }
 
@@ -10828,15 +10690,17 @@ private fun PlayerUtilityDock(
     onDownload: () -> Unit
 ) {
     val strings = LocalLevyraStrings.current
-    Surface(
-        color = Color.Black.copy(alpha = 0.22f),
-        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.11f)),
-        shape = RoundedCornerShape(28.dp),
-        modifier = Modifier.fillMaxWidth()
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .playerGlass(
+                shape = LevyraPlayerDesign.ShapeLg,
+                fill = LevyraPlayerDesign.GlassFillSunken
+            )
     ) {
         Row(
             modifier = Modifier.padding(
-                horizontal = 8.dp,
+                horizontal = LevyraPlayerDesign.SpaceSm,
                 vertical = if (compact) 7.dp else 8.dp
             ),
             verticalAlignment = Alignment.CenterVertically
@@ -11326,6 +11190,16 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
     val secondaryContent = remember(secondary) {
         secondary.playerContentColor(listOf(PlayerDarkSurface))
     }
+    val playerControlLabels = remember(strings) {
+        PlayerControlLabels(
+            shuffle = strings.shuffle,
+            previous = strings.previous,
+            play = strings.play,
+            pause = strings.pause,
+            next = strings.next,
+            repeat = strings.repeat
+        )
+    }
     val artworkUrl = track?.largeThumbnailUrl?.ifBlank { track.thumbnailUrl }.orEmpty()
     var mediaSeekFeedbackMs by remember(track?.id) { mutableStateOf(0L) }
     var mediaSeekFeedbackEvent by remember(track?.id) { mutableStateOf(0) }
@@ -11351,23 +11225,23 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
     }
 
     val artScale by animateFloatAsState(
-        targetValue = if (state.isPlaying) 1f else 0.972f,
-        animationSpec = tween(190, easing = FastOutSlowInEasing),
+        targetValue = if (state.isPlaying) 1f else 0.945f,
+        animationSpec = if (state.animationsEnabled) LevyraPlayerDesign.expressiveSpring() else snap(),
         label = "artwork-scale"
     )
     val artCorner by animateDpAsState(
-        targetValue = if (state.isPlaying) 26.dp else 28.dp,
-        animationSpec = tween(190, easing = FastOutSlowInEasing),
+        targetValue = if (state.isPlaying) LevyraPlayerDesign.CornerLg else LevyraPlayerDesign.CornerXl,
+        animationSpec = if (state.animationsEnabled) LevyraPlayerDesign.expressiveSpring() else snap(),
         label = "artwork-corner"
     )
     val artShadow by animateFloatAsState(
-        targetValue = if (state.isPlaying) 24f else 15f,
-        animationSpec = tween(190, easing = FastOutSlowInEasing),
+        targetValue = if (state.isPlaying) 28f else 14f,
+        animationSpec = if (state.animationsEnabled) LevyraPlayerDesign.smoothSpring() else snap(),
         label = "artwork-shadow"
     )
     val artOffset by animateDpAsState(
-        targetValue = if (state.isPlaying) 0.dp else 3.dp,
-        animationSpec = tween(190, easing = FastOutSlowInEasing),
+        targetValue = if (state.isPlaying) 0.dp else 4.dp,
+        animationSpec = if (state.animationsEnabled) LevyraPlayerDesign.expressiveSpring() else snap(),
         label = "artwork-offset"
     )
 
@@ -11381,11 +11255,11 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
             mutableStateOf(false)
         }
         val playerHorizontalPadding = when {
-            state.isVideoMode -> 8.dp
-            compactPlayer -> 18.dp
-            else -> 20.dp
+            state.isVideoMode -> LevyraPlayerDesign.SpaceSm
+            compactPlayer -> LevyraPlayerDesign.GutterCompact
+            else -> LevyraPlayerDesign.Gutter
         }
-        val playerItemSpacing = if (compactPlayer) 8.dp else 10.dp
+        val playerItemSpacing = if (compactPlayer) LevyraPlayerDesign.SpaceSm else LevyraPlayerDesign.SpaceMd
         val artworkSize = minOf(
             (maxWidth - playerHorizontalPadding * 2f).coerceAtLeast(180.dp),
             520.dp
@@ -11416,24 +11290,25 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
             verticalArrangement = Arrangement.spacedBy(playerItemSpacing)
         ) {
             item {
+                val headerButtonSize = if (compactPlayer) {
+                    LevyraPlayerDesign.HeaderButtonCompact
+                } else {
+                    LevyraPlayerDesign.HeaderButton
+                }
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(if (compactPlayer) 46.dp else 48.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                        .height(LevyraPlayerDesign.MinimumTouchTarget),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(LevyraPlayerDesign.SpaceSm)
                 ) {
-                    Box(modifier = Modifier.width(86.dp), contentAlignment = Alignment.CenterStart) {
-                        PlayerRoundIconButton(
-                            icon = Icons.Rounded.KeyboardArrowDown,
-                            contentDescription = strings.back,
-                            size = if (compactPlayer) 39.dp else 40.dp,
-                            iconSize = if (compactPlayer) 26.dp else 27.dp,
-                            tint = Color.White,
-                            background = Color.Black.copy(alpha = 0.22f),
-                            borderColor = Color.White.copy(alpha = 0.12f),
-                            onClick = { viewModel.selectTab(LevyraTab.Home) }
-                        )
-                    }
+                    PlayerGlassIconButton(
+                        icon = Icons.Rounded.KeyboardArrowDown,
+                        contentDescription = strings.back,
+                        size = headerButtonSize,
+                        iconSize = if (compactPlayer) 25.dp else 26.dp,
+                        onClick = { viewModel.selectTab(LevyraTab.Home) }
+                    )
                     Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
                         if (track != null && (track.videoUrl.isNotBlank() || track.counterpartVideoId.isNotBlank())) {
                             PlayerModeSwitch(
@@ -11443,53 +11318,44 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                                 onVideo = viewModel::toggleVideoMode
                             )
                         } else {
-                            Surface(
-                                color = Color.Black.copy(alpha = 0.20f),
-                                border = BorderStroke(1.dp, Color.White.copy(alpha = 0.10f)),
-                                shape = CircleShape
+                            Box(
+                                modifier = Modifier
+                                    .playerGlass(
+                                        shape = LevyraPlayerDesign.ShapePill,
+                                        fill = LevyraPlayerDesign.GlassFillSunken
+                                    )
+                                    .padding(horizontal = 14.dp, vertical = 7.dp)
                             ) {
                                 Text(
                                     text = strings.formatPlayingFrom(track?.source ?: "LEVYRA"),
-                                    color = Color.White.copy(alpha = 0.72f),
+                                    color = LevyraPlayerDesign.TextSecondary,
                                     fontSize = 10.sp,
                                     fontWeight = FontWeight.Black,
                                     letterSpacing = 1.1.sp,
                                     maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier.padding(horizontal = 13.dp, vertical = 7.dp)
+                                    overflow = TextOverflow.Ellipsis
                                 )
                             }
                         }
                     }
-                    Row(
-                        modifier = Modifier.width(86.dp),
-                        horizontalArrangement = Arrangement.End,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        if (state.isVideoMode) {
-                            PlayerRoundIconButton(
-                                icon = Icons.Rounded.PictureInPictureAlt,
-                                contentDescription = strings.pictureInPicture,
-                                size = if (compactPlayer) 39.dp else 40.dp,
-                                iconSize = if (compactPlayer) 20.dp else 20.dp,
-                                tint = Color.White,
-                                background = Color.Black.copy(alpha = 0.22f),
-                                borderColor = primary.copy(alpha = 0.38f),
-                                onClick = { LevyraPipBridge.enter() }
-                            )
-                            Spacer(modifier = Modifier.width(6.dp))
-                        }
-                        PlayerRoundIconButton(
-                            icon = Icons.Rounded.MoreVert,
-                            contentDescription = strings.options,
-                            size = if (compactPlayer) 39.dp else 40.dp,
-                            iconSize = if (compactPlayer) 22.dp else 23.dp,
-                            tint = Color.White,
-                            background = Color.Black.copy(alpha = 0.22f),
-                            borderColor = Color.White.copy(alpha = 0.12f),
-                            onClick = { viewModel.openAudioQualityPanel() }
+                    if (state.isVideoMode) {
+                        PlayerGlassIconButton(
+                            icon = Icons.Rounded.PictureInPictureAlt,
+                            contentDescription = strings.pictureInPicture,
+                            size = headerButtonSize,
+                            iconSize = 20.dp,
+                            borderTop = primary.copy(alpha = 0.48f),
+                            borderBottom = primary.copy(alpha = 0.14f),
+                            onClick = { LevyraPipBridge.enter() }
                         )
                     }
+                    PlayerGlassIconButton(
+                        icon = Icons.Rounded.MoreVert,
+                        contentDescription = strings.options,
+                        size = headerButtonSize,
+                        iconSize = if (compactPlayer) 21.dp else 22.dp,
+                        onClick = { viewModel.openAudioQualityPanel() }
+                    )
                 }
             }
             if (track == null) {
@@ -11746,10 +11612,25 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                     }
                 }
                 item {
+                    val isFavorite = track.id in state.favoriteIds
+                    val favoriteFill = primary.copy(alpha = 0.42f)
+                    val favoriteTint = remember(favoriteFill) {
+                        Color.White.playerContentColor(listOf(favoriteFill.playerCompositeOver(PlayerDarkSurface)))
+                    }
+                    val favoriteScale by animateFloatAsState(
+                        targetValue = if (isFavorite) 1.08f else 1f,
+                        animationSpec = LevyraPlayerDesign.expressiveSpring(),
+                        label = "player-favorite-scale"
+                    )
+                    val actionSize = if (compactPlayer) {
+                        LevyraPlayerDesign.UtilityButtonCompact
+                    } else {
+                        LevyraPlayerDesign.UtilityButton
+                    }
                     Column(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 4.dp)
+                            .padding(horizontal = LevyraPlayerDesign.SpaceXs)
                     ) {
                         Row(
                             modifier = Modifier.fillMaxWidth(),
@@ -11758,51 +11639,82 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                             Column(modifier = Modifier.weight(1f)) {
                                 Text(
                                     text = track.title,
-                                    color = Color.White,
-                                    fontSize = if (compactPlayer) 24.sp else 25.sp,
-                                    lineHeight = if (compactPlayer) 28.sp else 29.sp,
+                                    color = LevyraPlayerDesign.TextPrimary,
+                                    fontSize = if (compactPlayer) 24.sp else 26.sp,
+                                    lineHeight = if (compactPlayer) 28.sp else 30.sp,
                                     fontWeight = FontWeight.Black,
-                                    maxLines = 2,
-                                    overflow = TextOverflow.Ellipsis
-                                )
-                                Spacer(modifier = Modifier.height(if (compactPlayer) 3.dp else 4.dp))
-                                Text(
-                                    text = track.artist,
-                                    color = Color.White.copy(alpha = 0.68f),
-                                    fontSize = if (compactPlayer) 14.sp else 15.sp,
-                                    fontWeight = FontWeight.Medium,
-                                    maxLines = 1,
+                                    letterSpacing = (-0.4).sp,
+                                    maxLines = if (state.animationsEnabled) 1 else 2,
                                     overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier.clickable { viewModel.openArtist(track) }
-                                )
-                            }
-                            Spacer(modifier = Modifier.width(10.dp))
-                            Row(horizontalArrangement = Arrangement.spacedBy(7.dp)) {
-                                PlayerRoundIconButton(
-                                    icon = Icons.AutoMirrored.Rounded.PlaylistAdd,
-                                    contentDescription = strings.addToPlaylist,
-                                    size = if (compactPlayer) 44.dp else 46.dp,
-                                    iconSize = if (compactPlayer) 22.dp else 23.dp,
-                                    tint = Color.White.copy(alpha = 0.82f),
-                                    background = Color.Black.copy(alpha = 0.20f),
-                                    borderColor = Color.White.copy(alpha = 0.12f),
-                                    onClick = { playlistTarget = track }
-                                )
-                                val isFavorite = track.id in state.favoriteIds
-                                PlayerRoundIconButton(
-                                    icon = if (isFavorite) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
-                                    contentDescription = strings.favoritesPlain,
-                                    size = if (compactPlayer) 44.dp else 46.dp,
-                                    iconSize = if (compactPlayer) 23.dp else 24.dp,
-                                    tint = if (isFavorite) {
-                                        Color.White.playerContentColor(
-                                            listOf(primary.copy(alpha = 0.46f).playerCompositeOver(PlayerDarkSurface))
+                                    modifier = if (state.animationsEnabled) {
+                                        Modifier.basicMarquee(
+                                            iterations = Int.MAX_VALUE,
+                                            repeatDelayMillis = 2_600
                                         )
                                     } else {
-                                        Color.White.copy(alpha = 0.78f)
+                                        Modifier
+                                    }
+                                )
+                                Spacer(modifier = Modifier.height(LevyraPlayerDesign.SpaceXs))
+                                Row(
+                                    modifier = Modifier
+                                        .clip(LevyraPlayerDesign.ShapePill)
+                                        .clickable(
+                                            onClickLabel = strings.openArtist,
+                                            onClick = { viewModel.openArtist(track) }
+                                        )
+                                        .padding(end = LevyraPlayerDesign.SpaceXs),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(LevyraPlayerDesign.SpaceXxs)
+                                ) {
+                                    Text(
+                                        text = track.artist,
+                                        color = LevyraPlayerDesign.TextSecondary,
+                                        fontSize = if (compactPlayer) 14.sp else 15.sp,
+                                        fontWeight = FontWeight.SemiBold,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        modifier = Modifier.weight(1f, fill = false)
+                                    )
+                                    Icon(
+                                        imageVector = Icons.Rounded.ChevronRight,
+                                        contentDescription = null,
+                                        tint = LevyraPlayerDesign.TextTertiary,
+                                        modifier = Modifier.size(16.dp)
+                                    )
+                                }
+                            }
+                            Spacer(modifier = Modifier.width(LevyraPlayerDesign.SpaceSm))
+                            Row(horizontalArrangement = Arrangement.spacedBy(LevyraPlayerDesign.SpaceXs)) {
+                                PlayerGlassIconButton(
+                                    icon = Icons.AutoMirrored.Rounded.PlaylistAdd,
+                                    contentDescription = strings.addToPlaylist,
+                                    size = actionSize,
+                                    iconSize = if (compactPlayer) 22.dp else 23.dp,
+                                    tint = LevyraPlayerDesign.TextSecondary,
+                                    onClick = { playlistTarget = track }
+                                )
+                                PlayerGlassIconButton(
+                                    icon = if (isFavorite) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
+                                    contentDescription = strings.favoritesPlain,
+                                    size = actionSize,
+                                    iconSize = if (compactPlayer) 23.dp else 24.dp,
+                                    tint = if (isFavorite) favoriteTint else LevyraPlayerDesign.TextSecondary,
+                                    fill = if (isFavorite) favoriteFill else LevyraPlayerDesign.GlassFill,
+                                    borderTop = if (isFavorite) {
+                                        primary.playerMix(Color.White, 0.3f).copy(alpha = 0.7f)
+                                    } else {
+                                        LevyraPlayerDesign.GlassBorderTop
                                     },
-                                    background = if (isFavorite) primary.copy(alpha = 0.46f) else Color.Black.copy(alpha = 0.20f),
-                                    borderColor = if (isFavorite) primary.playerMix(Color.White, 0.25f).copy(alpha = 0.62f) else Color.White.copy(alpha = 0.12f),
+                                    borderBottom = if (isFavorite) {
+                                        primary.copy(alpha = 0.2f)
+                                    } else {
+                                        LevyraPlayerDesign.GlassBorderBottom
+                                    },
+                                    modifier = Modifier.graphicsLayer {
+                                        scaleX = favoriteScale
+                                        scaleY = favoriteScale
+                                    },
                                     onClick = { viewModel.toggleFavorite(track) }
                                 )
                             }
@@ -11820,29 +11732,33 @@ private fun PlayerScreen(viewModel: PlayerViewModel, state: LevyraUiState) {
                 item {
                     PlayerTimeline(
                         positionMs = state.positionMs,
+                        bufferedPositionMs = state.bufferedPositionMs,
                         durationMs = state.durationMs,
                         activeColor = primary,
                         secondaryColor = secondary,
+                        isPlaying = state.isPlaying,
+                        animationsEnabled = state.animationsEnabled,
                         compact = compactPlayer,
                         onSeek = viewModel::seekTo
                     )
                 }
                 item {
-                    MainPlayerControls(
+                    PlayerTransportControls(
                         isPlaying = state.isPlaying,
                         isResolving = state.isResolving,
                         shuffleOn = state.shuffleEnabled,
-                        repeatMode = state.repeatMode,
-                        activeColor = primary,
-                        secondaryColor = secondary,
-                        activeContentColor = primaryContent,
-                        secondaryContentColor = secondaryContent,
+                        repeatOn = state.repeatMode != com.luc4n3x.levyra.domain.RepeatMode.Off,
+                        repeatOne = state.repeatMode == com.luc4n3x.levyra.domain.RepeatMode.One,
+                        accent = primary,
+                        accentSecondary = secondary,
                         compact = compactPlayer,
+                        labels = playerControlLabels,
                         onShuffle = viewModel::toggleShuffle,
                         onPrevious = viewModel::previous,
                         onToggle = viewModel::togglePlay,
                         onNext = viewModel::next,
-                        onRepeat = viewModel::toggleRepeat
+                        onRepeat = viewModel::toggleRepeat,
+                        modifier = Modifier.padding(vertical = LevyraPlayerDesign.SpaceXs)
                     )
                 }
                 item {
@@ -12518,216 +12434,55 @@ private fun YoutubeCommentAvatar(
 @Composable
 private fun PlayerTimeline(
     positionMs: Long,
+    bufferedPositionMs: Long,
     durationMs: Long,
     activeColor: Color,
     secondaryColor: Color,
+    isPlaying: Boolean,
+    animationsEnabled: Boolean,
     compact: Boolean,
     onSeek: (Float) -> Unit
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(
-                top = if (compact) 0.dp else 1.dp,
-                bottom = if (compact) 2.dp else 3.dp
-            )
-    ) {
+    Column(modifier = Modifier.fillMaxWidth()) {
         PremiumSeekbar(
             positionMs = positionMs,
             durationMs = durationMs,
+            bufferedPositionMs = bufferedPositionMs,
             onSeekTo = { seekMs ->
                 if (durationMs > 0L) {
                     onSeek((seekMs.toFloat() / durationMs.toFloat()).coerceIn(0f, 1f))
                 }
             },
             activeColor = activeColor,
-            inactiveColor = secondaryColor.copy(alpha = 0.35f)
+            trailingColor = secondaryColor,
+            inactiveColor = Color.White.copy(alpha = 0.16f),
+            isPlaying = isPlaying,
+            animated = animationsEnabled
         )
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 3.dp),
-            horizontalArrangement = Arrangement.SpaceBetween
+                .padding(horizontal = LevyraPlayerDesign.SpaceXs),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
                 text = formatDuration(positionMs),
-                color = Color.White.copy(alpha = 0.68f),
-                fontSize = if (compact) 10.5.sp else 11.sp,
-                fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
-                fontWeight = FontWeight.SemiBold
+                color = LevyraPlayerDesign.TextSecondary,
+                fontSize = if (compact) 11.sp else 11.5.sp,
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = 0.2.sp
             )
             Text(
                 text = formatDuration(durationMs),
-                color = Color.White.copy(alpha = 0.50f),
-                fontSize = if (compact) 10.5.sp else 11.sp,
-                fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
-                fontWeight = FontWeight.Medium
+                color = LevyraPlayerDesign.TextTertiary,
+                fontSize = if (compact) 11.sp else 11.5.sp,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 0.2.sp
             )
         }
     }
 }
-
-
-@Composable
-private fun MainPlayerControls(
-    isPlaying: Boolean,
-    isResolving: Boolean,
-    shuffleOn: Boolean,
-    repeatMode: com.luc4n3x.levyra.domain.RepeatMode,
-    activeColor: Color,
-    secondaryColor: Color,
-    activeContentColor: Color,
-    secondaryContentColor: Color,
-    compact: Boolean,
-    onShuffle: () -> Unit,
-    onPrevious: () -> Unit,
-    onToggle: () -> Unit,
-    onNext: () -> Unit,
-    onRepeat: () -> Unit
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(
-                horizontal = 2.dp,
-                vertical = if (compact) 3.dp else 4.dp
-            ),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        SpringIconButton(onClick = onShuffle, contentDescription = LocalLevyraStrings.current.shuffle) {
-            PlayerRoundIconButton(
-                icon = Icons.Rounded.Shuffle,
-                contentDescription = null,
-                size = if (compact) 38.dp else 40.dp,
-                iconSize = if (compact) 21.dp else 22.dp,
-                tint = if (shuffleOn) activeContentColor else Color.White.copy(alpha = 0.58f),
-                background = Color.Transparent,
-                borderColor = Color.Transparent,
-                onClick = {}
-            )
-        }
-        PlayerTransportButton(
-            icon = Icons.Rounded.SkipPrevious,
-            contentDescription = LocalLevyraStrings.current.previous,
-            compact = compact,
-            onClick = onPrevious
-        )
-        val playShape = RoundedCornerShape(30.dp)
-        val playGradient = remember(activeColor, secondaryColor) {
-            playerContrastGradient(
-                start = activeColor.playerMix(Color.White, 0.16f),
-                end = secondaryColor.playerMix(Color.White, 0.08f),
-                minimumContrast = PlayerMinimumContrast
-            )
-        }
-        val playToggleDescription = if (isPlaying) LocalLevyraStrings.current.pause else LocalLevyraStrings.current.play
-        SpringIconButton(onClick = onToggle, pressedScale = 0.90f, contentDescription = playToggleDescription) {
-            Box(
-                modifier = Modifier
-                    .size(
-                        width = if (compact) 78.dp else 82.dp,
-                        height = if (compact) 64.dp else 66.dp
-                    )
-                    .shadow(
-                        elevation = if (compact) 16.dp else 18.dp,
-                        shape = playShape,
-                        clip = false,
-                        ambientColor = activeColor.copy(alpha = 0.46f),
-                        spotColor = secondaryColor.copy(alpha = 0.52f)
-                    )
-                    .background(
-                        Brush.linearGradient(
-                            listOf(playGradient.start, playGradient.end)
-                        ),
-                        playShape
-                    )
-                    .border(BorderStroke(1.dp, Color.White.copy(alpha = 0.22f)), playShape),
-                contentAlignment = Alignment.Center
-            ) {
-                if (isResolving) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(if (compact) 28.dp else 29.dp),
-                        strokeWidth = 3.2.dp,
-                        color = playGradient.content
-                    )
-                } else {
-                    AnimatedContent(
-                        targetState = isPlaying,
-                        transitionSpec = {
-                            fadeIn(tween(120, easing = FastOutSlowInEasing)) togetherWith
-                                fadeOut(tween(90, easing = FastOutSlowInEasing))
-                        },
-                        label = "play-icon"
-                    ) { playing ->
-                        Box(
-                            modifier = Modifier.size(if (compact) 39.dp else 41.dp),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                imageVector = if (playing) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
-                                contentDescription = null,
-                                tint = playGradient.content,
-                                modifier = Modifier
-                                    .size(if (compact) 35.dp else 36.dp)
-                                    .offset(x = if (playing) 0.dp else 1.dp)
-                            )
-                        }
-                    }
-                }
-            }
-        }
-        PlayerTransportButton(
-            icon = Icons.Rounded.SkipNext,
-            contentDescription = LocalLevyraStrings.current.next,
-            compact = compact,
-            onClick = onNext
-        )
-        val repeatIcon = if (repeatMode == com.luc4n3x.levyra.domain.RepeatMode.One) Icons.Rounded.RepeatOne else Icons.Rounded.Repeat
-        SpringIconButton(onClick = onRepeat, contentDescription = LocalLevyraStrings.current.repeat) {
-            PlayerRoundIconButton(
-                icon = repeatIcon,
-                contentDescription = null,
-                size = if (compact) 38.dp else 40.dp,
-                iconSize = if (compact) 21.dp else 22.dp,
-                tint = if (repeatMode != com.luc4n3x.levyra.domain.RepeatMode.Off) secondaryContentColor else Color.White.copy(alpha = 0.58f),
-                background = Color.Transparent,
-                borderColor = Color.Transparent,
-                onClick = {}
-            )
-        }
-    }
-}
-
-@Composable
-private fun PlayerTransportButton(
-    icon: ImageVector,
-    contentDescription: String,
-    compact: Boolean,
-    onClick: () -> Unit
-) {
-    SpringIconButton(onClick = onClick, pressedScale = 0.88f, contentDescription = contentDescription) {
-        Box(
-            modifier = Modifier
-                .size(
-                    width = if (compact) 54.dp else 56.dp,
-                    height = if (compact) 52.dp else 54.dp
-                )
-                .background(Color.White.copy(alpha = 0.11f), RoundedCornerShape(20.dp))
-                .border(BorderStroke(1.dp, Color.White.copy(alpha = 0.12f)), RoundedCornerShape(20.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                tint = Color.White,
-                modifier = Modifier.size(if (compact) 30.dp else 31.dp)
-            )
-        }
-    }
-}
-
-
 
 @Composable
 private fun PlayerOptionsRow(
@@ -12807,8 +12562,8 @@ private fun OptionChip(
 
     Surface(
         color = background,
-        border = BorderStroke(1.dp, borderColor),
-        shape = RoundedCornerShape(18.dp),
+        border = BorderStroke(LevyraPlayerDesign.Hairline, borderColor),
+        shape = LevyraPlayerDesign.ShapeSm,
         modifier = modifier
             .height(if (compact) 40.dp else 42.dp)
             .graphicsLayer { this.alpha = alpha }
@@ -16124,7 +15879,10 @@ private fun MiniPlayer(
         animationSpec = tween(420, easing = LinearOutSlowInEasing),
         label = "mini-progress"
     )
-    val containerShape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
+    val containerShape = RoundedCornerShape(
+        topStart = LevyraPlayerDesign.CornerLg,
+        topEnd = LevyraPlayerDesign.CornerLg
+    )
     Surface(
         color = Color.Transparent,
         shape = containerShape,
@@ -16162,15 +15920,18 @@ private fun MiniPlayer(
                 Box(
                     modifier = Modifier
                         .size(48.dp)
-                        .shadow(8.dp, RoundedCornerShape(15.dp), clip = false)
-                        .clip(RoundedCornerShape(15.dp))
+                        .shadow(8.dp, LevyraPlayerDesign.ShapeSm, clip = false)
+                        .clip(LevyraPlayerDesign.ShapeSm)
                         .pressable(onClick = onOpen)
                 ) {
                     CoverImage(track, Modifier.fillMaxSize())
                     Box(
                         modifier = Modifier
                             .matchParentSize()
-                            .border(BorderStroke(1.dp, Color.White.copy(alpha = 0.16f)), RoundedCornerShape(15.dp))
+                            .border(
+                                BorderStroke(LevyraPlayerDesign.Hairline, Color.White.copy(alpha = 0.16f)),
+                                LevyraPlayerDesign.ShapeSm
+                            )
                     )
                 }
                 Column(
@@ -16262,10 +16023,15 @@ private fun MiniPlayerToggleButton(
 ) {
     val playBg = buttonColor.copy(alpha = 1f)
     val playTint = Color.White.playerContentColor(listOf(playBg))
+    val corner by animateDpAsState(
+        targetValue = if (isPlaying) 14.dp else 20.dp,
+        animationSpec = LevyraPlayerDesign.expressiveSpring(),
+        label = "mini-play-corner"
+    )
     Box(
         modifier = Modifier
             .size(40.dp)
-            .background(playBg, CircleShape)
+            .background(playBg, RoundedCornerShape(corner))
             .pressable(onClick = onToggle),
         contentAlignment = Alignment.Center
     ) {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -14087,6 +14087,19 @@ private fun GreetingBar(userName: String, isResolving: Boolean, onSettings: () -
     val greeting = remember(userName, strings, greetingHour) {
         strings.formatGreeting(userName, greetingHour)
     }
+    val isLight = LevyraIsLight
+    val chipBackground = if (isLight) Color.White.copy(alpha = 0.90f) else Color(0xFF12141C)
+    val chipWash = LevyraCyan.copy(alpha = if (isLight) 0.10f else 0.16f)
+    val chipBorderStart = LevyraCyan.copy(alpha = if (isLight) 0.34f else 0.42f)
+    val chipBorderEnd = Color.White.copy(alpha = if (isLight) 0.06f else 0.08f)
+    val greetingTextColor = if (isLight) LevyraText.copy(alpha = 0.82f) else Color.White.copy(alpha = 0.90f)
+    val settingsBackground = if (isLight) Color.White.copy(alpha = 0.94f) else Color(0xFF12141C)
+    val settingsWashTop = LevyraCyan.copy(alpha = if (isLight) 0.10f else 0.18f)
+    val settingsWashBottom = LevyraViolet.copy(alpha = if (isLight) 0.06f else 0.12f)
+    val settingsBorderTop = Color.White.copy(alpha = if (isLight) 0.24f else 0.20f)
+    val settingsBorderBottom = Color.White.copy(alpha = if (isLight) 0.06f else 0.05f)
+    val settingsIconTint = if (isLight) LevyraText.copy(alpha = 0.88f) else Color.White.copy(alpha = 0.92f)
+    val settingsElevation = if (isLight) 3.dp else 10.dp
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -14102,27 +14115,10 @@ private fun GreetingBar(userName: String, isResolving: Boolean, onSettings: () -
             Row(
                 modifier = Modifier
                     .clip(greetingShape)
-                    .background(
-                        if (LevyraIsLight) Color.White.copy(alpha = 0.90f) else Color(0xFF12141C)
-                    )
-                    .background(
-                        Brush.horizontalGradient(
-                            listOf(
-                                LevyraCyan.copy(alpha = if (LevyraIsLight) 0.10f else 0.16f),
-                                Color.Transparent
-                            )
-                        )
-                    )
+                    .background(chipBackground)
+                    .background(Brush.horizontalGradient(listOf(chipWash, Color.Transparent)))
                     .border(
-                        BorderStroke(
-                            1.dp,
-                            Brush.horizontalGradient(
-                                listOf(
-                                    LevyraCyan.copy(alpha = if (LevyraIsLight) 0.34f else 0.42f),
-                                    Color.White.copy(alpha = if (LevyraIsLight) 0.06f else 0.08f)
-                                )
-                            )
-                        ),
+                        BorderStroke(1.dp, Brush.horizontalGradient(listOf(chipBorderStart, chipBorderEnd))),
                         greetingShape
                     )
                     .padding(start = 5.dp, end = 14.dp, top = 5.dp, bottom = 5.dp),
@@ -14160,7 +14156,7 @@ private fun GreetingBar(userName: String, isResolving: Boolean, onSettings: () -
                 }
                 Text(
                     text = greeting,
-                    color = if (LevyraIsLight) LevyraText.copy(alpha = 0.82f) else Color.White.copy(alpha = 0.90f),
+                    color = greetingTextColor,
                     fontSize = 13.sp,
                     lineHeight = 15.sp,
                     fontWeight = FontWeight.SemiBold,
@@ -14181,36 +14177,19 @@ private fun GreetingBar(userName: String, isResolving: Boolean, onSettings: () -
             modifier = Modifier
                 .size(46.dp)
                 .shadow(
-                    elevation = if (LevyraIsLight) 3.dp else 10.dp,
+                    elevation = settingsElevation,
                     shape = CircleShape,
                     clip = false,
                     ambientColor = LevyraCyan.copy(alpha = 0.30f),
                     spotColor = Color.Black.copy(alpha = 0.60f)
                 )
+                .background(settingsBackground, CircleShape)
                 .background(
-                    if (LevyraIsLight) Color.White.copy(alpha = 0.94f) else Color(0xFF12141C),
-                    CircleShape
-                )
-                .background(
-                    Brush.linearGradient(
-                        listOf(
-                            LevyraCyan.copy(alpha = if (LevyraIsLight) 0.10f else 0.18f),
-                            Color.Transparent,
-                            LevyraViolet.copy(alpha = if (LevyraIsLight) 0.06f else 0.12f)
-                        )
-                    ),
+                    Brush.linearGradient(listOf(settingsWashTop, Color.Transparent, settingsWashBottom)),
                     CircleShape
                 )
                 .border(
-                    BorderStroke(
-                        1.dp,
-                        Brush.verticalGradient(
-                            listOf(
-                                Color.White.copy(alpha = if (LevyraIsLight) 0.24f else 0.20f),
-                                Color.White.copy(alpha = if (LevyraIsLight) 0.06f else 0.05f)
-                            )
-                        )
-                    ),
+                    BorderStroke(1.dp, Brush.verticalGradient(listOf(settingsBorderTop, settingsBorderBottom))),
                     CircleShape
                 )
                 .pressable(onClick = onSettings),
@@ -14226,7 +14205,7 @@ private fun GreetingBar(userName: String, isResolving: Boolean, onSettings: () -
                 Icon(
                     imageVector = Icons.Rounded.Settings,
                     contentDescription = strings.settings,
-                    tint = if (LevyraIsLight) LevyraText.copy(alpha = 0.88f) else Color.White.copy(alpha = 0.92f),
+                    tint = settingsIconTint,
                     modifier = Modifier.size(21.dp)
                 )
             }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerColorContrast.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerColorContrast.kt
@@ -1,0 +1,164 @@
+package com.luc4n3x.levyra.ui
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+
+internal val PlayerDarkSurface = Color(0xFF0B0B10)
+internal const val PlayerMinimumContrast = 4.5f
+internal const val PlayerStrongContrast = 7f
+
+internal data class PlayerContrastAdjustment(
+    val color: Color,
+    val amount: Float,
+    val valid: Boolean
+)
+
+internal data class PlayerContrastGradient(
+    val start: Color,
+    val end: Color,
+    val content: Color
+)
+
+internal fun Color.playerMix(other: Color, amount: Float): Color {
+    val fraction = amount.coerceIn(0f, 1f)
+    return Color(
+        red = red + (other.red - red) * fraction,
+        green = green + (other.green - green) * fraction,
+        blue = blue + (other.blue - blue) * fraction,
+        alpha = alpha + (other.alpha - alpha) * fraction
+    )
+}
+
+internal fun Color.playerCompositeOver(background: Color): Color {
+    val foregroundAlpha = alpha.coerceIn(0f, 1f)
+    val backgroundAlpha = background.alpha.coerceIn(0f, 1f)
+    val outputAlpha = foregroundAlpha + backgroundAlpha * (1f - foregroundAlpha)
+    if (outputAlpha <= 0f) return Color.Transparent
+    return Color(
+        red = (red * foregroundAlpha + background.red * backgroundAlpha * (1f - foregroundAlpha)) / outputAlpha,
+        green = (green * foregroundAlpha + background.green * backgroundAlpha * (1f - foregroundAlpha)) / outputAlpha,
+        blue = (blue * foregroundAlpha + background.blue * backgroundAlpha * (1f - foregroundAlpha)) / outputAlpha,
+        alpha = outputAlpha
+    )
+}
+
+internal fun playerContrastRatio(foreground: Color, background: Color): Float {
+    val opaqueBackground = background.playerCompositeOver(Color.Black).copy(alpha = 1f)
+    val opaqueForeground = foreground.playerCompositeOver(opaqueBackground).copy(alpha = 1f)
+    val foregroundLuminance = opaqueForeground.luminance()
+    val backgroundLuminance = opaqueBackground.luminance()
+    val lighter = maxOf(foregroundLuminance, backgroundLuminance)
+    val darker = minOf(foregroundLuminance, backgroundLuminance)
+    return (lighter + 0.05f) / (darker + 0.05f)
+}
+
+internal fun Color.playerAdjustForegroundToward(
+    target: Color,
+    backgrounds: List<Color>,
+    minimumContrast: Float
+): PlayerContrastAdjustment {
+    val source = copy(alpha = 1f)
+    val opaqueTarget = target.copy(alpha = 1f)
+    if (backgrounds.all { playerContrastRatio(source, it) >= minimumContrast }) {
+        return PlayerContrastAdjustment(source, 0f, true)
+    }
+    if (backgrounds.any { playerContrastRatio(opaqueTarget, it) < minimumContrast }) {
+        return PlayerContrastAdjustment(opaqueTarget, 1f, false)
+    }
+    var low = 0f
+    var high = 1f
+    repeat(24) {
+        val middle = (low + high) / 2f
+        val candidate = source.playerMix(opaqueTarget, middle).copy(alpha = 1f)
+        if (backgrounds.all { playerContrastRatio(candidate, it) >= minimumContrast }) {
+            high = middle
+        } else {
+            low = middle
+        }
+    }
+    return PlayerContrastAdjustment(source.playerMix(opaqueTarget, high).copy(alpha = 1f), high, true)
+}
+
+internal fun Color.playerContentColor(
+    backgrounds: List<Color>,
+    minimumContrast: Float = PlayerMinimumContrast
+): Color {
+    val white = playerAdjustForegroundToward(Color.White, backgrounds, minimumContrast)
+    val black = playerAdjustForegroundToward(Color.Black, backgrounds, minimumContrast)
+    return when {
+        white.valid && black.valid -> if (white.amount <= black.amount) white.color else black.color
+        white.valid -> white.color
+        black.valid -> black.color
+        else -> if (backgrounds.sumOf { it.luminance().toDouble() } / backgrounds.size.coerceAtLeast(1) < 0.5) Color.White else Color.Black
+    }
+}
+
+internal fun Color.playerAdjustBackgroundFor(
+    content: Color,
+    minimumContrast: Float
+): PlayerContrastAdjustment {
+    val source = copy(alpha = 1f)
+    if (playerContrastRatio(content, source) >= minimumContrast) {
+        return PlayerContrastAdjustment(source, 0f, true)
+    }
+    val target = if (content.luminance() >= 0.5f) Color.Black else Color.White
+    if (playerContrastRatio(content, target) < minimumContrast) {
+        return PlayerContrastAdjustment(target, 1f, false)
+    }
+    var low = 0f
+    var high = 1f
+    repeat(24) {
+        val middle = (low + high) / 2f
+        val candidate = source.playerMix(target, middle).copy(alpha = 1f)
+        if (playerContrastRatio(content, candidate) >= minimumContrast) {
+            high = middle
+        } else {
+            low = middle
+        }
+    }
+    return PlayerContrastAdjustment(source.playerMix(target, high).copy(alpha = 1f), high, true)
+}
+
+internal fun playerContrastGradient(
+    start: Color,
+    end: Color,
+    minimumContrast: Float = PlayerMinimumContrast
+): PlayerContrastGradient {
+    fun candidate(content: Color): Pair<PlayerContrastGradient, Float>? {
+        val safeStart = start.playerAdjustBackgroundFor(content, minimumContrast)
+        val safeEnd = end.playerAdjustBackgroundFor(content, minimumContrast)
+        if (!safeStart.valid || !safeEnd.valid) return null
+        return PlayerContrastGradient(safeStart.color, safeEnd.color, content) to safeStart.amount + safeEnd.amount
+    }
+    val white = candidate(Color.White)
+    val black = candidate(Color.Black)
+    return when {
+        white != null && black != null -> if (white.second <= black.second) white.first else black.first
+        white != null -> white.first
+        black != null -> black.first
+        else -> PlayerContrastGradient(Color.Black, Color.Black, Color.White)
+    }
+}
+
+internal fun Color.playerMutedContentColor(
+    backgrounds: List<Color>,
+    minimumContrast: Float = PlayerMinimumContrast
+): Color {
+    val source = copy(alpha = 1f)
+    if (backgrounds.any { playerContrastRatio(source, it) < minimumContrast }) return source
+    val averageBackground = backgrounds.fold(Color.Transparent) { accumulator, color ->
+        if (accumulator == Color.Transparent) color.copy(alpha = 1f) else accumulator.playerMix(color.copy(alpha = 1f), 0.5f)
+    }
+    var low = 0f
+    var high = 1f
+    repeat(24) {
+        val middle = (low + high) / 2f
+        val candidate = source.playerMix(averageBackground, middle).copy(alpha = 1f)
+        if (backgrounds.all { playerContrastRatio(candidate, it) >= minimumContrast }) {
+            low = middle
+        } else {
+            high = middle
+        }
+    }
+    return source.playerMix(averageBackground, low).copy(alpha = 1f)
+}

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
@@ -149,7 +149,8 @@ fun PlayerTransportControls(
 ) {
     val utilitySize = if (compact) LevyraPlayerDesign.UtilityButtonCompact else LevyraPlayerDesign.UtilityButton
     val transportSize = if (compact) LevyraPlayerDesign.TransportButtonCompact else LevyraPlayerDesign.TransportButton
-    val primarySize = if (compact) LevyraPlayerDesign.PrimaryButtonCompact else LevyraPlayerDesign.PrimaryButton
+    val primaryWidth = if (compact) LevyraPlayerDesign.PrimaryWidthCompact else LevyraPlayerDesign.PrimaryWidth
+    val primaryHeight = if (compact) LevyraPlayerDesign.PrimaryHeightCompact else LevyraPlayerDesign.PrimaryHeight
 
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -170,8 +171,7 @@ fun PlayerTransportControls(
             icon = Icons.Rounded.SkipPrevious,
             contentDescription = labels.previous,
             size = transportSize,
-            iconSize = if (compact) 28.dp else 30.dp,
-            shape = LevyraPlayerDesign.ShapeMd,
+            iconSize = if (compact) 27.dp else 29.dp,
             onClick = onPrevious
         )
         PlayerPrimaryButton(
@@ -179,8 +179,8 @@ fun PlayerTransportControls(
             isResolving = isResolving,
             accent = accent,
             accentSecondary = accentSecondary,
-            size = primarySize,
-            animated = animated,
+            width = primaryWidth,
+            height = primaryHeight,
             playLabel = labels.play,
             pauseLabel = labels.pause,
             onClick = onToggle
@@ -189,8 +189,7 @@ fun PlayerTransportControls(
             icon = Icons.Rounded.SkipNext,
             contentDescription = labels.next,
             size = transportSize,
-            iconSize = if (compact) 28.dp else 30.dp,
-            shape = LevyraPlayerDesign.ShapeMd,
+            iconSize = if (compact) 27.dp else 29.dp,
             onClick = onNext
         )
         PlayerModeToggleButton(
@@ -306,7 +305,7 @@ private fun Modifier.playerPrimarySurface(
     )
 
 @Composable
-private fun PlayerPrimaryIcon(isPlaying: Boolean, size: Dp, tint: Color) {
+private fun PlayerPrimaryIcon(isPlaying: Boolean, iconSize: Dp, tint: Color) {
     AnimatedContent(
         targetState = isPlaying,
         transitionSpec = { playerPrimaryIconTransition() },
@@ -317,8 +316,8 @@ private fun PlayerPrimaryIcon(isPlaying: Boolean, size: Dp, tint: Color) {
             contentDescription = null,
             tint = tint,
             modifier = Modifier
-                .size(size * 0.46f)
-                .offset(x = if (playing) 0.dp else size * 0.02f)
+                .size(iconSize)
+                .offset(x = if (playing) 0.dp else 1.dp)
         )
     }
 }
@@ -329,8 +328,8 @@ private fun PlayerPrimaryButton(
     isResolving: Boolean,
     accent: Color,
     accentSecondary: Color,
-    size: Dp,
-    animated: Boolean,
+    width: Dp,
+    height: Dp,
     playLabel: String,
     pauseLabel: String,
     onClick: () -> Unit
@@ -342,12 +341,7 @@ private fun PlayerPrimaryButton(
             minimumContrast = PlayerMinimumContrast
         )
     }
-    val corner by animateDpAsState(
-        targetValue = if (isPlaying) size * 0.34f else size / 2f,
-        animationSpec = if (animated) LevyraPlayerDesign.expressiveSpring() else snap(),
-        label = "player-primary-corner"
-    )
-    val shape = RoundedCornerShape(corner)
+    val shape = RoundedCornerShape(LevyraPlayerDesign.PrimaryCorner)
 
     SpringIconButton(
         onClick = onClick,
@@ -356,7 +350,7 @@ private fun PlayerPrimaryButton(
     ) {
         Box(
             modifier = Modifier
-                .size(size)
+                .size(width = width, height = height)
                 .playerPrimarySurface(
                     shape = shape,
                     gradient = gradient,
@@ -367,14 +361,14 @@ private fun PlayerPrimaryButton(
         ) {
             if (isResolving) {
                 CircularProgressIndicator(
-                    modifier = Modifier.size(size * 0.36f),
+                    modifier = Modifier.size(height * 0.44f),
                     strokeWidth = 3.dp,
                     color = gradient.content
                 )
             } else {
                 PlayerPrimaryIcon(
                     isPlaying = isPlaying,
-                    size = size,
+                    iconSize = height * 0.53f,
                     tint = gradient.content
                 )
             }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
@@ -2,6 +2,10 @@ package com.luc4n3x.levyra.ui.components
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.snap
@@ -33,6 +37,7 @@ import androidx.compose.material.icons.rounded.SkipPrevious
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -42,9 +47,11 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.toggleableState
+import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.luc4n3x.levyra.ui.PlayerContrastGradient
 import com.luc4n3x.levyra.ui.PlayerDarkSurface
 import com.luc4n3x.levyra.ui.PlayerMinimumContrast
 import com.luc4n3x.levyra.ui.playerCompositeOver
@@ -52,6 +59,14 @@ import com.luc4n3x.levyra.ui.playerContentColor
 import com.luc4n3x.levyra.ui.playerContrastGradient
 import com.luc4n3x.levyra.ui.playerMix
 import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
+
+@Immutable
+data class PlayerAccentColors(
+    val primary: Color,
+    val secondary: Color,
+    val primaryTarget: Color,
+    val secondaryTarget: Color
+)
 
 data class PlayerControlLabels(
     val shuffle: String,
@@ -135,8 +150,7 @@ fun PlayerTransportControls(
     shuffleOn: Boolean,
     repeatOn: Boolean,
     repeatOne: Boolean,
-    accent: Color,
-    accentSecondary: Color,
+    accents: PlayerAccentColors,
     compact: Boolean,
     animated: Boolean,
     labels: PlayerControlLabels,
@@ -161,7 +175,8 @@ fun PlayerTransportControls(
             icon = Icons.Rounded.Shuffle,
             contentDescription = labels.shuffle,
             active = shuffleOn,
-            accent = accent,
+            accent = accents.primary,
+            accentTarget = accents.primaryTarget,
             size = utilitySize,
             iconSize = if (compact) 20.dp else 21.dp,
             animated = animated,
@@ -177,10 +192,11 @@ fun PlayerTransportControls(
         PlayerPrimaryButton(
             isPlaying = isPlaying,
             isResolving = isResolving,
-            accent = accent,
-            accentSecondary = accentSecondary,
+            accentTarget = accents.primaryTarget,
+            accentSecondaryTarget = accents.secondaryTarget,
             width = primaryWidth,
             height = primaryHeight,
+            animated = animated,
             playLabel = labels.play,
             pauseLabel = labels.pause,
             onClick = onToggle
@@ -196,7 +212,8 @@ fun PlayerTransportControls(
             icon = if (repeatOne) Icons.Rounded.RepeatOne else Icons.Rounded.Repeat,
             contentDescription = labels.repeat,
             active = repeatOn,
-            accent = accentSecondary,
+            accent = accents.secondary,
+            accentTarget = accents.secondaryTarget,
             size = utilitySize,
             iconSize = if (compact) 20.dp else 21.dp,
             animated = animated,
@@ -211,14 +228,17 @@ private fun PlayerModeToggleButton(
     contentDescription: String,
     active: Boolean,
     accent: Color,
+    accentTarget: Color,
     size: Dp,
     iconSize: Dp,
     animated: Boolean,
     onClick: () -> Unit
 ) {
     val fill = if (active) accent.copy(alpha = 0.30f) else Color.Transparent
-    val activeTint = remember(accent) {
-        accent.playerContentColor(listOf(accent.copy(alpha = 0.30f).playerCompositeOver(PlayerDarkSurface)))
+    val activeTint = remember(accentTarget) {
+        accentTarget.playerContentColor(
+            listOf(accentTarget.copy(alpha = 0.30f).playerCompositeOver(PlayerDarkSurface))
+        )
     }
     val tint = if (active) activeTint else LevyraPlayerDesign.IconIdle
     val corner by animateDpAsState(
@@ -234,10 +254,12 @@ private fun PlayerModeToggleButton(
 
     SpringIconButton(
         onClick = onClick,
-        modifier = Modifier.sizeIn(
-            minWidth = LevyraPlayerDesign.MinimumTouchTarget,
-            minHeight = LevyraPlayerDesign.MinimumTouchTarget
-        ),
+        modifier = Modifier
+            .sizeIn(
+                minWidth = LevyraPlayerDesign.MinimumTouchTarget,
+                minHeight = LevyraPlayerDesign.MinimumTouchTarget
+            )
+            .semantics { toggleableState = ToggleableState(active) },
         pressedScale = 0.86f,
         contentDescription = contentDescription
     ) {
@@ -269,18 +291,17 @@ private fun playerPrimaryIconTransition(): ContentTransform =
 
 private fun Modifier.playerPrimarySurface(
     shape: Shape,
-    gradient: PlayerContrastGradient,
-    accent: Color,
-    accentSecondary: Color
+    start: Color,
+    end: Color
 ): Modifier = this
     .shadow(
         elevation = 20.dp,
         shape = shape,
         clip = false,
-        ambientColor = accent.copy(alpha = 0.50f),
-        spotColor = accentSecondary.copy(alpha = 0.58f)
+        ambientColor = start.copy(alpha = 0.50f),
+        spotColor = end.copy(alpha = 0.58f)
     )
-    .background(Brush.linearGradient(listOf(gradient.start, gradient.end)), shape)
+    .background(Brush.linearGradient(listOf(start, end)), shape)
     .background(
         Brush.verticalGradient(
             listOf(
@@ -305,10 +326,16 @@ private fun Modifier.playerPrimarySurface(
     )
 
 @Composable
-private fun PlayerPrimaryIcon(isPlaying: Boolean, iconSize: Dp, tint: Color) {
+private fun PlayerPrimaryIcon(isPlaying: Boolean, iconSize: Dp, tint: Color, animated: Boolean) {
     AnimatedContent(
         targetState = isPlaying,
-        transitionSpec = { playerPrimaryIconTransition() },
+        transitionSpec = {
+            if (animated) {
+                playerPrimaryIconTransition()
+            } else {
+                EnterTransition.None togetherWith ExitTransition.None
+            }
+        },
         label = "player-primary-icon"
     ) { playing ->
         Icon(
@@ -326,21 +353,39 @@ private fun PlayerPrimaryIcon(isPlaying: Boolean, iconSize: Dp, tint: Color) {
 private fun PlayerPrimaryButton(
     isPlaying: Boolean,
     isResolving: Boolean,
-    accent: Color,
-    accentSecondary: Color,
+    accentTarget: Color,
+    accentSecondaryTarget: Color,
     width: Dp,
     height: Dp,
+    animated: Boolean,
     playLabel: String,
     pauseLabel: String,
     onClick: () -> Unit
 ) {
-    val gradient = remember(accent, accentSecondary) {
+    val gradient = remember(accentTarget, accentSecondaryTarget) {
         playerContrastGradient(
-            start = accent.playerMix(Color.White, 0.16f),
-            end = accentSecondary.playerMix(Color.White, 0.06f),
+            start = accentTarget.playerMix(Color.White, 0.16f),
+            end = accentSecondaryTarget.playerMix(Color.White, 0.06f),
             minimumContrast = PlayerMinimumContrast
         )
     }
+    val colorSpec: AnimationSpec<Color> =
+        if (animated) LevyraPlayerDesign.emphasizedTween(700) else snap()
+    val gradientStart by animateColorAsState(
+        targetValue = gradient.start,
+        animationSpec = colorSpec,
+        label = "player-primary-start"
+    )
+    val gradientEnd by animateColorAsState(
+        targetValue = gradient.end,
+        animationSpec = colorSpec,
+        label = "player-primary-end"
+    )
+    val gradientContent by animateColorAsState(
+        targetValue = gradient.content,
+        animationSpec = colorSpec,
+        label = "player-primary-content"
+    )
     val shape = RoundedCornerShape(LevyraPlayerDesign.PrimaryCorner)
 
     SpringIconButton(
@@ -353,9 +398,8 @@ private fun PlayerPrimaryButton(
                 .size(width = width, height = height)
                 .playerPrimarySurface(
                     shape = shape,
-                    gradient = gradient,
-                    accent = accent,
-                    accentSecondary = accentSecondary
+                    start = gradientStart,
+                    end = gradientEnd
                 ),
             contentAlignment = Alignment.Center
         ) {
@@ -363,13 +407,14 @@ private fun PlayerPrimaryButton(
                 CircularProgressIndicator(
                     modifier = Modifier.size(height * 0.44f),
                     strokeWidth = 3.dp,
-                    color = gradient.content
+                    color = gradientContent
                 )
             } else {
                 PlayerPrimaryIcon(
                     isPlaying = isPlaying,
                     iconSize = height * 0.53f,
-                    tint = gradient.content
+                    tint = gradientContent,
+                    animated = animated
                 )
             }
         }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
@@ -1,0 +1,351 @@
+package com.luc4n3x.levyra.ui.components
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.Repeat
+import androidx.compose.material.icons.rounded.RepeatOne
+import androidx.compose.material.icons.rounded.Shuffle
+import androidx.compose.material.icons.rounded.SkipNext
+import androidx.compose.material.icons.rounded.SkipPrevious
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.luc4n3x.levyra.ui.PlayerDarkSurface
+import com.luc4n3x.levyra.ui.PlayerMinimumContrast
+import com.luc4n3x.levyra.ui.playerCompositeOver
+import com.luc4n3x.levyra.ui.playerContentColor
+import com.luc4n3x.levyra.ui.playerContrastGradient
+import com.luc4n3x.levyra.ui.playerMix
+import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
+
+data class PlayerControlLabels(
+    val shuffle: String,
+    val previous: String,
+    val play: String,
+    val pause: String,
+    val next: String,
+    val repeat: String
+)
+
+fun Modifier.playerGlass(
+    shape: Shape,
+    fill: Color = LevyraPlayerDesign.GlassFill,
+    borderTop: Color = LevyraPlayerDesign.GlassBorderTop,
+    borderBottom: Color = LevyraPlayerDesign.GlassBorderBottom
+): Modifier = this
+    .background(fill, shape)
+    .background(
+        Brush.verticalGradient(
+            listOf(
+                LevyraPlayerDesign.GlassSpecular,
+                Color.Transparent,
+                Color.Black.copy(alpha = 0.06f)
+            )
+        ),
+        shape
+    )
+    .border(
+        BorderStroke(
+            LevyraPlayerDesign.Hairline,
+            Brush.verticalGradient(listOf(borderTop, borderBottom))
+        ),
+        shape
+    )
+
+@Composable
+fun PlayerGlassIconButton(
+    icon: ImageVector,
+    contentDescription: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    size: Dp = LevyraPlayerDesign.HeaderButton,
+    iconSize: Dp = 21.dp,
+    tint: Color = LevyraPlayerDesign.TextPrimary,
+    fill: Color = LevyraPlayerDesign.GlassFill,
+    borderTop: Color = LevyraPlayerDesign.GlassBorderTop,
+    borderBottom: Color = LevyraPlayerDesign.GlassBorderBottom,
+    shape: Shape = CircleShape,
+    enabled: Boolean = true
+) {
+    SpringIconButton(
+        onClick = onClick,
+        modifier = modifier.sizeIn(
+            minWidth = LevyraPlayerDesign.MinimumTouchTarget,
+            minHeight = LevyraPlayerDesign.MinimumTouchTarget
+        ),
+        enabled = enabled,
+        pressedScale = 0.88f,
+        contentDescription = contentDescription
+    ) {
+        Box(
+            modifier = Modifier
+                .size(size)
+                .playerGlass(shape = shape, fill = fill, borderTop = borderTop, borderBottom = borderBottom),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = tint,
+                modifier = Modifier.size(iconSize)
+            )
+        }
+    }
+}
+
+@Composable
+fun PlayerTransportControls(
+    isPlaying: Boolean,
+    isResolving: Boolean,
+    shuffleOn: Boolean,
+    repeatOn: Boolean,
+    repeatOne: Boolean,
+    accent: Color,
+    accentSecondary: Color,
+    compact: Boolean,
+    labels: PlayerControlLabels,
+    onShuffle: () -> Unit,
+    onPrevious: () -> Unit,
+    onToggle: () -> Unit,
+    onNext: () -> Unit,
+    onRepeat: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val utilitySize = if (compact) LevyraPlayerDesign.UtilityButtonCompact else LevyraPlayerDesign.UtilityButton
+    val transportSize = if (compact) LevyraPlayerDesign.TransportButtonCompact else LevyraPlayerDesign.TransportButton
+    val primarySize = if (compact) LevyraPlayerDesign.PrimaryButtonCompact else LevyraPlayerDesign.PrimaryButton
+
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        PlayerModeToggleButton(
+            icon = Icons.Rounded.Shuffle,
+            contentDescription = labels.shuffle,
+            active = shuffleOn,
+            accent = accent,
+            size = utilitySize,
+            iconSize = if (compact) 20.dp else 21.dp,
+            onClick = onShuffle
+        )
+        PlayerGlassIconButton(
+            icon = Icons.Rounded.SkipPrevious,
+            contentDescription = labels.previous,
+            size = transportSize,
+            iconSize = if (compact) 28.dp else 30.dp,
+            shape = LevyraPlayerDesign.ShapeMd,
+            onClick = onPrevious
+        )
+        PlayerPrimaryButton(
+            isPlaying = isPlaying,
+            isResolving = isResolving,
+            accent = accent,
+            accentSecondary = accentSecondary,
+            size = primarySize,
+            playLabel = labels.play,
+            pauseLabel = labels.pause,
+            onClick = onToggle
+        )
+        PlayerGlassIconButton(
+            icon = Icons.Rounded.SkipNext,
+            contentDescription = labels.next,
+            size = transportSize,
+            iconSize = if (compact) 28.dp else 30.dp,
+            shape = LevyraPlayerDesign.ShapeMd,
+            onClick = onNext
+        )
+        PlayerModeToggleButton(
+            icon = if (repeatOne) Icons.Rounded.RepeatOne else Icons.Rounded.Repeat,
+            contentDescription = labels.repeat,
+            active = repeatOn,
+            accent = accentSecondary,
+            size = utilitySize,
+            iconSize = if (compact) 20.dp else 21.dp,
+            onClick = onRepeat
+        )
+    }
+}
+
+@Composable
+private fun PlayerModeToggleButton(
+    icon: ImageVector,
+    contentDescription: String,
+    active: Boolean,
+    accent: Color,
+    size: Dp,
+    iconSize: Dp,
+    onClick: () -> Unit
+) {
+    val fill = if (active) accent.copy(alpha = 0.30f) else Color.Transparent
+    val activeTint = remember(accent) {
+        accent.playerContentColor(listOf(accent.copy(alpha = 0.30f).playerCompositeOver(PlayerDarkSurface)))
+    }
+    val tint = if (active) activeTint else LevyraPlayerDesign.IconIdle
+    val corner by animateDpAsState(
+        targetValue = if (active) size / 2f else size * 0.34f,
+        animationSpec = LevyraPlayerDesign.expressiveSpring(),
+        label = "player-toggle-corner"
+    )
+    val borderAlpha by animateFloatAsState(
+        targetValue = if (active) 0.55f else 0f,
+        animationSpec = LevyraPlayerDesign.standardTween(),
+        label = "player-toggle-border"
+    )
+
+    SpringIconButton(
+        onClick = onClick,
+        modifier = Modifier.sizeIn(
+            minWidth = LevyraPlayerDesign.MinimumTouchTarget,
+            minHeight = LevyraPlayerDesign.MinimumTouchTarget
+        ),
+        pressedScale = 0.86f,
+        contentDescription = contentDescription
+    ) {
+        Box(
+            modifier = Modifier
+                .size(size)
+                .background(fill, RoundedCornerShape(corner))
+                .border(
+                    BorderStroke(LevyraPlayerDesign.Hairline, accent.copy(alpha = borderAlpha)),
+                    RoundedCornerShape(corner)
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = tint,
+                modifier = Modifier.size(iconSize)
+            )
+        }
+    }
+}
+
+@Composable
+private fun PlayerPrimaryButton(
+    isPlaying: Boolean,
+    isResolving: Boolean,
+    accent: Color,
+    accentSecondary: Color,
+    size: Dp,
+    playLabel: String,
+    pauseLabel: String,
+    onClick: () -> Unit
+) {
+    val gradient = remember(accent, accentSecondary) {
+        playerContrastGradient(
+            start = accent.playerMix(Color.White, 0.16f),
+            end = accentSecondary.playerMix(Color.White, 0.06f),
+            minimumContrast = PlayerMinimumContrast
+        )
+    }
+    val corner by animateDpAsState(
+        targetValue = if (isPlaying) size * 0.34f else size / 2f,
+        animationSpec = LevyraPlayerDesign.expressiveSpring(),
+        label = "player-primary-corner"
+    )
+    val shape = RoundedCornerShape(corner)
+
+    SpringIconButton(
+        onClick = onClick,
+        pressedScale = 0.92f,
+        contentDescription = if (isPlaying) pauseLabel else playLabel
+    ) {
+        Box(
+            modifier = Modifier
+                .size(size)
+                .shadow(
+                    elevation = 20.dp,
+                    shape = shape,
+                    clip = false,
+                    ambientColor = accent.copy(alpha = 0.50f),
+                    spotColor = accentSecondary.copy(alpha = 0.58f)
+                )
+                .background(Brush.linearGradient(listOf(gradient.start, gradient.end)), shape)
+                .background(
+                    Brush.verticalGradient(
+                        listOf(
+                            Color.White.copy(alpha = 0.18f),
+                            Color.Transparent,
+                            Color.Black.copy(alpha = 0.10f)
+                        )
+                    ),
+                    shape
+                )
+                .border(
+                    BorderStroke(
+                        LevyraPlayerDesign.Hairline,
+                        Brush.verticalGradient(
+                            listOf(
+                                Color.White.copy(alpha = 0.34f),
+                                Color.White.copy(alpha = 0.08f)
+                            )
+                        )
+                    ),
+                    shape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            if (isResolving) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(size * 0.36f),
+                    strokeWidth = 3.dp,
+                    color = gradient.content
+                )
+            } else {
+                AnimatedContent(
+                    targetState = isPlaying,
+                    transitionSpec = {
+                        (fadeIn(LevyraPlayerDesign.standardTween(140)) +
+                            scaleIn(initialScale = 0.72f, animationSpec = LevyraPlayerDesign.standardTween(140))) togetherWith
+                            (fadeOut(LevyraPlayerDesign.standardTween(100)) +
+                                scaleOut(targetScale = 0.72f, animationSpec = LevyraPlayerDesign.standardTween(100)))
+                    },
+                    label = "player-primary-icon"
+                ) { playing ->
+                    Icon(
+                        imageVector = if (playing) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+                        contentDescription = null,
+                        tint = gradient.content,
+                        modifier = Modifier
+                            .size(size * 0.46f)
+                            .offset(x = if (playing) 0.dp else size * 0.02f)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
@@ -1,6 +1,7 @@
 package com.luc4n3x.levyra.ui.components
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.snap
@@ -43,6 +44,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.luc4n3x.levyra.ui.PlayerContrastGradient
 import com.luc4n3x.levyra.ui.PlayerDarkSurface
 import com.luc4n3x.levyra.ui.PlayerMinimumContrast
 import com.luc4n3x.levyra.ui.playerCompositeOver
@@ -260,6 +262,67 @@ private fun PlayerModeToggleButton(
     }
 }
 
+private fun playerPrimaryIconTransition(): ContentTransform =
+    (fadeIn(LevyraPlayerDesign.standardTween(140)) +
+        scaleIn(initialScale = 0.72f, animationSpec = LevyraPlayerDesign.standardTween(140))) togetherWith
+        (fadeOut(LevyraPlayerDesign.standardTween(100)) +
+            scaleOut(targetScale = 0.72f, animationSpec = LevyraPlayerDesign.standardTween(100)))
+
+private fun Modifier.playerPrimarySurface(
+    shape: Shape,
+    gradient: PlayerContrastGradient,
+    accent: Color,
+    accentSecondary: Color
+): Modifier = this
+    .shadow(
+        elevation = 20.dp,
+        shape = shape,
+        clip = false,
+        ambientColor = accent.copy(alpha = 0.50f),
+        spotColor = accentSecondary.copy(alpha = 0.58f)
+    )
+    .background(Brush.linearGradient(listOf(gradient.start, gradient.end)), shape)
+    .background(
+        Brush.verticalGradient(
+            listOf(
+                Color.White.copy(alpha = 0.18f),
+                Color.Transparent,
+                Color.Black.copy(alpha = 0.10f)
+            )
+        ),
+        shape
+    )
+    .border(
+        BorderStroke(
+            LevyraPlayerDesign.Hairline,
+            Brush.verticalGradient(
+                listOf(
+                    Color.White.copy(alpha = 0.34f),
+                    Color.White.copy(alpha = 0.08f)
+                )
+            )
+        ),
+        shape
+    )
+
+@Composable
+private fun PlayerPrimaryIcon(isPlaying: Boolean, size: Dp, tint: Color) {
+    AnimatedContent(
+        targetState = isPlaying,
+        transitionSpec = { playerPrimaryIconTransition() },
+        label = "player-primary-icon"
+    ) { playing ->
+        Icon(
+            imageVector = if (playing) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+            contentDescription = null,
+            tint = tint,
+            modifier = Modifier
+                .size(size * 0.46f)
+                .offset(x = if (playing) 0.dp else size * 0.02f)
+        )
+    }
+}
+
 @Composable
 private fun PlayerPrimaryButton(
     isPlaying: Boolean,
@@ -294,35 +357,11 @@ private fun PlayerPrimaryButton(
         Box(
             modifier = Modifier
                 .size(size)
-                .shadow(
-                    elevation = 20.dp,
+                .playerPrimarySurface(
                     shape = shape,
-                    clip = false,
-                    ambientColor = accent.copy(alpha = 0.50f),
-                    spotColor = accentSecondary.copy(alpha = 0.58f)
-                )
-                .background(Brush.linearGradient(listOf(gradient.start, gradient.end)), shape)
-                .background(
-                    Brush.verticalGradient(
-                        listOf(
-                            Color.White.copy(alpha = 0.18f),
-                            Color.Transparent,
-                            Color.Black.copy(alpha = 0.10f)
-                        )
-                    ),
-                    shape
-                )
-                .border(
-                    BorderStroke(
-                        LevyraPlayerDesign.Hairline,
-                        Brush.verticalGradient(
-                            listOf(
-                                Color.White.copy(alpha = 0.34f),
-                                Color.White.copy(alpha = 0.08f)
-                            )
-                        )
-                    ),
-                    shape
+                    gradient = gradient,
+                    accent = accent,
+                    accentSecondary = accentSecondary
                 ),
             contentAlignment = Alignment.Center
         ) {
@@ -333,25 +372,11 @@ private fun PlayerPrimaryButton(
                     color = gradient.content
                 )
             } else {
-                AnimatedContent(
-                    targetState = isPlaying,
-                    transitionSpec = {
-                        (fadeIn(LevyraPlayerDesign.standardTween(140)) +
-                            scaleIn(initialScale = 0.72f, animationSpec = LevyraPlayerDesign.standardTween(140))) togetherWith
-                            (fadeOut(LevyraPlayerDesign.standardTween(100)) +
-                                scaleOut(targetScale = 0.72f, animationSpec = LevyraPlayerDesign.standardTween(100)))
-                    },
-                    label = "player-primary-icon"
-                ) { playing ->
-                    Icon(
-                        imageVector = if (playing) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
-                        contentDescription = null,
-                        tint = gradient.content,
-                        modifier = Modifier
-                            .size(size * 0.46f)
-                            .offset(x = if (playing) 0.dp else size * 0.02f)
-                    )
-                }
+                PlayerPrimaryIcon(
+                    isPlaying = isPlaying,
+                    size = size,
+                    tint = gradient.content
+                )
             }
         }
     }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
@@ -3,6 +3,7 @@ package com.luc4n3x.levyra.ui.components
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
@@ -135,6 +136,7 @@ fun PlayerTransportControls(
     accent: Color,
     accentSecondary: Color,
     compact: Boolean,
+    animated: Boolean,
     labels: PlayerControlLabels,
     onShuffle: () -> Unit,
     onPrevious: () -> Unit,
@@ -159,6 +161,7 @@ fun PlayerTransportControls(
             accent = accent,
             size = utilitySize,
             iconSize = if (compact) 20.dp else 21.dp,
+            animated = animated,
             onClick = onShuffle
         )
         PlayerGlassIconButton(
@@ -175,6 +178,7 @@ fun PlayerTransportControls(
             accent = accent,
             accentSecondary = accentSecondary,
             size = primarySize,
+            animated = animated,
             playLabel = labels.play,
             pauseLabel = labels.pause,
             onClick = onToggle
@@ -194,6 +198,7 @@ fun PlayerTransportControls(
             accent = accentSecondary,
             size = utilitySize,
             iconSize = if (compact) 20.dp else 21.dp,
+            animated = animated,
             onClick = onRepeat
         )
     }
@@ -207,6 +212,7 @@ private fun PlayerModeToggleButton(
     accent: Color,
     size: Dp,
     iconSize: Dp,
+    animated: Boolean,
     onClick: () -> Unit
 ) {
     val fill = if (active) accent.copy(alpha = 0.30f) else Color.Transparent
@@ -216,12 +222,12 @@ private fun PlayerModeToggleButton(
     val tint = if (active) activeTint else LevyraPlayerDesign.IconIdle
     val corner by animateDpAsState(
         targetValue = if (active) size / 2f else size * 0.34f,
-        animationSpec = LevyraPlayerDesign.expressiveSpring(),
+        animationSpec = if (animated) LevyraPlayerDesign.expressiveSpring() else snap(),
         label = "player-toggle-corner"
     )
     val borderAlpha by animateFloatAsState(
         targetValue = if (active) 0.55f else 0f,
-        animationSpec = LevyraPlayerDesign.standardTween(),
+        animationSpec = if (animated) LevyraPlayerDesign.standardTween() else snap(),
         label = "player-toggle-border"
     )
 
@@ -261,6 +267,7 @@ private fun PlayerPrimaryButton(
     accent: Color,
     accentSecondary: Color,
     size: Dp,
+    animated: Boolean,
     playLabel: String,
     pauseLabel: String,
     onClick: () -> Unit
@@ -274,7 +281,7 @@ private fun PlayerPrimaryButton(
     }
     val corner by animateDpAsState(
         targetValue = if (isPlaying) size * 0.34f else size / 2f,
-        animationSpec = LevyraPlayerDesign.expressiveSpring(),
+        animationSpec = if (animated) LevyraPlayerDesign.expressiveSpring() else snap(),
         label = "player-primary-corner"
     )
     val shape = RoundedCornerShape(corner)

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PremiumSeekbar.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PremiumSeekbar.kt
@@ -320,6 +320,6 @@ internal fun formatSeekbarMillis(ms: Long): String {
     return if (hours > 0L) {
         String.format(Locale.US, "%d:%02d:%02d", hours, minutes, seconds)
     } else {
-        String.format(Locale.US, "%02d:%02d", minutes, seconds)
+        String.format(Locale.US, "%d:%02d", minutes, seconds)
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PremiumSeekbar.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PremiumSeekbar.kt
@@ -227,21 +227,25 @@ fun PremiumSeekbar(
             val handleHeight = LevyraPlayerDesign.HandleHeight.toPx() +
                 (LevyraPlayerDesign.HandleHeightActive - LevyraPlayerDesign.HandleHeight).toPx() * handleScale.value
             val gap = trackHeight * 1.1f
+            val capInset = trackHeight / 2f
+            val trackStart = capInset
+            val trackEnd = (totalWidth - capInset).coerceAtLeast(trackStart)
+            val trackSpan = trackEnd - trackStart
 
-            val handleX = seekbarHandleCenterX(effectiveProgress, totalWidth, handleWidth)
-            val activeEnd = (handleX - handleWidth / 2f - gap).coerceAtLeast(0f)
-            val inactiveStart = (handleX + handleWidth / 2f + gap).coerceAtMost(totalWidth)
+            val handleX = trackStart + seekbarHandleCenterX(effectiveProgress, trackSpan, handleWidth)
+            val activeEnd = (handleX - handleWidth / 2f - gap).coerceIn(trackStart, trackEnd)
+            val inactiveStart = (handleX + handleWidth / 2f + gap).coerceIn(trackStart, trackEnd)
 
-            if (inactiveStart < totalWidth) {
+            if (inactiveStart < trackEnd) {
                 drawRoundRect(
                     color = inactiveColor,
                     topLeft = Offset(inactiveStart, centerY - trackHeight / 2f),
-                    size = Size(totalWidth - inactiveStart, trackHeight),
+                    size = Size(trackEnd - inactiveStart, trackHeight),
                     cornerRadius = CornerRadius(trackHeight / 2f, trackHeight / 2f)
                 )
             }
 
-            val bufferedEnd = (bufferedProgress * totalWidth).coerceIn(0f, totalWidth)
+            val bufferedEnd = (trackStart + bufferedProgress * trackSpan).coerceIn(trackStart, trackEnd)
             if (bufferedEnd > inactiveStart) {
                 drawRoundRect(
                     color = thumbColor.copy(alpha = 0.22f),
@@ -251,21 +255,23 @@ fun PremiumSeekbar(
                 )
             }
 
-            if (activeEnd > 0f) {
+            val activeSpan = activeEnd - trackStart
+            if (activeSpan > 0f) {
                 val amplitudePx = LevyraPlayerDesign.WaveAmplitude.toPx() * waveAmplitude.value
                 if (amplitudePx > 0.4f) {
                     val wavelength = LevyraPlayerDesign.WavePeriodDp.dp.toPx()
                     val taper = wavelength * 0.75f
-                    val samples = seekbarWaveSampleCount(activeEnd)
-                    val step = activeEnd / samples
+                    val samples = seekbarWaveSampleCount(activeSpan)
+                    val step = activeSpan / samples
                     wavePath.rewind()
-                    var x = 0f
+                    var offsetX = 0f
                     var index = 0
                     while (index <= samples) {
-                        val local = seekbarWaveTaper(x, activeEnd, taper)
-                        val y = centerY + seekbarWaveOffset(x, amplitudePx * local, wavelength, wavePhase.value)
-                        if (index == 0) wavePath.moveTo(x, y) else wavePath.lineTo(x, y)
-                        x += step
+                        val local = seekbarWaveTaper(offsetX, activeSpan, taper)
+                        val y = centerY + seekbarWaveOffset(offsetX, amplitudePx * local, wavelength, wavePhase.value)
+                        val pointX = trackStart + offsetX
+                        if (index == 0) wavePath.moveTo(pointX, y) else wavePath.lineTo(pointX, y)
+                        offsetX += step
                         index += 1
                     }
                     drawPath(
@@ -280,8 +286,8 @@ fun PremiumSeekbar(
                 } else {
                     drawRoundRect(
                         color = activeColor,
-                        topLeft = Offset(0f, centerY - trackHeight / 2f),
-                        size = Size(activeEnd, trackHeight),
+                        topLeft = Offset(trackStart, centerY - trackHeight / 2f),
+                        size = Size(activeSpan, trackHeight),
                         cornerRadius = CornerRadius(trackHeight / 2f, trackHeight / 2f)
                     )
                 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PremiumSeekbar.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PremiumSeekbar.kt
@@ -1,22 +1,24 @@
 package com.luc4n3x.levyra.ui.components
 
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -24,14 +26,22 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.setProgress
@@ -41,7 +51,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.luc4n3x.levyra.ui.theme.LevyraCyan
 import com.luc4n3x.levyra.ui.theme.LevyraMuted
+import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
 import java.util.Locale
+import kotlin.math.PI
+import kotlin.math.roundToInt
 
 @Composable
 fun PremiumSeekbar(
@@ -49,73 +62,98 @@ fun PremiumSeekbar(
     durationMs: Long,
     onSeekTo: (Long) -> Unit,
     modifier: Modifier = Modifier,
+    bufferedPositionMs: Long = 0L,
     activeColor: Color = LevyraCyan,
+    trailingColor: Color = activeColor,
     inactiveColor: Color = LevyraMuted.copy(alpha = 0.35f),
-    thumbColor: Color = Color.White
+    thumbColor: Color = Color.White,
+    isPlaying: Boolean = false,
+    animated: Boolean = true,
+    contentDescription: String? = null
 ) {
+    val density = LocalDensity.current
+    val haptics = LocalHapticFeedback.current
+
     var isDragging by remember { mutableStateOf(false) }
     var dragProgressFraction by remember { mutableFloatStateOf(0f) }
+    var widthPx by remember { mutableFloatStateOf(0f) }
 
     val effectiveProgress = if (isDragging) {
         dragProgressFraction
     } else {
-        if (durationMs > 0L) (positionMs.toFloat() / durationMs.toFloat()).coerceIn(0f, 1f) else 0f
+        seekbarProgressFraction(positionMs, durationMs)
+    }
+    val bufferedProgress = remember(bufferedPositionMs, durationMs, effectiveProgress) {
+        seekbarProgressFraction(bufferedPositionMs, durationMs).coerceAtLeast(effectiveProgress)
     }
 
-    val trackThicknessScale = remember { Animatable(1f) }
-    val thumbScale = remember { Animatable(0.4f) }
+    val trackScale = remember { Animatable(1f) }
+    val handleScale = remember { Animatable(0f) }
+    val waveAmplitude = remember { Animatable(0f) }
 
     LaunchedEffect(isDragging) {
-        trackThicknessScale.animateTo(
-            targetValue = if (isDragging) 1.5f else 1f,
-            animationSpec = spring(
-                dampingRatio = 0.7f,
-                stiffness = Spring.StiffnessMedium
-            )
+        trackScale.animateTo(
+            targetValue = if (isDragging) 1.55f else 1f,
+            animationSpec = LevyraPlayerDesign.expressiveSpring()
         )
     }
-    
     LaunchedEffect(isDragging) {
-        thumbScale.animateTo(
-            targetValue = if (isDragging) 1f else 0.4f,
-            animationSpec = spring(
-                dampingRatio = 0.8f,
-                stiffness = Spring.StiffnessMedium
-            )
+        handleScale.animateTo(
+            targetValue = if (isDragging) 1f else 0f,
+            animationSpec = LevyraPlayerDesign.expressiveSpring()
         )
     }
 
-    val density = LocalDensity.current
+    val waveActive = animated && isPlaying && !isDragging && durationMs > 0L
+    LaunchedEffect(waveActive) {
+        waveAmplitude.animateTo(
+            targetValue = if (waveActive) 1f else 0f,
+            animationSpec = LevyraPlayerDesign.smoothSpring()
+        )
+    }
 
-    BoxWithConstraints(
+    val wavePath = remember { Path() }
+    val wavePhase = remember { Animatable(0f) }
+    LaunchedEffect(waveActive) {
+        if (!waveActive) return@LaunchedEffect
+        wavePhase.snapTo(0f)
+        wavePhase.animateTo(
+            targetValue = -2f * PI.toFloat(),
+            animationSpec = infiniteRepeatable(
+                animation = tween(LevyraPlayerDesign.WaveCycleMillis, easing = LinearEasing),
+                repeatMode = RepeatMode.Restart
+            )
+        )
+    }
+
+    val scrubMillis by remember(durationMs) {
+        derivedStateOf { seekbarSeekMillis(dragProgressFraction, durationMs) }
+    }
+
+    Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(56.dp)
-            .padding(vertical = 4.dp),
-        contentAlignment = Alignment.Center
+            .height(LevyraPlayerDesign.MinimumTouchTarget)
+            .onSizeChanged { widthPx = it.width.toFloat() },
+        contentAlignment = Alignment.CenterStart
     ) {
-        val widthPx = with(density) { constraints.maxWidth.toDp().toPx() }
-        val seekPosMs = (effectiveProgress * durationMs.coerceAtLeast(0L)).toLong()
-
-        if (isDragging) {
-            val tooltipHalfWidthPx = with(density) { 32.dp.toPx() }
-                .coerceAtMost(widthPx / 2f)
-            val tooltipMax = (widthPx - tooltipHalfWidthPx).coerceAtLeast(tooltipHalfWidthPx)
-            val tooltipOffsetPx = (effectiveProgress * widthPx)
-                .coerceIn(tooltipHalfWidthPx, tooltipMax)
-            val tooltipOffsetDp = with(density) { (tooltipOffsetPx - tooltipHalfWidthPx).toDp() }
-
+        if (isDragging && widthPx > 0f) {
+            val tooltipWidthPx = with(density) { 74.dp.toPx() }
+            val offsetX = seekbarTooltipOffsetX(effectiveProgress, widthPx, tooltipWidthPx)
             Box(
                 modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .offset { IntOffset(with(density) { tooltipOffsetDp.toPx().toInt() }, -36.dp.roundToPx()) }
-                    .shadow(8.dp, RoundedCornerShape(8.dp))
-                    .background(Color(0xFF1E1E24), RoundedCornerShape(8.dp))
-                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                    .offset { IntOffset(offsetX.roundToInt(), with(density) { (-34).dp.roundToPx() }) }
+                    .background(Color(0xFF101014).copy(alpha = 0.94f), LevyraPlayerDesign.ShapeXs)
+                    .border(
+                        width = LevyraPlayerDesign.Hairline,
+                        color = activeColor.copy(alpha = 0.55f),
+                        shape = LevyraPlayerDesign.ShapeXs
+                    )
+                    .padding(horizontal = 12.dp, vertical = 6.dp),
                 contentAlignment = Alignment.Center
             ) {
                 Text(
-                    text = formatMs(seekPosMs),
+                    text = formatSeekbarMillis(scrubMillis),
                     color = Color.White,
                     fontSize = 12.sp,
                     fontWeight = FontWeight.Bold
@@ -126,8 +164,10 @@ fun PremiumSeekbar(
         Canvas(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(48.dp)
+                .height(LevyraPlayerDesign.MinimumTouchTarget)
+                .clipToBounds()
                 .semantics {
+                    contentDescription?.let { this.contentDescription = it }
                     progressBarRangeInfo = ProgressBarRangeInfo(
                         current = effectiveProgress,
                         range = 0f..1f,
@@ -135,7 +175,7 @@ fun PremiumSeekbar(
                     )
                     setProgress { targetValue ->
                         if (durationMs > 0L) {
-                            onSeekTo((targetValue.coerceIn(0f, 1f) * durationMs).toLong())
+                            onSeekTo(seekbarSeekMillis(targetValue, durationMs))
                             true
                         } else {
                             false
@@ -144,9 +184,10 @@ fun PremiumSeekbar(
                 }
                 .pointerInput(durationMs) {
                     detectTapGestures { offset ->
-                        if (durationMs > 0L && widthPx > 0f) {
-                            val targetFrac = (offset.x / widthPx).coerceIn(0f, 1f)
-                            onSeekTo((targetFrac * durationMs).toLong())
+                        if (durationMs > 0L && size.width > 0) {
+                            val fraction = seekbarFractionAt(offset.x, size.width.toFloat())
+                            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                            onSeekTo(seekbarSeekMillis(fraction, durationMs))
                         }
                     }
                 }
@@ -155,83 +196,120 @@ fun PremiumSeekbar(
                     detectHorizontalDragGestures(
                         onDragStart = { offset ->
                             isDragging = true
-                            if (widthPx > 0f) {
-                                dragProgressFraction = (offset.x / widthPx).coerceIn(0f, 1f)
-                            }
+                            dragProgressFraction = seekbarFractionAt(offset.x, size.width.toFloat())
+                            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
                         },
                         onDragEnd = {
                             isDragging = false
-                            if (durationMs > 0L) {
-                                onSeekTo((dragProgressFraction * durationMs).toLong())
-                            }
+                            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                            onSeekTo(seekbarSeekMillis(dragProgressFraction, durationMs))
                         },
-                        onDragCancel = {
-                            isDragging = false
-                        },
+                        onDragCancel = { isDragging = false },
                         onHorizontalDrag = { change, _ ->
                             change.consume()
-                            if (widthPx > 0f) {
-                                dragProgressFraction = (change.position.x / widthPx).coerceIn(0f, 1f)
-                            }
+                            dragProgressFraction = seekbarFractionAt(change.position.x, size.width.toFloat())
                         }
                     )
                 }
         ) {
             val totalWidth = size.width
-            val totalHeight = size.height
-            val centerY = totalHeight / 2f
-            
-            val baseTrackHeight = 3.dp.toPx()
-            val currentTrackHeight = baseTrackHeight * trackThicknessScale.value
-            
-            val activeWidth = totalWidth * effectiveProgress
+            if (totalWidth <= 0f) return@Canvas
+            val centerY = size.height / 2f
 
-            drawRoundRect(
-                color = inactiveColor,
-                topLeft = Offset(0f, centerY - currentTrackHeight / 2f),
-                size = Size(totalWidth, currentTrackHeight),
-                cornerRadius = CornerRadius(currentTrackHeight / 2f, currentTrackHeight / 2f)
-            )
+            val baseTrackHeight = LevyraPlayerDesign.TrackHeight.toPx()
+            val trackHeight = baseTrackHeight * trackScale.value
+            val handleWidth = LevyraPlayerDesign.HandleWidth.toPx() +
+                (LevyraPlayerDesign.HandleWidthActive - LevyraPlayerDesign.HandleWidth).toPx() * handleScale.value
+            val handleHeight = LevyraPlayerDesign.HandleHeight.toPx() +
+                (LevyraPlayerDesign.HandleHeightActive - LevyraPlayerDesign.HandleHeight).toPx() * handleScale.value
+            val gap = trackHeight * 1.1f
 
-            val activeTrackHeight = currentTrackHeight * 1.15f
-            
-            drawRoundRect(
-                color = activeColor.copy(alpha = 0.20f),
-                topLeft = Offset(0f, centerY - activeTrackHeight * 1.5f),
-                size = Size(activeWidth, activeTrackHeight * 3f),
-                cornerRadius = CornerRadius(activeTrackHeight * 1.5f, activeTrackHeight * 1.5f)
-            )
+            val handleX = seekbarHandleCenterX(effectiveProgress, totalWidth, handleWidth)
+            val activeEnd = (handleX - handleWidth / 2f - gap).coerceAtLeast(0f)
+            val inactiveStart = (handleX + handleWidth / 2f + gap).coerceAtMost(totalWidth)
 
-            drawRoundRect(
-                color = activeColor,
-                topLeft = Offset(0f, centerY - activeTrackHeight / 2f),
-                size = Size(activeWidth, activeTrackHeight),
-                cornerRadius = CornerRadius(activeTrackHeight / 2f, activeTrackHeight / 2f)
-            )
-
-            val thumbX = activeWidth.coerceIn(0f, totalWidth)
-            val baseThumbRadius = 8.dp.toPx()
-            val currentThumbRadius = baseThumbRadius * thumbScale.value
-
-            if (currentThumbRadius > 0.5f) {
-                drawCircle(
-                    color = activeColor.copy(alpha = 0.35f),
-                    radius = currentThumbRadius * 1.8f,
-                    center = Offset(thumbX, centerY)
-                )
-                drawCircle(
-                    color = thumbColor,
-                    radius = currentThumbRadius,
-                    center = Offset(thumbX, centerY)
+            if (inactiveStart < totalWidth) {
+                drawRoundRect(
+                    color = inactiveColor,
+                    topLeft = Offset(inactiveStart, centerY - trackHeight / 2f),
+                    size = Size(totalWidth - inactiveStart, trackHeight),
+                    cornerRadius = CornerRadius(trackHeight / 2f, trackHeight / 2f)
                 )
             }
+
+            val bufferedEnd = (bufferedProgress * totalWidth).coerceIn(0f, totalWidth)
+            if (bufferedEnd > inactiveStart) {
+                drawRoundRect(
+                    color = thumbColor.copy(alpha = 0.22f),
+                    topLeft = Offset(inactiveStart, centerY - trackHeight / 2f),
+                    size = Size(bufferedEnd - inactiveStart, trackHeight),
+                    cornerRadius = CornerRadius(trackHeight / 2f, trackHeight / 2f)
+                )
+            }
+
+            if (activeEnd > 0f) {
+                val amplitudePx = LevyraPlayerDesign.WaveAmplitude.toPx() * waveAmplitude.value
+                if (amplitudePx > 0.4f) {
+                    val wavelength = LevyraPlayerDesign.WavePeriodDp.dp.toPx()
+                    val taper = wavelength * 0.75f
+                    val samples = seekbarWaveSampleCount(activeEnd)
+                    val step = activeEnd / samples
+                    wavePath.rewind()
+                    var x = 0f
+                    var index = 0
+                    while (index <= samples) {
+                        val local = seekbarWaveTaper(x, activeEnd, taper)
+                        val y = centerY + seekbarWaveOffset(x, amplitudePx * local, wavelength, wavePhase.value)
+                        if (index == 0) wavePath.moveTo(x, y) else wavePath.lineTo(x, y)
+                        x += step
+                        index += 1
+                    }
+                    drawPath(
+                        path = wavePath,
+                        color = activeColor,
+                        style = Stroke(
+                            width = trackHeight,
+                            cap = StrokeCap.Round,
+                            join = StrokeJoin.Round
+                        )
+                    )
+                } else {
+                    drawRoundRect(
+                        color = activeColor,
+                        topLeft = Offset(0f, centerY - trackHeight / 2f),
+                        size = Size(activeEnd, trackHeight),
+                        cornerRadius = CornerRadius(trackHeight / 2f, trackHeight / 2f)
+                    )
+                }
+            }
+
+            if (handleScale.value > 0.01f) {
+                drawRoundRect(
+                    color = trailingColor.copy(alpha = 0.30f * handleScale.value),
+                    topLeft = Offset(handleX - handleWidth * 1.6f, centerY - handleHeight * 0.65f),
+                    size = Size(handleWidth * 3.2f, handleHeight * 1.30f),
+                    cornerRadius = CornerRadius(handleWidth * 1.6f, handleWidth * 1.6f)
+                )
+            }
+
+            drawRoundRect(
+                color = thumbColor,
+                topLeft = Offset(handleX - handleWidth / 2f, centerY - handleHeight / 2f),
+                size = Size(handleWidth, handleHeight),
+                cornerRadius = CornerRadius(handleWidth / 2f, handleWidth / 2f)
+            )
         }
     }
 }
 
-private fun formatMs(ms: Long): String {
-    val totalSec = (ms / 1000L).coerceAtLeast(0L)
-    val mins = totalSec / 60L
-    val secs = totalSec % 60L
-    return String.format(Locale.US, "%02d:%02d", mins, secs)
+internal fun formatSeekbarMillis(ms: Long): String {
+    val totalSeconds = (ms / 1_000L).coerceAtLeast(0L)
+    val hours = totalSeconds / 3_600L
+    val minutes = (totalSeconds % 3_600L) / 60L
+    val seconds = totalSeconds % 60L
+    return if (hours > 0L) {
+        String.format(Locale.US, "%d:%02d:%02d", hours, minutes, seconds)
+    } else {
+        String.format(Locale.US, "%02d:%02d", minutes, seconds)
+    }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PremiumSeekbar.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PremiumSeekbar.kt
@@ -1,9 +1,11 @@
 package com.luc4n3x.levyra.ui.components
 
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
@@ -91,24 +93,26 @@ fun PremiumSeekbar(
     val handleScale = remember { Animatable(0f) }
     val waveAmplitude = remember { Animatable(0f) }
 
-    LaunchedEffect(isDragging) {
+    val scrubSpec: AnimationSpec<Float> =
+        if (animated) LevyraPlayerDesign.expressiveSpring() else snap()
+    LaunchedEffect(isDragging, animated) {
         trackScale.animateTo(
             targetValue = if (isDragging) 1.55f else 1f,
-            animationSpec = LevyraPlayerDesign.expressiveSpring()
+            animationSpec = scrubSpec
         )
     }
-    LaunchedEffect(isDragging) {
+    LaunchedEffect(isDragging, animated) {
         handleScale.animateTo(
             targetValue = if (isDragging) 1f else 0f,
-            animationSpec = LevyraPlayerDesign.expressiveSpring()
+            animationSpec = scrubSpec
         )
     }
 
     val waveActive = animated && isPlaying && !isDragging && durationMs > 0L
-    LaunchedEffect(waveActive) {
+    LaunchedEffect(waveActive, animated) {
         waveAmplitude.animateTo(
             targetValue = if (waveActive) 1f else 0f,
-            animationSpec = LevyraPlayerDesign.smoothSpring()
+            animationSpec = if (animated) LevyraPlayerDesign.smoothSpring() else snap()
         )
     }
 

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/SeekbarGeometry.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/SeekbarGeometry.kt
@@ -1,0 +1,57 @@
+package com.luc4n3x.levyra.ui.components
+
+import kotlin.math.PI
+import kotlin.math.ceil
+import kotlin.math.sin
+
+internal const val SeekbarWaveSampleStepPx = 3f
+
+internal fun seekbarFractionAt(x: Float, widthPx: Float): Float {
+    if (widthPx <= 0f) return 0f
+    return (x / widthPx).coerceIn(0f, 1f)
+}
+
+internal fun seekbarProgressFraction(positionMs: Long, durationMs: Long): Float {
+    if (durationMs <= 0L) return 0f
+    return (positionMs.toFloat() / durationMs.toFloat()).coerceIn(0f, 1f)
+}
+
+internal fun seekbarHandleCenterX(fraction: Float, widthPx: Float, handleWidthPx: Float): Float {
+    if (widthPx <= 0f) return 0f
+    val half = (handleWidthPx / 2f).coerceAtMost(widthPx / 2f)
+    return (fraction.coerceIn(0f, 1f) * widthPx).coerceIn(half, widthPx - half)
+}
+
+internal fun seekbarTooltipOffsetX(fraction: Float, widthPx: Float, tooltipWidthPx: Float): Float {
+    if (widthPx <= 0f) return 0f
+    if (tooltipWidthPx >= widthPx) return 0f
+    val centered = fraction.coerceIn(0f, 1f) * widthPx - tooltipWidthPx / 2f
+    return centered.coerceIn(0f, widthPx - tooltipWidthPx)
+}
+
+internal fun seekbarWaveSampleCount(widthPx: Float): Int {
+    if (widthPx <= 0f) return 0
+    return ceil(widthPx / SeekbarWaveSampleStepPx).toInt().coerceIn(1, 900)
+}
+
+internal fun seekbarWaveTaper(x: Float, activeWidthPx: Float, taperPx: Float): Float {
+    if (activeWidthPx <= 0f || taperPx <= 0f) return 0f
+    val fromStart = (x / taperPx).coerceIn(0f, 1f)
+    val fromEnd = ((activeWidthPx - x) / taperPx).coerceIn(0f, 1f)
+    return minOf(fromStart, fromEnd)
+}
+
+internal fun seekbarWaveOffset(
+    x: Float,
+    amplitudePx: Float,
+    wavelengthPx: Float,
+    phase: Float
+): Float {
+    if (amplitudePx <= 0f || wavelengthPx <= 0f) return 0f
+    return amplitudePx * sin((2f * PI.toFloat() * x / wavelengthPx) + phase)
+}
+
+internal fun seekbarSeekMillis(fraction: Float, durationMs: Long): Long {
+    if (durationMs <= 0L) return 0L
+    return (fraction.coerceIn(0f, 1f) * durationMs).toLong().coerceIn(0L, durationMs)
+}

--- a/app/src/main/java/com/luc4n3x/levyra/ui/theme/PlayerDesign.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/theme/PlayerDesign.kt
@@ -41,10 +41,13 @@ object LevyraPlayerDesign {
     val HeaderButtonCompact: Dp = 40.dp
     val UtilityButton: Dp = 46.dp
     val UtilityButtonCompact: Dp = 44.dp
-    val TransportButton: Dp = 58.dp
-    val TransportButtonCompact: Dp = 54.dp
-    val PrimaryButton: Dp = 76.dp
-    val PrimaryButtonCompact: Dp = 70.dp
+    val TransportButton: Dp = 54.dp
+    val TransportButtonCompact: Dp = 50.dp
+    val PrimaryWidth: Dp = 80.dp
+    val PrimaryWidthCompact: Dp = 74.dp
+    val PrimaryHeight: Dp = 66.dp
+    val PrimaryHeightCompact: Dp = 62.dp
+    val PrimaryCorner: Dp = 30.dp
     val MinimumTouchTarget: Dp = 48.dp
 
     val Hairline: Dp = 1.dp

--- a/app/src/main/java/com/luc4n3x/levyra/ui/theme/PlayerDesign.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/theme/PlayerDesign.kt
@@ -1,0 +1,99 @@
+package com.luc4n3x.levyra.ui.theme
+
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.SpringSpec
+import androidx.compose.animation.core.TweenSpec
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+object LevyraPlayerDesign {
+
+    val CornerXs: Dp = 12.dp
+    val CornerSm: Dp = 16.dp
+    val CornerMd: Dp = 22.dp
+    val CornerLg: Dp = 28.dp
+    val CornerXl: Dp = 34.dp
+
+    val ShapeXs: Shape = RoundedCornerShape(CornerXs)
+    val ShapeSm: Shape = RoundedCornerShape(CornerSm)
+    val ShapeMd: Shape = RoundedCornerShape(CornerMd)
+    val ShapeLg: Shape = RoundedCornerShape(CornerLg)
+    val ShapeXl: Shape = RoundedCornerShape(CornerXl)
+    val ShapePill: Shape = RoundedCornerShape(percent = 50)
+
+    val SpaceXxs: Dp = 2.dp
+    val SpaceXs: Dp = 4.dp
+    val SpaceSm: Dp = 8.dp
+    val SpaceMd: Dp = 12.dp
+    val SpaceLg: Dp = 18.dp
+    val SpaceXl: Dp = 24.dp
+
+    val GutterCompact: Dp = 18.dp
+    val Gutter: Dp = 22.dp
+
+    val HeaderButton: Dp = 42.dp
+    val HeaderButtonCompact: Dp = 40.dp
+    val UtilityButton: Dp = 46.dp
+    val UtilityButtonCompact: Dp = 44.dp
+    val TransportButton: Dp = 58.dp
+    val TransportButtonCompact: Dp = 54.dp
+    val PrimaryButton: Dp = 76.dp
+    val PrimaryButtonCompact: Dp = 70.dp
+    val MinimumTouchTarget: Dp = 48.dp
+
+    val Hairline: Dp = 1.dp
+    val TrackHeight: Dp = 5.dp
+    val TrackHeightActive: Dp = 8.dp
+    val WaveAmplitude: Dp = 3.dp
+    val HandleWidth: Dp = 4.dp
+    val HandleWidthActive: Dp = 6.dp
+    val HandleHeight: Dp = 22.dp
+    val HandleHeightActive: Dp = 32.dp
+
+    val Emphasized: Easing = CubicBezierEasing(0.2f, 0f, 0f, 1f)
+    val Standard: Easing = CubicBezierEasing(0.3f, 0f, 0.1f, 1f)
+    val Decelerate: Easing = CubicBezierEasing(0.05f, 0.7f, 0.1f, 1f)
+
+    const val ExpressiveDamping: Float = 0.62f
+    const val ExpressiveStiffness: Float = 340f
+    const val SmoothDamping: Float = 0.9f
+    const val SmoothStiffness: Float = 520f
+    const val SnappyDamping: Float = 0.82f
+    const val SnappyStiffness: Float = 1_100f
+
+    fun <T> expressiveSpring(): SpringSpec<T> =
+        spring(dampingRatio = ExpressiveDamping, stiffness = ExpressiveStiffness)
+
+    fun <T> smoothSpring(): SpringSpec<T> =
+        spring(dampingRatio = SmoothDamping, stiffness = SmoothStiffness)
+
+    fun <T> snappySpring(): SpringSpec<T> =
+        spring(dampingRatio = SnappyDamping, stiffness = SnappyStiffness)
+
+    fun <T> emphasizedTween(durationMillis: Int = 320): TweenSpec<T> =
+        tween(durationMillis = durationMillis, easing = Emphasized)
+
+    fun <T> standardTween(durationMillis: Int = 220): TweenSpec<T> =
+        tween(durationMillis = durationMillis, easing = Standard)
+
+    const val WavePeriodDp: Float = 26f
+    const val WaveCycleMillis: Int = 1_600
+
+    val GlassFill: Color = Color.White.copy(alpha = 0.09f)
+    val GlassFillStrong: Color = Color.White.copy(alpha = 0.14f)
+    val GlassFillSunken: Color = Color.Black.copy(alpha = 0.26f)
+    val GlassBorderTop: Color = Color.White.copy(alpha = 0.24f)
+    val GlassBorderBottom: Color = Color.White.copy(alpha = 0.06f)
+    val GlassSpecular: Color = Color.White.copy(alpha = 0.10f)
+
+    val TextPrimary: Color = Color.White
+    val TextSecondary: Color = Color.White.copy(alpha = 0.72f)
+    val TextTertiary: Color = Color.White.copy(alpha = 0.52f)
+    val IconIdle: Color = Color.White.copy(alpha = 0.62f)
+}

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -888,6 +888,7 @@ private fun libraryProjection(state: LevyraUiState): LibraryProjection = Library
 private data class PlayerProjection(
     val animationsEnabled: Boolean,
     val audioNormalization: Boolean,
+    val bufferedPositionMs: Long,
     val currentTrack: Track?,
     val durationMs: Long,
     val favoriteIds: Set<String>,
@@ -910,6 +911,7 @@ private data class PlayerProjection(
 private fun playerProjection(state: LevyraUiState): PlayerProjection = PlayerProjection(
     animationsEnabled = state.animationsEnabled,
     audioNormalization = state.audioNormalization,
+    bufferedPositionMs = state.bufferedPositionMs,
     currentTrack = state.currentTrack,
     durationMs = state.durationMs,
     favoriteIds = state.favoriteIds,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
@@ -107,6 +107,7 @@ data class LevyraUiState(
     val searchError: String? = null,
     val playerError: String? = null,
     val positionMs: Long = 0L,
+    val bufferedPositionMs: Long = 0L,
     val durationMs: Long = 0L,
     val smartScore: Int = 94,
     val repeatMode: RepeatMode = RepeatMode.Off,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -1526,6 +1526,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                         isResolving = false,
                         isPlaying = shouldPlay,
                         positionMs = positionMs,
+                        bufferedPositionMs = positionMs,
                         durationMs = resolved.durationMs.takeIf { duration -> duration > 0L } ?: it.durationMs,
                         playerError = null
                     )
@@ -4300,6 +4301,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 youtubeEngagement = YoutubeEngagementState(videoId = engagementVideoId),
                 isPlaying = false,
                 positionMs = 0L,
+                bufferedPositionMs = 0L,
                 durationMs = track.durationMs,
                 motionArtwork = null,
                 motionArtworkLoading = it.animationsEnabled
@@ -4385,6 +4387,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 isResolving = false,
                 isPlaying = false,
                 positionMs = 0L,
+                bufferedPositionMs = 0L,
                 durationMs = track.durationMs,
                 currentTrack = track.copy(streamUrl = ""),
                 playerError = if (retryWhenOnline) null else cleanUserError(error)
@@ -5438,6 +5441,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 isPlaying = false,
                 isResolving = false,
                 positionMs = 0L,
+                bufferedPositionMs = 0L,
                 durationMs = 0L,
                 motionArtwork = null,
                 motionArtworkLoading = false,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -1587,6 +1587,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                         isResolving = false,
                         isPlaying = playWhenReady,
                         positionMs = positionMs,
+                        bufferedPositionMs = positionMs,
                         durationMs = resolved.durationMs.takeIf { duration -> duration > 0L } ?: it.durationMs,
                         playerError = null
                     )

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -5621,6 +5621,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 } else {
                     player.positionMs
                 }
+                val buffered = (player.bufferedPositionMs / 1_000L) * 1_000L
                 val active = lyricsEngine.currentLine(position, snapshot.lyrics)
                 val playbackStateChanged = snapshot.isPlaying != player.isPlaying
                 val shouldPublishUi = snapshot.selectedTab == LevyraTab.Player ||
@@ -5632,6 +5633,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                     _state.update {
                         it.copy(
                             positionMs = position,
+                            bufferedPositionMs = buffered.coerceAtLeast(position),
                             durationMs = duration,
                             isPlaying = player.isPlaying,
                             activeLyric = active

--- a/app/src/test/java/com/luc4n3x/levyra/ui/components/SeekbarGeometryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/components/SeekbarGeometryTest.kt
@@ -101,8 +101,8 @@ class SeekbarGeometryTest {
 
     @Test
     fun `scrub label switches to hours only for long tracks`() {
-        assertEquals("00:00", formatSeekbarMillis(-5_000L))
-        assertEquals("03:07", formatSeekbarMillis(187_000L))
+        assertEquals("0:00", formatSeekbarMillis(-5_000L))
+        assertEquals("3:07", formatSeekbarMillis(187_000L))
         assertEquals("1:00:05", formatSeekbarMillis(3_605_000L))
     }
 }

--- a/app/src/test/java/com/luc4n3x/levyra/ui/components/SeekbarGeometryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/components/SeekbarGeometryTest.kt
@@ -1,0 +1,108 @@
+package com.luc4n3x.levyra.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SeekbarGeometryTest {
+
+    @Test
+    fun `progress fraction is zero when duration is unknown`() {
+        assertEquals(0f, seekbarProgressFraction(5_000L, 0L), 0f)
+        assertEquals(0f, seekbarProgressFraction(5_000L, -1L), 0f)
+    }
+
+    @Test
+    fun `progress fraction never leaves the unit range`() {
+        assertEquals(0.5f, seekbarProgressFraction(30_000L, 60_000L), 0.0001f)
+        assertEquals(1f, seekbarProgressFraction(90_000L, 60_000L), 0f)
+        assertEquals(0f, seekbarProgressFraction(-4_000L, 60_000L), 0f)
+    }
+
+    @Test
+    fun `touch fraction is clamped to the visible track`() {
+        assertEquals(0f, seekbarFractionAt(-40f, 200f), 0f)
+        assertEquals(1f, seekbarFractionAt(400f, 200f), 0f)
+        assertEquals(0.25f, seekbarFractionAt(50f, 200f), 0.0001f)
+    }
+
+    @Test
+    fun `touch fraction is zero without a measured width`() {
+        assertEquals(0f, seekbarFractionAt(120f, 0f), 0f)
+    }
+
+    @Test
+    fun `handle stays fully inside the track at both ends`() {
+        val width = 300f
+        val handle = 12f
+        assertEquals(6f, seekbarHandleCenterX(0f, width, handle), 0.0001f)
+        assertEquals(294f, seekbarHandleCenterX(1f, width, handle), 0.0001f)
+        assertEquals(150f, seekbarHandleCenterX(0.5f, width, handle), 0.0001f)
+    }
+
+    @Test
+    fun `handle center survives a track narrower than the handle`() {
+        val center = seekbarHandleCenterX(0.5f, 8f, 40f)
+        assertTrue(center in 0f..8f)
+    }
+
+    @Test
+    fun `tooltip stays within the track bounds`() {
+        val width = 400f
+        val tooltip = 80f
+        assertEquals(0f, seekbarTooltipOffsetX(0f, width, tooltip), 0.0001f)
+        assertEquals(320f, seekbarTooltipOffsetX(1f, width, tooltip), 0.0001f)
+        assertEquals(160f, seekbarTooltipOffsetX(0.5f, width, tooltip), 0.0001f)
+    }
+
+    @Test
+    fun `tooltip wider than the track collapses to the start`() {
+        assertEquals(0f, seekbarTooltipOffsetX(0.5f, 40f, 90f), 0f)
+    }
+
+    @Test
+    fun `wave sample count stays bounded`() {
+        assertEquals(0, seekbarWaveSampleCount(0f))
+        assertEquals(1, seekbarWaveSampleCount(1f))
+        assertTrue(seekbarWaveSampleCount(100_000f) <= 900)
+    }
+
+    @Test
+    fun `wave amplitude tapers to zero at both edges`() {
+        val activeWidth = 200f
+        val taper = 20f
+        assertEquals(0f, seekbarWaveTaper(0f, activeWidth, taper), 0.0001f)
+        assertEquals(0f, seekbarWaveTaper(activeWidth, activeWidth, taper), 0.0001f)
+        assertEquals(1f, seekbarWaveTaper(100f, activeWidth, taper), 0.0001f)
+    }
+
+    @Test
+    fun `wave offset is flat without amplitude or wavelength`() {
+        assertEquals(0f, seekbarWaveOffset(10f, 0f, 30f, 0f), 0f)
+        assertEquals(0f, seekbarWaveOffset(10f, 4f, 0f, 0f), 0f)
+    }
+
+    @Test
+    fun `wave offset follows the sine of the travelled distance`() {
+        val wavelength = 40f
+        val amplitude = 3f
+        assertEquals(0f, seekbarWaveOffset(0f, amplitude, wavelength, 0f), 0.0001f)
+        assertEquals(amplitude, seekbarWaveOffset(wavelength / 4f, amplitude, wavelength, 0f), 0.0001f)
+        assertEquals(-amplitude, seekbarWaveOffset(3f * wavelength / 4f, amplitude, wavelength, 0f), 0.0001f)
+    }
+
+    @Test
+    fun `seek millis is clamped to the track duration`() {
+        assertEquals(0L, seekbarSeekMillis(0.5f, 0L))
+        assertEquals(30_000L, seekbarSeekMillis(0.5f, 60_000L))
+        assertEquals(60_000L, seekbarSeekMillis(4f, 60_000L))
+        assertEquals(0L, seekbarSeekMillis(-2f, 60_000L))
+    }
+
+    @Test
+    fun `scrub label switches to hours only for long tracks`() {
+        assertEquals("00:00", formatSeekbarMillis(-5_000L))
+        assertEquals("03:07", formatSeekbarMillis(187_000L))
+        assertEquals("1:00:05", formatSeekbarMillis(3_605_000L))
+    }
+}


### PR DESCRIPTION
## Summary

- The player screen looked assembled from independent widgets: seven different corner radii, four button sizes, ad-hoc spacing and per-widget tween durations. This introduces one design scale for the whole player surface and rebuilds the progress and transport controls on top of it.

## Scope

- [x] Player / audio
- [ ] Stream extraction
- [ ] Downloads
- [x] UI / Compose
- [ ] Localization
- [ ] Android Auto / media session
- [ ] CI / release
- [ ] Documentation

## What changed

**Design tokens**
- New `LevyraPlayerDesign` (`ui/theme/PlayerDesign.kt`): shape scale, spacing scale, control sizes, motion springs/easings and glass tokens. The player, the mini player, the mode switch and the utility dock now read from it instead of hardcoding values.

**Seekbar (`PremiumSeekbar`)**
- Amplitude track that animates while playing and flattens when paused or scrubbed.
- Buffered-ahead segment drawn behind the remaining track.
- Handle morphs from a thin bar to a tall capsule on scrub, with a gap between handle and track so it stays readable at any position.
- Scrub tooltip now derives its border from the current artwork accent instead of a hardcoded grey, and shows hours for long tracks.
- Haptic feedback on tap-seek, scrub start and scrub end.
- Full 48dp touch target; existing `ProgressBarRangeInfo` / `setProgress` semantics preserved.

**Transport controls**
- New `PlayerTransportControls` replaces `MainPlayerControls` / `PlayerTransportButton`.
- Primary button morphs between a circle (paused) and a squircle (playing) on a spring, keeping the contrast-checked accent gradient and the resolving spinner.
- Shuffle and repeat became tonal toggles that morph shape and grow an accent border when active, instead of only changing icon tint.
- Previous/next share one size and corner family with the rest of the player.

**Glass surfaces**
- New `playerGlass` modifier and `PlayerGlassIconButton`: layered tint, specular top highlight and a top-to-bottom border gradient.
- Applied to the header buttons, the "playing from" pill, the mode switch, the title actions and the utility dock, so every chrome surface reads the same.

**Title block**
- Marquee on the title so long names are readable instead of truncated (falls back to two static lines when animations are off).
- Artist row is now a single tappable target with a chevron affordance and an accessible click label.
- Favorite button keeps the contrast-checked accent fill and adds a spring pop on toggle.

**Buffered position**
- `LevyraPlayer.bufferedPositionMs` is published through `LevyraUiState` (quantised to whole seconds so it does not add state churn) and consumed by the seekbar.

**Refactor**
- The player colour/contrast helpers moved out of `LevyraApp.kt` into `ui/PlayerColorContrast.kt` as `internal`, so the new component files can reuse them. Behaviour is unchanged, the code is identical apart from visibility.

**Behaviour preserved**
- Song/video mode choice, PiP entry, player gestures (double-tap seek, long-press speed, brightness/volume drags), motion artwork fallback, queue/lyrics/advanced panel and the YouTube engagement row are untouched.
- Every new animation is gated on the existing `animationsEnabled` preference.
- No new localization keys: the new components take their labels from the existing catalog through `PlayerControlLabels`.

## Testing

- [ ] `gradle --no-daemon :app:lintRelease`
- [ ] `gradle --no-daemon testReleaseUnitTest`
- [ ] `gradle --no-daemon assembleRelease`
- [ ] APK installed on device
- [ ] Playback tested
- [ ] Downloads tested
- [ ] Language switching tested

Not run locally: this environment's network policy blocks `dl.google.com`, so the Android Gradle Plugin cannot be resolved and no Gradle task could be executed. The checkboxes above are left unchecked for CI and a device pass.

Added `SeekbarGeometryTest` covering the new pure geometry: progress/fraction clamping, handle and tooltip bounds, wave sampling and taper, seek mapping and the scrub time format.

## Release safety

- [x] `levyraVersionName` and `levyraVersionCode` are correct
- [x] No secrets, keystores, APKs or ZIPs committed
- [x] No duplicated release workflows
- [x] Credits and licenses updated when adding external components


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the player interface with glass-styled controls, animated artwork, improved metadata interactions, and picture-in-picture support.
  * Added shuffle, repeat, transport, and mode-switch controls with localized labels.
  * Enhanced the seek bar with buffered progress, waveform visuals, drag tooltips, haptic feedback, and improved accessibility.
  * Added smoother animations, responsive loading states, and refined visual styling.

* **Bug Fixes**
  * Improved playback progress tracking so buffered progress remains accurate and never falls behind playback.

* **Tests**
  * Added coverage for seek bar geometry, waveform behavior, seeking, clamping, and time formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->