### PR TITLE
Add a full desktop artist page

### DIFF
--- a/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/CatalogController.kt
+++ b/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/state/CatalogController.kt
@@ -1,7 +1,9 @@
 package com.luc4n3x.levyra.desktop.app.state
 
 import com.luc4n3x.levyra.desktop.core.catalog.CatalogRepository
+import com.luc4n3x.levyra.desktop.core.model.ArtistDetail
 import com.luc4n3x.levyra.desktop.core.model.CatalogPage
+import com.luc4n3x.levyra.desktop.core.model.CollectionDetail
 import com.luc4n3x.levyra.desktop.core.model.CollectionRef
 import com.luc4n3x.levyra.desktop.core.model.SearchFilter
 import com.luc4n3x.levyra.desktop.core.storage.LibraryStore
@@ -31,6 +33,7 @@ data class SearchUiState(
 data class CollectionUiState(
     val ref: CollectionRef? = null,
     val page: CatalogPage = CatalogPage(),
+    val artist: ArtistDetail? = null,
     val loading: Boolean = false,
     val loadingMore: Boolean = false,
     val error: String = ""
@@ -141,7 +144,7 @@ class CatalogController(
     fun openCollection(ref: CollectionRef) {
         cancelCollectionJobs()
         collectionState.value = CollectionUiState(ref = ref, loading = true)
-        collectionJob = scope.launch { loadCollection { catalog.collection(ref).let { it.ref to it.page } } }
+        collectionJob = scope.launch { loadCollection { catalog.collection(ref) } }
     }
 
     fun openCollectionFromUrl(url: String, onOpened: () -> Unit) {
@@ -151,7 +154,7 @@ class CatalogController(
         collectionState.value = CollectionUiState(loading = true)
         onOpened()
         collectionJob = scope.launch {
-            loadCollection { catalog.collectionFromUrl(trimmed).let { it.ref to it.page } }
+            loadCollection { catalog.collectionFromUrl(trimmed) }
         }
     }
 
@@ -183,10 +186,14 @@ class CatalogController(
         }
     }
 
-    private suspend fun loadCollection(load: suspend () -> Pair<CollectionRef, CatalogPage>) {
+    private suspend fun loadCollection(load: suspend () -> CollectionDetail) {
         try {
-            val (ref, page) = load()
-            collectionState.value = CollectionUiState(ref = ref, page = page)
+            val detail = load()
+            collectionState.value = CollectionUiState(
+                ref = detail.ref,
+                page = detail.page,
+                artist = detail.artist
+            )
         } catch (cancellation: CancellationException) {
             throw cancellation
         } catch (error: Exception) {

--- a/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/ui/screens/ArtistScreen.kt
+++ b/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/ui/screens/ArtistScreen.kt
@@ -1,0 +1,499 @@
+package com.luc4n3x.levyra.desktop.app.ui.screens
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.luc4n3x.levyra.desktop.app.state.CollectionUiState
+import com.luc4n3x.levyra.desktop.app.ui.components.CollectionCard
+import com.luc4n3x.levyra.desktop.app.ui.components.EmptyState
+import com.luc4n3x.levyra.desktop.app.ui.components.ErrorBanner
+import com.luc4n3x.levyra.desktop.app.ui.components.LoadingRow
+import com.luc4n3x.levyra.desktop.app.ui.components.ScrollableColumn
+import com.luc4n3x.levyra.desktop.app.ui.components.TrackActions
+import com.luc4n3x.levyra.desktop.app.ui.components.TrackRow
+import com.luc4n3x.levyra.desktop.app.ui.i18n.LocalStrings
+import com.luc4n3x.levyra.desktop.app.ui.icons.LevyraIcons
+import com.luc4n3x.levyra.desktop.app.ui.theme.LocalAccentColor
+import com.luc4n3x.levyra.desktop.core.model.ArtistDetail
+import com.luc4n3x.levyra.desktop.core.model.CollectionRef
+import java.util.Locale
+
+@Composable
+fun ArtistScreen(
+    state: CollectionUiState,
+    actions: TrackActions,
+    onBack: () -> Unit,
+    onPlayAll: () -> Unit,
+    onShuffleAll: () -> Unit,
+    onEnqueueAll: () -> Unit,
+    onOpenCollection: (CollectionRef) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val strings = LocalStrings.current
+    val artist = state.artist
+
+    when {
+        artist == null && state.loading -> {
+            Column(
+                modifier = modifier.fillMaxSize().padding(28.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                ArtistBackRow(title = state.ref?.title.orEmpty(), onBack = onBack)
+                LoadingRow(label = strings.loading)
+            }
+            return
+        }
+
+        artist == null && state.error.isNotBlank() -> {
+            Column(
+                modifier = modifier.fillMaxSize().padding(28.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                ArtistBackRow(title = state.ref?.title.orEmpty(), onBack = onBack)
+                ErrorBanner(message = state.error, actionLabel = strings.close, onAction = onBack)
+            }
+            return
+        }
+
+        artist == null -> {
+            EmptyState(
+                icon = LevyraIcons.Disc,
+                title = strings.searchNoResults,
+                modifier = modifier
+            )
+            return
+        }
+    }
+
+    ScrollableColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = 28.dp, vertical = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(18.dp)
+    ) {
+        item {
+            ArtistHero(
+                artist = artist,
+                onBack = onBack,
+                onPlayAll = onPlayAll,
+                onShuffleAll = onShuffleAll,
+                onEnqueueAll = onEnqueueAll
+            )
+        }
+
+        if (state.error.isNotBlank()) {
+            item {
+                ErrorBanner(message = state.error, actionLabel = strings.close, onAction = onBack)
+            }
+        }
+
+        if (artist.biography.isNotBlank()) {
+            item {
+                ArtistBiographyCard(artist.biography)
+            }
+        }
+
+        if (artist.tracks.isNotEmpty()) {
+            item { ArtistSectionTitle(strings.homeTopTracks) }
+            itemsIndexed(
+                artist.tracks.take(MAX_VISIBLE_TRACKS),
+                key = { _, track -> "artist-track-${track.id}" }
+            ) { index, track ->
+                TrackRow(
+                    track = track,
+                    isCurrent = track.id == actions.currentTrackId,
+                    isFavorite = actions.isFavorite(track),
+                    onPlay = { actions.onPlay(artist.tracks, index) },
+                    onPlayNext = { actions.onPlayNext(track) },
+                    onEnqueue = { actions.onEnqueue(track) },
+                    onToggleFavorite = { actions.onToggleFavorite(track) },
+                    onAddToPlaylist = { actions.onAddToPlaylist(track) },
+                    position = index + 1
+                )
+            }
+        }
+
+        if (artist.albums.isNotEmpty()) {
+            item {
+                ArtistCollectionSection(
+                    title = strings.filterAlbums,
+                    collections = artist.albums,
+                    onOpenCollection = onOpenCollection
+                )
+            }
+        }
+
+        if (artist.videos.isNotEmpty()) {
+            item { ArtistSectionTitle(strings.filterVideos) }
+            itemsIndexed(
+                artist.videos.take(MAX_VISIBLE_VIDEOS),
+                key = { _, track -> "artist-video-${track.id}" }
+            ) { index, track ->
+                TrackRow(
+                    track = track,
+                    isCurrent = track.id == actions.currentTrackId,
+                    isFavorite = actions.isFavorite(track),
+                    onPlay = { actions.onPlay(artist.videos, index) },
+                    onPlayNext = { actions.onPlayNext(track) },
+                    onEnqueue = { actions.onEnqueue(track) },
+                    onToggleFavorite = { actions.onToggleFavorite(track) },
+                    onAddToPlaylist = { actions.onAddToPlaylist(track) },
+                    position = index + 1
+                )
+            }
+        }
+
+        if (artist.playlists.isNotEmpty()) {
+            item {
+                ArtistCollectionSection(
+                    title = strings.filterPlaylists,
+                    collections = artist.playlists,
+                    onOpenCollection = onOpenCollection
+                )
+            }
+        }
+
+        if (artist.relatedArtists.isNotEmpty()) {
+            item {
+                ArtistRelatedSection(
+                    title = strings.filterArtists,
+                    artists = artist.relatedArtists,
+                    onOpenArtist = onOpenCollection
+                )
+            }
+        }
+
+        if (!artist.hasContent) {
+            item {
+                EmptyState(icon = LevyraIcons.Disc, title = strings.searchNoResults)
+            }
+        }
+
+        item { Spacer(modifier = Modifier.height(8.dp)) }
+    }
+}
+
+@Composable
+private fun ArtistHero(
+    artist: ArtistDetail,
+    onBack: () -> Unit,
+    onPlayAll: () -> Unit,
+    onShuffleAll: () -> Unit,
+    onEnqueueAll: () -> Unit
+) {
+    val strings = LocalStrings.current
+    val accent = LocalAccentColor.current
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(28.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        border = BorderStroke(1.dp, accent.copy(alpha = 0.25f)),
+        shadowElevation = 14.dp
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(300.dp)
+                .background(
+                    Brush.linearGradient(
+                        listOf(
+                            accent.copy(alpha = 0.42f),
+                            MaterialTheme.colorScheme.surfaceContainerHigh,
+                            MaterialTheme.colorScheme.surfaceContainer
+                        )
+                    )
+                )
+        ) {
+            if (artist.bannerUrl.isNotBlank()) {
+                AsyncImage(
+                    model = artist.bannerUrl,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        Brush.verticalGradient(
+                            listOf(
+                                Color.Black.copy(alpha = 0.08f),
+                                Color.Black.copy(alpha = 0.36f),
+                                MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.98f)
+                            )
+                        )
+                    )
+            )
+
+            Surface(
+                modifier = Modifier.padding(18.dp),
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.surface.copy(alpha = 0.84f)
+            ) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        imageVector = LevyraIcons.ChevronLeft,
+                        contentDescription = null,
+                        modifier = Modifier.size(21.dp)
+                    )
+                }
+            }
+
+            Row(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .fillMaxWidth()
+                    .padding(horizontal = 30.dp, vertical = 26.dp),
+                horizontalArrangement = Arrangement.spacedBy(24.dp),
+                verticalAlignment = Alignment.Bottom
+            ) {
+                ArtistPortrait(artist.portraitUrl)
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    Text(
+                        text = artist.name,
+                        style = MaterialTheme.typography.displaySmall,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    if (artist.subscriberCount >= 0L) {
+                        Text(
+                            text = formatArtistCount(artist.subscriberCount),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                        Button(onClick = onPlayAll, enabled = artist.tracks.isNotEmpty()) {
+                            Text(strings.playAll)
+                        }
+                        OutlinedButton(onClick = onShuffleAll, enabled = artist.tracks.isNotEmpty()) {
+                            Text(strings.shufflePlay)
+                        }
+                        OutlinedButton(onClick = onEnqueueAll, enabled = artist.tracks.isNotEmpty()) {
+                            Text(strings.addToQueue)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ArtistPortrait(url: String) {
+    Surface(
+        modifier = Modifier.size(176.dp),
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        border = BorderStroke(4.dp, MaterialTheme.colorScheme.surface),
+        shadowElevation = 16.dp
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            if (url.isBlank()) {
+                Icon(
+                    imageVector = LevyraIcons.Disc,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(54.dp)
+                )
+            } else {
+                AsyncImage(
+                    model = url,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ArtistBiographyCard(text: String) {
+    val strings = LocalStrings.current
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(22.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 22.dp, vertical = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Text(
+                text = strings.settingsAbout,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun ArtistCollectionSection(
+    title: String,
+    collections: List<CollectionRef>,
+    onOpenCollection: (CollectionRef) -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        ArtistSectionTitle(title)
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            contentPadding = PaddingValues(end = 18.dp)
+        ) {
+            items(collections, key = { it.id }) { ref ->
+                CollectionCard(
+                    ref = ref,
+                    onClick = { onOpenCollection(ref) },
+                    modifier = Modifier.width(176.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ArtistRelatedSection(
+    title: String,
+    artists: List<CollectionRef>,
+    onOpenArtist: (CollectionRef) -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        ArtistSectionTitle(title)
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            contentPadding = PaddingValues(end = 18.dp)
+        ) {
+            items(artists, key = { it.id }) { artist ->
+                Column(
+                    modifier = Modifier
+                        .width(132.dp)
+                        .clip(RoundedCornerShape(18.dp))
+                        .clickable { onOpenArtist(artist) }
+                        .padding(8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    Surface(
+                        modifier = Modifier.size(112.dp),
+                        shape = CircleShape,
+                        color = MaterialTheme.colorScheme.surfaceContainerHighest
+                    ) {
+                        if (artist.artworkUrl.isBlank()) {
+                            Box(contentAlignment = Alignment.Center) {
+                                Icon(
+                                    imageVector = LevyraIcons.Disc,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(34.dp)
+                                )
+                            }
+                        } else {
+                            AsyncImage(
+                                model = artist.artworkUrl,
+                                contentDescription = null,
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier.fillMaxSize()
+                            )
+                        }
+                    }
+                    Text(
+                        text = artist.title,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ArtistSectionTitle(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleLarge,
+        fontWeight = FontWeight.SemiBold
+    )
+}
+
+@Composable
+private fun ArtistBackRow(title: String, onBack: () -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(
+                imageVector = LevyraIcons.ChevronLeft,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+internal fun formatArtistCount(value: Long): String {
+    val safe = value.coerceAtLeast(0L)
+    return when {
+        safe >= 1_000_000_000L -> String.format(Locale.ROOT, "%.1fB", safe / 1_000_000_000.0)
+        safe >= 1_000_000L -> String.format(Locale.ROOT, "%.1fM", safe / 1_000_000.0)
+        safe >= 1_000L -> String.format(Locale.ROOT, "%.1fK", safe / 1_000.0)
+        else -> safe.toString()
+    }.replace(".0", "")
+}
+
+private const val MAX_VISIBLE_TRACKS = 12
+private const val MAX_VISIBLE_VIDEOS = 8

--- a/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/ui/screens/CollectionScreen.kt
+++ b/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/ui/screens/CollectionScreen.kt
@@ -35,6 +35,7 @@ import com.luc4n3x.levyra.desktop.app.ui.components.TrackActions
 import com.luc4n3x.levyra.desktop.app.ui.components.TrackRow
 import com.luc4n3x.levyra.desktop.app.ui.i18n.LocalStrings
 import com.luc4n3x.levyra.desktop.app.ui.icons.LevyraIcons
+import com.luc4n3x.levyra.desktop.core.model.CollectionKind
 import com.luc4n3x.levyra.desktop.core.model.CollectionRef
 
 @Composable
@@ -49,6 +50,20 @@ fun CollectionScreen(
     onOpenCollection: (CollectionRef) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    if (state.ref?.kind == CollectionKind.ARTIST) {
+        ArtistScreen(
+            state = state,
+            actions = actions,
+            onBack = onBack,
+            onPlayAll = onPlayAll,
+            onShuffleAll = onShuffleAll,
+            onEnqueueAll = onEnqueueAll,
+            onOpenCollection = onOpenCollection,
+            modifier = modifier
+        )
+        return
+    }
+
     val strings = LocalStrings.current
     val tracks = state.page.tracks
 

--- a/desktop/core/src/main/kotlin/com/luc4n3x/levyra/desktop/core/catalog/CatalogRepository.kt
+++ b/desktop/core/src/main/kotlin/com/luc4n3x/levyra/desktop/core/catalog/CatalogRepository.kt
@@ -310,7 +310,6 @@ internal fun chooseDesktopArtistName(requestedName: String, resolvedName: String
     return when {
         looksLikeTrackTitle -> requested
         requestedKey == resolvedKey -> requested
-        resolvedKey.contains(requestedKey) && resolved.length > requested.length + 3 -> requested
         else -> resolved
     }
 }

--- a/desktop/core/src/main/kotlin/com/luc4n3x/levyra/desktop/core/catalog/CatalogRepository.kt
+++ b/desktop/core/src/main/kotlin/com/luc4n3x/levyra/desktop/core/catalog/CatalogRepository.kt
@@ -1,6 +1,7 @@
 package com.luc4n3x.levyra.desktop.core.catalog
 
 import com.luc4n3x.levyra.desktop.core.charts.PlayableMatcher
+import com.luc4n3x.levyra.desktop.core.model.ArtistDetail
 import com.luc4n3x.levyra.desktop.core.model.CatalogPage
 import com.luc4n3x.levyra.desktop.core.model.CollectionDetail
 import com.luc4n3x.levyra.desktop.core.model.CollectionKind
@@ -8,12 +9,14 @@ import com.luc4n3x.levyra.desktop.core.model.CollectionRef
 import com.luc4n3x.levyra.desktop.core.model.PageCursor
 import com.luc4n3x.levyra.desktop.core.model.SearchFilter
 import com.luc4n3x.levyra.desktop.core.model.Track
+import java.util.Locale
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.schabi.newpipe.extractor.ServiceList
 import org.schabi.newpipe.extractor.StreamingService
 import org.schabi.newpipe.extractor.channel.ChannelInfo
+import org.schabi.newpipe.extractor.channel.ChannelInfoItem
 import org.schabi.newpipe.extractor.channel.ChannelTabInfo
 import org.schabi.newpipe.extractor.linkhandler.ChannelTabs
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler
@@ -144,32 +147,197 @@ class CatalogRepository(
         )
     }
 
-    private fun artistDetail(ref: CollectionRef): CollectionDetail {
+    private suspend fun artistDetail(ref: CollectionRef): CollectionDetail {
         val info = ChannelInfo.getInfo(service, ref.url)
-        val tabs = info.tabs.orEmpty()
-        val merged = preferredTabs(tabs)
-            .mapNotNull { tab -> runCatching { ChannelTabInfo.getInfo(service, tab) }.getOrNull() }
-            .map { tab -> CatalogMapper.toPage(tab.relatedItems.orEmpty(), null, null) }
+        val resolvedName = chooseDesktopArtistName(ref.title, info.name.orEmpty())
+        val tabPages = info.tabs.orEmpty().mapNotNull { handler ->
+            val page = runCatching { ChannelTabInfo.getInfo(service, handler) }
+                .getOrNull()
+                ?.let { CatalogMapper.toPage(it.relatedItems.orEmpty(), null, null) }
+                ?: return@mapNotNull null
+            ArtistTabPage(desktopArtistTabKind(handler), page)
+        }
+        val merged = tabPages
+            .map(ArtistTabPage::page)
             .fold(CatalogPage()) { accumulator, page -> accumulator.mergedWith(page) }
+
+        val tracksFromTab = tabPages
+            .filter { it.kind == DesktopArtistTabKind.TRACKS }
+            .flatMap { it.page.tracks }
+            .distinctBy { it.id }
+        val topTracks = tracksFromTab
+            .ifEmpty { merged.tracks.filter { artistLabelMatches(it.artist, resolvedName) } }
+            .ifEmpty { fallbackArtistTracks(ref.title.ifBlank { resolvedName }) }
+            .distinctBy { it.id }
+            .take(MAX_ARTIST_TRACKS)
+
+        val videos = tabPages
+            .filter { it.kind == DesktopArtistTabKind.VIDEOS }
+            .flatMap { it.page.tracks }
+            .filterNot { video -> topTracks.any { it.id == video.id } }
+            .distinctBy { it.id }
+            .take(MAX_ARTIST_VIDEOS)
+
+        val albumsFromTab = tabPages
+            .filter { it.kind == DesktopArtistTabKind.ALBUMS }
+            .flatMap { it.page.collections }
+            .map { it.copy(kind = CollectionKind.ALBUM) }
+            .distinctBy { it.id }
+        val albums = albumsFromTab
+            .ifEmpty { fallbackArtistAlbums(ref.title.ifBlank { resolvedName }) }
+            .distinctBy { it.id }
+            .take(MAX_ARTIST_ALBUMS)
+
+        val playlists = tabPages
+            .filter { it.kind == DesktopArtistTabKind.PLAYLISTS }
+            .flatMap { it.page.collections }
+            .map { it.copy(kind = CollectionKind.PLAYLIST) }
+            .distinctBy { it.id }
+            .take(MAX_ARTIST_PLAYLISTS)
+
+        val relatedArtists = info.relatedItems
+            .orEmpty()
+            .filterIsInstance<ChannelInfoItem>()
+            .mapNotNull(CatalogMapper::toCollection)
+            .filterNot { artistLabelMatches(it.title, resolvedName) }
+            .distinctBy { it.id }
+            .take(MAX_RELATED_ARTISTS)
+
+        val portrait = desktopArtistArtworkUrl(
+            info.avatarUrl.orEmpty().ifBlank { ref.artworkUrl },
+            ARTIST_PORTRAIT_SIZE
+        )
+        val banner = info.bannerUrl.orEmpty().trim()
+        val biography = info.description.orEmpty()
+            .replace(Regex("\\s*\\n+\\s*"), "\n")
+            .replace(Regex("[ \\t]{2,}"), " ")
+            .trim()
+        val artist = ArtistDetail(
+            name = resolvedName,
+            biography = biography,
+            portraitUrl = portrait,
+            bannerUrl = banner,
+            subscriberCount = info.subscriberCount,
+            tracks = topTracks,
+            videos = videos,
+            albums = albums,
+            playlists = playlists,
+            relatedArtists = relatedArtists
+        )
         val page = CatalogPage(
-            tracks = merged.tracks.distinctBy { it.id },
-            collections = merged.collections.distinctBy { it.id },
+            tracks = (topTracks + videos).distinctBy { it.id },
+            collections = (albums + playlists + relatedArtists).distinctBy { it.id },
             cursor = null
         )
         return CollectionDetail(
             ref = ref.copy(
-                title = info.name.orEmpty().ifBlank { ref.title },
-                artworkUrl = ref.artworkUrl.ifBlank { info.avatarUrl.orEmpty() },
-                itemCount = page.tracks.size.toLong()
+                title = resolvedName,
+                artworkUrl = portrait,
+                itemCount = topTracks.size.toLong()
             ),
-            page = page
+            page = page,
+            artist = artist
         )
     }
 
-    private fun preferredTabs(tabs: List<ListLinkHandler>): List<ListLinkHandler> {
-        val order = listOf(ChannelTabs.TRACKS, ChannelTabs.VIDEOS, ChannelTabs.ALBUMS, ChannelTabs.PLAYLISTS)
-        return order.mapNotNull { name ->
-            tabs.firstOrNull { tab -> tab.contentFilters.orEmpty().any { it.name == name } }
-        }
+    private suspend fun fallbackArtistTracks(name: String): List<Track> {
+        val page = runCatching { search(name, SearchFilter.SONGS) }.getOrDefault(CatalogPage())
+        val matching = page.tracks.filter { artistLabelMatches(it.artist, name) }
+        return matching.ifEmpty { page.tracks }.take(MAX_ARTIST_TRACKS)
+    }
+
+    private suspend fun fallbackArtistAlbums(name: String): List<CollectionRef> {
+        val page = runCatching { search(name, SearchFilter.ALBUMS) }.getOrDefault(CatalogPage())
+        val matching = page.collections.filter { artistLabelMatches(it.subtitle, name) }
+        return matching.ifEmpty { page.collections }
+            .map { it.copy(kind = CollectionKind.ALBUM) }
+            .take(MAX_ARTIST_ALBUMS)
+    }
+
+    private data class ArtistTabPage(
+        val kind: DesktopArtistTabKind?,
+        val page: CatalogPage
+    )
+
+    private companion object {
+        const val MAX_ARTIST_TRACKS = 20
+        const val MAX_ARTIST_VIDEOS = 16
+        const val MAX_ARTIST_ALBUMS = 24
+        const val MAX_ARTIST_PLAYLISTS = 16
+        const val MAX_RELATED_ARTISTS = 16
+        const val ARTIST_PORTRAIT_SIZE = 720
     }
 }
+
+internal enum class DesktopArtistTabKind {
+    TRACKS,
+    VIDEOS,
+    ALBUMS,
+    PLAYLISTS
+}
+
+internal fun desktopArtistTabKind(handler: ListLinkHandler): DesktopArtistTabKind? {
+    val labels = handler.contentFilters.orEmpty().map { it.name }
+    return desktopArtistTabKind(labels)
+}
+
+internal fun desktopArtistTabKind(labels: List<String>): DesktopArtistTabKind? {
+    val tokens = labels.map { it.trim().lowercase(Locale.ROOT) }
+    fun matches(primary: String, aliases: List<String>): Boolean {
+        val expected = primary.lowercase(Locale.ROOT)
+        return tokens.any { token ->
+            token == expected || aliases.any { alias -> token.contains(alias) }
+        }
+    }
+    return when {
+        matches(ChannelTabs.TRACKS, listOf("track", "song", "brani", "canzoni")) -> DesktopArtistTabKind.TRACKS
+        matches(ChannelTabs.VIDEOS, listOf("video", "clip")) -> DesktopArtistTabKind.VIDEOS
+        matches(ChannelTabs.ALBUMS, listOf("album", "release", "discografia")) -> DesktopArtistTabKind.ALBUMS
+        matches(ChannelTabs.PLAYLISTS, listOf("playlist", "mix")) -> DesktopArtistTabKind.PLAYLISTS
+        else -> null
+    }
+}
+
+internal fun chooseDesktopArtistName(requestedName: String, resolvedName: String): String {
+    val requested = CatalogMapper.cleanArtist(requestedName).trim()
+    val resolved = CatalogMapper.cleanArtist(resolvedName).trim()
+    if (resolved.isBlank()) return requested
+    if (requested.isBlank()) return resolved
+    val requestedKey = desktopArtistIdentity(requested)
+    val resolvedKey = desktopArtistIdentity(resolved)
+    val looksLikeTrackTitle = !requested.contains(" - ") &&
+        resolved.startsWith("$requested - ", ignoreCase = true)
+    return when {
+        looksLikeTrackTitle -> requested
+        requestedKey == resolvedKey -> requested
+        resolvedKey.contains(requestedKey) && resolved.length > requested.length + 3 -> requested
+        else -> resolved
+    }
+}
+
+internal fun desktopArtistArtworkUrl(url: String, size: Int = 720): String {
+    val clean = url.trim()
+    if (clean.isBlank()) return ""
+    val youtubeImage = clean.contains("yt3.", ignoreCase = true) ||
+        clean.contains("googleusercontent.com", ignoreCase = true) ||
+        clean.contains("ggpht.com", ignoreCase = true)
+    if (!youtubeImage) return clean
+    val suffix = clean.substringAfterLast('=', "")
+    if (suffix.isBlank() || (!suffix.startsWith('s') && !suffix.startsWith('w'))) return clean
+    val base = clean.substringBeforeLast('=')
+    return "$base=s${size.coerceIn(256, 1280)}-c-k-c0x00ffffff-no-rj"
+}
+
+private fun artistLabelMatches(candidate: String, artistName: String): Boolean {
+    val candidateKey = desktopArtistIdentity(candidate)
+    val artistKey = desktopArtistIdentity(artistName)
+    if (candidateKey.isBlank() || artistKey.isBlank()) return false
+    return candidateKey == artistKey ||
+        candidateKey.contains(artistKey) ||
+        artistKey.contains(candidateKey)
+}
+
+private fun desktopArtistIdentity(value: String): String = CatalogMapper.cleanArtist(value)
+    .lowercase(Locale.ROOT)
+    .replace(Regex("[^\\p{L}\\p{N}]+"), " ")
+    .trim()

--- a/desktop/core/src/main/kotlin/com/luc4n3x/levyra/desktop/core/model/Catalog.kt
+++ b/desktop/core/src/main/kotlin/com/luc4n3x/levyra/desktop/core/model/Catalog.kt
@@ -49,7 +49,29 @@ data class CatalogPage(
     }
 }
 
+data class ArtistDetail(
+    val name: String,
+    val biography: String = "",
+    val portraitUrl: String = "",
+    val bannerUrl: String = "",
+    val subscriberCount: Long = -1L,
+    val tracks: List<Track> = emptyList(),
+    val videos: List<Track> = emptyList(),
+    val albums: List<CollectionRef> = emptyList(),
+    val playlists: List<CollectionRef> = emptyList(),
+    val relatedArtists: List<CollectionRef> = emptyList()
+) {
+    val hasContent: Boolean
+        get() = tracks.isNotEmpty() ||
+            videos.isNotEmpty() ||
+            albums.isNotEmpty() ||
+            playlists.isNotEmpty() ||
+            relatedArtists.isNotEmpty() ||
+            biography.isNotBlank()
+}
+
 data class CollectionDetail(
     val ref: CollectionRef,
-    val page: CatalogPage
+    val page: CatalogPage,
+    val artist: ArtistDetail? = null
 )

--- a/desktop/core/src/test/kotlin/com/luc4n3x/levyra/desktop/core/catalog/CatalogArtistDetailTest.kt
+++ b/desktop/core/src/test/kotlin/com/luc4n3x/levyra/desktop/core/catalog/CatalogArtistDetailTest.kt
@@ -1,0 +1,55 @@
+package com.luc4n3x.levyra.desktop.core.catalog
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CatalogArtistDetailTest {
+    @Test
+    fun trackLikeResolvedChannelNameDoesNotReplaceArtistName() {
+        assertEquals(
+            "HUGEL",
+            chooseDesktopArtistName(
+                requestedName = "HUGEL",
+                resolvedName = "HUGEL - Isihloko"
+            )
+        )
+    }
+
+    @Test
+    fun officialArtistNameIsKeptWhenItIsNotAFalseTrackTitle() {
+        assertEquals(
+            "The Weeknd",
+            chooseDesktopArtistName(
+                requestedName = "Weeknd",
+                resolvedName = "The Weeknd"
+            )
+        )
+    }
+
+    @Test
+    fun youtubePortraitIsPromotedToHighResolution() {
+        val upgraded = desktopArtistArtworkUrl(
+            "https://yt3.googleusercontent.com/example=s88-c-k-c0x00ffffff-no-rj",
+            size = 720
+        )
+
+        assertTrue(upgraded.endsWith("=s720-c-k-c0x00ffffff-no-rj"))
+    }
+
+    @Test
+    fun channelTabsAreRecognizedWithLocalizedLabels() {
+        assertEquals(
+            DesktopArtistTabKind.TRACKS,
+            desktopArtistTabKind(listOf("Brani"))
+        )
+        assertEquals(
+            DesktopArtistTabKind.ALBUMS,
+            desktopArtistTabKind(listOf("Discografia album"))
+        )
+        assertEquals(
+            DesktopArtistTabKind.VIDEOS,
+            desktopArtistTabKind(listOf("Music videos"))
+        )
+    }
+}


### PR DESCRIPTION
## What changed

- replaces the generic collection layout for artists with a dedicated desktop artist screen
- adds a banner hero, circular high-resolution official portrait, biography, popular tracks, albums, videos, playlists and related artists
- prefers the official channel avatar over the low-resolution search thumbnail
- prevents track-like channel names such as `HUGEL - Isihloko` from replacing the requested artist name while preserving legitimate official names
- loads every relevant channel tab and falls back to artist-scoped song and album searches when a provider tab is empty
- adds tests for artist-name correction, artwork resolution and localized channel-tab recognition

## Why

Artist results were opened through the generic collection screen. This produced an empty-playlist message, disabled actions and a badly cropped low-resolution image instead of the artist experience already available on Android.

## Impact

Opening an artist on Windows now displays a proper artist profile while album and playlist screens continue using the existing collection layout. Provider data that is unavailable is omitted rather than fabricated.

## Validation

- Desktop `assemble check` completed successfully
- all desktop core, player and app tests passed
- pull request is mergeable with `main`
