### PR TITLE
docs: add professional Codex and ChatGPT project guidance

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,77 @@
+# Levyra OpenAI Agent Configuration
+
+This directory contains the repository-local configuration intended for Codex and other OpenAI coding-agent workflows.
+
+## Design goals
+
+- Keep one authoritative engineering contract in the root `AGENTS.md`.
+- Reuse Levyra's existing, battle-tested procedures under `.claude/rules/` and `.claude/skills/` instead of copying them into a second tree.
+- Give Codex a discoverable repository skill that routes work to the correct Levyra procedure.
+- Give ChatGPT a clear project setup document without pretending that a `.chatgpt/` directory is loaded automatically.
+- Keep Claude-specific hooks, settings, permissions, agents, and marketplaces isolated under `.claude/`.
+
+## How each assistant uses the repository
+
+### Codex
+
+Codex should start from the repository root so it can discover `AGENTS.md` and `.agents/skills/levyra-engineering/SKILL.md`.
+
+Expected flow:
+
+1. Read `AGENTS.md`.
+2. Load the `levyra-engineering` skill for implementation, review, debugging, or release-preparation work.
+3. Follow the matching procedure under `.claude/skills/` and rule files under `.claude/rules/`.
+4. Inspect current code and tests before making assumptions.
+5. Make the smallest coherent change and report validation truthfully.
+
+### ChatGPT
+
+The normal GitHub connection in ChatGPT is used to search and analyze repository content. It does not turn a repository folder into automatic global instructions, and the standard GitHub connection is not a substitute for Codex when code must be modified and published.
+
+Create a ChatGPT Project for Levyra, connect or select this repository, and paste the contents of `docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md` into the Project instructions.
+
+That Project configuration directs ChatGPT to use:
+
+- `AGENTS.md` as the engineering contract;
+- `docs/ARCHITECTURE.md` as the architectural overview;
+- `.claude/rules/` as path- and domain-specific rules;
+- `.claude/skills/` as task procedures;
+- current code, tests, workflows, and pull requests as live evidence.
+
+### Claude Code
+
+Claude Code continues to use `.claude/CLAUDE.md`, `.claude/rules/`, `.claude/skills/`, `.claude/agents/`, `.claude/settings.json`, and `.claude/hooks/`.
+
+The root `AGENTS.md` does not replace Claude's own configuration. It provides a shared repository contract so the product invariants and validation standards stay consistent across assistants.
+
+## Directory structure
+
+```text
+AGENTS.md
+.agents/
+├── README.md
+└── skills/
+    └── levyra-engineering/
+        └── SKILL.md
+docs/
+└── ai/
+    ├── README.md
+    └── CHATGPT_PROJECT_INSTRUCTIONS.md
+.claude/
+├── CLAUDE.md
+├── rules/
+├── skills/
+├── agents/
+├── hooks/
+└── settings.json
+```
+
+## Maintenance rules
+
+- Put repository-wide product and engineering invariants in `AGENTS.md`.
+- Put architecture detail in `docs/ARCHITECTURE.md`.
+- Keep specialized procedures in `.claude/skills/` and route to them from the OpenAI skill.
+- Keep Claude-only permissions, hooks, plugins, and subagents in `.claude/`.
+- Update the ChatGPT Project instructions only when the collaboration contract changes.
+- Do not copy entire procedure files into `.agents/`; duplication creates drift and conflicting instructions.
+- When a review identifies a recurring project-specific failure, update the narrowest authoritative rule or procedure rather than adding the same warning everywhere.

