### PR TITLE
fix: bound remote announcement payloads

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/ui/support/RemoteAnnouncementRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/support/RemoteAnnouncementRepository.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import com.luc4n3x.levyra.BuildConfig
 import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
 import com.luc4n3x.levyra.domain.LevyraLanguageCatalog
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
 import java.net.URI
 import java.time.Instant
 import java.util.concurrent.TimeUnit
@@ -29,6 +31,7 @@ private const val KEY_APP_LAUNCH_COUNT = "app_launch_count"
 private const val KEY_LAST_APP_LAUNCH_AT = "last_app_launch_at"
 private const val KEY_SNOOZED_UNTIL_PREFIX = "snoozed_until_"
 private const val MAX_ANNOUNCEMENTS = 20
+internal const val MAX_REMOTE_ANNOUNCEMENT_PAYLOAD_BYTES = 2 * 1_024 * 1_024
 private const val MAX_COMPLETED_IDS = 200
 private const val MAX_RECORDED_LAUNCHES = 10_000
 private const val APP_LAUNCH_SESSION_GAP_MS = 30L * 60L * 1_000L
@@ -271,6 +274,29 @@ internal object RemoteAnnouncementParser {
     }
 }
 
+internal fun readBoundedAnnouncementPayload(
+    input: InputStream,
+    declaredLength: Long,
+    maxBytes: Int = MAX_REMOTE_ANNOUNCEMENT_PAYLOAD_BYTES
+): String? {
+    require(maxBytes > 0)
+    if (declaredLength > maxBytes) return null
+    val initialCapacity = declaredLength
+        .takeIf { it in 1..maxBytes.toLong() }
+        ?.toInt()
+        ?: minOf(8 * 1_024, maxBytes)
+    val output = ByteArrayOutputStream(initialCapacity)
+    val buffer = ByteArray(minOf(8 * 1_024, maxBytes))
+    while (true) {
+        val read = input.read(buffer)
+        if (read < 0) break
+        if (read == 0) continue
+        if (output.size() > maxBytes - read) return null
+        output.write(buffer, 0, read)
+    }
+    return output.toByteArray().toString(Charsets.UTF_8)
+}
+
 internal class RemoteAnnouncementRepository(context: Context) {
     private val appContext = context.applicationContext
     private val store = RemoteAnnouncementStore(appContext)
@@ -371,7 +397,10 @@ internal class RemoteAnnouncementRepository(context: Context) {
                         CatalogState(cached, available = true)
                     }
                     response.isSuccessful -> {
-                        val raw = response.body.string()
+                        val body = response.body
+                        val raw = body.byteStream().use { input ->
+                            readBoundedAnnouncementPayload(input, body.contentLength())
+                        } ?: return@use CatalogState(cached, available = cached != null)
                         val parsed = RemoteAnnouncementParser.parse(raw)
                             ?: return@use CatalogState(cached, available = cached != null)
                         store.saveCatalog(raw, response.header("ETag"), nowMs)

--- a/app/src/test/java/com/luc4n3x/levyra/ui/support/RemoteAnnouncementRepositoryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/support/RemoteAnnouncementRepositoryTest.kt
@@ -1,6 +1,8 @@
 package com.luc4n3x.levyra.ui.support
 
 import com.luc4n3x.levyra.domain.LevyraLanguageCatalog
+import java.io.ByteArrayInputStream
+import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Instant
@@ -224,6 +226,48 @@ class RemoteAnnouncementRepositoryTest {
 
         assertNotNull(copy)
         assertEquals("Service notice", copy?.settingsTitle)
+    }
+
+    @Test
+    fun boundedPayloadReaderAcceptsContentWithinLimit() {
+        val raw = """{"schemaVersion":2,"announcements":[]}"""
+        val bytes = raw.toByteArray()
+
+        val decoded = readBoundedAnnouncementPayload(
+            input = ByteArrayInputStream(bytes),
+            declaredLength = bytes.size.toLong(),
+            maxBytes = bytes.size
+        )
+
+        assertEquals(raw, decoded)
+    }
+
+    @Test
+    fun boundedPayloadReaderRejectsOversizedDeclaredContentWithoutReading() {
+        val unreadable = object : InputStream() {
+            override fun read(): Int = error("Oversized payload must be rejected before reading")
+        }
+
+        assertNull(
+            readBoundedAnnouncementPayload(
+                input = unreadable,
+                declaredLength = 65L,
+                maxBytes = 64
+            )
+        )
+    }
+
+    @Test
+    fun boundedPayloadReaderRejectsOversizedContentWithUnknownLength() {
+        val bytes = ByteArray(65) { 'x'.code.toByte() }
+
+        assertNull(
+            readBoundedAnnouncementPayload(
+                input = ByteArrayInputStream(bytes),
+                declaredLength = -1L,
+                maxBytes = 64
+            )
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

- cap downloaded remote-announcement catalogs at 2 MiB before JSON parsing or persistence
- reject oversized responses both when `Content-Length` is known and when the response is streamed with an unknown length
- keep the existing cached catalog or bundled fallback when the remote payload is rejected
- add focused tests for accepted, declared-oversized, and streamed-oversized payloads

## Cause and previous behavior

`RemoteAnnouncementRepository.refresh()` called `response.body.string()` for every successful response. That reads the complete body into memory without a bound. A mistakenly or maliciously oversized file at the configured remote endpoint could therefore cause avoidable memory pressure or an out-of-memory failure before the existing schema and field-count validation ran.

## Impact

Remote configuration remains fully supported within a 2 MiB ceiling, which is large enough for the current schema limits and localized catalog. Oversized content is treated like any other invalid/unavailable remote catalog: Levyra retains a valid cache when present, otherwise it uses the packaged fallback.

## Files

- `app/src/main/java/com/luc4n3x/levyra/ui/support/RemoteAnnouncementRepository.kt`
- `app/src/test/java/com/luc4n3x/levyra/ui/support/RemoteAnnouncementRepositoryTest.kt`

## Verification

- `levyra-worker verify`: passed
- Android regex compatibility check: passed
- focused boundary tests included in the unit-test suite

## Risks

Low. A future valid announcement catalog larger than 2 MiB would be rejected and fall back safely; the limit should be raised deliberately if the schema is expanded enough to require it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of remote announcements by limiting downloaded payload sizes.
  * Oversized or unreadable announcement responses now safely fall back to the cached catalog.
  * Prevented invalid or excessively large content from being processed or saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->