### PR TITLE
Redesign the Android bottom navigation bar

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -48,6 +48,8 @@ import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.animation.EnterTransition
@@ -124,6 +126,11 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Album
+import androidx.compose.material.icons.outlined.Explore
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.LibraryMusic
+import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.rounded.Album
 import androidx.compose.material.icons.rounded.Explicit
 import androidx.compose.material.icons.rounded.Explore
@@ -423,8 +430,12 @@ private val LevyraTabBarHeight = 76.dp
 /** Mini player height: content row, progress line and its trailing spacer. */
 private val LevyraMiniPlayerHeight = 77.dp
 private val LevyraBottomContentGap = 16.dp
+private val LevyraTabIndicatorTop = 11.dp
+private val LevyraTabIndicatorHeight = 36.dp
+private val LevyraTabIndicatorShape = RoundedCornerShape(topStart = 18.dp, topEnd = 18.dp, bottomStart = 15.dp, bottomEnd = 15.dp)
+private val LevyraTabBarTopCorner = 26.dp
+private val LevyraTabScrimHeight = 22.dp
 private val LevyraNavigationBlue = Color(0xFF0A84FF)
-private val LevyraNavigationBlueDeep = Color(0xFF0066E6)
 private val LevyraHomeGlowViolet = Color(0xFF6E5CF0)
 
 private val LevyraIsLight: Boolean get() = LevyraActivePalette.isLight
@@ -494,122 +505,137 @@ private fun cinematicTextBrush(): Brush {
     }
 }
 
+private data class LevyraTabEntry(
+    val tab: LevyraTab,
+    val selectedIcon: ImageVector,
+    val unselectedIcon: ImageVector,
+    val label: String
+)
+
 @Composable
