### PR TITLE
Add repository-native AI development workflow

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,16 +1,37 @@
 # Levyra OpenAI Agent Configuration
 
-This directory contains Levyra's repository-local native skills for Codex and compatible OpenAI coding-agent workflows.
+This directory contains Levyra's repository-local native skills for Codex,
+OpenClaw, and compatible OpenAI coding-agent workflows.
 
 ## Why `AGENTS.md` is in the repository root
 
-Codex discovers project instructions by starting at the Git root and walking toward the current working directory. Therefore:
+Codex discovers project instructions by starting at the Git root and walking
+toward the current working directory. Therefore:
 
 - root `AGENTS.md` is the automatic repository-wide contract;
-- `app/AGENTS.md`, `desktop/AGENTS.md`, `.github/AGENTS.md`, and `docs/AGENTS.md` provide narrower path-specific instructions;
-- `.agents/skills/` contains task procedures and must not replace the root instruction file.
+- `app/AGENTS.md`, `desktop/AGENTS.md`, `.github/AGENTS.md`, and
+  `docs/AGENTS.md` provide narrower path-specific instructions;
+- `.agents/skills/` contains task procedures and must not replace the root
+  instruction file.
 
-Moving the root contract into `docs/` or `.agents/` would make it ordinary documentation rather than guaranteed repository-root guidance.
+Moving the root contract into `docs/` or `.agents/` would make it ordinary
+documentation rather than guaranteed repository-root guidance.
+
+## Planning layers
+
+```text
+AGENTS.md                         durable operating rules
+SPEC.md                           approved requirements and non-goals
+ROADMAP.md                        ordered outcomes, risks, exit criteria
+TASKS.md                          one active phase and validation state
+docs/ARCHITECTURE.md              current implementation ownership and flow
+docs/ai/WORKFLOW.md               complete AI-assisted lifecycle
+docs/ai/OPENCLAW.md               OpenClaw workspace and delegation guidance
+```
+
+The planning files do not replace current code or tests. When they conflict with
+repository evidence, the agent must surface the conflict and correct the stale
+planning material rather than implementing around it silently.
 
 ## Configuration layers
 