--- a/.agents/skills/levyra-engineering/SKILL.md
+++ b/.agents/skills/levyra-engineering/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: levyra-engineering
+description: Analyze, implement, debug, review, or validate changes in the Levyra Android music application. Use for any task involving Levyra code, architecture, playback, extraction, Compose, Room, networking, security, CI, pull requests, or releases.
+---
+
+# Levyra engineering workflow
+
+## Start here
+
+1. Read the root `AGENTS.md` completely.
+2. Read `docs/ARCHITECTURE.md`.
+3. Classify the task using the routing table below.
+4. Read every matching procedure and rule before editing.
+5. Inspect the relevant implementation and nearby tests.
+
+Do not rely on a remembered version of Levyra. Current repository content is authoritative.
+
+## Route the task
+
+Several routes may apply at the same time. A playback change that also modifies stream resolution must use both the player and extractor procedures. A remote-media change may also require the security review procedure.
+
+| Domain | Procedure | Supporting rules |
+| --- | --- | --- |
+| Playback, queue, Media3, MediaSession, notification, Android Auto, prefetch, audio/video mode | `.claude/skills/levyra-player/SKILL.md` | `.claude/rules/player.md`, `.claude/rules/architecture.md` |
+| InnerTube, extractor, stream resolution, player-config synchronization, retry, tokens, network fallback | `.claude/skills/levyra-extractor/SKILL.md` | `.claude/rules/extractor-network.md`, `.claude/rules/security.md` |
+| Room entities, DAOs, migrations, schema, caches, stores, backup | `.claude/skills/levyra-database/SKILL.md` | `.claude/rules/data-room.md`, `.claude/rules/architecture.md` |
+| Compose screens, state projections, animation, lifecycle, accessibility, localization | `.claude/skills/levyra-compose/SKILL.md` | `.claude/rules/compose-ui.md`, `.claude/rules/localization.md` |
+| Decorative motion artwork | `.claude/skills/levyra-motion-artwork/SKILL.md` | `.claude/rules/player.md`, `.claude/rules/security.md` |
+| Secrets, URLs, redirects, SSRF, MIME handling, permissions, privacy, workflow exposure | `.claude/skills/levyra-security-review/SKILL.md` | `.claude/rules/security.md` |
+| Review of a branch, commit, patch, or pull request | `.claude/skills/levyra-pr-review/SKILL.md` | All rules relevant to the changed files |
+| Pre-merge or pre-release validation, version values, signing, APK output, release workflows | `.claude/skills/levyra-release-check/SKILL.md` | `.claude/rules/testing-release.md` |
+
+The procedure files are plain repository instructions. Ignore Claude-only metadata such as agent or tool declarations when the current environment does not support them; follow the engineering steps and safety requirements themselves.
+
+## Establish the change contract
+
+Before editing, identify:
+
+- the exact user-visible or developer-visible problem;
+- the current behavior and control flow;
+- behavior that must remain unchanged;
+- the likely root cause;
+- the smallest set of files that should change;
+- tests or evidence needed to prove the fix;
+- checks that require an Android SDK, credentials, CI, emulator, physical device, Android Auto, notification access, or external network.
+
+Do not expand the task into broad refactoring unless the existing architecture makes the requested fix impossible without it.
+
+## Implement safely
+
+- Keep playback requests ahead of artwork, lyrics, enrichment, prefetch, refresh, and diagnostics.
+- Preserve the user's explicit audio/song versus native-video choice.
+- Preserve Media3, MediaSession, notification, Android Auto, queue, and background-service synchronization.
+- Keep I/O and orchestration outside composables.
+- Keep blocking work off the main thread.
+- Reuse existing clients, stores, caches, scopes, dispatchers, and lifecycle owners.
+- Use identity and generation checks for late asynchronous results.
+- Re-throw `CancellationException`.
+- Do not turn transient failures into permanent misses.
+- Preserve user data with explicit Room migrations.
+- Validate provider-controlled URLs and redirects at every hop.
+- Do not change version values, signing, publication, or workflow permissions unless explicitly requested.
+
+## Validate proportionally
+
+Run the narrowest relevant tests first. Then run the applicable repository checks from `AGENTS.md` when the environment supports them.
+
+For documentation-only changes:
+
+- verify all referenced repository paths exist;
+- verify command examples match current build files and workflows;
+- check Markdown structure and code fences;
+- inspect the complete diff for accidental code, version, workflow, or generated-file changes.
+
+For code changes:
+
+- add regression tests that fail for the original defect and pass with the fix when practical;
+- run focused tests before broad suites;
+- use the repository Gradle wrapper;
+- run `git diff --check`;
+- report blocked and skipped checks explicitly.
+
+## Review before delivery
+
+Inspect the final diff and confirm:
+
+- only intended files changed;
+- no credentials, keystores, private configuration, APKs, ZIPs, or build output were added;
+- no unrelated formatting or dependency churn occurred;
+- no version value changed accidentally;
+- tests match the changed behavior;
+- comments and documentation describe the current implementation rather than an abandoned approach;
+- manual checks are not represented as completed without evidence.
+
+## Report
+
+Provide:
+
+1. root cause or rationale;
+2. concise implementation summary;
+3. files changed;
+4. important behavior preserved;
+5. tests and checks run with results;
+6. checks not run and why;
+7. residual risks and manual validation;
+8. a professional commit message when requested.
+
+Do not commit, push, open a pull request, merge, tag, or release unless the user explicitly authorizes that external action.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,143 @@
+# Levyra Engineering Instructions
+
+## Purpose and scope
+
+This file is the repository-level operating contract for coding agents working on Levyra. It applies to the entire repository unless a more specific `AGENTS.md` is added closer to the files being changed.
+
+Use these instructions for analysis, implementation, review, testing, documentation, and release preparation. Repository code, tests, build files, and current documentation always take precedence over assumptions or remembered behavior.
+
+## Sources of truth
+
+Read the following in this order before making a non-trivial change:
+
+1. This `AGENTS.md`.
+2. `docs/ARCHITECTURE.md`.
+3. The relevant implementation and nearby tests.
+4. The matching rule files under `.claude/rules/`.
+5. The matching workflow under `.claude/skills/` or `.agents/skills/levyra-engineering/SKILL.md`.
+6. Existing CI and release workflows when the task touches build, signing, packaging, extraction configuration, or publication.
+
+Do not treat README copy, old discussions, previous agent output, or stale review comments as more authoritative than the current repository.
+
+## Product mission
+
+Levyra is a native Android music application built with Kotlin, Jetpack Compose, AndroidX Media3, Room, WorkManager, OkHttp, and Coil. Protect playback reliability, responsiveness, privacy, and the user's existing choices before adding visual polish or speculative optimization.
+
+## Non-negotiable product behavior
+
+- The user controls whether playback uses song/audio mode or native video mode. Never remove, hide, merge, or silently override that choice.
+- Motion artwork is decorative and belongs to song/audio mode only. It must never replace native video mode, produce audible output, or delay playback.
+- Static artwork is the immediate and permanent fallback. Artwork failures must never leave a blank player or interrupt audio.
+- The audible player, MediaSession, notification, Android Auto, queue, and background service must remain synchronized.
+- Direct playback requests are the critical path. Home refresh, artwork, lyrics, diagnostics, prefetch, and enrichment must yield to playback.
+- Existing downloads, favorites, playlists, queue state, lyrics, history, settings, localization, and backup behavior must be preserved unless the task explicitly changes them.
+- Do not add Spotify endpoints, account login, cookies, GraphQL, tokens, scraping, telemetry, or tracking unless the repository owner explicitly requests that integration.
+
+## Architecture and concurrency rules
+
+- Preserve unidirectional data flow: user intent -> ViewModel or controller -> repository or player operation -> immutable state -> Compose.
+- Keep network, database, decoding, file, metadata, and parsing work off the main thread.
+- Reuse the existing OkHttp, Coil, Media3, Room, queue, cache, coroutine, and lifecycle infrastructure instead of creating parallel stacks.
+- Make ownership explicit for coroutines, players, callbacks, receivers, surfaces, decoders, cache entries, and in-flight work.
+- Shared asynchronous work must not depend on the lifecycle of its first caller. Cancellation by one waiter must not cancel work still required by another waiter.
+- Protect asynchronous publication with identity and generation checks whenever an older job can finish after a newer one.
+- Treat cancellation separately from failure. Re-throw `CancellationException`; never cache or report it as a normal miss.
+- Distinguish conclusive no-match results from transient transport, timeout, server, parsing, or verification failures.
+- Do not negative-cache inconclusive failures.
+- Bound retries, timeouts, concurrency, response sizes, storage growth, and prefetch work.
+- Keep durable identity independent from mutable display text.
+
+## Work method
+
+1. Restate the requested scope internally and identify behavior that must remain unchanged.
+2. Inspect the complete current path through the relevant UI, state, repository, player, database, service, workflow, and tests.
+3. Identify the root cause before editing. Do not hide a defect with retries, delays, broad exception handling, or duplicated state.
+4. Make the smallest coherent change that fixes the cause and fits the existing architecture.
+5. Avoid unrelated cleanup, formatting churn, dependency upgrades, renames, and refactors.
+6. Add or update regression tests for bugs, matching logic, security boundaries, migrations, and concurrency behavior when applicable.
+7. Run the narrowest useful checks first, then the applicable project checks.
+8. Inspect the final diff for unrelated changes, generated files, secrets, credentials, binary artifacts, conflict markers, and accidental version changes.
+9. Report exactly what changed, what ran, what passed, what failed, and what remains unverified.
+
+When the owner says "only this", modify only the named behavior or files unless an additional change is strictly required for correctness. State that requirement before expanding scope.
+
+## Build and validation
+
+Use the repository Gradle wrapper, never a system Gradle installation.
+
+```bash
+./gradlew --no-daemon :app:testDebugUnitTest
+./gradlew --no-daemon :app:lintRelease
+./gradlew --no-daemon --no-configuration-cache assembleRelease
+git diff --check
+```
+
+Guidance:
+
+- Start with focused tests for the affected module or class.
+- Android release tasks require the inputs documented in `app/build.gradle.kts` and mirrored by `.github/workflows/pr-check.yml`.
+- Do not add real credentials, a keystore, `local.properties`, or private configuration to make a local build pass.
+- A missing Android SDK, unavailable signing input, absent device, or blocked network is a blocked check, not a pass.
+- Never claim a build, emulator, device, Android Auto, notification, PiP, or playback check succeeded without evidence.
+- Documentation-only changes do not require an Android build unless they alter executable examples, workflow behavior, or build instructions. Validate paths, commands, Markdown, and the final diff instead.
+
+## Task routing
+
+Before reading widely or editing, load the matching procedure. Several procedures may apply to one task.
+
+| Task touches | Read and follow |
+| --- | --- |
+| Playback, queue, Media3, MediaSession, notification, Android Auto, prefetch, audio/video mode | `.claude/skills/levyra-player/SKILL.md` |
+| InnerTube, extractor, stream resolution, player-config sync, tokens, retries, network fallback | `.claude/skills/levyra-extractor/SKILL.md` |
+| Room entities, DAOs, migrations, schema, caches, stores, backup | `.claude/skills/levyra-database/SKILL.md` |
+| Compose screens, state projections, animation, lifecycle, accessibility, localization | `.claude/skills/levyra-compose/SKILL.md` |
+| Decorative motion artwork | `.claude/skills/levyra-motion-artwork/SKILL.md` |
+| Secrets, remote URLs, redirects, SSRF, MIME handling, permissions, privacy, workflow exposure | `.claude/skills/levyra-security-review/SKILL.md` |
+| Reviewing a branch, commit, patch, or pull request | `.claude/skills/levyra-pr-review/SKILL.md` |
+| Pre-merge or pre-release validation, version values, signing, APK output, release workflows | `.claude/skills/levyra-release-check/SKILL.md` |
+
+The `.claude/skills/` procedures are shared engineering playbooks despite their location. Codex and ChatGPT should read them as repository documentation; they do not require Claude-specific tooling to be useful.
+
+## Security and repository safety
+
+- Never commit or expose secrets, passwords, tokens, cookies, private URLs, keystores, signing material, `.env` files, or `local.properties`.
+- Never commit APKs, ZIPs, generated build output, IDE state, or temporary diagnostics unless explicitly required and already accepted by repository policy.
+- Validate every provider-controlled media URL across scheme, host, port, user info, DNS/IP destination, redirect hops, MIME type, timeout, and response-size bounds.
+- Preserve least privilege in Android permissions and GitHub workflow permissions.
+- Do not weaken transport, redirect, MIME, signature, or host validation to make one provider response pass.
+- Update credits and licenses when adding external code, assets, models, components, or dependencies.
+
+## Versioning, releases, and external actions
+
+- Do not change `levyraVersionName` or `levyraVersionCode` unless the task is explicitly a release or version task.
+- Do not tag, publish, release, merge, enable auto-merge, modify repository settings, or update store metadata without explicit approval.
+- Do not commit, push, or open a pull request unless the user explicitly asks for that external action.
+- When publication is requested, use a dedicated branch and a draft pull request by default. Never push directly to `main` unless the owner explicitly requests it after reviewing the exact scope.
+- Keep pull request descriptions and checklists truthful. Leave manual and device-only checks unmarked until they are actually completed.
+
+## Review standard
+
+For reviews, prioritize findings over summaries. Each finding must include:
+
+- severity and confidence;
+- exact file and line or symbol;
+- triggering scenario;
+- user or system consequence;
+- smallest compatible fix;
+- missing regression coverage.
+
+Do not report speculative issues without a concrete failure path. Ignore comments that no longer apply to the current code.
+
+## Delivery contract
+
+Every completed implementation should include:
+
+- concise summary of the root cause and solution;
+- files changed;
+- behavior preserved;
+- tests and checks run with results;
+- skipped or blocked checks;
+- remaining risks or manual validation;
+- a professional commit message when requested.
+
+Never claim that a file, test, build, push, pull request, merge, or release exists unless it was actually created or verified.

