### PR TITLE
Ignore local build log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,8 @@ __pycache__/
 .claude/
 skills-lock.json
 
+# Local build diagnostics
+/[Bb]uild log.txt
+
 # Claude Code personal overrides (shared config lives in .claude/settings.json)
 .claude/settings.local.json


### PR DESCRIPTION
## Summary

- confirms `Build log.txt` is not tracked on `main`;
- ignores the root-level local build log in either `Build log.txt` or `build log.txt` form;
- prevents accidental future commits of this temporary diagnostic file.

No application, build configuration, dependency, workflow, version, signing, packaging, or release behavior is changed.