-private fun RowScope.TabButton(icon: ImageVector, label: String, selected: Boolean, onClick: () -> Unit) {
+private fun rememberLevyraTabEntries(): List<LevyraTabEntry> {
+    val strings = LocalLevyraStrings.current
+    return remember(strings) {
+        listOf(
+            LevyraTabEntry(LevyraTab.Home, Icons.Rounded.Home, Icons.Outlined.Home, strings.home),
+            LevyraTabEntry(LevyraTab.Search, Icons.Rounded.Search, Icons.Outlined.Search, strings.search),
+            LevyraTabEntry(LevyraTab.Explore, Icons.Rounded.Explore, Icons.Outlined.Explore, strings.explore),
+            LevyraTabEntry(LevyraTab.Library, Icons.Rounded.LibraryMusic, Icons.Outlined.LibraryMusic, strings.library),
+            LevyraTabEntry(LevyraTab.Player, Icons.Rounded.Album, Icons.Outlined.Album, strings.player)
+        )
+    }
+}
+
+@Composable
+private fun RowScope.TabButton(
+    entry: LevyraTabEntry,
+    isSelected: Boolean,
+    accent: Color,
+    onIndicator: Color,
+    showEqualizer: Boolean,
+    isPlaying: Boolean,
+    onClick: () -> Unit
+) {
+    val animationsEnabled = LocalAnimationsEnabled.current
+    val strings = LocalLevyraStrings.current
     val interactionSource = remember { MutableInteractionSource() }
     val pressed by interactionSource.collectIsPressedAsState()
+    val idleTint = if (LevyraIsLight) LevyraMuted else Color(0xFF8A8A93)
     val selectedProgress by animateFloatAsState(
-        targetValue = if (selected) 1f else 0f,
-        animationSpec = spring(dampingRatio = 0.82f, stiffness = Spring.StiffnessMediumLow),
+        targetValue = if (isSelected) 1f else 0f,
+        animationSpec = if (animationsEnabled) {
+            spring(dampingRatio = 0.82f, stiffness = Spring.StiffnessMediumLow)
+        } else {
+            snap()
+        },
         label = "tab-selected-progress"
     )
-    val pillWidth by animateDpAsState(
-        targetValue = if (selected) 56.dp else 34.dp,
-        animationSpec = spring(dampingRatio = 0.72f, stiffness = Spring.StiffnessMediumLow),
-        label = "tab-pill-width"
-    )
     val iconScale by animateFloatAsState(
-        targetValue = if (pressed) 0.86f else if (selected) 1.04f else 1f,
-        animationSpec = spring(dampingRatio = 0.62f, stiffness = Spring.StiffnessMedium),
+        targetValue = if (pressed) 0.88f else if (isSelected) 1.06f else 1f,
+        animationSpec = if (animationsEnabled) {
+            spring(dampingRatio = 0.62f, stiffness = Spring.StiffnessMedium)
+        } else {
+            snap()
+        },
         label = "tab-icon-scale"
     )
     val iconTint by animateColorAsState(
-        targetValue = if (selected) Color.White else if (LevyraIsLight) LevyraMuted else Color(0xFF85858D),
-        animationSpec = tween(220),
+        targetValue = if (isSelected) onIndicator else idleTint,
+        animationSpec = if (animationsEnabled) tween(220) else snap(),
         label = "tab-icon-tint"
     )
     val labelTint by animateColorAsState(
         targetValue = when {
-            selected && LevyraIsLight -> LevyraNavigationBlueDeep
-            selected -> LevyraNavigationBlue
-            LevyraIsLight -> LevyraMuted
-            else -> Color(0xFF8B8B94)
+            !isSelected -> idleTint
+            LevyraIsLight -> LevyraBlue
+            else -> accent
         },
-        animationSpec = tween(220),
+        animationSpec = if (animationsEnabled) tween(220) else snap(),
         label = "tab-label-tint"
     )
-    val pillShape = RoundedCornerShape(18.dp)
 
     Box(
         modifier = Modifier
             .weight(1f)
-            .fillMaxSize()
+            .fillMaxHeight()
+            .semantics(mergeDescendants = true) {
+                role = Role.Tab
+                selected = isSelected
+            }
             .pressable(
                 interactionSource = interactionSource,
-                pressedScale = 0.96f,
+                pressedScale = 0.93f,
                 onClick = onClick
             ),
-        contentAlignment = Alignment.Center
+        contentAlignment = Alignment.TopCenter
     ) {
         Column(
+            modifier = Modifier.padding(top = LevyraTabIndicatorTop),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(4.dp)
+            verticalArrangement = Arrangement.spacedBy(3.dp)
         ) {
             Box(
-                modifier = Modifier
-                    .width(pillWidth)
-                    .height(34.dp)
-                    .clip(pillShape)
-                    .background(
-                        brush = Brush.horizontalGradient(
-                            listOf(
-                                LevyraNavigationBlue.copy(alpha = 0.92f * selectedProgress),
-                                LevyraNavigationBlueDeep.copy(alpha = 0.78f * selectedProgress)
-                            )
-                        ),
-                        shape = pillShape
-                    )
-                    .border(
-                        width = 1.dp,
-                        color = Color(0xFF79BDFF).copy(alpha = 0.48f * selectedProgress),
-                        shape = pillShape
-                    ),
+                modifier = Modifier.height(LevyraTabIndicatorHeight),
                 contentAlignment = Alignment.Center
             ) {
-                if (selectedProgress > 0.01f) {
-                    Box(
+                if (showEqualizer) {
+                    ActiveTrackEqualizer(
+                        modifier = if (isPlaying) {
+                            Modifier.semantics { contentDescription = strings.playing }
+                        } else {
+                            Modifier
+                        },
+                        color = if (isSelected) onIndicator else accent,
+                        isPlaying = isPlaying,
+                        width = 19.dp,
+                        height = 15.dp
+                    )
+                } else {
+                    Icon(
+                        imageVector = if (isSelected) entry.selectedIcon else entry.unselectedIcon,
+                        contentDescription = null,
+                        tint = iconTint,
                         modifier = Modifier
-                            .matchParentSize()
-                            .graphicsLayer { alpha = selectedProgress }
-                            .background(
-                                Brush.radialGradient(
-                                    listOf(
-                                        Color.White.copy(alpha = 0.20f),
-                                        Color.Transparent
-                                    )
-                                ),
-                                pillShape
-                            )
+                            .size(22.dp)
+                            .graphicsLayer {
+                                scaleX = iconScale
+                                scaleY = iconScale
+                                translationY = -1.5.dp.toPx() * selectedProgress
+                            }
                     )
                 }
-                Icon(
-                    imageVector = icon,
-                    contentDescription = label,
-                    tint = iconTint,
-                    modifier = Modifier
-                        .size(23.dp)
-                        .graphicsLayer {
-                            scaleX = iconScale
-                            scaleY = iconScale
-                        }
-                )
             }
             Text(
-                text = label,
+                text = entry.label,
                 color = labelTint,
-                fontSize = 11.sp,
+                fontSize = 10.5.sp,
                 lineHeight = 12.sp,
-                letterSpacing = 0.05.sp,
-                fontWeight = if (selected) FontWeight.Black else FontWeight.Medium,
+                letterSpacing = 0.1.sp,
+                fontWeight = if (isSelected) FontWeight.ExtraBold else FontWeight.Medium,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            Box(
-                modifier = Modifier
-                    .width(18.dp * selectedProgress)
-                    .height(2.dp)
-                    .clip(RoundedCornerShape(99.dp))
-                    .background(LevyraNavigationBlue.copy(alpha = selectedProgress))
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(horizontal = 3.dp)
             )
         }
     }
@@ -1228,6 +1254,13 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
                 verticalArrangement = Arrangement.spacedBy(0.dp)
             ) {
                 AnimatedVisibility(
+                    visible = state.selectedTab != LevyraTab.Player,
+                    enter = miniEnter,
+                    exit = miniExit
+                ) {
+                    BottomTabsScrim()
+                }
+                AnimatedVisibility(
                     visible = state.selectedTab != LevyraTab.Player && state.currentTrack != null,
                     enter = miniEnter,
                     exit = miniExit
@@ -1255,7 +1288,8 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
                 ) {
                     BottomTabs(
                         selected = state.selectedTab,
-                        flatTop = state.currentTrack != null,
+                        hasActiveTrack = state.currentTrack != null,
+                        isPlaying = state.isPlaying,
                         onSelect = viewModel::selectTab
                     )
                 }
@@ -16961,39 +16995,195 @@ private fun VideoGlassCard(
 }
 
 @Composable
-private fun BottomTabs(selected: LevyraTab, flatTop: Boolean, onSelect: (LevyraTab) -> Unit) {
-    val strings = LocalLevyraStrings.current
-    val surfaceColor = if (LevyraIsLight) Color.White.copy(alpha = 0.96f) else Color(0xF708080B)
-    val linePrimary = if (LevyraIsLight) Color(0x1A11131F) else Color.White.copy(alpha = 0.07f)
-    Surface(
-        color = surfaceColor,
-        shape = RoundedCornerShape(0.dp),
-        shadowElevation = if (LevyraIsLight) 6.dp else 10.dp,
+private fun BottomTabsScrim() {
+    Box(
         modifier = Modifier
             .fillMaxWidth()
-            .drawBehind {
-                drawLine(
-                    color = linePrimary,
-                    start = androidx.compose.ui.geometry.Offset(0f, 0f),
-                    end = androidx.compose.ui.geometry.Offset(size.width, 0f),
-                    strokeWidth = 1.dp.toPx()
+            .height(LevyraTabScrimHeight)
+            .background(
+                Brush.verticalGradient(
+                    listOf(
+                        Color.Transparent,
+                        LevyraBlack.copy(alpha = 0.34f),
+                        LevyraBlack.copy(alpha = 0.72f)
+                    )
                 )
-            }
+            )
+    )
+}
+
+@Composable
+private fun BottomTabs(
+    selected: LevyraTab,
+    hasActiveTrack: Boolean,
+    isPlaying: Boolean,
+    onSelect: (LevyraTab) -> Unit
+) {
+    val entries = rememberLevyraTabEntries()
+    val animationsEnabled = LocalAnimationsEnabled.current
+    val haptics = LocalHapticFeedback.current
+    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+    val isLight = LevyraIsLight
+    val accentStart = LevyraCyan
+    val accentEnd = LevyraViolet
+    val onIndicator = if ((accentStart.luminance() + accentEnd.luminance()) / 2f > 0.5f) {
+        Color(0xFF06060A)
+    } else {
+        Color.White
+    }
+    val selectedIndex = entries.indexOfFirst { it.tab == selected }.coerceAtLeast(0)
+    val indicatorPosition by animateFloatAsState(
+        targetValue = selectedIndex.toFloat(),
+        animationSpec = if (animationsEnabled) {
+            spring(dampingRatio = 0.76f, stiffness = Spring.StiffnessMediumLow)
+        } else {
+            snap()
+        },
+        label = "tab-indicator-position"
+    )
+    val topCorner by animateDpAsState(
+        targetValue = if (hasActiveTrack) 0.dp else LevyraTabBarTopCorner,
+        animationSpec = if (animationsEnabled) tween(280, easing = FastOutSlowInEasing) else snap(),
+        label = "tab-bar-corner"
+    )
+    val barShape = RoundedCornerShape(topStart = topCorner, topEnd = topCorner)
+    val barBase = LevyraBlack
+    val barInk = LevyraInk
+    val barPanel = LevyraPanel
+    val barBrush = remember(isLight, barBase, barInk, barPanel) {
+        if (isLight) {
+            Brush.verticalGradient(listOf(Color.White, barInk, barPanel))
+        } else {
+            Brush.verticalGradient(listOf(barPanel, barInk, barBase))
+        }
+    }
+    val indicatorBrush = remember(accentStart, accentEnd) {
+        Brush.linearGradient(listOf(accentStart, accentEnd))
+    }
+    val indicatorBorderBrush = remember {
+        Brush.verticalGradient(listOf(Color.White.copy(alpha = 0.38f), Color.White.copy(alpha = 0.05f)))
+    }
+    val indicatorSheenBrush = remember {
+        Brush.verticalGradient(
+            listOf(Color.White.copy(alpha = 0.24f), Color.Transparent, Color.Black.copy(alpha = 0.10f))
+        )
+    }
+    val accentWashBrush = remember(accentStart) {
+        Brush.verticalGradient(listOf(accentStart.copy(alpha = 0.10f), Color.Transparent))
+    }
+    val hairline = if (isLight) Color(0x1A11131F) else Color.White.copy(alpha = 0.085f)
+
+    Surface(
+        color = barBase,
+        shape = barShape,
+        shadowElevation = if (isLight) 10.dp else 16.dp,
+        modifier = Modifier.fillMaxWidth()
     ) {
-        Column(modifier = Modifier.fillMaxWidth()) {
-            Row(
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(barBrush)
+                .drawBehind {
+                    val strokeWidth = 1.dp.toPx()
+                    val y = strokeWidth / 2f
+                    drawLine(
+                        color = hairline,
+                        start = Offset(0f, y),
+                        end = Offset(size.width, y),
+                        strokeWidth = strokeWidth
+                    )
+                    val slot = size.width / entries.size
+                    val rawCenter = slot * (indicatorPosition + 0.5f) / size.width
+                    val center = (if (isRtl) 1f - rawCenter else rawCenter).coerceIn(0f, 1f)
+                    val spread = 0.18f
+                    drawLine(
+                        brush = Brush.horizontalGradient(
+                            0f to Color.Transparent,
+                            (center - spread).coerceIn(0f, 1f) to Color.Transparent,
+                            center to accentStart.copy(alpha = 0.75f),
+                            (center + spread).coerceIn(0f, 1f) to Color.Transparent,
+                            1f to Color.Transparent
+                        ),
+                        start = Offset(0f, y),
+                        end = Offset(size.width, y),
+                        strokeWidth = strokeWidth * 1.6f
+                    )
+                }
+        ) {
+            BoxWithConstraints(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(76.dp)
-                    .padding(start = 8.dp, end = 8.dp, top = 8.dp, bottom = 7.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
+                    .height(LevyraTabBarHeight)
             ) {
-                TabButton(Icons.Rounded.Home, strings.home, selected == LevyraTab.Home) { onSelect(LevyraTab.Home) }
-                TabButton(Icons.Rounded.Search, strings.search, selected == LevyraTab.Search) { onSelect(LevyraTab.Search) }
-                TabButton(Icons.Rounded.Explore, strings.explore, selected == LevyraTab.Explore) { onSelect(LevyraTab.Explore) }
-                TabButton(Icons.Rounded.LibraryMusic, strings.library, selected == LevyraTab.Library) { onSelect(LevyraTab.Library) }
-                TabButton(Icons.Rounded.Album, strings.player, selected == LevyraTab.Player) { onSelect(LevyraTab.Player) }
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(LevyraTabIndicatorHeight)
+                        .background(accentWashBrush)
+                )
+
+                val slotWidth = maxWidth / entries.size
+                val indicatorWidth = (slotWidth - 16.dp).coerceIn(42.dp, 68.dp)
+                val density = LocalDensity.current
+                val slotPx = with(density) { slotWidth.toPx() }
+                val indicatorPx = with(density) { indicatorWidth.toPx() }
+                val indicatorTopPx = with(density) { LevyraTabIndicatorTop.roundToPx() }
+
+                Box(
+                    modifier = Modifier
+                        .offset {
+                            IntOffset(
+                                (slotPx * indicatorPosition + (slotPx - indicatorPx) / 2f).roundToInt(),
+                                indicatorTopPx
+                            )
+                        }
+                        .size(width = indicatorWidth, height = LevyraTabIndicatorHeight)
+                        .shadow(
+                            elevation = 14.dp,
+                            shape = LevyraTabIndicatorShape,
+                            clip = false,
+                            ambientColor = accentStart.copy(alpha = 0.55f),
+                            spotColor = accentEnd.copy(alpha = 0.65f)
+                        )
+                        .clip(LevyraTabIndicatorShape)
+                        .background(indicatorBrush)
+                        .border(
+                            width = 1.dp,
+                            brush = indicatorBorderBrush,
+                            shape = LevyraTabIndicatorShape
+                        )
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .matchParentSize()
+                            .background(indicatorSheenBrush)
+                    )
+                }
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .selectableGroup(),
+                    verticalAlignment = Alignment.Top
+                ) {
+                    entries.forEach { entry ->
+                        val isSelected = entry.tab == selected
+                        TabButton(
+                            entry = entry,
+                            isSelected = isSelected,
+                            accent = accentStart,
+                            onIndicator = onIndicator,
+                            showEqualizer = entry.tab == LevyraTab.Player && hasActiveTrack,
+                            isPlaying = isPlaying,
+                            onClick = {
+                                if (!isSelected) {
+                                    haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                }
+                                onSelect(entry.tab)
+                            }
+                        )
+                    }
+                }
             }
             Spacer(modifier = Modifier.navigationBarsPadding())
         }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -540,7 +540,7 @@ private fun RowScope.TabButton(
     val strings = LocalLevyraStrings.current
     val interactionSource = remember { MutableInteractionSource() }
     val pressed by interactionSource.collectIsPressedAsState()
-    val idleTint = if (LevyraIsLight) LevyraMuted else Color(0xFF8A8A93)
+    val idleTint = LevyraMuted
     val selectedProgress by animateFloatAsState(
         targetValue = if (isSelected) 1f else 0f,
         animationSpec = if (animationsEnabled) {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -250,7 +250,6 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.CompositingStrategy
-import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.StrokeCap
@@ -531,7 +530,6 @@ private fun RowScope.TabButton(
     entry: LevyraTabEntry,
     isSelected: Boolean,
     accent: Color,
-    onIndicator: Color,
     showEqualizer: Boolean,
     isPlaying: Boolean,
     onClick: () -> Unit
@@ -541,6 +539,7 @@ private fun RowScope.TabButton(
     val interactionSource = remember { MutableInteractionSource() }
     val pressed by interactionSource.collectIsPressedAsState()
     val idleTint = LevyraMuted
+    val selectedTint = if (LevyraIsLight) LevyraBlue else accent
     val selectedProgress by animateFloatAsState(
         targetValue = if (isSelected) 1f else 0f,
         animationSpec = if (animationsEnabled) {
@@ -560,16 +559,12 @@ private fun RowScope.TabButton(
         label = "tab-icon-scale"
     )
     val iconTint by animateColorAsState(
-        targetValue = if (isSelected) onIndicator else idleTint,
+        targetValue = if (isSelected) selectedTint else idleTint,
         animationSpec = if (animationsEnabled) tween(220) else snap(),
         label = "tab-icon-tint"
     )
     val labelTint by animateColorAsState(
-        targetValue = when {
-            !isSelected -> idleTint
-            LevyraIsLight -> LevyraBlue
-            else -> accent
-        },
+        targetValue = if (isSelected) selectedTint else idleTint,
         animationSpec = if (animationsEnabled) tween(220) else snap(),
         label = "tab-label-tint"
     )
@@ -605,7 +600,7 @@ private fun RowScope.TabButton(
                         } else {
                             Modifier
                         },
-                        color = if (isSelected) onIndicator else accent,
+                        color = if (isSelected) selectedTint else accent,
                         isPlaying = isPlaying,
                         width = 19.dp,
                         height = 15.dp
@@ -17022,15 +17017,8 @@ private fun BottomTabs(
     val entries = rememberLevyraTabEntries()
     val animationsEnabled = LocalAnimationsEnabled.current
     val haptics = LocalHapticFeedback.current
-    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
     val isLight = LevyraIsLight
     val accentStart = LevyraCyan
-    val accentEnd = LevyraViolet
-    val onIndicator = if ((accentStart.luminance() + accentEnd.luminance()) / 2f > 0.5f) {
-        Color(0xFF06060A)
-    } else {
-        Color.White
-    }
     val selectedIndex = entries.indexOfFirst { it.tab == selected }.coerceAtLeast(0)
     val indicatorPosition by animateFloatAsState(
         targetValue = selectedIndex.toFloat(),
@@ -17054,23 +17042,18 @@ private fun BottomTabs(
         if (isLight) {
             Brush.verticalGradient(listOf(Color.White, barInk, barPanel))
         } else {
-            Brush.verticalGradient(listOf(barPanel, barInk, barBase))
+            Brush.verticalGradient(listOf(barInk, barBase, barBase))
         }
     }
-    val indicatorBrush = remember(accentStart, accentEnd) {
-        Brush.linearGradient(listOf(accentStart, accentEnd))
-    }
-    val indicatorBorderBrush = remember {
-        Brush.verticalGradient(listOf(Color.White.copy(alpha = 0.38f), Color.White.copy(alpha = 0.05f)))
-    }
-    val indicatorSheenBrush = remember {
+    val indicatorBrush = remember(isLight, accentStart) {
         Brush.verticalGradient(
-            listOf(Color.White.copy(alpha = 0.24f), Color.Transparent, Color.Black.copy(alpha = 0.10f))
+            listOf(
+                accentStart.copy(alpha = if (isLight) 0.16f else 0.20f),
+                accentStart.copy(alpha = if (isLight) 0.08f else 0.10f)
+            )
         )
     }
-    val accentWashBrush = remember(accentStart) {
-        Brush.verticalGradient(listOf(accentStart.copy(alpha = 0.10f), Color.Transparent))
-    }
+    val indicatorBorderColor = accentStart.copy(alpha = if (isLight) 0.24f else 0.20f)
     val hairline = if (isLight) Color(0x1A11131F) else Color.White.copy(alpha = 0.085f)
 
     Surface(
@@ -17092,22 +17075,6 @@ private fun BottomTabs(
                         end = Offset(size.width, y),
                         strokeWidth = strokeWidth
                     )
-                    val slot = size.width / entries.size
-                    val rawCenter = slot * (indicatorPosition + 0.5f) / size.width
-                    val center = (if (isRtl) 1f - rawCenter else rawCenter).coerceIn(0f, 1f)
-                    val spread = 0.09f
-                    drawLine(
-                        brush = Brush.horizontalGradient(
-                            0f to Color.Transparent,
-                            (center - spread).coerceIn(0f, 1f) to Color.Transparent,
-                            center to accentStart.copy(alpha = 0.55f),
-                            (center + spread).coerceIn(0f, 1f) to Color.Transparent,
-                            1f to Color.Transparent
-                        ),
-                        start = Offset(0f, y),
-                        end = Offset(size.width, y),
-                        strokeWidth = strokeWidth * 1.6f
-                    )
                 }
         ) {
             BoxWithConstraints(
@@ -17115,13 +17082,6 @@ private fun BottomTabs(
                     .fillMaxWidth()
                     .height(LevyraTabBarHeight)
             ) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(LevyraTabIndicatorHeight)
-                        .background(accentWashBrush)
-                )
-
                 val slotWidth = maxWidth / entries.size
                 val indicatorWidth = (slotWidth - 34.dp).coerceIn(40.dp, 52.dp)
                 val density = LocalDensity.current
@@ -17138,27 +17098,14 @@ private fun BottomTabs(
                             )
                         }
                         .size(width = indicatorWidth, height = LevyraTabIndicatorHeight)
-                        .shadow(
-                            elevation = 14.dp,
-                            shape = LevyraTabIndicatorShape,
-                            clip = false,
-                            ambientColor = accentStart.copy(alpha = 0.55f),
-                            spotColor = accentEnd.copy(alpha = 0.65f)
-                        )
                         .clip(LevyraTabIndicatorShape)
                         .background(indicatorBrush)
                         .border(
                             width = 1.dp,
-                            brush = indicatorBorderBrush,
+                            color = indicatorBorderColor,
                             shape = LevyraTabIndicatorShape
                         )
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .matchParentSize()
-                            .background(indicatorSheenBrush)
-                    )
-                }
+                )
 
                 Row(
                     modifier = Modifier
@@ -17172,7 +17119,6 @@ private fun BottomTabs(
                             entry = entry,
                             isSelected = isSelected,
                             accent = accentStart,
-                            onIndicator = onIndicator,
                             showEqualizer = entry.tab == LevyraTab.Player && hasActiveTrack,
                             isPlaying = isPlaying,
                             onClick = {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -17095,12 +17095,12 @@ private fun BottomTabs(
                     val slot = size.width / entries.size
                     val rawCenter = slot * (indicatorPosition + 0.5f) / size.width
                     val center = (if (isRtl) 1f - rawCenter else rawCenter).coerceIn(0f, 1f)
-                    val spread = 0.18f
+                    val spread = 0.09f
                     drawLine(
                         brush = Brush.horizontalGradient(
                             0f to Color.Transparent,
                             (center - spread).coerceIn(0f, 1f) to Color.Transparent,
-                            center to accentStart.copy(alpha = 0.75f),
+                            center to accentStart.copy(alpha = 0.55f),
                             (center + spread).coerceIn(0f, 1f) to Color.Transparent,
                             1f to Color.Transparent
                         ),
@@ -17123,7 +17123,7 @@ private fun BottomTabs(
                 )
 
                 val slotWidth = maxWidth / entries.size
-                val indicatorWidth = (slotWidth - 16.dp).coerceIn(42.dp, 68.dp)
+                val indicatorWidth = (slotWidth - 34.dp).coerceIn(40.dp, 52.dp)
                 val density = LocalDensity.current
                 val slotPx = with(density) { slotWidth.toPx() }
                 val indicatorPx = with(density) { indicatorWidth.toPx() }


### PR DESCRIPTION
## Summary

The Android navigation bar (Home / Search / Explore / Library / Player) was five independently animated pills over a flat surface, hardcoded to an iOS-style blue that ignored the selected theme. This reworks it into a single navigation dock: one shared indicator that springs between tabs, icons that switch between outlined and filled, a now-playing equalizer on the Player tab, and colors that follow the active palette. The bar height and the bottom content inset are unchanged, so list padding, the mini player and the download HUD keep their existing positions.

The indicator is deliberately quiet. An earlier revision filled it with a saturated accent gradient; against a real home feed that made navigation chrome the brightest element on the screen, competing with the hero card and the accent chip at the top of the page. It is now a low-alpha accent tint with a hairline border, and the selected state is carried by the icon and label colour — the way the major music players do it.

## What changed

- `TabButton` no longer draws its own pill. `BottomTabs` owns a single indicator whose position is animated with a spring and applied in the **layout phase** (`Modifier.offset { IntOffset(...) }`), so the animation does not re-subcompose or re-measure the `BoxWithConstraints` every frame while the newly selected screen is composing.
- Tabs use `Icons.Outlined.*` when idle and `Icons.Rounded.*` when selected, with a small lift on selection and a press scale.
- The Player tab renders the existing `ActiveTrackEqualizer` instead of the album icon whenever a track is loaded. It freezes on its idle values when playback is paused, and only announces "playing" to TalkBack while actually playing.
- Bar gradient, indicator tint and label colour now derive from `LevyraActivePalette` (`black`/`ink`/`panel`/`cyan`) instead of the hardcoded `LevyraNavigationBlue*` pair, so AMOLED stays black, Minimal White stays light, and the cover/mood tints reach the navigation bar. The dark gradient starts from the palette ink rather than the lighter panel colour so the bar sits at the page's own black instead of reading as a raised slab.
- The bar rounds its top corners when nothing is playing and animates flat under the mini player. A short scrim fades scrolling content into the dock.
- All animations are gated on `LocalAnimationsEnabled` (the previous implementation animated unconditionally), selecting a different tab emits a light haptic, and each tab exposes `Role.Tab` + `selected` inside a `selectableGroup()`.
- Removed the now-unused `LevyraNavigationBlueDeep`; `LevyraNavigationBlue` is still used by the home glow.

No new user-facing strings were introduced — the labels are the existing `home` / `search` / `explore` / `library` / `player` catalog entries, and the equalizer description reuses `playing`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactor or maintenance
- [x] UI or UX change
- [x] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** UI

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [ ] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

**No Android SDK is available in the environment this branch was written in** (`ANDROID_HOME` is empty, no `local.properties`), so every `:app:` Gradle task fails at configuration time and none of them were run locally. CI (`.github/workflows/pr-check.yml`) is the authority. The **Signed Release APK** job passed on commit `07746fe`, which is positive evidence that the code compiles and assembles; the same job is re-running on each later commit.

What was verified locally: the full diff was re-read, every new symbol's import was checked against the existing import block, `material-icons-extended` is on the classpath (`app/build.gradle.kts:236`), and `git diff --check` is clean.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Physical device, dark theme, Italian | Home feed, nothing playing — indicator placement, rounded top corners, icon and label states | Verified from screenshots; drove the two proportion fixes and the recede pass below |
| — | RTL, light/AMOLED themes, equalizer with a track playing, font scale 2.0 | Not performed |

Device checks still owed before merge: RTL locale (Arabic/Hebrew) indicator alignment, Minimal White / Black AMOLED / Neon Cyan themes, the Player-tab equalizer with playback active, the corner flattening under the mini player, and font scale 2.0 label clipping (the label stack computes to roughly 74 dp inside the 76 dp bar, so it fits but with little margin).

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** None. No state, preference, database, or playback surface is touched; the change is confined to navigation chrome in `LevyraApp.kt`.
- **Known limitations:** The label stack has only ~2 dp of headroom at the largest system font scale.
- **Rollback plan:** Revert this PR

## Reviewer notes

- `app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt` is the only file changed.
- `indicatorPosition` is read only in the offset lambda (layout phase), never in composition. Keeping it out of composition is what stops the spring from re-subcomposing `BoxWithConstraints` on every frame during a tab switch, which is the same moment the destination screen is being composed.
- RTL needs no manual mirroring: `Modifier.offset { }` is layout-direction aware, and the `Row` places tabs in logical order, so the indicator follows. An earlier revision also hand-mirrored a glow drawn in `drawBehind` (`DrawScope` is *not* mirrored); that glow has since been removed.
- The `Row` has no horizontal padding on purpose: the indicator offset is computed from `maxWidth / entries.size`, so any padding on the row would desynchronise the indicator from the icon centers by a few dp at the outer tabs.
- The selected label uses `LevyraBlue` in light themes rather than `LevyraCyan`; Minimal White's `cyan` (`0xFF0084A8`) sits at roughly 4.05:1 against the light bar, below AA for 10.5 sp text, while `LevyraBlue` (`0xFF2E5BFF`) clears it.
- Selection is carried by four cues rather than a single strong fill: filled versus outlined icon, accent versus muted colour on icon and label, label weight, and the tinted indicator.
- No tests were added. `BottomTabs`/`TabButton` had none before, the composable is `private` and would need the whole ViewModel graph to exercise, and no Android test can be run from this environment — writing tests that cannot be executed would be worse than declaring the gap. The cheapest future guard would be a Compose test asserting the `Role.Tab` + `selected` semantics and the paused-state content description.

## Release note

The Android navigation bar has been redesigned with a sliding selection indicator, theme-aware colors, and a now-playing indicator on the Player tab.

## Related issues

N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [ ] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdciSQsd7HykDmt8CoRDnB