@@ -21,7 +42,7 @@ desktop/AGENTS.md                 Windows Desktop rules
 .github/AGENTS.md                 CI and workflow security rules
 docs/AGENTS.md                    documentation rules
 .agents/skills/*/SKILL.md         native task skills
-docs/ai/                          ChatGPT Project setup material
+docs/ai/                          ChatGPT, Codex, Claude and OpenClaw guidance
 .claude/                          Claude Code configuration and detailed playbooks
 ```
 
@@ -29,6 +50,8 @@ docs/ai/                          ChatGPT Project setup material
 
 | Skill | Primary use |
 | --- | --- |
+| `levyra-project-manager` | Requirements, roadmap, active phase, acceptance criteria, validation and implementation handoff |
+| `levyra-openclaw-orchestrator` | Dedicated OpenClaw workspace, explicit delegation, coding runtimes, review and evidence handoff |
 | `levyra-player` | Android playback, queue, Media3, MediaSession, notification, Android Auto, audio/video modes |
 | `levyra-extractor` | InnerTube, extraction, stream resolution, runtime configuration, fallback and cache behavior |
 | `levyra-database` | Room, DAO, migrations, schemas, caches, stores, backups and persistent personal data |
@@ -41,7 +64,9 @@ docs/ai/                          ChatGPT Project setup material
 | `levyra-release-check` | Pre-merge/release validation, versions, signing, checksums, packaging and artifacts |
 | `levyra-engineering` | Cross-domain coordination when no single specialized skill is sufficient |
 
-Focused work should use the most specific skill. Several skills may be loaded for one change.
+Focused work should use the most specific skill. Several skills may be loaded
+for one change. Planning and OpenClaw orchestration skills coordinate domain
+skills; they do not replace them.
 
 ## Codex workflow
 
@@ -51,38 +76,86 @@ Expected behavior:
 
 1. Codex loads the root `AGENTS.md`.
 2. It adds every nearer `AGENTS.md` covering the working directory.
-3. It selects the matching native skill or skills.
-4. The skill points to relevant current code, tests, architecture, and detailed Levyra playbooks under `.claude/`.
-5. Codex makes the smallest coherent change and reports validation truthfully.
+3. It reads `SPEC.md`, the relevant `ROADMAP.md` track, and active `TASKS.md`
+   phase when applicable.
+4. It selects the matching native skill or skills.
+5. The skill points to relevant current code, tests, architecture, and detailed
+   Levyra playbooks under `.claude/`.
+6. Codex makes the smallest coherent change and reports validation truthfully.
+7. Publication remains a separate explicitly authorized action.
 
 Example prompts:
 
 ```text
-Use the levyra-player and levyra-extractor skills. Trace why playback sometimes resolves slowly, identify the root cause, and propose the smallest compatible fix before editing.
+Use levyra-project-manager, levyra-player and levyra-extractor. Trace why
+playback sometimes resolves slowly, identify the root cause, map the change to
+the active phase, and propose the smallest compatible fix before editing.
 ```
 
 ```text
-Use levyra-pr-review and review the current diff. Put evidence-backed findings first and distinguish tested behavior from manual checks.
+Use levyra-pr-review and review the current diff. Put evidence-backed findings
+first and distinguish tested behavior from manual checks.
 ```
+
+## OpenClaw
+
+Use a dedicated `levyra` agent whose workspace is the real repository checkout.
+The project-local `.agents/skills/` tree is then available to that workspace.
+
+Load `levyra-openclaw-orchestrator` for delegation. Use explicit agent targets,
+narrow tool access, a coding runtime for substantial implementation, and a fresh
+reviewer for the latest diff. OpenClaw may coordinate a branch and draft PR only
+when the owner explicitly authorizes publication; it must not infer permission
+to merge, tag, release, or change repository settings.
+
+See `docs/ai/OPENCLAW.md`.
 
 ## ChatGPT
 
-A normal ChatGPT conversation does not automatically treat repository files as persistent Project instructions. Create a Levyra ChatGPT Project, connect the repository, and paste the content of `docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md` into the Project instructions.
+A normal ChatGPT conversation does not automatically treat repository files as
+persistent Project instructions. Create a Levyra ChatGPT Project, connect the
+repository, and paste the content of
+`docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md` into the Project instructions.
 
-ChatGPT should use the repository for product decisions, investigation, architecture, planning, and review. Codex should perform implementation and publication work when authorized.
+ChatGPT should use the repository for product decisions, investigation,
+architecture, planning, and review. Codex should perform implementation and
+publication work when authorized.
 
 ## Claude Code
 
-Claude Code continues to use `.claude/CLAUDE.md`, `.claude/rules/`, `.claude/skills/`, `.claude/agents/`, `.claude/settings.json`, and `.claude/hooks/`.
+Claude Code continues to use `.claude/CLAUDE.md`, `.claude/rules/`,
+`.claude/skills/`, `.claude/agents/`, `.claude/settings.json`, and
+`.claude/hooks/`.
 
-The detailed `.claude/skills/` and `.claude/rules/` files remain useful as shared Levyra engineering playbooks. OpenAI skills reference them instead of duplicating their full content.
+The detailed `.claude/skills/` and `.claude/rules/` files remain useful as shared
+Levyra engineering playbooks. OpenAI skills reference them instead of
+duplicating their full content.
+
+## Validation
+
+Run from the repository root after changing planning files, agent instructions,
+native skills, AI documentation, or agent validation:
+
+```bash
+python3 scripts/validate_agent_config.py
+```
+
+The validator checks required files, native skill front matter, skill-directory
+names, documented skill references, and the inventory in this file. The
+existing pull-request workflow runs the same command.
 
 ## Maintenance rules
 
 - Keep repository-wide invariants concise in root `AGENTS.md`.
 - Put path-specific constraints in the nearest `AGENTS.md`.
+- Keep durable requirements in `SPEC.md`.
+- Keep ordered outcomes and risks in `ROADMAP.md`.
+- Keep one active reviewable phase and truthful evidence in `TASKS.md`.
 - Keep each native skill focused on one repeatable job.
 - Put architecture in `docs/ARCHITECTURE.md`.
-- Update the narrowest detailed playbook when a recurring project-specific failure is discovered.
+- Update the narrowest detailed playbook when a recurring project-specific
+  failure is discovered.
 - Do not duplicate entire instructions across assistant-specific trees.
-- Verify every referenced file, command, version location, workflow, and artifact path after structural changes.
+- Do not mark task or validation status from an agent narrative.
+- Verify every referenced file, command, version location, workflow, artifact
+  path, skill name, and publication state after structural changes.

--- a/.agents/skills/levyra-openclaw-orchestrator/SKILL.md
+++ b/.agents/skills/levyra-openclaw-orchestrator/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: levyra-openclaw-orchestrator
+description: Coordinate Levyra work through OpenClaw using a dedicated repository workspace, explicit agent delegation, domain skills, coding runtimes, independent review, evidence collection, and owner-controlled publication.
+---
+
+# Levyra OpenClaw orchestration workflow
+
+## Role
+
+OpenClaw coordinates bounded work. It does not replace Levyra requirements,
+domain skills, coding runtimes, CI, independent review, or owner approval.
+
+Use a dedicated `levyra` agent whose workspace is the real Levyra checkout.
+Delegate with an explicit target agent and repository working directory.
+
+## Before delegation
+
+1. Read root and applicable nested `AGENTS.md`.
+2. Read `SPEC.md`, `ROADMAP.md`, and `TASKS.md`.
+3. Load `levyra-project-manager` and every matching domain skill.
+4. Inspect current branch, worktree, open pull request, review state, and
+   validation evidence.
+5. Confirm the exact outcome, scope boundary, and publication authorization in
+   the current owner request.
+
+Do not reuse stale branch, PR, review, or CI assumptions.
+
+## Delegated task contract
+
+Every coding-runtime task must state:
+
+- repository and working directory;
+- objective and acceptance criteria;
+- matching `AGENTS.md` files and native skills;
+- verified current behavior and root cause or rationale;
+- behavior that must remain unchanged;
+- prohibited changes;
+- expected files or modules;
+- focused and broader checks;
+- manual checks;
+- required delivery evidence;
+- whether branch, commit, push, or draft PR creation is authorized.
+
+## Execution sequence
+
+1. Delegate orientation or planning to the `levyra` agent.
+2. Use one coding runtime for one reviewable implementation phase.
+3. Run focused checks and inspect the diff.
+4. Run applicable repository gates.
+5. Delegate independent latest-commit review to a fresh reviewer.
+6. Return actionable findings to the implementation runtime.
+7. Re-run affected checks after every change.
+8. Publish only to a dedicated branch and draft PR when authorized.
+9. Return exact status to the coordinator and owner.
+10. Stop before merge, tag, release, store upload, or repository-setting changes
+    unless separately authorized for that exact action.
+
+## Tool policy
+
+The Levyra agent may use repository, command, Git, build/test, GitHub PR, review,
+and CI tools needed for the current task.
+
+Keep personal messaging, email, calendar, unrelated browser accounts,
+system-wide administration, release credentials, signing material, and
+repository settings outside the Levyra agent unless the owner explicitly
+requires and authorizes a narrowly scoped action.
+
+Prefer separate agents for research and system administration. Do not use a
+wildcard target allowlist when a narrow list is sufficient.
+
+## Review rules
+
+- A reviewer must inspect the latest diff and surrounding code.
+- CodeRabbit is a signal, not the source of requirements.
+- The implementation agent does not independently certify its own work.
+- Every finding needs severity, confidence, exact location, triggering scenario,
+  consequence, smallest compatible fix, and missing regression coverage.
+- Stale findings are closed only after checking the current commit.
+- Remaining findings require an evidence-backed explanation.
+
+## Status vocabulary
+
+Use these states precisely:
+
+- planned;
+- edited;
+- locally validated;
+- committed;
+- pushed;
+- pull request opened;
+- CI passed;
+- independently reviewed;
+- merged;
+- released.
+
+Never collapse several states into "done".
+
+## Final handoff
+
+Return:
+
+- delegated agents and runtimes used;
+- final scope;
+- files changed;
+- checks and exact results;
+- blocked or skipped checks;
+- review findings and resolution;
+- branch and commit;
+- pull request URL and current state;
+- manual checks still required;
+- explicit statement that merge and release did or did not occur.

--- a/.agents/skills/levyra-project-manager/SKILL.md
+++ b/.agents/skills/levyra-project-manager/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: levyra-project-manager
+description: Turn Levyra requirements and roadmap outcomes into one reviewable active phase using SPEC.md, ROADMAP.md, TASKS.md, acceptance criteria, validation, owner checkpoints, and domain-skill routing.
+---
+
+# Levyra project management workflow
+
+## Use this skill when
+
+- defining or updating a tracked engineering phase;
+- reconciling requirements, roadmap, tasks, architecture, and code;
+- preparing a precise implementation plan for Codex, Claude Code, or OpenClaw;
+- deciding whether a change is ready to hand to PR review;
+- updating task status from direct validation evidence.
+
+Do not use this skill instead of a domain skill. Load every relevant player,
+extractor, database, Compose, Desktop, security, CI, review, or release skill.
+
+## Required context
+
+1. Read the root and every applicable nested `AGENTS.md`.
+2. Read `SPEC.md`, `ROADMAP.md`, and `TASKS.md`.
+3. Read `docs/ARCHITECTURE.md` and relevant platform documentation.
+4. Inspect the current branch, worktree, complete affected control/data flow,
+   nearby tests, build files, workflows, and active review discussion.
+5. Load every matching native domain skill and referenced detailed Levyra
+   playbook.
+
+Current repository evidence overrides stale task text. Surface conflicts between
+requirements, roadmap, tasks, architecture, and implementation before editing.
+
+## Phase definition
+
+Create or revise one active phase with:
+
+- exact outcome;
+- roadmap track;
+- scope and non-goals;
+- behavior that must remain unchanged;
+- verified current behavior and root cause when fixing a defect;
+- acceptance criteria;
+- expected files and modules;
+- lifecycle, concurrency, persistence, security, localization, and release
+  implications;
+- focused automated checks;
+- applicable broader checks;
+- required manual checks;
+- rollback or revert boundary;
+- explicit owner checkpoints.
+
+Remove irrelevant template material. Do not invent requirements to make a plan
+look complete.
+
+## Execution
+
+1. Present the plan and stop only when the owner reserved approval or requested
+   planning without implementation.
+2. Execute one reviewable phase at a time.
+3. Make the smallest coherent change compatible with current architecture.
+4. Run focused checks during iteration.
+5. Inspect the complete diff before broader validation.
+6. Run applicable repository gates.
+7. Update `TASKS.md` only from direct command, CI, review, device, or owner
+   evidence.
+8. Hand the latest diff to `levyra-pr-review`.
+9. Use `levyra-release-check` only when merge or release readiness is actually in
+   scope.
+10. Publish a branch or draft pull request only when explicitly authorized.
+
+## Safety rules
+
+- Never rewrite owner-approved requirements without surfacing the change.
+- Never activate several unrelated phases in `TASKS.md`.
+- Never mark a check passed from an agent's narrative.
+- Never treat blocked validation as passed.
+- Never infer permission to push, open a PR, merge, tag, publish, release, or
+  change repository settings.
+- Never let planning files become a second source of implementation truth.
+- Keep Android and Desktop version and release work independent.
+- Keep project-specific facts in repository docs; keep this skill focused on the
+  reusable process.
+
+## Handoff
+
+Return:
+
+- requirement and roadmap mapping;
+- final scope and non-goals;
+- root cause or rationale;
+- exact files changed;
+- behavior preserved;
+- checks with exact results;
+- blocked and skipped checks;
+- open risks and manual validation;
+- `TASKS.md` status changes and evidence;
+- branch, commit, and PR state;
+- explicit merge/release state.

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -67,6 +67,9 @@ jobs:
           test -f gradle/wrapper/gradle-wrapper.jar
           test -f gradle/wrapper/gradle-wrapper.properties
 
+      - name: Validate Agent Configuration
+        run: python3 scripts/validate_agent_config.py
+
       - name: Prepare CI Release Signing
         shell: bash
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,19 +8,24 @@ Instruction order:
 
 1. root `AGENTS.md`;
 2. nearer path-specific `AGENTS.md` files;
-3. matching native skills under `.agents/skills/`;
-4. current architecture, implementation, tests, build files, and workflows;
-5. detailed Levyra playbooks under `.claude/skills/` and `.claude/rules/`.
+3. approved requirements and active planning in `SPEC.md`, `ROADMAP.md`, and `TASKS.md`;
+4. matching native skills under `.agents/skills/`;
+5. current architecture, implementation, tests, build files, and workflows;
+6. detailed Levyra playbooks under `.claude/skills/` and `.claude/rules/`.
 
-Current repository evidence always overrides remembered behavior, old discussions, stale comments, or previous agent output.
+Current repository evidence always overrides remembered behavior, old discussions, stale comments, previous agent output, or stale task status. Surface conflicts between planning files and implementation before editing.
 
 ## Repository map
 
+- `SPEC.md`: durable product and engineering requirements.
+- `ROADMAP.md`: ordered outcomes, risks, and phase exit criteria.
+- `TASKS.md`: one active reviewable phase and its truthful validation state.
 - `app/`: Android client; additional rules in `app/AGENTS.md`.
 - `desktop/`: independent Windows client; additional rules in `desktop/AGENTS.md`.
 - `.github/`: CI and release automation; additional rules in `.github/AGENTS.md`.
 - `docs/`: project documentation; additional rules in `docs/AGENTS.md`.
-- `.agents/skills/`: native Codex/OpenAI skills.
+- `docs/ai/`: ChatGPT, Codex, Claude Code, and OpenClaw collaboration guidance.
+- `.agents/skills/`: native Codex/OpenAI/OpenClaw-compatible skills.
 - `.claude/`: Claude Code configuration plus reusable Levyra engineering playbooks.
 
 ## Product invariants
@@ -41,6 +46,8 @@ Load every matching skill before reading widely or editing. Prefer focused skill
 
 | Task | Skill |
 | --- | --- |
+| Requirements, roadmap, active phase, acceptance criteria, task status, implementation handoff | `levyra-project-manager` |
+| OpenClaw delegation, coding-runtime coordination, evidence collection, safe publication handoff | `levyra-openclaw-orchestrator` |
 | Android playback, queue, Media3, MediaSession, notification, Android Auto, prefetch, audio/video mode | `levyra-player` |
 | InnerTube, extraction, stream resolution, runtime configuration, retry, cache, fallback | `levyra-extractor` |
 | Room, DAO, migration, schema, cache, store, backup, persistent personal data | `levyra-database` |
@@ -53,14 +60,27 @@ Load every matching skill before reading widely or editing. Prefer focused skill
 | Pre-merge or pre-release validation, versions, signing, checksums, packaging | `levyra-release-check` |
 | Genuine cross-domain work or initial architecture orientation | `levyra-engineering` |
 
-Several skills may apply. A playback change that modifies stream resolution uses player and extractor skills; provider-controlled media normally also requires security review.
+Several skills may apply. A playback change that modifies stream resolution uses player and extractor skills; provider-controlled media normally also requires security review. A tracked multi-phase task additionally uses `levyra-project-manager`; OpenClaw coordination additionally uses `levyra-openclaw-orchestrator`.
+
+## Planning documents
+
+Read only the planning material relevant to the task, but do not ignore an active phase:
+
+- `SPEC.md` defines approved durable requirements and non-goals.
+- `ROADMAP.md` orders outcomes, risks, and phase exit criteria; it is not release authorization.
+- `TASKS.md` records one active reviewable phase, validation evidence, and owner checkpoints.
+- `docs/ARCHITECTURE.md` describes current implementation ownership and data flow.
+- `docs/ai/WORKFLOW.md` defines the complete AI-assisted lifecycle.
+- `docs/ai/OPENCLAW.md` defines the recommended OpenClaw role and tool boundaries.
+
+Do not mark task status from an agent report. Update it only from a direct command, CI result, review, device check, or owner decision.
 
 ## Engineering rules
 
 - Preserve unidirectional data flow: user intent -> controller/ViewModel -> repository/player operation -> immutable state -> UI.
 - Keep network, database, parsing, decoding, file, metadata, and blocking native work off UI threads.
 - Reuse existing clients, stores, caches, scopes, dispatchers, queues, lifecycle owners, extractors, players, and persistence.
-- Do not create a second source of truth for playback, queue, persistence, localization, update state, or release state.
+- Do not create a second source of truth for playback, queue, persistence, localization, update state, release state, requirements, or active task status.
 - Make ownership explicit for coroutines, players, callbacks, receivers, surfaces, native handles, decoders, files, caches, and in-flight work.
 - One caller cancelling shared work must not cancel work still required by another caller.
 - Use identity and generation checks when older asynchronous work can publish after newer work.
@@ -73,21 +93,29 @@ Several skills may apply. A playback change that modifies stream resolution uses
 ## Work method
 
 1. Define the exact requested outcome and scope.
-2. Identify behavior and compatibility that must remain unchanged.
-3. Inspect the complete current control/data flow and nearby tests.
-4. Identify the root cause before editing.
-5. Make the smallest coherent change compatible with current architecture.
-6. Avoid unrelated cleanup, formatting churn, dependency upgrades, renames, and broad refactors.
-7. Add or update regression tests for defects, migrations, matching, security boundaries, lifecycle, and concurrency when applicable.
-8. Run focused checks first, then applicable broader checks.
-9. Inspect the complete final diff for unrelated edits, generated files, secrets, binaries, conflict markers, and accidental version changes.
-10. Report exactly what changed, what ran, what passed, what failed, and what remains unverified.
+2. Read `SPEC.md`, the relevant roadmap track, and the active `TASKS.md` phase when applicable.
+3. Identify behavior and compatibility that must remain unchanged.
+4. Inspect the complete current control/data flow and nearby tests.
+5. Identify the root cause before editing.
+6. Make the smallest coherent change compatible with current architecture.
+7. Avoid unrelated cleanup, formatting churn, dependency upgrades, renames, and broad refactors.
+8. Add or update regression tests for defects, migrations, matching, security boundaries, lifecycle, and concurrency when applicable.
+9. Run focused checks first, then applicable broader checks.
+10. Inspect the complete final diff for unrelated edits, generated files, secrets, binaries, conflict markers, and accidental version changes.
+11. Synchronize specification, roadmap, tasks, architecture, and user documentation when the approved requirement or architecture changes.
+12. Report exactly what changed, what ran, what passed, what failed, and what remains unverified.
 
 When the owner says "only this", modify only the named behavior or files unless an additional change is strictly required for correctness. State that dependency before expanding scope.
 
 ## Validation
 
 Use repository wrappers, never a system Gradle installation.
+
+Agent configuration checks from the repository root:
+
+```bash
+python3 scripts/validate_agent_config.py
+```
 
 Android checks from the repository root:
 
@@ -107,16 +135,16 @@ Desktop checks from `desktop/`:
 
 On Windows use `gradlew.bat`.
 
-Start with the narrowest relevant test. Missing SDKs, JDKs, signing inputs, libvlc, WiX, network, CI, emulator, device, or OS support are blocked checks, not passes. Never claim build, playback, device, Android Auto, notification, PiP, installer, update, protocol, media-key, or native VLC success without direct evidence.
+Start with the narrowest relevant test. Missing SDKs, JDKs, signing inputs, libvlc, WiX, network, CI, emulator, device, or OS support are blocked checks, not passes. Never claim build, playback, device, Android Auto, notification, PiP, installer, update, protocol, media-key, native VLC, agent-configuration, review, or CI success without direct evidence.
 
 ## Security and repository safety
 
 - Never commit or expose passwords, secrets, tokens, cookies, private URLs, keystores, signing material, `.env`, or `local.properties`.
 - Never commit APKs, installers, ZIPs, build output, IDE state, native runtime bundles, or temporary diagnostics unless explicitly required and accepted by repository policy.
 - Validate provider-controlled URLs across scheme, host, port, user info, DNS/IP destination, every redirect hop, MIME, timeout, filename/path, and response-size bounds.
-- Preserve least privilege in Android permissions and GitHub workflow permissions.
+- Preserve least privilege in Android permissions, GitHub workflow permissions, coding-agent tools, and OpenClaw agent allowlists.
 - Do not weaken transport, redirect, MIME, checksum, signature, or host validation to make one response pass.
-- Treat fork code, workflow inputs, downloaded artifacts, deep links, update metadata, filenames, and local IPC as untrusted where applicable.
+- Treat fork code, workflow inputs, downloaded artifacts, deep links, update metadata, filenames, local IPC, and third-party skills as untrusted where applicable.
 - Update credits and licenses when adding external code, assets, models, libraries, native files, or design references.
 
 ## Versions, releases, and external actions
@@ -124,6 +152,7 @@ Start with the narrowest relevant test. Missing SDKs, JDKs, signing inputs, libv
 - Do not change Android or Desktop version values unless the task explicitly requests that platform's release/version change.
 - Do not commit, push, open a pull request, merge, tag, publish, release, or change repository settings without explicit authorization.
 - When publication is authorized, use a dedicated branch and draft pull request by default. Push directly to `main` only when explicitly requested for the exact scope.
+- OpenClaw or any delegated coding runtime must not infer publication, merge, tag, or release permission from an implementation request.
 - Keep PR descriptions and checklists truthful; leave manual/device checks unmarked until actually performed.
 
 ## Delivery contract
@@ -139,4 +168,4 @@ Report:
 - professional commit message when requested;
 - verified branch, commit, PR, merge, or release state when applicable.
 
-Never represent a plan as an applied patch or an unverified result as completed.
+Never represent a plan as an applied patch or an unverified result as completed. Distinguish planned, edited, locally validated, committed, pushed, pull request opened, CI passed, reviewed, merged, and released.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,196 @@
+# Levyra Engineering Roadmap
+
+## Purpose
+
+This roadmap orders durable engineering outcomes. It is not a release calendar
+and does not authorize implementation by itself. The active reviewable phase,
+owner decisions, and validation state are recorded in `TASKS.md`.
+
+A task may span several roadmap tracks, but direct playback reliability, user
+data safety, privacy, and explicit user choices always take precedence over
+visual polish or feature breadth.
+
+## Track 1 - Playback critical path
+
+### Outcomes
+
+- Direct playback starts through the lowest-latency valid path.
+- Stream resolution, cache, retry, and fallback behavior remain bounded.
+- Queue, Media3 player, MediaSession, notification, Android Auto, and background
+  service expose one synchronized state.
+- Song/audio mode and native-video mode remain explicit and independently
+  correct.
+- DSP work remains real-time safe and does not allocate, block, scan mutable
+  collections, or perform expensive transcendentals per sample.
+
+### Exit criteria for a phase
+
+- The triggering scenario has a regression test where practical.
+- Cancellation, stale publication, lifecycle cleanup, and fallback ordering are
+  covered.
+- Focused playback tests pass.
+- Device-only checks are listed separately and are not implied by unit tests.
+
+### Primary risks
+
+Concurrency races, stale callbacks, shared-work cancellation, audio underruns,
+provider changes, hidden fallback latency, and duplicated playback state.
+
+## Track 2 - Persistence, offline use, and recovery
+
+### Outcomes
+
+- Room migrations are explicit and preserve existing data.
+- Downloads and exported files remain bounded, resumable, and recoverable.
+- Preferences, backups, queues, playlists, favorites, lyrics, and history keep
+  backward-compatible identity.
+- Offline content remains usable without remote decoration.
+
+### Exit criteria for a phase
+
+- Migration and serialization tests cover old and new representations.
+- Backup and restore behavior is verified for changed settings.
+- Storage growth, cleanup, cancellation, and partial failure are bounded.
+- No user data is silently reset to simplify implementation.
+
+### Primary risks
+
+Destructive schema changes, mutable display text used as identity, partial file
+writes, stale cache publication, and backup incompatibility.
+
+## Track 3 - Responsive, accessible interface
+
+### Outcomes
+
+- Startup restores usable cached content before secondary refresh.
+- Scrolling and common navigation remain responsive on constrained devices.
+- Screen projections avoid unrelated recomposition.
+- Accessibility, localization, RTL, reduced motion, lifecycle, and
+  configuration changes are preserved.
+- Optional motion and artwork never become correctness dependencies.
+
+### Exit criteria for a phase
+
+- State ownership and effect keys are explicit.
+- Lazy list keys are stable and unique.
+- Visible changes include localization and accessibility review.
+- Performance-sensitive changes include focused measurement or a reproducible
+  comparison when available.
+- Screenshots or device checks are recorded for visual changes.
+
+### Primary risks
+
+Main-thread work, broad state observation, unstable identity, repeated decoding,
+unbounded animation, inaccessible controls, and stale localized text.
+
+## Track 4 - Extractor and remote-media resilience
+
+### Outcomes
+
+- Current extractor paths are observable and fail over deliberately.
+- Runtime configuration, BotGuard/PO-token boundaries, cache semantics, and
+  provider failures remain distinguishable.
+- Remote media is validated before playback, caching, writing, or display.
+- Provider degradation does not corrupt durable user state.
+
+### Exit criteria for a phase
+
+- Failure classes remain distinct in code and tests.
+- Timeouts, redirects, MIME, response sizes, and host boundaries are bounded.
+- Negative cache entries represent only conclusive misses.
+- Fallback tests cover ordering and stale configuration.
+
+### Primary risks
+
+Provider drift, prompt or metadata injection, SSRF, redirect abuse, poisoning of
+negative caches, and retry storms.
+
+## Track 5 - Windows Desktop reliability
+
+### Outcomes
+
+- Desktop playback, downloads, mini player, deep links, media keys, update flow,
+  and packaging remain independently testable.
+- libvlc and native resources have explicit ownership and cleanup.
+- Windows installers and portable artifacts preserve their established paths
+  and naming.
+- Desktop releases never alter Android versioning or latest-release semantics.
+
+### Exit criteria for a phase
+
+- Desktop wrapper checks pass in a supported environment.
+- Native VLC, installer, update, protocol, and media-key checks are reported
+  separately from JVM tests.
+- Packaging and version changes are limited to the Desktop platform.
+
+### Primary risks
+
+Native handle leaks, OS-specific assumptions, packaging drift, update integrity,
+and accidental Android/Desktop release coupling.
+
+## Track 6 - Distribution and repository integrity
+
+### Outcomes
+
+- Pull requests provide reproducible evidence.
+- CI uses least privilege and keeps untrusted code away from secrets.
+- Android, F-Droid, and Desktop artifacts remain separated.
+- Version, signing, checksums, release metadata, and artifact names are
+  deliberate and verifiable.
+- Duplicate or overlapping automation is prevented.
+
+### Exit criteria for a phase
+
+- Applicable CI, dependency, security, and release guards pass on the latest
+  commit.
+- Manual release checks remain unmarked until performed.
+- Every external action is explicitly authorized.
+- Rollback or revert scope is clear.
+
+### Primary risks
+
+Workflow privilege mistakes, secret exposure, artifact replacement, stale CI
+results, accidental publication, and misleading release evidence.
+
+## Track 7 - Agent-assisted engineering
+
+### Outcomes
+
+- `AGENTS.md` defines durable repository and path contracts.
+- `SPEC.md`, `ROADMAP.md`, and `TASKS.md` keep requirements, sequencing, and
+  current work separate.
+- Native skills encode repeatable Levyra workflows instead of generic advice.
+- ChatGPT, Codex, Claude Code, and OpenClaw use the same repository facts while
+  retaining separate permission and publication boundaries.
+- Implementation, independent review, CI, manual testing, merge, and release
+  remain distinct gates.
+
+### Exit criteria for a phase
+
+- Agent configuration validation passes.
+- Every referenced skill and planning document exists.
+- The current task phase has explicit acceptance criteria and validation.
+- A coding agent cannot infer permission to merge or release.
+- OpenClaw delegation uses a dedicated Levyra workspace/agent and returns
+  branch, diff, checks, blockers, and PR state to the owner.
+
+### Primary risks
+
+Stale instructions, duplicated rules, excessive tool access, self-review,
+unverified completion claims, and autonomous publication beyond the owner's
+request.
+
+## Prioritization rule
+
+When priorities conflict, use this order:
+
+1. safety, privacy, and user data;
+2. direct playback and explicit playback choices;
+3. lifecycle, concurrency, and resource ownership;
+4. offline reliability and recoverability;
+5. responsive and accessible UI;
+6. release and repository integrity;
+7. optional enrichment and visual polish.
+
+Update `TASKS.md` when activating a phase. Update this roadmap only when the
+ordered outcomes, risks, or exit criteria themselves change.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,161 @@
+# Levyra Product and Engineering Specification
+
+## Purpose
+
+This document defines Levyra's durable product behavior, engineering boundaries,
+and acceptance criteria. It complements `docs/ARCHITECTURE.md`: the
+specification states what must remain true, while the architecture document
+describes how the current repository implements it.
+
+Current implementation, tests, build files, workflows, and the nearest
+`AGENTS.md` always override stale assumptions. Proposed behavior belongs here
+only after the owner has approved it as a project requirement.
+
+## Product scope
+
+Levyra provides independent Android and Windows Desktop music clients.
+
+The Android client is a Kotlin application built around Jetpack Compose,
+AndroidX Media3, Room, WorkManager, OkHttp, Coil, and repository-owned playback
+and persistence layers.
+
+The Windows Desktop client is an independent Compose Multiplatform application
+with its own playback, packaging, versioning, and release lifecycle.
+
+## Required product behavior
+
+### Playback
+
+- A direct user playback request has priority over artwork, lyrics, refresh,
+  diagnostics, metadata enrichment, prefetch, and animation.
+- Android users retain an explicit choice between song/audio mode and native
+  video mode. The application must not silently merge, remove, or override that
+  choice.
+- Audible playback, queue state, MediaSession, notification, Android Auto, and
+  background service state remain synchronized.
+- Static artwork is always a valid fallback. Decorative motion artwork is
+  muted, optional, limited to song/audio mode, and must never delay playback.
+- Stream resolution, fallback, retry, cache, and cancellation behavior must be
+  bounded and observable. An inconclusive failure must not be stored as a
+  conclusive negative result.
+- Older asynchronous work must not publish over newer user intent.
+
+### User data and settings
+
+- Downloads, favorites, playlists, queues, lyrics, history, settings,
+  localization, onboarding state, sessions, and backups are preserved unless a
+  change explicitly targets them.
+- Persistent schema changes require explicit, non-destructive migrations and
+  regression coverage.
+- Durable identity must not depend on mutable display text.
+- Backup and restore behavior must remain backward compatible when new settings
+  are introduced.
+
+### Interface and accessibility
+
+- Compose state follows unidirectional data flow and keeps screen projections
+  stable and appropriately scoped.
+- Network, database, parsing, decoding, file, metadata, and blocking native work
+  remain off the UI thread.
+- Lists use stable unique identity and avoid unnecessary recomposition.
+- User-facing text is localized through the existing localization system.
+- Accessibility, RTL behavior, reduced-motion choices, lifecycle, and
+  configuration changes are considered for visible changes.
+- Cached usable content remains visible while secondary refresh work runs.
+
+### Offline and network behavior
+
+- Offline content remains usable without requiring remote enrichment.
+- Retries, timeouts, response sizes, concurrency, caches, storage growth,
+  downloads, and prefetch are bounded.
+- Provider-controlled URLs and redirects are treated as untrusted input.
+- Cancellation is not reported, cached, or counted as an ordinary failure.
+
+## Architecture boundaries
+
+- Preserve the current unidirectional flow:
+  `user intent -> controller/ViewModel -> repository/player operation ->
+  immutable state -> UI`.
+- Reuse existing clients, stores, caches, dispatchers, scopes, queues, lifecycle
+  owners, players, extractors, and persistence.
+- Do not create a second source of truth for playback, queue, persistence,
+  localization, update state, or release state.
+- Resource ownership must be explicit for coroutines, callbacks, receivers,
+  surfaces, native handles, decoders, players, files, caches, and in-flight
+  requests.
+- Shared work must outlive any one caller when other callers still require it.
+- Android and Desktop modules must not acquire accidental release or version
+  coupling.
+
+## Security and privacy
+
+- Levyra does not add account login, cookies, private tokens, telemetry,
+  tracking, or unrelated data collection without explicit approval.
+- Secrets, signing material, keystores, private URLs, `.env`, and
+  `local.properties` never enter the repository.
+- Remote URLs are validated across scheme, host, port, user info, DNS/IP
+  destination, redirect hops, MIME, timeout, filename/path, and response size
+  where applicable.
+- Android permissions and GitHub Actions permissions follow least privilege.
+- Transport, redirect, MIME, checksum, signature, or host validation must not be
+  weakened to make one provider response pass.
+- Fork code, workflow inputs, downloaded artifacts, deep links, update
+  metadata, filenames, and local IPC are untrusted at their relevant boundary.
+
+## Platform and release boundaries
+
+- Android and Desktop version values, packages, tags, artifacts, signing,
+  installers, and releases are independent.
+- Version values change only as part of an explicitly authorized release task.
+- Publishing, merging, tagging, releasing, changing repository settings, and
+  uploading store metadata require explicit owner authorization.
+- Source builds intended for F-Droid preserve their separate unsigned and
+  reproducible-build requirements.
+
+## Engineering process requirements
+
+- Read applicable `AGENTS.md` files, this specification, the active roadmap and
+  task phase, relevant native skills, current code, and nearby tests before
+  editing.
+- Identify the verified current behavior and root cause before implementing a
+  defect fix.
+- Prefer the smallest coherent change that preserves unrelated behavior.
+- Avoid drive-by refactors, dependency churn, version changes, formatting
+  noise, speculative abstraction, and parallel infrastructure.
+- Add or update regression coverage for defects, migrations, matching,
+  security boundaries, lifecycle, and concurrency when applicable.
+- Run focused validation first, then the applicable broader repository checks.
+- Treat a blocked check as blocked, never as passed.
+- Use a dedicated branch and draft pull request by default when publication is
+  authorized.
+
+## Non-goals
+
+- Replacing current architecture with a generic framework because an agent
+  prefers a different pattern.
+- Making Android and Desktop feature-identical at the cost of platform
+  reliability.
+- Allowing artwork, animation, lyrics, or enrichment to own the playback
+  critical path.
+- Adding broad autonomous publication or release permissions to an AI agent.
+- Treating generated code or an agent report as validation evidence.
+- Copying external agent instructions without adapting them to Levyra's current
+  repository and risks.
+
+## Acceptance criteria for any change
+
+A change is ready for review only when:
+
+1. its requirement and scope are explicit;
+2. behavior that must remain unchanged is identified;
+3. the implementation matches current architecture and ownership;
+4. relevant focused tests pass or are truthfully reported as blocked;
+5. applicable Android, Desktop, documentation, CI, security, or release checks
+   are defined and run where the environment supports them;
+6. the complete diff contains no unrelated edits, generated artifacts, secrets,
+   conflict markers, or accidental version changes;
+7. manual checks are listed and left unverified until actually performed;
+8. `SPEC.md`, `ROADMAP.md`, `TASKS.md`, architecture, and user documentation are
+   synchronized when the change affects them;
+9. review findings are fixed or explicitly explained against the latest commit;
+10. merge and release remain separate owner-controlled actions.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,87 @@
+# Levyra Active Tasks
+
+## Active phase
+
+**Name:** Agent-assisted engineering foundation  
+**Roadmap track:** Track 7 - Agent-assisted engineering  
+**Status:** In review  
+**Scope:** Repository-local planning, orchestration, and validation files only.
+No Android or Desktop product behavior, dependency, version, signing, or release
+change is part of this phase.
+
+## Acceptance criteria
+
+- Durable requirements live in `SPEC.md`.
+- Ordered engineering outcomes live in `ROADMAP.md`.
+- This file records only the active reviewable phase and truthful validation
+  state.
+- A native project-management skill coordinates planning without replacing
+  domain skills.
+- A native OpenClaw skill defines safe delegation and owner-controlled
+  publication boundaries.
+- AI workflow documentation explains implementation, independent review, CI,
+  manual testing, merge, and release as separate gates.
+- A standard-library validation script checks required files, skill metadata,
+  and documented skill references.
+- The existing PR workflow runs that validation.
+- Existing product code, versions, dependencies, signing, and release behavior
+  remain unchanged.
+
+## Work items
+
+- [x] Compare the useful Titus AI workflow patterns with Levyra's existing
+      repository instructions and native skills.
+- [x] Keep Levyra's existing specialized `AGENTS.md` hierarchy as the primary
+      source of project behavior.
+- [x] Add `SPEC.md`, `ROADMAP.md`, and `TASKS.md` with distinct responsibilities.
+- [x] Add the `levyra-project-manager` native skill.
+- [x] Add the `levyra-openclaw-orchestrator` native skill.
+- [x] Add the complete AI development workflow and OpenClaw integration guide.
+- [x] Update root, OpenAI, and ChatGPT routing documentation.
+- [x] Add `scripts/validate_agent_config.py`.
+- [x] Add agent-configuration validation to the existing PR check.
+- [ ] Confirm the agent-configuration validation job passes on the pull request.
+- [ ] Complete an independent latest-commit review and address actionable
+      findings.
+- [ ] Merge only after owner approval.
+
+## Validation matrix
+
+| Check | Required | Current state |
+| --- | --- | --- |
+| `python3 scripts/validate_agent_config.py` | Yes | Pending CI on the published branch |
+| Markdown path and command review | Yes | Performed during authoring; CI validates required paths |
+| Android unit tests, lint, and release compile | Existing PR gate | Pending CI; no product code changed |
+| Desktop build | No for this docs/config-only phase | Not run |
+| Device, playback, Android Auto, notification, PiP | No for this phase | Not applicable |
+| Windows installer, update, protocol, media keys | No for this phase | Not applicable |
+| Independent review | Yes | Pending |
+| Merge or release | Separate owner action | Not authorized by this file |
+
+## Behavior preserved
+
+- Android and Desktop implementation files are untouched.
+- Playback, queue, MediaSession, notification, Android Auto, downloads, Room,
+  preferences, backups, localization, and UI behavior are unchanged.
+- Android and Desktop versions, tags, packages, signing, artifacts, and release
+  workflows remain independent.
+- Existing Claude and OpenAI domain skills remain the detailed engineering
+  playbooks.
+
+## Follow-up queue
+
+These items are not activated by this phase:
+
+- apply the documented OpenClaw workspace and agent configuration on the owner's
+  machine;
+- add a scheduled GitHub review-summary workflow in OpenClaw after tool access
+  and notification behavior are explicitly approved;
+- revise roadmap priorities when the owner selects the next product phase;
+- archive or replace this active phase after merge.
+
+## Update rule
+
+Do not mark a check complete from an agent's narrative. Record the exact command,
+CI run, review, device check, or owner decision that provides the evidence.
+Replace this active phase when new work begins instead of accumulating unrelated
+tasks indefinitely.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -15,13 +15,26 @@ These instructions extend the root `AGENTS.md` for documentation under `docs/`.
 
 ## AI documentation
 
-- `AGENTS.md` files define repository and path-specific operating contracts.
-- `.agents/skills/` contains native OpenAI/Codex task skills.
+- Root and nested `AGENTS.md` files define repository-wide and path-specific operating contracts.
+- `SPEC.md` defines durable owner-approved requirements and non-goals.
+- `ROADMAP.md` defines ordered outcomes, risks, and phase exit criteria; it does not authorize implementation or release.
+- `TASKS.md` records one active reviewable phase and direct validation evidence.
+- `.agents/skills/` contains native OpenAI/Codex/OpenClaw-compatible task skills.
 - `.claude/` contains Claude Code configuration and shared Levyra engineering playbooks.
 - `docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md` is the source text for the Levyra ChatGPT Project; repository files cannot apply those Project instructions automatically.
+- `docs/ai/WORKFLOW.md` defines the complete AI-assisted engineering lifecycle and its independent review, CI, manual testing, merge, and release gates.
+- `docs/ai/OPENCLAW.md` defines the recommended OpenClaw workspace, delegation, tool, and publication boundaries.
+
+Keep these documents synchronized with current repository behavior, but do not duplicate entire domain playbooks across them. When planning documents conflict with current code or tests, surface and correct the stale documentation rather than silently documenting the conflict as intended behavior.
 
 ## Validation
 
 For documentation-only changes, verify referenced paths and commands, inspect Markdown headings and code fences, check links where possible, and inspect the final diff for accidental code, workflow, version, binary, or secret changes.
 
-Do not claim builds or tests ran merely because a documented command appears correct.
+After changing AI planning files, agent instructions, native skills, AI documentation, or their validation, run:
+
+```bash
+python3 scripts/validate_agent_config.py
+```
+
+Do not claim builds, tests, agent-configuration checks, CI, device checks, reviews, publication, merge, or release merely because a documented command appears correct.

--- a/docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md
+++ b/docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md
@@ -4,39 +4,85 @@ You are the technical collaborator for the Levyra project.
 
 Repository: `LUC4N3X/Levyra-deepsound`
 
-Help the repository owner make accurate product and engineering decisions, investigate defects, design minimal changes, review code and pull requests, prepare precise Codex tasks, and verify published results. Be direct, evidence-based, and protective of existing behavior.
+Help the repository owner make accurate product and engineering decisions,
+maintain requirements and active phases, investigate defects, design minimal
+changes, review code and pull requests, prepare precise Codex/OpenClaw tasks,
+and verify published results. Be direct, evidence-based, and protective of
+existing behavior.
 
 ## Required repository context
 
-Before giving a technical conclusion, proposing code, reviewing a change, or preparing work for Codex:
+Before giving a technical conclusion, proposing code, reviewing a change, or
+preparing work for Codex, Claude Code, or OpenClaw:
 
 1. Read the root `AGENTS.md`.
-2. Read every nearer `AGENTS.md` covering the affected paths, including `app/AGENTS.md`, `desktop/AGENTS.md`, `.github/AGENTS.md`, or `docs/AGENTS.md` when applicable.
-3. Select and read every matching native skill under `.agents/skills/`.
-4. Read `docs/ARCHITECTURE.md` and the relevant platform documentation.
-5. Inspect the current implementation and nearby tests.
-6. Read matching detailed playbooks under `.claude/skills/` and `.claude/rules/` when referenced by the native skill.
-7. Inspect build files and GitHub workflows for CI, signing, packaging, configuration sync, versioning, artifacts, or releases.
+2. Read every nearer `AGENTS.md` covering the affected paths, including
+   `app/AGENTS.md`, `desktop/AGENTS.md`, `.github/AGENTS.md`, or
+   `docs/AGENTS.md` when applicable.
+3. Read `SPEC.md`, the relevant `ROADMAP.md` track, and the active phase in
+   `TASKS.md`.
+4. Select and read every matching native skill under `.agents/skills/`.
+5. Read `docs/ARCHITECTURE.md` and the relevant platform documentation.
+6. Inspect the current implementation and nearby tests.
+7. Read matching detailed playbooks under `.claude/skills/` and
+   `.claude/rules/` when referenced by the native skill.
+8. Inspect build files and GitHub workflows for CI, signing, packaging,
+   configuration sync, versioning, artifacts, or releases.
 
-Prefer current repository evidence over previous chat memory, old branches, stale comments, or remembered implementations. When access is incomplete, separate verified facts from assumptions and state exactly what could not be inspected.
+Prefer current repository evidence over previous chat memory, old branches,
+stale comments, stale task status, or remembered implementations. When access is
+incomplete, separate verified facts from assumptions and state exactly what
+could not be inspected. Surface conflicts between specification, roadmap,
+tasks, architecture, and code before recommending implementation.
+
+## Planning responsibilities
+
+The repository separates planning concerns:
+
+- `SPEC.md` contains durable owner-approved product and engineering requirements
+  and non-goals.
+- `ROADMAP.md` orders outcomes, risks, and phase exit criteria. It is not release
+  authorization.
+- `TASKS.md` contains one active reviewable phase and direct validation
+  evidence.
+
+Use `levyra-project-manager` when creating or reconciling a tracked phase.
+Update task status only from a direct command, CI result, review, device check,
+or owner decision. Never mark a task complete because an agent says it is
+complete.
 
 ## Native skill routing
 
 Use the most specific skill or combination of skills:
 
-- `levyra-player`: Android playback, queue, Media3, MediaSession, notification, Android Auto, prefetch, audio/video modes.
-- `levyra-extractor`: InnerTube, extraction, stream resolution, runtime configuration, retry, cache and fallback.
-- `levyra-database`: Room, DAO, migrations, schema, caches, stores, backups and persistent personal data.
-- `levyra-compose`: Android Compose UI, state, navigation, animation, lifecycle, accessibility, RTL and localization.
-- `levyra-motion-artwork`: decorative motion artwork, provider matching, muted playback and remote-media safety.
-- `levyra-desktop`: Windows Desktop, Compose Multiplatform, libvlc, downloads, mini player, deep links, updates and packaging.
-- `levyra-security-review`: secrets, URLs, redirects, SSRF, MIME, permissions, privacy and update integrity.
-- `levyra-ci-workflows`: GitHub Actions, CI, F-Droid, configuration sync, artifacts and automation security.
+- `levyra-project-manager`: requirements, roadmap, active phase, acceptance
+  criteria, validation and implementation handoff.
+- `levyra-openclaw-orchestrator`: dedicated OpenClaw workspace, explicit agent
+  delegation, coding runtimes, review and evidence handoff.
+- `levyra-player`: Android playback, queue, Media3, MediaSession, notification,
+  Android Auto, prefetch, audio/video modes.
+- `levyra-extractor`: InnerTube, extraction, stream resolution, runtime
+  configuration, retry, cache and fallback.
+- `levyra-database`: Room, DAO, migrations, schema, caches, stores, backups and
+  persistent personal data.
+- `levyra-compose`: Android Compose UI, state, navigation, animation, lifecycle,
+  accessibility, RTL and localization.
+- `levyra-motion-artwork`: decorative motion artwork, provider matching, muted
+  playback and remote-media safety.
+- `levyra-desktop`: Windows Desktop, Compose Multiplatform, libvlc, downloads,
+  mini player, deep links, updates and packaging.
+- `levyra-security-review`: secrets, URLs, redirects, SSRF, MIME, permissions,
+  privacy and update integrity.
+- `levyra-ci-workflows`: GitHub Actions, CI, F-Droid, configuration sync,
+  artifacts and automation security.
 - `levyra-pr-review`: review of branches, commits, patches and pull requests.
-- `levyra-release-check`: pre-merge/release validation, versions, signing, checksums, packaging and artifacts.
-- `levyra-engineering`: genuine cross-domain coordination when no specialized skill is sufficient by itself.
+- `levyra-release-check`: pre-merge/release validation, versions, signing,
+  checksums, packaging and artifacts.
+- `levyra-engineering`: genuine cross-domain coordination when no specialized
+  skill is sufficient by itself.
 
-Several skills may apply. Do not use the general coordinator to avoid reading a more precise skill.
+Several skills may apply. Do not use a planning or coordinator skill to avoid
+reading a more precise domain skill.
 
 ## Core product priorities
 
@@ -44,40 +90,55 @@ Protect, in order:
 
 1. playback reliability;
 2. explicit Android song/audio and native-video choices;
-3. synchronization between player, MediaSession, notification, Android Auto, queue and background service;
+3. synchronization between player, MediaSession, notification, Android Auto,
+   queue and background service;
 4. correct lifecycle, coroutine and native-resource ownership;
 5. privacy and security;
 6. preservation of user data and settings;
 7. responsive UI and reliable offline behavior;
 8. visual polish and optional enrichment.
 
-Artwork, lyrics, refresh, diagnostics, prefetch, metadata enrichment and animation must never delay or destabilize direct playback.
+Artwork, lyrics, refresh, diagnostics, prefetch, metadata enrichment and
+animation must never delay or destabilize direct playback.
 
-Android and Desktop versioning, packaging, tags, artifacts and releases are independent. Never change one platform's version merely because the other platform is changing.
+Android and Desktop versioning, packaging, tags, artifacts and releases are
+independent. Never change one platform's version merely because the other
+platform is changing.
 
 ## Engineering behavior
 
 - Trace the actual current path before identifying a root cause.
 - State which existing behavior must remain unchanged.
 - Prefer the smallest coherent change compatible with current architecture.
-- Avoid speculative refactors, parallel infrastructure, unrelated cleanup, dependency churn and version upgrades.
-- Keep blocking network, database, parsing, decoding, file, metadata and native work off UI threads.
-- Reuse existing clients, stores, caches, scopes, queues, lifecycle owners, players and extractors.
-- Do not create a second source of truth for playback, persistence, localization, update state or release state.
+- Avoid speculative refactors, parallel infrastructure, unrelated cleanup,
+  dependency churn and version upgrades.
+- Keep blocking network, database, parsing, decoding, file, metadata and native
+  work off UI threads.
+- Reuse existing clients, stores, caches, scopes, queues, lifecycle owners,
+  players and extractors.
+- Do not create a second source of truth for playback, persistence,
+  localization, update state, release state, requirements, or task status.
 - Treat cancellation separately from failure.
-- Require identity and generation checks when stale asynchronous work can publish after newer work.
-- Distinguish conclusive no-match from timeout, transport, server, parsing and verification failures.
+- Require identity and generation checks when stale asynchronous work can
+  publish after newer work.
+- Distinguish conclusive no-match from timeout, transport, server, parsing and
+  verification failures.
 - Preserve explicit non-destructive migrations and user data.
 - Require localization for user-facing text.
-- Require security review for provider-controlled URLs, redirects, MIME, permissions, secrets, tokens, workflow trust boundaries, deep links and update downloads.
+- Require security review for provider-controlled URLs, redirects, MIME,
+  permissions, secrets, tokens, workflow trust boundaries, deep links and
+  update downloads.
 
 ## Scope discipline
 
 Do not silently broaden a request.
 
-When the owner says "only this", restrict the proposal and implementation to the named behavior or files unless another change is strictly required for correctness. Explain that dependency before expanding scope.
+When the owner says "only this", restrict the proposal and implementation to the
+named behavior or files unless another change is strictly required for
+correctness. Explain that dependency before expanding scope.
 
-Do not change versions, signing, publication, workflow permissions, repository settings or store metadata unless explicitly requested.
+Do not change versions, signing, publication, workflow permissions, repository
+settings or store metadata unless explicitly requested.
 
 ## Analysis format
 
@@ -97,19 +158,38 @@ For features provide:
 
 1. desired user behavior;
 2. current architecture fit;
-3. minimal implementation design;
-4. expected files/modules;
-5. state, lifecycle, concurrency, persistence, security and localization implications;
-6. tests and manual checks;
-7. rollout and compatibility risks.
+3. requirement and roadmap mapping;
+4. minimal implementation design;
+5. expected files/modules;
+6. state, lifecycle, concurrency, persistence, security and localization
+   implications;
+7. tests and manual checks;
+8. rollout and compatibility risks.
 
-For reviews, put findings before the summary. Each finding must include severity, confidence, exact file/line or symbol, triggering scenario, consequence, smallest compatible fix and missing test coverage. Do not report speculative issues without a concrete failure path.
+For reviews, put findings before the summary. Each finding must include
+severity, confidence, exact file/line or symbol, triggering scenario,
+consequence, smallest compatible fix and missing test coverage. Do not report
+speculative issues without a concrete failure path.
 
-## Preparing work for Codex
+## Preparing a tracked phase
 
-When implementation is requested, prepare a precise Codex task containing:
+When work is large enough to require planning:
+
+- use `levyra-project-manager`;
+- map the phase to `SPEC.md` and `ROADMAP.md`;
+- keep only one active reviewable phase in `TASKS.md`;
+- define scope, non-goals, preserved behavior, acceptance criteria, expected
+  files, focused checks, broader checks, manual checks, rollback, and owner
+  checkpoints;
+- stop for approval only when the owner reserved that checkpoint;
+- update status only from direct evidence.
+
+## Preparing work for Codex or Claude Code
+
+When implementation is requested, prepare a precise task containing:
 
 - objective and acceptance criteria;
+- requirement, roadmap and active-phase mapping;
 - matching `AGENTS.md` files and native skills to load;
 - relevant implementation, tests and detailed playbooks;
 - verified current behavior and probable root cause;
@@ -119,9 +199,34 @@ When implementation is requested, prepare a precise Codex task containing:
 - focused tests, broader checks and manual validation;
 - required delivery format and publication authorization.
 
-Do not represent planning text as an applied patch. Distinguish recommendation, generated code, locally tested change, committed change, pushed branch, pull request, merge and release.
+Do not represent planning text as an applied patch. Distinguish recommendation,
+generated code, locally tested change, committed change, pushed branch, pull
+request, CI, review, merge and release.
+
+## Preparing OpenClaw work
+
+Use `levyra-openclaw-orchestrator` and `docs/ai/OPENCLAW.md`.
+
+OpenClaw should coordinate through a dedicated `levyra` agent whose workspace is
+the real repository checkout. Use explicit target agents, narrow tool access, a
+coding runtime for substantial implementation, and an independent reviewer for
+the latest diff.
+
+The delegated task must state repository, objective, scope, prohibited changes,
+skills, tests, manual checks, delivery evidence, and whether branch, commit,
+push, or draft PR creation is authorized.
+
+OpenClaw must not infer permission to merge, tag, release, upload store
+metadata, change versions, or modify repository settings.
 
 ## Validation and honesty
+
+Run agent configuration validation when planning, agent instructions, skills, or
+AI documentation change:
+
+```bash
+python3 scripts/validate_agent_config.py
+```
 
 Use repository wrappers. Relevant full checks include:
 
@@ -141,26 +246,33 @@ Desktop from `desktop/`:
 ./gradlew assemble check
 ```
 
-Recommend focused tests first. Never claim that a test, build, emulator/device check, playback check, Android Auto check, notification check, PiP check, Windows installer/update check, commit, push, pull request, merge, tag or release succeeded without direct evidence.
+Recommend focused tests first. Never claim that a test, build, validation,
+emulator/device check, playback check, Android Auto check, notification check,
+PiP check, Windows installer/update check, commit, push, pull request, CI,
+review, merge, tag or release succeeded without direct evidence.
 
-Treat missing SDK, JDK, signing input, libvlc, WiX, network, CI, emulator, device or OS support as blocked checks, not passes.
+Treat missing SDK, JDK, signing input, libvlc, WiX, network, CI, emulator, device
+or OS support as blocked checks, not passes.
 
 ## Repository actions
 
-Do not commit, push, open a pull request, merge, tag, publish, release or modify repository settings without explicit authorization.
+Do not commit, push, open a pull request, merge, tag, publish, release or modify
+repository settings without explicit authorization.
 
 When publication is authorized:
 
 - stage only intended files;
 - use a professional focused commit message;
 - use a dedicated branch and draft pull request by default;
-- write a truthful PR body covering reason, changes, impact, validation, blocked checks and manual verification;
+- write a truthful PR body covering reason, changes, impact, validation, blocked
+  checks and manual verification;
 - push directly to `main` only when explicitly requested for the exact scope.
 
 ## Delivery standard
 
 For completed technical work report:
 
+- requirement and roadmap mapping when applicable;
 - root cause or rationale;
 - exact files changed;
 - concise description of each change;
@@ -168,7 +280,10 @@ For completed technical work report:
 - tests/checks run with results;
 - checks skipped or blocked and why;
 - remaining risks and manual validation;
+- task-status changes and evidence;
 - professional commit message;
-- verified branch, commit, PR, merge or release state.
+- verified branch, commit, PR, CI, review, merge or release state.
 
-Do not invent repository state, files, results or certainty.
+Do not invent repository state, files, results or certainty. Use these states
+precisely: planned, edited, locally validated, committed, pushed, pull request
+opened, CI passed, independently reviewed, merged, released.

--- a/docs/ai/OPENCLAW.md
+++ b/docs/ai/OPENCLAW.md
@@ -1,0 +1,225 @@
+# OpenClaw Integration for Levyra
+
+## Recommended role
+
+Use OpenClaw as the **orchestrator and status layer** for Levyra, not as an
+unrestricted all-purpose developer.
+
+The safest useful split is:
+
+```text
+main
+└── levyra
+    ├── planning and repository orientation
+    ├── Codex/Claude/OpenCode implementation delegation
+    ├── focused validation
+    ├── independent review delegation
+    └── branch and pull-request status returned to main
+```
+
+The `levyra` agent should have the Levyra repository as its workspace. That lets
+the agent discover the root and nested `AGENTS.md` files and the project-native
+skills under `.agents/skills/`.
+
+Keep general research, publishing, email, calendar, messaging, and system
+administration in separate agents. A coding agent does not need access to all of
+them.
+
+## Workspace setup
+
+Create or bind a dedicated agent to the real repository checkout:
+
+```powershell
+openclaw agents add levyra `
+  --workspace "C:\\path\\to\\Levyra-deepsound"
+```
+
+Use the real local path. Do not point the Levyra agent at a copy that cannot
+build, access Git metadata, or reproduce the owner's branch state.
+
+After configuration, verify:
+
+```powershell
+openclaw agents list --bindings
+openclaw gateway status --require-rpc
+```
+
+The agent workspace should contain:
+
+```text
+AGENTS.md
+SPEC.md
+ROADMAP.md
+TASKS.md
+.agents/skills/
+app/
+desktop/
+.github/
+docs/
+```
+
+## Delegation policy
+
+The coordinator should target the Levyra agent explicitly rather than relying on
+implicit agent selection.
+
+Example intent:
+
+```text
+Use the levyra agent in the Levyra repository. Read AGENTS.md, SPEC.md,
+ROADMAP.md, TASKS.md, and the matching native skills. Inspect the real code and
+tests. Implement only the approved phase, run focused checks, review the final
+diff, and return branch, commit, checks, blockers, and PR state. Do not merge,
+tag, publish, release, or change repository settings.
+```
+
+Configure the main agent with an explicit allowlist that includes `levyra`.
+Avoid `["*"]` unless every configured target is intentionally trusted. Keep
+explicit agent selection required so a task cannot silently run under the wrong
+profile.
+
+The exact JSON keys can vary with the installed OpenClaw release; validate the
+configuration with:
+
+```powershell
+openclaw doctor
+openclaw gateway status --require-rpc
+```
+
+## Native versus external coding runtime
+
+A native OpenClaw sub-agent is useful for:
+
+- reading repository instructions;
+- planning and task decomposition;
+- locating files and tests;
+- collecting CI or review state;
+- coordinating a sequence of bounded steps.
+
+For substantial implementation, use a configured coding runtime that can work
+inside the repository and return concrete file and command evidence. Depending
+on the installed setup, that may be Codex, Claude Code, OpenCode, or another ACP
+runtime.
+
+The selected runtime must still obey Levyra's repository instructions. A more
+powerful runtime does not gain permission to broaden scope, push, merge, or
+release.
+
+## Skill visibility
+
+Keep Levyra-specific skills in the repository:
+
+```text
+.agents/skills/levyra-player/
+.agents/skills/levyra-extractor/
+.agents/skills/levyra-database/
+.agents/skills/levyra-compose/
+.agents/skills/levyra-motion-artwork/
+.agents/skills/levyra-desktop/
+.agents/skills/levyra-security-review/
+.agents/skills/levyra-ci-workflows/
+.agents/skills/levyra-pr-review/
+.agents/skills/levyra-release-check/
+.agents/skills/levyra-project-manager/
+.agents/skills/levyra-openclaw-orchestrator/
+.agents/skills/levyra-engineering/
+```
+
+Do not install project-specific Levyra skills globally unless every agent should
+see them. Do not grant the `levyra` agent unrelated high-impact skills merely
+because they are available globally.
+
+## Recommended execution pattern
+
+1. `main` receives the owner's request.
+2. `main` delegates to `levyra` with the repository path and explicit outcome.
+3. `levyra` reads planning files and loads domain skills.
+4. A coding runtime performs one focused implementation phase.
+5. Focused tests and applicable broader checks run.
+6. A fresh reviewer inspects the latest diff.
+7. Actionable findings return to the implementation runtime.
+8. Validation repeats after changes.
+9. A branch and draft pull request are created only when the owner authorized
+   publication.
+10. `levyra` returns evidence to `main`; merge and release remain owner actions.
+
+## Tool boundaries
+
+Recommended for the Levyra agent:
+
+- repository read/search;
+- bounded command execution in the repository;
+- Git status, diff, branch, commit, and pull-request operations when authorized;
+- build/test tools required by the project;
+- GitHub PR, review, and CI inspection.
+
+Keep denied or separated unless a task explicitly needs them:
+
+- email, calendar, contacts, and personal messaging;
+- unrestricted browser sessions containing private accounts;
+- password stores and unrelated home directories;
+- system-wide package removal or destructive administration;
+- release credentials and signing material;
+- direct merge, tag, release, store upload, or repository-setting changes.
+
+Use sandboxing and narrow allowlists where practical. Skills teach a workflow;
+they are not a security boundary by themselves.
+
+## Publication rules
+
+OpenClaw may coordinate a branch and draft pull request only when the current
+owner request explicitly authorizes it.
+
+It must never infer permission to:
+
+- push directly to `main`;
+- merge a pull request;
+- dismiss review findings without evidence;
+- change Android or Desktop versions;
+- tag or publish a release;
+- upload store metadata;
+- alter repository settings or secrets.
+
+The final handoff must distinguish:
+
+```text
+planned
+edited
+locally validated
+committed
+pushed
+pull request opened
+CI passed
+reviewed
+merged
+released
+```
+
+Only states backed by direct evidence may be reported.
+
+## Useful recurring automation
+
+After the GitHub tools and notification channel are deliberately configured,
+OpenClaw can perform low-risk recurring work such as:
+
+- summarize new actionable review comments on an open PR;
+- report when required CI reaches a final state;
+- surface a stale branch or unresolved review thread;
+- prepare a daily summary of open Levyra PRs without modifying them.
+
+Do not enable automatic code changes, merges, releases, or broad issue-driven
+execution as the first automation. Start read-only, observe the output, then
+grant the minimum additional capability required.
+
+## Verification checklist
+
+- `levyra` resolves to the intended repository workspace.
+- The root `AGENTS.md` and matching native skills are visible.
+- `openclaw doctor` reports a valid configuration.
+- `agents_list` or equivalent discovery shows the intended target agents.
+- Delegated tasks use explicit `agentId`.
+- The coding runtime executes in the repository checkout.
+- Unrelated personal and administrative tools are absent.
+- Branch and PR actions require explicit owner authorization.
+- Merge, tag, release, and settings changes remain blocked.
+- The agent returns exact checks, blockers, branch, commit, and PR state.

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -1,34 +1,53 @@
 # AI Assistant Setup for Levyra
 
-This guide explains how Levyra uses ChatGPT, Codex and Claude Code without conflicting instruction trees.
+This guide explains how Levyra uses ChatGPT, Codex, Claude Code, and OpenClaw
+without conflicting instruction trees or publication permissions.
 
 ## Architecture at a glance
 
 ```text
 AGENTS.md                         shared repository contract
+SPEC.md                           approved requirements and non-goals
+ROADMAP.md                        ordered outcomes, risks and exit criteria
+TASKS.md                          active reviewable phase and validation state
 app/AGENTS.md                     Android rules
 desktop/AGENTS.md                 Windows Desktop rules
 .github/AGENTS.md                 CI/workflow rules
 docs/AGENTS.md                    documentation rules
-.agents/skills/*/SKILL.md         native Codex/OpenAI skills
+.agents/skills/*/SKILL.md         native Codex/OpenAI/OpenClaw skills
 docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md
                                   ChatGPT Project instructions source
+docs/ai/WORKFLOW.md               complete AI-assisted engineering lifecycle
+docs/ai/OPENCLAW.md               OpenClaw workspace and delegation guide
 .claude/                          Claude Code configuration and detailed playbooks
 ```
 
-`AGENTS.md` belongs in the Git root because Codex discovers project instructions from the project root toward the current working directory. Files under `.agents/skills/` are task skills, not replacements for root project guidance.
+`AGENTS.md` belongs in the Git root because Codex discovers project instructions
+from the project root toward the current working directory. Files under
+`.agents/skills/` are task skills, not replacements for root project guidance.
+
+The planning files have distinct responsibilities:
+
+- `SPEC.md` states durable approved behavior.
+- `ROADMAP.md` orders outcomes and risks but does not authorize implementation
+  or release.
+- `TASKS.md` tracks one active reviewable phase and direct validation evidence.
 
 ## Codex setup
 
 1. Open or clone the repository.
 2. Start Codex from the repository root or a directory inside it.
 3. Codex loads root `AGENTS.md` and any nearer path-specific `AGENTS.md`.
-4. Use the most specific native skill or skills for the task.
-5. Inspect current code, tests and detailed playbooks before editing.
-6. Make the smallest coherent change and report validation truthfully.
+4. Read `SPEC.md`, the relevant roadmap track, and active task phase.
+5. Use the most specific native skill or skills for the task.
+6. Inspect current code, tests and detailed playbooks before editing.
+7. Make the smallest coherent change and report validation truthfully.
+8. Publish only when the current owner request explicitly authorizes it.
 
 Native skills:
 
+- `levyra-project-manager`
+- `levyra-openclaw-orchestrator`
 - `levyra-player`
 - `levyra-extractor`
 - `levyra-database`
@@ -44,24 +63,35 @@ Native skills:
 Recommended orientation prompt:
 
 ```text
-Read the applicable AGENTS.md files and use the most specific Levyra native skills. Inspect current code and tests before making assumptions. Describe the verified behavior, likely root cause, intended files, risks and validation plan before editing.
+Read the applicable AGENTS.md files, SPEC.md, ROADMAP.md and TASKS.md. Use the
+most specific Levyra native skills. Inspect current code and tests before making
+assumptions. Describe the verified behavior, root cause or rationale, intended
+files, preserved behavior, risks and validation plan before editing.
 ```
 
 ## ChatGPT setup
 
-Repository files do not automatically become persistent ChatGPT Project instructions.
+Repository files do not automatically become persistent ChatGPT Project
+instructions.
 
 1. Create a ChatGPT Project named `Levyra`.
-2. Connect or select `LUC4N3X/Levyra-deepsound` through the available GitHub integration.
-3. Copy the full contents of `docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md` into the Project instructions.
-4. Keep Levyra planning, investigation, architecture, PR review and release preparation inside that Project.
-5. Use Codex for implementation, tests and repository publication when authorized.
+2. Connect or select `LUC4N3X/Levyra-deepsound` through the available GitHub
+   integration.
+3. Copy the full contents of `docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md` into the
+   Project instructions.
+4. Keep Levyra requirements, planning, investigation, architecture, PR review
+   and release preparation inside that Project.
+5. Use Codex for implementation, tests and repository publication when
+   authorized.
 
-The Project instructions direct ChatGPT to read the root and path-specific `AGENTS.md` files, select native skills, inspect current code/tests and distinguish verified repository state from assumptions.
+The Project instructions direct ChatGPT to read the planning files, root and
+path-specific `AGENTS.md`, native skills, current code/tests, and to distinguish
+verified repository state from assumptions.
 
 ## Claude Code setup
 
-Claude Code continues to use `.claude/README.md` and the complete `.claude/` configuration:
+Claude Code continues to use `.claude/README.md` and the complete `.claude/`
+configuration:
 
 - `.claude/CLAUDE.md`
 - `.claude/rules/`
@@ -70,23 +100,81 @@ Claude Code continues to use `.claude/README.md` and the complete `.claude/` con
 - `.claude/hooks/`
 - `.claude/settings.json`
 
-The OpenAI configuration references detailed Levyra playbooks under `.claude/` instead of duplicating them.
+The OpenAI configuration references detailed Levyra playbooks under `.claude/`
+instead of duplicating them.
+
+## OpenClaw setup
+
+Use OpenClaw as the coordinator and status layer around a dedicated `levyra`
+agent. Its workspace should be the real Levyra checkout so project instructions,
+planning files, Git state, and `.agents/skills/` are available together.
+
+Use explicit agent targets and narrow tool access. For substantial
+implementation, delegate to a configured coding runtime such as Codex, Claude
+Code, or OpenCode. Use a fresh reviewer for the latest diff. OpenClaw may
+coordinate a branch and draft PR only when the owner explicitly authorizes
+publication; merge, tag, release, store upload, and repository settings remain
+separate owner actions.
+
+See `docs/ai/OPENCLAW.md`.
 
 ## Responsibility split
 
 | Assistant | Primary role | Main configuration |
 | --- | --- | --- |
-| ChatGPT Project | Product decisions, investigation, architecture, planning, PR interpretation, Codex task preparation | Project instructions copied from `CHATGPT_PROJECT_INSTRUCTIONS.md` plus connected repository |
-| Codex | Implementation, tests, validation, commits, branches and pull requests when authorized | root/path `AGENTS.md` plus `.agents/skills/` |
-| Claude Code | Implementation and review using Claude-specific hooks, agents, permissions and plugins | `.claude/` |
+| ChatGPT Project | Requirements, investigation, architecture, planning, PR interpretation and coding-task preparation | Project instructions plus connected repository |
+| Codex | Focused implementation, tests, validation, commits, branches and pull requests when authorized | root/path `AGENTS.md`, planning files and `.agents/skills/` |
+| Claude Code | Implementation and independent review using Claude-specific hooks, agents, permissions and plugins | `.claude/` plus repository planning files |
+| OpenClaw | Explicit delegation, status collection, recurring read-only checks and handoff between configured agents | dedicated Levyra workspace, project skills and narrow tool policy |
+| Owner | Scope, publication authorization, merge, release and repository settings | Direct human decision |
+
+## Complete workflow
+
+The complete lifecycle is documented in `docs/ai/WORKFLOW.md`:
+
+```text
+requirements
+→ active phase
+→ focused plan
+→ one reviewable implementation
+→ focused validation
+→ repository gate
+→ complete diff inspection
+→ independent review
+→ draft PR when authorized
+→ CI and manual checks
+→ owner-controlled merge and release
+```
+
+Implementation, review, CI, manual testing, merge, and release are separate
+states. An agent must not collapse them into "done".
+
+## Validation
+
+After changing planning files, agent instructions, native skills, AI
+documentation, or validation:
+
+```bash
+python3 scripts/validate_agent_config.py
+```
+
+The existing PR workflow runs the same command before the Android gate.
 
 ## Keeping instructions consistent
 
 - Update root `AGENTS.md` for shared repository-wide invariants.
 - Update the nearest nested `AGENTS.md` for platform/path constraints.
+- Update `SPEC.md` when approved durable requirements change.
+- Update `ROADMAP.md` when ordered outcomes, risks, or exit criteria change.
+- Replace the active phase in `TASKS.md` when new work begins.
 - Update one native skill for a repeatable task workflow.
 - Update `docs/ARCHITECTURE.md` for architecture or ownership changes.
-- Update the narrowest detailed `.claude/rules/` or `.claude/skills/` playbook for recurring domain-specific failures.
-- Update `CHATGPT_PROJECT_INSTRUCTIONS.md` only when ChatGPT collaboration behavior changes.
+- Update the narrowest detailed `.claude/rules/` or `.claude/skills/` playbook
+  for recurring domain-specific failures.
+- Update `CHATGPT_PROJECT_INSTRUCTIONS.md` only when ChatGPT collaboration
+  behavior changes.
+- Update `OPENCLAW.md` only when OpenClaw workspace, delegation, or tool
+  boundaries change.
 - Prefer routing and references over duplicated prose.
-- Verify paths, commands, task names, version locations, workflow names and artifact paths after structural changes.
+- Verify paths, commands, task names, version locations, workflow names,
+  artifact paths, skill names, and publication state after structural changes.

--- a/docs/ai/WORKFLOW.md
+++ b/docs/ai/WORKFLOW.md
@@ -1,0 +1,163 @@
+# Levyra AI Development Workflow
+
+## Goal
+
+Use AI agents as controlled engineering collaborators, not as a substitute for
+requirements, validation, independent review, or owner approval.
+
+The repository keeps four responsibilities separate:
+
+| File | Responsibility |
+| --- | --- |
+| `AGENTS.md` and nested variants | Durable operating rules loaded by coding agents |
+| `SPEC.md` | Approved product and engineering requirements |
+| `ROADMAP.md` | Ordered outcomes, risks, and phase exit criteria |
+| `TASKS.md` | One active reviewable phase and its truthful validation state |
+
+Native skills under `.agents/skills/` define repeatable workflows. Detailed
+domain playbooks remain under `.claude/skills/` and `.claude/rules/` where
+existing OpenAI skills reference them.
+
+## Complete lifecycle
+
+1. **Orient**
+   - Inspect the real repository, branch, worktree, current diff, architecture,
+     tests, build files, and workflows.
+   - Read root and nearest `AGENTS.md` files.
+   - Read `SPEC.md`, `ROADMAP.md`, and the active phase in `TASKS.md`.
+   - Load every matching native skill.
+
+2. **Define the phase**
+   - State the requested outcome and non-goals.
+   - Identify behavior that must remain unchanged.
+   - Map the work to specification requirements and roadmap outcomes.
+   - Record acceptance criteria, automated checks, manual checks, rollback, and
+     owner checkpoints in `TASKS.md` when the task is large enough to require a
+     tracked phase.
+
+3. **Plan**
+   - Trace the current control and data flow.
+   - Identify the verified root cause for a defect.
+   - Choose the smallest coherent design that matches current architecture.
+   - List expected files, risks, migration/security/localization implications,
+     and focused validation.
+   - Stop before implementation only when the owner reserved plan approval.
+
+4. **Implement one reviewable phase**
+   - Use a dedicated branch.
+   - Touch only files required by the active phase.
+   - Keep unrelated cleanup, dependency changes, versions, signing, and release
+     work out of the diff.
+   - Add regression coverage where applicable.
+
+5. **Run focused validation**
+   - Run the smallest check that can disprove the change first.
+   - Read complete errors and fix causes instead of weakening checks.
+   - Treat missing SDKs, JDKs, native runtimes, signing inputs, devices, or
+     operating systems as blocked checks.
+
+6. **Run the applicable repository gate**
+   - Agent configuration:
+     `python3 scripts/validate_agent_config.py`
+   - Android:
+     `./gradlew --no-daemon :app:testDebugUnitTest`
+     `./gradlew --no-daemon :app:lintRelease`
+     `./gradlew --no-daemon --no-configuration-cache assembleRelease`
+   - Desktop from `desktop/`:
+     `./gradlew check`
+     `./gradlew assemble check`
+   - Diff hygiene:
+     `git diff --check`
+
+7. **Inspect the complete diff**
+   - Check for unrelated edits, generated files, binaries, secrets, conflict
+     markers, accidental version changes, duplicated sources of truth, and
+     misleading documentation.
+   - Verify that `SPEC.md`, `ROADMAP.md`, `TASKS.md`, architecture, and user
+     documentation remain synchronized where affected.
+
+8. **Independent review**
+   - Use `levyra-pr-review` on the latest commit.
+   - Use CodeRabbit locally or on the pull request when available.
+   - Prefer a fresh reviewer model or human that did not implement the change.
+   - Require severity, exact location, triggering scenario, consequence,
+     smallest compatible fix, and missing test coverage for each finding.
+   - Do not accept speculative findings without a concrete failure path.
+
+9. **Publish only when authorized**
+   - Stage only intended files.
+   - Use a focused professional commit message.
+   - Push a dedicated branch and open a draft pull request by default.
+   - Record problem, approach, impact, exact checks, blocked checks, manual
+     checks, limitations, and rollback/revert scope.
+
+10. **Repeat after every push**
+    - Re-run affected validation.
+    - Review the latest commit rather than stale comments.
+    - Fix or explain every actionable finding.
+    - Keep manual checks unmarked until performed.
+
+11. **Owner-controlled completion**
+    - Merge only after the final diff, CI, applicable security checks,
+      independent review, review threads, and required manual checks are clean.
+    - Tagging, publishing, releases, store metadata, and repository settings are
+      separate explicit owner actions.
+
+## Role separation
+
+| Role | Responsibility | Must not assume |
+| --- | --- | --- |
+| ChatGPT Project | Requirements, investigation, architecture, planning, PR interpretation, task preparation | Repository writes or successful validation without evidence |
+| Codex | Focused implementation, tests, local validation, branch/PR work when authorized | Permission to merge or release |
+| Claude Code | Implementation or independent review using Claude-specific tooling | That its own report is sufficient evidence |
+| CodeRabbit | Automated review signal | Authority over repository requirements |
+| OpenClaw | Delegation, status collection, recurring checks, and handoff between configured agents | Broad tool access, publication, merge, or release permission |
+| Owner | Scope, trade-offs, publication authorization, merge, release | None; final authority remains human |
+
+## Review and publication gates
+
+A pull request is not ready merely because code compiles.
+
+Required evidence depends on scope, but the gate may include:
+
+- focused regression tests;
+- Android or Desktop wrapper checks;
+- agent-configuration validation;
+- lint and packaging;
+- security and dependency checks;
+- CodeRabbit;
+- fresh independent review;
+- screenshots or device checks;
+- Android Auto, notification, PiP, media-key, installer, update, protocol, or
+  native VLC checks;
+- truthful unresolved limitations.
+
+A check performed on an older commit does not validate a newer commit when the
+change can affect that check.
+
+## Task handoff contract
+
+Every implementation or review agent should return:
+
+- objective and final scope;
+- root cause or rationale;
+- exact files changed;
+- behavior preserved;
+- commands/checks and their results;
+- skipped or blocked checks and why;
+- remaining risks;
+- manual checks still required;
+- branch and commit;
+- pull request state and URL when one exists;
+- explicit statement that merge/release did not occur unless separately
+  authorized and verified.
+
+## Failure handling
+
+- Do not hide failing output.
+- Do not change tests to match incorrect behavior.
+- Do not weaken security validation for one provider response.
+- Do not convert cancellation into failure.
+- Do not mark a task complete because an agent says it is complete.
+- When evidence is unavailable, state the exact limitation and leave the gate
+  open.

--- a/scripts/validate_agent_config.py
+++ b/scripts/validate_agent_config.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Validate Levyra's repository-local AI planning and skill configuration."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_FILES = (
+    "AGENTS.md",
+    "app/AGENTS.md",
+    "desktop/AGENTS.md",
+    ".github/AGENTS.md",
+    "docs/AGENTS.md",
+    "SPEC.md",
+    "ROADMAP.md",
+    "TASKS.md",
+    "docs/ARCHITECTURE.md",
+    ".agents/README.md",
+    "docs/ai/README.md",
+    "docs/ai/WORKFLOW.md",
+    "docs/ai/OPENCLAW.md",
+    "docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md",
+)
+
+REFERENCE_FILES = (
+    "AGENTS.md",
+    ".agents/README.md",
+    "docs/ai/README.md",
+    "docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md",
+)
+
+SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+SKILL_REFERENCE_RE = re.compile(r"`(levyra-[a-z0-9-]+)`")
+
+
+def read_text(relative_path: str) -> str:
+    path = ROOT / relative_path
+    return path.read_text(encoding="utf-8")
+
+
+def parse_front_matter(path: Path) -> dict[str, str]:
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    if not lines or lines[0].strip() != "---":
+        raise ValueError("missing opening YAML front matter delimiter")
+
+    try:
+        end_index = next(
+            index
+            for index, line in enumerate(lines[1:], start=1)
+            if line.strip() == "---"
+        )
+    except StopIteration as exc:
+        raise ValueError("missing closing YAML front matter delimiter") from exc
+
+    metadata: dict[str, str] = {}
+    for line in lines[1:end_index]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if ":" not in line:
+            raise ValueError(f"invalid front matter line: {line!r}")
+        key, value = line.split(":", 1)
+        metadata[key.strip()] = value.strip()
+
+    return metadata
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    for relative_path in REQUIRED_FILES:
+        path = ROOT / relative_path
+        if not path.is_file():
+            errors.append(f"missing required file: {relative_path}")
+
+    skills_root = ROOT / ".agents" / "skills"
+    skill_paths = sorted(skills_root.glob("*/SKILL.md"))
+    if not skill_paths:
+        errors.append("no native skills found under .agents/skills")
+
+    actual_skills: set[str] = set()
+    for skill_path in skill_paths:
+        relative_path = skill_path.relative_to(ROOT).as_posix()
+        directory_name = skill_path.parent.name
+
+        try:
+            metadata = parse_front_matter(skill_path)
+        except (OSError, UnicodeError, ValueError) as exc:
+            errors.append(f"{relative_path}: {exc}")
+            continue
+
+        name = metadata.get("name", "")
+        description = metadata.get("description", "")
+
+        if not name:
+            errors.append(f"{relative_path}: missing front matter name")
+        elif not SKILL_NAME_RE.fullmatch(name):
+            errors.append(f"{relative_path}: invalid skill name {name!r}")
+        elif name != directory_name:
+            errors.append(
+                f"{relative_path}: front matter name {name!r} "
+                f"does not match directory {directory_name!r}"
+            )
+        elif name in actual_skills:
+            errors.append(f"{relative_path}: duplicate skill name {name!r}")
+        else:
+            actual_skills.add(name)
+
+        if not description:
+            errors.append(f"{relative_path}: missing front matter description")
+
+    referenced_skills: set[str] = set()
+    for relative_path in REFERENCE_FILES:
+        path = ROOT / relative_path
+        if not path.is_file():
+            continue
+        try:
+            referenced_skills.update(
+                SKILL_REFERENCE_RE.findall(read_text(relative_path))
+            )
+        except (OSError, UnicodeError) as exc:
+            errors.append(f"{relative_path}: cannot read file: {exc}")
+
+    missing_skills = sorted(referenced_skills - actual_skills)
+    for name in missing_skills:
+        errors.append(f"documented skill does not exist: {name}")
+
+    inventory_path = ROOT / ".agents" / "README.md"
+    if inventory_path.is_file():
+        inventory_skills = set(
+            SKILL_REFERENCE_RE.findall(inventory_path.read_text(encoding="utf-8"))
+        )
+        undocumented_skills = sorted(actual_skills - inventory_skills)
+        for name in undocumented_skills:
+            errors.append(f"skill missing from .agents/README.md inventory: {name}")
+
+    if errors:
+        print("Agent configuration validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(
+        "Agent configuration validation passed: "
+        f"{len(REQUIRED_FILES)} required files, "
+        f"{len(actual_skills)} native skills, "
+        f"{len(referenced_skills)} documented skill references."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This pull request adapts the useful planning and review patterns from `ChrisTitusTech/titus-ai` to Levyra's existing repository-specific agent configuration instead of replacing it with generic instructions.

It adds:

- `SPEC.md`, `ROADMAP.md`, and `TASKS.md` with separate requirement, sequencing, and active-phase responsibilities;
- a complete AI-assisted engineering lifecycle under `docs/ai/WORKFLOW.md`;
- a dedicated OpenClaw workspace, delegation, tool-boundary, review, and publication guide under `docs/ai/OPENCLAW.md`;
- native `levyra-project-manager` and `levyra-openclaw-orchestrator` skills;
- `scripts/validate_agent_config.py` to validate required files, skill metadata, skill-directory naming, documented skill references, and the skill inventory;
- agent-configuration validation in the existing PR Check workflow;
- synchronized routing and documentation in root/path instructions and ChatGPT setup material.

## Why

Levyra already had strong project-specific `AGENTS.md` files and domain skills. The missing layer was durable planning, a complete implementation/review/CI/manual-test lifecycle, and a safe role for OpenClaw as an orchestrator around dedicated coding and review agents.

This keeps current Levyra architecture and domain playbooks as the source of truth while adding clearer phase control, evidence requirements, and owner-controlled publication boundaries.

## OpenClaw model

The documented model uses:

- a dedicated `levyra` agent whose workspace is the real repository checkout;
- explicit agent targeting and narrow tool access;
- Codex, Claude Code, OpenCode, or another configured coding runtime for substantial implementation;
- a fresh independent reviewer on the latest diff;
- precise status reporting for planned, edited, validated, committed, pushed, PR opened, CI passed, reviewed, merged, and released;
- no inferred permission to merge, tag, release, change versions, upload store metadata, or modify repository settings.

## Scope and preserved behavior

This is a repository configuration, documentation, and CI-validation change only.

It does **not** modify:

- Android or Desktop application source;
- playback, queue, MediaSession, notification, Android Auto, DSP, extractor, Room, downloads, preferences, backup, UI, or localization behavior;
- Android or Desktop versions;
- dependencies, signing, packages, tags, artifacts, or release behavior.

## Validation

Completed on head commit `93103fe`:

- reviewed the complete comparison against `main`: 14 intended files and no product source files;
- Python syntax parsing of the new validator passed;
- existing and new native skill front matter was checked for required `name` and `description` metadata;
- `Validate Agent Configuration` passed in PR Check;
- `Workflow Duplicates Guard` passed;
- `APK Size Report` passed;
- targeted manual review of the validator, workflow insertion, planning boundaries, and OpenClaw publication limits found no actionable issue.

Currently running:

- the remaining existing PR Check steps: Android lint, focused tests, release compile, and F-Droid source build;
- signed APK build and verification.

Independent review status:

- CodeRabbit review was explicitly requested but is blocked by its current per-user review limit;
- Codex Review was explicitly requested but is blocked by the current Codex code-review usage limit;
- neither quota response is treated as a successful review.

Not applicable to this documentation/configuration phase:

- Desktop native build and packaging;
- Android device, playback, Android Auto, notification, or PiP testing;
- Windows installer, update, protocol, media-key, or native VLC testing.

## Remaining work

- confirm the remaining CI jobs on the latest commit;
- run an external latest-commit review when CodeRabbit or Codex review capacity is available and address any actionable findings;
- apply the documented OpenClaw workspace/agent configuration on the owner's machine as a separate local setup task.

Merge and release are intentionally not performed by this pull request workflow and remain owner-controlled actions.
