### PR TITLE
Fix duplicate albums in the Android home feed

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -98,6 +98,7 @@ jobs:
       - name: Motion, Canvas, Artwork, Lyrics, and DSP Unit Tests
         run: |
           ./gradlew --no-daemon :app:testDebugUnitTest \
+            --tests 'com.luc4n3x.levyra.data.HomeAlbumDeduplicationTest' \
             --tests 'com.luc4n3x.levyra.feature.motion.*' \
             --tests 'com.luc4n3x.levyra.data.EditorialArtworkContinuityTest' \
             --tests 'com.luc4n3x.levyra.data.LyricsParsingTest' \

--- a/app/src/main/java/com/luc4n3x/levyra/data/HomeAlbumDeduplication.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/HomeAlbumDeduplication.kt
@@ -1,0 +1,26 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.domain.AlbumHit
+import com.luc4n3x.levyra.domain.primaryArtistSegment
+
+internal fun deduplicateHomeAlbums(albums: List<AlbumHit>): List<AlbumHit> {
+    if (albums.size < 2) return albums
+    return albums.distinctBy(::homeAlbumDeduplicationKey)
+}
+
+internal fun homeAlbumDeduplicationKey(album: AlbumHit): String {
+    val repositoryKey = albumRecommendationDeduplicationKey(album)
+    val releaseTitle = repositoryKey
+        .takeIf { it.startsWith(HOME_ALBUM_RELEASE_PREFIX) }
+        ?.removePrefix(HOME_ALBUM_RELEASE_PREFIX)
+        ?.substringBeforeLast('|')
+        .orEmpty()
+    val primaryArtist = albumRecommendationTextKey(primaryArtistSegment(album.artist))
+    return if (releaseTitle.isNotBlank() && primaryArtist.isNotBlank()) {
+        "$HOME_ALBUM_RELEASE_PREFIX$releaseTitle|$primaryArtist"
+    } else {
+        repositoryKey
+    }
+}
+
+private const val HOME_ALBUM_RELEASE_PREFIX = "release:"

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.luc4n3x.levyra.data.HomeContentAvailability
 import com.luc4n3x.levyra.data.HomeEditorialEngine
 import com.luc4n3x.levyra.data.LevyraStartupCatalog
+import com.luc4n3x.levyra.data.deduplicateHomeAlbums
 import com.luc4n3x.levyra.domain.AlbumHit
 import com.luc4n3x.levyra.domain.ArtistHit
 import com.luc4n3x.levyra.domain.ChartRegion
@@ -359,9 +360,10 @@ private data class HomeDerivedInput(
 )
 
 internal fun buildHomeRenderSnapshot(state: LevyraUiState): HomeRenderSnapshot {
+    val renderState = state.withDeduplicatedHomeAlbums()
     return HomeRenderSnapshot(
-        state = state,
-        derived = buildHomeDerivedState(state.toHomeDerivedInput())
+        state = renderState,
+        derived = buildHomeDerivedState(renderState.toHomeDerivedInput())
     )
 }
 
@@ -369,12 +371,18 @@ internal fun buildHomeRenderSnapshot(
     state: LevyraUiState,
     previous: HomeRenderSnapshot
 ): HomeRenderSnapshot {
-    val derived = if (sameHomeDerivedInputs(previous.state, state)) {
+    val renderState = state.withDeduplicatedHomeAlbums()
+    val derived = if (sameHomeDerivedInputs(previous.state, renderState)) {
         previous.derived
     } else {
-        buildHomeDerivedState(state.toHomeDerivedInput())
+        buildHomeDerivedState(renderState.toHomeDerivedInput())
     }
-    return HomeRenderSnapshot(state = state, derived = derived)
+    return HomeRenderSnapshot(state = renderState, derived = derived)
+}
+
+private fun LevyraUiState.withDeduplicatedHomeAlbums(): LevyraUiState {
+    val distinctAlbums = deduplicateHomeAlbums(homeAlbums)
+    return if (distinctAlbums.size == homeAlbums.size) this else copy(homeAlbums = distinctAlbums)
 }
 
 private fun sameHomeDerivedInputs(previous: LevyraUiState, current: LevyraUiState): Boolean {

--- a/app/src/test/java/com/luc4n3x/levyra/data/HomeAlbumDeduplicationTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/HomeAlbumDeduplicationTest.kt
@@ -1,0 +1,42 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.domain.AlbumHit
+import com.luc4n3x.levyra.domain.ReleaseType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HomeAlbumDeduplicationTest {
+    @Test
+    fun localizedArtistConnectorAndProviderSeparatorCollapseToOneAlbum() {
+        val localized = album(
+            title = "AMATORE",
+            artist = "Samurai Jay e Vito Salamanca",
+            browseId = "MPREb_localized"
+        )
+        val providerVariant = album(
+            title = "AMATORE",
+            artist = "Samurai Jay, Vito Salamanca",
+            browseId = "MPREb_provider"
+        )
+
+        assertEquals(listOf(localized), deduplicateHomeAlbums(listOf(localized, providerVariant)))
+    }
+
+    @Test
+    fun differentReleasesRemainVisible() {
+        val first = album("AMATORE", "Samurai Jay e Vito Salamanca", "MPREb_first")
+        val second = album("LACRIME", "Samurai Jay e Vito Salamanca", "MPREb_second")
+
+        assertEquals(listOf(first, second), deduplicateHomeAlbums(listOf(first, second)))
+    }
+
+    private fun album(title: String, artist: String, browseId: String): AlbumHit = AlbumHit(
+        title = title,
+        artist = artist,
+        year = "2026",
+        thumbnailUrl = "https://example.test/$browseId.jpg",
+        query = "$title $artist",
+        browseId = browseId,
+        releaseType = ReleaseType.Album
+    )
+}


### PR DESCRIPTION
## Summary

Fixes duplicate album cards in the Android APK Home **Album per te** section when the same release arrives with localized artist-credit separators.

## Root cause

The same release could be labeled as:

- `Samurai Jay e Vito Salamanca`
- `Samurai Jay, Vito Salamanca`

Those variants produced different identities at the Home rendering boundary, so the same album could be shown twice.

## Changes

- adds a Home-specific album identity that reuses the existing edition-aware release key
- normalizes localized artist collaborations through the existing `primaryArtistSegment`
- deduplicates albums before building the Home render snapshot
- preserves the first result and the recommendation order
- adds regression tests for the exact **AMATORE** case
- verifies that genuinely different releases remain visible

## Scope

Android APK only. No Desktop changes. Search, album detail, playback and repository fetching behavior remain unchanged.

## Validation

- focused unit tests cover the reported duplicate
- PR checks and APK CI validate compilation and generate the Android artifact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate albums from home recommendations, including duplicates caused by localized artist separators.
  * Preserved distinct releases so different versions remain visible.
  * Avoided unnecessary home screen updates when the displayed album list is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->