--- a/docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md
+++ b/docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md
@@ -1,0 +1,150 @@
+# ChatGPT Project Instructions — Levyra
+
+You are the technical collaborator for the Levyra project.
+
+Repository: `LUC4N3X/Levyra-deepsound`
+
+Your job is to help the repository owner make accurate product and engineering decisions, investigate defects, design minimal changes, review code and pull requests, prepare implementation plans, and coordinate work with Codex. Be direct, evidence-based, and protective of existing behavior.
+
+## Required repository context
+
+Before giving a technical conclusion, proposing code, reviewing a change, or preparing work for Codex:
+
+1. Read the root `AGENTS.md`.
+2. Read `docs/ARCHITECTURE.md`.
+3. Inspect the current implementation and nearby tests for the affected behavior.
+4. Read every matching procedure under `.claude/skills/` and rule under `.claude/rules/`.
+5. Inspect relevant build files and GitHub workflows when the request touches CI, signing, packaging, extraction configuration, versioning, or releases.
+6. Prefer current repository evidence over previous chat memory, old branches, stale comments, or remembered implementations.
+
+When repository access is incomplete or a required file cannot be inspected, state the limitation clearly and separate verified facts from assumptions.
+
+## Core product priorities
+
+Protect these priorities in order:
+
+1. playback reliability;
+2. correct user-controlled song/audio and native-video modes;
+3. synchronization between player, MediaSession, notification, Android Auto, queue, and background service;
+4. responsiveness and correct coroutine/lifecycle ownership;
+5. privacy and security;
+6. preservation of user data and settings;
+7. visual polish and optional enrichment.
+
+Artwork, lyrics, refresh, diagnostics, prefetch, metadata enrichment, and animation must never delay or destabilize direct playback.
+
+## Engineering behavior
+
+- Identify the root cause before recommending a fix.
+- Trace the current path from user intent through state, repository, player, database, service, and UI as applicable.
+- State which existing behavior must remain unchanged.
+- Prefer the smallest coherent change compatible with the existing architecture.
+- Avoid speculative refactors, parallel infrastructure, unrelated cleanup, dependency churn, or version upgrades.
+- Keep I/O, database, parsing, decoding, file, and network work off the main thread.
+- Reuse existing Media3, OkHttp, Coil, Room, queue, cache, coroutine, and lifecycle infrastructure.
+- Treat cancellation separately from failure and never describe a cancelled operation as a normal miss.
+- Require identity and generation checks when stale asynchronous work can publish after newer work.
+- Distinguish conclusive no-match results from transient timeout, transport, server, parsing, and verification failures.
+- Preserve explicit Room migrations and existing user data.
+- Require localization entries for user-facing text.
+- Require security review for provider-controlled URLs, redirects, MIME handling, permissions, secrets, tokens, cookies, and workflow exposure.
+
+## Scope discipline
+
+When the owner requests a specific change, do not silently broaden it.
+
+If the owner says "only this", restrict the proposal to that behavior or those files unless another modification is strictly required for correctness. Explain the dependency before expanding the scope.
+
+Do not change `levyraVersionName`, `levyraVersionCode`, signing, publication, release workflows, repository settings, or store metadata unless explicitly requested.
+
+## Analysis format
+
+For bugs or regressions, provide:
+
+1. verified behavior;
+2. probable root cause and confidence;
+3. user impact;
+4. files and symbols involved;
+5. minimal proposed change;
+6. behavior that must remain unchanged;
+7. risks and edge cases;
+8. regression tests and validation;
+9. any facts still unverified.
+
+For feature requests, provide:
+
+1. desired user behavior;
+2. current architecture fit;
+3. minimal implementation design;
+4. files likely involved;
+5. state, lifecycle, concurrency, database, security, and localization implications;
+6. tests and manual checks;
+7. rollout or compatibility risks.
+
+For pull request reviews, place findings before the summary. Each finding must contain severity, confidence, exact file/line or symbol, triggering scenario, consequence, smallest compatible fix, and missing test coverage. Do not report speculative findings without a concrete failure path.
+
+## Preparing work for Codex
+
+When the owner wants an implementation, prepare a precise Codex task containing:
+
+- objective and acceptance criteria;
+- relevant repository files and procedures to read;
+- current behavior and root cause;
+- required behavior to preserve;
+- exact scope boundaries;
+- expected files or modules;
+- required tests and commands;
+- prohibited changes;
+- delivery requirements.
+
+Tell Codex to read `AGENTS.md` and use `.agents/skills/levyra-engineering/SKILL.md` before editing.
+
+Do not represent planning text as an applied patch. Distinguish clearly between a recommendation, generated code, a locally tested change, a pushed branch, and an opened pull request.
+
+## Validation and honesty
+
+Use the repository Gradle wrapper for build instructions.
+
+Relevant full checks include:
+
+```bash
+./gradlew --no-daemon :app:testDebugUnitTest
+./gradlew --no-daemon :app:lintRelease
+./gradlew --no-daemon --no-configuration-cache assembleRelease
+git diff --check
+```
+
+Recommend focused tests before broad suites.
+
+Never claim that a test, build, emulator check, physical-device check, Android Auto check, notification check, PiP check, commit, push, pull request, merge, tag, or release succeeded unless there is direct evidence.
+
+Treat missing SDK components, credentials, signing inputs, network access, CI access, emulator, or device access as blocked checks, not successful checks.
+
+## Repository actions
+
+Do not commit, push, open a pull request, merge, tag, publish, release, or modify repository settings without explicit authorization from the owner.
+
+When the owner authorizes publication:
+
+- use a dedicated branch;
+- stage only intended files;
+- use a professional, focused commit message;
+- open a draft pull request by default;
+- provide a truthful PR body describing the reason, changes, impact, validation, blocked checks, and manual verification;
+- do not push directly to `main` unless the owner explicitly requests it after reviewing the exact scope.
+
+## Delivery standard
+
+For completed technical work or a Codex result, report:
+
+- root cause or rationale;
+- exact files changed;
+- concise description of each change;
+- behavior preserved;
+- tests and checks run with results;
+- checks skipped or blocked and why;
+- remaining risks and manual validation;
+- professional commit message;
+- branch and pull request status when applicable.
+
+Do not invent repository state, results, files, or certainty.

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -1,0 +1,58 @@
+# AI Assistant Setup for Levyra
+
+This guide explains how to use Levyra with ChatGPT, Codex, and Claude Code without creating conflicting instruction trees.
+
+## Repository contract
+
+`AGENTS.md` is the shared repository-level engineering contract. It defines product invariants, architecture rules, validation expectations, repository safety, release boundaries, and delivery requirements.
+
+Specialized Levyra rules and procedures remain under `.claude/rules/` and `.claude/skills/`. They are written as repository documentation and may be read by any assistant. Claude-specific execution settings, permissions, hooks, plugins, and subagents remain isolated under `.claude/`.
+
+## Codex setup
+
+1. Open or clone the repository.
+2. Start Codex from the repository root.
+3. Confirm that the root `AGENTS.md` is in scope.
+4. Use the repository skill at `.agents/skills/levyra-engineering/SKILL.md` for Levyra implementation, debugging, review, and release-preparation tasks.
+5. Let the skill route the task to the relevant procedure under `.claude/skills/`.
+
+Recommended first prompt:
+
+```text
+Read AGENTS.md and use the levyra-engineering skill. Inspect the current repository before making assumptions. Do not modify or publish anything until you have described the root cause, intended files, risks, and validation plan.
+```
+
+## ChatGPT setup
+
+ChatGPT can use a connected GitHub repository to search and analyze current code and documentation. Repository files are not a replacement for ChatGPT Project instructions, so configure the Project explicitly.
+
+1. Create a ChatGPT Project named `Levyra`.
+2. Connect or select the `LUC4N3X/Levyra-deepsound` repository through the GitHub app available in your ChatGPT experience.
+3. Copy the full contents of `docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md` into the Project instructions.
+4. Keep Levyra planning, architecture discussions, bug analysis, PR review, and release preparation inside that Project so the instructions remain active.
+5. Use Codex when the task requires editing, testing, committing, pushing, or opening a pull request.
+
+The standard ChatGPT GitHub connection is primarily for repository search and analysis. Access and write capabilities can vary by product experience, so never assume that a change was published unless the resulting branch, commit, or pull request was verified on GitHub.
+
+## Claude Code setup
+
+Claude Code continues to use `.claude/README.md` and the complete `.claude/` configuration.
+
+Start Claude Code from the repository root and follow the usage notes in `.claude/README.md`.
+
+## Responsibility split
+
+| Assistant | Primary role | Main configuration |
+| --- | --- | --- |
+| ChatGPT Project | Product decisions, planning, architecture discussion, repository analysis, PR interpretation | Project instructions copied from `docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md` plus connected GitHub repository |
+| Codex | Implementation, tests, local validation, commits, branches, pull requests when authorized | `AGENTS.md` and `.agents/skills/levyra-engineering/SKILL.md` |
+| Claude Code | Implementation and review using Claude-specific hooks, agents, permissions, and skills | `.claude/` |
+
+## Keeping instructions consistent
+
+- Update `AGENTS.md` for shared repository-wide rules.
+- Update `docs/ARCHITECTURE.md` for architecture.
+- Update the narrowest matching file under `.claude/rules/` or `.claude/skills/` for domain-specific procedures.
+- Update `CHATGPT_PROJECT_INSTRUCTIONS.md` only when ChatGPT collaboration behavior changes.
+- Do not copy an entire rule or skill into several assistant-specific directories.
+- Prefer links and routing over duplicated prose.


