### PR TITLE
perf(extractor): take the BotGuard cold start off the playback critical path

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraYoutubeSessionPoTokenProvider.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraYoutubeSessionPoTokenProvider.kt
@@ -2,8 +2,6 @@ package com.luc4n3x.levyra.data
 
 import android.content.Context
 import android.os.Looper
-import com.luc4n3x.levyra.BuildConfig
-import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.runBlocking
@@ -21,13 +19,7 @@ import java.io.IOException
  * compatibility fallback remains non-blocking.
  */
 internal class LevyraYoutubeSessionPoTokenProvider(context: Context) : YoutubeSessionPoTokenProvider {
-    private val appContext = context.applicationContext
-    private val security = YoutubePlaybackSecurity(
-        appContext,
-        LevyraHttpClientFactory.youtubePlayer(),
-        BuildConfig.YOUTUBE_INNERTUBE_API_KEY,
-        LevyraPreferences(appContext)
-    )
+    private val security = YoutubePlaybackSecurity.getInstance(context)
 
     override fun getSessionPoToken(
         clientName: String,

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraYoutubeSessionPoTokenProvider.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraYoutubeSessionPoTokenProvider.kt
@@ -35,7 +35,7 @@ internal class LevyraYoutubeSessionPoTokenProvider(context: Context) : YoutubeSe
         return try {
             runBlocking {
                 withTimeout(PROVIDER_TIMEOUT_MS) {
-                    val session = security.currentSession()
+                    val session = security.currentSessionRequired()
                     val tokens = security.poTokensRequired(session.visitorData, session)
                     tokens.playerToken
                         .takeIf(String::isNotBlank)

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -100,7 +100,7 @@ class PlaybackResolver private constructor(private val context: Context) {
     private val videoSelector = LevyraVideoStreamSelector(context)
     private val youtubeHttpClient = LevyraHttpClientFactory.youtubePlayer()
     private val jsonMediaType = "application/json; charset=utf-8".toMediaType()
-    private val playbackSecurity = YoutubePlaybackSecurity(context, youtubeHttpClient, apiKey, userPreferences)
+    private val playbackSecurity = YoutubePlaybackSecurity.getInstance(context)
     private val resilienceEngine = PlaybackResilienceEngine(context)
     private val sourceMatchStore = PlaybackSourceMatchStore(LevyraDatabase.get(context).playbackSourceMatchDao())
     private val sourceMatchScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -183,6 +183,11 @@ class PlaybackResolver private constructor(private val context: Context) {
                 }
             })
         }
+    }
+
+    fun warmPlaybackSecurity() {
+        if (!hasInternetCapableNetwork()) return
+        playbackSecurity.warmUp()
     }
 
     suspend fun enrichYoutubeEngagement(track: Track): Track {
@@ -1382,6 +1387,9 @@ class PlaybackResolver private constructor(private val context: Context) {
             playbackSecurity.cachedSession()
         }
         val poTokens = if (profile.requiresPoToken) playbackSecurity.poTokens(track.id, session) else null
+        if (profile.requiresPoToken && poTokens == null) {
+            throw YoutubePlayerRequestException(null, "Integrity token non disponibile per ${profile.label}")
+        }
         val signatureTimestamp = if (profile.clientName.startsWith("WEB")) {
             runCatching { YoutubeJavaScriptPlayerManager.getSignatureTimestamp(track.id) }.getOrNull()
         } else {

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -1386,10 +1386,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         } else {
             playbackSecurity.cachedSession()
         }
-        val poTokens = if (profile.requiresPoToken) playbackSecurity.poTokens(track.id, session) else null
-        if (profile.requiresPoToken && poTokens == null) {
-            throw YoutubePlayerRequestException(null, "Integrity token non disponibile per ${profile.label}")
-        }
+        val poTokens = if (profile.requiresPoToken) playbackSecurity.poTokensForPlayback(track.id, session) else null
         val signatureTimestamp = if (profile.clientName.startsWith("WEB")) {
             runCatching { YoutubeJavaScriptPlayerManager.getSignatureTimestamp(track.id) }.getOrNull()
         } else {

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
@@ -61,6 +61,11 @@ internal class YoutubePlayerRequestException(
     message: String
 ) : IllegalStateException(message)
 
+internal class YoutubePoTokenRuntimeUnavailableException(
+    message: String,
+    cause: Throwable? = null
+) : IllegalStateException(message, cause)
+
 internal class YoutubePlaybackSecurity private constructor(
     context: Context,
     private val httpClient: OkHttpClient,
@@ -134,16 +139,14 @@ internal class YoutubePlaybackSecurity private constructor(
         return tokenGenerator.generate(videoId, session.visitorData, session.generation, FULL_WAIT_BUDGET_MS)
     }
 
-    suspend fun poTokens(videoId: String, session: YoutubeGuestSession): YoutubePoTokens? {
-        if (videoId.isBlank() || session.visitorData.isBlank()) return null
-        return try {
-            tokenGenerator.generate(videoId, session.visitorData, session.generation, FAST_WAIT_BUDGET_MS)
-        } catch (error: CancellationException) {
-            throw error
-        } catch (error: Throwable) {
-            Timber.w(error, "PO Token generation failed")
-            null
+    suspend fun poTokensForPlayback(
+        videoId: String,
+        session: YoutubeGuestSession
+    ): YoutubePoTokens {
+        if (videoId.isBlank() || session.visitorData.isBlank()) {
+            throw YoutubePoTokenRuntimeUnavailableException("Identita ospite assente per $videoId")
         }
+        return tokenGenerator.generate(videoId, session.visitorData, session.generation, FAST_WAIT_BUDGET_MS)
     }
 
     suspend fun rotateIfNeeded(error: Throwable): Boolean {
@@ -228,6 +231,9 @@ internal class YoutubePlaybackSecurity private constructor(
 
     private fun classifyFailure(error: Throwable): RotationDecision {
         val chain = generateSequence(error) { it.cause }.toList()
+        if (isLocalRuntimeFailure(error)) {
+            return RotationDecision(rotate = false, immediate = false, resetCounter = false)
+        }
         val requestError = chain.filterIsInstance<YoutubePlayerRequestException>().firstOrNull()
         val blob = chain.joinToString(" ") { it.message.orEmpty() }.lowercase()
         return evaluateFailure(blob, requestError?.httpCode)
@@ -303,6 +309,11 @@ internal class YoutubePlaybackSecurity private constructor(
         internal fun shouldRotateGuestSession(message: String, httpCode: Int?): Boolean {
             return evaluateFailure(message.lowercase(), httpCode).rotate
         }
+
+        internal fun isLocalRuntimeFailure(error: Throwable): Boolean {
+            return generateSequence(error) { it.cause }
+                .any { it is YoutubePoTokenRuntimeUnavailableException }
+        }
     }
 }
 
@@ -334,7 +345,8 @@ private class YoutubeWebPoTokenGenerator(
             streamingToken = ready.runtime.generate(videoId)
         } catch (error: CancellationException) {
             if (error !is TimeoutCancellationException) throw error
-        } catch (_: Throwable) {
+        } catch (error: Throwable) {
+            Timber.d(error, "PO Token mint failed on the active runtime, rebuilding")
         }
         if (streamingToken == null) {
             session = session(visitorData, generation, discard = session)
@@ -349,7 +361,7 @@ private class YoutubeWebPoTokenGenerator(
         return try {
             withTimeout(waitBudgetMs) { session.deferred.await() }
         } catch (error: TimeoutCancellationException) {
-            throw IllegalStateException("Integrity runtime not ready within $waitBudgetMs ms", error)
+            throw YoutubePoTokenRuntimeUnavailableException("Integrity runtime not ready within $waitBudgetMs ms", error)
         }
     }
 
@@ -398,7 +410,7 @@ private class YoutubeWebPoTokenGenerator(
         ) {
             PoTokenSessionAction.REUSE -> return@withLock current!!
             PoTokenSessionAction.BACKOFF ->
-                throw IllegalStateException("Integrity runtime in backoff for ${cooldownUntil - now} ms")
+                throw YoutubePoTokenRuntimeUnavailableException("Integrity runtime in backoff for ${cooldownUntil - now} ms")
             PoTokenSessionAction.BUILD -> Unit
         }
         active = null
@@ -616,16 +628,16 @@ internal class YoutubePoTokenRuntime private constructor(
             mintJob(binding).await()
         } catch (error: CancellationException) {
             if (currentCoroutineContext().isActive) {
-                throw IllegalStateException("Integrity runtime closed while minting", error)
+                throw YoutubePoTokenRuntimeUnavailableException("Integrity runtime closed while minting", error)
             }
             throw error
         }
     }
 
     private fun mintJob(binding: String): Deferred<String> {
-        inFlightTokens[binding]?.let { return it }
+        inFlightTokens[binding]?.takeIf { !it.isCompleted }?.let { return it }
         synchronized(inFlightTokens) {
-            inFlightTokens[binding]?.let { return it }
+            inFlightTokens[binding]?.takeIf { !it.isCompleted }?.let { return it }
             val job = scope.async { mintToken(binding) }
             inFlightTokens[binding] = job
             job.invokeOnCompletion { inFlightTokens.remove(binding, job) }

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
@@ -9,15 +9,23 @@ import android.webkit.WebChromeClient
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.annotation.Keep
+import com.luc4n3x.levyra.BuildConfig
+import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
 import com.luc4n3x.levyra.domain.LevyraContentLocales
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -53,7 +61,7 @@ internal class YoutubePlayerRequestException(
     message: String
 ) : IllegalStateException(message)
 
-internal class YoutubePlaybackSecurity(
+internal class YoutubePlaybackSecurity private constructor(
     context: Context,
     private val httpClient: OkHttpClient,
     private val apiKey: String,
@@ -64,6 +72,29 @@ internal class YoutubePlaybackSecurity(
     private val sessionMutex = Mutex()
     private val failureCount = AtomicInteger(0)
     private val tokenGenerator = YoutubeWebPoTokenGenerator(appContext, httpClient)
+
+    private val warmScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val lastWarmAtMs = AtomicLong(0L)
+
+    fun warmUp() {
+        val now = System.currentTimeMillis()
+        val previous = lastWarmAtMs.get()
+        if (now - previous < WARM_COOLDOWN_MS) return
+        if (!lastWarmAtMs.compareAndSet(previous, now)) return
+        warmScope.launch {
+            try {
+                val session = currentSession()
+                if (session.visitorData.isNotBlank()) {
+                    tokenGenerator.prewarm(session.visitorData, session.generation)
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                lastWarmAtMs.set(0L)
+                Timber.d(error, "PO Token warm-up skipped")
+            }
+        }
+    }
 
     fun cachedSession(): YoutubeGuestSession {
         return YoutubeGuestSession(
@@ -89,6 +120,7 @@ internal class YoutubePlaybackSecurity(
             .putLong(KEY_GENERATION, generation)
             .putLong(KEY_UPDATED_AT, System.currentTimeMillis())
             .apply()
+        lastWarmAtMs.set(0L)
         tokenGenerator.invalidate()
     }
 
@@ -99,13 +131,13 @@ internal class YoutubePlaybackSecurity(
         require(videoId.isNotBlank() && session.visitorData.isNotBlank()) {
             "PO Token binding and visitor identity are required"
         }
-        return tokenGenerator.generate(videoId, session.visitorData, session.generation)
+        return tokenGenerator.generate(videoId, session.visitorData, session.generation, FULL_WAIT_BUDGET_MS)
     }
 
     suspend fun poTokens(videoId: String, session: YoutubeGuestSession): YoutubePoTokens? {
         if (videoId.isBlank() || session.visitorData.isBlank()) return null
         return try {
-            poTokensRequired(videoId, session)
+            tokenGenerator.generate(videoId, session.visitorData, session.generation, FAST_WAIT_BUDGET_MS)
         } catch (error: CancellationException) {
             throw error
         } catch (error: Throwable) {
@@ -132,6 +164,7 @@ internal class YoutubePlaybackSecurity(
                 .putLong(KEY_GENERATION, generation)
                 .putLong(KEY_LAST_ROTATION, now)
                 .apply()
+            lastWarmAtMs.set(0L)
             tokenGenerator.invalidate()
             val fresh = try {
                 fetchVisitorData()
@@ -212,6 +245,25 @@ internal class YoutubePlaybackSecurity(
         private const val KEY_UPDATED_AT = "updated_at"
         private const val KEY_LAST_ROTATION = "last_rotation"
         private const val ROTATION_COOLDOWN_MS = 30_000L
+        private const val WARM_COOLDOWN_MS = 60_000L
+
+        private const val FULL_WAIT_BUDGET_MS = 35_000L
+        private const val FAST_WAIT_BUDGET_MS = 4_000L
+
+        @Volatile
+        private var instance: YoutubePlaybackSecurity? = null
+
+        fun getInstance(context: Context): YoutubePlaybackSecurity {
+            val appContext = context.applicationContext
+            return instance ?: synchronized(this) {
+                instance ?: YoutubePlaybackSecurity(
+                    appContext,
+                    LevyraHttpClientFactory.youtubePlayer(),
+                    BuildConfig.YOUTUBE_INNERTUBE_API_KEY,
+                    LevyraPreferences(appContext)
+                ).also { instance = it }
+            }
+        }
         private const val WEB_CLIENT_VERSION = "2.20260630.01.00"
         private const val WEB_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
         private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
@@ -258,76 +310,235 @@ private class YoutubeWebPoTokenGenerator(
     private val context: Context,
     private val httpClient: OkHttpClient
 ) {
-    private val mutex = Mutex()
-    private val closeScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val lock = Mutex()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val invalidationVersion = AtomicLong(0L)
-    private var runtime: YoutubePoTokenRuntime? = null
-    private var runtimeVersion = -1L
-    private var sessionId = ""
-    private var sessionGeneration = -1L
-    private var playerRequestToken = ""
+    private val consecutiveBuildFailures = AtomicInteger(0)
+    private val nextBuildAttemptAtMs = AtomicLong(0L)
 
-    suspend fun generate(videoId: String, visitorData: String, generation: Long): YoutubePoTokens {
-        return mutex.withLock {
-            val version = invalidationVersion.get()
-            val recreate = runtime == null ||
-                runtime?.isExpired == true ||
-                runtimeVersion != version ||
-                sessionId != visitorData ||
-                sessionGeneration != generation
-            if (recreate) recreate(visitorData, generation, version)
-            var active = runtime ?: throw IllegalStateException("Runtime PO Token assente")
-            val streamingToken = try {
-                active.generate(videoId)
-            } catch (error: TimeoutCancellationException) {
-                recreate(visitorData, generation, invalidationVersion.get())
-                active = runtime ?: throw error
-                active.generate(videoId)
-            } catch (error: CancellationException) {
-                throw error
-            } catch (error: Throwable) {
-                recreate(visitorData, generation, invalidationVersion.get())
-                active = runtime ?: throw error
-                active.generate(videoId)
-            }
-            YoutubePoTokens(
-                playerToken = playerRequestToken,
-                streamingToken = streamingToken
-            )
+    @Volatile
+    private var active: PoTokenSession? = null
+
+    suspend fun generate(
+        videoId: String,
+        visitorData: String,
+        generation: Long,
+        waitBudgetMs: Long
+    ): YoutubePoTokens {
+        cachedTokens(videoId, visitorData, generation)?.let { return it }
+
+        var session = session(visitorData, generation, discard = null)
+        var ready = awaitBuild(session, waitBudgetMs)
+        var streamingToken: String? = null
+        try {
+            streamingToken = ready.runtime.generate(videoId)
+        } catch (error: CancellationException) {
+            if (error !is TimeoutCancellationException) throw error
+        } catch (_: Throwable) {
         }
+        if (streamingToken == null) {
+            session = session(visitorData, generation, discard = session)
+            ready = awaitBuild(session, waitBudgetMs)
+            streamingToken = ready.runtime.generate(videoId)
+        }
+        refreshAheadIfStale(session, visitorData, generation)
+        return YoutubePoTokens(playerToken = ready.playerToken, streamingToken = streamingToken)
+    }
+
+    private suspend fun awaitBuild(session: PoTokenSession, waitBudgetMs: Long): ReadyPoTokenRuntime {
+        return try {
+            withTimeout(waitBudgetMs) { session.deferred.await() }
+        } catch (error: TimeoutCancellationException) {
+            throw IllegalStateException("Integrity runtime not ready within $waitBudgetMs ms", error)
+        }
+    }
+
+    suspend fun prewarm(visitorData: String, generation: Long) {
+        val session = session(visitorData, generation, discard = null)
+        session.deferred.await()
     }
 
     fun invalidate() {
         invalidationVersion.incrementAndGet()
-        closeScope.launch {
-            mutex.withLock { clearRuntime() }
+        scope.launch {
+            val retired = lock.withLock {
+                active.also { active = null }
+            }
+            closeWhenSettled(retired, graceMs = RETIRE_GRACE_MS)
         }
     }
 
-    private suspend fun recreate(visitorData: String, generation: Long, version: Long) {
-        clearRuntime()
-        val fresh = YoutubePoTokenRuntime.create(context, httpClient)
-        val sessionToken = try {
-            fresh.generate(visitorData)
-        } catch (error: Throwable) {
-            fresh.close()
-            throw error
-        }
-        runtime = fresh
-        runtimeVersion = version
-        sessionId = visitorData
-        sessionGeneration = generation
-        playerRequestToken = sessionToken
+    private fun cachedTokens(videoId: String, visitorData: String, generation: Long): YoutubePoTokens? {
+        val current = active ?: return null
+        if (!current.matches(visitorData, generation, invalidationVersion.get())) return null
+        val ready = current.ready ?: return null
+        if (ready.runtime.isExpired) return null
+        val cached = ready.runtime.cachedToken(videoId) ?: return null
+        return YoutubePoTokens(playerToken = ready.playerToken, streamingToken = cached)
     }
 
-    private suspend fun clearRuntime() {
-        val old = runtime
-        runtime = null
-        runtimeVersion = -1L
-        sessionId = ""
-        sessionGeneration = -1L
-        playerRequestToken = ""
-        old?.close()
+    private suspend fun session(
+        visitorData: String,
+        generation: Long,
+        discard: PoTokenSession?
+    ): PoTokenSession = lock.withLock {
+        val version = invalidationVersion.get()
+        val current = active
+        val now = System.currentTimeMillis()
+        val cooldownUntil = nextBuildAttemptAtMs.get()
+        when (
+            PoTokenSessionPolicy.decide(
+                hasSession = current != null,
+                discarded = current != null && current === discard,
+                matches = current != null && current.matches(visitorData, generation, version),
+                usable = current != null && current.isUsable,
+                nowMs = now,
+                nextBuildAttemptAtMs = cooldownUntil
+            )
+        ) {
+            PoTokenSessionAction.REUSE -> return@withLock current!!
+            PoTokenSessionAction.BACKOFF ->
+                throw IllegalStateException("Integrity runtime in backoff for ${cooldownUntil - now} ms")
+            PoTokenSessionAction.BUILD -> Unit
+        }
+        active = null
+        closeWhenSettled(current, graceMs = 0L)
+        val fresh = startSession(visitorData, generation, version, armBackoffOnFailure = true)
+        active = fresh
+        fresh
+    }
+
+    private fun startSession(
+        visitorData: String,
+        generation: Long,
+        version: Long,
+        armBackoffOnFailure: Boolean
+    ): PoTokenSession {
+        val session = PoTokenSession(visitorData, generation, version)
+        session.deferred = scope.async(start = CoroutineStart.LAZY) {
+            try {
+                val runtime = YoutubePoTokenRuntime.create(context, httpClient)
+                val playerToken = try {
+                    runtime.generate(visitorData)
+                } catch (error: Throwable) {
+                    runtime.close()
+                    throw error
+                }
+                val ready = ReadyPoTokenRuntime(runtime, playerToken)
+                session.ready = ready
+                consecutiveBuildFailures.set(0)
+                nextBuildAttemptAtMs.set(0L)
+                ready
+            } catch (error: CancellationException) {
+                session.failed = true
+                throw error
+            } catch (error: Throwable) {
+                session.failed = true
+                if (armBackoffOnFailure) {
+                    val failures = consecutiveBuildFailures.incrementAndGet()
+                    nextBuildAttemptAtMs.set(System.currentTimeMillis() + PoTokenBackoff.delayMs(failures))
+                }
+                throw error
+            }
+        }
+        session.deferred.start()
+        return session
+    }
+
+    private fun refreshAheadIfStale(session: PoTokenSession, visitorData: String, generation: Long) {
+        val ready = session.ready ?: return
+        if (!ready.runtime.isStale) return
+        if (!session.refreshing.compareAndSet(false, true)) return
+        scope.launch {
+            val version = invalidationVersion.get()
+            val replacement = startSession(visitorData, generation, version, armBackoffOnFailure = false)
+            val built = runCatching { replacement.deferred.await() }.getOrNull()
+            if (built == null) {
+                session.refreshing.set(false)
+                return@launch
+            }
+            val retired = lock.withLock {
+                if (active === session && invalidationVersion.get() == version) {
+                    active = replacement
+                    session
+                } else {
+                    replacement
+                }
+            }
+            closeWhenSettled(retired, graceMs = RETIRE_GRACE_MS)
+        }
+    }
+
+    private fun closeWhenSettled(session: PoTokenSession?, graceMs: Long) {
+        if (session == null) return
+        scope.launch {
+            val ready = runCatching { session.deferred.await() }.getOrNull() ?: return@launch
+            if (graceMs > 0L) delay(graceMs)
+            ready.runtime.close()
+        }
+    }
+
+    private class PoTokenSession(
+        val visitorData: String,
+        val generation: Long,
+        val version: Long
+    ) {
+        lateinit var deferred: Deferred<ReadyPoTokenRuntime>
+        val refreshing = AtomicBoolean(false)
+
+        @Volatile
+        var ready: ReadyPoTokenRuntime? = null
+
+        @Volatile
+        var failed = false
+
+        fun matches(visitorData: String, generation: Long, version: Long): Boolean =
+            this.visitorData == visitorData && this.generation == generation && this.version == version
+
+        val isUsable: Boolean
+            get() {
+                if (failed) return false
+                val current = ready ?: return true
+                return !current.runtime.isExpired
+            }
+    }
+
+    private class ReadyPoTokenRuntime(
+        val runtime: YoutubePoTokenRuntime,
+        val playerToken: String
+    )
+
+    private companion object {
+        const val RETIRE_GRACE_MS = 15_000L
+    }
+}
+
+internal enum class PoTokenSessionAction { REUSE, BACKOFF, BUILD }
+
+internal object PoTokenSessionPolicy {
+    fun decide(
+        hasSession: Boolean,
+        discarded: Boolean,
+        matches: Boolean,
+        usable: Boolean,
+        nowMs: Long,
+        nextBuildAttemptAtMs: Long
+    ): PoTokenSessionAction {
+        if (hasSession && !discarded && matches && usable) return PoTokenSessionAction.REUSE
+        if (nowMs < nextBuildAttemptAtMs) return PoTokenSessionAction.BACKOFF
+        return PoTokenSessionAction.BUILD
+    }
+}
+
+internal object PoTokenBackoff {
+    private const val BASE_MS = 2_000L
+    private const val MAX_MS = 60_000L
+    private const val MAX_SHIFT = 5
+
+    fun delayMs(consecutiveFailures: Int): Long {
+        if (consecutiveFailures <= 0) return 0L
+        val shift = (consecutiveFailures - 1).coerceAtMost(MAX_SHIFT)
+        return (BASE_MS shl shift).coerceAtMost(MAX_MS)
     }
 }
 
@@ -341,12 +552,16 @@ internal class YoutubePoTokenRuntime private constructor(
     private val ready = CompletableDeferred<Unit>()
     private val tokenWaiters = ConcurrentHashMap<String, CompletableDeferred<String>>()
     private val tokenCache = BoundedPoTokenCache(MAX_TOKEN_CACHE_ENTRIES)
+    private val inFlightTokens = ConcurrentHashMap<String, Deferred<String>>()
     private val closed = AtomicBoolean(false)
     private val dead = AtomicBoolean(false)
     private val initializationStarted = AtomicBoolean(false)
 
     @Volatile
     private var expiresAtMs = 0L
+
+    @Volatile
+    private var refreshAtMs = 0L
 
     init {
         webView.settings.javaScriptEnabled = true
@@ -382,10 +597,43 @@ internal class YoutubePoTokenRuntime private constructor(
     val isExpired: Boolean
         get() = closed.get() || dead.get() || expiresAtMs <= System.currentTimeMillis()
 
+    val isStale: Boolean
+        get() = isExpired || refreshAtMs <= System.currentTimeMillis()
+
+    fun cachedToken(identifier: String): String? {
+        if (isUnavailable()) return null
+        val binding = identifier.trim()
+        if (binding.isEmpty() || binding.length > MAX_BINDING_LENGTH) return null
+        return tokenCache.get(binding)
+    }
+
     suspend fun generate(identifier: String): String {
         val binding = identifier.trim()
         require(binding.isNotEmpty() && binding.length <= MAX_BINDING_LENGTH) { "Invalid PO Token binding" }
         tokenCache.get(binding)?.let { return it }
+        ensureActive()
+        return try {
+            mintJob(binding).await()
+        } catch (error: CancellationException) {
+            if (currentCoroutineContext().isActive) {
+                throw IllegalStateException("Integrity runtime closed while minting", error)
+            }
+            throw error
+        }
+    }
+
+    private fun mintJob(binding: String): Deferred<String> {
+        inFlightTokens[binding]?.let { return it }
+        synchronized(inFlightTokens) {
+            inFlightTokens[binding]?.let { return it }
+            val job = scope.async { mintToken(binding) }
+            inFlightTokens[binding] = job
+            job.invokeOnCompletion { inFlightTokens.remove(binding, job) }
+            return job
+        }
+    }
+
+    private suspend fun mintToken(binding: String): String {
         ensureActive()
         try {
             withTimeout(INIT_TIMEOUT_MS) { ready.await() }
@@ -457,7 +705,9 @@ internal class YoutubePoTokenRuntime private constructor(
                 val body = JSONArray().put(REQUEST_KEY).put(response).toString()
                 val integrityResponse = requestBotguard(GENERATE_URL, body)
                 val parsed = parseIntegrityTokenData(integrityResponse)
-                expiresAtMs = safeExpiryAt(System.currentTimeMillis(), parsed.second)
+                val issuedAt = System.currentTimeMillis()
+                expiresAtMs = safeExpiryAt(issuedAt, parsed.second)
+                refreshAtMs = refreshDeadline(issuedAt, expiresAtMs)
                 webView.evaluateJavascript(
                     "try{createPoTokenMinter(window.__levyraWebPoSignalOutput,${parsed.first}).then(function(){$JS_INTERFACE.onMinterReady();}).catch(function(e){$JS_INTERFACE.onInitError(String(e));});}catch(e){$JS_INTERFACE.onInitError(String(e));}",
                     null
@@ -670,6 +920,11 @@ internal class YoutubePoTokenRuntime private constructor(
                 throw IllegalStateException("Integrity token TTL non valido")
             }
             return jsUint8Array(bytes) to ttl
+        }
+
+        internal fun refreshDeadline(issuedAtMs: Long, expiresAtMs: Long): Long {
+            if (expiresAtMs <= issuedAtMs) return expiresAtMs
+            return issuedAtMs + (expiresAtMs - issuedAtMs) * 3L / 4L
         }
 
         internal fun safeExpiryAt(nowMs: Long, ttlSeconds: Long): Long {

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
@@ -407,7 +407,7 @@ private class YoutubeWebPoTokenGenerator(
         generation: Long
     ): YoutubePoTokens {
         var session = session(visitorData, generation, discard = null)
-        var ready = session.deferred.await()
+        var ready = awaitBuild(session)
         var streamingToken: String? = null
         try {
             streamingToken = ready.runtime.generate(videoId)
@@ -418,11 +418,19 @@ private class YoutubeWebPoTokenGenerator(
         }
         if (streamingToken == null) {
             session = session(visitorData, generation, discard = session)
-            ready = session.deferred.await()
+            ready = awaitBuild(session)
             streamingToken = ready.runtime.generate(videoId)
         }
         refreshAheadIfStale(session, visitorData, generation)
         return YoutubePoTokens(playerToken = ready.playerToken, streamingToken = streamingToken)
+    }
+
+    private suspend fun awaitBuild(session: PoTokenSession): ReadyPoTokenRuntime {
+        return try {
+            session.deferred.await()
+        } catch (error: Throwable) {
+            throw localizePoTokenBuildFailure(error)
+        }
     }
 
     suspend fun prewarm(visitorData: String, generation: Long) {
@@ -704,6 +712,12 @@ private class YoutubeWebPoTokenGenerator(
         const val RETIRE_GRACE_MS = 15_000L
         const val REFRESH_RETRY_COOLDOWN_MS = 15_000L
     }
+}
+
+internal fun localizePoTokenBuildFailure(error: Throwable): Throwable = when (error) {
+    is CancellationException -> error
+    is YoutubePoTokenRuntimeUnavailableException -> error
+    else -> YoutubePoTokenRuntimeUnavailableException("Integrity runtime build failed", error)
 }
 
 private data class PoTokenBudgetResult<T>(val value: T)

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
@@ -1,6 +1,7 @@
 package com.luc4n3x.levyra.data
 
 import android.content.Context
+import android.os.SystemClock
 import android.util.Base64
 import android.webkit.ConsoleMessage
 import android.webkit.JavascriptInterface
@@ -27,18 +28,23 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
+import okhttp3.Call
+import okhttp3.Callback
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
 import org.json.JSONArray
 import org.json.JSONObject
 import timber.log.Timber
+import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.util.LinkedHashMap
 import java.util.UUID
@@ -49,7 +55,8 @@ import java.util.concurrent.atomic.AtomicLong
 
 internal data class YoutubeGuestSession(
     val visitorData: String,
-    val generation: Long
+    val generation: Long,
+    val playbackDeadlineElapsedMs: Long = Long.MAX_VALUE
 )
 
 internal data class YoutubePoTokens(
@@ -89,7 +96,7 @@ internal class YoutubePlaybackSecurity private constructor(
         if (!lastWarmAtMs.compareAndSet(previous, now)) return
         warmScope.launch {
             try {
-                val session = currentSession()
+                val session = currentSessionRequired()
                 if (session.visitorData.isNotBlank()) {
                     tokenGenerator.prewarm(session.visitorData, session.generation)
                 }
@@ -109,7 +116,16 @@ internal class YoutubePlaybackSecurity private constructor(
         )
     }
 
-    suspend fun currentSession(): YoutubeGuestSession = sessionMutex.withLock {
+    suspend fun currentSession(): YoutubeGuestSession {
+        val deadline = safeElapsedDeadline(SystemClock.elapsedRealtime(), FAST_WAIT_BUDGET_MS)
+        return withPoTokenWaitBudget(FAST_WAIT_BUDGET_MS) {
+            ensureCurrentSession().copy(playbackDeadlineElapsedMs = deadline)
+        }
+    }
+
+    suspend fun currentSessionRequired(): YoutubeGuestSession = ensureCurrentSession()
+
+    private suspend fun ensureCurrentSession(): YoutubeGuestSession = sessionMutex.withLock {
         val cached = cachedSession()
         if (cached.visitorData.isNotBlank()) return@withLock cached
         val fresh = fetchVisitorData()
@@ -147,7 +163,15 @@ internal class YoutubePlaybackSecurity private constructor(
         if (videoId.isBlank() || session.visitorData.isBlank()) {
             throw YoutubePoTokenRuntimeUnavailableException("Identita ospite assente per $videoId")
         }
-        return tokenGenerator.generate(videoId, session.visitorData, session.generation, FAST_WAIT_BUDGET_MS)
+        val remainingBudgetMs = remainingPoTokenWaitBudget(
+            deadlineElapsedMs = session.playbackDeadlineElapsedMs,
+            fallbackBudgetMs = FAST_WAIT_BUDGET_MS,
+            nowElapsedMs = SystemClock.elapsedRealtime()
+        )
+        if (remainingBudgetMs <= 0L) {
+            throw YoutubePoTokenRuntimeUnavailableException("Playback security wait budget exhausted")
+        }
+        return tokenGenerator.generate(videoId, session.visitorData, session.generation, remainingBudgetMs)
     }
 
     suspend fun rotateIfNeeded(error: Throwable): Boolean {
@@ -188,7 +212,7 @@ internal class YoutubePlaybackSecurity private constructor(
         failureCount.set(0)
     }
 
-    private suspend fun fetchVisitorData(): String = withContext(Dispatchers.IO) {
+    private suspend fun fetchVisitorData(): String {
         val locale = LevyraContentLocales.forLanguage(preferences.languageCode())
         val client = JSONObject()
             .put("clientName", "WEB")
@@ -210,15 +234,7 @@ internal class YoutubePlaybackSecurity private constructor(
             .header("X-Youtube-Client-Name", "1")
             .header("X-Youtube-Client-Version", WEB_CLIENT_VERSION)
             .build()
-        httpClient.newCall(request).execute().use { response ->
-            val text = response.body.string()
-            if (!response.isSuccessful) throw YoutubePlayerRequestException(response.code, "visitor_id HTTP ${response.code}")
-            JSONObject(text)
-                .optJSONObject("responseContext")
-                ?.optString("visitorData")
-                .orEmpty()
-                .ifBlank { throw IllegalStateException("visitorData assente") }
-        }
+        return httpClient.awaitVisitorData(request)
     }
 
     private fun persistSession(visitorData: String, generation: Long): YoutubeGuestSession {
@@ -318,6 +334,38 @@ internal class YoutubePlaybackSecurity private constructor(
         }
     }
 }
+
+private suspend fun OkHttpClient.awaitVisitorData(request: Request): String =
+    suspendCancellableCoroutine { continuation ->
+        val call = newCall(request)
+        continuation.invokeOnCancellation { call.cancel() }
+        call.enqueue(object : Callback {
+            override fun onFailure(call: Call, error: IOException) {
+                continuation.tryResumeWithException(error)?.let(continuation::completeResume)
+            }
+
+            override fun onResponse(call: Call, response: Response) {
+                val result = runCatching {
+                    response.use {
+                        val text = it.body.string()
+                        if (!it.isSuccessful) {
+                            throw YoutubePlayerRequestException(it.code, "visitor_id HTTP ${it.code}")
+                        }
+                        JSONObject(text)
+                            .optJSONObject("responseContext")
+                            ?.optString("visitorData")
+                            .orEmpty()
+                            .ifBlank { throw IllegalStateException("visitorData assente") }
+                    }
+                }
+                result.onSuccess { visitorData ->
+                    continuation.tryResume(visitorData)?.let(continuation::completeResume)
+                }.onFailure { error ->
+                    continuation.tryResumeWithException(error)?.let(continuation::completeResume)
+                }
+            }
+        })
+    }
 
 private class YoutubeWebPoTokenGenerator(
     private val context: Context,
@@ -670,6 +718,21 @@ internal suspend fun <T> withPoTokenWaitBudget(
         ?: throw YoutubePoTokenRuntimeUnavailableException(
             "Integrity runtime or token not ready within $waitBudgetMs ms"
         )
+}
+
+internal fun safeElapsedDeadline(nowElapsedMs: Long, budgetMs: Long): Long {
+    require(budgetMs > 0L) { "PO Token wait budget must be positive" }
+    return if (nowElapsedMs > Long.MAX_VALUE - budgetMs) Long.MAX_VALUE else nowElapsedMs + budgetMs
+}
+
+internal fun remainingPoTokenWaitBudget(
+    deadlineElapsedMs: Long,
+    fallbackBudgetMs: Long,
+    nowElapsedMs: Long
+): Long {
+    require(fallbackBudgetMs > 0L) { "Fallback PO Token budget must be positive" }
+    if (deadlineElapsedMs == Long.MAX_VALUE) return fallbackBudgetMs
+    return (deadlineElapsedMs - nowElapsedMs).coerceAtLeast(0L)
 }
 
 internal enum class PoTokenSessionAction { REUSE, BACKOFF, BUILD }

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
@@ -13,6 +13,7 @@ import androidx.annotation.Keep
 import com.luc4n3x.levyra.BuildConfig
 import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
 import com.luc4n3x.levyra.domain.LevyraContentLocales
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -341,7 +342,7 @@ private suspend fun OkHttpClient.awaitVisitorData(request: Request): String =
         continuation.invokeOnCancellation { call.cancel() }
         call.enqueue(object : Callback {
             override fun onFailure(call: Call, error: IOException) {
-                continuation.tryResumeWithException(error)?.let(continuation::completeResume)
+                continuation.resumeResultIfActive(Result.failure(error))
             }
 
             override fun onResponse(call: Call, response: Response) {
@@ -358,14 +359,15 @@ private suspend fun OkHttpClient.awaitVisitorData(request: Request): String =
                             .ifBlank { throw IllegalStateException("visitorData assente") }
                     }
                 }
-                result.onSuccess { visitorData ->
-                    continuation.tryResume(visitorData)?.let(continuation::completeResume)
-                }.onFailure { error ->
-                    continuation.tryResumeWithException(error)?.let(continuation::completeResume)
-                }
+                continuation.resumeResultIfActive(result)
             }
         })
     }
+
+private fun <T> CancellableContinuation<T>.resumeResultIfActive(result: Result<T>) {
+    if (!isActive) return
+    runCatching { resumeWith(result) }
+}
 
 private class YoutubeWebPoTokenGenerator(
     private val context: Context,

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
@@ -23,14 +23,15 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -270,6 +271,7 @@ internal class YoutubePlaybackSecurity private constructor(
                 ).also { instance = it }
             }
         }
+
         private const val WEB_CLIENT_VERSION = "2.20260630.01.00"
         private const val WEB_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
         private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
@@ -326,9 +328,13 @@ private class YoutubeWebPoTokenGenerator(
     private val invalidationVersion = AtomicLong(0L)
     private val consecutiveBuildFailures = AtomicInteger(0)
     private val nextBuildAttemptAtMs = AtomicLong(0L)
+    private val nextRefreshAttemptAtMs = AtomicLong(0L)
 
     @Volatile
     private var active: PoTokenSession? = null
+
+    @Volatile
+    private var replacement: PoTokenSession? = null
 
     suspend fun generate(
         videoId: String,
@@ -336,33 +342,37 @@ private class YoutubeWebPoTokenGenerator(
         generation: Long,
         waitBudgetMs: Long
     ): YoutubePoTokens {
-        cachedTokens(videoId, visitorData, generation)?.let { return it }
+        cachedTokens(videoId, visitorData, generation)?.let { cached ->
+            refreshAheadIfStale(cached.session, visitorData, generation)
+            return cached.tokens
+        }
+        return withPoTokenWaitBudget(waitBudgetMs) {
+            generateWithinBudget(videoId, visitorData, generation)
+        }
+    }
 
+    private suspend fun generateWithinBudget(
+        videoId: String,
+        visitorData: String,
+        generation: Long
+    ): YoutubePoTokens {
         var session = session(visitorData, generation, discard = null)
-        var ready = awaitBuild(session, waitBudgetMs)
+        var ready = session.deferred.await()
         var streamingToken: String? = null
         try {
             streamingToken = ready.runtime.generate(videoId)
         } catch (error: CancellationException) {
-            if (error !is TimeoutCancellationException) throw error
+            throw error
         } catch (error: Throwable) {
             Timber.d(error, "PO Token mint failed on the active runtime, rebuilding")
         }
         if (streamingToken == null) {
             session = session(visitorData, generation, discard = session)
-            ready = awaitBuild(session, waitBudgetMs)
+            ready = session.deferred.await()
             streamingToken = ready.runtime.generate(videoId)
         }
         refreshAheadIfStale(session, visitorData, generation)
         return YoutubePoTokens(playerToken = ready.playerToken, streamingToken = streamingToken)
-    }
-
-    private suspend fun awaitBuild(session: PoTokenSession, waitBudgetMs: Long): ReadyPoTokenRuntime {
-        return try {
-            withTimeout(waitBudgetMs) { session.deferred.await() }
-        } catch (error: TimeoutCancellationException) {
-            throw YoutubePoTokenRuntimeUnavailableException("Integrity runtime not ready within $waitBudgetMs ms", error)
-        }
     }
 
     suspend fun prewarm(visitorData: String, generation: Long) {
@@ -371,22 +381,39 @@ private class YoutubeWebPoTokenGenerator(
     }
 
     fun invalidate() {
-        invalidationVersion.incrementAndGet()
+        val invalidatedVersion = invalidationVersion.incrementAndGet()
+        resetBuildAndRefreshBackoff()
         scope.launch {
             val retired = lock.withLock {
-                active.also { active = null }
+                val retiredActive = active
+                    ?.takeIf { PoTokenInvalidationPolicy.shouldRetire(it.version, invalidatedVersion) }
+                if (retiredActive != null) active = null
+                val retiredReplacement = replacement
+                    ?.takeIf { PoTokenInvalidationPolicy.shouldRetire(it.version, invalidatedVersion) }
+                if (retiredReplacement != null) replacement = null
+                retiredActive to retiredReplacement
             }
-            closeWhenSettled(retired, graceMs = RETIRE_GRACE_MS)
+            closeWhenSettled(retired.first, graceMs = RETIRE_GRACE_MS)
+            if (retired.second !== retired.first) {
+                closeWhenSettled(retired.second, graceMs = RETIRE_GRACE_MS)
+            }
         }
     }
 
-    private fun cachedTokens(videoId: String, visitorData: String, generation: Long): YoutubePoTokens? {
+    private fun cachedTokens(
+        videoId: String,
+        visitorData: String,
+        generation: Long
+    ): CachedPoTokens? {
         val current = active ?: return null
         if (!current.matches(visitorData, generation, invalidationVersion.get())) return null
         val ready = current.ready ?: return null
         if (ready.runtime.isExpired) return null
         val cached = ready.runtime.cachedToken(videoId) ?: return null
-        return YoutubePoTokens(playerToken = ready.playerToken, streamingToken = cached)
+        return CachedPoTokens(
+            session = current,
+            tokens = YoutubePoTokens(playerToken = ready.playerToken, streamingToken = cached)
+        )
     }
 
     private suspend fun session(
@@ -396,14 +423,30 @@ private class YoutubeWebPoTokenGenerator(
     ): PoTokenSession = lock.withLock {
         val version = invalidationVersion.get()
         val current = active
+        val pendingReplacement = replacement
+        val replacementMatches = pendingReplacement?.matches(visitorData, generation, version) == true
+        if (
+            PoTokenReplacementPolicy.shouldJoin(
+                hasReplacement = pendingReplacement != null,
+                replacementMatches = replacementMatches,
+                replacementUsable = pendingReplacement?.isUsable == true,
+                hasActive = current != null,
+                activeDiscarded = current != null && current === discard,
+                activeMatches = current?.matches(visitorData, generation, version) == true,
+                activeUsable = current?.isUsable == true
+            )
+        ) {
+            return@withLock pendingReplacement!!
+        }
+
         val now = System.currentTimeMillis()
         val cooldownUntil = nextBuildAttemptAtMs.get()
         when (
             PoTokenSessionPolicy.decide(
                 hasSession = current != null,
                 discarded = current != null && current === discard,
-                matches = current != null && current.matches(visitorData, generation, version),
-                usable = current != null && current.isUsable,
+                matches = current?.matches(visitorData, generation, version) == true,
+                usable = current?.isUsable == true,
                 nowMs = now,
                 nextBuildAttemptAtMs = cooldownUntil
             )
@@ -413,8 +456,16 @@ private class YoutubeWebPoTokenGenerator(
                 throw YoutubePoTokenRuntimeUnavailableException("Integrity runtime in backoff for ${cooldownUntil - now} ms")
             PoTokenSessionAction.BUILD -> Unit
         }
+
         active = null
-        closeWhenSettled(current, graceMs = 0L)
+        closeWhenSettled(current, graceMs = RETIRE_GRACE_MS)
+
+        val obsoleteReplacement = replacement
+        replacement = null
+        if (obsoleteReplacement !== current) {
+            closeWhenSettled(obsoleteReplacement, graceMs = RETIRE_GRACE_MS)
+        }
+
         val fresh = startSession(visitorData, generation, version, armBackoffOnFailure = true)
         active = fresh
         fresh
@@ -438,18 +489,23 @@ private class YoutubeWebPoTokenGenerator(
                 }
                 val ready = ReadyPoTokenRuntime(runtime, playerToken)
                 session.ready = ready
-                consecutiveBuildFailures.set(0)
-                nextBuildAttemptAtMs.set(0L)
+                resetBuildBackoff()
                 ready
             } catch (error: CancellationException) {
                 session.failed = true
+                if (
+                    armBackoffOnFailure &&
+                    PoTokenBuildFailurePolicy.shouldArmBackoff(
+                        cancellation = true,
+                        ownerActive = currentCoroutineContext().isActive
+                    )
+                ) {
+                    armBuildBackoff()
+                }
                 throw error
             } catch (error: Throwable) {
                 session.failed = true
-                if (armBackoffOnFailure) {
-                    val failures = consecutiveBuildFailures.incrementAndGet()
-                    nextBuildAttemptAtMs.set(System.currentTimeMillis() + PoTokenBackoff.delayMs(failures))
-                }
+                if (armBackoffOnFailure) armBuildBackoff()
                 throw error
             }
         }
@@ -457,28 +513,94 @@ private class YoutubeWebPoTokenGenerator(
         return session
     }
 
-    private fun refreshAheadIfStale(session: PoTokenSession, visitorData: String, generation: Long) {
+    private fun refreshAheadIfStale(
+        session: PoTokenSession,
+        visitorData: String,
+        generation: Long
+    ) {
         val ready = session.ready ?: return
         if (!ready.runtime.isStale) return
+        val now = System.currentTimeMillis()
+        if (now < nextRefreshAttemptAtMs.get()) return
         if (!session.refreshing.compareAndSet(false, true)) return
+
         scope.launch {
             val version = invalidationVersion.get()
-            val replacement = startSession(visitorData, generation, version, armBackoffOnFailure = false)
-            val built = runCatching { replacement.deferred.await() }.getOrNull()
-            if (built == null) {
+            val candidate = lock.withLock {
+                if (
+                    active !== session ||
+                    !session.matches(visitorData, generation, version)
+                ) {
+                    return@withLock null
+                }
+                replacement
+                    ?.takeIf { it.matches(visitorData, generation, version) && it.isUsable }
+                    ?: startSession(
+                        visitorData = visitorData,
+                        generation = generation,
+                        version = version,
+                        armBackoffOnFailure = false
+                    ).also { replacement = it }
+            }
+
+            if (candidate == null) {
                 session.refreshing.set(false)
                 return@launch
             }
+
+            val built = try {
+                candidate.deferred.await()
+            } catch (error: CancellationException) {
+                if (!currentCoroutineContext().isActive) throw error
+                null
+            } catch (error: Throwable) {
+                Timber.d(error, "PO Token refresh-ahead build failed")
+                null
+            }
+
+            if (built == null) {
+                nextRefreshAttemptAtMs.set(System.currentTimeMillis() + REFRESH_RETRY_COOLDOWN_MS)
+                lock.withLock {
+                    if (replacement === candidate) replacement = null
+                }
+                closeWhenSettled(candidate, graceMs = 0L)
+                session.refreshing.set(false)
+                return@launch
+            }
+
             val retired = lock.withLock {
-                if (active === session && invalidationVersion.get() == version) {
-                    active = replacement
+                if (
+                    active === session &&
+                    invalidationVersion.get() == version &&
+                    candidate.matches(visitorData, generation, version)
+                ) {
+                    active = candidate
+                    if (replacement === candidate) replacement = null
                     session
                 } else {
-                    replacement
+                    if (replacement === candidate) replacement = null
+                    candidate
                 }
             }
+            nextRefreshAttemptAtMs.set(0L)
+            session.refreshing.set(false)
             closeWhenSettled(retired, graceMs = RETIRE_GRACE_MS)
         }
+    }
+
+    private fun armBuildBackoff() {
+        val failures = consecutiveBuildFailures.incrementAndGet()
+        nextBuildAttemptAtMs.set(System.currentTimeMillis() + PoTokenBackoff.delayMs(failures))
+    }
+
+    private fun resetBuildBackoff() {
+        consecutiveBuildFailures.set(0)
+        nextBuildAttemptAtMs.set(0L)
+    }
+
+    private fun resetBuildAndRefreshBackoff() {
+        resetBuildBackoff()
+        nextRefreshAttemptAtMs.set(0L)
     }
 
     private fun closeWhenSettled(session: PoTokenSession?, graceMs: Long) {
@@ -489,6 +611,11 @@ private class YoutubeWebPoTokenGenerator(
             ready.runtime.close()
         }
     }
+
+    private data class CachedPoTokens(
+        val session: PoTokenSession,
+        val tokens: YoutubePoTokens
+    )
 
     private class PoTokenSession(
         val visitorData: String,
@@ -522,7 +649,24 @@ private class YoutubeWebPoTokenGenerator(
 
     private companion object {
         const val RETIRE_GRACE_MS = 15_000L
+        const val REFRESH_RETRY_COOLDOWN_MS = 15_000L
     }
+}
+
+private data class PoTokenBudgetResult<T>(val value: T)
+
+internal suspend fun <T> withPoTokenWaitBudget(
+    waitBudgetMs: Long,
+    block: suspend () -> T
+): T {
+    require(waitBudgetMs > 0L) { "PO Token wait budget must be positive" }
+    val result = withTimeoutOrNull(waitBudgetMs) {
+        PoTokenBudgetResult(block())
+    }
+    return result?.value
+        ?: throw YoutubePoTokenRuntimeUnavailableException(
+            "Integrity runtime or token not ready within $waitBudgetMs ms"
+        )
 }
 
 internal enum class PoTokenSessionAction { REUSE, BACKOFF, BUILD }
@@ -540,6 +684,31 @@ internal object PoTokenSessionPolicy {
         if (nowMs < nextBuildAttemptAtMs) return PoTokenSessionAction.BACKOFF
         return PoTokenSessionAction.BUILD
     }
+}
+
+internal object PoTokenReplacementPolicy {
+    fun shouldJoin(
+        hasReplacement: Boolean,
+        replacementMatches: Boolean,
+        replacementUsable: Boolean,
+        hasActive: Boolean,
+        activeDiscarded: Boolean,
+        activeMatches: Boolean,
+        activeUsable: Boolean
+    ): Boolean {
+        if (!hasReplacement || !replacementMatches || !replacementUsable) return false
+        return !hasActive || activeDiscarded || !activeMatches || !activeUsable
+    }
+}
+
+internal object PoTokenInvalidationPolicy {
+    fun shouldRetire(sessionVersion: Long, invalidatedVersion: Long): Boolean =
+        sessionVersion < invalidatedVersion
+}
+
+internal object PoTokenBuildFailurePolicy {
+    fun shouldArmBackoff(cancellation: Boolean, ownerActive: Boolean): Boolean =
+        !cancellation || ownerActive
 }
 
 internal object PoTokenBackoff {

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
@@ -489,12 +489,13 @@ private class YoutubeWebPoTokenGenerator(
                 }
                 val ready = ReadyPoTokenRuntime(runtime, playerToken)
                 session.ready = ready
-                resetBuildBackoff()
+                if (version == invalidationVersion.get()) resetBuildBackoff()
                 ready
             } catch (error: CancellationException) {
                 session.failed = true
                 if (
                     armBackoffOnFailure &&
+                    version == invalidationVersion.get() &&
                     PoTokenBuildFailurePolicy.shouldArmBackoff(
                         cancellation = true,
                         ownerActive = currentCoroutineContext().isActive
@@ -505,7 +506,7 @@ private class YoutubeWebPoTokenGenerator(
                 throw error
             } catch (error: Throwable) {
                 session.failed = true
-                if (armBackoffOnFailure) armBuildBackoff()
+                if (armBackoffOnFailure && version == invalidationVersion.get()) armBuildBackoff()
                 throw error
             }
         }
@@ -559,7 +560,9 @@ private class YoutubeWebPoTokenGenerator(
             }
 
             if (built == null) {
-                nextRefreshAttemptAtMs.set(System.currentTimeMillis() + REFRESH_RETRY_COOLDOWN_MS)
+                if (version == invalidationVersion.get()) {
+                    nextRefreshAttemptAtMs.set(System.currentTimeMillis() + REFRESH_RETRY_COOLDOWN_MS)
+                }
                 lock.withLock {
                     if (replacement === candidate) replacement = null
                 }
@@ -582,7 +585,7 @@ private class YoutubeWebPoTokenGenerator(
                     candidate
                 }
             }
-            nextRefreshAttemptAtMs.set(0L)
+            if (version == invalidationVersion.get()) nextRefreshAttemptAtMs.set(0L)
             session.refreshing.set(false)
             closeWhenSettled(retired, graceMs = RETIRE_GRACE_MS)
         }

--- a/app/src/main/java/com/luc4n3x/levyra/data/network/LevyraHttpClientFactory.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/network/LevyraHttpClientFactory.kt
@@ -88,6 +88,7 @@ object LevyraHttpClientFactory {
                 .readTimeout(12, TimeUnit.SECONDS)
                 .writeTimeout(5, TimeUnit.SECONDS)
                 .callTimeout(15, TimeUnit.SECONDS)
+                .addInterceptor(YoutubeClientIdentityInterceptor)
                 .addInterceptor(BrotliInterceptor)
                 .retryOnConnectionFailure(true)
                 .let { applyNetworkIntelligence(it, context) }

--- a/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeClientIdentityInterceptor.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeClientIdentityInterceptor.kt
@@ -1,0 +1,127 @@
+package com.luc4n3x.levyra.data.network
+
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+
+/**
+ * Keeps the transport identity coherent with the declared InnerTube client.
+ *
+ * The BotGuard WebView currently mints PO tokens as Chrome 131, so WEB-family requests that may
+ * present those tokens must use the same browser identity. Native clients must not carry browser
+ * navigation headers, and Android Music must use the package-style user agent emitted by the app.
+ */
+internal object YoutubeClientIdentityInterceptor : Interceptor {
+    internal const val PO_TOKEN_WEB_USER_AGENT =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+            "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+
+    private const val HEADER_CLIENT_NAME = "X-Youtube-Client-Name"
+    private const val HEADER_CLIENT_VERSION = "X-Youtube-Client-Version"
+    private const val HEADER_ORIGIN = "Origin"
+    private const val HEADER_REFERER = "Referer"
+    private const val HEADER_USER_AGENT = "User-Agent"
+
+    private const val CLIENT_WEB = "1"
+    private const val CLIENT_ANDROID = "3"
+    private const val CLIENT_IOS = "5"
+    private const val CLIENT_ANDROID_MUSIC = "21"
+    private const val CLIENT_ANDROID_VR = "28"
+    private const val CLIENT_WEB_EMBEDDED = "56"
+    private const val CLIENT_WEB_REMIX = "67"
+
+    private val nativeClientNames = setOf(
+        CLIENT_ANDROID,
+        CLIENT_IOS,
+        CLIENT_ANDROID_MUSIC,
+        CLIENT_ANDROID_VR
+    )
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        return chain.proceed(normalize(chain.request()))
+    }
+
+    internal fun normalize(request: Request): Request {
+        val clientName = request.header(HEADER_CLIENT_NAME) ?: return request
+        val builder = request.newBuilder()
+
+        when {
+            clientName == CLIENT_ANDROID_MUSIC -> {
+                request.header(HEADER_CLIENT_VERSION)
+                    ?.trim()
+                    ?.takeIf(String::isNotEmpty)
+                    ?.let { version ->
+                        builder.header(
+                            HEADER_USER_AGENT,
+                            "com.google.android.apps.youtube.music/$version " +
+                                "(Linux; U; Android 15) gzip"
+                        )
+                    }
+                builder.removeHeader(HEADER_ORIGIN)
+                builder.removeHeader(HEADER_REFERER)
+            }
+
+            clientName in nativeClientNames -> {
+                builder.removeHeader(HEADER_ORIGIN)
+                builder.removeHeader(HEADER_REFERER)
+            }
+
+            clientName == CLIENT_WEB ||
+                clientName == CLIENT_WEB_REMIX ||
+                clientName == CLIENT_WEB_EMBEDDED -> {
+                builder.header(HEADER_USER_AGENT, PO_TOKEN_WEB_USER_AGENT)
+                normalizeBrowserNavigationHeaders(request, builder, clientName)
+            }
+
+            else -> return request
+        }
+
+        return builder.build()
+    }
+
+    private fun normalizeBrowserNavigationHeaders(
+        request: Request,
+        builder: Request.Builder,
+        clientName: String
+    ) {
+        val existingOrigin = request.header(HEADER_ORIGIN)
+        val existingReferer = request.header(HEADER_REFERER)
+        if (existingOrigin == null && existingReferer == null) return
+
+        val host = if (clientName == CLIENT_WEB_REMIX) {
+            "music.youtube.com"
+        } else {
+            "www.youtube.com"
+        }
+        builder.header(HEADER_ORIGIN, "https://$host")
+        builder.header(
+            HEADER_REFERER,
+            normalizeReferer(existingReferer, host, clientName == CLIENT_WEB_EMBEDDED)
+        )
+    }
+
+    private fun normalizeReferer(
+        existingReferer: String?,
+        host: String,
+        embedded: Boolean
+    ): String {
+        val parsed = existingReferer?.toHttpUrlOrNull()
+        if (parsed == null) return "https://$host/"
+
+        if (!embedded && parsed.host == "youtu.be") {
+            val videoId = parsed.pathSegments.firstOrNull().orEmpty()
+            if (videoId.isNotBlank()) return "https://$host/watch?v=$videoId"
+        }
+
+        if (embedded && !parsed.encodedPath.startsWith("/embed/")) {
+            return "https://$host/"
+        }
+
+        return parsed.newBuilder()
+            .scheme("https")
+            .host(host)
+            .build()
+            .toString()
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -855,6 +855,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             delay(playbackWarmPlan.delayMs)
             awaitHomeUiIdle(startupPlan)
             resolver.warmNetwork()
+            if (!playbackPlan.lowRam && !playbackPlan.powerConstrained) {
+                resolver.warmPlaybackSecurity()
+            }
             val hot = (orbitSeed.take(1) + initialTracks.take(playbackWarmPlan.trackCount))
                 .filter { it.id.isNotBlank() || it.videoUrl.isNotBlank() || it.title.isNotBlank() }
                 .distinctBy { playbackIdentity(it) }

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicWatchParserTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicWatchParserTest.kt
@@ -672,6 +672,25 @@ class YoutubeMusicWatchParserTest {
     }
 
     @Test
+    fun localRuntimeFailuresDoNotDisturbGuestSessionRotationState() {
+        assertTrue(
+            YoutubePlaybackSecurity.isLocalRuntimeFailure(
+                YoutubePoTokenRuntimeUnavailableException("Integrity runtime in backoff for 4000 ms")
+            )
+        )
+        assertTrue(
+            YoutubePlaybackSecurity.isLocalRuntimeFailure(
+                IllegalStateException(
+                    "wrapped",
+                    YoutubePoTokenRuntimeUnavailableException("Integrity runtime not ready within 4000 ms")
+                )
+            )
+        )
+        assertFalse(YoutubePlaybackSecurity.isLocalRuntimeFailure(YoutubePlayerRequestException(403, "Forbidden")))
+        assertFalse(YoutubePlaybackSecurity.isLocalRuntimeFailure(IllegalStateException("PO token rejected")))
+    }
+
+    @Test
     fun poTokenSessionIsReusedEvenWhileBuildBackoffIsArmed() {
         val action = PoTokenSessionPolicy.decide(
             hasSession = true,

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicWatchParserTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicWatchParserTest.kt
@@ -655,4 +655,79 @@ class YoutubeMusicWatchParserTest {
         assertFalse(YoutubePoTokenRuntime.isValidPoToken("invalid token with spaces"))
     }
 
+    @Test
+    fun poTokenRefreshDeadlineLandsBeforeExpiry() {
+        val issuedAt = 1_000L
+        val expiresAt = YoutubePoTokenRuntime.safeExpiryAt(issuedAt, 3_600L)
+        val refreshAt = YoutubePoTokenRuntime.refreshDeadline(issuedAt, expiresAt)
+
+        assertTrue(refreshAt > issuedAt)
+        assertTrue(refreshAt < expiresAt)
+    }
+
+    @Test
+    fun poTokenRefreshDeadlineNeverExceedsAnAlreadyElapsedExpiry() {
+        assertEquals(500L, YoutubePoTokenRuntime.refreshDeadline(500L, 500L))
+        assertEquals(400L, YoutubePoTokenRuntime.refreshDeadline(500L, 400L))
+    }
+
+    @Test
+    fun poTokenSessionIsReusedEvenWhileBuildBackoffIsArmed() {
+        val action = PoTokenSessionPolicy.decide(
+            hasSession = true,
+            discarded = false,
+            matches = true,
+            usable = true,
+            nowMs = 1_000L,
+            nextBuildAttemptAtMs = 60_000L
+        )
+
+        assertEquals(PoTokenSessionAction.REUSE, action)
+    }
+
+    @Test
+    fun poTokenSessionRebuildsOnMismatchDiscardOrUnusableRuntime() {
+        assertEquals(
+            PoTokenSessionAction.BUILD,
+            PoTokenSessionPolicy.decide(false, discarded = false, matches = false, usable = false, nowMs = 0L, nextBuildAttemptAtMs = 0L)
+        )
+        assertEquals(
+            PoTokenSessionAction.BUILD,
+            PoTokenSessionPolicy.decide(true, discarded = true, matches = true, usable = true, nowMs = 0L, nextBuildAttemptAtMs = 0L)
+        )
+        assertEquals(
+            PoTokenSessionAction.BUILD,
+            PoTokenSessionPolicy.decide(true, discarded = false, matches = false, usable = true, nowMs = 0L, nextBuildAttemptAtMs = 0L)
+        )
+        assertEquals(
+            PoTokenSessionAction.BUILD,
+            PoTokenSessionPolicy.decide(true, discarded = false, matches = true, usable = false, nowMs = 0L, nextBuildAttemptAtMs = 0L)
+        )
+    }
+
+    @Test
+    fun poTokenBuildBackoffBlocksARebuildUntilItElapses() {
+        assertEquals(
+            PoTokenSessionAction.BACKOFF,
+            PoTokenSessionPolicy.decide(true, discarded = true, matches = true, usable = true, nowMs = 5_000L, nextBuildAttemptAtMs = 9_000L)
+        )
+        assertEquals(
+            PoTokenSessionAction.BUILD,
+            PoTokenSessionPolicy.decide(true, discarded = true, matches = true, usable = true, nowMs = 9_000L, nextBuildAttemptAtMs = 9_000L)
+        )
+    }
+
+    @Test
+    fun poTokenBuildBackoffGrowsAndStaysBounded() {
+        assertEquals(0L, PoTokenBackoff.delayMs(0))
+        assertEquals(0L, PoTokenBackoff.delayMs(-3))
+        assertEquals(2_000L, PoTokenBackoff.delayMs(1))
+        assertEquals(4_000L, PoTokenBackoff.delayMs(2))
+        assertEquals(32_000L, PoTokenBackoff.delayMs(5))
+
+        for (failures in 6..64) {
+            assertEquals(60_000L, PoTokenBackoff.delayMs(failures))
+        }
+    }
+
 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurityCoordinatorTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurityCoordinatorTest.kt
@@ -48,6 +48,49 @@ class YoutubePlaybackSecurityCoordinatorTest {
     }
 
     @Test
+    fun playbackDeadlineCarriesOnlyTheRemainingBudget() {
+        val deadline = safeElapsedDeadline(nowElapsedMs = 1_000L, budgetMs = 4_000L)
+
+        assertEquals(5_000L, deadline)
+        assertEquals(
+            2_500L,
+            remainingPoTokenWaitBudget(
+                deadlineElapsedMs = deadline,
+                fallbackBudgetMs = 4_000L,
+                nowElapsedMs = 2_500L
+            )
+        )
+        assertEquals(
+            0L,
+            remainingPoTokenWaitBudget(
+                deadlineElapsedMs = deadline,
+                fallbackBudgetMs = 4_000L,
+                nowElapsedMs = 5_500L
+            )
+        )
+    }
+
+    @Test
+    fun sessionsWithoutAPlaybackDeadlineUseTheFallbackBudget() {
+        assertEquals(
+            35_000L,
+            remainingPoTokenWaitBudget(
+                deadlineElapsedMs = Long.MAX_VALUE,
+                fallbackBudgetMs = 35_000L,
+                nowElapsedMs = 10_000L
+            )
+        )
+    }
+
+    @Test
+    fun elapsedDeadlineSaturatesInsteadOfOverflowing() {
+        assertEquals(
+            Long.MAX_VALUE,
+            safeElapsedDeadline(nowElapsedMs = Long.MAX_VALUE - 5L, budgetMs = 10L)
+        )
+    }
+
+    @Test
     fun invalidationRetiresOnlyOlderSessions() {
         assertTrue(PoTokenInvalidationPolicy.shouldRetire(sessionVersion = 4L, invalidatedVersion = 5L))
         assertFalse(PoTokenInvalidationPolicy.shouldRetire(sessionVersion = 5L, invalidatedVersion = 5L))

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurityCoordinatorTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurityCoordinatorTest.kt
@@ -13,7 +13,6 @@ class YoutubePlaybackSecurityCoordinatorTest {
 
     @Test
     fun poTokenWaitBudgetBoundsTheWholeOperation() {
-        val startedAt = System.nanoTime()
         val error = runCatching {
             runBlocking {
                 withPoTokenWaitBudget(25L) {
@@ -22,10 +21,8 @@ class YoutubePlaybackSecurityCoordinatorTest {
                 }
             }
         }.exceptionOrNull()
-        val elapsedMs = (System.nanoTime() - startedAt) / 1_000_000L
 
         assertTrue(error is YoutubePoTokenRuntimeUnavailableException)
-        assertTrue("elapsed=$elapsedMs", elapsedMs < 200L)
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurityCoordinatorTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurityCoordinatorTest.kt
@@ -1,11 +1,13 @@
 package com.luc4n3x.levyra.data
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -45,6 +47,25 @@ class YoutubePlaybackSecurityCoordinatorTest {
     @Test
     fun successfulWorkReturnsThroughTheBudgetWrapper() = runBlocking {
         assertEquals("ready", withPoTokenWaitBudget(500L) { "ready" })
+    }
+
+    @Test
+    fun botguardHttpBuildFailureIsLocalizedWithoutLosingItsCause() {
+        val source = YoutubePlayerRequestException(403, "BotGuard HTTP 403")
+        val localized = localizePoTokenBuildFailure(source)
+
+        assertTrue(localized is YoutubePoTokenRuntimeUnavailableException)
+        assertSame(source, localized.cause)
+        assertTrue(YoutubePlaybackSecurity.isLocalRuntimeFailure(localized))
+    }
+
+    @Test
+    fun buildFailureLocalizationPreservesCancellationAndExistingLocalErrors() {
+        val cancellation = CancellationException("cancelled")
+        val local = YoutubePoTokenRuntimeUnavailableException("already local")
+
+        assertSame(cancellation, localizePoTokenBuildFailure(cancellation))
+        assertSame(local, localizePoTokenBuildFailure(local))
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurityCoordinatorTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurityCoordinatorTest.kt
@@ -1,0 +1,159 @@
+package com.luc4n3x.levyra.data
+
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class YoutubePlaybackSecurityCoordinatorTest {
+
+    @Test
+    fun poTokenWaitBudgetBoundsTheWholeOperation() {
+        val startedAt = System.nanoTime()
+        val error = runCatching {
+            runBlocking {
+                withPoTokenWaitBudget(25L) {
+                    delay(250L)
+                    "unreachable"
+                }
+            }
+        }.exceptionOrNull()
+        val elapsedMs = (System.nanoTime() - startedAt) / 1_000_000L
+
+        assertTrue(error is YoutubePoTokenRuntimeUnavailableException)
+        assertTrue("elapsed=$elapsedMs", elapsedMs < 200L)
+    }
+
+    @Test
+    fun outerTimeoutIsNotConvertedIntoALocalRuntimeFailure() {
+        val error = runCatching {
+            runBlocking {
+                withTimeout(25L) {
+                    withPoTokenWaitBudget(1_000L) {
+                        delay(250L)
+                        "unreachable"
+                    }
+                }
+            }
+        }.exceptionOrNull()
+
+        assertTrue(error is TimeoutCancellationException)
+        assertFalse(error is YoutubePoTokenRuntimeUnavailableException)
+    }
+
+    @Test
+    fun successfulWorkReturnsThroughTheBudgetWrapper() = runBlocking {
+        assertEquals("ready", withPoTokenWaitBudget(500L) { "ready" })
+    }
+
+    @Test
+    fun invalidationRetiresOnlyOlderSessions() {
+        assertTrue(PoTokenInvalidationPolicy.shouldRetire(sessionVersion = 4L, invalidatedVersion = 5L))
+        assertFalse(PoTokenInvalidationPolicy.shouldRetire(sessionVersion = 5L, invalidatedVersion = 5L))
+        assertFalse(PoTokenInvalidationPolicy.shouldRetire(sessionVersion = 6L, invalidatedVersion = 5L))
+    }
+
+    @Test
+    fun replacementIsJoinedWhenTheActiveSessionCannotServe() {
+        assertTrue(
+            PoTokenReplacementPolicy.shouldJoin(
+                hasReplacement = true,
+                replacementMatches = true,
+                replacementUsable = true,
+                hasActive = true,
+                activeDiscarded = true,
+                activeMatches = true,
+                activeUsable = true
+            )
+        )
+        assertTrue(
+            PoTokenReplacementPolicy.shouldJoin(
+                hasReplacement = true,
+                replacementMatches = true,
+                replacementUsable = true,
+                hasActive = true,
+                activeDiscarded = false,
+                activeMatches = false,
+                activeUsable = true
+            )
+        )
+        assertTrue(
+            PoTokenReplacementPolicy.shouldJoin(
+                hasReplacement = true,
+                replacementMatches = true,
+                replacementUsable = true,
+                hasActive = true,
+                activeDiscarded = false,
+                activeMatches = true,
+                activeUsable = false
+            )
+        )
+    }
+
+    @Test
+    fun healthyActiveSessionWinsOverAReplacementBuild() {
+        assertFalse(
+            PoTokenReplacementPolicy.shouldJoin(
+                hasReplacement = true,
+                replacementMatches = true,
+                replacementUsable = true,
+                hasActive = true,
+                activeDiscarded = false,
+                activeMatches = true,
+                activeUsable = true
+            )
+        )
+    }
+
+    @Test
+    fun unusableOrMismatchedReplacementIsNeverJoined() {
+        assertFalse(
+            PoTokenReplacementPolicy.shouldJoin(
+                hasReplacement = true,
+                replacementMatches = false,
+                replacementUsable = true,
+                hasActive = false,
+                activeDiscarded = false,
+                activeMatches = false,
+                activeUsable = false
+            )
+        )
+        assertFalse(
+            PoTokenReplacementPolicy.shouldJoin(
+                hasReplacement = true,
+                replacementMatches = true,
+                replacementUsable = false,
+                hasActive = false,
+                activeDiscarded = false,
+                activeMatches = false,
+                activeUsable = false
+            )
+        )
+    }
+
+    @Test
+    fun ownedCancellationArmsBackoffButScopeShutdownDoesNot() {
+        assertTrue(
+            PoTokenBuildFailurePolicy.shouldArmBackoff(
+                cancellation = true,
+                ownerActive = true
+            )
+        )
+        assertFalse(
+            PoTokenBuildFailurePolicy.shouldArmBackoff(
+                cancellation = true,
+                ownerActive = false
+            )
+        )
+        assertTrue(
+            PoTokenBuildFailurePolicy.shouldArmBackoff(
+                cancellation = false,
+                ownerActive = false
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/network/YoutubeClientIdentityInterceptorTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/network/YoutubeClientIdentityInterceptorTest.kt
@@ -1,0 +1,163 @@
+package com.luc4n3x.levyra.data.network
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+import okhttp3.Request
+
+class YoutubeClientIdentityInterceptorTest {
+
+    @Test
+    fun webPlayerUsesTheSameBrowserIdentityAsBotGuardMinting() {
+        val request = playerRequest(
+            clientName = "1",
+            clientVersion = "2.20260630.01.00",
+            userAgent = "Mozilla/5.0 Chrome/142.0.0.0",
+            origin = "https://www.youtube.com",
+            referer = "https://www.youtube.com/watch?v=abcdefghijk"
+        )
+
+        val normalized = YoutubeClientIdentityInterceptor.normalize(request)
+
+        assertEquals(
+            YoutubeClientIdentityInterceptor.PO_TOKEN_WEB_USER_AGENT,
+            normalized.header("User-Agent")
+        )
+        assertEquals("https://www.youtube.com", normalized.header("Origin"))
+        assertEquals(
+            "https://www.youtube.com/watch?v=abcdefghijk",
+            normalized.header("Referer")
+        )
+    }
+
+    @Test
+    fun visitorRequestChangesOnlyTheWebUserAgent() {
+        val request = Request.Builder()
+            .url("https://youtubei.googleapis.com/youtubei/v1/visitor_id")
+            .header("User-Agent", "Mozilla/5.0 Chrome/142.0.0.0")
+            .header("X-Youtube-Client-Name", "1")
+            .header("X-Youtube-Client-Version", "2.20260630.01.00")
+            .build()
+
+        val normalized = YoutubeClientIdentityInterceptor.normalize(request)
+
+        assertEquals(
+            YoutubeClientIdentityInterceptor.PO_TOKEN_WEB_USER_AGENT,
+            normalized.header("User-Agent")
+        )
+        assertNull(normalized.header("Origin"))
+        assertNull(normalized.header("Referer"))
+    }
+
+    @Test
+    fun androidMusicUsesANativeAppIdentityAndDropsBrowserNavigationHeaders() {
+        val request = playerRequest(
+            clientName = "21",
+            clientVersion = "8.10.52",
+            userAgent = "Mozilla/5.0 (Linux; Android 15) com.google.android.apps.youtube.music/8.10.52",
+            origin = "https://www.youtube.com",
+            referer = "https://www.youtube.com/watch?v=abcdefghijk"
+        )
+
+        val normalized = YoutubeClientIdentityInterceptor.normalize(request)
+
+        assertEquals(
+            "com.google.android.apps.youtube.music/8.10.52 (Linux; U; Android 15) gzip",
+            normalized.header("User-Agent")
+        )
+        assertNull(normalized.header("Origin"))
+        assertNull(normalized.header("Referer"))
+    }
+
+    @Test
+    fun nativeClientsDoNotCarryBrowserNavigationHeaders() {
+        listOf("3", "5", "28").forEach { clientName ->
+            val request = playerRequest(
+                clientName = clientName,
+                clientVersion = "1.0",
+                userAgent = "native-client/1.0",
+                origin = "https://www.youtube.com",
+                referer = "https://www.youtube.com/watch?v=abcdefghijk"
+            )
+
+            val normalized = YoutubeClientIdentityInterceptor.normalize(request)
+
+            assertEquals("native-client/1.0", normalized.header("User-Agent"))
+            assertNull(normalized.header("Origin"))
+            assertNull(normalized.header("Referer"))
+        }
+    }
+
+    @Test
+    fun webRemixUsesMusicOriginAndReferer() {
+        val request = playerRequest(
+            clientName = "67",
+            clientVersion = "1.20260423.01.00",
+            userAgent = "Mozilla/5.0 Chrome/142.0.0.0",
+            origin = "https://www.youtube.com",
+            referer = "https://www.youtube.com/watch?v=abcdefghijk"
+        )
+
+        val normalized = YoutubeClientIdentityInterceptor.normalize(request)
+
+        assertEquals("https://music.youtube.com", normalized.header("Origin"))
+        assertEquals(
+            "https://music.youtube.com/watch?v=abcdefghijk",
+            normalized.header("Referer")
+        )
+    }
+
+    @Test
+    fun embeddedClientPreservesOnlyAnEmbedReferer() {
+        val valid = playerRequest(
+            clientName = "56",
+            clientVersion = "1.20260423.01.00",
+            userAgent = "Mozilla/5.0 Chrome/142.0.0.0",
+            origin = "https://www.youtube.com",
+            referer = "https://www.youtube.com/embed/abcdefghijk"
+        )
+        val invalid = valid.newBuilder()
+            .header("Referer", "https://www.youtube.com/watch?v=abcdefghijk")
+            .build()
+
+        assertEquals(
+            "https://www.youtube.com/embed/abcdefghijk",
+            YoutubeClientIdentityInterceptor.normalize(valid).header("Referer")
+        )
+        assertEquals(
+            "https://www.youtube.com/",
+            YoutubeClientIdentityInterceptor.normalize(invalid).header("Referer")
+        )
+    }
+
+    @Test
+    fun unknownClientIsLeftUntouched() {
+        val request = playerRequest(
+            clientName = "999",
+            clientVersion = "1.0",
+            userAgent = "custom/1.0",
+            origin = "https://example.com",
+            referer = "https://example.com/video"
+        )
+
+        assertSame(request, YoutubeClientIdentityInterceptor.normalize(request))
+    }
+
+    private fun playerRequest(
+        clientName: String,
+        clientVersion: String,
+        userAgent: String,
+        origin: String,
+        referer: String
+    ): Request {
+        return Request.Builder()
+            .url("https://youtubei.googleapis.com/youtubei/v1/player")
+            .header("User-Agent", userAgent)
+            .header("Origin", origin)
+            .header("Referer", referer)
+            .header("X-Youtube-Client-Name", clientName)
+            .header("X-Youtube-Client-Version", clientVersion)
+            .build()
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -369,6 +369,23 @@ Levyra distinguishes:
 - Streaming or GVS PO Token bound to the guest session.
  
 The isolated WebView runtime performs BotGuard initialization and token generation only for profiles that need it.
+
+One runtime is shared process-wide by the direct resolver and the vendored extractor. Its build runs
+in a scope owned by the generator rather than in the first caller, so a losing race branch or an
+abandoned prefetch never destroys a runtime another track is waiting on. Consequences:
+
+- the runtime is warmed once from the startup idle path, gated by the low-RAM and power-constrained
+  plan, so a cold BotGuard start is normally paid before the first tap rather than during it; the
+  warm-up never runs from the tap path, because building the WebView happens on the main thread;
+- a profile that declares `requiresPoToken` fails its branch rather than sending a token-less
+  request, so a bot gate cannot rotate the guest session and discard the build it was waiting for;
+- concurrent client profiles join the same build and the same per-video mint instead of serializing;
+- an approaching integrity-token expiry is replaced in the background while the current runtime keeps
+  serving, so expiry never lands as a cold rebuild on playback;
+- repeated build failures back off exponentially (2s to 60s), so a resolve fails over to the clients
+  that need no PO Token instead of re-paying an initialization timeout each attempt;
+- best-effort callers wait only briefly for a cold build and degrade rather than hold a race slot,
+  while the build continues for whoever asks next.
  
 ```text
 Player token

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -381,7 +381,8 @@ abandoned prefetch never destroys a runtime another track is waiting on. Consequ
   request, so a bot gate cannot rotate the guest session and discard the build it was waiting for;
 - concurrent client profiles join the same build and the same per-video mint instead of serializing;
 - an approaching integrity-token expiry is replaced in the background while the current runtime keeps
-  serving, so expiry never lands as a cold rebuild on playback;
+  serving, so expiry normally does not land as a cold rebuild on playback. The replacement is
+  best-effort: if it fails, or if the runtime fails afterwards, a cold rebuild still happens;
 - repeated build failures back off exponentially (2s to 60s), so a resolve fails over to the clients
   that need no PO Token instead of re-paying an initialization timeout each attempt;
 - best-effort callers wait only briefly for a cold build and degrade rather than hold a race slot,


### PR DESCRIPTION
## Summary

The PO Token path was correct but slow, and it fought itself. `YoutubeWebPoTokenGenerator` held a single mutex around the entire flow, including the expensive build (WebView + BotGuard interpreter download + integrity token round trip). Because that build ran inside the *first caller's* coroutine, the hedge cancelling a losing branch destroyed a runtime another track was still waiting on, so the next track paid the cold start all over again.

This moves the build into a generator-owned supervised scope, warms it once off the critical path, and makes expiry and failure handling incremental instead of cliff-edged. User-facing result: the clients that require a PO Token no longer stall behind a cold start on a tap, and repeated BotGuard failures degrade to the token-less clients instead of re-paying an initialization timeout on every attempt.

## What changed

- Build runs in a generator-owned `SupervisorJob` scope. Concurrent client profiles join the same job; a cancelled race branch or abandoned prefetch no longer tears down a runtime another waiter needs.
- Warm-up runs once from the startup idle path, gated by the low-RAM and power-constrained plan. It deliberately does **not** run from `warmNetwork()`, which is also called on the tap path — building the WebView happens on the main thread.
- Already-minted tokens are served without taking the lock; per-video mints are single-flighted inside the runtime scope.
- A runtime approaching integrity-token expiry is replaced in the background while the current one keeps serving, so expiry never lands as a cold rebuild during playback.
- Exponential backoff (2s..60s) after build failures. A background refresh-ahead failure does not arm it.
- A profile declaring `requiresPoToken` now fails its branch when no token is available, instead of sending a token-less request. A bot gate on such a request would reach `rotateIfNeeded`, rotate the guest session, and discard the very build it was waiting for.
- Best-effort callers wait on a short budget (4s) and degrade; `poTokensRequired` keeps the full budget. Either way the build continues for whoever asks next.
- The warm cooldown resets when the runtime is invalidated, so a rotation is not followed by a 60s blind window.
- A retired runtime stays alive briefly so an in-flight mint can finish.
- One process-wide `YoutubePlaybackSecurity`: `LevyraYoutubeSessionPoTokenProvider` was building a second WebView, a second BotGuard cold start, and a second integrity token for the same guest session.
- Local failure messages are worded so they no longer match the guest-session rotation markers (`TOKEN_MARKERS` matches on `po token`). A local backoff or wait budget is not a YouTube signal, and rotating visitor identity would not fix it.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactor or maintenance
- [ ] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** Streaming / Player

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [x] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

The Android SDK is not available in the environment this branch was developed in (`ANDROID_HOME` unset, no `local.properties`, no cached Gradle distribution), so no `:app:` Gradle task could be run. **CI is the authority for the build, lint, and unit-test result.** Nothing here should be read as a passing Android build.

What *was* verified, and how: `YoutubePlaybackSecurity.kt` was compiled with a standalone Kotlin compiler against the real `kotlinx-coroutines-core`, with hand-written stubs for the Android, OkHttp, and JSON surfaces. It compiles clean, so the suspend contexts, `Deferred`/`async` usage, `withTimeout`, and `currentCoroutineContext().isActive` disambiguation type-check. The new pure helpers (`PoTokenBackoff.delayMs`, `refreshDeadline`, `PoTokenSessionPolicy.decide`) were then executed from that compiled output, alongside a harness asserting the property the whole rewrite depends on: an owned build survives caller cancellation, is shared rather than duplicated, and a wait-budget expiry surfaces as a failure while genuine caller cancellation still propagates untouched. 24/24 checks passed.

New unit tests cover the backoff curve and its bound, the refresh deadline, and the session decision — including the subtle ordering guarantee that a still-usable session is reused even while the build backoff is armed.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
|  |  | Not performed |

## Risk and compatibility

- **Risk level:** Medium
- **Compatibility or migration notes:** None. No schema, preference, or persisted-format change; the guest-session SharedPreferences keys are untouched.
- **Known limitations:** Latency was not measured on a device. The claimed improvement is structural (work moved off the critical path, lock contention removed); the actual millisecond gain on first playback still needs a real device to confirm.
- **Rollback plan:** Revert this PR

## Reviewer notes

- `YoutubePlaybackSecurity.kt` is the whole change; the other files are call-site adjustments.
- Worth closest review: `session()` and `startSession()` — the reuse/backoff/build decision and the identity+generation+version match that decides whether an existing build can be joined.
- `closeWhenSettled(session, graceMs)` awaits the retired build before closing rather than cancelling it, so a runtime is never leaked mid-build. The grace window exists because a caller may still be minting on a runtime that was just swapped out.
- The `requiresPoToken` fail-fast means WEB and WEB_REMIX will not attempt a resolve at all when BotGuard is unavailable. That is intentional: those requests were going to be bot-gated anyway, and letting them through started a rotation loop. Tiers 0–3 (Android VR, Android Music, Android, iOS) need no token and remain the primary path.

## Release note

None

## Related issues

- Closes #
- Related to #

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR