### PR TITLE
Fix Android splash icon clipping on Samsung devices

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_splash_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_splash_foreground.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@mipmap/ic_launcher_foreground"
+    android:insetLeft="12dp"
+    android:insetTop="12dp"
+    android:insetRight="12dp"
+    android:insetBottom="12dp" />

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_splash.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_splash.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_splash_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -2,6 +2,6 @@
 <resources>
     <style name="Theme.Levyra" parent="Theme.Levyra.Base">
         <item name="android:windowSplashScreenBackground">@color/levyra_black</item>
-        <item name="android:windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_splash</item>
     </style>
 </resources>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Levyra" parent="Theme.Levyra.Base">
+        <item name="android:windowSplashScreenBackground">@color/levyra_black</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
+    </style>
+</resources>

--- a/app/src/main/res/values-v33/themes.xml
+++ b/app/src/main/res/values-v33/themes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Levyra" parent="Theme.Levyra.Base">
+        <item name="android:windowSplashScreenBackground">@color/levyra_black</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
+        <item name="android:windowSplashScreenBehavior">icon_preferred</item>
+    </style>
+</resources>

--- a/app/src/main/res/values-v33/themes.xml
+++ b/app/src/main/res/values-v33/themes.xml
@@ -2,7 +2,7 @@
 <resources>
     <style name="Theme.Levyra" parent="Theme.Levyra.Base">
         <item name="android:windowSplashScreenBackground">@color/levyra_black</item>
-        <item name="android:windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_splash</item>
         <item name="android:windowSplashScreenBehavior">icon_preferred</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.Levyra" parent="android:style/Theme.Material.NoActionBar">
+    <style name="Theme.Levyra.Base" parent="android:style/Theme.Material.NoActionBar">
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowActionBar">false</item>
         <item name="android:windowBackground">@color/levyra_black</item>
@@ -8,4 +8,6 @@
         <item name="android:statusBarColor">@color/levyra_black</item>
         <item name="android:windowLightStatusBar">false</item>
     </style>
+
+    <style name="Theme.Levyra" parent="Theme.Levyra.Base" />
 </resources>


### PR DESCRIPTION
## Summary

Keeps the existing Levyra launcher artwork unchanged while fixing the visible edge clipping reported on a Samsung device during the Android system splash. The splash now uses a dedicated adaptive icon that reuses the current background and foreground artwork, with a 12 dp safe inset applied only to the splash foreground.

## What changed

- Extracted shared window styling into `Theme.Levyra.Base`.
- Added Android 12+ and Android 13+ system splash theme overrides.
- Added `ic_launcher_splash`, a dedicated adaptive icon used only during cold start.
- Reused the existing `ic_launcher_background` and `ic_launcher_foreground` assets without altering their pixels or colors.
- Added a 12 dp inset around the splash foreground so Samsung/One UI masks do not crop the outer curves.
- Kept `android:windowSplashScreenBehavior=icon_preferred` on Android 13+.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor or maintenance
- [x] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** System integration / launcher branding / startup theme

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease` — rerunning in `PR Check` after the Samsung-safe inset update
- [ ] Targeted tests were added or updated — not applicable; resource-only API-qualified theme change
- [ ] Workflow Duplicates Guard — rerunning for the latest head
- [ ] SonarQube Cloud Quality Gate — rerunning for the latest head
- [ ] APK Artifact and APK Size Report — rerunning for the latest head

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Samsung / One UI | Original system splash displayed the current icon too close to the adaptive mask, visibly clipping the outer mark | Reproduced from the supplied device screenshot |
| Samsung / One UI | Updated splash uses the same icon with a 12 dp foreground safe inset | Pending APK installation from this PR artifact |
| Android 12+ | Cold launch displays the dedicated adaptive splash icon on the existing black background | Pending CI artifact / device confirmation |
| Android 8–11 | Existing launcher and runtime theme remain unchanged | Verified by resource qualifiers and shared base-theme inheritance |

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** None. The launcher icon used on the home screen is unchanged. The dedicated icon is referenced only from API 31+ splash resources.
- **Known limitations:** Final visual spacing should be confirmed on the same Samsung device after installing the PR APK.
- **Rollback plan:** Revert this PR.

## Reviewer notes

- `app/src/main/res/drawable/ic_launcher_splash_foreground.xml` applies the 12 dp safe inset.
- `app/src/main/res/mipmap-anydpi-v26/ic_launcher_splash.xml` keeps the resource adaptive instead of wrapping the complete launcher icon as a generic drawable.
- `values-v31` and `values-v33` reference only the dedicated splash icon.
- No application code, player behavior, versioning, signing, F-Droid configuration, desktop files, or existing image assets changed.

## Release note

Levyra’s current icon now fits cleanly within the system splash on Samsung and other Android devices with aggressive icon masks.

## Related issues

- N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR — latest checks are running
