### PR TITLE
Refactor Home Screen UI (YT Music Theme)

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/ui/HomeExperience.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/HomeExperience.kt
@@ -170,14 +170,14 @@ private fun homeHaloBrush(
 )
 
 private fun homeHaloAlpha(isLight: Boolean, prominent: Boolean, leading: Boolean): Float = when {
-    isLight && prominent && leading -> 0.16f
-    isLight && prominent -> 0.045f
-    isLight && leading -> 0.10f
-    isLight -> 0.028f
-    prominent && leading -> 0.28f
-    prominent -> 0.075f
-    leading -> 0.20f
-    else -> 0.055f
+    isLight && prominent && leading -> 0.12f
+    isLight && prominent -> 0.035f
+    isLight && leading -> 0.08f
+    isLight -> 0.02f
+    prominent && leading -> 0.14f
+    prominent -> 0.04f
+    leading -> 0.10f
+    else -> 0.03f
 }
 
 private fun homeWaveBrush(primary: Color, secondary: Color, isLight: Boolean): Brush =

--- a/app/src/main/java/com/luc4n3x/levyra/ui/HomeExperience.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/HomeExperience.kt
@@ -98,152 +98,43 @@ internal fun LevyraHomeAtmosphere(
 private fun Modifier.homeAtmosphereBackground(
     primary: Color,
     secondary: Color,
-    isLight: Boolean
+    isLight: Boolean // Ignored, always dark theme for Home
 ): Modifier = drawWithCache {
     val width = size.width
     val height = size.height
-    val safeRadius = width.coerceAtLeast(1f)
-    val leftCenter = Offset(width * 0.12f, height * 0.06f)
-    val rightCenter = Offset(width * 0.96f, height * 0.22f)
-    val leftRadius = safeRadius * 0.94f
-    val rightRadius = safeRadius * 0.78f
-    val fadeTop = height * 0.46f
+    val fadeTop = height * 0.4f
 
-    val base = homeBaseBrush(isLight)
-    val leftHalo = homeHaloBrush(primary, isLight, leftCenter, leftRadius, prominent = true)
-    val rightHalo = homeHaloBrush(secondary, isLight, rightCenter, rightRadius, prominent = false)
-    val wave = homeWavePath(width, height)
-    val echo = homeEchoPath(width, height)
-    val waveBrush = homeWaveBrush(primary, secondary, isLight)
-    val bottomFade = homeBottomFadeBrush(isLight, fadeTop, height)
+    // Very dark premium gradient inspired by YT Music
+    val topGradient = Brush.radialGradient(
+        colors = listOf(
+            primary.copy(alpha = 0.15f),
+            secondary.copy(alpha = 0.05f),
+            Color.Transparent
+        ),
+        center = Offset(width / 2f, 0f),
+        radius = width.coerceAtLeast(height) * 0.8f
+    )
+
+    val backgroundDark = Color(0xFF030303) // Very deep dark gray/black
+
+    val bottomFade = Brush.verticalGradient(
+        colors = listOf(
+            Color.Transparent,
+            backgroundDark.copy(alpha = 0.8f),
+            backgroundDark
+        ),
+        startY = 0f,
+        endY = fadeTop
+    )
 
     onDrawBehind {
-        drawRect(base)
-        drawCircle(leftHalo, radius = leftRadius, center = leftCenter)
-        drawCircle(rightHalo, radius = rightRadius, center = rightCenter)
-        drawPath(wave, brush = waveBrush, style = Stroke(width = 1.25.dp.toPx()))
-        drawPath(
-            echo,
-            color = homeEchoColor(primary, isLight),
-            style = Stroke(width = 0.75.dp.toPx())
-        )
+        drawRect(backgroundDark)
+        drawRect(topGradient)
+        // Draw the fade to ensure it completely blends to black at the bottom
         drawRect(
             brush = bottomFade,
-            topLeft = Offset(0f, fadeTop),
-            size = Size(width, height - fadeTop)
+            topLeft = Offset(0f, 0f),
+            size = Size(width, height)
         )
     }
-}
-
-private fun homeBaseBrush(isLight: Boolean): Brush = if (isLight) {
-    Brush.verticalGradient(
-        listOf(
-            Color(0xFFF9FAFF),
-            Color(0xFFF4F6FC),
-            Color(0xFFF1F3F8)
-        )
-    )
-} else {
-    Brush.verticalGradient(
-        colorStops = arrayOf(
-            0f to LevyraHomeDesign.CanvasMid,
-            0.34f to LevyraHomeDesign.CanvasDark,
-            1f to Color.Black
-        )
-    )
-}
-
-private fun homeHaloBrush(
-    color: Color,
-    isLight: Boolean,
-    center: Offset,
-    radius: Float,
-    prominent: Boolean
-): Brush = Brush.radialGradient(
-    colors = listOf(
-        color.copy(alpha = homeHaloAlpha(isLight, prominent, leading = true)),
-        color.copy(alpha = homeHaloAlpha(isLight, prominent, leading = false)),
-        Color.Transparent
-    ),
-    center = center,
-    radius = radius
-)
-
-private fun homeHaloAlpha(isLight: Boolean, prominent: Boolean, leading: Boolean): Float = when {
-    isLight && prominent && leading -> 0.12f
-    isLight && prominent -> 0.035f
-    isLight && leading -> 0.08f
-    isLight -> 0.02f
-    prominent && leading -> 0.14f
-    prominent -> 0.04f
-    leading -> 0.10f
-    else -> 0.03f
-}
-
-private fun homeWaveBrush(primary: Color, secondary: Color, isLight: Boolean): Brush =
-    Brush.horizontalGradient(
-        listOf(
-            Color.Transparent,
-            primary.copy(alpha = if (isLight) 0.08f else 0.16f),
-            secondary.copy(alpha = if (isLight) 0.06f else 0.12f),
-            Color.Transparent
-        )
-    )
-
-private fun homeBottomFadeBrush(isLight: Boolean, fadeTop: Float, height: Float): Brush =
-    Brush.verticalGradient(
-        colors = if (isLight) {
-            listOf(
-                Color.Transparent,
-                Color(0xFFF1F3F8).copy(alpha = 0.86f),
-                Color(0xFFF1F3F8)
-            )
-        } else {
-            listOf(Color.Transparent, Color.Black.copy(alpha = 0.72f), Color.Black)
-        },
-        startY = fadeTop,
-        endY = height
-    )
-
-private fun homeEchoColor(primary: Color, isLight: Boolean): Color =
-    if (isLight) primary.copy(alpha = 0.035f) else Color.White.copy(alpha = 0.035f)
-
-private fun homeWavePath(width: Float, height: Float): Path = Path().apply {
-    moveTo(-width * 0.08f, height * 0.29f)
-    cubicTo(
-        width * 0.18f,
-        height * 0.19f,
-        width * 0.33f,
-        height * 0.37f,
-        width * 0.54f,
-        height * 0.25f
-    )
-    cubicTo(
-        width * 0.72f,
-        height * 0.15f,
-        width * 0.89f,
-        height * 0.31f,
-        width * 1.08f,
-        height * 0.21f
-    )
-}
-
-private fun homeEchoPath(width: Float, height: Float): Path = Path().apply {
-    moveTo(-width * 0.06f, height * 0.32f)
-    cubicTo(
-        width * 0.19f,
-        height * 0.23f,
-        width * 0.36f,
-        height * 0.41f,
-        width * 0.56f,
-        height * 0.29f
-    )
-    cubicTo(
-        width * 0.74f,
-        height * 0.19f,
-        width * 0.91f,
-        height * 0.34f,
-        width * 1.07f,
-        height * 0.25f
-    )
 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/HomeExperience.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/HomeExperience.kt
@@ -107,8 +107,8 @@ private fun Modifier.homeAtmosphereBackground(
     // Cool deep cosmic gradient
     val topGradient = Brush.radialGradient(
         colors = listOf(
-            primary.copy(alpha = 0.25f),
-            secondary.copy(alpha = 0.15f),
+            primary.copy(alpha = 0.08f),
+            secondary.copy(alpha = 0.04f),
             Color.Transparent
         ),
         center = Offset(width / 2f, 0f),

--- a/app/src/main/java/com/luc4n3x/levyra/ui/HomeExperience.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/HomeExperience.kt
@@ -123,8 +123,8 @@ private fun Modifier.homeAtmosphereBackground(
             backgroundDark.copy(alpha = 0.8f),
             backgroundDark
         ),
-        startY = 0f,
-        endY = fadeTop
+        startY = fadeTop,
+        endY = height
     )
 
     onDrawBehind {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/HomeExperience.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/HomeExperience.kt
@@ -104,18 +104,18 @@ private fun Modifier.homeAtmosphereBackground(
     val height = size.height
     val fadeTop = height * 0.4f
 
-    // Very dark premium gradient inspired by YT Music
+    // Cool deep cosmic gradient
     val topGradient = Brush.radialGradient(
         colors = listOf(
-            primary.copy(alpha = 0.15f),
-            secondary.copy(alpha = 0.05f),
+            primary.copy(alpha = 0.25f),
+            secondary.copy(alpha = 0.15f),
             Color.Transparent
         ),
         center = Offset(width / 2f, 0f),
-        radius = width.coerceAtLeast(height) * 0.8f
+        radius = width.coerceAtLeast(height) * 0.9f
     )
 
-    val backgroundDark = Color(0xFF030303) // Very deep dark gray/black
+    val backgroundDark = Color(0xFF0C0A15) // Deep cosmic purple-blue, not total black
 
     val bottomFade = Brush.verticalGradient(
         colors = listOf(
@@ -130,7 +130,7 @@ private fun Modifier.homeAtmosphereBackground(
     onDrawBehind {
         drawRect(backgroundDark)
         drawRect(topGradient)
-        // Draw the fade to ensure it completely blends to black at the bottom
+        // Draw the fade to ensure it completely blends to the cosmic color at the bottom
         drawRect(
             brush = bottomFade,
             topLeft = Offset(0f, 0f),

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -410,7 +410,7 @@ private const val HOME_HORIZONTAL_ROW_CONTENT_TYPE = "home-horizontal-row"
 private val LevyraTabBarHeight = 76.dp
 /** Mini player height: content row, progress line and its trailing spacer. */
 private val LevyraMiniPlayerHeight = 77.dp
-private val LevyraBottomContentGap = 16.dp
+private val LevyraBottomContentGap = 48.dp
 private val LevyraNavigationBlue = Color(0xFF0A84FF)
 private val LevyraNavigationBlueDeep = Color(0xFF0066E6)
 private val LevyraHomeGlowViolet = Color(0xFF6E5CF0)
@@ -541,8 +541,8 @@ private fun RowScope.TabButton(icon: ImageVector, label: String, selected: Boole
                     .background(
                         brush = Brush.horizontalGradient(
                             listOf(
-                                LevyraNavigationBlue.copy(alpha = 0.92f * selectedProgress),
-                                LevyraNavigationBlueDeep.copy(alpha = 0.78f * selectedProgress)
+                                Color.White.copy(alpha = 0.12f * selectedProgress),
+                                Color.White.copy(alpha = 0.08f * selectedProgress)
                             )
                         ),
                         shape = pillShape
@@ -5809,7 +5809,7 @@ private fun HomeEditorialSpotlight(
                 fontSize = 14.sp,
                 lineHeight = 17.sp,
                 fontWeight = FontWeight.SemiBold,
-                maxLines = 1,
+                maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )
             Text(
@@ -5818,7 +5818,7 @@ private fun HomeEditorialSpotlight(
                 fontSize = 11.5.sp,
                 lineHeight = 14.sp,
                 fontWeight = FontWeight.Medium,
-                maxLines = 1,
+                maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )
             if (isCurrent) {
@@ -7520,7 +7520,7 @@ private fun ContinueListeningCard(
                         fontSize = 10.8.sp,
                         lineHeight = 12.5.sp,
                         fontWeight = FontWeight.Medium,
-                        maxLines = 1,
+                        maxLines = 2,
                         overflow = TextOverflow.Ellipsis
                     )
                 }
@@ -14357,7 +14357,7 @@ private fun MoodRow(moods: List<Mood>, selectedId: String?, onSelect: (Mood) -> 
     LazyRow(
         modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
-        contentPadding = PaddingValues(horizontal = HomeHorizontalInset)
+        contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalInset + 24.dp)
     ) {
         items(
             items = moods,

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -6151,11 +6151,13 @@ private fun HomeQuickSelectionGrid(
     }
     if (displayTracks.isEmpty()) return
 
+    val strings = LocalLevyraStrings.current
+    val headingText = remember(strings) { strings.quickPicks.ifBlank { "Selezione rapida" } }
     val rows = remember(displayTracks) { displayTracks.chunked(3) }
 
     Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
         Text(
-            text = "Selezione rapida",
+            text = headingText,
             color = if (LevyraIsLight) LevyraText else Color.White,
             fontSize = 20.sp,
             fontWeight = FontWeight.ExtraBold,
@@ -6208,20 +6210,11 @@ private fun HomeQuickSelectionCard(
             .border(BorderStroke(borderPx, borderColor), shape)
             .pressable(onClick = onClick)
     ) {
-        if (track.artworkUrl.isNotBlank()) {
-            StableRemoteArtwork(
-                url = track.artworkUrl,
-                contentDescription = track.title,
-                modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop,
-                highRes = true
-            )
-        } else {
-            InstantArtworkPlaceholder(
-                track = track,
-                modifier = Modifier.fillMaxSize()
-            )
-        }
+        CoverImage(
+            track = track,
+            modifier = Modifier.fillMaxSize(),
+            highRes = true
+        )
 
         Box(
             modifier = Modifier

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -5269,6 +5269,11 @@ private fun HomeScreen(
             ?: resonanceTracks
     }
     val homeReleaseTracks = remember(newReleases) { newReleases?.tracks.orEmpty() }
+    val quickSelectionTracks = remember(visiblePersonalTracks, quickPicks, state.favorites, homeReleaseTracks, resonanceTracks) {
+        LevyraPersonalOrbit.distinctRecordings(
+            visiblePersonalTracks + (quickPicks?.tracks.orEmpty()) + state.favorites + homeReleaseTracks + resonanceTracks
+        ).take(9)
+    }
     val homeBottomInset = tabBarBottomContentInset(
         miniPlayerVisible = state.currentTrack != null,
         animationsEnabled = state.animationsEnabled
@@ -5299,35 +5304,12 @@ private fun HomeScreen(
         }
         item(key = "home-quick-access", contentType = "home-quick-access") {
             HomeSectionInset {
-                LevyraHomeQuickAccessGrid(
-                    state = LevyraHomeQuickAccessState(
-                        tracks = LevyraHomeQuickAccessTracks(
-                            current = state.currentTrack,
-                            mix = homeMixTracks.firstOrNull(),
-                            favorite = state.favorites.firstOrNull(),
-                            release = homeReleaseTracks.firstOrNull(),
-                            chart = state.charts.firstOrNull()
-                        ),
-                        availability = LevyraHomeQuickAccessAvailability(
-                            hasMix = homeMixTracks.isNotEmpty(),
-                            hasFavorites = state.favorites.isNotEmpty(),
-                            hasNewReleases = homeReleaseTracks.isNotEmpty(),
-                            hasCharts = state.charts.isNotEmpty()
-                        ),
-                        playback = LevyraHomeQuickAccessPlayback(
-                            isPlaying = state.isPlaying,
-                            isResolving = state.isResolving
-                        ),
-                        isLight = LevyraIsLight
-                    ),
-                    actions = LevyraHomeQuickAccessActions(
-                        onContinue = viewModel::togglePlay,
-                        onMix = { viewModel.playAll(homeMixTracks) },
-                        onFavorites = { viewModel.playAll(state.favorites) },
-                        onNewReleases = { viewModel.playAll(homeReleaseTracks) },
-                        onCharts = { viewModel.playAll(state.charts) },
-                        onSearch = { viewModel.searchNow() }
-                    )
+                HomeQuickSelectionGrid(
+                    tracks = quickSelectionTracks,
+                    currentId = state.currentTrack?.id,
+                    isPlaying = state.isPlaying,
+                    isResolving = state.isResolving,
+                    onPlay = { track -> viewModel.playFrom(quickSelectionTracks, track) }
                 )
             }
         }
@@ -6155,58 +6137,147 @@ private fun CollectionArtworkMosaic(
 }
 
 @Composable
-private fun HomeQuickAccessGrid(
-    hasMix: Boolean,
-    hasFavorites: Boolean,
-    hasNewReleases: Boolean,
-    onMix: () -> Unit,
-    onFavorites: () -> Unit,
-    onNewReleases: () -> Unit,
-    onSearch: () -> Unit
+private fun HomeQuickSelectionGrid(
+    tracks: List<Track>,
+    currentId: String?,
+    isPlaying: Boolean,
+    isResolving: Boolean,
+    onPlay: (Track) -> Unit
 ) {
+    val displayTracks = remember(tracks) {
+        tracks
+            .distinctBy(LevyraPersonalOrbit::identityKey)
+            .take(9)
+    }
+    if (displayTracks.isEmpty()) return
+
+    val rows = remember(displayTracks) { displayTracks.chunked(3) }
+
     Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(10.dp)
-        ) {
-            QuickAction(
-                icon = Icons.Rounded.Shuffle,
-                label = LocalLevyraStrings.current.mixForYou,
-                accent = LevyraCyan,
-                enabled = hasMix,
-                modifier = Modifier.weight(1f),
-                onClick = onMix
+        Text(
+            text = "Selezione rapida",
+            color = if (LevyraIsLight) LevyraText else Color.White,
+            fontSize = 20.sp,
+            fontWeight = FontWeight.ExtraBold,
+            letterSpacing = (-0.4).sp
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            rows.forEach { rowTracks ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    rowTracks.forEach { track ->
+                        HomeQuickSelectionCard(
+                            track = track,
+                            isCurrent = track.id == currentId,
+                            isPlaying = isPlaying && track.id == currentId,
+                            isResolving = isResolving && track.id == currentId,
+                            modifier = Modifier.weight(1f),
+                            onClick = { onPlay(track) }
+                        )
+                    }
+                    repeat(3 - rowTracks.size) {
+                        Spacer(modifier = Modifier.weight(1f))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HomeQuickSelectionCard(
+    track: Track,
+    isCurrent: Boolean,
+    isPlaying: Boolean,
+    isResolving: Boolean,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    val shape = RoundedCornerShape(14.dp)
+    val cardBackground = if (LevyraIsLight) Color.White else Color(0xFF12141D)
+    val borderColor = if (isCurrent) LevyraCyan else Color.White.copy(alpha = if (LevyraIsLight) 0.12f else 0.08f)
+    val borderPx = if (isCurrent) 1.5.dp else 1.dp
+
+    Box(
+        modifier = modifier
+            .aspectRatio(1.05f)
+            .clip(shape)
+            .background(cardBackground, shape)
+            .border(BorderStroke(borderPx, borderColor), shape)
+            .pressable(onClick = onClick)
+    ) {
+        if (track.artworkUrl.isNotBlank()) {
+            StableRemoteArtwork(
+                url = track.artworkUrl,
+                contentDescription = track.title,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop,
+                highRes = true
             )
-            QuickAction(
-                icon = Icons.Rounded.Favorite,
-                label = LocalLevyraStrings.current.favoritesPlain,
-                accent = LevyraPink,
-                enabled = hasFavorites,
-                modifier = Modifier.weight(1f),
-                onClick = onFavorites
+        } else {
+            InstantArtworkPlaceholder(
+                track = track,
+                modifier = Modifier.fillMaxSize()
             )
         }
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(10.dp)
-        ) {
-            QuickAction(
-                icon = Icons.Rounded.Bolt,
-                label = LocalLevyraStrings.current.newReleases,
-                accent = LevyraViolet,
-                enabled = hasNewReleases,
-                modifier = Modifier.weight(1f),
-                onClick = onNewReleases
-            )
-            QuickAction(
-                icon = Icons.Rounded.Search,
-                label = LocalLevyraStrings.current.search,
-                accent = Color(0xFFB7C7FF),
-                enabled = true,
-                modifier = Modifier.weight(1f),
-                onClick = onSearch
-            )
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        colorStops = arrayOf(
+                            0.0f to Color.Transparent,
+                            0.38f to Color.Transparent,
+                            0.70f to Color.Black.copy(alpha = 0.55f),
+                            1.0f to Color.Black.copy(alpha = 0.92f)
+                        )
+                    )
+                )
+        )
+
+        if (isCurrent) {
+            Box(
+                modifier = Modifier
+                    .padding(6.dp)
+                    .align(Alignment.TopEnd)
+                    .size(22.dp)
+                    .clip(CircleShape)
+                    .background(LevyraCyan)
+                    .border(1.dp, Color.Black.copy(alpha = 0.3f), CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                if (isResolving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(12.dp),
+                        strokeWidth = 1.5.dp,
+                        color = Color.Black
+                    )
+                } else {
+                    Icon(
+                        imageVector = if (isPlaying) Icons.Rounded.GraphicEq else Icons.Rounded.PlayArrow,
+                        contentDescription = null,
+                        tint = Color.Black,
+                        modifier = Modifier.size(13.dp)
+                    )
+                }
+            }
         }
+
+        Text(
+            text = track.title,
+            color = Color.White,
+            fontSize = 11.5.sp,
+            fontWeight = FontWeight.Bold,
+            lineHeight = 14.sp,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(horizontal = 8.dp, vertical = 7.dp)
+        )
     }
 }
 

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -13997,28 +13997,21 @@ private fun GreetingBar(userName: String, isResolving: Boolean, onSettings: () -
                     .size(24.dp)
                     .pressable(onClick = onSearch)
             )
-            Box(
-                modifier = Modifier
-                    .size(32.dp)
-                    .clip(CircleShape)
-                    .background(Color(0xFF333333))
-                    .pressable(onClick = onSettings),
-                contentAlignment = Alignment.Center
-            ) {
-                if (isResolving) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(16.dp),
-                        strokeWidth = 2.dp,
-                        color = LevyraCyan
-                    )
-                } else {
-                    Text(
-                        text = userName.take(1).uppercase(),
-                        color = Color.White,
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 14.sp
-                    )
-                }
+            if (isResolving) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp).padding(4.dp),
+                    strokeWidth = 2.dp,
+                    color = LevyraCyan
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.Rounded.Settings,
+                    contentDescription = "Settings",
+                    tint = Color.White,
+                    modifier = Modifier
+                        .size(24.dp)
+                        .pressable(onClick = onSettings)
+                )
             }
         }
     }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -662,38 +662,26 @@ private fun ActiveTrackEqualizer(
 }
 @Composable
 private fun HomePlayAllButton(onClick: () -> Unit, size: Dp = 36.dp) {
-    Box(
+    Surface(
+        color = Color.Transparent,
+        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.3f)),
+        shape = RoundedCornerShape(50),
         modifier = Modifier
-            .size(size)
-            .clip(CircleShape)
-            .background(
-                Brush.linearGradient(
-                    listOf(
-                        LevyraCyan.copy(alpha = 0.15f),
-                        LevyraViolet.copy(alpha = 0.11f)
-                    )
-                ),
-                CircleShape
-            )
-            .border(
-                1.dp,
-                Brush.linearGradient(
-                    listOf(
-                        LevyraCyan.copy(alpha = 0.45f),
-                        LevyraViolet.copy(alpha = 0.32f)
-                    )
-                ),
-                CircleShape
-            )
-            .pressable(onClick = onClick),
-        contentAlignment = Alignment.Center
+            .height(28.dp)
+            .pressable(onClick = onClick)
     ) {
-        Icon(
-            imageVector = Icons.Rounded.PlayArrow,
-            contentDescription = LocalLevyraStrings.current.play,
-            tint = LevyraCyan,
-            modifier = Modifier.size(size * 0.55f)
-        )
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = LocalLevyraStrings.current.playAll,
+                color = Color.White,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Bold
+            )
+        }
     }
 }
 
@@ -740,19 +728,19 @@ private fun HomeSectionHeader(
         ) {
             Text(
                 text = displayTitle,
-                color = LevyraText,
-                fontSize = 22.sp,
-                lineHeight = 26.sp,
-                letterSpacing = (-0.60).sp,
-                fontWeight = FontWeight.Bold,
+                color = Color.White,
+                fontSize = 24.sp,
+                lineHeight = 28.sp,
+                letterSpacing = (-0.50).sp,
+                fontWeight = FontWeight.ExtraBold,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
             if (displaySubtitle.isNotBlank()) {
                 Text(
                     text = displaySubtitle,
-                    color = LevyraMuted,
-                    fontSize = 12.5.sp,
+                    color = Color.White.copy(alpha = 0.7f),
+                    fontSize = 13.sp,
                     lineHeight = 16.sp,
                     fontWeight = FontWeight.Medium,
                     maxLines = 1,
@@ -5305,6 +5293,7 @@ private fun HomeScreen(
         item(key = "home-quick-access", contentType = "home-quick-access") {
             HomeSectionInset {
                 HomeQuickSelectionGrid(
+                    userName = state.userName,
                     tracks = quickSelectionTracks,
                     currentId = state.currentTrack?.id,
                     isPlaying = state.isPlaying,
@@ -6138,6 +6127,7 @@ private fun CollectionArtworkMosaic(
 
 @Composable
 private fun HomeQuickSelectionGrid(
+    userName: String,
     tracks: List<Track>,
     currentId: String?,
     isPlaying: Boolean,
@@ -6155,14 +6145,23 @@ private fun HomeQuickSelectionGrid(
     val headingText = remember(strings) { strings.quickPicks.ifBlank { "Selezione rapida" } }
     val rows = remember(displayTracks) { displayTracks.chunked(3) }
 
-    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-        Text(
-            text = headingText,
-            color = if (LevyraIsLight) LevyraText else Color.White,
-            fontSize = 20.sp,
-            fontWeight = FontWeight.ExtraBold,
-            letterSpacing = (-0.4).sp
-        )
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                text = userName.uppercase(),
+                color = Color.White.copy(alpha = 0.7f),
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 0.5.sp
+            )
+            Text(
+                text = headingText,
+                color = Color.White,
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = (-0.5).sp
+            )
+        }
         Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
             rows.forEach { rowTracks ->
                 Row(
@@ -6197,8 +6196,8 @@ private fun HomeQuickSelectionCard(
     modifier: Modifier = Modifier,
     onClick: () -> Unit
 ) {
-    val shape = RoundedCornerShape(14.dp)
-    val cardBackground = if (LevyraIsLight) Color.White else Color(0xFF12141D)
+    val shape = RoundedCornerShape(8.dp)
+    val cardBackground = Color(0xFF12141D)
     val borderColor = if (isCurrent) LevyraCyan else Color.White.copy(alpha = if (LevyraIsLight) 0.12f else 0.08f)
     val borderPx = if (isCurrent) 1.5.dp else 1.dp
 
@@ -6262,9 +6261,9 @@ private fun HomeQuickSelectionCard(
         Text(
             text = track.title,
             color = Color.White,
-            fontSize = 11.5.sp,
+            fontSize = 13.sp,
             fontWeight = FontWeight.Bold,
-            lineHeight = 14.sp,
+            lineHeight = 16.sp,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier
@@ -14115,131 +14114,58 @@ private fun LevyraWordmark(fontSize: TextUnit = 30.sp, dotSize: Dp = 5.dp) {
 @Composable
 private fun GreetingBar(userName: String, isResolving: Boolean, onSettings: () -> Unit) {
     val strings = LocalLevyraStrings.current
-    val greetingHour = java.util.Calendar.getInstance().get(java.util.Calendar.HOUR_OF_DAY)
-    val greeting = remember(userName, strings, greetingHour) {
-        strings.formatGreeting(userName, greetingHour)
-    }
-    val isLight = LevyraIsLight
-    val chipBackground = if (isLight) Color.White.copy(alpha = 0.90f) else Color(0xFF12141C)
-    val chipWash = LevyraCyan.copy(alpha = if (isLight) 0.10f else 0.16f)
-    val chipBorderStart = LevyraCyan.copy(alpha = if (isLight) 0.34f else 0.42f)
-    val chipBorderEnd = Color.White.copy(alpha = if (isLight) 0.06f else 0.08f)
-    val greetingTextColor = if (isLight) LevyraText.copy(alpha = 0.82f) else Color.White.copy(alpha = 0.90f)
-    val settingsBackground = if (isLight) Color.White.copy(alpha = 0.94f) else Color(0xFF12141C)
-    val settingsWashTop = LevyraCyan.copy(alpha = if (isLight) 0.10f else 0.18f)
-    val settingsWashBottom = LevyraViolet.copy(alpha = if (isLight) 0.06f else 0.12f)
-    val settingsBorderTop = Color.White.copy(alpha = if (isLight) 0.24f else 0.20f)
-    val settingsBorderBottom = Color.White.copy(alpha = if (isLight) 0.06f else 0.05f)
-    val settingsIconTint = if (isLight) LevyraText.copy(alpha = 0.88f) else Color.White.copy(alpha = 0.92f)
-    val settingsElevation = if (isLight) 2.dp else 8.dp
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(top = 2.dp),
+            .padding(top = 8.dp, bottom = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp)
+        horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            val greetingShape = RoundedCornerShape(999.dp)
-            Row(
+            LevyraLogoMark(size = 32.dp)
+            Text(
+                text = "Music",
+                color = Color.White,
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = (-0.5).sp
+            )
+        }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.Search,
+                contentDescription = "Search",
+                tint = Color.White,
+                modifier = Modifier.size(24.dp)
+            )
+            Box(
                 modifier = Modifier
-                    .clip(greetingShape)
-                    .background(chipBackground)
-                    .background(Brush.horizontalGradient(listOf(chipWash, Color.Transparent)))
-                    .border(
-                        BorderStroke(1.dp, Brush.horizontalGradient(listOf(chipBorderStart, chipBorderEnd))),
-                        greetingShape
-                    )
-                    .padding(start = 5.dp, end = 14.dp, top = 5.dp, bottom = 5.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(9.dp)
+                    .size(32.dp)
+                    .clip(CircleShape)
+                    .background(Color(0xFF333333))
+                    .pressable(onClick = onSettings),
+                contentAlignment = Alignment.Center
             ) {
-                Box(
-                    modifier = Modifier
-                        .size(28.dp)
-                        .shadow(
-                            elevation = 8.dp,
-                            shape = CircleShape,
-                            clip = false,
-                            ambientColor = LevyraCyan.copy(alpha = 0.55f),
-                            spotColor = LevyraViolet.copy(alpha = 0.65f)
-                        )
-                        .background(
-                            Brush.linearGradient(
-                                listOf(
-                                    LevyraCyan.copy(alpha = 0.95f),
-                                    LevyraViolet.copy(alpha = 0.90f)
-                                )
-                            ),
-                            CircleShape
-                        )
-                        .border(1.dp, Color.White.copy(alpha = 0.22f), CircleShape),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(
-                        imageVector = Icons.Rounded.Headphones,
-                        contentDescription = null,
-                        tint = Color.White,
-                        modifier = Modifier.size(15.dp)
+                if (isResolving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                        color = LevyraCyan
+                    )
+                } else {
+                    Text(
+                        text = userName.take(1).uppercase(),
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 14.sp
                     )
                 }
-                Text(
-                    text = greeting,
-                    color = greetingTextColor,
-                    fontSize = 13.sp,
-                    lineHeight = 15.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    letterSpacing = (-0.1).sp,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                LevyraLogoMark(size = 40.dp)
-                LevyraWordmark(fontSize = 29.sp, dotSize = 4.dp)
-            }
-        }
-        Box(
-            modifier = Modifier
-                .size(42.dp)
-                .shadow(
-                    elevation = settingsElevation,
-                    shape = CircleShape,
-                    clip = false,
-                    ambientColor = LevyraCyan.copy(alpha = 0.30f),
-                    spotColor = Color.Black.copy(alpha = 0.60f)
-                )
-                .background(settingsBackground, CircleShape)
-                .background(
-                    Brush.linearGradient(listOf(settingsWashTop, Color.Transparent, settingsWashBottom)),
-                    CircleShape
-                )
-                .border(
-                    BorderStroke(1.dp, Brush.verticalGradient(listOf(settingsBorderTop, settingsBorderBottom))),
-                    CircleShape
-                )
-                .pressable(onClick = onSettings),
-            contentAlignment = Alignment.Center
-        ) {
-            if (isResolving) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(18.dp),
-                    strokeWidth = 2.dp,
-                    color = LevyraCyan
-                )
-            } else {
-                Icon(
-                    imageVector = Icons.Rounded.Settings,
-                    contentDescription = strings.settings,
-                    tint = settingsIconTint,
-                    modifier = Modifier.size(21.dp)
-                )
             }
         }
     }
@@ -14583,8 +14509,8 @@ private fun SearchDock(query: String, isSearching: Boolean, onQuery: (String) ->
 @Composable
 private fun MoodRow(moods: List<Mood>, selectedId: String?, onSelect: (Mood) -> Unit) {
     LazyRow(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
+        modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
     ) {
         items(
             items = moods,
@@ -14592,30 +14518,22 @@ private fun MoodRow(moods: List<Mood>, selectedId: String?, onSelect: (Mood) -> 
             contentType = { "home-mood" }
         ) { mood ->
             val selected = mood.id == selectedId
+            val backgroundColor = if (selected) Color.White else Color.White.copy(alpha = 0.12f)
+            val textColor = if (selected) Color.Black else Color.White
             Box(
                 modifier = Modifier
-                    .clip(CircleShape)
-                    .background(
-                        if (selected) {
-                            Brush.linearGradient(listOf(LevyraCyan, LevyraViolet))
-                        } else {
-                            SolidColor(if (LevyraIsLight) Color.White.copy(alpha = 0.82f) else Color(0xFF0C0D10))
-                        },
-                        CircleShape
-                    )
-                    .then(
-                        if (selected) Modifier
-                        else Modifier.border(Dp.Hairline, LevyraAdaptiveSoftHairline, CircleShape)
-                    )
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(backgroundColor)
+                    .border(1.dp, Color.White.copy(alpha = 0.05f), RoundedCornerShape(8.dp))
                     .pressable(onClick = { onSelect(mood) })
             ) {
                 Text(
                     text = mood.title,
-                    color = if (selected) Color.White else LevyraText,
-                    fontSize = 13.sp,
-                    fontWeight = FontWeight.ExtraBold,
+                    color = textColor,
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.Medium,
                     maxLines = 1,
-                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 9.dp)
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp)
                 )
             }
         }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -5266,7 +5266,7 @@ private fun HomeScreen(
         miniPlayerVisible = state.currentTrack != null,
         animationsEnabled = state.animationsEnabled
     )
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0C0A15))) {
         LevyraHomeAtmosphere(
             accentStart = animatedHomeAccentStart,
             accentEnd = animatedHomeAccentEnd,
@@ -5285,7 +5285,7 @@ private fun HomeScreen(
         item(key = "home-top", contentType = "home-header") {
             HomeSectionInset {
                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                    GreetingBar(state.userName, state.isResolving, onSettings = viewModel::openSettings)
+                    GreetingBar(state.userName, state.isResolving, onSettings = viewModel::openSettings, onSearch = viewModel::openSearchScreen)
                     MoodRow(moods = state.moods, selectedId = state.selectedMood?.id, onSelect = viewModel::selectMood)
                 }
             }
@@ -14101,7 +14101,7 @@ private fun LevyraWordmark(fontSize: TextUnit = 30.sp, dotSize: Dp = 5.dp) {
 }
 
 @Composable
-private fun GreetingBar(userName: String, isResolving: Boolean, onSettings: () -> Unit) {
+private fun GreetingBar(userName: String, isResolving: Boolean, onSettings: () -> Unit, onSearch: () -> Unit) {
     val strings = LocalLevyraStrings.current
     Row(
         modifier = Modifier
@@ -14154,7 +14154,9 @@ private fun GreetingBar(userName: String, isResolving: Boolean, onSettings: () -
                 imageVector = Icons.Rounded.Search,
                 contentDescription = "Search",
                 tint = Color.White,
-                modifier = Modifier.size(24.dp)
+                modifier = Modifier
+                    .size(24.dp)
+                    .pressable(onClick = onSearch)
             )
             Box(
                 modifier = Modifier

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -5258,11 +5258,6 @@ private fun HomeScreen(
             ?: resonanceTracks
     }
     val homeReleaseTracks = remember(newReleases) { newReleases?.tracks.orEmpty() }
-    val quickSelectionTracks = remember(visiblePersonalTracks, quickPicks, state.favorites, homeReleaseTracks, resonanceTracks) {
-        LevyraPersonalOrbit.distinctRecordings(
-            visiblePersonalTracks + (quickPicks?.tracks.orEmpty()) + state.favorites + homeReleaseTracks + resonanceTracks
-        ).take(9)
-    }
     val homeBottomInset = tabBarBottomContentInset(
         miniPlayerVisible = state.currentTrack != null,
         animationsEnabled = state.animationsEnabled
@@ -6112,154 +6107,6 @@ private fun CollectionArtworkMosaic(
                 )
             }
         }
-    }
-}
-
-@Composable
-private fun HomeQuickSelectionGrid(
-    userName: String,
-    tracks: List<Track>,
-    currentId: String?,
-    isPlaying: Boolean,
-    isResolving: Boolean,
-    onPlay: (Track) -> Unit
-) {
-    val displayTracks = remember(tracks) {
-        tracks
-            .distinctBy(LevyraPersonalOrbit::identityKey)
-            .take(9)
-    }
-    if (displayTracks.isEmpty()) return
-
-    val strings = LocalLevyraStrings.current
-    val headingText = remember(strings) { strings.quickPicks.ifBlank { "Selezione rapida" } }
-    val rows = remember(displayTracks) { displayTracks.chunked(3) }
-
-    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-            Text(
-                text = userName.uppercase(),
-                color = Color.White.copy(alpha = 0.7f),
-                fontSize = 12.sp,
-                fontWeight = FontWeight.Medium,
-                letterSpacing = 0.5.sp
-            )
-            Text(
-                text = headingText,
-                color = Color.White,
-                fontSize = 24.sp,
-                fontWeight = FontWeight.Bold,
-                letterSpacing = (-0.5).sp
-            )
-        }
-        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-            rows.forEach { rowTracks ->
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(10.dp)
-                ) {
-                    rowTracks.forEach { track ->
-                        HomeQuickSelectionCard(
-                            track = track,
-                            isCurrent = track.id == currentId,
-                            isPlaying = isPlaying && track.id == currentId,
-                            isResolving = isResolving && track.id == currentId,
-                            modifier = Modifier.weight(1f),
-                            onClick = { onPlay(track) }
-                        )
-                    }
-                    repeat(3 - rowTracks.size) {
-                        Spacer(modifier = Modifier.weight(1f))
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun HomeQuickSelectionCard(
-    track: Track,
-    isCurrent: Boolean,
-    isPlaying: Boolean,
-    isResolving: Boolean,
-    modifier: Modifier = Modifier,
-    onClick: () -> Unit
-) {
-    val shape = RoundedCornerShape(8.dp)
-    val cardBackground = Color(0xFF12141D)
-    val borderColor = if (isCurrent) LevyraCyan else Color.White.copy(alpha = if (LevyraIsLight) 0.12f else 0.08f)
-    val borderPx = if (isCurrent) 1.5.dp else 1.dp
-
-    Box(
-        modifier = modifier
-            .aspectRatio(1.05f)
-            .clip(shape)
-            .background(cardBackground, shape)
-            .border(BorderStroke(borderPx, borderColor), shape)
-            .pressable(onClick = onClick)
-    ) {
-        CoverImage(
-            track = track,
-            modifier = Modifier.fillMaxSize(),
-            highRes = true
-        )
-
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(
-                    Brush.verticalGradient(
-                        colorStops = arrayOf(
-                            0.0f to Color.Transparent,
-                            0.38f to Color.Transparent,
-                            0.70f to Color.Black.copy(alpha = 0.55f),
-                            1.0f to Color.Black.copy(alpha = 0.92f)
-                        )
-                    )
-                )
-        )
-
-        if (isCurrent) {
-            Box(
-                modifier = Modifier
-                    .padding(6.dp)
-                    .align(Alignment.TopEnd)
-                    .size(22.dp)
-                    .clip(CircleShape)
-                    .background(LevyraCyan)
-                    .border(1.dp, Color.Black.copy(alpha = 0.3f), CircleShape),
-                contentAlignment = Alignment.Center
-            ) {
-                if (isResolving) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(12.dp),
-                        strokeWidth = 1.5.dp,
-                        color = Color.Black
-                    )
-                } else {
-                    Icon(
-                        imageVector = if (isPlaying) Icons.Rounded.GraphicEq else Icons.Rounded.PlayArrow,
-                        contentDescription = null,
-                        tint = Color.Black,
-                        modifier = Modifier.size(13.dp)
-                    )
-                }
-            }
-        }
-
-        Text(
-            text = track.title,
-            color = Color.White,
-            fontSize = 13.sp,
-            fontWeight = FontWeight.Bold,
-            lineHeight = 16.sp,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier
-                .align(Alignment.BottomStart)
-                .padding(horizontal = 8.dp, vertical = 7.dp)
-        )
     }
 }
 
@@ -14112,16 +13959,7 @@ private fun GreetingBar(userName: String, isResolving: Boolean, onSettings: () -
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         val currentHour = java.time.LocalTime.now().hour
-        val greeting = when (currentHour) {
-            in 5..11 -> "Buongiorno"
-            in 12..17 -> "Buon pomeriggio"
-            else -> "Buonasera"
-        }
-        val displayGreeting = if (userName.isNotBlank()) {
-            "$greeting, $userName"
-        } else {
-            "$greeting, Luca"
-        }
+        val displayGreeting = strings.formatGreeting(userName, currentHour)
 
         Column(
             verticalArrangement = Arrangement.spacedBy(2.dp)
@@ -14153,7 +13991,7 @@ private fun GreetingBar(userName: String, isResolving: Boolean, onSettings: () -
         ) {
             Icon(
                 imageVector = Icons.Rounded.Search,
-                contentDescription = "Search",
+                contentDescription = strings.search,
                 tint = Color.White,
                 modifier = Modifier
                     .size(24.dp)

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -14374,34 +14374,26 @@ private fun MoodRow(moods: List<Mood>, selectedId: String?, onSelect: (Mood) -> 
             val selected = mood.id == selectedId
             
             val backgroundModifier = if (selected) {
-                Modifier.background(Brush.horizontalGradient(listOf(LevyraCyan, LevyraViolet)))
+                Modifier.background(Color.White)
             } else {
-                Modifier.background(Color.White.copy(alpha = 0.08f))
-            }
-            
-            val borderModifier = if (selected) {
-                Modifier
-            } else {
-                Modifier.border(1.dp, Brush.horizontalGradient(listOf(LevyraCyan.copy(alpha = 0.3f), LevyraViolet.copy(alpha = 0.3f))), CircleShape)
+                Modifier.background(Color(0xFF2A2A2A))
             }
             
             val textColor = if (selected) Color.Black else Color.White
             
             Box(
                 modifier = Modifier
-                    .clip(CircleShape)
+                    .clip(RoundedCornerShape(32.dp))
                     .then(backgroundModifier)
-                    .then(borderModifier)
                     .pressable(onClick = { onSelect(mood) })
             ) {
                 Text(
-                    text = mood.title.uppercase(),
+                    text = mood.title,
                     color = textColor,
-                    fontSize = 13.sp,
-                    fontWeight = FontWeight.Bold,
-                    letterSpacing = 1.sp,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
                     maxLines = 1,
-                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp)
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
                 )
             }
         }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -5290,18 +5290,7 @@ private fun HomeScreen(
                 }
             }
         }
-        item(key = "home-quick-access", contentType = "home-quick-access") {
-            HomeSectionInset {
-                HomeQuickSelectionGrid(
-                    userName = state.userName,
-                    tracks = quickSelectionTracks,
-                    currentId = state.currentTrack?.id,
-                    isPlaying = state.isPlaying,
-                    isResolving = state.isResolving,
-                    onPlay = { track -> viewModel.playFrom(quickSelectionTracks, track) }
-                )
-            }
-        }
+
         spotlightCandidate?.let { candidate ->
             val heroTrack = candidate.track
             item(key = "home-editorial-spotlight", contentType = "home-spotlight") {
@@ -14121,18 +14110,41 @@ private fun GreetingBar(userName: String, isResolving: Boolean, onSettings: () -
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        val currentHour = java.time.LocalTime.now().hour
+        val greeting = when (currentHour) {
+            in 5..11 -> "Buongiorno"
+            in 12..17 -> "Buon pomeriggio"
+            else -> "Buonasera"
+        }
+        val displayGreeting = if (userName.isNotBlank()) {
+            "$greeting, $userName"
+        } else {
+            "$greeting, Luca"
+        }
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(2.dp)
         ) {
-            LevyraLogoMark(size = 32.dp)
             Text(
-                text = "Music",
-                color = Color.White,
-                fontSize = 24.sp,
-                fontWeight = FontWeight.Bold,
-                letterSpacing = (-0.5).sp
+                text = displayGreeting,
+                color = Color.White.copy(alpha = 0.7f),
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Medium
             )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                LevyraLogoMark(size = 32.dp)
+                Text(
+                    text = "Levyra",
+                    color = Color.White,
+                    fontSize = 26.sp,
+                    fontWeight = FontWeight.ExtraBold,
+                    letterSpacing = (-0.8).sp,
+                    fontFamily = FontFamily.Default
+                )
+            }
         }
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -5284,11 +5284,11 @@ private fun HomeScreen(
             )
         ) {
         item(key = "home-top", contentType = "home-header") {
-            HomeSectionInset {
-                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                HomeSectionInset {
                     GreetingBar(state.userName, state.isResolving, onSettings = viewModel::openSettings, onSearch = viewModel::openSearchScreen)
-                    MoodRow(moods = state.moods, selectedId = state.selectedMood?.id, onSelect = viewModel::selectMood)
                 }
+                MoodRow(moods = state.moods, selectedId = state.selectedMood?.id, onSelect = viewModel::selectMood)
             }
         }
 
@@ -14524,8 +14524,9 @@ private fun SearchDock(query: String, isSearching: Boolean, onQuery: (String) ->
 @Composable
 private fun MoodRow(moods: List<Mood>, selectedId: String?, onSelect: (Mood) -> Unit) {
     LazyRow(
-        modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(10.dp)
+        modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        contentPadding = PaddingValues(horizontal = HomeHorizontalInset)
     ) {
         items(
             items = moods,
@@ -14533,22 +14534,36 @@ private fun MoodRow(moods: List<Mood>, selectedId: String?, onSelect: (Mood) -> 
             contentType = { "home-mood" }
         ) { mood ->
             val selected = mood.id == selectedId
-            val backgroundColor = if (selected) Color.White else Color.White.copy(alpha = 0.12f)
+            
+            val backgroundModifier = if (selected) {
+                Modifier.background(Brush.horizontalGradient(listOf(LevyraCyan, LevyraViolet)))
+            } else {
+                Modifier.background(Color.White.copy(alpha = 0.08f))
+            }
+            
+            val borderModifier = if (selected) {
+                Modifier
+            } else {
+                Modifier.border(1.dp, Brush.horizontalGradient(listOf(LevyraCyan.copy(alpha = 0.3f), LevyraViolet.copy(alpha = 0.3f))), CircleShape)
+            }
+            
             val textColor = if (selected) Color.Black else Color.White
+            
             Box(
                 modifier = Modifier
-                    .clip(RoundedCornerShape(8.dp))
-                    .background(backgroundColor)
-                    .border(1.dp, Color.White.copy(alpha = 0.05f), RoundedCornerShape(8.dp))
+                    .clip(CircleShape)
+                    .then(backgroundModifier)
+                    .then(borderModifier)
                     .pressable(onClick = { onSelect(mood) })
             ) {
                 Text(
-                    text = mood.title,
+                    text = mood.title.uppercase(),
                     color = textColor,
-                    fontSize = 15.sp,
-                    fontWeight = FontWeight.Medium,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Bold,
+                    letterSpacing = 1.sp,
                     maxLines = 1,
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp)
+                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp)
                 )
             }
         }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -272,6 +272,7 @@ import androidx.media3.common.VideoSize
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.ResolvedTextDirection
 import androidx.compose.ui.text.style.TextAlign

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -108,6 +108,7 @@ class HomeViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::homeP
     fun playAll(tracks: List<Track>) = root.playAll(tracks)
     fun playFrom(list: List<Track>, track: Track, loopOnCompletion: Boolean = false) = root.playFrom(list, track, loopOnCompletion)
     fun searchNow() = root.searchNow()
+    fun openSearchScreen() = root.selectTab(LevyraTab.Search)
     fun searchNow(query: String) = root.searchNow(query)
     fun selectChart(regionId: String) = root.selectChart(regionId)
     fun selectMood(mood: Mood) = root.selectMood(mood)


### PR DESCRIPTION
Refactored the Home Screen to use a dark premium theme. Updated the top bar, mood chips, quick selection grid, and section headers to match a modern YT Music inspired design.

**Latest updates:**
- Fixed background overriding issue to maintain readability on light themes (P1).
- Wired the search icon in the GreetingBar to correctly open the search flow (P2).
- Redesigned the MoodRow with a bespoke Levyra gradient glassmorphic style and fixed the edge clipping during horizontal scrolling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refreshed the home screen with a dark cosmic visual design and updated typography.
  * Added prominent search navigation to the home experience.
  * Introduced mood-based browsing with redesigned mood chips.
  * Added time-based greetings, logo branding, and updated settings access.
  * Replaced the circular play-all icon with a bordered text button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->