### PR DESCRIPTION
## Summary

Adds a professional, repository-native instruction layer for Codex and a complete setup package for ChatGPT Projects, while preserving the existing Claude Code configuration.

## What changed

- Added root `AGENTS.md` as the shared engineering contract for coding agents.
- Added `.agents/skills/levyra-engineering/SKILL.md` as the Codex entry point and task router.
- Added `.agents/README.md` to document how Codex, ChatGPT, and Claude Code divide responsibilities.
- Added `docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md` with production-ready English instructions to paste into the Levyra ChatGPT Project.
- Added `docs/ai/README.md` with setup and maintenance guidance.

## Design rationale

Levyra already has strong domain rules and procedures under `.claude/`. Copying all of them into a second OpenAI-specific tree would create drift and conflicting guidance. This change instead establishes:

1. one shared repository contract in `AGENTS.md`;
2. one Codex-discoverable skill that routes to the existing Levyra procedures;
3. explicit ChatGPT Project instructions for repository analysis and Codex handoff;
4. Claude-only hooks, settings, permissions, plugins, and subagents remaining isolated under `.claude/`.

## Developer impact

Codex receives clear scope, architecture, safety, validation, review, and delivery requirements before editing. ChatGPT receives a ready-to-use Project configuration for planning, repository analysis, PR review, and precise Codex task preparation.

No application code, Gradle configuration, CI workflow, version value, signing configuration, dependency, or release behavior is changed.

## Validation

- Compared `main` with `agent/add-codex-chatgpt-guidance`.
- Confirmed the final diff contains only five new Markdown files.
- Confirmed no code, build, workflow, binary artifact, credential, or version file changed.
- Verified referenced Levyra procedure and rule paths against the existing `.claude/` structure.
- Reviewed command examples against the existing project guidance.

Android unit tests, lint, and release assembly were not run because this is a documentation-only change with no executable or workflow modification.

## Manual follow-up after merge

Create or open the Levyra ChatGPT Project and paste the contents of `docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md` into its Project instructions. Repository files cannot configure ChatGPT Project instructions automatically.
