### PR TITLE
perf(charts): render Spotify Top 50 instantly on first install

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,12 @@
         android:resizeableActivity="true"
         android:enableOnBackInvokedCallback="true"
         android:theme="@style/Theme.Levyra">
+
+        <provider
+            android:name=".data.SpotifyChartBootstrapProvider"
+            android:authorities="${applicationId}.spotify-chart-bootstrap"
+            android:exported="false"
+            android:initOrder="100" />
         
         <meta-data
             android:name="com.google.android.gms.car.application"

--- a/app/src/main/assets/editorial/spotify-bootstrap.json
+++ b/app/src/main/assets/editorial/spotify-bootstrap.json
@@ -1,0 +1,29705 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-05T18:35:14Z",
+  "collections": [
+    {
+      "id": "top-50-it",
+      "kind": "chart",
+      "market": "IT",
+      "title": "Top 50 Italia",
+      "description": "Italia: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-f9f6f8fac4ee25604a42",
+          "title": "CANZONE D'AMORE",
+          "artists": [
+            {
+              "name": "Geolier"
+            }
+          ],
+          "album": {
+            "name": "TUTTO È POSSIBILE",
+            "releaseDate": "2026-01-16"
+          },
+          "durationMs": 180000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "DJH_dxVeDP4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCcVStX6y07F8-euPi0A7hLA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0250baf7830444097378d8fd90"
+        },
+        {
+          "position": 2,
+          "id": "levyra-a3a67fd116e2e016d65f",
+          "title": "OSSESSIONE",
+          "artists": [
+            {
+              "name": "Samurai Jay"
+            },
+            {
+              "name": "Vito Salamanca"
+            }
+          ],
+          "album": {
+            "name": "AMATORE",
+            "releaseDate": "2026-05-21"
+          },
+          "durationMs": 188184,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "T3Rr5eG4aZE",
+            "audioConfidence": 100,
+            "videoId": "kqTEc17L2Os",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UC3nql4uzUEsOGBBNwZzSlaA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ec6dd44403255d31f03eb164"
+        },
+        {
+          "position": 3,
+          "id": "levyra-5afa7dbd40a3374816b4",
+          "title": "LA TESTA GIRA",
+          "artists": [
+            {
+              "name": "Fred De Palma"
+            },
+            {
+              "name": "Anitta"
+            },
+            {
+              "name": "Emis Killa"
+            }
+          ],
+          "album": {
+            "name": "LA TESTA GIRA",
+            "releaseDate": "2026-03-27"
+          },
+          "durationMs": 179189,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "AmWqsuboukU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCp1stouVk4yrzRnWJHf9dow"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0203fcfef7dec7395e7f34a83b"
+        },
+        {
+          "position": 4,
+          "id": "levyra-83344ae59cdcf2d3c00a",
+          "title": "SWAG MUSIC",
+          "artists": [
+            {
+              "name": "Artie 5ive"
+            }
+          ],
+          "album": {
+            "name": "SWAG MUSIC",
+            "releaseDate": "2026-05-15"
+          },
+          "durationMs": 172714,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "s-98aXMUJwk",
+            "audioConfidence": 100,
+            "videoId": "pBNkcl2ibLc",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCTBoPyeNkz7oOvr7AZVuV3w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02367221e0ff226ec629714cc6"
+        },
+        {
+          "position": 5,
+          "id": "levyra-f7ed35597156e651ebcb",
+          "title": "Bad Bad Bad",
+          "artists": [
+            {
+              "name": "Shiva"
+            },
+            {
+              "name": "Geolier"
+            }
+          ],
+          "album": {
+            "name": "Vangelo",
+            "releaseDate": "2026-04-10"
+          },
+          "durationMs": 190588,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "S5yFh0ujK10",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCG8dba9iFwcp5UYB76Eu3gA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02106c24b2e7323189f68e8a4c"
+        },
+        {
+          "position": 6,
+          "id": "levyra-ab80f96e54209c135806",
+          "title": "Da Dio",
+          "artists": [
+            {
+              "name": "Bresh"
+            }
+          ],
+          "album": {
+            "name": "Mediterraneo (Dopo il Mare)",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 173415,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "0Jp_YOOEovg",
+            "audioConfidence": 100,
+            "videoId": "-ZwDJaZ2coY",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCFlpoDc1vib_Uk8UfDXzmrw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0213f95e59fc87aa92b6e63d70"
+        },
+        {
+          "position": 7,
+          "id": "levyra-4500512f5aa38edfe312",
+          "title": "Dai Dai",
+          "artists": [
+            {
+              "name": "Shakira"
+            },
+            {
+              "name": "Burna Boy"
+            }
+          ],
+          "album": {
+            "name": "Dai Dai",
+            "releaseDate": "2026-05-14"
+          },
+          "durationMs": 223448,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lFQdcPTTzSg",
+            "audioConfidence": 100,
+            "videoId": "fcnDmrtj6Sk",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCo6JijJGA3IvIiPsawDK3Ww"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0203cadf1b3fe324c1dc710ed4"
+        },
+        {
+          "position": 8,
+          "id": "levyra-d37befbfd42ade438185",
+          "title": "AL MIO PAESE",
+          "artists": [
+            {
+              "name": "Serena Brancale"
+            },
+            {
+              "name": "Levante"
+            },
+            {
+              "name": "DELIA"
+            }
+          ],
+          "album": {
+            "name": "SACRO",
+            "releaseDate": "2026-04-10"
+          },
+          "durationMs": 197591,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Y7ztJQaiCZc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UChexJ9ht1tA6M537EtnZkoQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ecbd5f439dd37770076dd49a"
+        },
+        {
+          "position": 9,
+          "id": "levyra-6dd76088e2a75fb31655",
+          "title": "AYAYAY",
+          "artists": [
+            {
+              "name": "Sfera Ebbasta"
+            },
+            {
+              "name": "DYSTINCT"
+            }
+          ],
+          "album": {
+            "name": "AYAYAY",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 146250,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "4XiXWxWCy_U",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7-K3cpctiu-1pUllHQqkvg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0253942b2114b943472cc99c83"
+        },
+        {
+          "position": 10,
+          "id": "levyra-faab7a949090256c774b",
+          "title": "2 GIORNI DI FILA (feat. Sfera Ebbasta, ANNA)",
+          "artists": [
+            {
+              "name": "Geolier"
+            },
+            {
+              "name": "Sfera Ebbasta"
+            },
+            {
+              "name": "ANNA"
+            }
+          ],
+          "album": {
+            "name": "TUTTO È POSSIBILE",
+            "releaseDate": "2026-01-16"
+          },
+          "durationMs": 211250,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "iAq2Kk5lu3c",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCcVStX6y07F8-euPi0A7hLA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0250baf7830444097378d8fd90"
+        },
+        {
+          "position": 11,
+          "id": "levyra-98126fee59297d93e6e7",
+          "title": "LA GRACIOSA",
+          "artists": [
+            {
+              "name": "Quevedo"
+            },
+            {
+              "name": "Elvis Crespo"
+            }
+          ],
+          "album": {
+            "name": "EL BAIFO",
+            "releaseDate": "2026-04-24"
+          },
+          "durationMs": 257713,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Kev3r6W4TPo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7PL9aor5qNRhvhWWVXyOqA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b84b5d956376cb8e55425f5"
+        },
+        {
+          "position": 12,
+          "id": "levyra-ef4e58155c9d1e772e30",
+          "title": "Talk To You (ft. 54 Ultra)",
+          "artists": [
+            {
+              "name": "ANOTR"
+            },
+            {
+              "name": "54 Ultra"
+            }
+          ],
+          "album": {
+            "name": "Withness",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 191076,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02aeb168f35ab002d77a4f3918"
+        },
+        {
+          "position": 13,
+          "id": "levyra-cd142045065055ea8d4e",
+          "title": "Sorry Scusa Lo Siento",
+          "artists": [
+            {
+              "name": "Pinguini Tattici Nucleari"
+            }
+          ],
+          "album": {
+            "name": "Sorry Scusa Lo Siento",
+            "releaseDate": "2026-05-15"
+          },
+          "durationMs": 200134,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d91aefd33813beab9a9f23ff"
+        },
+        {
+          "position": 14,
+          "id": "levyra-4d432349681132c92629",
+          "title": "WHITE GIRL WASTED",
+          "artists": [
+            {
+              "name": "ANNA"
+            }
+          ],
+          "album": {
+            "name": "WHITE GIRL WASTED",
+            "releaseDate": "2026-06-18"
+          },
+          "durationMs": 142153,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "utB2Qq8Zx98",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCrBqELGfjmdVc6U1utFnBZg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0202175b6fb6e333973c7af750"
+        },
+        {
+          "position": 15,
+          "id": "levyra-140f413e7951103928e8",
+          "title": "BAILE INoLVIDABLE",
+          "artists": [
+            {
+              "name": "Bad Bunny"
+            }
+          ],
+          "album": {
+            "name": "DeBÍ TiRAR MáS FOToS",
+            "releaseDate": "2025-01-05"
+          },
+          "durationMs": 367725,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "JseJETvMtHY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCiY3z8HAGD6BlSNKVn2kSvQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bbd45c8d36e0e045ef640411"
+        },
+        {
+          "position": 16,
+          "id": "levyra-743b3b6a4252eef93c18",
+          "title": "DAVVERODAVVERO",
+          "artists": [
+            {
+              "name": "Artie 5ive"
+            }
+          ],
+          "album": {
+            "name": "LA BELLAVITA",
+            "releaseDate": "2025-03-28"
+          },
+          "durationMs": 165922,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "eWXr67jeWW8",
+            "audioConfidence": 100,
+            "videoId": "iebA9mFRVlU",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCTBoPyeNkz7oOvr7AZVuV3w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029e03e651e481bb0b5fb14b7a"
+        },
+        {
+          "position": 17,
+          "id": "levyra-7e9359b39d53e197211d",
+          "title": "Canto d’amore (con Marco Mengoni)",
+          "artists": [
+            {
+              "name": "Angelina Mango"
+            },
+            {
+              "name": "Marco Mengoni"
+            }
+          ],
+          "album": {
+            "name": "Canto d’amore (con Marco Mengoni)",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 194184,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d5c202928352e775059dedbb"
+        },
+        {
+          "position": 18,
+          "id": "levyra-a8e1a57b2d7ff14d7cb1",
+          "title": "Obsessed",
+          "artists": [
+            {
+              "name": "Shiva"
+            },
+            {
+              "name": "ANNA"
+            }
+          ],
+          "album": {
+            "name": "Vangelo",
+            "releaseDate": "2026-04-10"
+          },
+          "durationMs": 180524,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "wfBW46YLha0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCG8dba9iFwcp5UYB76Eu3gA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02106c24b2e7323189f68e8a4c"
+        },
+        {
+          "position": 19,
+          "id": "levyra-c76349faadb3334c27e3",
+          "title": "Maladie",
+          "artists": [
+            {
+              "name": "Mauvais djo"
+            }
+          ],
+          "album": {
+            "name": "Maladie",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 192000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "RPVCkqWxBRs",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCmz_Ex4zmTVXvBSzXW_JnKw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020bec8cf6742b5d00f101b0e8"
+        },
+        {
+          "position": 20,
+          "id": "levyra-be36f408a1a82d5992da",
+          "title": "Movin' To The Sun",
+          "artists": [
+            {
+              "name": "HUGEL"
+            },
+            {
+              "name": "Imael Angel"
+            },
+            {
+              "name": "Ultra Naté"
+            }
+          ],
+          "album": {
+            "name": "Twenty One",
+            "releaseDate": "2026-06-26"
+          },
+          "durationMs": 142200,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "B827pl48xkU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCO1o6IjIVBcbr_DS1tmarhQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023c2eac0964d8ef1900f1c101"
+        },
+        {
+          "position": 21,
+          "id": "levyra-1f0edf79963b7cdd1026",
+          "title": "ROMANTICA",
+          "artists": [
+            {
+              "name": "Ultimo"
+            }
+          ],
+          "album": {
+            "name": "IL GIORNO CHE ASPETTAVO",
+            "releaseDate": "2026-06-19"
+          },
+          "durationMs": 193226,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7kH7tJwodAY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCv-FuU7xoxY8auq4r66KRFg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029afca8200dd46c68ff733b05"
+        },
+        {
+          "position": 22,
+          "id": "levyra-f982e183a122df021fae",
+          "title": "NUEVAYoL",
+          "artists": [
+            {
+              "name": "Bad Bunny"
+            }
+          ],
+          "album": {
+            "name": "DeBÍ TiRAR MáS FOToS",
+            "releaseDate": "2025-01-05"
+          },
+          "durationMs": 183685,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "WdSGEvDGZAo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCiY3z8HAGD6BlSNKVn2kSvQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bbd45c8d36e0e045ef640411"
+        },
+        {
+          "position": 23,
+          "id": "levyra-a95121d8a0f983fccbd0",
+          "title": "La Plena - W Sound 05",
+          "artists": [
+            {
+              "name": "W Sound"
+            },
+            {
+              "name": "Beéle"
+            },
+            {
+              "name": "Ovy On The Drums"
+            }
+          ],
+          "album": {
+            "name": "La Plena (W Sound 05)",
+            "releaseDate": "2025-02-19"
+          },
+          "durationMs": 150001,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "SEY1UKEmOrQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCPsX2ybNiGsJU8C_H9nkVLA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c0353d023daf5ebda0eb003b"
+        },
+        {
+          "position": 24,
+          "id": "levyra-0e0d24ef2d9b578a38f2",
+          "title": "FLAMENCO PARANOIA",
+          "artists": [
+            {
+              "name": "Samurai Jay"
+            },
+            {
+              "name": "Vito Salamanca"
+            }
+          ],
+          "album": {
+            "name": "AMATORE",
+            "releaseDate": "2026-05-21"
+          },
+          "durationMs": 164262,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "fQzoZqupAsQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC3nql4uzUEsOGBBNwZzSlaA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ec6dd44403255d31f03eb164"
+        },
+        {
+          "position": 25,
+          "id": "levyra-833532a3b49da12b42b4",
+          "title": "Jamaican (Bam Bam)",
+          "artists": [
+            {
+              "name": "HUGEL"
+            },
+            {
+              "name": "SOLTO (FR)"
+            }
+          ],
+          "album": {
+            "name": "Jamaican (Bam Bam)",
+            "releaseDate": "2025-11-07"
+          },
+          "durationMs": 156393,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02450a730dd72f3bf49882ae9d"
+        },
+        {
+          "position": 26,
+          "id": "levyra-51727e02fdcc830c89dc",
+          "title": "DtMF",
+          "artists": [
+            {
+              "name": "Bad Bunny"
+            }
+          ],
+          "album": {
+            "name": "DeBÍ TiRAR MáS FOToS",
+            "releaseDate": "2025-01-05"
+          },
+          "durationMs": 237117,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "TiebZllW8As",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCiY3z8HAGD6BlSNKVn2kSvQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bbd45c8d36e0e045ef640411"
+        },
+        {
+          "position": 27,
+          "id": "levyra-69b95efe3612654a33be",
+          "title": "Splinter Cell",
+          "artists": [
+            {
+              "name": "G.Mineiro"
+            },
+            {
+              "name": "Flatpearl"
+            },
+            {
+              "name": "Jiz"
+            },
+            {
+              "name": "Succo"
+            }
+          ],
+          "album": {
+            "name": "È O G.",
+            "releaseDate": "2026-06-04"
+          },
+          "durationMs": 117293,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0207bdc873725e7084d79d693f"
+        },
+        {
+          "position": 28,
+          "id": "levyra-9c1e85b0d05b440c86d7",
+          "title": "Giovani Re",
+          "artists": [
+            {
+              "name": "Sfera Ebbasta"
+            }
+          ],
+          "album": {
+            "name": "Famoso",
+            "releaseDate": "2021-02-12"
+          },
+          "durationMs": 168342,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "Wyvs_ZHVrIA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7-K3cpctiu-1pUllHQqkvg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02affffa7ab8803fca453be456"
+        },
+        {
+          "position": 29,
+          "id": "levyra-622ff7dcb62f5db85fbe",
+          "title": "AUTORITÀ",
+          "artists": [
+            {
+              "name": "Geolier"
+            }
+          ],
+          "album": {
+            "name": "TUTTO È POSSIBILE",
+            "releaseDate": "2026-01-16"
+          },
+          "durationMs": 183597,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "M1EVZrDiDOo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCcVStX6y07F8-euPi0A7hLA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0250baf7830444097378d8fd90"
+        },
+        {
+          "position": 30,
+          "id": "levyra-0a64969a5eb8e413dfbc",
+          "title": "Cabana",
+          "artists": [
+            {
+              "name": "Irama"
+            }
+          ],
+          "album": {
+            "name": "Antologia Della Vita e Della Morte",
+            "releaseDate": "2025-10-17"
+          },
+          "durationMs": 161454,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "ocyqKBfbiSE",
+            "audioConfidence": 100,
+            "videoId": "BXpM2nzD7es",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCgYUiM8JCtP8y5Qsi7V9g8A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026802a7c093a3e277b222b2bc"
+        },
+        {
+          "position": 31,
+          "id": "levyra-b474412ea43ef393166e",
+          "title": "Stupida sfortuna",
+          "artists": [
+            {
+              "name": "Fulminacci"
+            }
+          ],
+          "album": {
+            "name": "CALCINACCI",
+            "releaseDate": "2026-03-13"
+          },
+          "durationMs": 175013,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "XP_b3ih8_Tw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCtG4HsHqMZw5UCxqYk8o2sw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ff26d9e6888e0a1ab315aa6a"
+        },
+        {
+          "position": 32,
+          "id": "levyra-c46d8c42837c3ccee489",
+          "title": "Buon Vento",
+          "artists": [
+            {
+              "name": "Jovanotti"
+            },
+            {
+              "name": "Alfa"
+            }
+          ],
+          "album": {
+            "name": "Buon Vento",
+            "releaseDate": "2026-05-21"
+          },
+          "durationMs": 175101,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Ngg0sM-i4sc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC4MtajQrTsHUln-4DhX1Eow"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027265c7cbbc7f89bba30614ff"
+        },
+        {
+          "position": 33,
+          "id": "levyra-47764fdde285bb5be11a",
+          "title": "Beauty And A Beat",
+          "artists": [
+            {
+              "name": "Justin Bieber"
+            },
+            {
+              "name": "Nicki Minaj"
+            }
+          ],
+          "album": {
+            "name": "Believe",
+            "releaseDate": "2012-01-01"
+          },
+          "durationMs": 227986,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f1d02a6cec967f8b6b78f76e"
+        },
+        {
+          "position": 34,
+          "id": "levyra-f6663bc35697e813e41d",
+          "title": "Wonderwall - Remastered",
+          "artists": [
+            {
+              "name": "Oasis"
+            }
+          ],
+          "album": {
+            "name": "(What's The Story) Morning Glory? (Deluxe Remastered Edition)",
+            "releaseDate": "1995"
+          },
+          "durationMs": 258773,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027a4c8c59851c88f6794c3cbf"
+        },
+        {
+          "position": 35,
+          "id": "levyra-6195566c2269d8e5c0fa",
+          "title": "RAFFAELLA FICO",
+          "artists": [
+            {
+              "name": "Le-one"
+            },
+            {
+              "name": "Higashi"
+            }
+          ],
+          "album": {
+            "name": "RAFFAELLA FICO",
+            "releaseDate": "2026-07-07"
+          },
+          "durationMs": 132892,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "kaCRK7xgb44",
+            "audioConfidence": 100,
+            "videoId": "ejGwacs9oRE",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCBuDd4tSDB54ZRihQK9X21Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ef4b420fc6ce1f2fc7f3b176"
+        },
+        {
+          "position": 36,
+          "id": "levyra-dcf96b2e0a8b7cf0fe58",
+          "title": "Ogni Male",
+          "artists": [
+            {
+              "name": "Capo Plaza"
+            }
+          ],
+          "album": {
+            "name": "Hustle Mixtape Vol. 2",
+            "releaseDate": "2025-10-31"
+          },
+          "durationMs": 207230,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "8-dHPCGKbPg",
+            "audioConfidence": 100,
+            "videoId": "IFpCda-lgQI",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCe7uJ_G05_SoncfGmgleTGg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0261e1eb765192dae01672b56a"
+        },
+        {
+          "position": 37,
+          "id": "levyra-a3eb2fbf071bf63fb634",
+          "title": "Mayday",
+          "artists": [
+            {
+              "name": "Shiva"
+            },
+            {
+              "name": "Lazza"
+            },
+            {
+              "name": "Sfera Ebbasta"
+            }
+          ],
+          "album": {
+            "name": "Vangelo",
+            "releaseDate": "2026-04-10"
+          },
+          "durationMs": 218536,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02106c24b2e7323189f68e8a4c"
+        },
+        {
+          "position": 38,
+          "id": "levyra-3f2dcb748a0d34c72f83",
+          "title": "Self Aware",
+          "artists": [
+            {
+              "name": "Temper City"
+            }
+          ],
+          "album": {
+            "name": "Self Aware",
+            "releaseDate": "2026-02-15"
+          },
+          "durationMs": 180740,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "R-hYM3BqTbA",
+            "audioConfidence": 100,
+            "videoId": "mh4AQkw4Jjc",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCpWebSe88U-TOiO8YfKnTgg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d6c26d2ae723f7ab553d64cc"
+        },
+        {
+          "position": 39,
+          "id": "levyra-2d9f8301690224e46a1d",
+          "title": "VOLEVO CAPIRE CON MARRACASH",
+          "artists": [
+            {
+              "name": "Madame"
+            },
+            {
+              "name": "Marracash"
+            }
+          ],
+          "album": {
+            "name": "DISINCANTO",
+            "releaseDate": "2026-04-16"
+          },
+          "durationMs": 157333,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022e29d8e9ccb757f686385250"
+        },
+        {
+          "position": 40,
+          "id": "levyra-774334177283679dc754",
+          "title": "Tití Me Preguntó",
+          "artists": [
+            {
+              "name": "Bad Bunny"
+            }
+          ],
+          "album": {
+            "name": "Un Verano Sin Ti",
+            "releaseDate": "2022-05-06"
+          },
+          "durationMs": 243716,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "juRFjpB5Ppg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCiY3z8HAGD6BlSNKVn2kSvQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0249d694203245f241a1bcaa72"
+        },
+        {
+          "position": 41,
+          "id": "levyra-07541b2e57a277323319",
+          "title": "Questa domenica",
+          "artists": [
+            {
+              "name": "Olly"
+            },
+            {
+              "name": "Juli"
+            }
+          ],
+          "album": {
+            "name": "TUTTA VITA (SEMPRE)",
+            "releaseDate": "2025-09-26"
+          },
+          "durationMs": 216098,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "1QDWa1Zbabw",
+            "audioConfidence": 100,
+            "videoId": "Qa4rIEg8Bhk",
+            "videoConfidence": 97,
+            "confidence": 100,
+            "artistBrowseId": "UCNVNAaNubS4A-Myfkm0EpZA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026752cb3279906514dd04c8aa"
+        },
+        {
+          "position": 42,
+          "id": "levyra-70d4f6cb7e39fca2d4cf",
+          "title": "I romantici",
+          "artists": [
+            {
+              "name": "Tommaso Paradiso"
+            }
+          ],
+          "album": {
+            "name": "Casa Paradiso",
+            "releaseDate": "2025-11-28"
+          },
+          "durationMs": 239967,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "dJg1OhYJaYc",
+            "audioConfidence": 100,
+            "videoId": "VZSkFxDQSlY",
+            "videoConfidence": 97,
+            "confidence": 100,
+            "artistBrowseId": "UCYzipaHlpF98gCD-eH-0VQQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0285bdcaa3390bfe333d76ea37"
+        },
+        {
+          "position": 43,
+          "id": "levyra-facbb297d859f15c8eab",
+          "title": "AMOR",
+          "artists": [
+            {
+              "name": "Achille Lauro"
+            }
+          ],
+          "album": {
+            "name": "Comuni Mortali",
+            "releaseDate": "2025-04-18"
+          },
+          "durationMs": 177348,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "d4Or4IQUqc0",
+            "audioConfidence": 100,
+            "videoId": "v1cyMWcoh6M",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UC8GiGmefZ-VA1DXnXNnGCdw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02264663d274f67b13c4ae531e"
+        },
+        {
+          "position": 44,
+          "id": "levyra-637fe89b86ef4df58162",
+          "title": "Ora che non ho più te",
+          "artists": [
+            {
+              "name": "Cesare Cremonini"
+            }
+          ],
+          "album": {
+            "name": "ALASKA BABY",
+            "releaseDate": "2024-11-28"
+          },
+          "durationMs": 303032,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "NK4fl6h0MBI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC6zahbQP8eI-36w0xCnvxcQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028105d9afaf9247e8345e0ed6"
+        },
+        {
+          "position": 45,
+          "id": "levyra-0ec0093025a4d0a64138",
+          "title": "L'Amore Non Mi Basta",
+          "artists": [
+            {
+              "name": "Emma"
+            }
+          ],
+          "album": {
+            "name": "Schiena",
+            "releaseDate": "2013-01-01"
+          },
+          "durationMs": 211453,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dcceee76ed8d7d01d0b0d109"
+        },
+        {
+          "position": 46,
+          "id": "levyra-991117f52429e132807b",
+          "title": "Magnetic",
+          "artists": [
+            {
+              "name": "The Bausa"
+            }
+          ],
+          "album": {
+            "name": "Magnetic / Addicted To Your Love",
+            "releaseDate": "2026-02-27"
+          },
+          "durationMs": 181384,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02158cbe80b9b9573b46d2b50f"
+        },
+        {
+          "position": 47,
+          "id": "levyra-ff22c1bd7a09997d4ba9",
+          "title": "SOGNO AMERICANO",
+          "artists": [
+            {
+              "name": "Artie 5ive"
+            }
+          ],
+          "album": {
+            "name": "LA BELLAVITA",
+            "releaseDate": "2025-03-28"
+          },
+          "durationMs": 176000,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "pl1O7xaREFo",
+            "audioConfidence": 100,
+            "videoId": "-vptlqI8o6c",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCTBoPyeNkz7oOvr7AZVuV3w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029e03e651e481bb0b5fb14b7a"
+        },
+        {
+          "position": 48,
+          "id": "levyra-8d1c7417df9b3caa227d",
+          "title": "Labirinto",
+          "artists": [
+            {
+              "name": "Luchè"
+            }
+          ],
+          "album": {
+            "name": "Il mio lato peggiore",
+            "releaseDate": "2025-05-16"
+          },
+          "durationMs": 227321,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "1NPAbmPSbG4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCF32sV4o8K7Ykbk7kZup-Tg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c62c7920980cba87cda1867f"
+        },
+        {
+          "position": 49,
+          "id": "levyra-7d448b29f9e8c1623dbc",
+          "title": "Babyface",
+          "artists": [
+            {
+              "name": "Shiva"
+            },
+            {
+              "name": "Kid Yugi"
+            }
+          ],
+          "album": {
+            "name": "Vangelo",
+            "releaseDate": "2026-04-10"
+          },
+          "durationMs": 177934,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "TSwO2yBqBDA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCG8dba9iFwcp5UYB76Eu3gA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02106c24b2e7323189f68e8a4c"
+        },
+        {
+          "position": 50,
+          "id": "levyra-dafeafffd508f5966af8",
+          "title": "NEON",
+          "artists": [
+            {
+              "name": "Sfera Ebbasta"
+            },
+            {
+              "name": "Shiva"
+            }
+          ],
+          "album": {
+            "name": "SANTANA MONEY GANG",
+            "releaseDate": "2025-04-10"
+          },
+          "durationMs": 226906,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "o1lpNrC8BzI",
+            "audioConfidence": 100,
+            "videoId": "HCA87PbP26M",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7-K3cpctiu-1pUllHQqkvg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d6cdd0e09df54245b00fa9c6"
+        }
+      ]
+    },
+    {
+      "id": "top-50-us",
+      "kind": "chart",
+      "market": "US",
+      "title": "Top 50 USA",
+      "description": "Stati Uniti: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-d8ef61462b0bb69ebbf9",
+          "title": "Choosin' Texas",
+          "artists": [
+            {
+              "name": "Ella Langley"
+            }
+          ],
+          "album": {
+            "name": "Dandelion",
+            "releaseDate": "2026-04-10"
+          },
+          "durationMs": 231746,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "3s1sZbW7Rt8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCecnyZYofHiBVDJpx1XNYOQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028606848da949bbaddf447d87"
+        },
+        {
+          "position": 2,
+          "id": "levyra-98349a571204b2f4073a",
+          "title": "petal",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 184248,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "4mQyEqbaUOU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 3,
+          "id": "levyra-93683240d111e7825d3f",
+          "title": "hate that i made you love me",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 197949,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7CUz7Ec7cWc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 4,
+          "id": "levyra-4a8f3d180ce3d0b76564",
+          "title": "Earrings",
+          "artists": [
+            {
+              "name": "Malcolm Todd"
+            }
+          ],
+          "album": {
+            "name": "Sweet Boy",
+            "releaseDate": "2024-04-05"
+          },
+          "durationMs": 151500,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "BI9HQCzpDgQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCRLE_fwmN2CQw1vuWPwo6eA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022c1f34ecc1929fb59908aad1"
+        },
+        {
+          "position": 5,
+          "id": "levyra-2ed1782b29609516a5ec",
+          "title": "stupid song",
+          "artists": [
+            {
+              "name": "Olivia Rodrigo"
+            }
+          ],
+          "album": {
+            "name": "you seem pretty sad for a girl so in love",
+            "releaseDate": "2026-06-11"
+          },
+          "durationMs": 209680,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "P7VgXIZSN_w",
+            "audioConfidence": 100,
+            "videoId": "Rt9tW3cMLhI",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCE5XNpliPM-SmyFEp61tL_g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026949b83f85d782b21ce70583"
+        },
+        {
+          "position": 6,
+          "id": "levyra-dd9eca03b98592f2e76d",
+          "title": "Been By Now",
+          "artists": [
+            {
+              "name": "Morgan Wallen"
+            }
+          ],
+          "album": {
+            "name": "Been By Now",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 213805,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "HOqxmOXrZnY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC5xaQ6_dP7EGDmGLzVGZ1Ow"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02349f6c0133abbfca063891c1"
+        },
+        {
+          "position": 7,
+          "id": "levyra-e80e109c111990095c97",
+          "title": "kiss me",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 219584,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "bfszA_eFvnw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 8,
+          "id": "levyra-43f16056e5f10ba616f1",
+          "title": "like i do",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 167333,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "Pjq0RF3og-4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 9,
+          "id": "levyra-68807b02218cd619b1a0",
+          "title": "stay",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 148420,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "nOjzP-HHXG0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 10,
+          "id": "levyra-8ec7aac754851425fa49",
+          "title": "oh well",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 196166,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "4YQ06rGPfOc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 11,
+          "id": "levyra-398b2ca4b3fc8d25f97f",
+          "title": "Mr. Brightside",
+          "artists": [
+            {
+              "name": "The Killers"
+            }
+          ],
+          "album": {
+            "name": "Hot Fuss",
+            "releaseDate": "2004"
+          },
+          "durationMs": 222973,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "m2zUrruKjDQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCneQ7UWyu9USLDgMya6T7IA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ccdddd46119a4ff53eaf1f5d"
+        },
+        {
+          "position": 12,
+          "id": "levyra-f9b806bd267832b99371",
+          "title": "Be Her",
+          "artists": [
+            {
+              "name": "Ella Langley"
+            }
+          ],
+          "album": {
+            "name": "Dandelion",
+            "releaseDate": "2026-04-10"
+          },
+          "durationMs": 217240,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "A0ttKAXj1xU",
+            "audioConfidence": 100,
+            "videoId": "Dg47eNL_Usw",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCecnyZYofHiBVDJpx1XNYOQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028606848da949bbaddf447d87"
+        },
+        {
+          "position": 13,
+          "id": "levyra-1bcef17c13a5fa801cdb",
+          "title": "the cure",
+          "artists": [
+            {
+              "name": "Olivia Rodrigo"
+            }
+          ],
+          "album": {
+            "name": "you seem pretty sad for a girl so in love",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 297090,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "cmzCwz4NkOA",
+            "audioConfidence": 100,
+            "videoId": "B402rKl4bUg",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCE5XNpliPM-SmyFEp61tL_g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025cf234eeb7a2edf44bf64a46"
+        },
+        {
+          "position": 14,
+          "id": "levyra-071520a34becd05f202b",
+          "title": "big feelings",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 173622,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "arrDOc5I0uk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 15,
+          "id": "levyra-6f981c821b7889f85994",
+          "title": "weren't for the wind",
+          "artists": [
+            {
+              "name": "Ella Langley"
+            }
+          ],
+          "album": {
+            "name": "still hungover",
+            "releaseDate": "2024-11-01"
+          },
+          "durationMs": 193666,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "73ZD-sbo4UU",
+            "audioConfidence": 100,
+            "videoId": "U4NPZi2b0aQ",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCecnyZYofHiBVDJpx1XNYOQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02edf9ec71330d53881ee0c2d9"
+        },
+        {
+          "position": 16,
+          "id": "levyra-9d3e530cd74574baf20a",
+          "title": "Babydoll",
+          "artists": [
+            {
+              "name": "Dominic Fike"
+            }
+          ],
+          "album": {
+            "name": "Don't Forget About Me, Demos",
+            "releaseDate": "2018-10-16"
+          },
+          "durationMs": 97960,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "UnuEzP1rDLY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCsWqHrJvOU_uukQCU92VEvw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b1b6f41c1645af9757d5616"
+        },
+        {
+          "position": 17,
+          "id": "levyra-3ec1a84496dd0ab0e0ab",
+          "title": "Cinderella (feat. Ty Dolla $ign)",
+          "artists": [
+            {
+              "name": "Mac Miller"
+            },
+            {
+              "name": "Ty Dolla $ign"
+            }
+          ],
+          "album": {
+            "name": "The Divine Feminine",
+            "releaseDate": "2016-09-16"
+          },
+          "durationMs": 480186,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022e92f776279eaf45d14a33fd"
+        },
+        {
+          "position": 18,
+          "id": "levyra-35844a86b63c91c223c1",
+          "title": "Man I Need",
+          "artists": [
+            {
+              "name": "Olivia Dean"
+            }
+          ],
+          "album": {
+            "name": "The Art of Loving",
+            "releaseDate": "2025-09-26"
+          },
+          "durationMs": 184000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "fsGjRf-N71I",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC6GBKGYX6b3guHlqHLx6IzQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029a336bfb6d40bbd90a507417"
+        },
+        {
+          "position": 19,
+          "id": "levyra-88b6a09afc18d0ed7da3",
+          "title": "never get over me",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 228857,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "pBAzAia8cB4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 20,
+          "id": "levyra-411ee215adfe5f5c97c7",
+          "title": "Animal",
+          "artists": [
+            {
+              "name": "KATSEYE"
+            }
+          ],
+          "album": {
+            "name": "Animal",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 158494,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "vOfyxPRunFM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCX9kfYB9t0tnd6DYUC2iuKg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029e8d48f27391ce383862b8e8"
+        },
+        {
+          "position": 21,
+          "id": "levyra-44395d6f89d86a40b9cf",
+          "title": "freak",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 199809,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "wE91LVz8JXg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 22,
+          "id": "levyra-62f091057573870630ff",
+          "title": "Dreams - 2004 Remaster",
+          "artists": [
+            {
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "album": {
+            "name": "Rumours (Super Deluxe)",
+            "releaseDate": "1977-02-04"
+          },
+          "durationMs": 257800,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e52a59a28efa4773dd2bfe1b"
+        },
+        {
+          "position": 23,
+          "id": "levyra-1ac12898006e1ebb09eb",
+          "title": "Janice STFU",
+          "artists": [
+            {
+              "name": "Drake"
+            }
+          ],
+          "album": {
+            "name": "ICEMAN",
+            "releaseDate": "2026-05-15"
+          },
+          "durationMs": 237344,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "x30_IHP1x3s",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCU6cE7pdJPc6DU2jSrKEsdQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02fe9d3ab9adb1d3b59835b81c"
+        },
+        {
+          "position": 24,
+          "id": "levyra-9632ca59acfb984ebe73",
+          "title": "Broken Window Serenade",
+          "artists": [
+            {
+              "name": "Whiskey Myers"
+            }
+          ],
+          "album": {
+            "name": "Firewater",
+            "releaseDate": "2011-04-26"
+          },
+          "durationMs": 346333,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "RX_VXoi4Rck",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCWvcIzf9Iz1H2vZRxMX7ILg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022a56fbcf4c26d35d6e0bd9f1"
+        },
+        {
+          "position": 25,
+          "id": "levyra-5e9f38aea24c85f6f5cf",
+          "title": "Boston",
+          "artists": [
+            {
+              "name": "STELLA LEFTY"
+            }
+          ],
+          "album": {
+            "name": "Boston",
+            "releaseDate": "2026-03-27"
+          },
+          "durationMs": 170859,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "C2elY5Tctqg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCTXWFnISFBHXsfR-ghjU3qA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e6cb19b02e38d18246ac334f"
+        },
+        {
+          "position": 26,
+          "id": "levyra-48c137a2c8c48963294b",
+          "title": "bad thing (bunny hop)",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 208024,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "xtKJAAJqrfA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 27,
+          "id": "levyra-2f7a1c1b7bceb923f67c",
+          "title": "Loser",
+          "artists": [
+            {
+              "name": "Tame Impala"
+            }
+          ],
+          "album": {
+            "name": "Deadbeat",
+            "releaseDate": "2025-10-17"
+          },
+          "durationMs": 223069,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "MX7FSAnRPug",
+            "audioConfidence": 100,
+            "videoId": "s3a4OQR-10M",
+            "videoConfidence": 97,
+            "confidence": 100,
+            "artistBrowseId": "UCGz-eguN8tcic5kUG4s1ZgA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02208500450dcd0fd294d7bd3b"
+        },
+        {
+          "position": 28,
+          "id": "levyra-16b75f9a7cbde9a10910",
+          "title": "nowhere, nobody",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 172001,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "A0wYyF2vaZA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 29,
+          "id": "levyra-b31eb5e60513bbd613b7",
+          "title": "Billie Jean",
+          "artists": [
+            {
+              "name": "Michael Jackson"
+            }
+          ],
+          "album": {
+            "name": "Thriller",
+            "releaseDate": "1982-11-30"
+          },
+          "durationMs": 293802,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0232a7d87248d1b75463483df5"
+        },
+        {
+          "position": 30,
+          "id": "levyra-7d14ba70b640336228e8",
+          "title": "warning signs (interlude)",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 77342,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "i1hTPimYwRY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 31,
+          "id": "levyra-28082485462ce002493e",
+          "title": "drop dead",
+          "artists": [
+            {
+              "name": "Olivia Rodrigo"
+            }
+          ],
+          "album": {
+            "name": "you seem pretty sad for a girl so in love",
+            "releaseDate": "2026-06-11"
+          },
+          "durationMs": 224998,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "wLmLB4Zzyiw",
+            "audioConfidence": 100,
+            "videoId": "78wrful9cVU",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCE5XNpliPM-SmyFEp61tL_g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026949b83f85d782b21ce70583"
+        },
+        {
+          "position": 32,
+          "id": "levyra-43fc5d674de64abb7cfb",
+          "title": "I Got Better",
+          "artists": [
+            {
+              "name": "Morgan Wallen"
+            }
+          ],
+          "album": {
+            "name": "I’m The Problem",
+            "releaseDate": "2025-05-16"
+          },
+          "durationMs": 204963,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Xc-dEsMbQJM",
+            "audioConfidence": 100,
+            "videoId": "hwUixddbmrQ",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UC5xaQ6_dP7EGDmGLzVGZ1Ow"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0235ea219ce47813b5e2dc3745"
+        },
+        {
+          "position": 33,
+          "id": "levyra-69af28d5e532e7b01ce0",
+          "title": "Dead Fresh",
+          "artists": [
+            {
+              "name": "Lil Baby"
+            }
+          ],
+          "album": {
+            "name": "Dead Fresh",
+            "releaseDate": "2026-07-17"
+          },
+          "durationMs": 157020,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "RKZ2BJNgass",
+            "audioConfidence": 100,
+            "videoId": "PXxbEfhtDiM",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UC_z9AthnCGSAk_tZf-KqoFA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0299f0c412a5d80626ae972cf4"
+        },
+        {
+          "position": 34,
+          "id": "levyra-240441fa464122905a43",
+          "title": "oh yeah?",
+          "artists": [
+            {
+              "name": "Steve Lacy"
+            }
+          ],
+          "album": {
+            "name": "Oh yeah?",
+            "releaseDate": "2026-07-17"
+          },
+          "durationMs": 170584,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "2zPGWGqdfJ8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCju-DqP7JNtCnMWFXhLgPHQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024ea9ba86cd9506a004bab042"
+        },
+        {
+          "position": 35,
+          "id": "levyra-4435724e8934201fe429",
+          "title": "misery.",
+          "artists": [
+            {
+              "name": "pupsies"
+            }
+          ],
+          "album": {
+            "name": "misery.",
+            "releaseDate": "2026-03-18"
+          },
+          "durationMs": 166401,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qJKcADiAuAw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCp3AZ2_EV0KOSEL33IC1YWw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02316b7fde50dfbf4be72735c2"
+        },
+        {
+          "position": 36,
+          "id": "levyra-eade1c4be5015d681297",
+          "title": "Iris",
+          "artists": [
+            {
+              "name": "The Goo Goo Dolls"
+            }
+          ],
+          "album": {
+            "name": "Stay with You",
+            "releaseDate": "1998"
+          },
+          "durationMs": 289533,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029858a6eb4467d1916fe1d569"
+        },
+        {
+          "position": 37,
+          "id": "levyra-0fc37a3d8e53831d2737",
+          "title": "I Can't Love You Anymore",
+          "artists": [
+            {
+              "name": "Ella Langley"
+            },
+            {
+              "name": "Morgan Wallen"
+            }
+          ],
+          "album": {
+            "name": "Dandelion",
+            "releaseDate": "2026-04-10"
+          },
+          "durationMs": 228836,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "OTBY7wo4LuE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCecnyZYofHiBVDJpx1XNYOQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020c20b697b7cc3bfe3eb954bc"
+        },
+        {
+          "position": 38,
+          "id": "levyra-3f2dcb748a0d34c72f83",
+          "title": "Self Aware",
+          "artists": [
+            {
+              "name": "Temper City"
+            }
+          ],
+          "album": {
+            "name": "Self Aware",
+            "releaseDate": "2026-02-15"
+          },
+          "durationMs": 180740,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "R-hYM3BqTbA",
+            "audioConfidence": 100,
+            "videoId": "mh4AQkw4Jjc",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCpWebSe88U-TOiO8YfKnTgg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d6c26d2ae723f7ab553d64cc"
+        },
+        {
+          "position": 39,
+          "id": "levyra-9d0b06800b1f28aa3479",
+          "title": "Sweater Weather",
+          "artists": [
+            {
+              "name": "The Neighbourhood"
+            }
+          ],
+          "album": {
+            "name": "I Love You.",
+            "releaseDate": "2013-04-22"
+          },
+          "durationMs": 240400,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028265a736a1eb838ad5a0b921"
+        },
+        {
+          "position": 40,
+          "id": "levyra-f6663bc35697e813e41d",
+          "title": "Wonderwall - Remastered",
+          "artists": [
+            {
+              "name": "Oasis"
+            }
+          ],
+          "album": {
+            "name": "(What's The Story) Morning Glory? (Deluxe Remastered Edition)",
+            "releaseDate": "1995"
+          },
+          "durationMs": 258773,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027a4c8c59851c88f6794c3cbf"
+        },
+        {
+          "position": 41,
+          "id": "levyra-348d17842ca544561063",
+          "title": "So Easy (To Fall In Love)",
+          "artists": [
+            {
+              "name": "Olivia Dean"
+            }
+          ],
+          "album": {
+            "name": "The Art of Loving",
+            "releaseDate": "2025-09-26"
+          },
+          "durationMs": 169000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7f_mlKlOLMo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC6GBKGYX6b3guHlqHLx6IzQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029a336bfb6d40bbd90a507417"
+        },
+        {
+          "position": 42,
+          "id": "levyra-a4189e3f0895a5fe7573",
+          "title": "End of Beginning",
+          "artists": [
+            {
+              "name": "Djo"
+            }
+          ],
+          "album": {
+            "name": "DECIDE",
+            "releaseDate": "2022-09-16"
+          },
+          "durationMs": 159245,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Kf5pXDhx5Vc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCVskJK4TXr5gqSEcQbjIJIg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02fddfffec51b4580acae727c1"
+        },
+        {
+          "position": 43,
+          "id": "levyra-0f4e2ed6e4590d5199ee",
+          "title": "Chicago",
+          "artists": [
+            {
+              "name": "Michael Jackson"
+            }
+          ],
+          "album": {
+            "name": "XSCAPE",
+            "releaseDate": "2014-05-09"
+          },
+          "durationMs": 245565,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "wAoq__SQpwk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCoIOOL7QKuBhQHVKL8y7BEQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0235f36cb686b0d5a12ab3a9f0"
+        },
+        {
+          "position": 44,
+          "id": "levyra-7eaa5023d1cd67551d51",
+          "title": "Orbiter",
+          "artists": [
+            {
+              "name": "Noah Kahan"
+            }
+          ],
+          "album": {
+            "name": "The Great Divide: The Last Of The Bugs",
+            "releaseDate": "2026-04-25"
+          },
+          "durationMs": 286967,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "of6KPs4PTN0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCwGXlFP4Ba5do7KoxRJYgVQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c39789e2dbdad5af5736e07a"
+        },
+        {
+          "position": 45,
+          "id": "levyra-62c90b4af13ccbc9f4cd",
+          "title": "back to friends",
+          "artists": [
+            {
+              "name": "sombr"
+            }
+          ],
+          "album": {
+            "name": "I Barely Know Her",
+            "releaseDate": "2025-08-22"
+          },
+          "durationMs": 199032,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "c-8abSPAPOU",
+            "audioConfidence": 100,
+            "videoId": "c8zq4kAn_O0",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCyI0V6RmULLsRxegMTCmkWQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024229702de91cb3d3a4383302"
+        },
+        {
+          "position": 46,
+          "id": "levyra-47764fdde285bb5be11a",
+          "title": "Beauty And A Beat",
+          "artists": [
+            {
+              "name": "Justin Bieber"
+            },
+            {
+              "name": "Nicki Minaj"
+            }
+          ],
+          "album": {
+            "name": "Believe",
+            "releaseDate": "2012-01-01"
+          },
+          "durationMs": 227986,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f1d02a6cec967f8b6b78f76e"
+        },
+        {
+          "position": 47,
+          "id": "levyra-d5d19a1705964eca30c4",
+          "title": "bloodstream",
+          "artists": [
+            {
+              "name": "Alyssa Grace"
+            }
+          ],
+          "album": {
+            "name": "bloodstream",
+            "releaseDate": "2026-06-04"
+          },
+          "durationMs": 177428,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "CLSuAhT71yU",
+            "audioConfidence": 100,
+            "videoId": "FOJ4A4wixDg",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCXi-L3_hX9d3TdX5_wO-EJw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029c031feeff1647deb7577309"
+        },
+        {
+          "position": 48,
+          "id": "levyra-176e1c5309002f4cd715",
+          "title": "I Had Some Help (Feat. Morgan Wallen)",
+          "artists": [
+            {
+              "name": "Post Malone"
+            },
+            {
+              "name": "Morgan Wallen"
+            }
+          ],
+          "album": {
+            "name": "F-1 Trillion",
+            "releaseDate": "2024-08-15"
+          },
+          "durationMs": 178205,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0288208159b1b3c69eefdeb2e0"
+        },
+        {
+          "position": 49,
+          "id": "levyra-49d49694f22dae4fb540",
+          "title": "Ain't In LA",
+          "artists": [
+            {
+              "name": "ADÉLA"
+            }
+          ],
+          "album": {
+            "name": "Ain't In LA",
+            "releaseDate": "2026-07-23"
+          },
+          "durationMs": 184927,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "E2gPsY36uR0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0tecxozlRzTMrqvShI8QWg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b176fc721e1faba78b1ef35b"
+        },
+        {
+          "position": 50,
+          "id": "levyra-faa525634c7d085b0462",
+          "title": "E85",
+          "artists": [
+            {
+              "name": "Don Toliver"
+            }
+          ],
+          "album": {
+            "name": "OCTANE",
+            "releaseDate": "2026-01-30"
+          },
+          "durationMs": 153181,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "VrLwRDOVQ6U",
+            "audioConfidence": 100,
+            "videoId": "rVD-zV6ctoM",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCSzWQmDsKG37iKN2vw1G-2Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0225c28f3c9fbdbab1a88dd619"
+        }
+      ]
+    },
+    {
+      "id": "top-50-gb",
+      "kind": "chart",
+      "market": "GB",
+      "title": "Top 50 United Kingdom",
+      "description": "Regno Unito: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-6fbfa6207d16725c7a53",
+          "title": "Rein Me In (with Olivia Dean)",
+          "artists": [
+            {
+              "name": "Sam Fender"
+            },
+            {
+              "name": "Olivia Dean"
+            }
+          ],
+          "album": {
+            "name": "People Watching (Deluxe Edition)",
+            "releaseDate": "2025-12-05"
+          },
+          "durationMs": 339893,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0270722c52a53ef4a56f0c2eb0"
+        },
+        {
+          "position": 2,
+          "id": "levyra-ef444afbdd8812785bd5",
+          "title": "Man I Need",
+          "artists": [
+            {
+              "name": "Olivia Dean"
+            }
+          ],
+          "album": {
+            "name": "Man I Need",
+            "releaseDate": "2025-08-15"
+          },
+          "durationMs": 184000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "fsGjRf-N71I",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC6GBKGYX6b3guHlqHLx6IzQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e3d69e17dde129037a1f09e2"
+        },
+        {
+          "position": 3,
+          "id": "levyra-98349a571204b2f4073a",
+          "title": "petal",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 184248,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "4mQyEqbaUOU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 4,
+          "id": "levyra-93683240d111e7825d3f",
+          "title": "hate that i made you love me",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 197949,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7CUz7Ec7cWc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 5,
+          "id": "levyra-d8ef61462b0bb69ebbf9",
+          "title": "Choosin' Texas",
+          "artists": [
+            {
+              "name": "Ella Langley"
+            }
+          ],
+          "album": {
+            "name": "Dandelion",
+            "releaseDate": "2026-04-10"
+          },
+          "durationMs": 231746,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "3s1sZbW7Rt8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCecnyZYofHiBVDJpx1XNYOQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028606848da949bbaddf447d87"
+        },
+        {
+          "position": 6,
+          "id": "levyra-4500512f5aa38edfe312",
+          "title": "Dai Dai",
+          "artists": [
+            {
+              "name": "Shakira"
+            },
+            {
+              "name": "Burna Boy"
+            }
+          ],
+          "album": {
+            "name": "Dai Dai",
+            "releaseDate": "2026-05-14"
+          },
+          "durationMs": 223448,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lFQdcPTTzSg",
+            "audioConfidence": 100,
+            "videoId": "fcnDmrtj6Sk",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCo6JijJGA3IvIiPsawDK3Ww"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0203cadf1b3fe324c1dc710ed4"
+        },
+        {
+          "position": 7,
+          "id": "levyra-2ed1782b29609516a5ec",
+          "title": "stupid song",
+          "artists": [
+            {
+              "name": "Olivia Rodrigo"
+            }
+          ],
+          "album": {
+            "name": "you seem pretty sad for a girl so in love",
+            "releaseDate": "2026-06-11"
+          },
+          "durationMs": 209680,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "P7VgXIZSN_w",
+            "audioConfidence": 100,
+            "videoId": "Rt9tW3cMLhI",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCE5XNpliPM-SmyFEp61tL_g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026949b83f85d782b21ce70583"
+        },
+        {
+          "position": 8,
+          "id": "levyra-1bcef17c13a5fa801cdb",
+          "title": "the cure",
+          "artists": [
+            {
+              "name": "Olivia Rodrigo"
+            }
+          ],
+          "album": {
+            "name": "you seem pretty sad for a girl so in love",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 297090,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "cmzCwz4NkOA",
+            "audioConfidence": 100,
+            "videoId": "B402rKl4bUg",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCE5XNpliPM-SmyFEp61tL_g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025cf234eeb7a2edf44bf64a46"
+        },
+        {
+          "position": 9,
+          "id": "levyra-398b2ca4b3fc8d25f97f",
+          "title": "Mr. Brightside",
+          "artists": [
+            {
+              "name": "The Killers"
+            }
+          ],
+          "album": {
+            "name": "Hot Fuss",
+            "releaseDate": "2004"
+          },
+          "durationMs": 222973,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "m2zUrruKjDQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCneQ7UWyu9USLDgMya6T7IA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ccdddd46119a4ff53eaf1f5d"
+        },
+        {
+          "position": 10,
+          "id": "levyra-9a4be11b00c0a461faf4",
+          "title": "Great Expectation",
+          "artists": [
+            {
+              "name": "SIENNA SPIRO"
+            }
+          ],
+          "album": {
+            "name": "Visitor",
+            "releaseDate": "2026-07-02"
+          },
+          "durationMs": 173975,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "_5-Dzam3jPU",
+            "audioConfidence": 100,
+            "videoId": "B452TVVco2Q",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCf5GUgSQC4CU8idz_OH8jqQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b09eea420767969b6729962b"
+        },
+        {
+          "position": 11,
+          "id": "levyra-4a8f3d180ce3d0b76564",
+          "title": "Earrings",
+          "artists": [
+            {
+              "name": "Malcolm Todd"
+            }
+          ],
+          "album": {
+            "name": "Sweet Boy",
+            "releaseDate": "2024-04-05"
+          },
+          "durationMs": 151500,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "BI9HQCzpDgQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCRLE_fwmN2CQw1vuWPwo6eA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022c1f34ecc1929fb59908aad1"
+        },
+        {
+          "position": 12,
+          "id": "levyra-ef4e58155c9d1e772e30",
+          "title": "Talk To You (ft. 54 Ultra)",
+          "artists": [
+            {
+              "name": "ANOTR"
+            },
+            {
+              "name": "54 Ultra"
+            }
+          ],
+          "album": {
+            "name": "Withness",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 191076,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02aeb168f35ab002d77a4f3918"
+        },
+        {
+          "position": 13,
+          "id": "levyra-f957ea7f2a4c33cfcabb",
+          "title": "Free Your Mind",
+          "artists": [
+            {
+              "name": "Prospa"
+            },
+            {
+              "name": "Cloonee"
+            }
+          ],
+          "album": {
+            "name": "Free Your Mind",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 201700,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "V9Suvx0K5Eo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCgj1S1QjZw6EP1jSlfo3www"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02586475e0e7697109f9c69a49"
+        },
+        {
+          "position": 14,
+          "id": "levyra-3673bb0d7af8280b701f",
+          "title": "iloveitiloveitiloveit",
+          "artists": [
+            {
+              "name": "Bella Kay"
+            }
+          ],
+          "album": {
+            "name": "My Reckless Abandon",
+            "releaseDate": "2026-07-12"
+          },
+          "durationMs": 183237,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "OqTpNnSnwxQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UChgng6_x6IoIUldSZX415HQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029596fe56f6e29ff9d519ac08"
+        },
+        {
+          "position": 15,
+          "id": "levyra-b31eb5e60513bbd613b7",
+          "title": "Billie Jean",
+          "artists": [
+            {
+              "name": "Michael Jackson"
+            }
+          ],
+          "album": {
+            "name": "Thriller",
+            "releaseDate": "1982-11-30"
+          },
+          "durationMs": 293802,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0232a7d87248d1b75463483df5"
+        },
+        {
+          "position": 16,
+          "id": "levyra-f6663bc35697e813e41d",
+          "title": "Wonderwall - Remastered",
+          "artists": [
+            {
+              "name": "Oasis"
+            }
+          ],
+          "album": {
+            "name": "(What's The Story) Morning Glory? (Deluxe Remastered Edition)",
+            "releaseDate": "1995"
+          },
+          "durationMs": 258773,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027a4c8c59851c88f6794c3cbf"
+        },
+        {
+          "position": 17,
+          "id": "levyra-505f651c6eec9a976bfe",
+          "title": "Raindance (feat. Tems)",
+          "artists": [
+            {
+              "name": "Dave"
+            },
+            {
+              "name": "Tems"
+            }
+          ],
+          "album": {
+            "name": "The Boy Who Played the Harp",
+            "releaseDate": "2025-10-23"
+          },
+          "durationMs": 219743,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02fecaa7826bb0cbe139a8cb83"
+        },
+        {
+          "position": 18,
+          "id": "levyra-b83cc5d423e9892843c8",
+          "title": "Homewrecker",
+          "artists": [
+            {
+              "name": "sombr"
+            }
+          ],
+          "album": {
+            "name": "Homewrecker",
+            "releaseDate": "2026-02-05"
+          },
+          "durationMs": 209066,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "E9onENVBmKY",
+            "audioConfidence": 100,
+            "videoId": "mQezde_qeXw",
+            "videoConfidence": 97,
+            "confidence": 100,
+            "artistBrowseId": "UCyI0V6RmULLsRxegMTCmkWQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029a8d41dca4c7d0ef23d76dd7"
+        },
+        {
+          "position": 19,
+          "id": "levyra-9d3e530cd74574baf20a",
+          "title": "Babydoll",
+          "artists": [
+            {
+              "name": "Dominic Fike"
+            }
+          ],
+          "album": {
+            "name": "Don't Forget About Me, Demos",
+            "releaseDate": "2018-10-16"
+          },
+          "durationMs": 97960,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "UnuEzP1rDLY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCsWqHrJvOU_uukQCU92VEvw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b1b6f41c1645af9757d5616"
+        },
+        {
+          "position": 20,
+          "id": "levyra-9824cf7c6204b58ac7c7",
+          "title": "Iris",
+          "artists": [
+            {
+              "name": "The Goo Goo Dolls"
+            }
+          ],
+          "album": {
+            "name": "Dizzy up the Girl",
+            "releaseDate": "1998"
+          },
+          "durationMs": 289533,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02eda9478c39a21e1cdc6609ca"
+        },
+        {
+          "position": 21,
+          "id": "levyra-16c4cb886ff34d0d5230",
+          "title": "Ordinary",
+          "artists": [
+            {
+              "name": "Alex Warren"
+            }
+          ],
+          "album": {
+            "name": "You'll Be Alright, Kid (Chapter 1)",
+            "releaseDate": "2024-09-26"
+          },
+          "durationMs": 186964,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Q2NePVoGxYg",
+            "audioConfidence": 100,
+            "videoId": "u2ah9tWTkmk",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCXATF3-9RFGyY-it_d2hB6A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028d18d73bbfc8985d52865edf"
+        },
+        {
+          "position": 22,
+          "id": "levyra-3ec1a84496dd0ab0e0ab",
+          "title": "Cinderella (feat. Ty Dolla $ign)",
+          "artists": [
+            {
+              "name": "Mac Miller"
+            },
+            {
+              "name": "Ty Dolla $ign"
+            }
+          ],
+          "album": {
+            "name": "The Divine Feminine",
+            "releaseDate": "2016-09-16"
+          },
+          "durationMs": 480186,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022e92f776279eaf45d14a33fd"
+        },
+        {
+          "position": 23,
+          "id": "levyra-e80e109c111990095c97",
+          "title": "kiss me",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 219584,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "bfszA_eFvnw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 24,
+          "id": "levyra-348d17842ca544561063",
+          "title": "So Easy (To Fall In Love)",
+          "artists": [
+            {
+              "name": "Olivia Dean"
+            }
+          ],
+          "album": {
+            "name": "The Art of Loving",
+            "releaseDate": "2025-09-26"
+          },
+          "durationMs": 169000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7f_mlKlOLMo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC6GBKGYX6b3guHlqHLx6IzQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029a336bfb6d40bbd90a507417"
+        },
+        {
+          "position": 25,
+          "id": "levyra-62f091057573870630ff",
+          "title": "Dreams - 2004 Remaster",
+          "artists": [
+            {
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "album": {
+            "name": "Rumours (Super Deluxe)",
+            "releaseDate": "1977-02-04"
+          },
+          "durationMs": 257800,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e52a59a28efa4773dd2bfe1b"
+        },
+        {
+          "position": 26,
+          "id": "levyra-43f16056e5f10ba616f1",
+          "title": "like i do",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 167333,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "Pjq0RF3og-4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 27,
+          "id": "levyra-47764fdde285bb5be11a",
+          "title": "Beauty And A Beat",
+          "artists": [
+            {
+              "name": "Justin Bieber"
+            },
+            {
+              "name": "Nicki Minaj"
+            }
+          ],
+          "album": {
+            "name": "Believe",
+            "releaseDate": "2012-01-01"
+          },
+          "durationMs": 227986,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f1d02a6cec967f8b6b78f76e"
+        },
+        {
+          "position": 28,
+          "id": "levyra-d5d19a1705964eca30c4",
+          "title": "bloodstream",
+          "artists": [
+            {
+              "name": "Alyssa Grace"
+            }
+          ],
+          "album": {
+            "name": "bloodstream",
+            "releaseDate": "2026-06-04"
+          },
+          "durationMs": 177428,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "CLSuAhT71yU",
+            "audioConfidence": 100,
+            "videoId": "FOJ4A4wixDg",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCXi-L3_hX9d3TdX5_wO-EJw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029c031feeff1647deb7577309"
+        },
+        {
+          "position": 29,
+          "id": "levyra-a122ff203ed432fe839b",
+          "title": "WHERE IS MY HUSBAND!",
+          "artists": [
+            {
+              "name": "RAYE"
+            }
+          ],
+          "album": {
+            "name": "THIS MUSIC MAY CONTAIN HOPE.",
+            "releaseDate": "2026-03-27"
+          },
+          "durationMs": 197142,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "94mq0YBsn8U",
+            "audioConfidence": 100,
+            "videoId": "rK5TyISxZ_M",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCvyjk7zKlaFyNIPZ-Pyvkng"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0297c0928704e5a2bd8d4c5b90"
+        },
+        {
+          "position": 30,
+          "id": "levyra-411ee215adfe5f5c97c7",
+          "title": "Animal",
+          "artists": [
+            {
+              "name": "KATSEYE"
+            }
+          ],
+          "album": {
+            "name": "Animal",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 158494,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "vOfyxPRunFM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCX9kfYB9t0tnd6DYUC2iuKg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029e8d48f27391ce383862b8e8"
+        },
+        {
+          "position": 31,
+          "id": "levyra-5e9f38aea24c85f6f5cf",
+          "title": "Boston",
+          "artists": [
+            {
+              "name": "STELLA LEFTY"
+            }
+          ],
+          "album": {
+            "name": "Boston",
+            "releaseDate": "2026-03-27"
+          },
+          "durationMs": 170859,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "C2elY5Tctqg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCTXWFnISFBHXsfR-ghjU3qA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e6cb19b02e38d18246ac334f"
+        },
+        {
+          "position": 32,
+          "id": "levyra-8ec7aac754851425fa49",
+          "title": "oh well",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 196166,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "4YQ06rGPfOc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 33,
+          "id": "levyra-3ed68515a2e244956429",
+          "title": "Material Lover - from The Devil Wears Prada 2 Original Motion Picture",
+          "artists": [
+            {
+              "name": "SIENNA SPIRO"
+            }
+          ],
+          "album": {
+            "name": "Visitor (Deluxe)",
+            "releaseDate": "2026-07-03"
+          },
+          "durationMs": 178016,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0231990a335ce5d02dc159e5c4"
+        },
+        {
+          "position": 34,
+          "id": "levyra-6d5bcfc700b0d4a05493",
+          "title": "On 2nite",
+          "artists": [
+            {
+              "name": "Silva Bumpa"
+            }
+          ],
+          "album": {
+            "name": "On 2nite",
+            "releaseDate": "2026-05-29"
+          },
+          "durationMs": 158848,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "3DC68QxuPPQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCwHSANxj07P1I-PC5Og1qhQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02df5399677b85e9f581bb9833"
+        },
+        {
+          "position": 35,
+          "id": "levyra-68807b02218cd619b1a0",
+          "title": "stay",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 148420,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "nOjzP-HHXG0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 36,
+          "id": "levyra-5c2f779c76102bb23aa0",
+          "title": "Midnight Sun",
+          "artists": [
+            {
+              "name": "Zara Larsson"
+            }
+          ],
+          "album": {
+            "name": "Midnight Sun",
+            "releaseDate": "2025-09-26"
+          },
+          "durationMs": 189898,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0293872dded9b6fe861ac52752"
+        },
+        {
+          "position": 37,
+          "id": "levyra-1ac12898006e1ebb09eb",
+          "title": "Janice STFU",
+          "artists": [
+            {
+              "name": "Drake"
+            }
+          ],
+          "album": {
+            "name": "ICEMAN",
+            "releaseDate": "2026-05-15"
+          },
+          "durationMs": 237344,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "x30_IHP1x3s",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCU6cE7pdJPc6DU2jSrKEsdQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02fe9d3ab9adb1d3b59835b81c"
+        },
+        {
+          "position": 38,
+          "id": "levyra-28082485462ce002493e",
+          "title": "drop dead",
+          "artists": [
+            {
+              "name": "Olivia Rodrigo"
+            }
+          ],
+          "album": {
+            "name": "you seem pretty sad for a girl so in love",
+            "releaseDate": "2026-06-11"
+          },
+          "durationMs": 224998,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "wLmLB4Zzyiw",
+            "audioConfidence": 100,
+            "videoId": "78wrful9cVU",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCE5XNpliPM-SmyFEp61tL_g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026949b83f85d782b21ce70583"
+        },
+        {
+          "position": 39,
+          "id": "levyra-2f7a1c1b7bceb923f67c",
+          "title": "Loser",
+          "artists": [
+            {
+              "name": "Tame Impala"
+            }
+          ],
+          "album": {
+            "name": "Deadbeat",
+            "releaseDate": "2025-10-17"
+          },
+          "durationMs": 223069,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "MX7FSAnRPug",
+            "audioConfidence": 100,
+            "videoId": "s3a4OQR-10M",
+            "videoConfidence": 97,
+            "confidence": 100,
+            "artistBrowseId": "UCGz-eguN8tcic5kUG4s1ZgA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02208500450dcd0fd294d7bd3b"
+        },
+        {
+          "position": 40,
+          "id": "levyra-8d52dd5a928cec18a91f",
+          "title": "Lush Life",
+          "artists": [
+            {
+              "name": "Zara Larsson"
+            }
+          ],
+          "album": {
+            "name": "So Good",
+            "releaseDate": "2017-03-17"
+          },
+          "durationMs": 200646,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "RG-D4bcg54s",
+            "audioConfidence": 100,
+            "videoId": "tD4HCZe-tew",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCB-GmTOjewVU2F_7S4ZFmEA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02401bf6103d4b7f5230a21582"
+        },
+        {
+          "position": 41,
+          "id": "levyra-07bfa81c9a33aafde0f1",
+          "title": "Nice To Each Other",
+          "artists": [
+            {
+              "name": "Olivia Dean"
+            }
+          ],
+          "album": {
+            "name": "Nice To Each Other",
+            "releaseDate": "2025-05-30"
+          },
+          "durationMs": 209000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Psvc4Sex2h8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC6GBKGYX6b3guHlqHLx6IzQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a9e75099d7065c71cc7ede72"
+        },
+        {
+          "position": 42,
+          "id": "levyra-65b1dfd5ff8b7ee3a359",
+          "title": "Riptide",
+          "artists": [
+            {
+              "name": "Vance Joy"
+            }
+          ],
+          "album": {
+            "name": "Dream Your Life Away (Deluxe Edition)",
+            "releaseDate": "2014-08-05"
+          },
+          "durationMs": 204280,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0205d081cbdc2f67d37a364d63"
+        },
+        {
+          "position": 43,
+          "id": "levyra-be36f408a1a82d5992da",
+          "title": "Movin' To The Sun",
+          "artists": [
+            {
+              "name": "HUGEL"
+            },
+            {
+              "name": "Imael Angel"
+            },
+            {
+              "name": "Ultra Naté"
+            }
+          ],
+          "album": {
+            "name": "Twenty One",
+            "releaseDate": "2026-06-26"
+          },
+          "durationMs": 142200,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "B827pl48xkU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCO1o6IjIVBcbr_DS1tmarhQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023c2eac0964d8ef1900f1c101"
+        },
+        {
+          "position": 44,
+          "id": "levyra-66d26b9c701d4a8f11d7",
+          "title": "Beat It",
+          "artists": [
+            {
+              "name": "Michael Jackson"
+            }
+          ],
+          "album": {
+            "name": "Thriller",
+            "releaseDate": "1982-11-30"
+          },
+          "durationMs": 258296,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "kOn-HdEg6AQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCoIOOL7QKuBhQHVKL8y7BEQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0232a7d87248d1b75463483df5"
+        },
+        {
+          "position": 45,
+          "id": "levyra-3f2dcb748a0d34c72f83",
+          "title": "Self Aware",
+          "artists": [
+            {
+              "name": "Temper City"
+            }
+          ],
+          "album": {
+            "name": "Self Aware",
+            "releaseDate": "2026-02-15"
+          },
+          "durationMs": 180740,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "R-hYM3BqTbA",
+            "audioConfidence": 100,
+            "videoId": "mh4AQkw4Jjc",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCpWebSe88U-TOiO8YfKnTgg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d6c26d2ae723f7ab553d64cc"
+        },
+        {
+          "position": 46,
+          "id": "levyra-62c90b4af13ccbc9f4cd",
+          "title": "back to friends",
+          "artists": [
+            {
+              "name": "sombr"
+            }
+          ],
+          "album": {
+            "name": "I Barely Know Her",
+            "releaseDate": "2025-08-22"
+          },
+          "durationMs": 199032,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "c-8abSPAPOU",
+            "audioConfidence": 100,
+            "videoId": "c8zq4kAn_O0",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCyI0V6RmULLsRxegMTCmkWQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024229702de91cb3d3a4383302"
+        },
+        {
+          "position": 47,
+          "id": "levyra-071520a34becd05f202b",
+          "title": "big feelings",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 173622,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "arrDOc5I0uk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 48,
+          "id": "levyra-cc1ba641d63d5045df7d",
+          "title": "12 to 12",
+          "artists": [
+            {
+              "name": "sombr"
+            }
+          ],
+          "album": {
+            "name": "I Barely Know Her",
+            "releaseDate": "2025-08-22"
+          },
+          "durationMs": 242903,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Lylp6w7LpHc",
+            "audioConfidence": 100,
+            "videoId": "cZgUiR31m-Y",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCyI0V6RmULLsRxegMTCmkWQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024229702de91cb3d3a4383302"
+        },
+        {
+          "position": 49,
+          "id": "levyra-a4189e3f0895a5fe7573",
+          "title": "End of Beginning",
+          "artists": [
+            {
+              "name": "Djo"
+            }
+          ],
+          "album": {
+            "name": "DECIDE",
+            "releaseDate": "2022-09-16"
+          },
+          "durationMs": 159245,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Kf5pXDhx5Vc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCVskJK4TXr5gqSEcQbjIJIg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02fddfffec51b4580acae727c1"
+        },
+        {
+          "position": 50,
+          "id": "levyra-49d49694f22dae4fb540",
+          "title": "Ain't In LA",
+          "artists": [
+            {
+              "name": "ADÉLA"
+            }
+          ],
+          "album": {
+            "name": "Ain't In LA",
+            "releaseDate": "2026-07-23"
+          },
+          "durationMs": 184927,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "E2gPsY36uR0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0tecxozlRzTMrqvShI8QWg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b176fc721e1faba78b1ef35b"
+        }
+      ]
+    },
+    {
+      "id": "top-50-es",
+      "kind": "chart",
+      "market": "ES",
+      "title": "Top 50 España",
+      "description": "Spagna: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-98126fee59297d93e6e7",
+          "title": "LA GRACIOSA",
+          "artists": [
+            {
+              "name": "Quevedo"
+            },
+            {
+              "name": "Elvis Crespo"
+            }
+          ],
+          "album": {
+            "name": "EL BAIFO",
+            "releaseDate": "2026-04-24"
+          },
+          "durationMs": 257713,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Kev3r6W4TPo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7PL9aor5qNRhvhWWVXyOqA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b84b5d956376cb8e55425f5"
+        },
+        {
+          "position": 2,
+          "id": "levyra-fe2aa3332649a8eb3075",
+          "title": "AL GOLPITO",
+          "artists": [
+            {
+              "name": "Quevedo"
+            },
+            {
+              "name": "Nueva Línea"
+            }
+          ],
+          "album": {
+            "name": "EL BAIFO",
+            "releaseDate": "2026-04-24"
+          },
+          "durationMs": 207734,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "FPELTXZBnrg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7PL9aor5qNRhvhWWVXyOqA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b84b5d956376cb8e55425f5"
+        },
+        {
+          "position": 3,
+          "id": "levyra-1f64ca227f66b05d0ff4",
+          "title": "De Lejitos - Remix",
+          "artists": [
+            {
+              "name": "Jay Wheeler"
+            },
+            {
+              "name": "Omar Courtz"
+            }
+          ],
+          "album": {
+            "name": "La Voz Favorita",
+            "releaseDate": "2026-05-28"
+          },
+          "durationMs": 276000,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "dkH6bUnsy1Y",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC17u1K8tiqxxFhPMbM50ASA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c132fb4ba462a3859c4f2ff3"
+        },
+        {
+          "position": 4,
+          "id": "levyra-dd8ec08b46ca24eb3e90",
+          "title": "Baby Lover",
+          "artists": [
+            {
+              "name": "Ñengo Flow"
+            }
+          ],
+          "album": {
+            "name": "Real G4 Life Vol. 3",
+            "releaseDate": "2017-02-10"
+          },
+          "durationMs": 194838,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028027684a0bac31a4e2b5f6f3"
+        },
+        {
+          "position": 5,
+          "id": "levyra-e583f0f7dd5621e4de7b",
+          "title": "Dichavate",
+          "artists": [
+            {
+              "name": "Ya Ice Dilan"
+            },
+            {
+              "name": "Rey Tony"
+            },
+            {
+              "name": "Helabusador"
+            },
+            {
+              "name": "JipMusic Global"
+            },
+            {
+              "name": "Dj Honda"
+            }
+          ],
+          "album": {
+            "name": "Dichavate",
+            "releaseDate": "2025-12-24"
+          },
+          "durationMs": 246428,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "l1T1fvkMEoc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC9aJbR9Q8nscvZaMw_cH4Ww"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b27ddff7799d494c71b6b308"
+        },
+        {
+          "position": 6,
+          "id": "levyra-40da58cabedd66144be9",
+          "title": "SUPERESTRELLA",
+          "artists": [
+            {
+              "name": "Aitana"
+            }
+          ],
+          "album": {
+            "name": "CUARTO AZUL",
+            "releaseDate": "2025-05-29"
+          },
+          "durationMs": 183529,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "ElvzE2cPclc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCkyzcFsGWVYSUGaR7YB9OYQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e9c382b5b9b3221428da47c2"
+        },
+        {
+          "position": 7,
+          "id": "levyra-d72d2d5fbc066c3785d8",
+          "title": "pa ti toa <3",
+          "artists": [
+            {
+              "name": "Ana Mena"
+            },
+            {
+              "name": "Lola Indigo"
+            }
+          ],
+          "album": {
+            "name": "pa ti toa <3",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 213001,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "-W5tVu4tHKE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCeZqJb8O79XPE0xjL6VxNqA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028b3a60fa528510d0e3a4fca3"
+        },
+        {
+          "position": 8,
+          "id": "levyra-ee756b60bf2502419db8",
+          "title": "After",
+          "artists": [
+            {
+              "name": "Conep"
+            }
+          ],
+          "album": {
+            "name": "TRAPPii 2",
+            "releaseDate": "2026-07-07"
+          },
+          "durationMs": 167428,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "_s3PWh0hJp8",
+            "audioConfidence": 100,
+            "videoId": "6dfNMwl6sSM",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCcL6TjmX01Db1p_e6jkSkBQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02fc4c6fd337d7bb4ee4602f0d"
+        },
+        {
+          "position": 9,
+          "id": "levyra-4500512f5aa38edfe312",
+          "title": "Dai Dai",
+          "artists": [
+            {
+              "name": "Shakira"
+            },
+            {
+              "name": "Burna Boy"
+            }
+          ],
+          "album": {
+            "name": "Dai Dai",
+            "releaseDate": "2026-05-14"
+          },
+          "durationMs": 223448,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lFQdcPTTzSg",
+            "audioConfidence": 100,
+            "videoId": "fcnDmrtj6Sk",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCo6JijJGA3IvIiPsawDK3Ww"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0203cadf1b3fe324c1dc710ed4"
+        },
+        {
+          "position": 10,
+          "id": "levyra-95fc2ff9fb4e8d7642dc",
+          "title": "NI BORRACHO",
+          "artists": [
+            {
+              "name": "Quevedo"
+            }
+          ],
+          "album": {
+            "name": "EL BAIFO",
+            "releaseDate": "2026-04-24"
+          },
+          "durationMs": 248440,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "eEvRSYIW-wg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7PL9aor5qNRhvhWWVXyOqA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b84b5d956376cb8e55425f5"
+        },
+        {
+          "position": 11,
+          "id": "levyra-55697c53138308e9feb3",
+          "title": "Las mas bonitas son p#tas",
+          "artists": [
+            {
+              "name": "Anuel AA"
+            }
+          ],
+          "album": {
+            "name": "Las mas bonitas son p#tas",
+            "releaseDate": "2026-06-26"
+          },
+          "durationMs": 159840,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "5xJP3p4LSKw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCbBaYg2UToDaoOwo-R6xi4g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c2c4ebb82fba77deba3d6f02"
+        },
+        {
+          "position": 12,
+          "id": "levyra-e4e7d7f89b9d4c599075",
+          "title": "DAALE",
+          "artists": [
+            {
+              "name": "mvrk"
+            }
+          ],
+          "album": {
+            "name": "Please Behave Radio Vol.2",
+            "releaseDate": "2026-07-17"
+          },
+          "durationMs": 164324,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "plG-PRB5d84",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCkHpGlGRwk0aN2sw8o8iuLA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0231e46a99a69e1cf0138bc1ff"
+        },
+        {
+          "position": 13,
+          "id": "levyra-08c3c9d090d1de1fbbca",
+          "title": "KOKO",
+          "artists": [
+            {
+              "name": "Omar Courtz"
+            }
+          ],
+          "album": {
+            "name": "POR SI MAÑANA NO ESTOY",
+            "releaseDate": "2026-02-19"
+          },
+          "durationMs": 195146,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "az3_6jmrcHY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCieB8sWI6qEOX6r_UnJU12w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0290af5246adcaa93acb721c17"
+        },
+        {
+          "position": 14,
+          "id": "levyra-6684c340c7796ffae27e",
+          "title": "BnB",
+          "artists": [
+            {
+              "name": "Young Miko"
+            },
+            {
+              "name": "Clarent"
+            }
+          ],
+          "album": {
+            "name": "Do Not Disturb: Late Checkout",
+            "releaseDate": "2026-05-29"
+          },
+          "durationMs": 157053,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029c8aeb68e2d5cb49ede9fe55"
+        },
+        {
+          "position": 15,
+          "id": "levyra-183916958567fc0d5a27",
+          "title": "EL BAIFO",
+          "artists": [
+            {
+              "name": "Quevedo"
+            }
+          ],
+          "album": {
+            "name": "EL BAIFO",
+            "releaseDate": "2026-04-24"
+          },
+          "durationMs": 199480,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "o6hp8423LAQ",
+            "audioConfidence": 100,
+            "videoId": "LZPLBSRnxSY",
+            "videoConfidence": 95,
+            "confidence": 100,
+            "artistBrowseId": "UC7PL9aor5qNRhvhWWVXyOqA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b84b5d956376cb8e55425f5"
+        },
+        {
+          "position": 16,
+          "id": "levyra-e9e723d3b6d150af8df4",
+          "title": "MUCHACHA",
+          "artists": [
+            {
+              "name": "Aissa"
+            },
+            {
+              "name": "Rvfv"
+            },
+            {
+              "name": "Kreamly"
+            }
+          ],
+          "album": {
+            "name": "MUCHACHA",
+            "releaseDate": "2026-02-05"
+          },
+          "durationMs": 192750,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "J6Tga8CornY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCxcdeROhhi_7T4pW1ZtOvUA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bf3151af9c5e4d7c1de59ae9"
+        },
+        {
+          "position": 17,
+          "id": "levyra-2d4499f559f5aaf274c9",
+          "title": "NO ME GUILLO v2",
+          "artists": [
+            {
+              "name": "ANMI"
+            },
+            {
+              "name": "La Pantera"
+            },
+            {
+              "name": "Kabasaki"
+            }
+          ],
+          "album": {
+            "name": "NO ME GUILLO v2",
+            "releaseDate": "2026-07-10"
+          },
+          "durationMs": 195109,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "woyRHxXdDjY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UClQAEC2wu1yij9l3I6oZrgw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02fc36582a6a0ec306ac4485f6"
+        },
+        {
+          "position": 18,
+          "id": "levyra-a95121d8a0f983fccbd0",
+          "title": "La Plena - W Sound 05",
+          "artists": [
+            {
+              "name": "W Sound"
+            },
+            {
+              "name": "Beéle"
+            },
+            {
+              "name": "Ovy On The Drums"
+            }
+          ],
+          "album": {
+            "name": "La Plena (W Sound 05)",
+            "releaseDate": "2025-02-19"
+          },
+          "durationMs": 150001,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "SEY1UKEmOrQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCPsX2ybNiGsJU8C_H9nkVLA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c0353d023daf5ebda0eb003b"
+        },
+        {
+          "position": 19,
+          "id": "levyra-f22bd7ca45150ac27d9d",
+          "title": "Dardos",
+          "artists": [
+            {
+              "name": "Romeo Santos"
+            },
+            {
+              "name": "Prince Royce"
+            }
+          ],
+          "album": {
+            "name": "Better Late Than Never",
+            "releaseDate": "2025-11-28"
+          },
+          "durationMs": 243070,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "KufdwNmWx30",
+            "audioConfidence": 100,
+            "videoId": "7KrNh9YaeDg",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCpB_98tUTs3zSiOxZuGPnOA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0291750ed467a5ecc14beaa03f"
+        },
+        {
+          "position": 20,
+          "id": "levyra-6a0bf7968aa2cd85d63a",
+          "title": "AIRE",
+          "artists": [
+            {
+              "name": "Lucho RK"
+            }
+          ],
+          "album": {
+            "name": "AIRE",
+            "releaseDate": "2026-07-08"
+          },
+          "durationMs": 141180,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "dVBHtE2OvHA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCOoQ6A-vMFiooFco0Nf8OdQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026fa386d1a81a54b9e6d0b5c1"
+        },
+        {
+          "position": 21,
+          "id": "levyra-06392a9bf8b5b2c37f0e",
+          "title": "TU VAS SIN (fav)",
+          "artists": [
+            {
+              "name": "Rels B"
+            }
+          ],
+          "album": {
+            "name": "afroLOVA 25'",
+            "releaseDate": "2025-06-20"
+          },
+          "durationMs": 110495,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "YajRphE8stY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCNASXW_h23CkeOLZjCk7VLw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020e409fad9527196e73e423ba"
+        },
+        {
+          "position": 22,
+          "id": "levyra-247fdff5999edd8e6bcd",
+          "title": "SCANDIC",
+          "artists": [
+            {
+              "name": "Quevedo"
+            }
+          ],
+          "album": {
+            "name": "EL BAIFO",
+            "releaseDate": "2026-04-24"
+          },
+          "durationMs": 181421,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "pjf30S5KidM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7PL9aor5qNRhvhWWVXyOqA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b84b5d956376cb8e55425f5"
+        },
+        {
+          "position": 23,
+          "id": "levyra-8ca0c620c2d7e2b5713e",
+          "title": "Quiero más",
+          "artists": [
+            {
+              "name": "La Pantera"
+            }
+          ],
+          "album": {
+            "name": "Quiero más",
+            "releaseDate": "2026-07-27"
+          },
+          "durationMs": 151048,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "OI-ofZNs5js",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCVcoqmzOo3QmzMdf8InN_Tw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ca4982d10588f35750f07a7d"
+        },
+        {
+          "position": 24,
+          "id": "levyra-eaf1ff4bad890d4b41f9",
+          "title": "ALGO VA A PASAR",
+          "artists": [
+            {
+              "name": "Quevedo"
+            },
+            {
+              "name": "La Pantera"
+            },
+            {
+              "name": "Lucho RK"
+            },
+            {
+              "name": "Juseph"
+            }
+          ],
+          "album": {
+            "name": "EL BAIFO",
+            "releaseDate": "2026-04-24"
+          },
+          "durationMs": 248374,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "GZl_RJidBtk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7PL9aor5qNRhvhWWVXyOqA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b84b5d956376cb8e55425f5"
+        },
+        {
+          "position": 25,
+          "id": "levyra-4cf6c1c1b8f964fca54e",
+          "title": "capaz (merengueton)",
+          "artists": [
+            {
+              "name": "Alleh"
+            },
+            {
+              "name": "Yorghaki"
+            }
+          ],
+          "album": {
+            "name": "LA CIUDAD",
+            "releaseDate": "2024-12-24"
+          },
+          "durationMs": 173858,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "OcvTUMwvc4Y",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC6bZ3StEygawlV6sbCsZduQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0253596a050e8369c51da11029"
+        },
+        {
+          "position": 26,
+          "id": "levyra-bcac7c7cad0dc6e83346",
+          "title": "EL BACHATÓN DE LA L",
+          "artists": [
+            {
+              "name": "Lola Indigo"
+            },
+            {
+              "name": "Lucho RK"
+            }
+          ],
+          "album": {
+            "name": "EL BACHATÓN DE LA L",
+            "releaseDate": "2026-05-21"
+          },
+          "durationMs": 201233,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "h49e7y_wPio",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCydg_dYqBrPZ4-X1MnxD37A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b90711be912b8f71d9ae6ebf"
+        },
+        {
+          "position": 27,
+          "id": "levyra-f9792846e0c8195ec05a",
+          "title": "POR TI",
+          "artists": [
+            {
+              "name": "Yapi"
+            },
+            {
+              "name": "SOUNDPLUG"
+            }
+          ],
+          "album": {
+            "name": "POR TI",
+            "releaseDate": "2026-02-19"
+          },
+          "durationMs": 115200,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Y935cPsbmuk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCyJt1KQJbG1ESx5ElTiTFuw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02414c832feb9b2b6954d898ea"
+        },
+        {
+          "position": 28,
+          "id": "levyra-f982e183a122df021fae",
+          "title": "NUEVAYoL",
+          "artists": [
+            {
+              "name": "Bad Bunny"
+            }
+          ],
+          "album": {
+            "name": "DeBÍ TiRAR MáS FOToS",
+            "releaseDate": "2025-01-05"
+          },
+          "durationMs": 183685,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "WdSGEvDGZAo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCiY3z8HAGD6BlSNKVn2kSvQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bbd45c8d36e0e045ef640411"
+        },
+        {
+          "position": 29,
+          "id": "levyra-59e3b177b10978b918d0",
+          "title": "FOREVER TU GANTEL",
+          "artists": [
+            {
+              "name": "Omar Courtz"
+            },
+            {
+              "name": "Ñengo Flow"
+            }
+          ],
+          "album": {
+            "name": "POR SI MAÑANA NO ESTOY",
+            "releaseDate": "2026-02-19"
+          },
+          "durationMs": 226533,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "B88eLylKYHo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCieB8sWI6qEOX6r_UnJU12w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0290af5246adcaa93acb721c17"
+        },
+        {
+          "position": 30,
+          "id": "levyra-1e7bed11dfc6e09365f6",
+          "title": "El Fin del Mundo",
+          "artists": [
+            {
+              "name": "La La Love You"
+            },
+            {
+              "name": "Axolotes Mexicanos"
+            }
+          ],
+          "album": {
+            "name": "La la Love You Bonus",
+            "releaseDate": "2020-12-11"
+          },
+          "durationMs": 188093,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029b4f15da533537034a532591"
+        },
+        {
+          "position": 31,
+          "id": "levyra-140f413e7951103928e8",
+          "title": "BAILE INoLVIDABLE",
+          "artists": [
+            {
+              "name": "Bad Bunny"
+            }
+          ],
+          "album": {
+            "name": "DeBÍ TiRAR MáS FOToS",
+            "releaseDate": "2025-01-05"
+          },
+          "durationMs": 367725,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "JseJETvMtHY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCiY3z8HAGD6BlSNKVn2kSvQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bbd45c8d36e0e045ef640411"
+        },
+        {
+          "position": 32,
+          "id": "levyra-bead30dfc5128607a348",
+          "title": "LA VILLA",
+          "artists": [
+            {
+              "name": "Ryan Castro"
+            },
+            {
+              "name": "Kapo"
+            },
+            {
+              "name": "Gangsta"
+            }
+          ],
+          "album": {
+            "name": "HOPI SENDÉ",
+            "releaseDate": "2025-10-23"
+          },
+          "durationMs": 192111,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "4ejzzT8_AE0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCDxiGGtBV3CQiE-NKLEFgUg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024f0b5d2c8e5f6b86fcd73ca9"
+        },
+        {
+          "position": 33,
+          "id": "levyra-8e45340105429717fa16",
+          "title": "Cuando No Era Cantante RMX - Remix",
+          "artists": [
+            {
+              "name": "El Bogueto"
+            },
+            {
+              "name": "Anuel AA"
+            },
+            {
+              "name": "Fuerza Regida"
+            },
+            {
+              "name": "Yung Beef"
+            }
+          ],
+          "album": {
+            "name": "Eso Si Es De Gangster",
+            "releaseDate": "2026-03-25"
+          },
+          "durationMs": 327488,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b80e69903cd8b7cfb16e804"
+        },
+        {
+          "position": 34,
+          "id": "levyra-8d7134aaf33018839105",
+          "title": "Columbia",
+          "artists": [
+            {
+              "name": "Quevedo"
+            }
+          ],
+          "album": {
+            "name": "Columbia",
+            "releaseDate": "2023-07-07"
+          },
+          "durationMs": 186000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "p_sf9DFRgBE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7PL9aor5qNRhvhWWVXyOqA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02acbcd04fa4069f14741477ee"
+        },
+        {
+          "position": 35,
+          "id": "levyra-897bbe6a9dec92a456ec",
+          "title": "TOCATE SOLA",
+          "artists": [
+            {
+              "name": "Lucho RK"
+            },
+            {
+              "name": "La Pantera"
+            }
+          ],
+          "album": {
+            "name": "TA FACIL",
+            "releaseDate": "2025-11-28"
+          },
+          "durationMs": 175681,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "gwYkmZIAh_M",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCOoQ6A-vMFiooFco0Nf8OdQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dde3d16b29b14773781a0931"
+        },
+        {
+          "position": 36,
+          "id": "levyra-9d87f3376f1b2692a791",
+          "title": "Corrupta",
+          "artists": [
+            {
+              "name": "Rvfv"
+            }
+          ],
+          "album": {
+            "name": "Éxitos España",
+            "releaseDate": "2026-06-18"
+          },
+          "durationMs": 159600,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "4hUrUdimGzY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCj6HoOP59UGegqUC-fu4Wlg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023e513539cda42cc2f9fb8132"
+        },
+        {
+          "position": 37,
+          "id": "levyra-2f006db3f39ae2bc835f",
+          "title": "YO y TÚ",
+          "artists": [
+            {
+              "name": "Ovy On The Drums"
+            },
+            {
+              "name": "Quevedo"
+            },
+            {
+              "name": "Beéle"
+            }
+          ],
+          "album": {
+            "name": "YO y TÚ",
+            "releaseDate": "2025-06-11"
+          },
+          "durationMs": 198153,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "CcqmAiO8ZHw",
+            "audioConfidence": 100,
+            "videoId": "qy6PB3LQizY",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCtfkGa4ie0BivwCPWCHalOw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027e3722344b0226b81ae8b50c"
+        },
+        {
+          "position": 38,
+          "id": "levyra-68a64cdd4478aef98013",
+          "title": "CAPRICHOSO",
+          "artists": [
+            {
+              "name": "Quevedo"
+            }
+          ],
+          "album": {
+            "name": "EL BAIFO",
+            "releaseDate": "2026-04-24"
+          },
+          "durationMs": 186552,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Nq0xK2rEwfE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7PL9aor5qNRhvhWWVXyOqA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b84b5d956376cb8e55425f5"
+        },
+        {
+          "position": 39,
+          "id": "levyra-990a72d6066df35b8f56",
+          "title": "MATADORA",
+          "artists": [
+            {
+              "name": "KAROL G"
+            }
+          ],
+          "album": {
+            "name": "MATADORA",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 144650,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "OTImlQYTCag",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7n3gWRN0vQzgiOKc51aZ4w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a28f412a17d863410ff9cfbf"
+        },
+        {
+          "position": 40,
+          "id": "levyra-16084b535dd655f20ffd",
+          "title": "La Bachata",
+          "artists": [
+            {
+              "name": "Manuel Turizo"
+            }
+          ],
+          "album": {
+            "name": "2000",
+            "releaseDate": "2023-03-17"
+          },
+          "durationMs": 162637,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "sBLM_LzfCz4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCfh2j2Dq-aSeLhzuPOsnhVg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022a2cea2167b62a7822a48e6a"
+        },
+        {
+          "position": 41,
+          "id": "levyra-d69031f9f4adbdcfcdb4",
+          "title": "HOOKAH Y CALOR",
+          "artists": [
+            {
+              "name": "Quevedo"
+            }
+          ],
+          "album": {
+            "name": "EL BAIFO",
+            "releaseDate": "2026-04-24"
+          },
+          "durationMs": 212908,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "vWLgRmLN2HI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7PL9aor5qNRhvhWWVXyOqA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b84b5d956376cb8e55425f5"
+        },
+        {
+          "position": 42,
+          "id": "levyra-2f9ca58ace6915466665",
+          "title": "Fuga",
+          "artists": [
+            {
+              "name": "Jay Wheeler"
+            }
+          ],
+          "album": {
+            "name": "La Voz Favorita",
+            "releaseDate": "2026-05-28"
+          },
+          "durationMs": 181277,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "SNMbLhyGaqY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC17u1K8tiqxxFhPMbM50ASA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c132fb4ba462a3859c4f2ff3"
+        },
+        {
+          "position": 43,
+          "id": "levyra-5a11c56bfc5584eea2df",
+          "title": "DROGA",
+          "artists": [
+            {
+              "name": "Mora"
+            },
+            {
+              "name": "C. Tangana"
+            }
+          ],
+          "album": {
+            "name": "LO MISMO DE SIEMPRE",
+            "releaseDate": "2025-05-18"
+          },
+          "durationMs": 222626,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "3wOR5AQrBgg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCgDpp8Ex8Yz6hhHjbl3W5mg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024cbf1f88953e2f87db81f9bd"
+        },
+        {
+          "position": 44,
+          "id": "levyra-51727e02fdcc830c89dc",
+          "title": "DtMF",
+          "artists": [
+            {
+              "name": "Bad Bunny"
+            }
+          ],
+          "album": {
+            "name": "DeBÍ TiRAR MáS FOToS",
+            "releaseDate": "2025-01-05"
+          },
+          "durationMs": 237117,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "TiebZllW8As",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCiY3z8HAGD6BlSNKVn2kSvQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bbd45c8d36e0e045ef640411"
+        },
+        {
+          "position": 45,
+          "id": "levyra-4a335b2a3e0d73a7694f",
+          "title": "Me Rehúso",
+          "artists": [
+            {
+              "name": "Danny Ocean"
+            }
+          ],
+          "album": {
+            "name": "54+1",
+            "releaseDate": "2019-03-22"
+          },
+          "durationMs": 205714,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d8243a13e6f41310a5fa7b96"
+        },
+        {
+          "position": 46,
+          "id": "levyra-4df11dcde71567432728",
+          "title": "QLOO*",
+          "artists": [
+            {
+              "name": "Young Cister"
+            },
+            {
+              "name": "Kreamly"
+            }
+          ],
+          "album": {
+            "name": "LA CIUDAD NUNCA DUERME*",
+            "releaseDate": "2026-01-15"
+          },
+          "durationMs": 146460,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "F9viEDm36uk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCXARTBbf3MIRdnk87GEHwYA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028eecda5e1e3b66578c162938"
+        },
+        {
+          "position": 47,
+          "id": "levyra-47764fdde285bb5be11a",
+          "title": "Beauty And A Beat",
+          "artists": [
+            {
+              "name": "Justin Bieber"
+            },
+            {
+              "name": "Nicki Minaj"
+            }
+          ],
+          "album": {
+            "name": "Believe",
+            "releaseDate": "2012-01-01"
+          },
+          "durationMs": 227986,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f1d02a6cec967f8b6b78f76e"
+        },
+        {
+          "position": 48,
+          "id": "levyra-e353442fb71195a8138c",
+          "title": "SI ME HICIERA EL DE LA LENGUA (REMIX) (feat. Luar La L)",
+          "artists": [
+            {
+              "name": "FANTA ROSARIO"
+            },
+            {
+              "name": "Jon Z"
+            },
+            {
+              "name": "Hades66"
+            },
+            {
+              "name": "Ñengo Flow"
+            },
+            {
+              "name": "Luar La L"
+            }
+          ],
+          "album": {
+            "name": "SI ME HICIERA EL DE LA LENGUA (REMIX) (feat. Luar La L)",
+            "releaseDate": "2026-07-30"
+          },
+          "durationMs": 324000,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "tewj8kZqxLg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCNu8xPGI-LYNcm0Akb5E0Mg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0268d2c30541264c994aa9bcd5"
+        },
+        {
+          "position": 49,
+          "id": "levyra-7c9ecdcf8fb3dff06cd0",
+          "title": "La Morocha",
+          "artists": [
+            {
+              "name": "Luck Ra"
+            },
+            {
+              "name": "BM"
+            }
+          ],
+          "album": {
+            "name": "QUE NOS FALTE TODO",
+            "releaseDate": "2024-02-02"
+          },
+          "durationMs": 134144,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "E-sSJwncEng",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC1Us4mzRzPi3isXnnt8RZAg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02db091e5bdcd06ef5b252366d"
+        },
+        {
+          "position": 50,
+          "id": "levyra-07d6a1d039a7507b29e8",
+          "title": "SOLEAO",
+          "artists": [
+            {
+              "name": "Myke Towers"
+            },
+            {
+              "name": "Quevedo"
+            }
+          ],
+          "album": {
+            "name": "ISLAND BOYZ",
+            "releaseDate": "2025-07-17"
+          },
+          "durationMs": 218305,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "pmil-5LqbV0",
+            "audioConfidence": 100,
+            "videoId": "JgqsAvvwZAQ",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCYPsIfSIEwWcoynHBP5k1dg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022393ac757022287d011243ff"
+        }
+      ]
+    },
+    {
+      "id": "top-50-fr",
+      "kind": "chart",
+      "market": "FR",
+      "title": "Top 50 France",
+      "description": "Francia: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-66dd78c9e452d793f3da",
+          "title": "Sexy Nana",
+          "artists": [
+            {
+              "name": "Aya Nakamura"
+            },
+            {
+              "name": "La Rvfleuze"
+            }
+          ],
+          "album": {
+            "name": "Destinée Supremacy",
+            "releaseDate": "2026-05-30"
+          },
+          "durationMs": 156254,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "ygyno6J_AyQ",
+            "audioConfidence": 100,
+            "videoId": "MEKERDMnC48",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCY7MKTmE_knveIpCPwdJv1w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022f694bf86d4a7975d6c2bdc4"
+        },
+        {
+          "position": 2,
+          "id": "levyra-c7eb84b1a5bb6a5efa43",
+          "title": "Pilé",
+          "artists": [
+            {
+              "name": "Mauvais djo"
+            }
+          ],
+          "album": {
+            "name": "L'undertaker, Pt. 1",
+            "releaseDate": "2025-08-15"
+          },
+          "durationMs": 156076,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "w1-iaK49zBg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCmz_Ex4zmTVXvBSzXW_JnKw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028ee092eb7a383ab57bd51dee"
+        },
+        {
+          "position": 3,
+          "id": "levyra-c76349faadb3334c27e3",
+          "title": "Maladie",
+          "artists": [
+            {
+              "name": "Mauvais djo"
+            }
+          ],
+          "album": {
+            "name": "Maladie",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 192000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "RPVCkqWxBRs",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCmz_Ex4zmTVXvBSzXW_JnKw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020bec8cf6742b5d00f101b0e8"
+        },
+        {
+          "position": 4,
+          "id": "levyra-4500512f5aa38edfe312",
+          "title": "Dai Dai",
+          "artists": [
+            {
+              "name": "Shakira"
+            },
+            {
+              "name": "Burna Boy"
+            }
+          ],
+          "album": {
+            "name": "Dai Dai",
+            "releaseDate": "2026-05-14"
+          },
+          "durationMs": 223448,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lFQdcPTTzSg",
+            "audioConfidence": 100,
+            "videoId": "fcnDmrtj6Sk",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCo6JijJGA3IvIiPsawDK3Ww"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0203cadf1b3fe324c1dc710ed4"
+        },
+        {
+          "position": 5,
+          "id": "levyra-e1ca7e3f5b9a1b9e020d",
+          "title": "Pineapple",
+          "artists": [
+            {
+              "name": "Leto"
+            }
+          ],
+          "album": {
+            "name": "Pineapple",
+            "releaseDate": "2026-04-10"
+          },
+          "durationMs": 160487,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "t-qNeD3_NQQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCyvI6LcB3xesdtxo1nH2_Rg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cf00bf67a35e73a5566ca122"
+        },
+        {
+          "position": 6,
+          "id": "levyra-12e2b60b03083cef3b38",
+          "title": "Pocahontas",
+          "artists": [
+            {
+              "name": "PLK"
+            }
+          ],
+          "album": {
+            "name": "Grand Garçon",
+            "releaseDate": "2026-03-12"
+          },
+          "durationMs": 168546,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0281e87c483fb4f5448e3b5539"
+        },
+        {
+          "position": 7,
+          "id": "levyra-5349aaa3e87d6922bdc3",
+          "title": "Séminaire",
+          "artists": [
+            {
+              "name": "Bello&Dallas"
+            }
+          ],
+          "album": {
+            "name": "Sarah B.",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 153061,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "28ZSDTVFJoQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7rCYDRIXc-ZkSlSPqx2wug"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ac496ec72329a774430963ce"
+        },
+        {
+          "position": 8,
+          "id": "levyra-33079da417dc9d198636",
+          "title": "melodrama",
+          "artists": [
+            {
+              "name": "disiz"
+            },
+            {
+              "name": "Theodora"
+            }
+          ],
+          "album": {
+            "name": "on s'en rappellera pas",
+            "releaseDate": "2025-11-21"
+          },
+          "durationMs": 176213,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "O2tKlnfrLkY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCLxywkV1hSsZPvRvRGjQh3g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02690365cf88e5be15e0f91652"
+        },
+        {
+          "position": 9,
+          "id": "levyra-dbc8e522c85a152bf91a",
+          "title": "RENÉ CAOVILLA",
+          "artists": [
+            {
+              "name": "Gambi"
+            }
+          ],
+          "album": {
+            "name": "RENÉ CAOVILLA",
+            "releaseDate": "2026-04-03"
+          },
+          "durationMs": 137973,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c9e2d3e80b2d008df4fb3bec"
+        },
+        {
+          "position": 10,
+          "id": "levyra-833532a3b49da12b42b4",
+          "title": "Jamaican (Bam Bam)",
+          "artists": [
+            {
+              "name": "HUGEL"
+            },
+            {
+              "name": "SOLTO (FR)"
+            }
+          ],
+          "album": {
+            "name": "Jamaican (Bam Bam)",
+            "releaseDate": "2025-11-07"
+          },
+          "durationMs": 156393,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02450a730dd72f3bf49882ae9d"
+        },
+        {
+          "position": 11,
+          "id": "levyra-c421ec8a260a57308ba8",
+          "title": "Mélo Décalé",
+          "artists": [
+            {
+              "name": "Tiakola"
+            }
+          ],
+          "album": {
+            "name": "Mélo Décalé",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 156066,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "E8glAzvbP4Q",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCl0tfz41M64qoo64WS_Ce7g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02673fbaf5267f522690e3760a"
+        },
+        {
+          "position": 12,
+          "id": "levyra-f982e183a122df021fae",
+          "title": "NUEVAYoL",
+          "artists": [
+            {
+              "name": "Bad Bunny"
+            }
+          ],
+          "album": {
+            "name": "DeBÍ TiRAR MáS FOToS",
+            "releaseDate": "2025-01-05"
+          },
+          "durationMs": 183685,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "WdSGEvDGZAo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCiY3z8HAGD6BlSNKVn2kSvQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bbd45c8d36e0e045ef640411"
+        },
+        {
+          "position": 13,
+          "id": "levyra-d6a44409d0cc31ae282e",
+          "title": "Sicario",
+          "artists": [
+            {
+              "name": "Timal"
+            }
+          ],
+          "album": {
+            "name": "Sicario",
+            "releaseDate": "2026-06-26"
+          },
+          "durationMs": 149538,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "3iNsyOall6s",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCDVkSalI27I-LYlbF7U9FYA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020d5b13db07b016b05c5db198"
+        },
+        {
+          "position": 14,
+          "id": "levyra-564f865d9acaf47ec2b4",
+          "title": "À l'aise",
+          "artists": [
+            {
+              "name": "TRIANGLE DES BERMUDES"
+            },
+            {
+              "name": "L2B"
+            },
+            {
+              "name": "MC YOSHI"
+            },
+            {
+              "name": "Mauvais djo"
+            },
+            {
+              "name": "Kokosvoice"
+            }
+          ],
+          "album": {
+            "name": "404",
+            "releaseDate": "2026-04-03"
+          },
+          "durationMs": 179640,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "TZoFcN797K8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCDBNRVcVAZ2qRUvmTvm9VbA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d90230a78f5a8ae52fb79f27"
+        },
+        {
+          "position": 15,
+          "id": "levyra-068e26149c37b2d16226",
+          "title": "méli-mélo",
+          "artists": [
+            {
+              "name": "kulturr"
+            }
+          ],
+          "album": {
+            "name": "HOPE. : Imani",
+            "releaseDate": "2025-12-12"
+          },
+          "durationMs": 153779,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "8pwir5jpFYU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCV1Bf5Fi3yowLIM-KIwhszg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0278901c947287e59fb0c5ae85"
+        },
+        {
+          "position": 16,
+          "id": "levyra-b739a79737ad1f90db81",
+          "title": "LOVE YOU",
+          "artists": [
+            {
+              "name": "Nono La Grinta"
+            }
+          ],
+          "album": {
+            "name": "The cat",
+            "releaseDate": "2026-05-22"
+          },
+          "durationMs": 147692,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "YIpRcM_qF9s",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCwvAKJiU1dS_QZAQukDFqYA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023250bc8f253c45d0a96ff5b4"
+        },
+        {
+          "position": 17,
+          "id": "levyra-676be456f8ebb31101af",
+          "title": "La pétasse",
+          "artists": [
+            {
+              "name": "Aya Nakamura"
+            }
+          ],
+          "album": {
+            "name": "Destinée Supremacy",
+            "releaseDate": "2026-05-30"
+          },
+          "durationMs": 150511,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022f694bf86d4a7975d6c2bdc4"
+        },
+        {
+          "position": 18,
+          "id": "levyra-9916110fa4c34bdce25a",
+          "title": "Parfum quartier",
+          "artists": [
+            {
+              "name": "Jul"
+            }
+          ],
+          "album": {
+            "name": "Parfum quartier",
+            "releaseDate": "2017-09-24"
+          },
+          "durationMs": 226210,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "d4VKhBUgLJM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCYO-8CIkoBoUG2nOWz57Q9g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0243c8b89de39bc66cf21c4674"
+        },
+        {
+          "position": 19,
+          "id": "levyra-37dbe114de723a292a9d",
+          "title": "Soleil",
+          "artists": [
+            {
+              "name": "GIMS"
+            }
+          ],
+          "album": {
+            "name": "Soleil",
+            "releaseDate": "2026-04-03"
+          },
+          "durationMs": 131563,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "WpWLY6Xdi_g",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCanUjmTDohFr8OMpfk5xWBQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02da7027e8cccc2cc011fdd078"
+        },
+        {
+          "position": 20,
+          "id": "levyra-bb60aff06bd9968cbaa5",
+          "title": "Paris",
+          "artists": [
+            {
+              "name": "Nono La Grinta"
+            }
+          ],
+          "album": {
+            "name": "RESTART",
+            "releaseDate": "2025-04-25"
+          },
+          "durationMs": 172259,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "oiRGbFibIpE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCwvAKJiU1dS_QZAQukDFqYA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d51502fea36c21429432c88c"
+        },
+        {
+          "position": 21,
+          "id": "levyra-3a5cdad3ce482d24ecdb",
+          "title": "PARISIENNE",
+          "artists": [
+            {
+              "name": "GIMS"
+            },
+            {
+              "name": "La Mano 1.9"
+            }
+          ],
+          "album": {
+            "name": "LE NORD SE SOUVIENT : L'ODYSSÉE",
+            "releaseDate": "2025-02-20"
+          },
+          "durationMs": 158859,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "ERk4Lx-mOqQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCanUjmTDohFr8OMpfk5xWBQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021b012e79a3124fad3af4355a"
+        },
+        {
+          "position": 22,
+          "id": "levyra-3f2dcb748a0d34c72f83",
+          "title": "Self Aware",
+          "artists": [
+            {
+              "name": "Temper City"
+            }
+          ],
+          "album": {
+            "name": "Self Aware",
+            "releaseDate": "2026-02-15"
+          },
+          "durationMs": 180740,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "R-hYM3BqTbA",
+            "audioConfidence": 100,
+            "videoId": "mh4AQkw4Jjc",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCpWebSe88U-TOiO8YfKnTgg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d6c26d2ae723f7ab553d64cc"
+        },
+        {
+          "position": 23,
+          "id": "levyra-c02ad52e9379e3a0b1c5",
+          "title": "MON BÉBÉ",
+          "artists": [
+            {
+              "name": "RnBoi"
+            }
+          ],
+          "album": {
+            "name": "My Eyes Only - Flashback",
+            "releaseDate": "2026-03-27"
+          },
+          "durationMs": 130500,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "BK2RQhxf8Z4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCqJdiFli4XZWXWoBVLkjfeg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02628e0c90703f88e9bc55c191"
+        },
+        {
+          "position": 24,
+          "id": "levyra-6f761e3c27920048b473",
+          "title": "ELLE VOULAIT",
+          "artists": [
+            {
+              "name": "RnBoi"
+            }
+          ],
+          "album": {
+            "name": "My Eyes Only - Flashback",
+            "releaseDate": "2026-03-27"
+          },
+          "durationMs": 145920,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "tf_LpdYBLAg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCqJdiFli4XZWXWoBVLkjfeg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02628e0c90703f88e9bc55c191"
+        },
+        {
+          "position": 25,
+          "id": "levyra-62067bc9eb65d7129202",
+          "title": "Balek",
+          "artists": [
+            {
+              "name": "TRIANGLE DES BERMUDES"
+            },
+            {
+              "name": "Aya Nakamura"
+            },
+            {
+              "name": "MC YOSHI"
+            },
+            {
+              "name": "Mauvais djo"
+            },
+            {
+              "name": "Kokosvoice"
+            }
+          ],
+          "album": {
+            "name": "404",
+            "releaseDate": "2026-04-03"
+          },
+          "durationMs": 177666,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "8Wc9K2I8L2g",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCDBNRVcVAZ2qRUvmTvm9VbA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d90230a78f5a8ae52fb79f27"
+        },
+        {
+          "position": 26,
+          "id": "levyra-db39a87e066432188f32",
+          "title": "Mopao aye",
+          "artists": [
+            {
+              "name": "TRIANGLE DES BERMUDES"
+            },
+            {
+              "name": "MC YOSHI"
+            },
+            {
+              "name": "Mauvais djo"
+            },
+            {
+              "name": "Kokosvoice"
+            }
+          ],
+          "album": {
+            "name": "404",
+            "releaseDate": "2026-04-03"
+          },
+          "durationMs": 198520,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d90230a78f5a8ae52fb79f27"
+        },
+        {
+          "position": 27,
+          "id": "levyra-0cd4bc69f543c8c5cce4",
+          "title": "Coco Chanel",
+          "artists": [
+            {
+              "name": "Meryl"
+            },
+            {
+              "name": "Eva"
+            }
+          ],
+          "album": {
+            "name": "La Dame",
+            "releaseDate": "2025-11-28"
+          },
+          "durationMs": 130800,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "nSozQlDpD1U",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCxF_3BaeGCWLlFzwq09ecWg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0241dd05e63de1761df09d45bd"
+        },
+        {
+          "position": 28,
+          "id": "levyra-ce2c1c28c7a7e8764206",
+          "title": "SPA",
+          "artists": [
+            {
+              "name": "GIMS"
+            },
+            {
+              "name": "Theodora"
+            }
+          ],
+          "album": {
+            "name": "SPA",
+            "releaseDate": "2026-01-16"
+          },
+          "durationMs": 183307,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Zm9RJff5fjw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCanUjmTDohFr8OMpfk5xWBQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028ce0ef2ca4bcf46eba239a62"
+        },
+        {
+          "position": 29,
+          "id": "levyra-ef4e58155c9d1e772e30",
+          "title": "Talk To You (ft. 54 Ultra)",
+          "artists": [
+            {
+              "name": "ANOTR"
+            },
+            {
+              "name": "54 Ultra"
+            }
+          ],
+          "album": {
+            "name": "Withness",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 191076,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02aeb168f35ab002d77a4f3918"
+        },
+        {
+          "position": 30,
+          "id": "levyra-93683240d111e7825d3f",
+          "title": "hate that i made you love me",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 197949,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7CUz7Ec7cWc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 31,
+          "id": "levyra-7e429ff4323cb4476367",
+          "title": "PARLU",
+          "artists": [
+            {
+              "name": "La Rvfleuze"
+            }
+          ],
+          "album": {
+            "name": "Numéro d'écrou",
+            "releaseDate": "2026-03-27"
+          },
+          "durationMs": 141266,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0289566d8748d73a0cc76a3267"
+        },
+        {
+          "position": 32,
+          "id": "levyra-ee7c3dd10561b6928690",
+          "title": "Je pense à toi",
+          "artists": [
+            {
+              "name": "Guy2Bezbar"
+            }
+          ],
+          "album": {
+            "name": "Jeunesse Dorée",
+            "releaseDate": "2025-10-03"
+          },
+          "durationMs": 172786,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "_yHNys271T8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCkxgruCRpla_REeLsrGBi1Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a5f29b9fe6b830be1e353929"
+        },
+        {
+          "position": 33,
+          "id": "levyra-9d3e530cd74574baf20a",
+          "title": "Babydoll",
+          "artists": [
+            {
+              "name": "Dominic Fike"
+            }
+          ],
+          "album": {
+            "name": "Don't Forget About Me, Demos",
+            "releaseDate": "2018-10-16"
+          },
+          "durationMs": 97960,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "UnuEzP1rDLY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCsWqHrJvOU_uukQCU92VEvw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b1b6f41c1645af9757d5616"
+        },
+        {
+          "position": 34,
+          "id": "levyra-ba7e30670a5e93a07bcd",
+          "title": "VIVE LA MONNAIE",
+          "artists": [
+            {
+              "name": "GIMS"
+            },
+            {
+              "name": "Mauvais djo"
+            }
+          ],
+          "album": {
+            "name": "VIVE LA MONNAIE",
+            "releaseDate": "2026-07-17"
+          },
+          "durationMs": 184186,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "GJ0J2sRuXsA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCanUjmTDohFr8OMpfk5xWBQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025213f3f1cfd85a16eddcb720"
+        },
+        {
+          "position": 35,
+          "id": "levyra-6fdfa1092129ae77bc6a",
+          "title": "Menace",
+          "artists": [
+            {
+              "name": "PNL"
+            }
+          ],
+          "album": {
+            "name": "Deux frères",
+            "releaseDate": "2019-04-05"
+          },
+          "durationMs": 188864,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026c3966c4dd0eb2273696fe16"
+        },
+        {
+          "position": 36,
+          "id": "levyra-cb5278a2b8a7a7d3139d",
+          "title": "ONE TRACK MIND",
+          "artists": [
+            {
+              "name": "Naïka"
+            }
+          ],
+          "album": {
+            "name": "ECLESIA",
+            "releaseDate": "2026-02-20"
+          },
+          "durationMs": 200640,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "zFFEAxyr0Jo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCt1y5QDfs2nGjE3vQJg_jYg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c9e26bd0a6282711132bb27e"
+        },
+        {
+          "position": 37,
+          "id": "levyra-cbd6ad0b590c688dcc79",
+          "title": "Dracula - JENNIE Remix",
+          "artists": [
+            {
+              "name": "Tame Impala"
+            },
+            {
+              "name": "JENNIE"
+            }
+          ],
+          "album": {
+            "name": "Dracula (Remix)",
+            "releaseDate": "2026-02-06"
+          },
+          "durationMs": 209720,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "6KjVYeQ9SRw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCGz-eguN8tcic5kUG4s1ZgA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c7c031ce9d06b131f8563676"
+        },
+        {
+          "position": 38,
+          "id": "levyra-2ec9b61e58fc72768338",
+          "title": "B.M.S (by my side)",
+          "artists": [
+            {
+              "name": "Rambo goyard"
+            }
+          ],
+          "album": {
+            "name": "B.M.S (by my side)",
+            "releaseDate": "2025-12-21"
+          },
+          "durationMs": 125454,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "BFAIDkgrp2M",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCGFkTwDPBK6rdxN7rQ-TVbA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02db29800222c202ae748cba1b"
+        },
+        {
+          "position": 39,
+          "id": "levyra-b6945e6f83f8754085c0",
+          "title": "Jalouse",
+          "artists": [
+            {
+              "name": "Werenoi"
+            },
+            {
+              "name": "SDM"
+            },
+            {
+              "name": "Vacra"
+            }
+          ],
+          "album": {
+            "name": "Diamant Noir",
+            "releaseDate": "2025-04-11"
+          },
+          "durationMs": 192432,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "LPDvKF_h8_o",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCm6FmMolN-n38Oj8-ZHVuHg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f4aec0b976368624d9281ace"
+        },
+        {
+          "position": 40,
+          "id": "levyra-a1ea7473d2c8b5683651",
+          "title": "La vie qu'on mène",
+          "artists": [
+            {
+              "name": "Ninho"
+            }
+          ],
+          "album": {
+            "name": "Destin",
+            "releaseDate": "2019-03-22"
+          },
+          "durationMs": 193443,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028c7e885a89abd9500f39a1d0"
+        },
+        {
+          "position": 41,
+          "id": "levyra-a27a535f890a22e9ec5a",
+          "title": "Chemin d'or",
+          "artists": [
+            {
+              "name": "Werenoi"
+            }
+          ],
+          "album": {
+            "name": "Carré",
+            "releaseDate": "2023-03-09"
+          },
+          "durationMs": 212093,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02454178915a2bb0bb78cfebaf"
+        },
+        {
+          "position": 42,
+          "id": "levyra-98349a571204b2f4073a",
+          "title": "petal",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 184248,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "4mQyEqbaUOU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 43,
+          "id": "levyra-9485e84648946670beb9",
+          "title": "Full",
+          "artists": [
+            {
+              "name": "Bilouki"
+            }
+          ],
+          "album": {
+            "name": "24 KARA",
+            "releaseDate": "2026-04-03"
+          },
+          "durationMs": 163636,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "4pcKzC78kWs",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCBa360FPDkgab5CekFOrijg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026cc61128eb8d0a8330771c27"
+        },
+        {
+          "position": 44,
+          "id": "levyra-f906ccedfde8cc096357",
+          "title": "Argent Sale - A COLORS SHOW",
+          "artists": [
+            {
+              "name": "La Rvfleuze"
+            },
+            {
+              "name": "COLORS"
+            }
+          ],
+          "album": {
+            "name": "Argent Sale - A COLORS SHOW",
+            "releaseDate": "2026-02-16"
+          },
+          "durationMs": 164307,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "2OL1n5R6ogI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCOBSsvA4X0FyWIZLtAe63Sw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e18339fa86707ccf2cd59eab"
+        },
+        {
+          "position": 45,
+          "id": "levyra-6d53da36bd7fd61934fd",
+          "title": "Miss Kitoko",
+          "artists": [
+            {
+              "name": "Theodora"
+            }
+          ],
+          "album": {
+            "name": "Miss Kitoko",
+            "releaseDate": "2026-03-12"
+          },
+          "durationMs": 149916,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "rbaOn9SAAnk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC4d0QCjObDdjnutbp5fVpCw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0277476e39a57edadc8638be46"
+        },
+        {
+          "position": 46,
+          "id": "levyra-a8b2e2496dc664654c28",
+          "title": "Réanymé",
+          "artists": [
+            {
+              "name": "Tayc"
+            },
+            {
+              "name": "Anyme023"
+            }
+          ],
+          "album": {
+            "name": "JOŸA",
+            "releaseDate": "2026-05-16"
+          },
+          "durationMs": 151875,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7fyJzGY8Tio",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCjItmeylMPcafIMD7DEhwoQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e028611f6a625443b2993ee4"
+        },
+        {
+          "position": 47,
+          "id": "levyra-3e3a61f2d951c66735ff",
+          "title": "RUINART",
+          "artists": [
+            {
+              "name": "R2"
+            }
+          ],
+          "album": {
+            "name": "7/7 : 24/24",
+            "releaseDate": "2025-06-27"
+          },
+          "durationMs": 174493,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "moE3QFMggu0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC-vYcQ39gufSn-dT_H-0LRg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0221fc8957d575e1ed7ab42594"
+        },
+        {
+          "position": 48,
+          "id": "levyra-b31eb5e60513bbd613b7",
+          "title": "Billie Jean",
+          "artists": [
+            {
+              "name": "Michael Jackson"
+            }
+          ],
+          "album": {
+            "name": "Thriller",
+            "releaseDate": "1982-11-30"
+          },
+          "durationMs": 293802,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0232a7d87248d1b75463483df5"
+        },
+        {
+          "position": 49,
+          "id": "levyra-b03225741190f6e12576",
+          "title": "Serrure #5",
+          "artists": [
+            {
+              "name": "La Rvfleuze"
+            }
+          ],
+          "album": {
+            "name": "Serrure #5",
+            "releaseDate": "2025-08-12"
+          },
+          "durationMs": 138591,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "03VxpbYtW8Y",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCOBSsvA4X0FyWIZLtAe63Sw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026a0a0602090c1587af91c47a"
+        },
+        {
+          "position": 50,
+          "id": "levyra-a122ff203ed432fe839b",
+          "title": "WHERE IS MY HUSBAND!",
+          "artists": [
+            {
+              "name": "RAYE"
+            }
+          ],
+          "album": {
+            "name": "THIS MUSIC MAY CONTAIN HOPE.",
+            "releaseDate": "2026-03-27"
+          },
+          "durationMs": 197142,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "94mq0YBsn8U",
+            "audioConfidence": 100,
+            "videoId": "rK5TyISxZ_M",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCvyjk7zKlaFyNIPZ-Pyvkng"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0297c0928704e5a2bd8d4c5b90"
+        }
+      ]
+    },
+    {
+      "id": "top-50-de",
+      "kind": "chart",
+      "market": "DE",
+      "title": "Top 50 Deutschland",
+      "description": "Germania: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-4500512f5aa38edfe312",
+          "title": "Dai Dai",
+          "artists": [
+            {
+              "name": "Shakira"
+            },
+            {
+              "name": "Burna Boy"
+            }
+          ],
+          "album": {
+            "name": "Dai Dai",
+            "releaseDate": "2026-05-14"
+          },
+          "durationMs": 223448,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lFQdcPTTzSg",
+            "audioConfidence": 100,
+            "videoId": "fcnDmrtj6Sk",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCo6JijJGA3IvIiPsawDK3Ww"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0203cadf1b3fe324c1dc710ed4"
+        },
+        {
+          "position": 2,
+          "id": "levyra-dabb544b7d1012d509f7",
+          "title": "KILLY MANJARO",
+          "artists": [
+            {
+              "name": "Summer Cem"
+            },
+            {
+              "name": "BILLA JOE"
+            }
+          ],
+          "album": {
+            "name": "KILLY MANJARO",
+            "releaseDate": "2026-05-21"
+          },
+          "durationMs": 146133,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Q5uVvydqjmA",
+            "audioConfidence": 100,
+            "videoId": "Tg80GfpT4WU",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCklynm6hL4tGjUox157cxww"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c5e3c29805829b4664754260"
+        },
+        {
+          "position": 3,
+          "id": "levyra-be36f408a1a82d5992da",
+          "title": "Movin' To The Sun",
+          "artists": [
+            {
+              "name": "HUGEL"
+            },
+            {
+              "name": "Imael Angel"
+            },
+            {
+              "name": "Ultra Naté"
+            }
+          ],
+          "album": {
+            "name": "Twenty One",
+            "releaseDate": "2026-06-26"
+          },
+          "durationMs": 142200,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "B827pl48xkU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCO1o6IjIVBcbr_DS1tmarhQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023c2eac0964d8ef1900f1c101"
+        },
+        {
+          "position": 4,
+          "id": "levyra-3f2dcb748a0d34c72f83",
+          "title": "Self Aware",
+          "artists": [
+            {
+              "name": "Temper City"
+            }
+          ],
+          "album": {
+            "name": "Self Aware",
+            "releaseDate": "2026-02-15"
+          },
+          "durationMs": 180740,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "R-hYM3BqTbA",
+            "audioConfidence": 100,
+            "videoId": "mh4AQkw4Jjc",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCpWebSe88U-TOiO8YfKnTgg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d6c26d2ae723f7ab553d64cc"
+        },
+        {
+          "position": 5,
+          "id": "levyra-398b2ca4b3fc8d25f97f",
+          "title": "Mr. Brightside",
+          "artists": [
+            {
+              "name": "The Killers"
+            }
+          ],
+          "album": {
+            "name": "Hot Fuss",
+            "releaseDate": "2004"
+          },
+          "durationMs": 222973,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "m2zUrruKjDQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCneQ7UWyu9USLDgMya6T7IA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ccdddd46119a4ff53eaf1f5d"
+        },
+        {
+          "position": 6,
+          "id": "levyra-3323e0507a67bf7efe55",
+          "title": "Augenblick",
+          "artists": [
+            {
+              "name": "Pashanim"
+            }
+          ],
+          "album": {
+            "name": "Lounge Musik",
+            "releaseDate": "2026-07-23"
+          },
+          "durationMs": 127071,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "-UBIc5dd4U0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCZQd1fU9v7-jFOmOojsHXNw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f3a40de140573a3d70b6eaf4"
+        },
+        {
+          "position": 7,
+          "id": "levyra-47764fdde285bb5be11a",
+          "title": "Beauty And A Beat",
+          "artists": [
+            {
+              "name": "Justin Bieber"
+            },
+            {
+              "name": "Nicki Minaj"
+            }
+          ],
+          "album": {
+            "name": "Believe",
+            "releaseDate": "2012-01-01"
+          },
+          "durationMs": 227986,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f1d02a6cec967f8b6b78f76e"
+        },
+        {
+          "position": 8,
+          "id": "levyra-ac945df102deca9c1fe5",
+          "title": "Gut Genug (mit Blumengarten & Shirin David)",
+          "artists": [
+            {
+              "name": "KITSCHKRIEG"
+            },
+            {
+              "name": "Blumengarten"
+            },
+            {
+              "name": "Shirin David"
+            }
+          ],
+          "album": {
+            "name": "KITSCHKRIEG ZWEI",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 188852,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027c8ca044c71fda2957065c06"
+        },
+        {
+          "position": 9,
+          "id": "levyra-833532a3b49da12b42b4",
+          "title": "Jamaican (Bam Bam)",
+          "artists": [
+            {
+              "name": "HUGEL"
+            },
+            {
+              "name": "SOLTO (FR)"
+            }
+          ],
+          "album": {
+            "name": "Jamaican (Bam Bam)",
+            "releaseDate": "2025-11-07"
+          },
+          "durationMs": 156393,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02450a730dd72f3bf49882ae9d"
+        },
+        {
+          "position": 10,
+          "id": "levyra-1351b3e940a780343726",
+          "title": "Hin und Her",
+          "artists": [
+            {
+              "name": "AK AUSSERKONTROLLE"
+            }
+          ],
+          "album": {
+            "name": "Hin und Her",
+            "releaseDate": "2026-06-11"
+          },
+          "durationMs": 158206,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "6VlTbGmHSIA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UChv9s1NVKfhXH-2E8Sd74mQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023553feb05f3c9b924b4e0fbf"
+        },
+        {
+          "position": 11,
+          "id": "levyra-b5feecfee1fe83e93a01",
+          "title": "WER BIST DU DENN?",
+          "artists": [
+            {
+              "name": "Jazeek"
+            },
+            {
+              "name": "Luciano"
+            }
+          ],
+          "album": {
+            "name": "WER BIST DU DENN?",
+            "releaseDate": "2026-07-30"
+          },
+          "durationMs": 147884,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "Z96gx2HFe6k",
+            "audioConfidence": 100,
+            "videoId": "tOVzhU4mp-o",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCS9cNQRHjxp46FjDAk7PWZQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ed4d44758466d7567332de6c"
+        },
+        {
+          "position": 12,
+          "id": "levyra-e2fb7ff2caa8b0160954",
+          "title": "The One That Got Away",
+          "artists": [
+            {
+              "name": "Katy Perry"
+            }
+          ],
+          "album": {
+            "name": "Teenage Dream",
+            "releaseDate": "2010-01-01"
+          },
+          "durationMs": 227333,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021d955011a3ed477dc77865ad"
+        },
+        {
+          "position": 13,
+          "id": "levyra-8d52dd5a928cec18a91f",
+          "title": "Lush Life",
+          "artists": [
+            {
+              "name": "Zara Larsson"
+            }
+          ],
+          "album": {
+            "name": "So Good",
+            "releaseDate": "2017-03-17"
+          },
+          "durationMs": 200646,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "RG-D4bcg54s",
+            "audioConfidence": 100,
+            "videoId": "tD4HCZe-tew",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCB-GmTOjewVU2F_7S4ZFmEA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02401bf6103d4b7f5230a21582"
+        },
+        {
+          "position": 14,
+          "id": "levyra-b31eb5e60513bbd613b7",
+          "title": "Billie Jean",
+          "artists": [
+            {
+              "name": "Michael Jackson"
+            }
+          ],
+          "album": {
+            "name": "Thriller",
+            "releaseDate": "1982-11-30"
+          },
+          "durationMs": 293802,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0232a7d87248d1b75463483df5"
+        },
+        {
+          "position": 15,
+          "id": "levyra-86984ecab8fd5a9fdee6",
+          "title": "Berlin calling",
+          "artists": [
+            {
+              "name": "Pashanim"
+            }
+          ],
+          "album": {
+            "name": "Lounge Musik",
+            "releaseDate": "2026-07-23"
+          },
+          "durationMs": 117906,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f3a40de140573a3d70b6eaf4"
+        },
+        {
+          "position": 16,
+          "id": "levyra-742f86f042b11f934da7",
+          "title": "Kein Kokain",
+          "artists": [
+            {
+              "name": "Drunken Masters"
+            },
+            {
+              "name": "Ikkimel"
+            }
+          ],
+          "album": {
+            "name": "Ikkimel die Geile EP",
+            "releaseDate": "2026-07-17"
+          },
+          "durationMs": 176883,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02311c1f1ae76a930b1c044227"
+        },
+        {
+          "position": 17,
+          "id": "levyra-50e6bdfc15aa875f492e",
+          "title": "ABC",
+          "artists": [
+            {
+              "name": "LACAZETTE"
+            }
+          ],
+          "album": {
+            "name": "ABC",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 149677,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023843258b0c6a95bf3c12c915"
+        },
+        {
+          "position": 18,
+          "id": "levyra-98349a571204b2f4073a",
+          "title": "petal",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 184248,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "4mQyEqbaUOU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 19,
+          "id": "levyra-93683240d111e7825d3f",
+          "title": "hate that i made you love me",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 197949,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7CUz7Ec7cWc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 20,
+          "id": "levyra-9d3e530cd74574baf20a",
+          "title": "Babydoll",
+          "artists": [
+            {
+              "name": "Dominic Fike"
+            }
+          ],
+          "album": {
+            "name": "Don't Forget About Me, Demos",
+            "releaseDate": "2018-10-16"
+          },
+          "durationMs": 97960,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "UnuEzP1rDLY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCsWqHrJvOU_uukQCU92VEvw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b1b6f41c1645af9757d5616"
+        },
+        {
+          "position": 21,
+          "id": "levyra-ef4e58155c9d1e772e30",
+          "title": "Talk To You (ft. 54 Ultra)",
+          "artists": [
+            {
+              "name": "ANOTR"
+            },
+            {
+              "name": "54 Ultra"
+            }
+          ],
+          "album": {
+            "name": "Withness",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 191076,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02aeb168f35ab002d77a4f3918"
+        },
+        {
+          "position": 22,
+          "id": "levyra-75eb8ac9f9539527c520",
+          "title": "FREAKED OUT",
+          "artists": [
+            {
+              "name": "Fat Papi"
+            },
+            {
+              "name": "prodshushy"
+            }
+          ],
+          "album": {
+            "name": "FREAKED OUT",
+            "releaseDate": "2026-06-04"
+          },
+          "durationMs": 158117,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "kFeYV_QO2oo",
+            "audioConfidence": 100,
+            "videoId": "Q6978DnF8C4",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCIxQaQgIMFBZgD086eu5dXA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dae2db6b9b0a2d5ef298075f"
+        },
+        {
+          "position": 23,
+          "id": "levyra-65b1dfd5ff8b7ee3a359",
+          "title": "Riptide",
+          "artists": [
+            {
+              "name": "Vance Joy"
+            }
+          ],
+          "album": {
+            "name": "Dream Your Life Away (Deluxe Edition)",
+            "releaseDate": "2014-08-05"
+          },
+          "durationMs": 204280,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0205d081cbdc2f67d37a364d63"
+        },
+        {
+          "position": 24,
+          "id": "levyra-f6663bc35697e813e41d",
+          "title": "Wonderwall - Remastered",
+          "artists": [
+            {
+              "name": "Oasis"
+            }
+          ],
+          "album": {
+            "name": "(What's The Story) Morning Glory? (Deluxe Remastered Edition)",
+            "releaseDate": "1995"
+          },
+          "durationMs": 258773,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027a4c8c59851c88f6794c3cbf"
+        },
+        {
+          "position": 25,
+          "id": "levyra-9824cf7c6204b58ac7c7",
+          "title": "Iris",
+          "artists": [
+            {
+              "name": "The Goo Goo Dolls"
+            }
+          ],
+          "album": {
+            "name": "Dizzy up the Girl",
+            "releaseDate": "1998"
+          },
+          "durationMs": 289533,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02eda9478c39a21e1cdc6609ca"
+        },
+        {
+          "position": 26,
+          "id": "levyra-66d26b9c701d4a8f11d7",
+          "title": "Beat It",
+          "artists": [
+            {
+              "name": "Michael Jackson"
+            }
+          ],
+          "album": {
+            "name": "Thriller",
+            "releaseDate": "1982-11-30"
+          },
+          "durationMs": 258296,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "kOn-HdEg6AQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCoIOOL7QKuBhQHVKL8y7BEQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0232a7d87248d1b75463483df5"
+        },
+        {
+          "position": 27,
+          "id": "levyra-66bb9ac4a2a3fe50bd34",
+          "title": "Hips Don't Lie (feat. Wyclef Jean)",
+          "artists": [
+            {
+              "name": "Shakira"
+            },
+            {
+              "name": "Wyclef Jean"
+            }
+          ],
+          "album": {
+            "name": "Oral Fixation, Vol. 2 (Expanded Edition)",
+            "releaseDate": "2005-11-28"
+          },
+          "durationMs": 220360,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0285432abc16fd92be0d435cb9"
+        },
+        {
+          "position": 28,
+          "id": "levyra-08735e6eba50b46580da",
+          "title": "In the End",
+          "artists": [
+            {
+              "name": "Linkin Park"
+            }
+          ],
+          "album": {
+            "name": "Hybrid Theory (Bonus Edition)",
+            "releaseDate": "2000-10-24"
+          },
+          "durationMs": 216880,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e2f039481babe23658fc719a"
+        },
+        {
+          "position": 29,
+          "id": "levyra-a4189e3f0895a5fe7573",
+          "title": "End of Beginning",
+          "artists": [
+            {
+              "name": "Djo"
+            }
+          ],
+          "album": {
+            "name": "DECIDE",
+            "releaseDate": "2022-09-16"
+          },
+          "durationMs": 159245,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Kf5pXDhx5Vc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCVskJK4TXr5gqSEcQbjIJIg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02fddfffec51b4580acae727c1"
+        },
+        {
+          "position": 30,
+          "id": "levyra-058a4aa28b664073a000",
+          "title": "Makina Time",
+          "artists": [
+            {
+              "name": "Dimitri Vegas & Like Mike"
+            },
+            {
+              "name": "Marlon Hoffstadt"
+            },
+            {
+              "name": "Dj Konik"
+            },
+            {
+              "name": "Dimitri Vegas"
+            },
+            {
+              "name": "Like Mike"
+            }
+          ],
+          "album": {
+            "name": "Makina Time",
+            "releaseDate": "2026-01-23"
+          },
+          "durationMs": 130090,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "jEIpk3DObFA",
+            "audioConfidence": 100,
+            "videoId": "Ed-r5SsBLx0",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCeNAGMwB7p3gxizQPsU9Cpw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029960bd6ef598fe5537e902ca"
+        },
+        {
+          "position": 31,
+          "id": "levyra-9d0b06800b1f28aa3479",
+          "title": "Sweater Weather",
+          "artists": [
+            {
+              "name": "The Neighbourhood"
+            }
+          ],
+          "album": {
+            "name": "I Love You.",
+            "releaseDate": "2013-04-22"
+          },
+          "durationMs": 240400,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028265a736a1eb838ad5a0b921"
+        },
+        {
+          "position": 32,
+          "id": "levyra-dbafc9b04b5a56b9694e",
+          "title": "Can't Hold Us (feat. Ray Dalton)",
+          "artists": [
+            {
+              "name": "Macklemore"
+            },
+            {
+              "name": "Ryan Lewis"
+            },
+            {
+              "name": "Macklemore & Ryan Lewis"
+            },
+            {
+              "name": "Ray Dalton"
+            }
+          ],
+          "album": {
+            "name": "The Heist",
+            "releaseDate": "2012-10-09"
+          },
+          "durationMs": 258431,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022a6b364528b128a4a17d100d"
+        },
+        {
+          "position": 33,
+          "id": "levyra-d43d31dade0c776df2b4",
+          "title": "Danza Kuduro - Version MTO",
+          "artists": [
+            {
+              "name": "Lucenzo"
+            },
+            {
+              "name": "Don Omar"
+            }
+          ],
+          "album": {
+            "name": "Emigrante Del Mundo (Remastered)",
+            "releaseDate": "2011-12-19"
+          },
+          "durationMs": 216352,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dd6b19d30e8b2531c625fbc4"
+        },
+        {
+          "position": 34,
+          "id": "levyra-ba39e936cdaaf4d0e07d",
+          "title": "Don't Stop Believin' (2022 Remaster)",
+          "artists": [
+            {
+              "name": "Journey"
+            }
+          ],
+          "album": {
+            "name": "Escape (2022 Remaster)",
+            "releaseDate": "1981-07-17"
+          },
+          "durationMs": 249600,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "mM3Vmn4pdog",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCPKnuPciHDB8qw-wyBVQo9A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0223290120a609a65e14cfe018"
+        },
+        {
+          "position": 35,
+          "id": "levyra-51727e02fdcc830c89dc",
+          "title": "DtMF",
+          "artists": [
+            {
+              "name": "Bad Bunny"
+            }
+          ],
+          "album": {
+            "name": "DeBÍ TiRAR MáS FOToS",
+            "releaseDate": "2025-01-05"
+          },
+          "durationMs": 237117,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "TiebZllW8As",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCiY3z8HAGD6BlSNKVn2kSvQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bbd45c8d36e0e045ef640411"
+        },
+        {
+          "position": 36,
+          "id": "levyra-16c4cb886ff34d0d5230",
+          "title": "Ordinary",
+          "artists": [
+            {
+              "name": "Alex Warren"
+            }
+          ],
+          "album": {
+            "name": "You'll Be Alright, Kid (Chapter 1)",
+            "releaseDate": "2024-09-26"
+          },
+          "durationMs": 186964,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Q2NePVoGxYg",
+            "audioConfidence": 100,
+            "videoId": "u2ah9tWTkmk",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCXATF3-9RFGyY-it_d2hB6A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028d18d73bbfc8985d52865edf"
+        },
+        {
+          "position": 37,
+          "id": "levyra-649125058c7679ea78ec",
+          "title": "New Religion",
+          "artists": [
+            {
+              "name": "Bebe Rexha"
+            },
+            {
+              "name": "Faithless"
+            }
+          ],
+          "album": {
+            "name": "DIRTY BLONDE",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 174400,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "MBnnWS1zcZI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UChwSjx8SnvG6k96a9xqYw1g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02855eca6b0b66944a7682c3b9"
+        },
+        {
+          "position": 38,
+          "id": "levyra-757dcaddc1cf5b747b6e",
+          "title": "The Emptiness Machine",
+          "artists": [
+            {
+              "name": "Linkin Park"
+            }
+          ],
+          "album": {
+            "name": "From Zero",
+            "releaseDate": "2024-11-15"
+          },
+          "durationMs": 190427,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "KBV_zpMm_0Q",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCxgN32UVVztKAQd2HkXzBtw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028be9eeb8f19696ef2fd3b6b4"
+        },
+        {
+          "position": 39,
+          "id": "levyra-4435724e8934201fe429",
+          "title": "misery.",
+          "artists": [
+            {
+              "name": "pupsies"
+            }
+          ],
+          "album": {
+            "name": "misery.",
+            "releaseDate": "2026-03-18"
+          },
+          "durationMs": 166401,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qJKcADiAuAw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCp3AZ2_EV0KOSEL33IC1YWw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02316b7fde50dfbf4be72735c2"
+        },
+        {
+          "position": 40,
+          "id": "levyra-62c90b4af13ccbc9f4cd",
+          "title": "back to friends",
+          "artists": [
+            {
+              "name": "sombr"
+            }
+          ],
+          "album": {
+            "name": "I Barely Know Her",
+            "releaseDate": "2025-08-22"
+          },
+          "durationMs": 199032,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "c-8abSPAPOU",
+            "audioConfidence": 100,
+            "videoId": "c8zq4kAn_O0",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCyI0V6RmULLsRxegMTCmkWQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024229702de91cb3d3a4383302"
+        },
+        {
+          "position": 41,
+          "id": "levyra-a122ff203ed432fe839b",
+          "title": "WHERE IS MY HUSBAND!",
+          "artists": [
+            {
+              "name": "RAYE"
+            }
+          ],
+          "album": {
+            "name": "THIS MUSIC MAY CONTAIN HOPE.",
+            "releaseDate": "2026-03-27"
+          },
+          "durationMs": 197142,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "94mq0YBsn8U",
+            "audioConfidence": 100,
+            "videoId": "rK5TyISxZ_M",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCvyjk7zKlaFyNIPZ-Pyvkng"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0297c0928704e5a2bd8d4c5b90"
+        },
+        {
+          "position": 42,
+          "id": "levyra-15fee2182e5e8b93e93e",
+          "title": "Numb",
+          "artists": [
+            {
+              "name": "Linkin Park"
+            }
+          ],
+          "album": {
+            "name": "Meteora",
+            "releaseDate": "2003-03-25"
+          },
+          "durationMs": 187520,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025f1f51d14e8bea89484ecd1b"
+        },
+        {
+          "position": 43,
+          "id": "levyra-9aa6985d9985f1b7e01e",
+          "title": "Love Me Not",
+          "artists": [
+            {
+              "name": "Ravyn Lenae"
+            }
+          ],
+          "album": {
+            "name": "Bird's Eye",
+            "releaseDate": "2024-08-09"
+          },
+          "durationMs": 213466,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "HfpR4tAmI7E",
+            "audioConfidence": 100,
+            "videoId": "cswfR85D7jM",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCN8pGtbprga7vJL5B4dhXrg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020e62daaea2c7b94053e1c142"
+        },
+        {
+          "position": 44,
+          "id": "levyra-7eaa50f4c76de07703f9",
+          "title": "Kalter Krieg",
+          "artists": [
+            {
+              "name": "Pashanim"
+            }
+          ],
+          "album": {
+            "name": "Lounge Musik",
+            "releaseDate": "2026-07-23"
+          },
+          "durationMs": 96750,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f3a40de140573a3d70b6eaf4"
+        },
+        {
+          "position": 45,
+          "id": "levyra-d204a7b2d9793051d53c",
+          "title": "Unwritten",
+          "artists": [
+            {
+              "name": "Natasha Bedingfield"
+            }
+          ],
+          "album": {
+            "name": "Unwritten",
+            "releaseDate": "2004-08-30"
+          },
+          "durationMs": 259333,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "iKejQrGq04w",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCYDsQPS-uLOz3DPhNOvkMQA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b337e1ca6629a53c66a3b0d4"
+        },
+        {
+          "position": 46,
+          "id": "levyra-991117f52429e132807b",
+          "title": "Magnetic",
+          "artists": [
+            {
+              "name": "The Bausa"
+            }
+          ],
+          "album": {
+            "name": "Magnetic / Addicted To Your Love",
+            "releaseDate": "2026-02-27"
+          },
+          "durationMs": 181384,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02158cbe80b9b9573b46d2b50f"
+        },
+        {
+          "position": 47,
+          "id": "levyra-8a81bdd04c29850082c7",
+          "title": "No Broke Boys",
+          "artists": [
+            {
+              "name": "Disco Lines"
+            },
+            {
+              "name": "Tinashe"
+            }
+          ],
+          "album": {
+            "name": "No Broke Boys",
+            "releaseDate": "2025-06-06"
+          },
+          "durationMs": 163994,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "l6Fx2nyU52w",
+            "audioConfidence": 100,
+            "videoId": "SenovvZlWIA",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCfP0uWE3TV2B-jGAcEaIN3A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02699b0363dda94e1f1e32eef5"
+        },
+        {
+          "position": 48,
+          "id": "levyra-0ccb64868625783f0662",
+          "title": "On The Floor",
+          "artists": [
+            {
+              "name": "Jennifer Lopez"
+            },
+            {
+              "name": "Pitbull"
+            }
+          ],
+          "album": {
+            "name": "Love?",
+            "releaseDate": "2011-04-29"
+          },
+          "durationMs": 284866,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d7b2aa3834b82b1cbe899a48"
+        },
+        {
+          "position": 49,
+          "id": "levyra-3aeae2ff072611e5ba00",
+          "title": "(When You Gonna) Give It Up to Me - Radio Version",
+          "artists": [
+            {
+              "name": "Sean Paul"
+            },
+            {
+              "name": "Keyshia Cole"
+            }
+          ],
+          "album": {
+            "name": "(When You Gonna) Give It Up to Me",
+            "releaseDate": "2006-06-20"
+          },
+          "durationMs": 243880,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "aUajNfZwkjY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCnCNNA05VZcH8wVJYtC-6ew"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a539563b3d77bd3ba17d016e"
+        },
+        {
+          "position": 50,
+          "id": "levyra-d5d19a1705964eca30c4",
+          "title": "bloodstream",
+          "artists": [
+            {
+              "name": "Alyssa Grace"
+            }
+          ],
+          "album": {
+            "name": "bloodstream",
+            "releaseDate": "2026-06-04"
+          },
+          "durationMs": 177428,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "CLSuAhT71yU",
+            "audioConfidence": 100,
+            "videoId": "FOJ4A4wixDg",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCXi-L3_hX9d3TdX5_wO-EJw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029c031feeff1647deb7577309"
+        }
+      ]
+    },
+    {
+      "id": "top-50-br",
+      "kind": "chart",
+      "market": "BR",
+      "title": "Top 50 Brasil",
+      "description": "Brasile: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-4fa9b5719ea4ddfa2915",
+          "title": "Cuida do Pet",
+          "artists": [
+            {
+              "name": "Oldilla"
+            },
+            {
+              "name": "Mc Iguinho Ct"
+            },
+            {
+              "name": "MC Willian"
+            },
+            {
+              "name": "Aaron Modesto"
+            },
+            {
+              "name": "Mc Negão Original"
+            },
+            {
+              "name": "DU'L"
+            },
+            {
+              "name": "Dj Aladin GDB"
+            }
+          ],
+          "album": {
+            "name": "Cuida do Pet",
+            "releaseDate": "2026-05-29"
+          },
+          "durationMs": 459212,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02abee4fe3c7900628e21a07d5"
+        },
+        {
+          "position": 2,
+          "id": "levyra-1e933ee45ca9ce631097",
+          "title": "Pau Pra Toda Obra",
+          "artists": [
+            {
+              "name": "Mc Jacaré"
+            },
+            {
+              "name": "MC Ryan SP"
+            },
+            {
+              "name": "Mc Lele JP"
+            },
+            {
+              "name": "Mc IG"
+            }
+          ],
+          "album": {
+            "name": "Pau Pra Toda Obra",
+            "releaseDate": "2026-06-19"
+          },
+          "durationMs": 228923,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "PfGj0RD-FQA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCAh2ywh0FAGXyWElhG6U1pQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e2e1ee4b54f545c7835d820e"
+        },
+        {
+          "position": 3,
+          "id": "levyra-136c11b757d477f178e2",
+          "title": "Peão Todo Tatuado",
+          "artists": [
+            {
+              "name": "Jeninho"
+            },
+            {
+              "name": "Mariana Fagundes"
+            }
+          ],
+          "album": {
+            "name": "Peão Todo Tatuado",
+            "releaseDate": "2026-03-06"
+          },
+          "durationMs": 133563,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "9eWo9z6zUi0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC9-9vwb1adgdq2VlZfXVeGw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024b475e7b048541cd6fcc3bdc"
+        },
+        {
+          "position": 4,
+          "id": "levyra-24f504d77bdd662b7d6c",
+          "title": "Cadeira Cativa - Ao Vivo",
+          "artists": [
+            {
+              "name": "Zé Neto & Cristiano"
+            }
+          ],
+          "album": {
+            "name": "Vocês & Deus, Vol. 1 (Ao Vivo no Rio de Janeiro)",
+            "releaseDate": "2026-04-07"
+          },
+          "durationMs": 160613,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "KTy17rny7vI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCm6Kk_E9qUcPEEAiwsOzzXQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cd6a20fcede386d2d3de6f91"
+        },
+        {
+          "position": 5,
+          "id": "levyra-95b606e7fdbc236982bc",
+          "title": "Famoso Ímã | O poderoso chatão",
+          "artists": [
+            {
+              "name": "Mc Lele JP"
+            },
+            {
+              "name": "Mc Poze do Rodo"
+            },
+            {
+              "name": "MC Leozinho ZS"
+            },
+            {
+              "name": "DJ GORDINHO DA VF"
+            }
+          ],
+          "album": {
+            "name": "Famoso Ímã | O poderoso chatão",
+            "releaseDate": "2026-02-18"
+          },
+          "durationMs": 217845,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "PGIwjNths6Q",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC8KRgfQSHjW40E0Y3DUKvYA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021381f350c5f7f620ee69a622"
+        },
+        {
+          "position": 6,
+          "id": "levyra-a8f6ac64da0f325c2abe",
+          "title": "Diário de um Cafajeste",
+          "artists": [
+            {
+              "name": "DJ Oreia"
+            },
+            {
+              "name": "Mc Lele JP"
+            },
+            {
+              "name": "MC Meno K"
+            },
+            {
+              "name": "MC Ryan SP"
+            },
+            {
+              "name": "MC Tuto"
+            },
+            {
+              "name": "Mc Negão Original"
+            }
+          ],
+          "album": {
+            "name": "Diário de um Cafajeste",
+            "releaseDate": "2025-11-06"
+          },
+          "durationMs": 357120,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0251b22c9a616f49cb2e881f45"
+        },
+        {
+          "position": 7,
+          "id": "levyra-9003f3f0dff2808f1bf2",
+          "title": "Eu Te Seguro - Ao Vivo",
+          "artists": [
+            {
+              "name": "Panda"
+            },
+            {
+              "name": "MJ Records"
+            }
+          ],
+          "album": {
+            "name": "Panda Sem Moderação 2, Vol.3",
+            "releaseDate": "2025-10-23"
+          },
+          "durationMs": 148561,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "JsvOjB_bSlo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCm_-Z3AAyEEAciecu61h8XA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ae0147d756dbb8f2f90d1d28"
+        },
+        {
+          "position": 8,
+          "id": "levyra-73ba6aeebd6aada1224b",
+          "title": "Menos Foco Mais Ansiedade (Ce Ta Nervosa)",
+          "artists": [
+            {
+              "name": "dj andreoli"
+            },
+            {
+              "name": "Mc Jacaré"
+            },
+            {
+              "name": "MC Ryan SP"
+            },
+            {
+              "name": "ZANOLINI"
+            },
+            {
+              "name": "Mc Lele JP"
+            },
+            {
+              "name": "MC LUUKY"
+            }
+          ],
+          "album": {
+            "name": "Menos Foco Mais Ansiedade (Ce Ta Nervosa)",
+            "releaseDate": "2026-05-28"
+          },
+          "durationMs": 234461,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b62a952841dd3828c821eddc"
+        },
+        {
+          "position": 9,
+          "id": "levyra-bbc6649bc4b9bcb84fdf",
+          "title": "Mente Barulhenta",
+          "artists": [
+            {
+              "name": "Mc IG"
+            },
+            {
+              "name": "Mc Lele JP"
+            },
+            {
+              "name": "DJ Oreia"
+            },
+            {
+              "name": "DJ Noiskita"
+            }
+          ],
+          "album": {
+            "name": "Quem Tá Vivo, Tá Vivendo",
+            "releaseDate": "2026-03-26"
+          },
+          "durationMs": 215433,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "DKfSkkIU3po",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCy8mM-ay_amwlPoX2Vc6dBA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025cc64d4066cf6ce2ad924cdc"
+        },
+        {
+          "position": 10,
+          "id": "levyra-ffb3d5f376de532cd712",
+          "title": "Carnívoro",
+          "artists": [
+            {
+              "name": "Mc Jacaré"
+            },
+            {
+              "name": "Mc Lele JP"
+            },
+            {
+              "name": "Mc Negão Original"
+            },
+            {
+              "name": "DJ Japa NK"
+            }
+          ],
+          "album": {
+            "name": "Carnívoro",
+            "releaseDate": "2026-02-13"
+          },
+          "durationMs": 216000,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "7_cLuhd7BPo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCAh2ywh0FAGXyWElhG6U1pQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025c67607fd2c208c66670703e"
+        },
+        {
+          "position": 11,
+          "id": "levyra-2e889c575e24cd373c78",
+          "title": "Reliquia do 2T",
+          "artists": [
+            {
+              "name": "DJ Gu"
+            },
+            {
+              "name": "MC Vine7"
+            },
+            {
+              "name": "MC Tuto"
+            },
+            {
+              "name": "MC Joãozinho VT"
+            },
+            {
+              "name": "Mc Dkziin"
+            },
+            {
+              "name": "MC Fr da Norte"
+            }
+          ],
+          "album": {
+            "name": "Reliquia do 2T",
+            "releaseDate": "2026-02-06"
+          },
+          "durationMs": 306000,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02602f97feddd13e75029f2b8f"
+        },
+        {
+          "position": 12,
+          "id": "levyra-3dad9954ee3ac827913b",
+          "title": "Pra Não Esquecer De Mim",
+          "artists": [
+            {
+              "name": "Aaron Modesto"
+            },
+            {
+              "name": "Mc Magal"
+            },
+            {
+              "name": "MC Meno K"
+            },
+            {
+              "name": "DJ Glenner"
+            }
+          ],
+          "album": {
+            "name": "Pra Não Esquecer De Mim",
+            "releaseDate": "2025-11-10"
+          },
+          "durationMs": 192755,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "E9eySJTXFm0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCAkUdG6M3gCi0SC87c0lU4g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0206ccbb3936e4801c05d5973b"
+        },
+        {
+          "position": 13,
+          "id": "levyra-45bb98a2bf5dfd9464c7",
+          "title": "Só Com Ela - Ao Vivo",
+          "artists": [
+            {
+              "name": "Murilo Huff"
+            },
+            {
+              "name": "Matheus Fernandes"
+            }
+          ],
+          "album": {
+            "name": "Só Com Ela (Ao Vivo)",
+            "releaseDate": "2026-06-18"
+          },
+          "durationMs": 168916,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7tW72qU5QoE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC-g0dJZGCPLIb7yoFndqmRA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0287097bdf05ba8614d414d85d"
+        },
+        {
+          "position": 14,
+          "id": "levyra-a71478aab5692ab9a19a",
+          "title": "Saudade Estranha - Du Nada - Ao Vivo",
+          "artists": [
+            {
+              "name": "Murilo Huff"
+            }
+          ],
+          "album": {
+            "name": "Saudade Estranha - Du Nada (Ao Vivo)",
+            "releaseDate": "2026-02-26"
+          },
+          "durationMs": 174794,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "smIegl1_YNU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC-g0dJZGCPLIb7yoFndqmRA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ec2ae25af833a1475ec4a7dd"
+        },
+        {
+          "position": 15,
+          "id": "levyra-627dc5af59fce79f38d1",
+          "title": "Beatriz",
+          "artists": [
+            {
+              "name": "2ZDinizz"
+            },
+            {
+              "name": "Leborato"
+            },
+            {
+              "name": "HHR"
+            }
+          ],
+          "album": {
+            "name": "Beatriz",
+            "releaseDate": "2025-07-15"
+          },
+          "durationMs": 247980,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qcbrCmIt7ww",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCcqoWPoUhKUKKABMeBMjQew"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f8fc839361eacee6af4af11a"
+        },
+        {
+          "position": 16,
+          "id": "levyra-703d6a4e9de1ed31589e",
+          "title": "Ignora (Ao Vivo)",
+          "artists": [
+            {
+              "name": "Felipe e Rodrigo"
+            }
+          ],
+          "album": {
+            "name": "Velhos Hábitos, Vol. 2 (Ao Vivo)",
+            "releaseDate": "2026-03-26"
+          },
+          "durationMs": 179215,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "1Y3fwC3FIBc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCMoYu0mVhcdW5IyZoWoYNBQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b335fa375ab39cf2bee69850"
+        },
+        {
+          "position": 17,
+          "id": "levyra-f2107acb9c57d999c504",
+          "title": "EXAGERADO",
+          "artists": [
+            {
+              "name": "MC Jvila"
+            },
+            {
+              "name": "MC Meno K"
+            },
+            {
+              "name": "Mc Rodrigo do CN"
+            },
+            {
+              "name": "DJ Glenner"
+            }
+          ],
+          "album": {
+            "name": "EXAGERADO",
+            "releaseDate": "2026-05-20"
+          },
+          "durationMs": 230625,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "fUN0oWDYJiM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCGWmpjdx-geQJATDvn-pimQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0215d9dd558b261f4aaa826c67"
+        },
+        {
+          "position": 18,
+          "id": "levyra-07f19c64808e6faf8a27",
+          "title": "Posso Até Não Te Dar Flores",
+          "artists": [
+            {
+              "name": "DJ Japa NK"
+            },
+            {
+              "name": "MC Meno K"
+            },
+            {
+              "name": "MC Ryan SP"
+            },
+            {
+              "name": "Mc Jacaré"
+            },
+            {
+              "name": "DJ DAVI DOGDOG"
+            }
+          ],
+          "album": {
+            "name": "Posso Até Não Te Dar Flores",
+            "releaseDate": "2025-09-11"
+          },
+          "durationMs": 162461,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "3dgBYJNzACo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC_O348PVKZ9rx_O5qRWgVmQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025ed03182ae8c1215b54c1fca"
+        },
+        {
+          "position": 19,
+          "id": "levyra-c3114004e93348033b3f",
+          "title": "Deixa Eu - Ao Vivo",
+          "artists": [
+            {
+              "name": "Murilo Huff"
+            }
+          ],
+          "album": {
+            "name": "Acústico (Ao Vivo)",
+            "releaseDate": "2025-08-14"
+          },
+          "durationMs": 158470,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "iyYAQygjmmQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC-g0dJZGCPLIb7yoFndqmRA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f678dfce3405c8d2f786b73f"
+        },
+        {
+          "position": 20,
+          "id": "levyra-bd44e24fed921c2ac694",
+          "title": "MTG Pra Ficar Legal",
+          "artists": [
+            {
+              "name": "DJ JZ"
+            },
+            {
+              "name": "Mc Fael Halls"
+            },
+            {
+              "name": "Mc Menor Thalis"
+            }
+          ],
+          "album": {
+            "name": "MTG Pra Ficar Legal",
+            "releaseDate": "2024-06-21"
+          },
+          "durationMs": 141692,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "Xb6zpm3U1NU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCGHj3SD8U_UaQBgTKS5H0jQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b9afc53a8f8897cf8745ba97"
+        },
+        {
+          "position": 21,
+          "id": "levyra-d28e56245021d63c5ad1",
+          "title": "AH, JESUS / CORAÇÃO IGUAL AO TEU",
+          "artists": [
+            {
+              "name": "Julliany Souza"
+            }
+          ],
+          "album": {
+            "name": "AH, JESUS / CORAÇÃO IGUAL AO TEU",
+            "releaseDate": "2026-05-21"
+          },
+          "durationMs": 747625,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "UBcBKjzY6AE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC8s-ceOAJGu1A8PxksQW2Og"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d856de25c19b8d3ab027c17b"
+        },
+        {
+          "position": 22,
+          "id": "levyra-9738c21077e0fc74df2f",
+          "title": "Ta Pedindo Toma",
+          "artists": [
+            {
+              "name": "MC Leozinho ZS"
+            },
+            {
+              "name": "MC Murilo MT"
+            },
+            {
+              "name": "Mc DR"
+            },
+            {
+              "name": "DJ JHOW BEATS"
+            },
+            {
+              "name": "MC RN do Capão"
+            },
+            {
+              "name": "Mc Pelourinho"
+            }
+          ],
+          "album": {
+            "name": "Na Contramão",
+            "releaseDate": "2026-07-28"
+          },
+          "durationMs": 276230,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "PPomNSCT-Hc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCXFN7z6G64pblSpXKhAd_CA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0258cd2ec75d9e36240cad9dce"
+        },
+        {
+          "position": 23,
+          "id": "levyra-68fcfb916bb338f70aa5",
+          "title": "Apaga Apaga Apaga - Ao Vivo",
+          "artists": [
+            {
+              "name": "Danilo e Davi"
+            }
+          ],
+          "album": {
+            "name": "Toma Essa Verdade (Ao Vivo)",
+            "releaseDate": "2024-08-09"
+          },
+          "durationMs": 178882,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020d5f00c853be5debb5eba851"
+        },
+        {
+          "position": 24,
+          "id": "levyra-b9b109db4fd567de0eea",
+          "title": "SWIM",
+          "artists": [
+            {
+              "name": "BTS"
+            }
+          ],
+          "album": {
+            "name": "ARIRANG",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 159007,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qZTVU04UOO4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC9vrvNSL3xcWGSkV86REBSg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dfa17fad7f190c901603270e"
+        },
+        {
+          "position": 25,
+          "id": "levyra-5ba911fa8681c6badf77",
+          "title": "Última Saudade (Ao Vivo)",
+          "artists": [
+            {
+              "name": "Henrique & Juliano"
+            }
+          ],
+          "album": {
+            "name": "Manifesto Musical 2, Vol. 1 (Ao Vivo)",
+            "releaseDate": "2024-12-13"
+          },
+          "durationMs": 150449,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025856830b78bbf4343b930538"
+        },
+        {
+          "position": 26,
+          "id": "levyra-bb3849ec8721d23ef42d",
+          "title": "Dois Enganados",
+          "artists": [
+            {
+              "name": "Murilo Huff"
+            },
+            {
+              "name": "Marília Mendonça"
+            }
+          ],
+          "album": {
+            "name": "Pra Ouvir Tomando Uma, Vol. 1",
+            "releaseDate": "2019-03-29"
+          },
+          "durationMs": 172751,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "F7DEmT2Htf0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC-g0dJZGCPLIb7yoFndqmRA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b6e7e3c36da82692dca0217f"
+        },
+        {
+          "position": 27,
+          "id": "levyra-346e1eb09bbcee858573",
+          "title": "Eu Duvido - Ao Vivo",
+          "artists": [
+            {
+              "name": "Guilherme & Benuto"
+            },
+            {
+              "name": "Panda"
+            }
+          ],
+          "album": {
+            "name": "Deu Rolo No Barretão (Verão) - Vol. 02 [Ao Vivo]",
+            "releaseDate": "2026-05-31"
+          },
+          "durationMs": 170658,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "pXGbTOmEGro",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCEL7LR-LrGBHqIehS5AW4nQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bedb9e39ee45979ce68b8449"
+        },
+        {
+          "position": 28,
+          "id": "levyra-7fb12b153a137e07e11d",
+          "title": "Não Namora - Ao Vivo",
+          "artists": [
+            {
+              "name": "Clayton & Romário"
+            },
+            {
+              "name": "Zé Neto & Cristiano"
+            }
+          ],
+          "album": {
+            "name": "Por Vocês (Vol. 1) [Ao Vivo]",
+            "releaseDate": "2026-04-23"
+          },
+          "durationMs": 135925,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "IkwVK8R0F6g",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC6IT6ReWQ5UrfI5ctUDerSw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02742b54b086099ea6ce724f7a"
+        },
+        {
+          "position": 29,
+          "id": "levyra-f75b024192e1a5078472",
+          "title": "Se Saudade Sentir (Se Prepara 3)",
+          "artists": [
+            {
+              "name": "Mc Livinho"
+            },
+            {
+              "name": "Mc Pedrinho"
+            },
+            {
+              "name": "Perera DJ"
+            },
+            {
+              "name": "DJ JB Mix"
+            }
+          ],
+          "album": {
+            "name": "Se Saudade Sentir (Se Prepara 3)",
+            "releaseDate": "2026-04-09"
+          },
+          "durationMs": 197533,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "LfttzDVsyqQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC1oMv_rIbwb7KavdiN5EWvQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0221abbbb12bdff228230a3a46"
+        },
+        {
+          "position": 30,
+          "id": "levyra-a89e4c85236c16eb9e28",
+          "title": "Irmão da Lua, Amigo das Estrelas",
+          "artists": [
+            {
+              "name": "Zezé Di Camargo & Luciano"
+            }
+          ],
+          "album": {
+            "name": "Zezé Di Camargo & Luciano 2003",
+            "releaseDate": "2003-09-15"
+          },
+          "durationMs": 251840,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/d77cb216a6f1d88a94681c23d4ac315a2363ab3f"
+        },
+        {
+          "position": 31,
+          "id": "levyra-04efe6ab46e5908be8dd",
+          "title": "Eu Me Apaixonei",
+          "artists": [
+            {
+              "name": "Vitinho Imperador"
+            }
+          ],
+          "album": {
+            "name": "Eu Me Apaixonei",
+            "releaseDate": "2025-02-27"
+          },
+          "durationMs": 205714,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "kTQqY7KeyL8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCkZl9lMzChky8Gh7FyZ0BEg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02781def2b7594a2cd1bf123b7"
+        },
+        {
+          "position": 32,
+          "id": "levyra-98349a571204b2f4073a",
+          "title": "petal",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 184248,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "4mQyEqbaUOU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 33,
+          "id": "levyra-8f52b0013c7f66d45981",
+          "title": "Cheiro De Culpado - Ao Vivo",
+          "artists": [
+            {
+              "name": "Júnior e Cézar"
+            }
+          ],
+          "album": {
+            "name": "Cheiro De Culpado (Ao Vivo)",
+            "releaseDate": "2025-11-06"
+          },
+          "durationMs": 161298,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qz1sSar0drU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCozNPjKvWto-Gz9o5JV395Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022352886a6fab375db431d2a7"
+        },
+        {
+          "position": 34,
+          "id": "levyra-ab359f885346a2055211",
+          "title": "QUANDO EU TOMO GIN DE 10",
+          "artists": [
+            {
+              "name": "Mc Neguinho do Morro"
+            },
+            {
+              "name": "MC NINA"
+            },
+            {
+              "name": "MITOS ENTRETENIMENTO"
+            }
+          ],
+          "album": {
+            "name": "QUANDO EU TOMO GIN DE 10",
+            "releaseDate": "2025-11-16"
+          },
+          "durationMs": 167999,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0293ab595611f716bdb522880b"
+        },
+        {
+          "position": 35,
+          "id": "levyra-25b6360696f10375903f",
+          "title": "Sal Grosso",
+          "artists": [
+            {
+              "name": "Anitta"
+            },
+            {
+              "name": "KBrum"
+            }
+          ],
+          "album": {
+            "name": "EQUILIBRIVM II",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 151596,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "IOhY-JnzVvM",
+            "audioConfidence": 100,
+            "videoId": "AevjWsReCtM",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCI99G32byWj1aH13pbxnTEw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02fc561bc173dc5cf4a08e0ab7"
+        },
+        {
+          "position": 36,
+          "id": "levyra-f6663bc35697e813e41d",
+          "title": "Wonderwall - Remastered",
+          "artists": [
+            {
+              "name": "Oasis"
+            }
+          ],
+          "album": {
+            "name": "(What's The Story) Morning Glory? (Deluxe Remastered Edition)",
+            "releaseDate": "1995"
+          },
+          "durationMs": 258773,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027a4c8c59851c88f6794c3cbf"
+        },
+        {
+          "position": 37,
+          "id": "levyra-6c87ea5d99daddf6c207",
+          "title": "Não Mexe nas Minhas Gavetas - Ao Vivo",
+          "artists": [
+            {
+              "name": "Danilo e Davi"
+            }
+          ],
+          "album": {
+            "name": "Aliança - Vol.1 (Ao Vivo)",
+            "releaseDate": "2026-01-29"
+          },
+          "durationMs": 126043,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "-mR_5UaDwCs",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCffWjqUO0JDOvH_F05qF4JA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b21bebf4df8085accf3bd88c"
+        },
+        {
+          "position": 38,
+          "id": "levyra-a01e8b7672e4be8d62f4",
+          "title": "P do Pecado - Ao Vivo",
+          "artists": [
+            {
+              "name": "Grupo Menos É Mais"
+            },
+            {
+              "name": "Simone Mendes"
+            }
+          ],
+          "album": {
+            "name": "MOLHO (Ao Vivo)",
+            "releaseDate": "2025-10-16"
+          },
+          "durationMs": 192367,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "R73PZgUFTRo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UChn53L2iJ2EY1CGZcO4aV6A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c89ff3434d85f33354c929b8"
+        },
+        {
+          "position": 39,
+          "id": "levyra-50bf5b1402e5b5096b7b",
+          "title": "ME POSTOU NO DAILY - FESTA DO BIG G",
+          "artists": [
+            {
+              "name": "MC GP"
+            },
+            {
+              "name": "Mc Lele JP"
+            },
+            {
+              "name": "DJ DAVI DOGDOG"
+            },
+            {
+              "name": "Dj Andrabeat"
+            }
+          ],
+          "album": {
+            "name": "MIXTAPE - BIG G",
+            "releaseDate": "2025-11-27"
+          },
+          "durationMs": 177230,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "jfwmSNLIqZk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCkTjtrL8umgzSwlafw6kRRg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029977a75e107f54d30e904177"
+        },
+        {
+          "position": 40,
+          "id": "levyra-5a7e93a5af75b9d80e1e",
+          "title": "Amo Minha Favela",
+          "artists": [
+            {
+              "name": "DJ Japa NK"
+            },
+            {
+              "name": "MC Meno K"
+            }
+          ],
+          "album": {
+            "name": "Amo Minha Favela",
+            "releaseDate": "2025-12-11"
+          },
+          "durationMs": 119538,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "hIFMdoi2jjM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC_O348PVKZ9rx_O5qRWgVmQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02876c7d6a4e1d999d2660dca8"
+        },
+        {
+          "position": 41,
+          "id": "levyra-543ba1b8992edd4ad980",
+          "title": "Bebe, Beija e Trai - Ao Vivo",
+          "artists": [
+            {
+              "name": "Mayke & Rodrigo"
+            },
+            {
+              "name": "Panda"
+            }
+          ],
+          "album": {
+            "name": "Bebe, Beija e Trai (Ao Vivo)",
+            "releaseDate": "2025-10-30"
+          },
+          "durationMs": 156536,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "d8GVIxbroc4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCvEjtos3SobkZOpSlBm-MPw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027123a50231e233b0e169450e"
+        },
+        {
+          "position": 42,
+          "id": "levyra-9f7f7ed97ef04e3a1b78",
+          "title": "Foi por Conveniência",
+          "artists": [
+            {
+              "name": "Marília Mendonça"
+            }
+          ],
+          "album": {
+            "name": "Foi por Conveniência",
+            "releaseDate": "2021-01-15"
+          },
+          "durationMs": 205586,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "F1Z2FhSNGb0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCj14PDgkcQQMz6v-g2eruBA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cbdde8a138debae4178aaaa4"
+        },
+        {
+          "position": 43,
+          "id": "levyra-a20415d50f537c91e3da",
+          "title": "Dois Gumes (Ao Vivo)",
+          "artists": [
+            {
+              "name": "Felipe e Rodrigo"
+            }
+          ],
+          "album": {
+            "name": "Velhos Hábitos, Vol. 2 (Ao Vivo)",
+            "releaseDate": "2026-03-26"
+          },
+          "durationMs": 191154,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "DD5hYLCzYf4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCMoYu0mVhcdW5IyZoWoYNBQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b335fa375ab39cf2bee69850"
+        },
+        {
+          "position": 44,
+          "id": "levyra-ee310ab5c68f575e23b0",
+          "title": "Tubarões - Ao Vivo",
+          "artists": [
+            {
+              "name": "Diego & Victor Hugo"
+            },
+            {
+              "name": "Diego"
+            },
+            {
+              "name": "Victor Hugo"
+            }
+          ],
+          "album": {
+            "name": "Ao Vivo Em Uberlândia",
+            "releaseDate": "2025-11-20"
+          },
+          "durationMs": 162580,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "amINFibEf7o",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCE705eB9XX_25xG_iOnImUg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d8ee93255a158269d92b0bf7"
+        },
+        {
+          "position": 45,
+          "id": "levyra-93683240d111e7825d3f",
+          "title": "hate that i made you love me",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 197949,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7CUz7Ec7cWc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 46,
+          "id": "levyra-b59b24b815c34e1c4d55",
+          "title": "Displicente - Ao Vivo",
+          "artists": [
+            {
+              "name": "Wesley Safadão"
+            },
+            {
+              "name": "Rey Vaqueiro"
+            }
+          ],
+          "album": {
+            "name": "Meu Forró É Mundo (Ao Vivo)",
+            "releaseDate": "2026-04-24"
+          },
+          "durationMs": 158589,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "yzWjW2sNQGw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UClG_7_PRAIW6VeGCbeA2U0w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c9ff322ca67960c0ab70d1dd"
+        },
+        {
+          "position": 47,
+          "id": "levyra-5989231cbeb98f550c2d",
+          "title": "Me Fala Qual Necessidade - Ao Vivo",
+          "artists": [
+            {
+              "name": "Henry Freitas"
+            }
+          ],
+          "album": {
+            "name": "Paralelos (Ao Vivo)",
+            "releaseDate": "2026-03-19"
+          },
+          "durationMs": 148195,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lUzvUUO1PVY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCDO4ladjMI7l_sX-cS6P0mQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023827f71bd45d25aebd22d335"
+        },
+        {
+          "position": 48,
+          "id": "levyra-c1eda19f5d626dd4e21c",
+          "title": "Quem É Esse? - Ao Vivo",
+          "artists": [
+            {
+              "name": "Julliany Souza"
+            }
+          ],
+          "album": {
+            "name": "A Maior Honra (Ao Vivo)",
+            "releaseDate": "2025-05-27"
+          },
+          "durationMs": 468953,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "3nq4oo7W74I",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC8s-ceOAJGu1A8PxksQW2Og"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e6a840b4d13f30e3e8e1c9b9"
+        },
+        {
+          "position": 49,
+          "id": "levyra-a988e8e8b81fdcd03d49",
+          "title": "Ele Ou Eu",
+          "artists": [
+            {
+              "name": "Léo Santana"
+            },
+            {
+              "name": "Pablo"
+            }
+          ],
+          "album": {
+            "name": "Ele Ou Eu",
+            "releaseDate": "2026-05-27"
+          },
+          "durationMs": 204351,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b1ced1a6b8fd0216f61c2ebe"
+        },
+        {
+          "position": 50,
+          "id": "levyra-7a069799532f8a892182",
+          "title": "Que Se Foda é Tudo Puta",
+          "artists": [
+            {
+              "name": "MC MN"
+            },
+            {
+              "name": "DJ Felipe Original"
+            },
+            {
+              "name": "Club Marconex Records"
+            },
+            {
+              "name": "Tropa da W&S"
+            }
+          ],
+          "album": {
+            "name": "Que Se Foda é Tudo Puta",
+            "releaseDate": "2026-05-08"
+          },
+          "durationMs": 168000,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028f0b78002d0586f329a48258"
+        }
+      ]
+    },
+    {
+      "id": "top-50-mx",
+      "kind": "chart",
+      "market": "MX",
+      "title": "Top 50 México",
+      "description": "Messico: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-c7bd886150a7e1c12387",
+          "title": "Nalguita y Teta",
+          "artists": [
+            {
+              "name": "Neton Vega"
+            }
+          ],
+          "album": {
+            "name": "Nalguita y Teta",
+            "releaseDate": "2026-03-27"
+          },
+          "durationMs": 187764,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "DAXXRuW5-mM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCHqMn3yv_kft6-kpbiMgDoA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026b0c57d574fae5bbb4f3c8de"
+        },
+        {
+          "position": 2,
+          "id": "levyra-c5590404af2d84936f75",
+          "title": "Ayúdame",
+          "artists": [
+            {
+              "name": "LOS DOS DE TAMAULIPAS"
+            }
+          ],
+          "album": {
+            "name": "Expansión",
+            "releaseDate": "2026-04-17"
+          },
+          "durationMs": 161348,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "jro2IZGBvJc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCjDCUfKytMMjrshUQJ30qxg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02aac44d7825750cbdbb8ee972"
+        },
+        {
+          "position": 3,
+          "id": "levyra-1f2b44c06a3566aba6c7",
+          "title": "Todo Lo Fue",
+          "artists": [
+            {
+              "name": "Lenin Ramírez"
+            }
+          ],
+          "album": {
+            "name": "Reinicio",
+            "releaseDate": "2024-05-24"
+          },
+          "durationMs": 192064,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0234fc9cf3365e3e9d5f86ffe3"
+        },
+        {
+          "position": 4,
+          "id": "levyra-a6cd016c8b2c04324ef0",
+          "title": "DEMENCIA",
+          "artists": [
+            {
+              "name": "Junior H"
+            },
+            {
+              "name": "Gael Valenzuela"
+            }
+          ],
+          "album": {
+            "name": "DEPR</3$$ED MFKZ",
+            "releaseDate": "2026-02-12"
+          },
+          "durationMs": 221663,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "QDm1WWheVD0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCwA5HHGsAlpU1UlhwWD52uA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f1b7ee109bd8626cad94f478"
+        },
+        {
+          "position": 5,
+          "id": "levyra-f601bc442a1e706e4ba7",
+          "title": "Polvo Rosita",
+          "artists": [
+            {
+              "name": "Lenin Ramírez"
+            }
+          ],
+          "album": {
+            "name": "Reinicio",
+            "releaseDate": "2024-05-24"
+          },
+          "durationMs": 159786,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0234fc9cf3365e3e9d5f86ffe3"
+        },
+        {
+          "position": 6,
+          "id": "levyra-7389dd9dcb6835feab70",
+          "title": "Pvta Luna",
+          "artists": [
+            {
+              "name": "Neton Vega"
+            }
+          ],
+          "album": {
+            "name": "Pvta Luna",
+            "releaseDate": "2025-09-26"
+          },
+          "durationMs": 198058,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020c3ba1d7cd1468c7e5a2ddda"
+        },
+        {
+          "position": 7,
+          "id": "levyra-3b33f7a664dfb60da9e3",
+          "title": "daño",
+          "artists": [
+            {
+              "name": "Peso Pluma"
+            },
+            {
+              "name": "Tito Double P"
+            }
+          ],
+          "album": {
+            "name": "DINASTÍA",
+            "releaseDate": "2025-12-25"
+          },
+          "durationMs": 197007,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "A0H_z03_6CU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCzmabbKsmXlWnI9N2kKQ4lA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a9e6a250ea86a8f387873ef9"
+        },
+        {
+          "position": 8,
+          "id": "levyra-40da58cabedd66144be9",
+          "title": "SUPERESTRELLA",
+          "artists": [
+            {
+              "name": "Aitana"
+            }
+          ],
+          "album": {
+            "name": "CUARTO AZUL",
+            "releaseDate": "2025-05-29"
+          },
+          "durationMs": 183529,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "ElvzE2cPclc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCkyzcFsGWVYSUGaR7YB9OYQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e9c382b5b9b3221428da47c2"
+        },
+        {
+          "position": 9,
+          "id": "levyra-6e9cbc7ca9e31201eabd",
+          "title": "TU SANCHO",
+          "artists": [
+            {
+              "name": "Fuerza Regida"
+            }
+          ],
+          "album": {
+            "name": "111XPANTIA",
+            "releaseDate": "2025-05-02"
+          },
+          "durationMs": 177994,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "a_H0K9W984E",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0kxNxFQCK6d2spPz5Sme7Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a2e90fbdec84b25e46573469"
+        },
+        {
+          "position": 10,
+          "id": "levyra-9790337fc02c5ea89eac",
+          "title": "Te Estoy Correteando",
+          "artists": [
+            {
+              "name": "LATIN MAFIA"
+            },
+            {
+              "name": "Fred again.."
+            }
+          ],
+          "album": {
+            "name": "9 months & 50 hours",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 193637,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "j3POFK8nR5w",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCdZtwhUvPz7akSSIbsG1VJA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023693271d3ed5b2a619c705e1"
+        },
+        {
+          "position": 11,
+          "id": "levyra-8e45340105429717fa16",
+          "title": "Cuando No Era Cantante RMX - Remix",
+          "artists": [
+            {
+              "name": "El Bogueto"
+            },
+            {
+              "name": "Anuel AA"
+            },
+            {
+              "name": "Fuerza Regida"
+            },
+            {
+              "name": "Yung Beef"
+            }
+          ],
+          "album": {
+            "name": "Eso Si Es De Gangster",
+            "releaseDate": "2026-03-25"
+          },
+          "durationMs": 327488,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b80e69903cd8b7cfb16e804"
+        },
+        {
+          "position": 12,
+          "id": "levyra-c26eeff3ae6a6f0ce4bc",
+          "title": "King of Watches",
+          "artists": [
+            {
+              "name": "Omar Camacho"
+            }
+          ],
+          "album": {
+            "name": "Nunca Voy a Morir",
+            "releaseDate": "2026-05-28"
+          },
+          "durationMs": 147200,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "8QlDHUi2Mw4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC5TYeA9Hw3L5VlZYtMt3pqg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0286626ffe26c2d2c68e8956b7"
+        },
+        {
+          "position": 13,
+          "id": "levyra-46414b6c5b19eeaf0f47",
+          "title": "La Formula",
+          "artists": [
+            {
+              "name": "El Rabbanito"
+            }
+          ],
+          "album": {
+            "name": "La Formula",
+            "releaseDate": "2026-06-17"
+          },
+          "durationMs": 158250,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "M8CMm84AUV8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCCiTG_Kx6tGxBNfbA70TVUQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0216bf298000f2e0edd6daa9de"
+        },
+        {
+          "position": 14,
+          "id": "levyra-e51fb7a2a12c97e285e1",
+          "title": "Ya Borracho",
+          "artists": [
+            {
+              "name": "Herencia De Grandes"
+            }
+          ],
+          "album": {
+            "name": "Noches Sin Fin",
+            "releaseDate": "2025-11-07"
+          },
+          "durationMs": 158074,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Bs2z-hQeNlQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCEppfvDmo8wDrh7nZVwfZ1Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02595c866ba8d19bd9dd531bdc"
+        },
+        {
+          "position": 15,
+          "id": "levyra-e9f002eab35b01f9c002",
+          "title": "Marlboro Rojo",
+          "artists": [
+            {
+              "name": "Fuerza Regida"
+            }
+          ],
+          "album": {
+            "name": "111XPANTIA",
+            "releaseDate": "2025-05-02"
+          },
+          "durationMs": 184173,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "1Lso4aJ9PTA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0kxNxFQCK6d2spPz5Sme7Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a2e90fbdec84b25e46573469"
+        },
+        {
+          "position": 16,
+          "id": "levyra-9516b387b501f7a031e0",
+          "title": "Doma",
+          "artists": [
+            {
+              "name": "Jósean Log"
+            }
+          ],
+          "album": {
+            "name": "Háblate de Mí",
+            "releaseDate": "2016-10-14"
+          },
+          "durationMs": 188612,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "1ywXRvrxll4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCRneYa6UK2F3zUP6M820eng"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a8659bf75fee7dc8c01afc67"
+        },
+        {
+          "position": 17,
+          "id": "levyra-b9b109db4fd567de0eea",
+          "title": "SWIM",
+          "artists": [
+            {
+              "name": "BTS"
+            }
+          ],
+          "album": {
+            "name": "ARIRANG",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 159007,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qZTVU04UOO4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC9vrvNSL3xcWGSkV86REBSg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dfa17fad7f190c901603270e"
+        },
+        {
+          "position": 18,
+          "id": "levyra-4d3336a2a95c20065a4d",
+          "title": "2+2",
+          "artists": [
+            {
+              "name": "Omar Camacho"
+            },
+            {
+              "name": "Victor Mendivil"
+            }
+          ],
+          "album": {
+            "name": "Nunca Voy a Morir",
+            "releaseDate": "2026-05-28"
+          },
+          "durationMs": 198300,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0286626ffe26c2d2c68e8956b7"
+        },
+        {
+          "position": 19,
+          "id": "levyra-181f52347c5b05f77940",
+          "title": "El Final De Nuestra Historia",
+          "artists": [
+            {
+              "name": "La Arrolladora Banda El Limón De Rene Camacho"
+            }
+          ],
+          "album": {
+            "name": "Y Que Quede Claro",
+            "releaseDate": "2007"
+          },
+          "durationMs": 195306,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023e9c35bc6427fdc8fbb90596"
+        },
+        {
+          "position": 20,
+          "id": "levyra-1e7bed11dfc6e09365f6",
+          "title": "El Fin del Mundo",
+          "artists": [
+            {
+              "name": "La La Love You"
+            },
+            {
+              "name": "Axolotes Mexicanos"
+            }
+          ],
+          "album": {
+            "name": "La la Love You Bonus",
+            "releaseDate": "2020-12-11"
+          },
+          "durationMs": 188093,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029b4f15da533537034a532591"
+        },
+        {
+          "position": 21,
+          "id": "levyra-4a335b2a3e0d73a7694f",
+          "title": "Me Rehúso",
+          "artists": [
+            {
+              "name": "Danny Ocean"
+            }
+          ],
+          "album": {
+            "name": "54+1",
+            "releaseDate": "2019-03-22"
+          },
+          "durationMs": 205714,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d8243a13e6f41310a5fa7b96"
+        },
+        {
+          "position": 22,
+          "id": "levyra-98281c4429df376cc70f",
+          "title": "Amor",
+          "artists": [
+            {
+              "name": "Emmanuel Cortes"
+            }
+          ],
+          "album": {
+            "name": "Memorias <3",
+            "releaseDate": "2023-07-28"
+          },
+          "durationMs": 199877,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "2C29r956v40",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCZHTMrelln_9zSM_dK_btCA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c6c1db32c9b68f4659795763"
+        },
+        {
+          "position": 23,
+          "id": "levyra-642d92fdcda957e8d8f7",
+          "title": "Gané",
+          "artists": [
+            {
+              "name": "Victor Mendivil"
+            },
+            {
+              "name": "Gabito Ballesteros"
+            }
+          ],
+          "album": {
+            "name": "Gané",
+            "releaseDate": "2026-06-10"
+          },
+          "durationMs": 260949,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f77053feae61e71a2309c513"
+        },
+        {
+          "position": 24,
+          "id": "levyra-af2acdd58d32a3f83df2",
+          "title": "Y LLORO",
+          "artists": [
+            {
+              "name": "Junior H"
+            }
+          ],
+          "album": {
+            "name": "$AD BOYZ 4 LIFE II",
+            "releaseDate": "2023-10-05"
+          },
+          "durationMs": 179013,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "m4Sc3cL53q0",
+            "audioConfidence": 100,
+            "videoId": "a8M1Es4cI_4",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCwA5HHGsAlpU1UlhwWD52uA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ef88ad49166e31598ff7d4d0"
+        },
+        {
+          "position": 25,
+          "id": "levyra-d2be9dccc35753c74e0c",
+          "title": "ME VALE V",
+          "artists": [
+            {
+              "name": "Tito Double P"
+            }
+          ],
+          "album": {
+            "name": "ACOMODO",
+            "releaseDate": "2026-05-28"
+          },
+          "durationMs": 186221,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "4IYsSKH7uCE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCATfo9SAdXImyc6ygfbzJBg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028cd8ee17cdc2cabc79d172b3"
+        },
+        {
+          "position": 26,
+          "id": "levyra-7c674956e5959ddc522b",
+          "title": "Que Nadie Sepa",
+          "artists": [
+            {
+              "name": "Cardenales De Nuevo León"
+            }
+          ],
+          "album": {
+            "name": "Que Nadie Sepa",
+            "releaseDate": "2021-04-01"
+          },
+          "durationMs": 211400,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dcc011325105a20e4719cf45"
+        },
+        {
+          "position": 27,
+          "id": "levyra-5170105dd79d6aa171b7",
+          "title": "Tus Mentiras (En Vivo)",
+          "artists": [
+            {
+              "name": "Moy Bobadilla"
+            }
+          ],
+          "album": {
+            "name": "Arriba La Moyombiza (En Vivo)",
+            "releaseDate": "2025-04-10"
+          },
+          "durationMs": 280250,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "BTtkaO1ZNI8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCYnqH5bAoV8XsBFFp3oEkSg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029a85e447c96bb43c859dff92"
+        },
+        {
+          "position": 28,
+          "id": "levyra-24e86334f827cea17b60",
+          "title": "caperuza",
+          "artists": [
+            {
+              "name": "Fuerza Regida"
+            }
+          ],
+          "album": {
+            "name": "111XPANTIA",
+            "releaseDate": "2025-05-02"
+          },
+          "durationMs": 179317,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "iTJO-eGyEOo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0kxNxFQCK6d2spPz5Sme7Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a2e90fbdec84b25e46573469"
+        },
+        {
+          "position": 29,
+          "id": "levyra-915da17442548d2f549f",
+          "title": "Oye Mi Amor",
+          "artists": [
+            {
+              "name": "Maná"
+            }
+          ],
+          "album": {
+            "name": "¿Dónde Jugarán Los Niños?",
+            "releaseDate": "1992"
+          },
+          "durationMs": 263306,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "OhXeBoTlCr4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCtSeeqnGJM5ngqJWZ1vQygw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0263f3b7f5abf86ad483b57b77"
+        },
+        {
+          "position": 30,
+          "id": "levyra-acd96ee4ef14619b2c94",
+          "title": "COQUETA",
+          "artists": [
+            {
+              "name": "Fuerza Regida"
+            },
+            {
+              "name": "Grupo Frontera"
+            }
+          ],
+          "album": {
+            "name": "MALA MÍA",
+            "releaseDate": "2024-12-19"
+          },
+          "durationMs": 241648,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0204874856f3c501181d060128"
+        },
+        {
+          "position": 31,
+          "id": "levyra-8e1a387c37495cd4d34b",
+          "title": "MATCHA",
+          "artists": [
+            {
+              "name": "Los Dareyes De La Sierra"
+            }
+          ],
+          "album": {
+            "name": "SABIA",
+            "releaseDate": "2026-04-16"
+          },
+          "durationMs": 156517,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023bc78f16328cc9ebef1b4010"
+        },
+        {
+          "position": 32,
+          "id": "levyra-fb3e643e34d46f866038",
+          "title": "QUE ONDA",
+          "artists": [
+            {
+              "name": "Calle 24"
+            },
+            {
+              "name": "Chino Pacas"
+            },
+            {
+              "name": "Fuerza Regida"
+            }
+          ],
+          "album": {
+            "name": "ONDEADO$",
+            "releaseDate": "2024-12-12"
+          },
+          "durationMs": 191703,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029068bf12aece9d168cc16848"
+        },
+        {
+          "position": 33,
+          "id": "levyra-bb945bbebcb2844bf2db",
+          "title": "Cuando No Era Cantante",
+          "artists": [
+            {
+              "name": "El Bogueto"
+            },
+            {
+              "name": "Yung Beef"
+            }
+          ],
+          "album": {
+            "name": "No Hay Loco Que No Corone",
+            "releaseDate": "2024-09-26"
+          },
+          "durationMs": 211084,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02842ff43668299304d6f021b2"
+        },
+        {
+          "position": 34,
+          "id": "levyra-ddd297a050391ef8161a",
+          "title": "tu con el",
+          "artists": [
+            {
+              "name": "Peso Pluma"
+            },
+            {
+              "name": "Tito Double P"
+            }
+          ],
+          "album": {
+            "name": "DINASTÍA",
+            "releaseDate": "2025-12-25"
+          },
+          "durationMs": 165682,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "b9yO-ktErU8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCzmabbKsmXlWnI9N2kKQ4lA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a9e6a250ea86a8f387873ef9"
+        },
+        {
+          "position": 35,
+          "id": "levyra-3671ff36f59bd1ddbd3d",
+          "title": "EL AMOR DE SU VIDA",
+          "artists": [
+            {
+              "name": "Grupo Frontera"
+            },
+            {
+              "name": "Grupo Firme"
+            }
+          ],
+          "album": {
+            "name": "El Comienzo",
+            "releaseDate": "2023-08-25"
+          },
+          "durationMs": 165848,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Qa4l4eLxb3Q",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCJa2FF4TUB13Mm0GurZAqog"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0285970fcddb682441dfa7bcf7"
+        },
+        {
+          "position": 36,
+          "id": "levyra-2fd47c2af3f9075ef393",
+          "title": "Perlas Negras",
+          "artists": [
+            {
+              "name": "Natanael Cano"
+            },
+            {
+              "name": "Gabito Ballesteros"
+            }
+          ],
+          "album": {
+            "name": "Porque La Demora",
+            "releaseDate": "2025-07-01"
+          },
+          "durationMs": 203357,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "jam_15pt_KY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC47k7qXysCBKeaYfc1zmkIA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b60ef80c5a8a3b25dd6bea6e"
+        },
+        {
+          "position": 37,
+          "id": "levyra-92a120460e0210859bbc",
+          "title": "EXCESOS",
+          "artists": [
+            {
+              "name": "Fuerza Regida"
+            }
+          ],
+          "album": {
+            "name": "Pa las Baby's Y Belikeada",
+            "releaseDate": "2023-10-20"
+          },
+          "durationMs": 187076,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "sVjHj0izNBk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0kxNxFQCK6d2spPz5Sme7Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ad57982065339f7dc2058efe"
+        },
+        {
+          "position": 38,
+          "id": "levyra-272d0f090516c89d634f",
+          "title": "dopamina",
+          "artists": [
+            {
+              "name": "Peso Pluma"
+            },
+            {
+              "name": "Tito Double P"
+            }
+          ],
+          "album": {
+            "name": "DINASTÍA",
+            "releaseDate": "2025-12-25"
+          },
+          "durationMs": 185326,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "vlNZYjhlY6I",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCzmabbKsmXlWnI9N2kKQ4lA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a9e6a250ea86a8f387873ef9"
+        },
+        {
+          "position": 39,
+          "id": "levyra-950573eaa565ac71353a",
+          "title": "EoO",
+          "artists": [
+            {
+              "name": "Bad Bunny"
+            }
+          ],
+          "album": {
+            "name": "DeBÍ TiRAR MáS FOToS",
+            "releaseDate": "2025-01-05"
+          },
+          "durationMs": 204768,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "JYekRpqL4O8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCiY3z8HAGD6BlSNKVn2kSvQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bbd45c8d36e0e045ef640411"
+        },
+        {
+          "position": 40,
+          "id": "levyra-ae18c168628147b1ee71",
+          "title": "MIENTRAS DUERMES",
+          "artists": [
+            {
+              "name": "Junior H"
+            }
+          ],
+          "album": {
+            "name": "$AD BOYZ 4 LIFE II",
+            "releaseDate": "2023-10-05"
+          },
+          "durationMs": 226035,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "AR9R8_Gzm8Y",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCwA5HHGsAlpU1UlhwWD52uA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ef88ad49166e31598ff7d4d0"
+        },
+        {
+          "position": 41,
+          "id": "levyra-3c65d0d90be4f7b4b47e",
+          "title": "FREESTYLE",
+          "artists": [
+            {
+              "name": "Hermanos Espinoza"
+            }
+          ],
+          "album": {
+            "name": "LINAJE",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 336026,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "q9WBFGS7Pf0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCFKk52XodaYhh_va8y0aOKw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0220a58a53b935b2942e8629a2"
+        },
+        {
+          "position": 42,
+          "id": "levyra-cbdd660154de0e72a342",
+          "title": "4x4",
+          "artists": [
+            {
+              "name": "Omar Camacho"
+            },
+            {
+              "name": "Victor Mendivil"
+            },
+            {
+              "name": "Angel Almaguer"
+            },
+            {
+              "name": "$HUPE"
+            }
+          ],
+          "album": {
+            "name": "Nunca Voy a Morir",
+            "releaseDate": "2026-05-28"
+          },
+          "durationMs": 288671,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "dAuGZo5b850",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC5TYeA9Hw3L5VlZYtMt3pqg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0286626ffe26c2d2c68e8956b7"
+        },
+        {
+          "position": 43,
+          "id": "levyra-c960dcf28ae7b61ccc59",
+          "title": "POR SUS BESOS",
+          "artists": [
+            {
+              "name": "Tito Double P"
+            }
+          ],
+          "album": {
+            "name": "ACOMODO",
+            "releaseDate": "2026-05-28"
+          },
+          "durationMs": 186142,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "ScgXrU_LHXg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCATfo9SAdXImyc6ygfbzJBg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028cd8ee17cdc2cabc79d172b3"
+        },
+        {
+          "position": 44,
+          "id": "levyra-aa3c0d8c32099095fd9e",
+          "title": "PUES YA NI PEDO",
+          "artists": [
+            {
+              "name": "Chuyin"
+            },
+            {
+              "name": "Fuerza Regida"
+            }
+          ],
+          "album": {
+            "name": "Los Locos Nunca Mueren",
+            "releaseDate": "2026-05-07"
+          },
+          "durationMs": 201033,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028f18cf2affad9a759d489200"
+        },
+        {
+          "position": 45,
+          "id": "levyra-140f413e7951103928e8",
+          "title": "BAILE INoLVIDABLE",
+          "artists": [
+            {
+              "name": "Bad Bunny"
+            }
+          ],
+          "album": {
+            "name": "DeBÍ TiRAR MáS FOToS",
+            "releaseDate": "2025-01-05"
+          },
+          "durationMs": 367725,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "JseJETvMtHY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCiY3z8HAGD6BlSNKVn2kSvQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bbd45c8d36e0e045ef640411"
+        },
+        {
+          "position": 46,
+          "id": "levyra-7ce556c5950dd7345d9c",
+          "title": "Tu Boda",
+          "artists": [
+            {
+              "name": "Oscar Maydon"
+            },
+            {
+              "name": "Fuerza Regida"
+            }
+          ],
+          "album": {
+            "name": "Rico o Muerto, Vol. 1",
+            "releaseDate": "2025-06-06"
+          },
+          "durationMs": 225880,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "sD9UX5_GiUc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCxTyOt1nVVexDlQub6kvvNQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020697c8807331635b1ca25e84"
+        },
+        {
+          "position": 47,
+          "id": "levyra-988d73e316b9b84b11b2",
+          "title": "chiclona",
+          "artists": [
+            {
+              "name": "Peso Pluma"
+            },
+            {
+              "name": "Tito Double P"
+            },
+            {
+              "name": "LENCHO"
+            }
+          ],
+          "album": {
+            "name": "DINASTÍA (DELUXE)",
+            "releaseDate": "2026-02-26"
+          },
+          "durationMs": 161620,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028ff0dc6e03af2b4b83e9e274"
+        },
+        {
+          "position": 48,
+          "id": "levyra-890bf9b797904172b8fe",
+          "title": "LAS NOCHES",
+          "artists": [
+            {
+              "name": "Junior H"
+            }
+          ],
+          "album": {
+            "name": "$AD BOYZ 4 LIFE II",
+            "releaseDate": "2023-10-05"
+          },
+          "durationMs": 226298,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "T_D6ah0zpi4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCwA5HHGsAlpU1UlhwWD52uA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ef88ad49166e31598ff7d4d0"
+        },
+        {
+          "position": 49,
+          "id": "levyra-98a22dd6fc9019e304b0",
+          "title": "Recuerdos en Común",
+          "artists": [
+            {
+              "name": "Eden Muñoz"
+            },
+            {
+              "name": "Alfredo Olivas"
+            }
+          ],
+          "album": {
+            "name": "Recuerdos en Común",
+            "releaseDate": "2026-07-23"
+          },
+          "durationMs": 214700,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "QmXr4I0mQI4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCtPkOPsVxV6wG2M2xoIE4hg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0295999ebac3e1eb87a568f9de"
+        },
+        {
+          "position": 50,
+          "id": "levyra-26d7a8d851e0d9b36069",
+          "title": "Tiroteo - Remix",
+          "artists": [
+            {
+              "name": "Marc Seguí"
+            },
+            {
+              "name": "Rauw Alejandro"
+            },
+            {
+              "name": "Pol Granch"
+            }
+          ],
+          "album": {
+            "name": "Tiroteo (Remix)",
+            "releaseDate": "2021-04-01"
+          },
+          "durationMs": 321555,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "v9SJykY5_T8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCOhTWa4ul4v4zT80X6QAQTg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cf206ae0c2100b85d30ab24c"
+        }
+      ]
+    },
+    {
+      "id": "top-50-nl",
+      "kind": "chart",
+      "market": "NL",
+      "title": "Top 50 Nederland",
+      "description": "Paesi Bassi: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-3084e9fd0d3f0c11a548",
+          "title": "Zwoele Zomernachten",
+          "artists": [
+            {
+              "name": "Rutger van Barneveld"
+            }
+          ],
+          "album": {
+            "name": "Zwoele Zomernachten",
+            "releaseDate": "2026-05-21"
+          },
+          "durationMs": 195454,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023efeddc55568b29b14f39885"
+        },
+        {
+          "position": 2,
+          "id": "levyra-4500512f5aa38edfe312",
+          "title": "Dai Dai",
+          "artists": [
+            {
+              "name": "Shakira"
+            },
+            {
+              "name": "Burna Boy"
+            }
+          ],
+          "album": {
+            "name": "Dai Dai",
+            "releaseDate": "2026-05-14"
+          },
+          "durationMs": 223448,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lFQdcPTTzSg",
+            "audioConfidence": 100,
+            "videoId": "fcnDmrtj6Sk",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCo6JijJGA3IvIiPsawDK3Ww"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0203cadf1b3fe324c1dc710ed4"
+        },
+        {
+          "position": 3,
+          "id": "levyra-6ee16aed4a05cfb8c303",
+          "title": "Cheerio",
+          "artists": [
+            {
+              "name": "Justen de Wildt"
+            }
+          ],
+          "album": {
+            "name": "Cheerio",
+            "releaseDate": "2026-02-27"
+          },
+          "durationMs": 148815,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "x0KHdgazJTU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCtyb3BWbcxid1wI2xbihX4Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cb272c86fa2c6cac5119b530"
+        },
+        {
+          "position": 4,
+          "id": "levyra-ef4e58155c9d1e772e30",
+          "title": "Talk To You (ft. 54 Ultra)",
+          "artists": [
+            {
+              "name": "ANOTR"
+            },
+            {
+              "name": "54 Ultra"
+            }
+          ],
+          "album": {
+            "name": "Withness",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 191076,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02aeb168f35ab002d77a4f3918"
+        },
+        {
+          "position": 5,
+          "id": "levyra-25ab46d13ccb61ed505b",
+          "title": "Zonnebank",
+          "artists": [
+            {
+              "name": "Ray & Beer"
+            }
+          ],
+          "album": {
+            "name": "Zonnebank",
+            "releaseDate": "2026-07-17"
+          },
+          "durationMs": 184656,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02604e91ba2a0fb25919a30b80"
+        },
+        {
+          "position": 6,
+          "id": "levyra-833532a3b49da12b42b4",
+          "title": "Jamaican (Bam Bam)",
+          "artists": [
+            {
+              "name": "HUGEL"
+            },
+            {
+              "name": "SOLTO (FR)"
+            }
+          ],
+          "album": {
+            "name": "Jamaican (Bam Bam)",
+            "releaseDate": "2025-11-07"
+          },
+          "durationMs": 156393,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02450a730dd72f3bf49882ae9d"
+        },
+        {
+          "position": 7,
+          "id": "levyra-991117f52429e132807b",
+          "title": "Magnetic",
+          "artists": [
+            {
+              "name": "The Bausa"
+            }
+          ],
+          "album": {
+            "name": "Magnetic / Addicted To Your Love",
+            "releaseDate": "2026-02-27"
+          },
+          "durationMs": 181384,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02158cbe80b9b9573b46d2b50f"
+        },
+        {
+          "position": 8,
+          "id": "levyra-0cbc6a888e7f9030296a",
+          "title": "BLIJF RUSTIG",
+          "artists": [
+            {
+              "name": "KM"
+            }
+          ],
+          "album": {
+            "name": "BLIJF RUSTIG",
+            "releaseDate": "2026-07-16"
+          },
+          "durationMs": 169346,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "1NLzR6bnNNQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCBPEopJwbPEeAv6-vLC9Icw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0270776354e56bf400264d4ed5"
+        },
+        {
+          "position": 9,
+          "id": "levyra-b50011865ca3b2649181",
+          "title": "Moët Dat Nou",
+          "artists": [
+            {
+              "name": "Robert van Hemert"
+            },
+            {
+              "name": "Donnie"
+            }
+          ],
+          "album": {
+            "name": "Moët Dat Nou",
+            "releaseDate": "2026-01-08"
+          },
+          "durationMs": 154691,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "p8aKGEbmDYg",
+            "audioConfidence": 100,
+            "videoId": "ESGPCD5q6EQ",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC6duRe-MFmYtrAw0v4QI_XA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02eb3368b67550cfce924b1804"
+        },
+        {
+          "position": 10,
+          "id": "levyra-0e04730303d7e8d42aeb",
+          "title": "POPULAIR",
+          "artists": [
+            {
+              "name": "Idaly"
+            },
+            {
+              "name": "Ronnie Flex"
+            },
+            {
+              "name": "Frenna"
+            }
+          ],
+          "album": {
+            "name": "POPULAIR",
+            "releaseDate": "2026-05-28"
+          },
+          "durationMs": 192786,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c13ca00e1f5f89f783963a0d"
+        },
+        {
+          "position": 11,
+          "id": "levyra-b2361cb3034b416dc872",
+          "title": "RMB (Ring My Bell)",
+          "artists": [
+            {
+              "name": "Aitch"
+            }
+          ],
+          "album": {
+            "name": "RMB (Ring My Bell)",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 174222,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "QY7ZblrGc8k",
+            "audioConfidence": 100,
+            "videoId": "3uUHZlEBQ6A",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCdbasYA6lUSImvxdqS1RuZQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026b31df00eabe45483ec9974b"
+        },
+        {
+          "position": 12,
+          "id": "levyra-f957ea7f2a4c33cfcabb",
+          "title": "Free Your Mind",
+          "artists": [
+            {
+              "name": "Prospa"
+            },
+            {
+              "name": "Cloonee"
+            }
+          ],
+          "album": {
+            "name": "Free Your Mind",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 201700,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "V9Suvx0K5Eo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCgj1S1QjZw6EP1jSlfo3www"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02586475e0e7697109f9c69a49"
+        },
+        {
+          "position": 13,
+          "id": "levyra-9922c5c7b891cf029a4d",
+          "title": "Zandloopster",
+          "artists": [
+            {
+              "name": "Robert van Hemert"
+            }
+          ],
+          "album": {
+            "name": "Zandloopster",
+            "releaseDate": "2026-06-04"
+          },
+          "durationMs": 142965,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "sjhQuVfeXJI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC6duRe-MFmYtrAw0v4QI_XA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e8c59d898fb01200a599cf09"
+        },
+        {
+          "position": 14,
+          "id": "levyra-c7eb84b1a5bb6a5efa43",
+          "title": "Pilé",
+          "artists": [
+            {
+              "name": "Mauvais djo"
+            }
+          ],
+          "album": {
+            "name": "L'undertaker, Pt. 1",
+            "releaseDate": "2025-08-15"
+          },
+          "durationMs": 156076,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "w1-iaK49zBg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCmz_Ex4zmTVXvBSzXW_JnKw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028ee092eb7a383ab57bd51dee"
+        },
+        {
+          "position": 15,
+          "id": "levyra-fb956f26117deb8a50f7",
+          "title": "Edge of Desire",
+          "artists": [
+            {
+              "name": "Jonas Blue"
+            },
+            {
+              "name": "Malive"
+            }
+          ],
+          "album": {
+            "name": "Edge of Desire",
+            "releaseDate": "2025-07-18"
+          },
+          "durationMs": 134905,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "91ArCmT8cF0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC9TtDYU2xYw98fHJS2l6Egw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d62a34460f9106ee437bb0b5"
+        },
+        {
+          "position": 16,
+          "id": "levyra-fc868a3aed6aac091f84",
+          "title": "SUPERSTAR",
+          "artists": [
+            {
+              "name": "Roxy Dekker"
+            }
+          ],
+          "album": {
+            "name": "SUPERSTAR",
+            "releaseDate": "2026-06-26"
+          },
+          "durationMs": 149589,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "G6wEf-JSYBI",
+            "audioConfidence": 100,
+            "videoId": "Ekx43PWVuU8",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCcqOETnlEv94qBP5DmdSQhg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c5aa46b4711e3bcc526cd9f5"
+        },
+        {
+          "position": 17,
+          "id": "levyra-552f5928a11042112d0c",
+          "title": "Bare Minimum (Starboy)",
+          "artists": [
+            {
+              "name": "Frsh"
+            },
+            {
+              "name": "KM"
+            },
+            {
+              "name": "LA$$A"
+            }
+          ],
+          "album": {
+            "name": "Bare Minimum (Starboy)",
+            "releaseDate": "2026-01-23"
+          },
+          "durationMs": 146086,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "tOg4Q1ijr1s",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCcw6n6P9qDvrZwvJJCJ71TQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02af5060eb55c81a7fcc210afd"
+        },
+        {
+          "position": 18,
+          "id": "levyra-81234f889aec9ecfd5be",
+          "title": "Mr. Know It All",
+          "artists": [
+            {
+              "name": "Teddy Swims"
+            }
+          ],
+          "album": {
+            "name": "Mr. Know It All",
+            "releaseDate": "2026-04-09"
+          },
+          "durationMs": 198425,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "SkHJ5ChXcDo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCAtlzufZmPhkiDApWM4bTRQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ecf61285415fd9c2a3f7d384"
+        },
+        {
+          "position": 19,
+          "id": "levyra-f3ec762a107edb040049",
+          "title": "Pilé - Gospel",
+          "artists": [
+            {
+              "name": "Mauvais djo"
+            },
+            {
+              "name": "Kano Choir"
+            }
+          ],
+          "album": {
+            "name": "Pilé (Gospel)",
+            "releaseDate": "2026-05-14"
+          },
+          "durationMs": 123720,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "grRKZU-s3Ps",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCmz_Ex4zmTVXvBSzXW_JnKw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028137fce21bfc6a7c3da0db67"
+        },
+        {
+          "position": 20,
+          "id": "levyra-7220197cd8722dca50cb",
+          "title": "I Just Might",
+          "artists": [
+            {
+              "name": "Bruno Mars"
+            }
+          ],
+          "album": {
+            "name": "The Romantic",
+            "releaseDate": "2026-02-27"
+          },
+          "durationMs": 212973,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023eb8dc748f7efb1470f74395"
+        },
+        {
+          "position": 21,
+          "id": "levyra-6fbfa6207d16725c7a53",
+          "title": "Rein Me In (with Olivia Dean)",
+          "artists": [
+            {
+              "name": "Sam Fender"
+            },
+            {
+              "name": "Olivia Dean"
+            }
+          ],
+          "album": {
+            "name": "People Watching (Deluxe Edition)",
+            "releaseDate": "2025-12-05"
+          },
+          "durationMs": 339893,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0270722c52a53ef4a56f0c2eb0"
+        },
+        {
+          "position": 22,
+          "id": "levyra-98349a571204b2f4073a",
+          "title": "petal",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 184248,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "4mQyEqbaUOU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 23,
+          "id": "levyra-93683240d111e7825d3f",
+          "title": "hate that i made you love me",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 197949,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7CUz7Ec7cWc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 24,
+          "id": "levyra-043831313a8f4677a888",
+          "title": "Kingdom of Fear",
+          "artists": [
+            {
+              "name": "Cameron Whitcomb"
+            }
+          ],
+          "album": {
+            "name": "The Hard Way (Complete Edition)",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 161075,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "elvaKRmP2PU",
+            "audioConfidence": 100,
+            "videoId": "63k0kNuCPak",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCHpZsd8IriyQ-znFZQWRrlQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022da659c346d3246862708860"
+        },
+        {
+          "position": 25,
+          "id": "levyra-91d939d46c7a1b1be7f6",
+          "title": "Echte Liefde Is Te Koop",
+          "artists": [
+            {
+              "name": "Samuel Welten"
+            }
+          ],
+          "album": {
+            "name": "Echte Liefde Is Te Koop",
+            "releaseDate": "2025-03-21"
+          },
+          "durationMs": 152659,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "uKxQ8DLWgng",
+            "audioConfidence": 100,
+            "videoId": "cw0AyFUHCfc",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCyaR4EFCB2yMZeZlZqUirdA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d58c5aba90745ffefc98705a"
+        },
+        {
+          "position": 26,
+          "id": "levyra-896575951e40b9ac060b",
+          "title": "FEVER DREAM",
+          "artists": [
+            {
+              "name": "Alex Warren"
+            }
+          ],
+          "album": {
+            "name": "FEVER DREAM",
+            "releaseDate": "2026-02-26"
+          },
+          "durationMs": 153430,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "3D2WPA9ZN30",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCXATF3-9RFGyY-it_d2hB6A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02867f5a2310b84cf508f9764b"
+        },
+        {
+          "position": 27,
+          "id": "levyra-b31eb5e60513bbd613b7",
+          "title": "Billie Jean",
+          "artists": [
+            {
+              "name": "Michael Jackson"
+            }
+          ],
+          "album": {
+            "name": "Thriller",
+            "releaseDate": "1982-11-30"
+          },
+          "durationMs": 293802,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0232a7d87248d1b75463483df5"
+        },
+        {
+          "position": 28,
+          "id": "levyra-c0731ce001d7425504da",
+          "title": "Rozen & Blaadjes",
+          "artists": [
+            {
+              "name": "Frsh"
+            },
+            {
+              "name": "Cristian D"
+            },
+            {
+              "name": "LA$$A"
+            }
+          ],
+          "album": {
+            "name": "Rozen & Blaadjes",
+            "releaseDate": "2026-04-24"
+          },
+          "durationMs": 149743,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02352b13b6e6bb5832d1ea4a38"
+        },
+        {
+          "position": 29,
+          "id": "levyra-d2552956772af21a7881",
+          "title": "Maak Me Nou Niet Gek",
+          "artists": [
+            {
+              "name": "Lil Kleine"
+            },
+            {
+              "name": "Samuel Welten"
+            },
+            {
+              "name": "De Amsterdamse Zomer"
+            }
+          ],
+          "album": {
+            "name": "Maak Me Nou Niet Gek",
+            "releaseDate": "2026-04-24"
+          },
+          "durationMs": 177205,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "sxY8NUE3aXg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCecZSAxmncKitnOhYtRA0zg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0200f9780e2e1d257e6a20282f"
+        },
+        {
+          "position": 30,
+          "id": "levyra-be36f408a1a82d5992da",
+          "title": "Movin' To The Sun",
+          "artists": [
+            {
+              "name": "HUGEL"
+            },
+            {
+              "name": "Imael Angel"
+            },
+            {
+              "name": "Ultra Naté"
+            }
+          ],
+          "album": {
+            "name": "Twenty One",
+            "releaseDate": "2026-06-26"
+          },
+          "durationMs": 142200,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "B827pl48xkU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCO1o6IjIVBcbr_DS1tmarhQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023c2eac0964d8ef1900f1c101"
+        },
+        {
+          "position": 31,
+          "id": "levyra-3f2dcb748a0d34c72f83",
+          "title": "Self Aware",
+          "artists": [
+            {
+              "name": "Temper City"
+            }
+          ],
+          "album": {
+            "name": "Self Aware",
+            "releaseDate": "2026-02-15"
+          },
+          "durationMs": 180740,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "R-hYM3BqTbA",
+            "audioConfidence": 100,
+            "videoId": "mh4AQkw4Jjc",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCpWebSe88U-TOiO8YfKnTgg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d6c26d2ae723f7ab553d64cc"
+        },
+        {
+          "position": 32,
+          "id": "levyra-8d52dd5a928cec18a91f",
+          "title": "Lush Life",
+          "artists": [
+            {
+              "name": "Zara Larsson"
+            }
+          ],
+          "album": {
+            "name": "So Good",
+            "releaseDate": "2017-03-17"
+          },
+          "durationMs": 200646,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "RG-D4bcg54s",
+            "audioConfidence": 100,
+            "videoId": "tD4HCZe-tew",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCB-GmTOjewVU2F_7S4ZFmEA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02401bf6103d4b7f5230a21582"
+        },
+        {
+          "position": 33,
+          "id": "levyra-649125058c7679ea78ec",
+          "title": "New Religion",
+          "artists": [
+            {
+              "name": "Bebe Rexha"
+            },
+            {
+              "name": "Faithless"
+            }
+          ],
+          "album": {
+            "name": "DIRTY BLONDE",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 174400,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "MBnnWS1zcZI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UChwSjx8SnvG6k96a9xqYw1g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02855eca6b0b66944a7682c3b9"
+        },
+        {
+          "position": 34,
+          "id": "levyra-ef444afbdd8812785bd5",
+          "title": "Man I Need",
+          "artists": [
+            {
+              "name": "Olivia Dean"
+            }
+          ],
+          "album": {
+            "name": "Man I Need",
+            "releaseDate": "2025-08-15"
+          },
+          "durationMs": 184000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "fsGjRf-N71I",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC6GBKGYX6b3guHlqHLx6IzQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e3d69e17dde129037a1f09e2"
+        },
+        {
+          "position": 35,
+          "id": "levyra-f6663bc35697e813e41d",
+          "title": "Wonderwall - Remastered",
+          "artists": [
+            {
+              "name": "Oasis"
+            }
+          ],
+          "album": {
+            "name": "(What's The Story) Morning Glory? (Deluxe Remastered Edition)",
+            "releaseDate": "1995"
+          },
+          "durationMs": 258773,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027a4c8c59851c88f6794c3cbf"
+        },
+        {
+          "position": 36,
+          "id": "levyra-411ee215adfe5f5c97c7",
+          "title": "Animal",
+          "artists": [
+            {
+              "name": "KATSEYE"
+            }
+          ],
+          "album": {
+            "name": "Animal",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 158494,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "vOfyxPRunFM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCX9kfYB9t0tnd6DYUC2iuKg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029e8d48f27391ce383862b8e8"
+        },
+        {
+          "position": 37,
+          "id": "levyra-45eb42743bd3b01bf5d7",
+          "title": "Africa",
+          "artists": [
+            {
+              "name": "TOTO"
+            }
+          ],
+          "album": {
+            "name": "Toto IV",
+            "releaseDate": "1982-04-08"
+          },
+          "durationMs": 295282,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ebd6d20c0082524244ef83df"
+        },
+        {
+          "position": 38,
+          "id": "levyra-5c2f779c76102bb23aa0",
+          "title": "Midnight Sun",
+          "artists": [
+            {
+              "name": "Zara Larsson"
+            }
+          ],
+          "album": {
+            "name": "Midnight Sun",
+            "releaseDate": "2025-09-25"
+          },
+          "durationMs": 189898,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027657f9028ea8bb2c18dca99f"
+        },
+        {
+          "position": 39,
+          "id": "levyra-255841206a15acb611ad",
+          "title": "Risk It All",
+          "artists": [
+            {
+              "name": "Bruno Mars"
+            }
+          ],
+          "album": {
+            "name": "The Romantic",
+            "releaseDate": "2026-02-27"
+          },
+          "durationMs": 204068,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "BF2_ipR1OI0",
+            "audioConfidence": 100,
+            "videoId": "lY5V4hSLWY8",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCZn4r7heNOPY-C43YIywnVA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023eb8dc748f7efb1470f74395"
+        },
+        {
+          "position": 40,
+          "id": "levyra-9824cf7c6204b58ac7c7",
+          "title": "Iris",
+          "artists": [
+            {
+              "name": "The Goo Goo Dolls"
+            }
+          ],
+          "album": {
+            "name": "Dizzy up the Girl",
+            "releaseDate": "1998"
+          },
+          "durationMs": 289533,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02eda9478c39a21e1cdc6609ca"
+        },
+        {
+          "position": 41,
+          "id": "levyra-747188c9a636101b13a8",
+          "title": "Jij Hebt Mij",
+          "artists": [
+            {
+              "name": "Kevin"
+            },
+            {
+              "name": "Roxy Dekker"
+            }
+          ],
+          "album": {
+            "name": "Jij Hebt Mij",
+            "releaseDate": "2026-04-30"
+          },
+          "durationMs": 125586,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02859e89e9c94df6c17b3ae851"
+        },
+        {
+          "position": 42,
+          "id": "levyra-0d8526f07fc39d8ac3b5",
+          "title": "Baila de Gasolina",
+          "artists": [
+            {
+              "name": "Effe Serieus"
+            }
+          ],
+          "album": {
+            "name": "Baila de Gasolina",
+            "releaseDate": "2025-01-17"
+          },
+          "durationMs": 140782,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "07q7mtSiP8s",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCmm2skobWmxSCXlYL6nhLnA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0214ac27578eb796fff15a07c9"
+        },
+        {
+          "position": 43,
+          "id": "levyra-47764fdde285bb5be11a",
+          "title": "Beauty And A Beat",
+          "artists": [
+            {
+              "name": "Justin Bieber"
+            },
+            {
+              "name": "Nicki Minaj"
+            }
+          ],
+          "album": {
+            "name": "Believe",
+            "releaseDate": "2012-01-01"
+          },
+          "durationMs": 227986,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f1d02a6cec967f8b6b78f76e"
+        },
+        {
+          "position": 44,
+          "id": "levyra-9edaa828c283337b3ff3",
+          "title": "De Enige",
+          "artists": [
+            {
+              "name": "Antoon"
+            }
+          ],
+          "album": {
+            "name": "De Enige",
+            "releaseDate": "2026-05-29"
+          },
+          "durationMs": 158400,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "2lfngYaRBcs",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCbiFI5x_aucnabHObp5W0YQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c65582ae414bcb5d90ea7201"
+        },
+        {
+          "position": 45,
+          "id": "levyra-2ed1782b29609516a5ec",
+          "title": "stupid song",
+          "artists": [
+            {
+              "name": "Olivia Rodrigo"
+            }
+          ],
+          "album": {
+            "name": "you seem pretty sad for a girl so in love",
+            "releaseDate": "2026-06-11"
+          },
+          "durationMs": 209680,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "P7VgXIZSN_w",
+            "audioConfidence": 100,
+            "videoId": "Rt9tW3cMLhI",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCE5XNpliPM-SmyFEp61tL_g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026949b83f85d782b21ce70583"
+        },
+        {
+          "position": 46,
+          "id": "levyra-9daab8849384cf257275",
+          "title": "Waar Blijf Je Nou",
+          "artists": [
+            {
+              "name": "Donnie"
+            },
+            {
+              "name": "Senna"
+            }
+          ],
+          "album": {
+            "name": "Waar Blijf Je Nou",
+            "releaseDate": "2026-03-26"
+          },
+          "durationMs": 178432,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "QZhZo_yQF44",
+            "audioConfidence": 100,
+            "videoId": "hVCcNMAFSSk",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCBhGnrt-sb3pJSHfoc1bR1A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02477dd945addfeaff211eb707"
+        },
+        {
+          "position": 47,
+          "id": "levyra-6d5bcfc700b0d4a05493",
+          "title": "On 2nite",
+          "artists": [
+            {
+              "name": "Silva Bumpa"
+            }
+          ],
+          "album": {
+            "name": "On 2nite",
+            "releaseDate": "2026-05-29"
+          },
+          "durationMs": 158848,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "3DC68QxuPPQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCwHSANxj07P1I-PC5Og1qhQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02df5399677b85e9f581bb9833"
+        },
+        {
+          "position": 48,
+          "id": "levyra-62f091057573870630ff",
+          "title": "Dreams - 2004 Remaster",
+          "artists": [
+            {
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "album": {
+            "name": "Rumours (Super Deluxe)",
+            "releaseDate": "1977-02-04"
+          },
+          "durationMs": 257800,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e52a59a28efa4773dd2bfe1b"
+        },
+        {
+          "position": 49,
+          "id": "levyra-42933bbf669c24619cdc",
+          "title": "Stupid (Move It)",
+          "artists": [
+            {
+              "name": "Dopebwoy"
+            },
+            {
+              "name": "AJ Tracey"
+            }
+          ],
+          "album": {
+            "name": "Stupid (Move It)",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 123573,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ff667901057062e3101f76b6"
+        },
+        {
+          "position": 50,
+          "id": "levyra-66d26b9c701d4a8f11d7",
+          "title": "Beat It",
+          "artists": [
+            {
+              "name": "Michael Jackson"
+            }
+          ],
+          "album": {
+            "name": "Thriller",
+            "releaseDate": "1982-11-30"
+          },
+          "durationMs": 258296,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "kOn-HdEg6AQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCoIOOL7QKuBhQHVKL8y7BEQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0232a7d87248d1b75463483df5"
+        }
+      ]
+    },
+    {
+      "id": "top-50-pl",
+      "kind": "chart",
+      "market": "PL",
+      "title": "Top 50 Polska",
+      "description": "Polonia: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-c2a85eca765476b95802",
+          "title": "Abi Mosa",
+          "artists": [
+            {
+              "name": "Malik Montana"
+            },
+            {
+              "name": "CUZCO$"
+            }
+          ],
+          "album": {
+            "name": "Abi Mosa",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 130666,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "QFFsfmtP914",
+            "audioConfidence": 100,
+            "videoId": "vA0jEuNeszQ",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCZRXd_KyHpZ8N2MUoZj2Btw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f36a16db4f3c6f2dad579d97"
+        },
+        {
+          "position": 2,
+          "id": "levyra-9f06e584ff15723cb8c4",
+          "title": "CALIFORNIA LOVE",
+          "artists": [
+            {
+              "name": "White 2115"
+            },
+            {
+              "name": "VVSimon"
+            },
+            {
+              "name": "Palar"
+            },
+            {
+              "name": "PMBTZ"
+            }
+          ],
+          "album": {
+            "name": "CALIFORNIA LOVE",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 213559,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "vtlRXh2C9_Y",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC8Yuo0-S4BMCXWzYajCbMug"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bb76d47861576a1f2a62911c"
+        },
+        {
+          "position": 3,
+          "id": "levyra-9212238175a4e1ec0df1",
+          "title": "Nareszcie",
+          "artists": [
+            {
+              "name": "Męskie Granie Orkiestra"
+            },
+            {
+              "name": "Igor Herbut"
+            },
+            {
+              "name": "Zalia"
+            },
+            {
+              "name": "Vito Bambino"
+            }
+          ],
+          "album": {
+            "name": "Nareszcie",
+            "releaseDate": "2026-04-22"
+          },
+          "durationMs": 182339,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "5AJCumKx1LU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCOqkuB-vURETPAh-TWNX4iQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028073fa20482d90d4d01ca556"
+        },
+        {
+          "position": 4,
+          "id": "levyra-4500512f5aa38edfe312",
+          "title": "Dai Dai",
+          "artists": [
+            {
+              "name": "Shakira"
+            },
+            {
+              "name": "Burna Boy"
+            }
+          ],
+          "album": {
+            "name": "Dai Dai",
+            "releaseDate": "2026-05-14"
+          },
+          "durationMs": 223448,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lFQdcPTTzSg",
+            "audioConfidence": 100,
+            "videoId": "fcnDmrtj6Sk",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCo6JijJGA3IvIiPsawDK3Ww"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0203cadf1b3fe324c1dc710ed4"
+        },
+        {
+          "position": 5,
+          "id": "levyra-007454478db440306e22",
+          "title": "STRAIGHT OUTTA CRACKHOUSE",
+          "artists": [
+            {
+              "name": "CrackHouse"
+            },
+            {
+              "name": "Divix"
+            },
+            {
+              "name": "Macias"
+            },
+            {
+              "name": "Amar"
+            },
+            {
+              "name": "Bandura"
+            },
+            {
+              "name": "Isiah Hilt"
+            }
+          ],
+          "album": {
+            "name": "STRAIGHT OUTTA CRACKHOUSE",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 148500,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025cbd975d4e8326de8f8ffe19"
+        },
+        {
+          "position": 6,
+          "id": "levyra-0b934628dc908d928bb1",
+          "title": "Stan Deweloperski",
+          "artists": [
+            {
+              "name": "Sequento"
+            },
+            {
+              "name": "Cypis"
+            },
+            {
+              "name": "Ba'langa"
+            }
+          ],
+          "album": {
+            "name": "Stan Deweloperski",
+            "releaseDate": "2026-04-28"
+          },
+          "durationMs": 136216,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "-fe3eBuym_w",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCcEOJZgkTN0vrL4HWTorJhg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02412dbfe4c42aa3e5dc27b23d"
+        },
+        {
+          "position": 7,
+          "id": "levyra-e19504f545cabf3e4190",
+          "title": "Mallorca",
+          "artists": [
+            {
+              "name": "Hellfield"
+            },
+            {
+              "name": "Sentino"
+            },
+            {
+              "name": "CrackHouse"
+            }
+          ],
+          "album": {
+            "name": "Mallorca",
+            "releaseDate": "2026-05-21"
+          },
+          "durationMs": 188678,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "ucArOI3IEP8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCs_CIazQCobdhdyBj7ttaVw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02be3f061a6c0e47355f5ef1dd"
+        },
+        {
+          "position": 8,
+          "id": "levyra-b7377316980224984a69",
+          "title": "RED FLAG",
+          "artists": [
+            {
+              "name": "White 2115"
+            },
+            {
+              "name": "PMBTZ"
+            }
+          ],
+          "album": {
+            "name": "RED FLAG",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 203478,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "vE63CfFGlmk",
+            "audioConfidence": 100,
+            "videoId": "GH4S7SGeTsQ",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC8Yuo0-S4BMCXWzYajCbMug"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0206f88e854265d0d78d7594aa"
+        },
+        {
+          "position": 9,
+          "id": "levyra-a7679fe15be4d0d99149",
+          "title": "Pach Pach",
+          "artists": [
+            {
+              "name": "Majki"
+            },
+            {
+              "name": "Major SPZ"
+            }
+          ],
+          "album": {
+            "name": "Nie dla wszystkich",
+            "releaseDate": "2025-11-28"
+          },
+          "durationMs": 115862,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "Z6zZGHZr2W8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCKhyrKTYWN0Q-ntKc26MeKw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e1e0a378a7f2a2031a2b2a72"
+        },
+        {
+          "position": 10,
+          "id": "levyra-37df9b30010d2e5b5191",
+          "title": "Sopot",
+          "artists": [
+            {
+              "name": "Żabson"
+            },
+            {
+              "name": "Hellfield"
+            },
+            {
+              "name": "Sentino"
+            }
+          ],
+          "album": {
+            "name": "Sopot",
+            "releaseDate": "2026-07-22"
+          },
+          "durationMs": 214101,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "NhTduOJgvjg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCIhUd7PAWCQwwBnN2RXfpGQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02806c394cf579b0573f51752d"
+        },
+        {
+          "position": 11,
+          "id": "levyra-9c78dace0f43046495c1",
+          "title": "Napalona",
+          "artists": [
+            {
+              "name": "David Tango"
+            },
+            {
+              "name": "SxK"
+            }
+          ],
+          "album": {
+            "name": "Napalona",
+            "releaseDate": "2026-04-29"
+          },
+          "durationMs": 180266,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "tsJYtDPhXH4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCj_sbfe6RTS1yk9P_GDeS7g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027791fc37c994011d4fae7fd6"
+        },
+        {
+          "position": 12,
+          "id": "levyra-89e4ea02cb489b7e46b1",
+          "title": "PAY ME",
+          "artists": [
+            {
+              "name": "javier"
+            },
+            {
+              "name": "gogetmxney"
+            }
+          ],
+          "album": {
+            "name": "PAY ME",
+            "releaseDate": "2026-07-23"
+          },
+          "durationMs": 138360,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "Go9QXikbV9Q",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCskRHPkyYWAVNYRsYObeWsQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02362dff912242fd9833c7e3fd"
+        },
+        {
+          "position": 13,
+          "id": "levyra-30cf266d9d0f8e266c18",
+          "title": "Saudi",
+          "artists": [
+            {
+              "name": "Tax Free"
+            },
+            {
+              "name": "Malik Montana"
+            },
+            {
+              "name": "Kazior"
+            },
+            {
+              "name": "TYK"
+            },
+            {
+              "name": "CUZCO$"
+            }
+          ],
+          "album": {
+            "name": "Saudi",
+            "releaseDate": "2026-04-30"
+          },
+          "durationMs": 164615,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "n0KcFVBoSKA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC9P7sVWgNfYyVGtiq7sy5dg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020d9053b5d236b442f5394009"
+        },
+        {
+          "position": 14,
+          "id": "levyra-c0a4363926e8c812a77f",
+          "title": "NIEKOŃCZĄCY ZŁY SEN",
+          "artists": [
+            {
+              "name": "Kubi Producent"
+            },
+            {
+              "name": "Sobel"
+            }
+          ],
+          "album": {
+            "name": "NIEKOŃCZĄCY ZŁY SEN",
+            "releaseDate": "2026-07-30"
+          },
+          "durationMs": 237000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Zke9nkUwBrQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCJ9DG6-cBjOJ8fCMPMaUsGQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0294eaaa557efc9e1a89f46f36"
+        },
+        {
+          "position": 15,
+          "id": "levyra-700bcc9777bd838b6a3c",
+          "title": "Kwadrat",
+          "artists": [
+            {
+              "name": "Majki"
+            },
+            {
+              "name": "Major SPZ"
+            }
+          ],
+          "album": {
+            "name": "Nie dla wszystkich",
+            "releaseDate": "2025-11-28"
+          },
+          "durationMs": 169714,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "ms0z09osdR8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCKhyrKTYWN0Q-ntKc26MeKw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e1e0a378a7f2a2031a2b2a72"
+        },
+        {
+          "position": 16,
+          "id": "levyra-b2f0f88859503729e41c",
+          "title": "LUBIĘ CIĘ JAK LATO",
+          "artists": [
+            {
+              "name": "MODELKI"
+            },
+            {
+              "name": "Vłodarski"
+            }
+          ],
+          "album": {
+            "name": "HOT HITS",
+            "releaseDate": "2026-04-23"
+          },
+          "durationMs": 124724,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "iQ6p7zZcqcM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCXc0EEPP__Y_hEhwhNOmrMw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020d94e580533357bcdfecf2b1"
+        },
+        {
+          "position": 17,
+          "id": "levyra-96afe5d614f7c1092adb",
+          "title": "Ty masz",
+          "artists": [
+            {
+              "name": "Gibbs"
+            },
+            {
+              "name": "Kukon"
+            },
+            {
+              "name": "Jonatan"
+            }
+          ],
+          "album": {
+            "name": "NURT",
+            "releaseDate": "2026-05-28"
+          },
+          "durationMs": 196363,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "3H2AvEHmrvM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCLCR-FbVVq1GsETOtdGG-mw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e2cb85cb33492a3567031b5b"
+        },
+        {
+          "position": 18,
+          "id": "levyra-dbe195f0b9b388e2a62a",
+          "title": "Piękny sen",
+          "artists": [
+            {
+              "name": "Malik Montana"
+            },
+            {
+              "name": "SRNO"
+            }
+          ],
+          "album": {
+            "name": "Piękny sen",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 123809,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "YN6ksBLQbu8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCZRXd_KyHpZ8N2MUoZj2Btw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bd8a8ddb55ae774cc0c0651a"
+        },
+        {
+          "position": 19,
+          "id": "levyra-b6851baabab361deaad2",
+          "title": "Zabiorę Cię Tam",
+          "artists": [
+            {
+              "name": "Fukaj"
+            },
+            {
+              "name": "Vito Bambino"
+            }
+          ],
+          "album": {
+            "name": "Znajdź mnie w tym",
+            "releaseDate": "2026-01-23"
+          },
+          "durationMs": 213189,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "XcgkFyD-RCs",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCaIFzZeaYiMvLjro-Q4sYOg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0263ab860cec59bccb9fd0cc5d"
+        },
+        {
+          "position": 20,
+          "id": "levyra-2b59f75d6b79fcca4c18",
+          "title": "dopóki się nie znüdzisz",
+          "artists": [
+            {
+              "name": "MIÜ"
+            },
+            {
+              "name": "Zalia"
+            }
+          ],
+          "album": {
+            "name": "Ü UP? mixtape",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 204827,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e7979064d55d89038f45e3fa"
+        },
+        {
+          "position": 21,
+          "id": "levyra-ebb76105ae6c4acb2137",
+          "title": "TO COŚ",
+          "artists": [
+            {
+              "name": "White 2115"
+            },
+            {
+              "name": "Palar"
+            },
+            {
+              "name": "VVSimon"
+            },
+            {
+              "name": "Mercury"
+            }
+          ],
+          "album": {
+            "name": "CALIFORNIA LOVE EP",
+            "releaseDate": "2026-04-10"
+          },
+          "durationMs": 180480,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021edb51642ad4f152cff42783"
+        },
+        {
+          "position": 22,
+          "id": "levyra-156cc9d1d24473c964e9",
+          "title": "Tajlandia",
+          "artists": [
+            {
+              "name": "Major SPZ"
+            },
+            {
+              "name": "Kemzy"
+            }
+          ],
+          "album": {
+            "name": "Tajlandia",
+            "releaseDate": "2026-06-11"
+          },
+          "durationMs": 148000,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "CQr-NpV5-4g",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCJqkejqDA4h94FN9-l-hCqA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0279893331dbf9b5ab0295267b"
+        },
+        {
+          "position": 23,
+          "id": "levyra-82cc085043fd3850db6f",
+          "title": "KAMIKAZE",
+          "artists": [
+            {
+              "name": "Mata"
+            },
+            {
+              "name": "Skolim"
+            },
+            {
+              "name": "Khaid"
+            }
+          ],
+          "album": {
+            "name": "2039: ZŁOTE PIASKI",
+            "releaseDate": "2025-08-14"
+          },
+          "durationMs": 182850,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "Es8hlZZ9Na0",
+            "audioConfidence": 100,
+            "videoId": "gBtbTl8r18U",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCG7AFz6cjuuZnJxMoTAC9lw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028f7e0a7c7f285011db487993"
+        },
+        {
+          "position": 24,
+          "id": "levyra-3f2dcb748a0d34c72f83",
+          "title": "Self Aware",
+          "artists": [
+            {
+              "name": "Temper City"
+            }
+          ],
+          "album": {
+            "name": "Self Aware",
+            "releaseDate": "2026-02-15"
+          },
+          "durationMs": 180740,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "R-hYM3BqTbA",
+            "audioConfidence": 100,
+            "videoId": "mh4AQkw4Jjc",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCpWebSe88U-TOiO8YfKnTgg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d6c26d2ae723f7ab553d64cc"
+        },
+        {
+          "position": 25,
+          "id": "levyra-2f8a12737cafd75e6e0a",
+          "title": "Kalinka",
+          "artists": [
+            {
+              "name": "Majki"
+            },
+            {
+              "name": "Major SPZ"
+            }
+          ],
+          "album": {
+            "name": "Nie dla wszystkich",
+            "releaseDate": "2025-11-28"
+          },
+          "durationMs": 188750,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "-4RzgB20nHw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCKhyrKTYWN0Q-ntKc26MeKw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e1e0a378a7f2a2031a2b2a72"
+        },
+        {
+          "position": 26,
+          "id": "levyra-ca16be0f5a16cea94f2b",
+          "title": "VHS",
+          "artists": [
+            {
+              "name": "PRO8L3M"
+            }
+          ],
+          "album": {
+            "name": "PRO8L3M",
+            "releaseDate": "2016-06-02"
+          },
+          "durationMs": 202506,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "UhF2VuDYwf4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCo5IMV6BlGacpcT0XhLg01w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f6d03dbfb15618ec00e00037"
+        },
+        {
+          "position": 27,
+          "id": "levyra-ee594d03ec5f1b6b11e7",
+          "title": "Bamboleo",
+          "artists": [
+            {
+              "name": "Sequento"
+            },
+            {
+              "name": "Maka"
+            },
+            {
+              "name": "Pancio"
+            }
+          ],
+          "album": {
+            "name": "Bamboleo",
+            "releaseDate": "2026-07-02"
+          },
+          "durationMs": 158918,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "wf5mNKk6GzQ",
+            "audioConfidence": 100,
+            "videoId": "KsVjY8xzxHw",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCcEOJZgkTN0vrL4HWTorJhg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cd7e6e82e18e31f004fec8f5"
+        },
+        {
+          "position": 28,
+          "id": "levyra-fe325a279f89d35a0bbc",
+          "title": "NIC NIE MIJA",
+          "artists": [
+            {
+              "name": "Otsochodzi"
+            },
+            {
+              "name": "lohleq"
+            }
+          ],
+          "album": {
+            "name": "NIC NIE MIJA / za tten rap",
+            "releaseDate": "2026-07-12"
+          },
+          "durationMs": 220000,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "DOYgrMTG3vI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCWiYjN9P7Mhz0kU0UvpAL2Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ec0895b196bcb5e96b5b64c0"
+        },
+        {
+          "position": 29,
+          "id": "levyra-47764fdde285bb5be11a",
+          "title": "Beauty And A Beat",
+          "artists": [
+            {
+              "name": "Justin Bieber"
+            },
+            {
+              "name": "Nicki Minaj"
+            }
+          ],
+          "album": {
+            "name": "Believe",
+            "releaseDate": "2012-01-01"
+          },
+          "durationMs": 227986,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f1d02a6cec967f8b6b78f76e"
+        },
+        {
+          "position": 30,
+          "id": "levyra-db1dee3a09c07674dd63",
+          "title": "tylko kochaj mnie",
+          "artists": [
+            {
+              "name": "Zalia"
+            }
+          ],
+          "album": {
+            "name": "tylko kochaj mnie",
+            "releaseDate": "2026-06-18"
+          },
+          "durationMs": 161342,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "EHip3y01RSg",
+            "audioConfidence": 100,
+            "videoId": "e8pRGY3jGaE",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCgL-COdtrC4nhUkBie4vBDA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0240a77233bb9e61396e9b4bc3"
+        },
+        {
+          "position": 31,
+          "id": "levyra-87c57788d206820cd6ae",
+          "title": "fantazje",
+          "artists": [
+            {
+              "name": "MIÜ"
+            },
+            {
+              "name": "Pezet"
+            },
+            {
+              "name": "Bedoes 2115"
+            }
+          ],
+          "album": {
+            "name": "Ü UP? mixtape",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 178144,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "4Crd6vxVmKw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCL-vFjQgsOI5c9Ws6V8tDtA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e7979064d55d89038f45e3fa"
+        },
+        {
+          "position": 32,
+          "id": "levyra-be36f408a1a82d5992da",
+          "title": "Movin' To The Sun",
+          "artists": [
+            {
+              "name": "HUGEL"
+            },
+            {
+              "name": "Imael Angel"
+            },
+            {
+              "name": "Ultra Naté"
+            }
+          ],
+          "album": {
+            "name": "Twenty One",
+            "releaseDate": "2026-06-26"
+          },
+          "durationMs": 142200,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "B827pl48xkU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCO1o6IjIVBcbr_DS1tmarhQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023c2eac0964d8ef1900f1c101"
+        },
+        {
+          "position": 33,
+          "id": "levyra-3d2701a227436af875ba",
+          "title": "Plan B",
+          "artists": [
+            {
+              "name": "Pezet"
+            },
+            {
+              "name": "Mata"
+            },
+            {
+              "name": "Kaz Bałagane"
+            },
+            {
+              "name": "Pedro"
+            },
+            {
+              "name": "Frenkie G"
+            }
+          ],
+          "album": {
+            "name": "Muzyka Popularna",
+            "releaseDate": "2025-10-31"
+          },
+          "durationMs": 192134,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02127c8bc6494e2eb9e44b05fb"
+        },
+        {
+          "position": 34,
+          "id": "levyra-2eff1b47e86e565be3b5",
+          "title": "RED BULL 64 BARS",
+          "artists": [
+            {
+              "name": "Avi"
+            },
+            {
+              "name": "Favst"
+            }
+          ],
+          "album": {
+            "name": "RED BULL 64 BARS",
+            "releaseDate": "2026-07-02"
+          },
+          "durationMs": 197938,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b98b23060300cc19b3ea6061"
+        },
+        {
+          "position": 35,
+          "id": "levyra-e826f517d74a54af39ac",
+          "title": "NIE CHCĘ WRACAĆ",
+          "artists": [
+            {
+              "name": "Fukaj"
+            },
+            {
+              "name": "charlie moncler"
+            },
+            {
+              "name": "Hubert."
+            }
+          ],
+          "album": {
+            "name": "INTERLUDIUM",
+            "releaseDate": "2025-05-22"
+          },
+          "durationMs": 204221,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021ec347a24026c30308e2b267"
+        },
+        {
+          "position": 36,
+          "id": "levyra-4ec90868bdd1bb5e4a4b",
+          "title": "Grand Soir",
+          "artists": [
+            {
+              "name": "wane"
+            }
+          ],
+          "album": {
+            "name": "Grand Soir",
+            "releaseDate": "2026-07-21"
+          },
+          "durationMs": 133135,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "tauhQ-GIgFg",
+            "audioConfidence": 100,
+            "videoId": "k9WN_ahN_zg",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UC9AOse7mrU67qbcc24JOmbw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bbe51a9c898b95c234a58ff6"
+        },
+        {
+          "position": 37,
+          "id": "levyra-05f00200a3cd63011a5d",
+          "title": "Nieskończoność",
+          "artists": [
+            {
+              "name": "Cheatz"
+            }
+          ],
+          "album": {
+            "name": "Zimowy Gdańsk",
+            "releaseDate": "2026-02-12"
+          },
+          "durationMs": 129632,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "vFDBthF0XeI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCF5bofeNb0VhkMK4_-H9tzw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b4734e9e1066199f265ba62b"
+        },
+        {
+          "position": 38,
+          "id": "levyra-98349a571204b2f4073a",
+          "title": "petal",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 184248,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "4mQyEqbaUOU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 39,
+          "id": "levyra-9cdcd140d63cf57ccc68",
+          "title": "California",
+          "artists": [
+            {
+              "name": "White 2115"
+            }
+          ],
+          "album": {
+            "name": "Rockstar",
+            "releaseDate": "2018-08-31"
+          },
+          "durationMs": 192760,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "l96l95doZCo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC8Yuo0-S4BMCXWzYajCbMug"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02fe1c1f6984ee1b0397aa479a"
+        },
+        {
+          "position": 40,
+          "id": "levyra-ff765897b0ffb129fad1",
+          "title": "NOWE CIOCIE",
+          "artists": [
+            {
+              "name": "rydawarrior"
+            },
+            {
+              "name": "CUZCO$"
+            }
+          ],
+          "album": {
+            "name": "NOWE CIOCIE",
+            "releaseDate": "2026-03-13"
+          },
+          "durationMs": 125333,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "iVmQSP198jI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCj9PxUKTXHICjZUHvC-63zQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0224481489b94a5c2e21661d8a"
+        },
+        {
+          "position": 41,
+          "id": "levyra-b25bd4e30aa2dfc4fefe",
+          "title": "SERIO",
+          "artists": [
+            {
+              "name": "Bary"
+            },
+            {
+              "name": "White Widow"
+            }
+          ],
+          "album": {
+            "name": "Kuba vs Bary",
+            "releaseDate": "2026-06-18"
+          },
+          "durationMs": 160000,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "SqaGz96nCQY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCd8OiG1MJCxO-M2x6cW1PPQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020aa6c796bc2e00b62df0a1df"
+        },
+        {
+          "position": 42,
+          "id": "levyra-c1ba1283ced89513686b",
+          "title": "SAMA",
+          "artists": [
+            {
+              "name": "Per Dżinn"
+            }
+          ],
+          "album": {
+            "name": "SAMA",
+            "releaseDate": "2026-06-23"
+          },
+          "durationMs": 132884,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "w-wZrcev0-o",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC2otvtrd4Va7EtBGFopWK-w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02283f4a167412a32aedbee93b"
+        },
+        {
+          "position": 43,
+          "id": "levyra-f41f6f2a685ac7151fd6",
+          "title": "Latamy",
+          "artists": [
+            {
+              "name": "Tax Free"
+            },
+            {
+              "name": "Malik Montana"
+            },
+            {
+              "name": "Kazior"
+            },
+            {
+              "name": "730 Huncho"
+            },
+            {
+              "name": "CUZCO$"
+            }
+          ],
+          "album": {
+            "name": "Latamy",
+            "releaseDate": "2026-06-19"
+          },
+          "durationMs": 166256,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "TDu95AahoyQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC9P7sVWgNfYyVGtiq7sy5dg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cac1016f8e3cbaf03babb0ca"
+        },
+        {
+          "position": 44,
+          "id": "levyra-5188b887ed0ec064cabe",
+          "title": "CZEMPION 2",
+          "artists": [
+            {
+              "name": "Malik Montana"
+            },
+            {
+              "name": "Kizo"
+            }
+          ],
+          "album": {
+            "name": "CZEMPION 2",
+            "releaseDate": "2026-06-26"
+          },
+          "durationMs": 154434,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "ADra8A8K_SI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCZRXd_KyHpZ8N2MUoZj2Btw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021695ee963ff2d6068e2c8ac6"
+        },
+        {
+          "position": 45,
+          "id": "levyra-93683240d111e7825d3f",
+          "title": "hate that i made you love me",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 197949,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7CUz7Ec7cWc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 46,
+          "id": "levyra-feb581399b788721203a",
+          "title": "KOLEJNA NOC",
+          "artists": [
+            {
+              "name": "Wac Toja"
+            }
+          ],
+          "album": {
+            "name": "KOLEJNA NOC",
+            "releaseDate": "2026-03-25"
+          },
+          "durationMs": 145174,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "srGoEDnPJpA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC6koBImWvf4HYCQd7nIVeRQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02288246cb0edad7aaea6a9b2d"
+        },
+        {
+          "position": 47,
+          "id": "levyra-ce2a0823df2f59ec47b1",
+          "title": "Adieu",
+          "artists": [
+            {
+              "name": "Majki"
+            },
+            {
+              "name": "Major SPZ"
+            },
+            {
+              "name": "Cypis"
+            }
+          ],
+          "album": {
+            "name": "Nie dla wszystkich",
+            "releaseDate": "2025-11-28"
+          },
+          "durationMs": 165714,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "Mt_JhrBdRlE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCKhyrKTYWN0Q-ntKc26MeKw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e1e0a378a7f2a2031a2b2a72"
+        },
+        {
+          "position": 48,
+          "id": "levyra-91eac85e763c85aaccd1",
+          "title": "LEPA",
+          "artists": [
+            {
+              "name": "Per Dżinn"
+            }
+          ],
+          "album": {
+            "name": "LEPA",
+            "releaseDate": "2026-06-02"
+          },
+          "durationMs": 109124,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "z7KIOTQscjo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC2otvtrd4Va7EtBGFopWK-w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028ae2bafc743e56d3d57b99c2"
+        },
+        {
+          "position": 49,
+          "id": "levyra-ef4e58155c9d1e772e30",
+          "title": "Talk To You (ft. 54 Ultra)",
+          "artists": [
+            {
+              "name": "ANOTR"
+            },
+            {
+              "name": "54 Ultra"
+            }
+          ],
+          "album": {
+            "name": "Withness",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 191076,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02aeb168f35ab002d77a4f3918"
+        },
+        {
+          "position": 50,
+          "id": "levyra-ec0bd99a5637cdde026c",
+          "title": "After",
+          "artists": [
+            {
+              "name": "Tax Free"
+            },
+            {
+              "name": "Malik Montana"
+            },
+            {
+              "name": "Kazior"
+            },
+            {
+              "name": "CUZCO$"
+            }
+          ],
+          "album": {
+            "name": "After",
+            "releaseDate": "2026-01-09"
+          },
+          "durationMs": 139354,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "nf4EEtJiSxs",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC9P7sVWgNfYyVGtiq7sy5dg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b7cf6284bb6f1351c8494f7b"
+        }
+      ]
+    },
+    {
+      "id": "top-50-ro",
+      "kind": "chart",
+      "market": "RO",
+      "title": "Top 50 România",
+      "description": "Romania: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-d66c44557776ca07780b",
+          "title": "7 din 7",
+          "artists": [
+            {
+              "name": "VANILLA"
+            },
+            {
+              "name": "Alex Velea"
+            }
+          ],
+          "album": {
+            "name": "7 din 7",
+            "releaseDate": "2026-07-06"
+          },
+          "durationMs": 167578,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "OT1G3ahhNys",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCm5s8ZhhrkBhOIikmS_QcRw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0252f5e70b8b1dfd9feeabb5fa"
+        },
+        {
+          "position": 2,
+          "id": "levyra-0c06edb56880a21e7e9c",
+          "title": "DEUCESS",
+          "artists": [
+            {
+              "name": "Berechet"
+            },
+            {
+              "name": "VANILLA"
+            }
+          ],
+          "album": {
+            "name": "#BACKto2016",
+            "releaseDate": "2026-07-01"
+          },
+          "durationMs": 174362,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02070a11e793f0b2d4270a1306"
+        },
+        {
+          "position": 3,
+          "id": "levyra-b29dc2134a5377e6c09d",
+          "title": "LA NOI E CEARTA",
+          "artists": [
+            {
+              "name": "Berechet"
+            },
+            {
+              "name": "CERCEL"
+            }
+          ],
+          "album": {
+            "name": "#BACKto2016",
+            "releaseDate": "2026-07-01"
+          },
+          "durationMs": 135000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02070a11e793f0b2d4270a1306"
+        },
+        {
+          "position": 4,
+          "id": "levyra-6c5560215734c1842b1c",
+          "title": "Ți-am furat femeia",
+          "artists": [
+            {
+              "name": "MADATORRICELLI"
+            }
+          ],
+          "album": {
+            "name": "Ți-am furat femeia",
+            "releaseDate": "2026-07-02"
+          },
+          "durationMs": 146526,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "coJ6N0OjF1k",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCyr_ncyeNdbE4xOUCFVYi5Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02111bc8c65445216590d41c4a"
+        },
+        {
+          "position": 5,
+          "id": "levyra-f66a90b05c4606b1a58a",
+          "title": "MI AMOR",
+          "artists": [
+            {
+              "name": "EFRA"
+            },
+            {
+              "name": "Alex Botea"
+            }
+          ],
+          "album": {
+            "name": "MI AMOR",
+            "releaseDate": "2026-07-16"
+          },
+          "durationMs": 160122,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "M1wURMYgfXw",
+            "audioConfidence": 100,
+            "videoId": "yqT-mt6kGws",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCK_bPoN_C4CaUumtnF8fPcg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b715d73bd6ae3af629295707"
+        },
+        {
+          "position": 6,
+          "id": "levyra-09d1782affa5b8d3296f",
+          "title": "TRECI PESTE",
+          "artists": [
+            {
+              "name": "VANILLA"
+            }
+          ],
+          "album": {
+            "name": "TRECI PESTE",
+            "releaseDate": "2026-02-14"
+          },
+          "durationMs": 138750,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "uUdyh6Oi3G0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCm5s8ZhhrkBhOIikmS_QcRw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0218a0290118248f1c9b26c2cb"
+        },
+        {
+          "position": 7,
+          "id": "levyra-ca118693e23c3ac3274c",
+          "title": "Te juri ca vrei",
+          "artists": [
+            {
+              "name": "Mariano"
+            }
+          ],
+          "album": {
+            "name": "Te juri ca vrei",
+            "releaseDate": "2026-03-01"
+          },
+          "durationMs": 163200,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "VIehh3I8Vn8",
+            "audioConfidence": 100,
+            "videoId": "U64Dx2Qx8G8",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCvn0z96caW1oafs0b-GGv_A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0259bf15c02d14660f9ad2569f"
+        },
+        {
+          "position": 8,
+          "id": "levyra-fbfd68771bcefb36d62b",
+          "title": "Nebunatica",
+          "artists": [
+            {
+              "name": "MADATORRICELLI"
+            },
+            {
+              "name": "LiToo The Purp"
+            }
+          ],
+          "album": {
+            "name": "Nebunatica",
+            "releaseDate": "2026-04-27"
+          },
+          "durationMs": 149677,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "nCBR4rBVn4M",
+            "audioConfidence": 100,
+            "videoId": "j4qO4mcb9xw",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCyr_ncyeNdbE4xOUCFVYi5Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0268dabf55d68572f7d4093602"
+        },
+        {
+          "position": 9,
+          "id": "levyra-b6858a372db83f8046e1",
+          "title": "CUM ESTI TU",
+          "artists": [
+            {
+              "name": "VANILLA"
+            }
+          ],
+          "album": {
+            "name": "CUM ESTI TU",
+            "releaseDate": "2026-06-19"
+          },
+          "durationMs": 165000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "-79tJd-O2g0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCm5s8ZhhrkBhOIikmS_QcRw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0217283152bd4d9d9fbd65d0bc"
+        },
+        {
+          "position": 10,
+          "id": "levyra-bcb7b0a1a4d542b5459d",
+          "title": "Știu ce vrea",
+          "artists": [
+            {
+              "name": "AlbertNbn"
+            },
+            {
+              "name": "VANILLA"
+            }
+          ],
+          "album": {
+            "name": "Știu ce vrea",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 139687,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7VQOWAa_tg4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC3q6Guf9usRRepqD3I54eUg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b87978c200ea75dd990bc5f7"
+        },
+        {
+          "position": 11,
+          "id": "levyra-c1ad6f647e53be006a3e",
+          "title": "Cântă lăutare",
+          "artists": [
+            {
+              "name": "Lele"
+            },
+            {
+              "name": "Manele VTM"
+            }
+          ],
+          "album": {
+            "name": "Cântă lăutare",
+            "releaseDate": "2026-06-03"
+          },
+          "durationMs": 173144,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "NGjlefWbFqY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCDItydY2JH0ORCuZLEpXN0g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020c0c35bf7f1a0328e781e920"
+        },
+        {
+          "position": 12,
+          "id": "levyra-266465a4b42c2236f968",
+          "title": "PRIETENA TA",
+          "artists": [
+            {
+              "name": "DZWS"
+            },
+            {
+              "name": "VANILLA"
+            },
+            {
+              "name": "Dj Nattan"
+            }
+          ],
+          "album": {
+            "name": "VARA BRAZIL",
+            "releaseDate": "2025-07-04"
+          },
+          "durationMs": 202220,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c8f76e46e6de9d071ae7582a"
+        },
+        {
+          "position": 13,
+          "id": "levyra-97066f2a9e9d7d9eb7df",
+          "title": "Doar Pentru Tine Amore",
+          "artists": [
+            {
+              "name": "Florin Cercel"
+            },
+            {
+              "name": "Antonia Cercel"
+            }
+          ],
+          "album": {
+            "name": "Doar Pentru Tine Amore",
+            "releaseDate": "2026-05-15"
+          },
+          "durationMs": 218186,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0296821612efc71c2d9ec230e8"
+        },
+        {
+          "position": 14,
+          "id": "levyra-bf5dda3226c64ae48ae5",
+          "title": "UP",
+          "artists": [
+            {
+              "name": "Badd G"
+            },
+            {
+              "name": "AlbertNbn"
+            },
+            {
+              "name": "VANILLA"
+            }
+          ],
+          "album": {
+            "name": "UP",
+            "releaseDate": "2026-07-17"
+          },
+          "durationMs": 137431,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "79liKeOWgA0",
+            "audioConfidence": 100,
+            "videoId": "dpnG4Ho6GiE",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCmTze8hAjaG6c0FtLq64M7Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02013f70f1ecb4182c8d5e0eaf"
+        },
+        {
+          "position": 15,
+          "id": "levyra-deeeba223e75d7ac87fb",
+          "title": "STIU CA TI-E DOR",
+          "artists": [
+            {
+              "name": "Berechet"
+            },
+            {
+              "name": "VANILLA"
+            },
+            {
+              "name": "21SIIEMPRE"
+            },
+            {
+              "name": "CERCEL"
+            }
+          ],
+          "album": {
+            "name": "STIU CA TI-E DOR",
+            "releaseDate": "2025-07-28"
+          },
+          "durationMs": 214649,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "PpU8W5DgGbk",
+            "audioConfidence": 100,
+            "videoId": "INE-l6DtsAY",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCiC_vxasVKRDBvZBaMIEGdg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bd0dee73171d570968ac650d"
+        },
+        {
+          "position": 16,
+          "id": "levyra-88f67411666e253b9efc",
+          "title": "CAND VINE NOAPTEA",
+          "artists": [
+            {
+              "name": "VANILLA"
+            }
+          ],
+          "album": {
+            "name": "CAND VINE NOAPTEA",
+            "releaseDate": "2025-12-05"
+          },
+          "durationMs": 148453,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0294f8c9168a79ba591e7b0a3b"
+        },
+        {
+          "position": 17,
+          "id": "levyra-cd758acd4e4a29c1e3fe",
+          "title": "Jamaica - Live",
+          "artists": [
+            {
+              "name": "Luis Gabriel"
+            }
+          ],
+          "album": {
+            "name": "Jamaica (Live)",
+            "releaseDate": "2026-03-25"
+          },
+          "durationMs": 184160,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0220f1f6f4177ae2b884dbd573"
+        },
+        {
+          "position": 18,
+          "id": "levyra-60d42bef2d075f0680df",
+          "title": "Mesterul Manele",
+          "artists": [
+            {
+              "name": "Alex Botea"
+            }
+          ],
+          "album": {
+            "name": "Mesterul Manele",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 200471,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "fZjP7ELZiO4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCwOHbMJAGZUXA6PAiDKemMg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025aaf00a1bd08a470c6b1b947"
+        },
+        {
+          "position": 19,
+          "id": "levyra-4500512f5aa38edfe312",
+          "title": "Dai Dai",
+          "artists": [
+            {
+              "name": "Shakira"
+            },
+            {
+              "name": "Burna Boy"
+            }
+          ],
+          "album": {
+            "name": "Dai Dai",
+            "releaseDate": "2026-05-14"
+          },
+          "durationMs": 223448,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lFQdcPTTzSg",
+            "audioConfidence": 100,
+            "videoId": "fcnDmrtj6Sk",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCo6JijJGA3IvIiPsawDK3Ww"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0203cadf1b3fe324c1dc710ed4"
+        },
+        {
+          "position": 20,
+          "id": "levyra-bd1efbc18fc18584b0e0",
+          "title": "Regele pe reggaeton",
+          "artists": [
+            {
+              "name": "rares"
+            },
+            {
+              "name": "Ursaru"
+            }
+          ],
+          "album": {
+            "name": "Regele pe reggaeton",
+            "releaseDate": "2026-05-08"
+          },
+          "durationMs": 122608,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Tsa__phnDh8",
+            "audioConfidence": 100,
+            "videoId": "o7t7X500O3o",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCl8xd24oAVaDgMvlpmhwDMg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02db8bff42ce8230ad7b110447"
+        },
+        {
+          "position": 21,
+          "id": "levyra-68d9050d57d22c981bf1",
+          "title": "Așa și așa",
+          "artists": [
+            {
+              "name": "Babasha"
+            },
+            {
+              "name": "Denis Ramniceanu"
+            }
+          ],
+          "album": {
+            "name": "Așa și așa",
+            "releaseDate": "2026-05-05"
+          },
+          "durationMs": 154160,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "JfSaGtYoqmo",
+            "audioConfidence": 100,
+            "videoId": "mKZiZBNXJWc",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCbfAFHARtgwNZKZnICS8o9Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025843dcc4b616a42dc200aec4"
+        },
+        {
+          "position": 22,
+          "id": "levyra-05fd47bd9d114b38f3fb",
+          "title": "Mă sună nebunele",
+          "artists": [
+            {
+              "name": "Lazy Ed"
+            }
+          ],
+          "album": {
+            "name": "Mă sună nebunele",
+            "releaseDate": "2026-02-13"
+          },
+          "durationMs": 189000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "dGLFTUHdMzs",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC3h8X6BJCtQNnLVZm0Ak3mw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e65f7309e064d591e7df4333"
+        },
+        {
+          "position": 23,
+          "id": "levyra-ac29cf6401aa9000d120",
+          "title": "Ramai talent",
+          "artists": [
+            {
+              "name": "Luis Gabriel"
+            }
+          ],
+          "album": {
+            "name": "Ramai talent",
+            "releaseDate": "2025-09-11"
+          },
+          "durationMs": 197730,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "tfsAE10-n0c",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCW_mfs0btK6pzgvo9XBlunA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b223de73f43e9831581af682"
+        },
+        {
+          "position": 24,
+          "id": "levyra-09e0ffb151812b650b44",
+          "title": "Jester",
+          "artists": [
+            {
+              "name": "AlbertNbn"
+            }
+          ],
+          "album": {
+            "name": "Jester",
+            "releaseDate": "2026-03-13"
+          },
+          "durationMs": 136875,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023c0a474c82d8cae261b1a29e"
+        },
+        {
+          "position": 25,
+          "id": "levyra-e3a4f24592c45968859a",
+          "title": "Mor după tine",
+          "artists": [
+            {
+              "name": "Lazy Ed"
+            },
+            {
+              "name": "JO"
+            }
+          ],
+          "album": {
+            "name": "Mor după tine",
+            "releaseDate": "2026-04-02"
+          },
+          "durationMs": 137500,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "rJKfLZcRD0I",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC3h8X6BJCtQNnLVZm0Ak3mw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ee620c9589220ff917d4fe80"
+        },
+        {
+          "position": 26,
+          "id": "levyra-d043a0d0d1d9832feac9",
+          "title": "PETER PARKER",
+          "artists": [
+            {
+              "name": "Petre Stefan"
+            }
+          ],
+          "album": {
+            "name": "Direct din Tei (Deluxe)",
+            "releaseDate": "2025-11-27"
+          },
+          "durationMs": 127187,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "cin8r0L-Lyc",
+            "audioConfidence": 100,
+            "videoId": "vTIgcxruwzI",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCAM0UhgFt4hLk1VH5Lnmi4g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c1b0a67fac1ee94208110734"
+        },
+        {
+          "position": 27,
+          "id": "levyra-5002042eb6adc9ead80f",
+          "title": "Mandarina",
+          "artists": [
+            {
+              "name": "Babasha"
+            },
+            {
+              "name": "VANILLA"
+            }
+          ],
+          "album": {
+            "name": "Carrera",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 152459,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "jRumDWUDnXM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCbfAFHARtgwNZKZnICS8o9Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027958ee0f32953be2fa6d1f4b"
+        },
+        {
+          "position": 28,
+          "id": "levyra-99f780a00941a2b7412f",
+          "title": "NA BELEA",
+          "artists": [
+            {
+              "name": "MADATORRICELLI"
+            }
+          ],
+          "album": {
+            "name": "NA BELEA",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 162666,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "dnTnGdQ5w_w",
+            "audioConfidence": 100,
+            "videoId": "NXUdJrTFdgQ",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCyr_ncyeNdbE4xOUCFVYi5Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025881d65d02aae41b7311746a"
+        },
+        {
+          "position": 29,
+          "id": "levyra-98349a571204b2f4073a",
+          "title": "petal",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 184248,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "4mQyEqbaUOU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 30,
+          "id": "levyra-56383f8621a508b2bbdc",
+          "title": "FATA DIN FAVELA",
+          "artists": [
+            {
+              "name": "VANILLA"
+            },
+            {
+              "name": "Badd G"
+            }
+          ],
+          "album": {
+            "name": "VARA BRAZIL",
+            "releaseDate": "2025-07-04"
+          },
+          "durationMs": 174375,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c8f76e46e6de9d071ae7582a"
+        },
+        {
+          "position": 31,
+          "id": "levyra-7da216a9179562339fb8",
+          "title": "Are basul big",
+          "artists": [
+            {
+              "name": "Tzanca Uraganu"
+            }
+          ],
+          "album": {
+            "name": "Are basul big",
+            "releaseDate": "2026-07-01"
+          },
+          "durationMs": 138274,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "6iXBkX3_0oc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCUfYDPYsR_AVR8cvcIB_YDA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0282695e769c6af8c1494199c6"
+        },
+        {
+          "position": 32,
+          "id": "levyra-5e48ab6720f2e5407c82",
+          "title": "Taj Mahal",
+          "artists": [
+            {
+              "name": "rares"
+            },
+            {
+              "name": "Lazy Ed"
+            },
+            {
+              "name": "Costel Biju"
+            }
+          ],
+          "album": {
+            "name": "Taj Mahal",
+            "releaseDate": "2026-03-11"
+          },
+          "durationMs": 161632,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "kKdmyjNwm6c",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCl8xd24oAVaDgMvlpmhwDMg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021c35b9f89b46e1fe9a55c322"
+        },
+        {
+          "position": 33,
+          "id": "levyra-75eb8ac9f9539527c520",
+          "title": "FREAKED OUT",
+          "artists": [
+            {
+              "name": "Fat Papi"
+            },
+            {
+              "name": "prodshushy"
+            }
+          ],
+          "album": {
+            "name": "FREAKED OUT",
+            "releaseDate": "2026-06-04"
+          },
+          "durationMs": 158117,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "kFeYV_QO2oo",
+            "audioConfidence": 100,
+            "videoId": "Q6978DnF8C4",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCIxQaQgIMFBZgD086eu5dXA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dae2db6b9b0a2d5ef298075f"
+        },
+        {
+          "position": 34,
+          "id": "levyra-833532a3b49da12b42b4",
+          "title": "Jamaican (Bam Bam)",
+          "artists": [
+            {
+              "name": "HUGEL"
+            },
+            {
+              "name": "SOLTO (FR)"
+            }
+          ],
+          "album": {
+            "name": "Jamaican (Bam Bam)",
+            "releaseDate": "2025-11-07"
+          },
+          "durationMs": 156393,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02450a730dd72f3bf49882ae9d"
+        },
+        {
+          "position": 35,
+          "id": "levyra-e783696a4dab24a778a6",
+          "title": "Mare Fumusete",
+          "artists": [
+            {
+              "name": "Denis Spaniolu'"
+            }
+          ],
+          "album": {
+            "name": "Mare Fumusete",
+            "releaseDate": "2023-06-18"
+          },
+          "durationMs": 210000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "SvIkieAwkcI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UChTFZ02T6GDouLivWy7PcCQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02db3fbf96a6d13530f61add30"
+        },
+        {
+          "position": 36,
+          "id": "levyra-f292bd6f8c963b162a36",
+          "title": "Peter Parker - Balkanic Version",
+          "artists": [
+            {
+              "name": "Lele"
+            },
+            {
+              "name": "Petre Stefan"
+            },
+            {
+              "name": "Manele VTM"
+            }
+          ],
+          "album": {
+            "name": "Peter Parker (Balkanic Version)",
+            "releaseDate": "2026-02-18"
+          },
+          "durationMs": 198837,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "zHcQCLBmyYg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCDItydY2JH0ORCuZLEpXN0g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02893bf3652c61c54656178230"
+        },
+        {
+          "position": 37,
+          "id": "levyra-4caa52b3ef2c1476357a",
+          "title": "Te pup",
+          "artists": [
+            {
+              "name": "Bogdan DLP"
+            }
+          ],
+          "album": {
+            "name": "Te pup",
+            "releaseDate": "2026-05-22"
+          },
+          "durationMs": 143565,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "SXwiI1IpZNY",
+            "audioConfidence": 100,
+            "videoId": "MbBWkJckso8",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCmcF56FbeZqOoDCsyOcxGZg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028b5bc27200d2983e9b697b28"
+        },
+        {
+          "position": 38,
+          "id": "levyra-12b907ba1b185c653aea",
+          "title": "Bipolară",
+          "artists": [
+            {
+              "name": "Denis Ramniceanu"
+            },
+            {
+              "name": "Ministerul Manelelor"
+            }
+          ],
+          "album": {
+            "name": "Bipolară",
+            "releaseDate": "2025-04-21"
+          },
+          "durationMs": 159157,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "rEw__mmeVaw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCdLL4C20HXxgiomZ9sYalcA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0246e514471152bbcb286e67cd"
+        },
+        {
+          "position": 39,
+          "id": "levyra-411ee215adfe5f5c97c7",
+          "title": "Animal",
+          "artists": [
+            {
+              "name": "KATSEYE"
+            }
+          ],
+          "album": {
+            "name": "Animal",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 158494,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "vOfyxPRunFM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCX9kfYB9t0tnd6DYUC2iuKg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029e8d48f27391ce383862b8e8"
+        },
+        {
+          "position": 40,
+          "id": "levyra-fbbdcc298b128666a04d",
+          "title": "Balerina mea",
+          "artists": [
+            {
+              "name": "Nikolas Sax"
+            }
+          ],
+          "album": {
+            "name": "Balerina mea",
+            "releaseDate": "2025-07-30"
+          },
+          "durationMs": 164837,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02df398182b06448740d321a0c"
+        },
+        {
+          "position": 41,
+          "id": "levyra-0ee847d85ad114f73987",
+          "title": "Ceai langa tine",
+          "artists": [
+            {
+              "name": "Theo Rose"
+            }
+          ],
+          "album": {
+            "name": "Ceai langa tine",
+            "releaseDate": "2026-07-14"
+          },
+          "durationMs": 149387,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "75HFkHn_n8A",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC4X0f6_0a77pL0ZtjpCo7sw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0223781186992f13efb6fbe30e"
+        },
+        {
+          "position": 42,
+          "id": "levyra-37b99df1cf9a74655dac",
+          "title": "Cupidoane",
+          "artists": [
+            {
+              "name": "Tzanca Uraganu"
+            }
+          ],
+          "album": {
+            "name": "Cupidoane",
+            "releaseDate": "2025-12-07"
+          },
+          "durationMs": 146872,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qfysNFY6TYk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCUfYDPYsR_AVR8cvcIB_YDA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bd1327b6bd632dd5b5556594"
+        },
+        {
+          "position": 43,
+          "id": "levyra-e9872ac07860b11e11aa",
+          "title": "IN MINTEA TA",
+          "artists": [
+            {
+              "name": "VANILLA"
+            },
+            {
+              "name": "Marrio Nadal"
+            }
+          ],
+          "album": {
+            "name": "IN MINTEA TA",
+            "releaseDate": "2025-12-19"
+          },
+          "durationMs": 120000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b51265ec55ad559b7fc66906"
+        },
+        {
+          "position": 44,
+          "id": "levyra-1c30006f0ea55da24494",
+          "title": "Toreador",
+          "artists": [
+            {
+              "name": "Mario"
+            },
+            {
+              "name": "Connect-R"
+            }
+          ],
+          "album": {
+            "name": "Toreador",
+            "releaseDate": "2026-06-01"
+          },
+          "durationMs": 194000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lJHaVs7AUXs",
+            "audioConfidence": 100,
+            "videoId": "niNDQO-Ie4g",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCCI-afwdjGrddpZkAx7Eitg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02130cd73336041b71164b1b84"
+        },
+        {
+          "position": 45,
+          "id": "levyra-a906d007445d79dd7edf",
+          "title": "Treat You Better",
+          "artists": [
+            {
+              "name": "Shawn Mendes"
+            }
+          ],
+          "album": {
+            "name": "Illuminate",
+            "releaseDate": "2017-04-20"
+          },
+          "durationMs": 187973,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qSay_8xzijg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC6ZjlLJhqP79nqGr3Ic6Adg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021376b4b16f4bfcba02dc571b"
+        },
+        {
+          "position": 46,
+          "id": "levyra-955a9d43368fb47f6c74",
+          "title": "Papaya",
+          "artists": [
+            {
+              "name": "Babasha"
+            }
+          ],
+          "album": {
+            "name": "Papaya",
+            "releaseDate": "2026-02-19"
+          },
+          "durationMs": 162782,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "02qzbjABMjk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCbfAFHARtgwNZKZnICS8o9Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c77e82068ae3407767172d2b"
+        },
+        {
+          "position": 47,
+          "id": "levyra-27edd467cebc735f6901",
+          "title": "Ban pe Ban",
+          "artists": [
+            {
+              "name": "Badd G"
+            },
+            {
+              "name": "VANILLA"
+            }
+          ],
+          "album": {
+            "name": "Ban pe Ban",
+            "releaseDate": "2025-10-07"
+          },
+          "durationMs": 153750,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "rixTguVA5tA",
+            "audioConfidence": 100,
+            "videoId": "61MlVb5viac",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCmTze8hAjaG6c0FtLq64M7Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021343400c64c13bc57b30fcff"
+        },
+        {
+          "position": 48,
+          "id": "levyra-4222a7ecfb2791935f70",
+          "title": "CATEL",
+          "artists": [
+            {
+              "name": "MADATORRICELLI"
+            }
+          ],
+          "album": {
+            "name": "CATEL",
+            "releaseDate": "2025-12-23"
+          },
+          "durationMs": 160000,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "HHgPd5wuK1A",
+            "audioConfidence": 100,
+            "videoId": "KyHYmy3YJsw",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCyr_ncyeNdbE4xOUCFVYi5Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0253399cbc68a3a50a6a8d2a81"
+        },
+        {
+          "position": 49,
+          "id": "levyra-967321824dd42fcdcdf0",
+          "title": "Balans",
+          "artists": [
+            {
+              "name": "Lazy Ed"
+            },
+            {
+              "name": "Mario"
+            }
+          ],
+          "album": {
+            "name": "Balans",
+            "releaseDate": "2026-01-15"
+          },
+          "durationMs": 134399,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "2mOUf2i8NOk",
+            "audioConfidence": 100,
+            "videoId": "kIdn9RruN7Q",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC3h8X6BJCtQNnLVZm0Ak3mw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026fd00856a2a74ff90cd46de2"
+        },
+        {
+          "position": 50,
+          "id": "levyra-72f086835aeac2f212ad",
+          "title": "SA TE PUP",
+          "artists": [
+            {
+              "name": "Connect-R"
+            }
+          ],
+          "album": {
+            "name": "SA TE PUP",
+            "releaseDate": "2026-06-16"
+          },
+          "durationMs": 173793,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "WF46ozR0_pM",
+            "audioConfidence": 100,
+            "videoId": "QXJPzNIXMKQ",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCWo3lcw0FK1Dzvu0wPfxySg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024bc3851b48ae970c10a36a85"
+        }
+      ]
+    },
+    {
+      "id": "top-50-gr",
+      "kind": "chart",
+      "market": "GR",
+      "title": "Top 50 Ελλάδα",
+      "description": "Grecia: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-ceeb3d1fe77b7ac7204f",
+          "title": "AURIO",
+          "artists": [
+            {
+              "name": "SNIK"
+            },
+            {
+              "name": "HIT MACHINE"
+            }
+          ],
+          "album": {
+            "name": "AURIO",
+            "releaseDate": "2026-07-30"
+          },
+          "durationMs": 155624,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025966576cd66d1f32aa637d05"
+        },
+        {
+          "position": 2,
+          "id": "levyra-935459dfb2bd3de28649",
+          "title": "TETTEH",
+          "artists": [
+            {
+              "name": "Strat"
+            },
+            {
+              "name": "Arab"
+            },
+            {
+              "name": "Trannos"
+            },
+            {
+              "name": "BeTaf Beats"
+            }
+          ],
+          "album": {
+            "name": "RICH BEFORE DEATH",
+            "releaseDate": "2026-07-17"
+          },
+          "durationMs": 183000,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025351da2e2c4af36864d18cfe"
+        },
+        {
+          "position": 3,
+          "id": "levyra-156b80b3ba0d65c3f51e",
+          "title": "PALOMA",
+          "artists": [
+            {
+              "name": "RACK"
+            },
+            {
+              "name": "MENJU"
+            },
+            {
+              "name": "Oge"
+            }
+          ],
+          "album": {
+            "name": "Love, Rack.",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 168500,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026cf7d438a7164bc14bde66cc"
+        },
+        {
+          "position": 4,
+          "id": "levyra-f3cf615da88062abef45",
+          "title": "Baila",
+          "artists": [
+            {
+              "name": "Light"
+            },
+            {
+              "name": "Arab"
+            }
+          ],
+          "album": {
+            "name": "Romeo II",
+            "releaseDate": "2026-06-25"
+          },
+          "durationMs": 130333,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0291bd401f07fbf2c4e189ef16"
+        },
+        {
+          "position": 5,
+          "id": "levyra-d5d6569bce5e47523a54",
+          "title": "Katsiki",
+          "artists": [
+            {
+              "name": "Light"
+            },
+            {
+              "name": "RACK"
+            }
+          ],
+          "album": {
+            "name": "Romeo II",
+            "releaseDate": "2026-06-25"
+          },
+          "durationMs": 152100,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0291bd401f07fbf2c4e189ef16"
+        },
+        {
+          "position": 6,
+          "id": "levyra-2a139e177272ae76b7d3",
+          "title": "Adam & Eve",
+          "artists": [
+            {
+              "name": "Light"
+            },
+            {
+              "name": "Noizy"
+            }
+          ],
+          "album": {
+            "name": "Romeo II",
+            "releaseDate": "2026-06-25"
+          },
+          "durationMs": 159600,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0291bd401f07fbf2c4e189ef16"
+        },
+        {
+          "position": 7,
+          "id": "levyra-dadb0e16ce1261823456",
+          "title": "MIA",
+          "artists": [
+            {
+              "name": "RACK"
+            },
+            {
+              "name": "FLY LO"
+            },
+            {
+              "name": "Beyond"
+            }
+          ],
+          "album": {
+            "name": "Love, Rack.",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 174750,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026cf7d438a7164bc14bde66cc"
+        },
+        {
+          "position": 8,
+          "id": "levyra-299af4656805ae3979f3",
+          "title": "GEITONIA KAI TILEFONO",
+          "artists": [
+            {
+              "name": "TOQUEL"
+            },
+            {
+              "name": "Bloody Hawk"
+            },
+            {
+              "name": "Beyond"
+            }
+          ],
+          "album": {
+            "name": "10 (PART 2)",
+            "releaseDate": "2026-07-02"
+          },
+          "durationMs": 174315,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0260480c15b7f2453906df9920"
+        },
+        {
+          "position": 9,
+          "id": "levyra-ae0e23170d76b7257345",
+          "title": "KLEIDIA",
+          "artists": [
+            {
+              "name": "SNIK"
+            },
+            {
+              "name": "Trannos"
+            }
+          ],
+          "album": {
+            "name": "SNIK X TRANNOS",
+            "releaseDate": "2026-06-18"
+          },
+          "durationMs": 174065,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e8b82cf1bf59378344a5e966"
+        },
+        {
+          "position": 10,
+          "id": "levyra-a8672dfd594843aea88c",
+          "title": "MENTALITE",
+          "artists": [
+            {
+              "name": "Ivan Greko"
+            },
+            {
+              "name": "DON LEON"
+            },
+            {
+              "name": "Tr4cer"
+            }
+          ],
+          "album": {
+            "name": "MENTALITE",
+            "releaseDate": "2026-07-29"
+          },
+          "durationMs": 151578,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02446c8d70d9fb74b429d34891"
+        },
+        {
+          "position": 11,
+          "id": "levyra-7ba7befd0bdceeb58e2f",
+          "title": "VACE ZELA",
+          "artists": [
+            {
+              "name": "TOQUEL"
+            }
+          ],
+          "album": {
+            "name": "10 (PART 2)",
+            "releaseDate": "2026-07-02"
+          },
+          "durationMs": 196540,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0260480c15b7f2453906df9920"
+        },
+        {
+          "position": 12,
+          "id": "levyra-3f33ef27de11b58f3fe2",
+          "title": "BANANA",
+          "artists": [
+            {
+              "name": "FLY LO"
+            },
+            {
+              "name": "Trannos"
+            },
+            {
+              "name": "BLVD"
+            }
+          ],
+          "album": {
+            "name": "VEGANZE",
+            "releaseDate": "2026-04-23"
+          },
+          "durationMs": 191020,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0274a6e46c2c5664e8cc94fbb8"
+        },
+        {
+          "position": 13,
+          "id": "levyra-be47cf5ea394751ac63e",
+          "title": "XIMEROMA",
+          "artists": [
+            {
+              "name": "TOQUEL"
+            },
+            {
+              "name": "Saske"
+            },
+            {
+              "name": "Beyond"
+            }
+          ],
+          "album": {
+            "name": "10 (PART 2)",
+            "releaseDate": "2026-07-02"
+          },
+          "durationMs": 157166,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0260480c15b7f2453906df9920"
+        },
+        {
+          "position": 14,
+          "id": "levyra-7c93af2e71e8933590c7",
+          "title": "POIOS NA SOU TO PEI",
+          "artists": [
+            {
+              "name": "TOQUEL"
+            },
+            {
+              "name": "LILA"
+            },
+            {
+              "name": "Beyond"
+            }
+          ],
+          "album": {
+            "name": "10",
+            "releaseDate": "2026-03-12"
+          },
+          "durationMs": 175714,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02858513e3fb054391e6a331ee"
+        },
+        {
+          "position": 15,
+          "id": "levyra-93e61ed1122b05bcb1c1",
+          "title": "MORE PUTA",
+          "artists": [
+            {
+              "name": "TOQUEL"
+            },
+            {
+              "name": "RACK"
+            },
+            {
+              "name": "Beyond"
+            }
+          ],
+          "album": {
+            "name": "10 (PART 2)",
+            "releaseDate": "2026-07-02"
+          },
+          "durationMs": 154705,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0260480c15b7f2453906df9920"
+        },
+        {
+          "position": 16,
+          "id": "levyra-3cef0fb075845c926adc",
+          "title": "Idi Amin",
+          "artists": [
+            {
+              "name": "Light"
+            }
+          ],
+          "album": {
+            "name": "Romeo II",
+            "releaseDate": "2026-06-25"
+          },
+          "durationMs": 156000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0291bd401f07fbf2c4e189ef16"
+        },
+        {
+          "position": 17,
+          "id": "levyra-42e74cbbb28e50aac802",
+          "title": "omw",
+          "artists": [
+            {
+              "name": "Light"
+            }
+          ],
+          "album": {
+            "name": "Romeo II",
+            "releaseDate": "2026-06-25"
+          },
+          "durationMs": 244000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0291bd401f07fbf2c4e189ef16"
+        },
+        {
+          "position": 18,
+          "id": "levyra-d84289acbb44cdeb8d0f",
+          "title": "THALASSA AKRIVI",
+          "artists": [
+            {
+              "name": "RACK"
+            },
+            {
+              "name": "LILA"
+            },
+            {
+              "name": "Beyond"
+            },
+            {
+              "name": "Sin Laurent"
+            }
+          ],
+          "album": {
+            "name": "Love, Rack.",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 169485,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026cf7d438a7164bc14bde66cc"
+        },
+        {
+          "position": 19,
+          "id": "levyra-a7c357527a4ad8c2d614",
+          "title": "MOLIS GNORISTIKAME",
+          "artists": [
+            {
+              "name": "Kidd"
+            },
+            {
+              "name": "BLVD"
+            }
+          ],
+          "album": {
+            "name": "MOLIS GNORISTIKAME",
+            "releaseDate": "2026-07-16"
+          },
+          "durationMs": 146820,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d6fc2f0184c077340116add4"
+        },
+        {
+          "position": 20,
+          "id": "levyra-1b44ee2aaf5331d637cb",
+          "title": "CASINO",
+          "artists": [
+            {
+              "name": "RACK"
+            },
+            {
+              "name": "Konstantinos Argiros"
+            },
+            {
+              "name": "Sin Laurent"
+            }
+          ],
+          "album": {
+            "name": "Love, Rack.",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 144124,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026cf7d438a7164bc14bde66cc"
+        },
+        {
+          "position": 21,
+          "id": "levyra-285892222a34c0b7bce4",
+          "title": "GEN Z",
+          "artists": [
+            {
+              "name": "SNIK"
+            },
+            {
+              "name": "Trannos"
+            }
+          ],
+          "album": {
+            "name": "SNIK X TRANNOS",
+            "releaseDate": "2026-06-18"
+          },
+          "durationMs": 169846,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e8b82cf1bf59378344a5e966"
+        },
+        {
+          "position": 22,
+          "id": "levyra-b652b0e703d9a8ce3566",
+          "title": "GAME OVER",
+          "artists": [
+            {
+              "name": "Strat"
+            },
+            {
+              "name": "Arab"
+            },
+            {
+              "name": "HermesHermes"
+            },
+            {
+              "name": "BeTaf Beats"
+            }
+          ],
+          "album": {
+            "name": "RICH BEFORE DEATH",
+            "releaseDate": "2026-07-17"
+          },
+          "durationMs": 195319,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025351da2e2c4af36864d18cfe"
+        },
+        {
+          "position": 23,
+          "id": "levyra-883c274f6f0151b2e66c",
+          "title": "PHUKET",
+          "artists": [
+            {
+              "name": "Strat"
+            },
+            {
+              "name": "Arab"
+            },
+            {
+              "name": "BeTaf Beats"
+            }
+          ],
+          "album": {
+            "name": "RICH BEFORE DEATH",
+            "releaseDate": "2026-07-17"
+          },
+          "durationMs": 148615,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025351da2e2c4af36864d18cfe"
+        },
+        {
+          "position": 24,
+          "id": "levyra-ab4b84e6cd44eb4523d5",
+          "title": "AVENTURA",
+          "artists": [
+            {
+              "name": "Likeboss"
+            },
+            {
+              "name": "Arab"
+            },
+            {
+              "name": "HermesHermes"
+            },
+            {
+              "name": "GMBeaTz"
+            }
+          ],
+          "album": {
+            "name": "AVENTURA",
+            "releaseDate": "2026-06-23"
+          },
+          "durationMs": 181492,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b7b813f1f7500a66518100a7"
+        },
+        {
+          "position": 25,
+          "id": "levyra-36833b7723831556e18c",
+          "title": "KAMIA",
+          "artists": [
+            {
+              "name": "TOQUEL"
+            },
+            {
+              "name": "Beyond"
+            }
+          ],
+          "album": {
+            "name": "10 (PART 2)",
+            "releaseDate": "2026-07-02"
+          },
+          "durationMs": 188000,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0260480c15b7f2453906df9920"
+        },
+        {
+          "position": 26,
+          "id": "levyra-4ed087058a83ae5e6699",
+          "title": "GIA SENA",
+          "artists": [
+            {
+              "name": "Strat"
+            },
+            {
+              "name": "Arab"
+            },
+            {
+              "name": "Trannos"
+            },
+            {
+              "name": "BeTaf Beats"
+            }
+          ],
+          "album": {
+            "name": "RICH BEFORE DEATH",
+            "releaseDate": "2026-07-17"
+          },
+          "durationMs": 203076,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025351da2e2c4af36864d18cfe"
+        },
+        {
+          "position": 27,
+          "id": "levyra-bd54c686087e72da5a3b",
+          "title": "BBB",
+          "artists": [
+            {
+              "name": "HermesHermes"
+            },
+            {
+              "name": "Stanley"
+            }
+          ],
+          "album": {
+            "name": "BBB",
+            "releaseDate": "2026-07-20"
+          },
+          "durationMs": 128611,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028f2d08eaada73e8c9de7a115"
+        },
+        {
+          "position": 28,
+          "id": "levyra-6ff203cbcb4f58a7b25a",
+          "title": "€€€",
+          "artists": [
+            {
+              "name": "TOQUEL"
+            },
+            {
+              "name": "FLY LO"
+            },
+            {
+              "name": "Beyond"
+            }
+          ],
+          "album": {
+            "name": "10",
+            "releaseDate": "2026-03-12"
+          },
+          "durationMs": 174153,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02858513e3fb054391e6a331ee"
+        },
+        {
+          "position": 29,
+          "id": "levyra-04bfba7e0fbd5c2ffec5",
+          "title": "TONIGHT",
+          "artists": [
+            {
+              "name": "SNIK"
+            },
+            {
+              "name": "Trannos"
+            }
+          ],
+          "album": {
+            "name": "SNIK X TRANNOS",
+            "releaseDate": "2026-06-18"
+          },
+          "durationMs": 213442,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e8b82cf1bf59378344a5e966"
+        },
+        {
+          "position": 30,
+          "id": "levyra-cf1c9cf0718bde5fb75d",
+          "title": "KAKOS GIA SENA",
+          "artists": [
+            {
+              "name": "TOQUEL"
+            },
+            {
+              "name": "Beyond"
+            }
+          ],
+          "album": {
+            "name": "10",
+            "releaseDate": "2026-03-12"
+          },
+          "durationMs": 181224,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02858513e3fb054391e6a331ee"
+        },
+        {
+          "position": 31,
+          "id": "levyra-ca3402df18fa73dae3e6",
+          "title": "A$$AP",
+          "artists": [
+            {
+              "name": "TOQUEL"
+            },
+            {
+              "name": "ObieDaz"
+            }
+          ],
+          "album": {
+            "name": "10 (PART 2)",
+            "releaseDate": "2026-07-02"
+          },
+          "durationMs": 146400,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0260480c15b7f2453906df9920"
+        },
+        {
+          "position": 32,
+          "id": "levyra-0529c8ecb9a6a5a4199e",
+          "title": "AMAZING - Remix",
+          "artists": [
+            {
+              "name": "SIDARTA"
+            },
+            {
+              "name": "RACK"
+            }
+          ],
+          "album": {
+            "name": "AMAZING (Remix)",
+            "releaseDate": "2026-02-13"
+          },
+          "durationMs": 158769,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026ea865c732774567bd3701f3"
+        },
+        {
+          "position": 33,
+          "id": "levyra-e83ba3b13b082a85b659",
+          "title": "ANNA",
+          "artists": [
+            {
+              "name": "RACK"
+            },
+            {
+              "name": "Beyond"
+            }
+          ],
+          "album": {
+            "name": "Love, Rack.",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 147000,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026cf7d438a7164bc14bde66cc"
+        },
+        {
+          "position": 34,
+          "id": "levyra-e86580a94a7ef93084a1",
+          "title": "LETE LETE",
+          "artists": [
+            {
+              "name": "SNIK"
+            },
+            {
+              "name": "Trannos"
+            },
+            {
+              "name": "Fy"
+            }
+          ],
+          "album": {
+            "name": "VRD",
+            "releaseDate": "2026-04-02"
+          },
+          "durationMs": 213120,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ad2e5c4961e7bb88a0ba3d7d"
+        },
+        {
+          "position": 35,
+          "id": "levyra-5d8e4cd35fe7cfd54fef",
+          "title": "Kantada",
+          "artists": [
+            {
+              "name": "APON"
+            }
+          ],
+          "album": {
+            "name": "Ixogenia",
+            "releaseDate": "2026-05-15"
+          },
+          "durationMs": 134857,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "gyKd0MSkZrU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCVwfUFIdTP2GmjuxupxfGcw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0284be39a3714e2caee9a5fab1"
+        },
+        {
+          "position": 36,
+          "id": "levyra-b007d3965fa5d0026e2a",
+          "title": "YAMAS",
+          "artists": [
+            {
+              "name": "RACK"
+            },
+            {
+              "name": "EVA"
+            },
+            {
+              "name": "Beyond"
+            }
+          ],
+          "album": {
+            "name": "Love, Rack.",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 172161,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026cf7d438a7164bc14bde66cc"
+        },
+        {
+          "position": 37,
+          "id": "levyra-4500512f5aa38edfe312",
+          "title": "Dai Dai",
+          "artists": [
+            {
+              "name": "Shakira"
+            },
+            {
+              "name": "Burna Boy"
+            }
+          ],
+          "album": {
+            "name": "Dai Dai",
+            "releaseDate": "2026-05-14"
+          },
+          "durationMs": 223448,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lFQdcPTTzSg",
+            "audioConfidence": 100,
+            "videoId": "fcnDmrtj6Sk",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCo6JijJGA3IvIiPsawDK3Ww"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0203cadf1b3fe324c1dc710ed4"
+        },
+        {
+          "position": 38,
+          "id": "levyra-7b1692c9088891914d10",
+          "title": "BOGOTA",
+          "artists": [
+            {
+              "name": "Ivan Greko"
+            }
+          ],
+          "album": {
+            "name": "TIGER LUV",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 109714,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "v6dK0KX6PG4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCNVqct8lq-HiaIOYgZLRi1g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a7130156a1e5007ac7139534"
+        },
+        {
+          "position": 39,
+          "id": "levyra-ca718bfde2f0fa6e1b62",
+          "title": "HAHAHA 2",
+          "artists": [
+            {
+              "name": "CHEKKIS"
+            },
+            {
+              "name": "HermesHermes"
+            },
+            {
+              "name": "SKEZ"
+            }
+          ],
+          "album": {
+            "name": "HAHAHA 2",
+            "releaseDate": "2026-06-08"
+          },
+          "durationMs": 176511,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b9b107c161d7aff7c2349b0f"
+        },
+        {
+          "position": 40,
+          "id": "levyra-ac71cae59d92f9af1501",
+          "title": "Safari",
+          "artists": [
+            {
+              "name": "Ria Ellinidou"
+            }
+          ],
+          "album": {
+            "name": "Sto Mualo Sou",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 194658,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "8Hl3h_EWrPc",
+            "audioConfidence": 100,
+            "videoId": "hE7Ufu97Rmo",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCrAyGU1-3kUZmC1vQhPxI-g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dedbcff44922e79b559b7a85"
+        },
+        {
+          "position": 41,
+          "id": "levyra-cf243b062a42976ab15a",
+          "title": "C’est La Vie",
+          "artists": [
+            {
+              "name": "Light"
+            }
+          ],
+          "album": {
+            "name": "Romeo II",
+            "releaseDate": "2026-06-25"
+          },
+          "durationMs": 171433,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "YP5jh0h9xxU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCrDgPAH4PdfhzAgF9pY2-YA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0291bd401f07fbf2c4e189ef16"
+        },
+        {
+          "position": 42,
+          "id": "levyra-3f10898a119d207610e3",
+          "title": "Cannes",
+          "artists": [
+            {
+              "name": "Light"
+            },
+            {
+              "name": "Saske"
+            }
+          ],
+          "album": {
+            "name": "Romeo II",
+            "releaseDate": "2026-06-25"
+          },
+          "durationMs": 196933,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0291bd401f07fbf2c4e189ef16"
+        },
+        {
+          "position": 43,
+          "id": "levyra-cc0bd6f9512f65df3b6c",
+          "title": "Street Code",
+          "artists": [
+            {
+              "name": "2shots"
+            },
+            {
+              "name": "Bres"
+            }
+          ],
+          "album": {
+            "name": "Street Code",
+            "releaseDate": "2026-07-30"
+          },
+          "durationMs": 160421,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02aae30e97c5bb7ff3c41add3d"
+        },
+        {
+          "position": 44,
+          "id": "levyra-0532ffe92977179898b7",
+          "title": "ANASA",
+          "artists": [
+            {
+              "name": "TOQUEL"
+            },
+            {
+              "name": "BoyPanda"
+            }
+          ],
+          "album": {
+            "name": "10 (PART 2)",
+            "releaseDate": "2026-07-02"
+          },
+          "durationMs": 125538,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0260480c15b7f2453906df9920"
+        },
+        {
+          "position": 45,
+          "id": "levyra-eb78cbc2e34414b8d143",
+          "title": "AMA SARESW",
+          "artists": [
+            {
+              "name": "Strat"
+            },
+            {
+              "name": "Arab"
+            },
+            {
+              "name": "BeTaf Beats"
+            }
+          ],
+          "album": {
+            "name": "RICH BEFORE DEATH",
+            "releaseDate": "2026-07-17"
+          },
+          "durationMs": 136615,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025351da2e2c4af36864d18cfe"
+        },
+        {
+          "position": 46,
+          "id": "levyra-766a9a975ca7614f6ad8",
+          "title": "AVANTAGE",
+          "artists": [
+            {
+              "name": "XRS"
+            },
+            {
+              "name": "RICTA"
+            },
+            {
+              "name": "Night Grind"
+            }
+          ],
+          "album": {
+            "name": "AVANTAGE",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 211718,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d1411954f229b3244c1d6a8d"
+        },
+        {
+          "position": 47,
+          "id": "levyra-2d382c82daa578f477f7",
+          "title": "CHANEL",
+          "artists": [
+            {
+              "name": "Trannos"
+            },
+            {
+              "name": "SNIK"
+            },
+            {
+              "name": "CHEKKIS"
+            }
+          ],
+          "album": {
+            "name": "WHY ALWAYS ME?",
+            "releaseDate": "2026-01-23"
+          },
+          "durationMs": 203000,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "TBukIn1WuN4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCaqQLpiAp1KfM289On7xWvg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02220291d442fa5918da0f4ea4"
+        },
+        {
+          "position": 48,
+          "id": "levyra-5a34be90b3d7c97b4433",
+          "title": "KIPSELI",
+          "artists": [
+            {
+              "name": "SNIK"
+            },
+            {
+              "name": "Trannos"
+            }
+          ],
+          "album": {
+            "name": "SNIK X TRANNOS",
+            "releaseDate": "2026-06-18"
+          },
+          "durationMs": 145000,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e8b82cf1bf59378344a5e966"
+        },
+        {
+          "position": 49,
+          "id": "levyra-d874e1f9a63e3e08b8c3",
+          "title": "Ki Esy Stin Paro?",
+          "artists": [
+            {
+              "name": "Light"
+            }
+          ],
+          "album": {
+            "name": "Romeo II",
+            "releaseDate": "2026-06-25"
+          },
+          "durationMs": 167166,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0291bd401f07fbf2c4e189ef16"
+        },
+        {
+          "position": 50,
+          "id": "levyra-885fc5f34a63a45a8358",
+          "title": "Eipes",
+          "artists": [
+            {
+              "name": "Thodoris Ferris"
+            }
+          ],
+          "album": {
+            "name": "Oso Tha Gyrizei I Gi",
+            "releaseDate": "2026-01-23"
+          },
+          "durationMs": 243936,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "gwVi8mr7BuE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCZg-uIuERCrE7EPu8H2tlxA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022eb8997de7846d967339e42c"
+        }
+      ]
+    },
+    {
+      "id": "top-50-se",
+      "kind": "chart",
+      "market": "SE",
+      "title": "Top 50 Sverige",
+      "description": "Svezia: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-c25ecb8756660267b94a",
+          "title": "Djurens vaggvisa",
+          "artists": [
+            {
+              "name": "Humlan Djojj"
+            },
+            {
+              "name": "Josefine Götestam"
+            }
+          ],
+          "album": {
+            "name": "Somna med Humlan Djojj",
+            "releaseDate": "2020-10-30"
+          },
+          "durationMs": 140046,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "9zbIlQOu7VE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCgdudhVrecjBxDEuk7-ZzmA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02463fce4562806107cddf6aea"
+        },
+        {
+          "position": 2,
+          "id": "levyra-4500512f5aa38edfe312",
+          "title": "Dai Dai",
+          "artists": [
+            {
+              "name": "Shakira"
+            },
+            {
+              "name": "Burna Boy"
+            }
+          ],
+          "album": {
+            "name": "Dai Dai",
+            "releaseDate": "2026-05-14"
+          },
+          "durationMs": 223448,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lFQdcPTTzSg",
+            "audioConfidence": 100,
+            "videoId": "fcnDmrtj6Sk",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCo6JijJGA3IvIiPsawDK3Ww"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0203cadf1b3fe324c1dc710ed4"
+        },
+        {
+          "position": 3,
+          "id": "levyra-ddb870aa7a7ab7bf936c",
+          "title": "Matadoren",
+          "artists": [
+            {
+              "name": "Yasin"
+            }
+          ],
+          "album": {
+            "name": "Matadoren",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 121133,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "e3ObGjmyhds",
+            "audioConfidence": 100,
+            "videoId": "nyc4nEE-og4",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCT9BhhnyTXyElpGV9pT8Tuw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02fc53c54434b2440d1c26b81e"
+        },
+        {
+          "position": 4,
+          "id": "levyra-9a4be11b00c0a461faf4",
+          "title": "Great Expectation",
+          "artists": [
+            {
+              "name": "SIENNA SPIRO"
+            }
+          ],
+          "album": {
+            "name": "Visitor",
+            "releaseDate": "2026-07-02"
+          },
+          "durationMs": 173975,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "_5-Dzam3jPU",
+            "audioConfidence": 100,
+            "videoId": "B452TVVco2Q",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCf5GUgSQC4CU8idz_OH8jqQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b09eea420767969b6729962b"
+        },
+        {
+          "position": 5,
+          "id": "levyra-8e5d63b8c1630864cfee",
+          "title": "Olyckligt kär",
+          "artists": [
+            {
+              "name": "ALEX"
+            }
+          ],
+          "album": {
+            "name": "Olyckligt kär",
+            "releaseDate": "2026-04-23"
+          },
+          "durationMs": 178500,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0209e6f59f6ebcc7cf00499117"
+        },
+        {
+          "position": 6,
+          "id": "levyra-aabfa879af7855307b31",
+          "title": "Babblarnas vaggvisa",
+          "artists": [
+            {
+              "name": "Babblarna"
+            }
+          ],
+          "album": {
+            "name": "Upp och ner och hit och dit med Babblarna",
+            "releaseDate": "2023-09-01"
+          },
+          "durationMs": 334053,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c4a9b2f7b917402f799b1ecd"
+        },
+        {
+          "position": 7,
+          "id": "levyra-45ea6ccc73c1974a619a",
+          "title": "Stjärnorna",
+          "artists": [
+            {
+              "name": "Humlan Djojj"
+            },
+            {
+              "name": "Josefine Götestam"
+            }
+          ],
+          "album": {
+            "name": "Somna med Humlan Djojj",
+            "releaseDate": "2020-10-30"
+          },
+          "durationMs": 166216,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "hDLulhk2pHA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCgdudhVrecjBxDEuk7-ZzmA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02463fce4562806107cddf6aea"
+        },
+        {
+          "position": 8,
+          "id": "levyra-f6663bc35697e813e41d",
+          "title": "Wonderwall - Remastered",
+          "artists": [
+            {
+              "name": "Oasis"
+            }
+          ],
+          "album": {
+            "name": "(What's The Story) Morning Glory? (Deluxe Remastered Edition)",
+            "releaseDate": "1995"
+          },
+          "durationMs": 258773,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027a4c8c59851c88f6794c3cbf"
+        },
+        {
+          "position": 9,
+          "id": "levyra-702026cb9a3eb2137fb9",
+          "title": "Humlehum",
+          "artists": [
+            {
+              "name": "Humlan Djojj"
+            },
+            {
+              "name": "Josefine Götestam"
+            }
+          ],
+          "album": {
+            "name": "Sov med Humlan Djojj",
+            "releaseDate": "2024-03-08"
+          },
+          "durationMs": 114124,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023c2941cc5b200a0b17f9c6de"
+        },
+        {
+          "position": 10,
+          "id": "levyra-b20248a4bad72c30607f",
+          "title": "Somna",
+          "artists": [
+            {
+              "name": "Humlan Djojj"
+            },
+            {
+              "name": "Josefine Götestam"
+            }
+          ],
+          "album": {
+            "name": "Somna med Humlan Djojj",
+            "releaseDate": "2020-10-30"
+          },
+          "durationMs": 160373,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "XFGUXddVLMA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCgdudhVrecjBxDEuk7-ZzmA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02463fce4562806107cddf6aea"
+        },
+        {
+          "position": 11,
+          "id": "levyra-93683240d111e7825d3f",
+          "title": "hate that i made you love me",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 197949,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7CUz7Ec7cWc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 12,
+          "id": "levyra-8d52dd5a928cec18a91f",
+          "title": "Lush Life",
+          "artists": [
+            {
+              "name": "Zara Larsson"
+            }
+          ],
+          "album": {
+            "name": "So Good",
+            "releaseDate": "2017-03-17"
+          },
+          "durationMs": 200646,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "RG-D4bcg54s",
+            "audioConfidence": 100,
+            "videoId": "tD4HCZe-tew",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCB-GmTOjewVU2F_7S4ZFmEA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02401bf6103d4b7f5230a21582"
+        },
+        {
+          "position": 13,
+          "id": "levyra-8fcf8f64a3e64dae17a9",
+          "title": "Atom",
+          "artists": [
+            {
+              "name": "Lovet"
+            },
+            {
+              "name": "Victor Leksell"
+            }
+          ],
+          "album": {
+            "name": "Atom",
+            "releaseDate": "2026-05-29"
+          },
+          "durationMs": 161500,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0283c4a1bbe24368dd124b54ec"
+        },
+        {
+          "position": 14,
+          "id": "levyra-ac5b04dcc3d3960aad19",
+          "title": "Nu säger vi godnatt",
+          "artists": [
+            {
+              "name": "Humlan Djojj"
+            },
+            {
+              "name": "Josefine Götestam"
+            }
+          ],
+          "album": {
+            "name": "Somna med Humlan Djojj",
+            "releaseDate": "2020-10-30"
+          },
+          "durationMs": 161481,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "brvLVduH7co",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCgdudhVrecjBxDEuk7-ZzmA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02463fce4562806107cddf6aea"
+        },
+        {
+          "position": 15,
+          "id": "levyra-5c2f779c76102bb23aa0",
+          "title": "Midnight Sun",
+          "artists": [
+            {
+              "name": "Zara Larsson"
+            }
+          ],
+          "album": {
+            "name": "Midnight Sun",
+            "releaseDate": "2025-09-25"
+          },
+          "durationMs": 189898,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027657f9028ea8bb2c18dca99f"
+        },
+        {
+          "position": 16,
+          "id": "levyra-b5757b4ddb9a6e270b83",
+          "title": "SLICKAR PÅ SNÖRET - Uptempo Remix",
+          "artists": [
+            {
+              "name": "Rök Liza"
+            },
+            {
+              "name": "Mio Johansson"
+            }
+          ],
+          "album": {
+            "name": "SLICKAR PÅ SNÖRET (Uptempo Remix)",
+            "releaseDate": "2026-06-11"
+          },
+          "durationMs": 127413,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0289270b7510420920f6115ab8"
+        },
+        {
+          "position": 17,
+          "id": "levyra-d8ef61462b0bb69ebbf9",
+          "title": "Choosin' Texas",
+          "artists": [
+            {
+              "name": "Ella Langley"
+            }
+          ],
+          "album": {
+            "name": "Dandelion",
+            "releaseDate": "2026-04-10"
+          },
+          "durationMs": 231746,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "3s1sZbW7Rt8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCecnyZYofHiBVDJpx1XNYOQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028606848da949bbaddf447d87"
+        },
+        {
+          "position": 18,
+          "id": "levyra-98349a571204b2f4073a",
+          "title": "petal",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 184248,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "4mQyEqbaUOU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 19,
+          "id": "levyra-b31eb5e60513bbd613b7",
+          "title": "Billie Jean",
+          "artists": [
+            {
+              "name": "Michael Jackson"
+            }
+          ],
+          "album": {
+            "name": "Thriller",
+            "releaseDate": "1982-11-30"
+          },
+          "durationMs": 293802,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0232a7d87248d1b75463483df5"
+        },
+        {
+          "position": 20,
+          "id": "levyra-9824cf7c6204b58ac7c7",
+          "title": "Iris",
+          "artists": [
+            {
+              "name": "The Goo Goo Dolls"
+            }
+          ],
+          "album": {
+            "name": "Dizzy up the Girl",
+            "releaseDate": "1998"
+          },
+          "durationMs": 289533,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02eda9478c39a21e1cdc6609ca"
+        },
+        {
+          "position": 21,
+          "id": "levyra-993618f2d04a8fa44687",
+          "title": "Godnattvisan",
+          "artists": [
+            {
+              "name": "Humlan Djojj"
+            },
+            {
+              "name": "Josefine Götestam"
+            }
+          ],
+          "album": {
+            "name": "Somna med Humlan Djojj",
+            "releaseDate": "2020-10-30"
+          },
+          "durationMs": 120545,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "9YU5lFqpgV4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCgdudhVrecjBxDEuk7-ZzmA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02463fce4562806107cddf6aea"
+        },
+        {
+          "position": 22,
+          "id": "levyra-3f2dcb748a0d34c72f83",
+          "title": "Self Aware",
+          "artists": [
+            {
+              "name": "Temper City"
+            }
+          ],
+          "album": {
+            "name": "Self Aware",
+            "releaseDate": "2026-02-15"
+          },
+          "durationMs": 180740,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "R-hYM3BqTbA",
+            "audioConfidence": 100,
+            "videoId": "mh4AQkw4Jjc",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCpWebSe88U-TOiO8YfKnTgg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d6c26d2ae723f7ab553d64cc"
+        },
+        {
+          "position": 23,
+          "id": "levyra-d5d19a1705964eca30c4",
+          "title": "bloodstream",
+          "artists": [
+            {
+              "name": "Alyssa Grace"
+            }
+          ],
+          "album": {
+            "name": "bloodstream",
+            "releaseDate": "2026-06-04"
+          },
+          "durationMs": 177428,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "CLSuAhT71yU",
+            "audioConfidence": 100,
+            "videoId": "FOJ4A4wixDg",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCXi-L3_hX9d3TdX5_wO-EJw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029c031feeff1647deb7577309"
+        },
+        {
+          "position": 24,
+          "id": "levyra-f3ec762a107edb040049",
+          "title": "Pilé - Gospel",
+          "artists": [
+            {
+              "name": "Mauvais djo"
+            },
+            {
+              "name": "Kano Choir"
+            }
+          ],
+          "album": {
+            "name": "Pilé (Gospel)",
+            "releaseDate": "2026-05-14"
+          },
+          "durationMs": 123720,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "grRKZU-s3Ps",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCmz_Ex4zmTVXvBSzXW_JnKw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028137fce21bfc6a7c3da0db67"
+        },
+        {
+          "position": 25,
+          "id": "levyra-d8eb99ba44bd033cb7e5",
+          "title": "Det ligger nåt i luften",
+          "artists": [
+            {
+              "name": "Bolaget"
+            }
+          ],
+          "album": {
+            "name": "Det ligger nåt i luften",
+            "releaseDate": "2026-06-03"
+          },
+          "durationMs": 150000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "P29lNw1CHYA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCVpv0aK1mbMOSgcKfd1cEcQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d9423d384c4165352efe9858"
+        },
+        {
+          "position": 26,
+          "id": "levyra-411ee215adfe5f5c97c7",
+          "title": "Animal",
+          "artists": [
+            {
+              "name": "KATSEYE"
+            }
+          ],
+          "album": {
+            "name": "Animal",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 158494,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "vOfyxPRunFM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCX9kfYB9t0tnd6DYUC2iuKg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029e8d48f27391ce383862b8e8"
+        },
+        {
+          "position": 27,
+          "id": "levyra-47764fdde285bb5be11a",
+          "title": "Beauty And A Beat",
+          "artists": [
+            {
+              "name": "Justin Bieber"
+            },
+            {
+              "name": "Nicki Minaj"
+            }
+          ],
+          "album": {
+            "name": "Believe",
+            "releaseDate": "2012-01-01"
+          },
+          "durationMs": 227986,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f1d02a6cec967f8b6b78f76e"
+        },
+        {
+          "position": 28,
+          "id": "levyra-b3848028b604a1f98044",
+          "title": "Happiness Is So Sad",
+          "artists": [
+            {
+              "name": "Swedish House Mafia"
+            },
+            {
+              "name": "Lykke Li"
+            }
+          ],
+          "album": {
+            "name": "Happiness Is So Sad",
+            "releaseDate": "2026-07-30"
+          },
+          "durationMs": 232835,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "XLU3cwwAUU8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCl5p1gD46TZVsoQmM8VZ2gQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ace7380e8ee73764ea11bbee"
+        },
+        {
+          "position": 29,
+          "id": "levyra-ba39e936cdaaf4d0e07d",
+          "title": "Don't Stop Believin' (2022 Remaster)",
+          "artists": [
+            {
+              "name": "Journey"
+            }
+          ],
+          "album": {
+            "name": "Escape (2022 Remaster)",
+            "releaseDate": "1981-07-17"
+          },
+          "durationMs": 249600,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "mM3Vmn4pdog",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCPKnuPciHDB8qw-wyBVQo9A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0223290120a609a65e14cfe018"
+        },
+        {
+          "position": 30,
+          "id": "levyra-9eb4933ab356c0e9c261",
+          "title": "Tusen spänn",
+          "artists": [
+            {
+              "name": "Tjuvjakt"
+            },
+            {
+              "name": "Fanny Avonne"
+            }
+          ],
+          "album": {
+            "name": "Tusen spänn",
+            "releaseDate": "2025-05-09"
+          },
+          "durationMs": 190344,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "xwJ4BGeplQw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCMuloCchUrcVPeG0GpPmZkg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02280a25dc13dab7d7d4d89a27"
+        },
+        {
+          "position": 31,
+          "id": "levyra-85910bd38ab343234c30",
+          "title": "Kan Inte Gå",
+          "artists": [
+            {
+              "name": "Bolaget"
+            }
+          ],
+          "album": {
+            "name": "Kan Inte Gå",
+            "releaseDate": "2021-12-29"
+          },
+          "durationMs": 146718,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02084c48557aa40e2d8af91178"
+        },
+        {
+          "position": 32,
+          "id": "levyra-35844a86b63c91c223c1",
+          "title": "Man I Need",
+          "artists": [
+            {
+              "name": "Olivia Dean"
+            }
+          ],
+          "album": {
+            "name": "The Art of Loving",
+            "releaseDate": "2025-09-26"
+          },
+          "durationMs": 184000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "fsGjRf-N71I",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC6GBKGYX6b3guHlqHLx6IzQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029a336bfb6d40bbd90a507417"
+        },
+        {
+          "position": 33,
+          "id": "levyra-7e552cedb029aecc0f34",
+          "title": "Stateside + Zara Larsson",
+          "artists": [
+            {
+              "name": "PinkPantheress"
+            },
+            {
+              "name": "Zara Larsson"
+            }
+          ],
+          "album": {
+            "name": "Fancy Some More?",
+            "releaseDate": "2025-10-10"
+          },
+          "durationMs": 184761,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02684ecc5bc1b724d0106ad694"
+        },
+        {
+          "position": 34,
+          "id": "levyra-74bf3acd8a9937f430fd",
+          "title": "Vila med mig",
+          "artists": [
+            {
+              "name": "Humlan Djojj"
+            },
+            {
+              "name": "Josefine Götestam"
+            }
+          ],
+          "album": {
+            "name": "Sov med Humlan Djojj",
+            "releaseDate": "2024-03-08"
+          },
+          "durationMs": 138947,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "8Wqa_EHl3-o",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCgdudhVrecjBxDEuk7-ZzmA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023c2941cc5b200a0b17f9c6de"
+        },
+        {
+          "position": 35,
+          "id": "levyra-06c5f823df8284870e5e",
+          "title": "Sunnanvind",
+          "artists": [
+            {
+              "name": "Mares"
+            }
+          ],
+          "album": {
+            "name": "Sunnanvind",
+            "releaseDate": "2019-03-15"
+          },
+          "durationMs": 202409,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "oTN2_UemjAs",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCmKiJuCQG9RfpJdY-pzd51w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a88dea1ea6c805c3d7d707e4"
+        },
+        {
+          "position": 36,
+          "id": "levyra-b9ef6647810d036542e2",
+          "title": "Babblarnas vaggvisa",
+          "artists": [
+            {
+              "name": "Vintergatan"
+            }
+          ],
+          "album": {
+            "name": "Babblarnas vaggvisa",
+            "releaseDate": "2022-04-08"
+          },
+          "durationMs": 305765,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0225531cb87b92028c845396a2"
+        },
+        {
+          "position": 37,
+          "id": "levyra-1c2288687238913595a6",
+          "title": "Dancing On My Own",
+          "artists": [
+            {
+              "name": "Robyn"
+            }
+          ],
+          "album": {
+            "name": "Body Talk",
+            "releaseDate": "2010-01-01"
+          },
+          "durationMs": 285853,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024689597708c1b0b3dcb9ecaf"
+        },
+        {
+          "position": 38,
+          "id": "levyra-66d26b9c701d4a8f11d7",
+          "title": "Beat It",
+          "artists": [
+            {
+              "name": "Michael Jackson"
+            }
+          ],
+          "album": {
+            "name": "Thriller",
+            "releaseDate": "1982-11-30"
+          },
+          "durationMs": 258296,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "kOn-HdEg6AQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCoIOOL7QKuBhQHVKL8y7BEQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0232a7d87248d1b75463483df5"
+        },
+        {
+          "position": 39,
+          "id": "levyra-16c4cb886ff34d0d5230",
+          "title": "Ordinary",
+          "artists": [
+            {
+              "name": "Alex Warren"
+            }
+          ],
+          "album": {
+            "name": "You'll Be Alright, Kid (Chapter 1)",
+            "releaseDate": "2024-09-26"
+          },
+          "durationMs": 186964,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Q2NePVoGxYg",
+            "audioConfidence": 100,
+            "videoId": "u2ah9tWTkmk",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCXATF3-9RFGyY-it_d2hB6A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028d18d73bbfc8985d52865edf"
+        },
+        {
+          "position": 40,
+          "id": "levyra-9865024b575fd60a1858",
+          "title": "Kygo Jo (feat. Lyng) - Kygo Remix",
+          "artists": [
+            {
+              "name": "Kygo"
+            },
+            {
+              "name": "Flow Kingz"
+            },
+            {
+              "name": "JMK"
+            },
+            {
+              "name": "Lyng"
+            }
+          ],
+          "album": {
+            "name": "Kygo Jo (feat. Lyng) [Kygo Remix]",
+            "releaseDate": "2026-07-07"
+          },
+          "durationMs": 153272,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020b00c491971f061b7cf617db"
+        },
+        {
+          "position": 41,
+          "id": "levyra-65b1dfd5ff8b7ee3a359",
+          "title": "Riptide",
+          "artists": [
+            {
+              "name": "Vance Joy"
+            }
+          ],
+          "album": {
+            "name": "Dream Your Life Away (Deluxe Edition)",
+            "releaseDate": "2014-08-05"
+          },
+          "durationMs": 204280,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0205d081cbdc2f67d37a364d63"
+        },
+        {
+          "position": 42,
+          "id": "levyra-45eb42743bd3b01bf5d7",
+          "title": "Africa",
+          "artists": [
+            {
+              "name": "TOTO"
+            }
+          ],
+          "album": {
+            "name": "Toto IV",
+            "releaseDate": "1982-04-08"
+          },
+          "durationMs": 295282,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ebd6d20c0082524244ef83df"
+        },
+        {
+          "position": 43,
+          "id": "levyra-3e37be65ac6838150e43",
+          "title": "Svagare än jag",
+          "artists": [
+            {
+              "name": "Ida-Lova"
+            }
+          ],
+          "album": {
+            "name": "Livet kommer döda oss, vi lever det ändå",
+            "releaseDate": "2026-04-10"
+          },
+          "durationMs": 187076,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "w41voyQ9CIk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCsVkzzVMuhPKIO65ds5lQkg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0201132dff19b25f00edba6538"
+        },
+        {
+          "position": 44,
+          "id": "levyra-165b0f3495554493dfe2",
+          "title": "Superlim & silvertejp",
+          "artists": [
+            {
+              "name": "Molly Sandén"
+            },
+            {
+              "name": "Miriam Bryant"
+            }
+          ],
+          "album": {
+            "name": "Superlim & silvertejp",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 193634,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "ExxBl8GGdjg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCRfOyXWS81kkYkNx0tNoCWw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02996f812fec9a52fe534a2345"
+        },
+        {
+          "position": 45,
+          "id": "levyra-62f091057573870630ff",
+          "title": "Dreams - 2004 Remaster",
+          "artists": [
+            {
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "album": {
+            "name": "Rumours (Super Deluxe)",
+            "releaseDate": "1977-02-04"
+          },
+          "durationMs": 257800,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e52a59a28efa4773dd2bfe1b"
+        },
+        {
+          "position": 46,
+          "id": "levyra-b8fc4a4e7a4f8b5e4eeb",
+          "title": "Ikväll Igen",
+          "artists": [
+            {
+              "name": "Bolaget"
+            }
+          ],
+          "album": {
+            "name": "Ikväll Igen",
+            "releaseDate": "2023-04-12"
+          },
+          "durationMs": 137727,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "DR1NpW9v8vY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCVpv0aK1mbMOSgcKfd1cEcQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02faf3af3d5e05b3dfed698cfa"
+        },
+        {
+          "position": 47,
+          "id": "levyra-896575951e40b9ac060b",
+          "title": "FEVER DREAM",
+          "artists": [
+            {
+              "name": "Alex Warren"
+            }
+          ],
+          "album": {
+            "name": "FEVER DREAM",
+            "releaseDate": "2026-02-26"
+          },
+          "durationMs": 153430,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "3D2WPA9ZN30",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCXATF3-9RFGyY-it_d2hB6A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02867f5a2310b84cf508f9764b"
+        },
+        {
+          "position": 48,
+          "id": "levyra-12e48ca2e92304ddabc2",
+          "title": "Viva L’Amor",
+          "artists": [
+            {
+              "name": "Medina"
+            }
+          ],
+          "album": {
+            "name": "Viva L’Amor",
+            "releaseDate": "2026-02-13"
+          },
+          "durationMs": 181800,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "aoOliw69_UA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCrJplmy5jjKqNr6ZFCPvZwg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026ba79c7d460adb84fd9cb6ad"
+        },
+        {
+          "position": 49,
+          "id": "levyra-446b00f068b38e3a51bf",
+          "title": "Välkommen in",
+          "artists": [
+            {
+              "name": "Veronica Maggio"
+            }
+          ],
+          "album": {
+            "name": "Satan i gatan (Bonus Version)",
+            "releaseDate": "2011-01-01"
+          },
+          "durationMs": 212453,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "ThEsX4IFepo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCbFYwzeKfzZ2YR0B68n_vMg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02de25b67688e3520e24612209"
+        },
+        {
+          "position": 50,
+          "id": "levyra-0fd906250526069c2957",
+          "title": "Fröjdo Frido",
+          "artists": [
+            {
+              "name": "Lovet"
+            }
+          ],
+          "album": {
+            "name": "Fröjdo Frido",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 156062,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "EEuiq1FJiAs",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCnCzUYmqknJ1F_l5cSXJQfA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ce9c46738d8ad2c6e240e72d"
+        }
+      ]
+    },
+    {
+      "id": "top-50-dk",
+      "kind": "chart",
+      "market": "DK",
+      "title": "Top 50 Danmark",
+      "description": "Danimarca: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-a6bf0b04132ad18f7a40",
+          "title": "Desperado",
+          "artists": [
+            {
+              "name": "Annika"
+            }
+          ],
+          "album": {
+            "name": "Desperado",
+            "releaseDate": "2026-06-26"
+          },
+          "durationMs": 193306,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "WqpYc5GLehg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCyslnI1Zn9oyPV_WPA54G8Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02eb1f5c04f3eb355e71bce294"
+        },
+        {
+          "position": 2,
+          "id": "levyra-93f773711e895ec72adf",
+          "title": "Hold Mit Tempo",
+          "artists": [
+            {
+              "name": "Lamin"
+            },
+            {
+              "name": "Annika"
+            }
+          ],
+          "album": {
+            "name": "WAVY",
+            "releaseDate": "2026-06-18"
+          },
+          "durationMs": 163437,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02456bc2e13fd231a9a30c0812"
+        },
+        {
+          "position": 3,
+          "id": "levyra-bfc121daeee3be39e627",
+          "title": "PPC",
+          "artists": [
+            {
+              "name": "D1MA"
+            },
+            {
+              "name": "Gilli"
+            }
+          ],
+          "album": {
+            "name": "PPC",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 196175,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d39aa5dd0cf9e12ca872a911"
+        },
+        {
+          "position": 4,
+          "id": "levyra-104a84d79db61f821db1",
+          "title": "Ringer Om Natten",
+          "artists": [
+            {
+              "name": "Christopher"
+            }
+          ],
+          "album": {
+            "name": "Ringer Om Natten",
+            "releaseDate": "2026-05-29"
+          },
+          "durationMs": 164000,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "uFo4ZA1HSi8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCk2d98LW5kM15q8SBRy3Nsw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023f062359fe78b4996db75b8d"
+        },
+        {
+          "position": 5,
+          "id": "levyra-675f15d0c3a1ca715cbc",
+          "title": "Drukner",
+          "artists": [
+            {
+              "name": "KESI"
+            },
+            {
+              "name": "Annika"
+            }
+          ],
+          "album": {
+            "name": "MEN SÅ KOM I MORGEN",
+            "releaseDate": "2026-05-08"
+          },
+          "durationMs": 197724,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0213b0ac021845f6636e95406f"
+        },
+        {
+          "position": 6,
+          "id": "levyra-4500512f5aa38edfe312",
+          "title": "Dai Dai",
+          "artists": [
+            {
+              "name": "Shakira"
+            },
+            {
+              "name": "Burna Boy"
+            }
+          ],
+          "album": {
+            "name": "Dai Dai",
+            "releaseDate": "2026-05-14"
+          },
+          "durationMs": 223448,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lFQdcPTTzSg",
+            "audioConfidence": 100,
+            "videoId": "fcnDmrtj6Sk",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCo6JijJGA3IvIiPsawDK3Ww"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0203cadf1b3fe324c1dc710ed4"
+        },
+        {
+          "position": 7,
+          "id": "levyra-d66330f471e3a30eced4",
+          "title": "spøgelse",
+          "artists": [
+            {
+              "name": "D1MA"
+            }
+          ],
+          "album": {
+            "name": "spøgelse",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 242727,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0252872f7690573944e98cdc43"
+        },
+        {
+          "position": 8,
+          "id": "levyra-44646226f4d7dd425cd0",
+          "title": "Ham Med Guitaren",
+          "artists": [
+            {
+              "name": "Christopher"
+            }
+          ],
+          "album": {
+            "name": "Ham Med Guitaren",
+            "releaseDate": "2026-03-13"
+          },
+          "durationMs": 194080,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020d692ead813ceee62c8923a4"
+        },
+        {
+          "position": 9,
+          "id": "levyra-b11b9e45c1d1ef5c1db6",
+          "title": "Vil du noget?",
+          "artists": [
+            {
+              "name": "Guldimund"
+            },
+            {
+              "name": "Saveus"
+            }
+          ],
+          "album": {
+            "name": "Vil du noget?",
+            "releaseDate": "2025-10-03"
+          },
+          "durationMs": 185326,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0254918a679523f4f50b5ec284"
+        },
+        {
+          "position": 10,
+          "id": "levyra-0dc10e23ec3dcb763f6d",
+          "title": "Livsforladt",
+          "artists": [
+            {
+              "name": "Annika"
+            }
+          ],
+          "album": {
+            "name": "Livsforladt",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 182204,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "-Mnc54QlHTg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCyslnI1Zn9oyPV_WPA54G8Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023ac56f770aa9b6c94f685606"
+        },
+        {
+          "position": 11,
+          "id": "levyra-f16a9b58738e45b545a2",
+          "title": "Jeg Ka' Ik' Mærke Noget (feat. Thomas Helmig)",
+          "artists": [
+            {
+              "name": "Christopher"
+            },
+            {
+              "name": "Thomas Helmig"
+            }
+          ],
+          "album": {
+            "name": "Jeg Ka' Ik' Mærke Noget (feat. Thomas Helmig)",
+            "releaseDate": "2026-07-17"
+          },
+          "durationMs": 158413,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "sACKaxIK-0g",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCk2d98LW5kM15q8SBRy3Nsw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02392a48148c3203446788fb43"
+        },
+        {
+          "position": 12,
+          "id": "levyra-c743e6c4981d509c26c7",
+          "title": "En drøm om et menneske",
+          "artists": [
+            {
+              "name": "APHACA"
+            }
+          ],
+          "album": {
+            "name": "VILD UNGDOM",
+            "releaseDate": "2026-02-27"
+          },
+          "durationMs": 178041,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02da68ea9cc43d36c732812015"
+        },
+        {
+          "position": 13,
+          "id": "levyra-81e0ad1540c072822f4b",
+          "title": "GØR NOGET",
+          "artists": [
+            {
+              "name": "Mille"
+            }
+          ],
+          "album": {
+            "name": "GØR NOGET",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 147121,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "usKeaOAb-fo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC50HGGCnQFTtXTBawFvcsSg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025e412e8846638b9e75b24410"
+        },
+        {
+          "position": 14,
+          "id": "levyra-9a4be11b00c0a461faf4",
+          "title": "Great Expectation",
+          "artists": [
+            {
+              "name": "SIENNA SPIRO"
+            }
+          ],
+          "album": {
+            "name": "Visitor",
+            "releaseDate": "2026-07-02"
+          },
+          "durationMs": 173975,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "_5-Dzam3jPU",
+            "audioConfidence": 100,
+            "videoId": "B452TVVco2Q",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCf5GUgSQC4CU8idz_OH8jqQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b09eea420767969b6729962b"
+        },
+        {
+          "position": 15,
+          "id": "levyra-02ebdc3242c766bf528f",
+          "title": "Flue i et spind",
+          "artists": [
+            {
+              "name": "APHACA"
+            }
+          ],
+          "album": {
+            "name": "VILD UNGDOM",
+            "releaseDate": "2026-02-27"
+          },
+          "durationMs": 224812,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02da68ea9cc43d36c732812015"
+        },
+        {
+          "position": 16,
+          "id": "levyra-4cf6c403c0e51defa06d",
+          "title": "En Som Dig (feat. Blæst, ADAAM & Back To Back)",
+          "artists": [
+            {
+              "name": "Rune Rask"
+            },
+            {
+              "name": "Hampenberg"
+            },
+            {
+              "name": "Blæst"
+            },
+            {
+              "name": "ADAAM"
+            },
+            {
+              "name": "Back To Back"
+            }
+          ],
+          "album": {
+            "name": "En Som Dig (feat. Blæst, ADAAM & Back To Back)",
+            "releaseDate": "2026-07-10"
+          },
+          "durationMs": 165412,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023c434db6b6764a3c2edf5b75"
+        },
+        {
+          "position": 17,
+          "id": "levyra-cefed4191cbfa879f29a",
+          "title": "Stolt (feat. Lamin)",
+          "artists": [
+            {
+              "name": "Annika"
+            },
+            {
+              "name": "Lamin"
+            }
+          ],
+          "album": {
+            "name": "AW",
+            "releaseDate": "2025-05-08"
+          },
+          "durationMs": 212472,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028da1b4e6ab06d849e9f944e5"
+        },
+        {
+          "position": 18,
+          "id": "levyra-f264c82001b9ada995f3",
+          "title": "Den Danske Sommer (feat. Birthe Kjær)",
+          "artists": [
+            {
+              "name": "Tobias Rahim"
+            },
+            {
+              "name": "Birthe Kjær"
+            }
+          ],
+          "album": {
+            "name": "Den Danske Sommer (feat. Birthe Kjær)",
+            "releaseDate": "2026-04-10"
+          },
+          "durationMs": 145620,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "fkVTUKTnNh4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCYho78aRBfQTdBKQifjiIGA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0245c418916a7eddf42abee575"
+        },
+        {
+          "position": 19,
+          "id": "levyra-ba27694621ca762823c9",
+          "title": "mig&mine",
+          "artists": [
+            {
+              "name": "D1MA"
+            }
+          ],
+          "album": {
+            "name": "mig&mine",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 130666,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0278f5e0e9f5120c24200012f9"
+        },
+        {
+          "position": 20,
+          "id": "levyra-0394a9ba09931bb3649a",
+          "title": "Ærlig Freestyle",
+          "artists": [
+            {
+              "name": "Anton Westerlin"
+            },
+            {
+              "name": "Annika"
+            }
+          ],
+          "album": {
+            "name": "Bag Gardinerne S1+S2",
+            "releaseDate": "2026-05-01"
+          },
+          "durationMs": 152821,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e644cad5656d44babc09b843"
+        },
+        {
+          "position": 21,
+          "id": "levyra-fa39ba4b81dc9f04e68b",
+          "title": "splittet til atomer",
+          "artists": [
+            {
+              "name": "D1MA"
+            }
+          ],
+          "album": {
+            "name": "splittet til atomer",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 172165,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02031a2777a97f5937f1989c57"
+        },
+        {
+          "position": 22,
+          "id": "levyra-e8af70d8eb18baafce0f",
+          "title": "Hele Vejen (feat. Mumle)",
+          "artists": [
+            {
+              "name": "Omar"
+            },
+            {
+              "name": "Mumle"
+            }
+          ],
+          "album": {
+            "name": "Højt At Flyve Dybt At Falde",
+            "releaseDate": "2026-01-16"
+          },
+          "durationMs": 177618,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "0CLlbnvpJh0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC1fWYodRzTSMr_HqWqdwRxg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02512a6e83d07141fe29bdf0ba"
+        },
+        {
+          "position": 23,
+          "id": "levyra-f42f8a3d03eb850d418a",
+          "title": "Bliv hvor du er (feat. Artigeardit)",
+          "artists": [
+            {
+              "name": "Rosa"
+            },
+            {
+              "name": "Artigeardit"
+            }
+          ],
+          "album": {
+            "name": "Lige Her, Lige Nu",
+            "releaseDate": "2026-04-17"
+          },
+          "durationMs": 172844,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ef8ce0725ede7587b81d8f43"
+        },
+        {
+          "position": 24,
+          "id": "levyra-ded7ad10edb7e7c1cb5e",
+          "title": "Dét Der Udenfor",
+          "artists": [
+            {
+              "name": "The Minds Of 99"
+            }
+          ],
+          "album": {
+            "name": "Dét Der Udenfor",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 214739,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e56b414311fdb73cc3c2c2bc"
+        },
+        {
+          "position": 25,
+          "id": "levyra-ecd40ff676efdf707117",
+          "title": "Cohiba",
+          "artists": [
+            {
+              "name": "Lamin"
+            },
+            {
+              "name": "Noah Carter"
+            },
+            {
+              "name": "Gilli"
+            }
+          ],
+          "album": {
+            "name": "WAVY",
+            "releaseDate": "2026-06-18"
+          },
+          "durationMs": 137755,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02456bc2e13fd231a9a30c0812"
+        },
+        {
+          "position": 26,
+          "id": "levyra-93683240d111e7825d3f",
+          "title": "hate that i made you love me",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 197949,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7CUz7Ec7cWc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 27,
+          "id": "levyra-3f8c407c1c3583370e3c",
+          "title": "kendt mig en uge",
+          "artists": [
+            {
+              "name": "Mille"
+            }
+          ],
+          "album": {
+            "name": "kendt mig en uge",
+            "releaseDate": "2025-03-21"
+          },
+          "durationMs": 186843,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "1yvcQFvPPMY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCKb6aBhrABSRjUWhKaPEMsQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023f6cfee0762fba2678f07091"
+        },
+        {
+          "position": 28,
+          "id": "levyra-a5c5cc56ab986820bd5c",
+          "title": "Portugal",
+          "artists": [
+            {
+              "name": "Benjamin Hav"
+            }
+          ],
+          "album": {
+            "name": "Portugal",
+            "releaseDate": "2026-05-22"
+          },
+          "durationMs": 209763,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "kZaSC9xuFTw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC5vomQgM4EuZ2DBeXNjILnA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0252556dc7b976aceb8cb98fa1"
+        },
+        {
+          "position": 29,
+          "id": "levyra-a615d064eb3037b233a4",
+          "title": "hader ik mig selv sammen med dig",
+          "artists": [
+            {
+              "name": "Mille"
+            }
+          ],
+          "album": {
+            "name": "(over)lever",
+            "releaseDate": "2026-01-23"
+          },
+          "durationMs": 136503,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "l7Bm9_5XcgM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC50HGGCnQFTtXTBawFvcsSg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a332964d22bffd9bee11a674"
+        },
+        {
+          "position": 30,
+          "id": "levyra-a6ea01d3ba67d4e844c5",
+          "title": "Hvis væggene kunne tale",
+          "artists": [
+            {
+              "name": "Artigeardit"
+            },
+            {
+              "name": "ozzy"
+            }
+          ],
+          "album": {
+            "name": "Den lange vej",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 178695,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f977662ff0ce24aa93b72b3a"
+        },
+        {
+          "position": 31,
+          "id": "levyra-98349a571204b2f4073a",
+          "title": "petal",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 184248,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "4mQyEqbaUOU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 32,
+          "id": "levyra-f09a2077479de06b3e3f",
+          "title": "Kogeplade",
+          "artists": [
+            {
+              "name": "Katinka"
+            }
+          ],
+          "album": {
+            "name": "Ved du jeg en snerle",
+            "releaseDate": "2026-04-10"
+          },
+          "durationMs": 157097,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "txTPNvekzi8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCxTUG24V0SDN4rFZ00Wg1nQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e919be3ae9ef5c8522270934"
+        },
+        {
+          "position": 33,
+          "id": "levyra-645cabc85ed6d1e7beb7",
+          "title": "Louisiana",
+          "artists": [
+            {
+              "name": "Artigeardit"
+            }
+          ],
+          "album": {
+            "name": "Den lange vej",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 172111,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f977662ff0ce24aa93b72b3a"
+        },
+        {
+          "position": 34,
+          "id": "levyra-f57bfbaa3ea9073775d7",
+          "title": "Ivrig",
+          "artists": [
+            {
+              "name": "Artigeardit"
+            }
+          ],
+          "album": {
+            "name": "Den lange vej",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 168285,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f977662ff0ce24aa93b72b3a"
+        },
+        {
+          "position": 35,
+          "id": "levyra-f98bd10710153c0fcb6e",
+          "title": "Smelter Under Månen",
+          "artists": [
+            {
+              "name": "APHACA"
+            }
+          ],
+          "album": {
+            "name": "Smelter Under Månen",
+            "releaseDate": "2024-06-21"
+          },
+          "durationMs": 198388,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0282cc2db34d5350c19bedfb24"
+        },
+        {
+          "position": 36,
+          "id": "levyra-707b79ae4555aded5f10",
+          "title": "Hørt Det Før (feat. Pil, Annika, Mille & Medina)",
+          "artists": [
+            {
+              "name": "Anton Westerlin"
+            },
+            {
+              "name": "Pil"
+            },
+            {
+              "name": "Annika"
+            },
+            {
+              "name": "Mille"
+            },
+            {
+              "name": "Medina"
+            }
+          ],
+          "album": {
+            "name": "Godaften",
+            "releaseDate": "2025-05-22"
+          },
+          "durationMs": 214976,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0276d936eaa29869e6567006ef"
+        },
+        {
+          "position": 37,
+          "id": "levyra-0e03b16877a150b9eb48",
+          "title": "Låst Inde",
+          "artists": [
+            {
+              "name": "Lamin"
+            }
+          ],
+          "album": {
+            "name": "WAVY",
+            "releaseDate": "2026-06-18"
+          },
+          "durationMs": 178347,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02456bc2e13fd231a9a30c0812"
+        },
+        {
+          "position": 38,
+          "id": "levyra-48f9ce770593e191b340",
+          "title": "family",
+          "artists": [
+            {
+              "name": "D1MA"
+            }
+          ],
+          "album": {
+            "name": "family",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 202615,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b4eeaf7b47b95c6dd7aaee08"
+        },
+        {
+          "position": 39,
+          "id": "levyra-5f61e7208f1a4e55e7a2",
+          "title": "Copenhagen City",
+          "artists": [
+            {
+              "name": "Emil Kruse"
+            },
+            {
+              "name": "OK OK"
+            },
+            {
+              "name": "Anthon Edwards"
+            }
+          ],
+          "album": {
+            "name": "Copenhagen City",
+            "releaseDate": "2025-10-17"
+          },
+          "durationMs": 171467,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0259f1e9df590274490f374d4d"
+        },
+        {
+          "position": 40,
+          "id": "levyra-1ba6ae2cd8e980a9a992",
+          "title": "Skyklapper",
+          "artists": [
+            {
+              "name": "Rosa"
+            }
+          ],
+          "album": {
+            "name": "Lige Her, Lige Nu",
+            "releaseDate": "2026-04-17"
+          },
+          "durationMs": 173259,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ef8ce0725ede7587b81d8f43"
+        },
+        {
+          "position": 41,
+          "id": "levyra-ef444afbdd8812785bd5",
+          "title": "Man I Need",
+          "artists": [
+            {
+              "name": "Olivia Dean"
+            }
+          ],
+          "album": {
+            "name": "Man I Need",
+            "releaseDate": "2025-08-15"
+          },
+          "durationMs": 184000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "fsGjRf-N71I",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC6GBKGYX6b3guHlqHLx6IzQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e3d69e17dde129037a1f09e2"
+        },
+        {
+          "position": 42,
+          "id": "levyra-1c61954821252af9c2f8",
+          "title": "Wild (feat. Englando)",
+          "artists": [
+            {
+              "name": "KLIKEN"
+            },
+            {
+              "name": "Englando"
+            }
+          ],
+          "album": {
+            "name": "Wild (feat. Englando)",
+            "releaseDate": "2026-07-29"
+          },
+          "durationMs": 162929,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0277af26b84ad3f01ece3f8dea"
+        },
+        {
+          "position": 43,
+          "id": "levyra-e0d1805af65c9b2d4fd7",
+          "title": "Stil permanent",
+          "artists": [
+            {
+              "name": "KESI"
+            }
+          ],
+          "album": {
+            "name": "MEN SÅ KOM I MORGEN",
+            "releaseDate": "2026-05-08"
+          },
+          "durationMs": 146335,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "4JRzfrEt5zA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCaSeIK9DvccdMf2XaciTqug"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0213b0ac021845f6636e95406f"
+        },
+        {
+          "position": 44,
+          "id": "levyra-972d3a936274b1cfd4ef",
+          "title": "drømmefanger (feat. URO)",
+          "artists": [
+            {
+              "name": "Mille"
+            },
+            {
+              "name": "URO"
+            }
+          ],
+          "album": {
+            "name": "(over)lever",
+            "releaseDate": "2026-01-23"
+          },
+          "durationMs": 150617,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a332964d22bffd9bee11a674"
+        },
+        {
+          "position": 45,
+          "id": "levyra-81336f9f984e524639d8",
+          "title": "Det Modsatte",
+          "artists": [
+            {
+              "name": "Mumle"
+            }
+          ],
+          "album": {
+            "name": "Det Modsatte",
+            "releaseDate": "2023-09-22"
+          },
+          "durationMs": 201863,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02355a56abf41a16e316cd10a5"
+        },
+        {
+          "position": 46,
+          "id": "levyra-62752fe61aeb6a6c44e6",
+          "title": "NATTEN BLIVER MORGEN",
+          "artists": [
+            {
+              "name": "D1MA"
+            }
+          ],
+          "album": {
+            "name": "N1YA",
+            "releaseDate": "2025-07-03"
+          },
+          "durationMs": 217374,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dec61ed9e5cda922efc9117c"
+        },
+        {
+          "position": 47,
+          "id": "levyra-8c520265aa02288d7e2c",
+          "title": "Blodigt (feat. Annika)",
+          "artists": [
+            {
+              "name": "Anton Westerlin"
+            },
+            {
+              "name": "Annika"
+            }
+          ],
+          "album": {
+            "name": "Godaften",
+            "releaseDate": "2025-05-22"
+          },
+          "durationMs": 182608,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0276d936eaa29869e6567006ef"
+        },
+        {
+          "position": 48,
+          "id": "levyra-47764fdde285bb5be11a",
+          "title": "Beauty And A Beat",
+          "artists": [
+            {
+              "name": "Justin Bieber"
+            },
+            {
+              "name": "Nicki Minaj"
+            }
+          ],
+          "album": {
+            "name": "Believe",
+            "releaseDate": "2012-01-01"
+          },
+          "durationMs": 227986,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f1d02a6cec967f8b6b78f76e"
+        },
+        {
+          "position": 49,
+          "id": "levyra-a81f4818d99a16b66ea1",
+          "title": "Du ligner din mor",
+          "artists": [
+            {
+              "name": "Benjamin Hav"
+            },
+            {
+              "name": "Lukas Graham"
+            }
+          ],
+          "album": {
+            "name": "Jeg vil bare gerne være et godt menneske, men det er ikke let.",
+            "releaseDate": "2025-01-31"
+          },
+          "durationMs": 187078,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026eda43841dbd5e6af576bfa2"
+        },
+        {
+          "position": 50,
+          "id": "levyra-b31eb5e60513bbd613b7",
+          "title": "Billie Jean",
+          "artists": [
+            {
+              "name": "Michael Jackson"
+            }
+          ],
+          "album": {
+            "name": "Thriller",
+            "releaseDate": "1982-11-30"
+          },
+          "durationMs": 293802,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0232a7d87248d1b75463483df5"
+        }
+      ]
+    },
+    {
+      "id": "top-50-cz",
+      "kind": "chart",
+      "market": "CZ",
+      "title": "Top 50 Česko",
+      "description": "Repubblica Ceca: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-7d2f4fe4b96fbd89ef88",
+          "title": "Neříkej, co má se stát",
+          "artists": [
+            {
+              "name": "Ewa Farna"
+            }
+          ],
+          "album": {
+            "name": "ADHD POP",
+            "releaseDate": "2026-06-15"
+          },
+          "durationMs": 172000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c46061b31876734c83391412"
+        },
+        {
+          "position": 2,
+          "id": "levyra-fc5f1e1bdd5fb8af48a7",
+          "title": "SuperStar (feat. Dollar Prync)",
+          "artists": [
+            {
+              "name": "Calin"
+            },
+            {
+              "name": "Dollar Prync"
+            }
+          ],
+          "album": {
+            "name": "Toxic Love",
+            "releaseDate": "2026-07-30"
+          },
+          "durationMs": 105517,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0257c283d6ab94a1f048b0fff4"
+        },
+        {
+          "position": 3,
+          "id": "levyra-ff59c4a0a3d769396833",
+          "title": "PERPETUUM MOBILE",
+          "artists": [
+            {
+              "name": "Ewa Farna"
+            }
+          ],
+          "album": {
+            "name": "ADHD POP",
+            "releaseDate": "2026-06-15"
+          },
+          "durationMs": 207440,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "pEVCvzAeqBU",
+            "audioConfidence": 100,
+            "videoId": "-uB0D0K2rWs",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCgmySpO1NRnCBWwXu8nTPGA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c46061b31876734c83391412"
+        },
+        {
+          "position": 4,
+          "id": "levyra-4500512f5aa38edfe312",
+          "title": "Dai Dai",
+          "artists": [
+            {
+              "name": "Shakira"
+            },
+            {
+              "name": "Burna Boy"
+            }
+          ],
+          "album": {
+            "name": "Dai Dai",
+            "releaseDate": "2026-05-14"
+          },
+          "durationMs": 223448,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lFQdcPTTzSg",
+            "audioConfidence": 100,
+            "videoId": "fcnDmrtj6Sk",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCo6JijJGA3IvIiPsawDK3Ww"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0203cadf1b3fe324c1dc710ed4"
+        },
+        {
+          "position": 5,
+          "id": "levyra-3aff07a6e881e1f73822",
+          "title": "thank you based god",
+          "artists": [
+            {
+              "name": "Yzomandias"
+            },
+            {
+              "name": "Nik Tendo"
+            }
+          ],
+          "album": {
+            "name": "EXIT U PALICE",
+            "releaseDate": "2026-06-17"
+          },
+          "durationMs": 145270,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b45257149b0523dae2939820"
+        },
+        {
+          "position": 6,
+          "id": "levyra-204c196e89c17c514165",
+          "title": "KENPACHI&YACHIRU",
+          "artists": [
+            {
+              "name": "P T K"
+            }
+          ],
+          "album": {
+            "name": "KARAKORAM DLC",
+            "releaseDate": "2026-05-14"
+          },
+          "durationMs": 163626,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "njGLpoTBM2o",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC1ZojWLY7kkDzc7nq_R2z_w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023d8a9e5413061f342488b5fe"
+        },
+        {
+          "position": 7,
+          "id": "levyra-48da52c0ac3bbe449c4a",
+          "title": "Jan Koller",
+          "artists": [
+            {
+              "name": "Mc Kenny"
+            }
+          ],
+          "album": {
+            "name": "CITYBOYZ NEVER LOSE",
+            "releaseDate": "2026-06-16"
+          },
+          "durationMs": 187512,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "00nSZ5JlzRw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC4meo6fDbl71vZbYa5rBsEQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022a5370eb5575e3e68b19760e"
+        },
+        {
+          "position": 8,
+          "id": "levyra-72bd359fea171dff9fb4",
+          "title": "Rockstar Lifestyle",
+          "artists": [
+            {
+              "name": "Yzomandias"
+            }
+          ],
+          "album": {
+            "name": "Rockstar Lifestyle (EUP SUMMER SEASON - 1st DROP)",
+            "releaseDate": "2026-08-03"
+          },
+          "durationMs": 190500,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02363017396272c68eff83885d"
+        },
+        {
+          "position": 9,
+          "id": "levyra-fb060d209080769a13c8",
+          "title": "v mojich snoch",
+          "artists": [
+            {
+              "name": "Sara Rikas"
+            }
+          ],
+          "album": {
+            "name": "v mojich snoch",
+            "releaseDate": "2026-07-27"
+          },
+          "durationMs": 221772,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "gA8ZFhYyqUo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7Jy_p35sz63TAYfgh32oaQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d5e31399e72cc75e2dbdfea4"
+        },
+        {
+          "position": 10,
+          "id": "levyra-8a0045b9058ae1b540d3",
+          "title": "COUPÉ",
+          "artists": [
+            {
+              "name": "Yzomandias"
+            },
+            {
+              "name": "Sara Rikas"
+            }
+          ],
+          "album": {
+            "name": "EXIT U PALICE",
+            "releaseDate": "2026-06-17"
+          },
+          "durationMs": 170000,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b45257149b0523dae2939820"
+        },
+        {
+          "position": 11,
+          "id": "levyra-09123880ac9451f4a315",
+          "title": "Pražský holky",
+          "artists": [
+            {
+              "name": "Calin"
+            }
+          ],
+          "album": {
+            "name": "Toxic Love",
+            "releaseDate": "2026-07-30"
+          },
+          "durationMs": 126614,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "79xPj-NSuvw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCwiGKkQcOlzMpXOc1xHFoeg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0257c283d6ab94a1f048b0fff4"
+        },
+        {
+          "position": 12,
+          "id": "levyra-47764fdde285bb5be11a",
+          "title": "Beauty And A Beat",
+          "artists": [
+            {
+              "name": "Justin Bieber"
+            },
+            {
+              "name": "Nicki Minaj"
+            }
+          ],
+          "album": {
+            "name": "Believe",
+            "releaseDate": "2012-01-01"
+          },
+          "durationMs": 227986,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f1d02a6cec967f8b6b78f76e"
+        },
+        {
+          "position": 13,
+          "id": "levyra-49d49694f22dae4fb540",
+          "title": "Ain't In LA",
+          "artists": [
+            {
+              "name": "ADÉLA"
+            }
+          ],
+          "album": {
+            "name": "Ain't In LA",
+            "releaseDate": "2026-07-23"
+          },
+          "durationMs": 184927,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "E2gPsY36uR0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0tecxozlRzTMrqvShI8QWg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b176fc721e1faba78b1ef35b"
+        },
+        {
+          "position": 14,
+          "id": "levyra-c1d7bbea4f2c72881303",
+          "title": "AMAMRAD",
+          "artists": [
+            {
+              "name": "Yzomandias"
+            },
+            {
+              "name": "Ektor"
+            }
+          ],
+          "album": {
+            "name": "EXIT U PALICE",
+            "releaseDate": "2026-06-17"
+          },
+          "durationMs": 193288,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b45257149b0523dae2939820"
+        },
+        {
+          "position": 15,
+          "id": "levyra-5d61ae2bd895f476ad88",
+          "title": "Limbo",
+          "artists": [
+            {
+              "name": "Yzomandias"
+            },
+            {
+              "name": "Dusan Vlk"
+            },
+            {
+              "name": "P T K"
+            }
+          ],
+          "album": {
+            "name": "Rockstar Lifestyle (EUP SUMMER SEASON - 1st DROP)",
+            "releaseDate": "2026-08-03"
+          },
+          "durationMs": 198418,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02363017396272c68eff83885d"
+        },
+        {
+          "position": 16,
+          "id": "levyra-29363ec9e4c1cef3ff09",
+          "title": "Vzpomeneš si?",
+          "artists": [
+            {
+              "name": "Ewa Farna"
+            },
+            {
+              "name": "Mirai"
+            }
+          ],
+          "album": {
+            "name": "ADHD POP",
+            "releaseDate": "2026-06-15"
+          },
+          "durationMs": 205440,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "-DfB6x3fYIs",
+            "audioConfidence": 100,
+            "videoId": "XEgiINEvg8o",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCgmySpO1NRnCBWwXu8nTPGA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c46061b31876734c83391412"
+        },
+        {
+          "position": 17,
+          "id": "levyra-ebb682d88685e0f18fee",
+          "title": "Vodka není voda",
+          "artists": [
+            {
+              "name": "Lboy Bsc"
+            },
+            {
+              "name": "Dorian"
+            },
+            {
+              "name": "Freez247"
+            }
+          ],
+          "album": {
+            "name": "Napoleon",
+            "releaseDate": "2025-10-24"
+          },
+          "durationMs": 206817,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "ScLpwTkfEHI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCCqSe41D6BnpFX1DJpXEwiQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0259ea06af85cc3d3ec799013a"
+        },
+        {
+          "position": 18,
+          "id": "levyra-e1731878d20e0d4f02a2",
+          "title": "Kdo??",
+          "artists": [
+            {
+              "name": "Robin Zoot"
+            },
+            {
+              "name": "BUKA"
+            }
+          ],
+          "album": {
+            "name": "Majitel",
+            "releaseDate": "2026-02-10"
+          },
+          "durationMs": 169600,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "xQpALImkMRw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCumucBkBKYHg42bdnSLhDfg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025e0d8a66c70f3cf49edeb13b"
+        },
+        {
+          "position": 19,
+          "id": "levyra-3f2dcb748a0d34c72f83",
+          "title": "Self Aware",
+          "artists": [
+            {
+              "name": "Temper City"
+            }
+          ],
+          "album": {
+            "name": "Self Aware",
+            "releaseDate": "2026-02-15"
+          },
+          "durationMs": 180740,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "R-hYM3BqTbA",
+            "audioConfidence": 100,
+            "videoId": "mh4AQkw4Jjc",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCpWebSe88U-TOiO8YfKnTgg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d6c26d2ae723f7ab553d64cc"
+        },
+        {
+          "position": 20,
+          "id": "levyra-f6663bc35697e813e41d",
+          "title": "Wonderwall - Remastered",
+          "artists": [
+            {
+              "name": "Oasis"
+            }
+          ],
+          "album": {
+            "name": "(What's The Story) Morning Glory? (Deluxe Remastered Edition)",
+            "releaseDate": "1995"
+          },
+          "durationMs": 258773,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027a4c8c59851c88f6794c3cbf"
+        },
+        {
+          "position": 21,
+          "id": "levyra-bca52f53030486e21341",
+          "title": "dřív bylo líp",
+          "artists": [
+            {
+              "name": "Yzomandias"
+            },
+            {
+              "name": "Viktor Sheen"
+            }
+          ],
+          "album": {
+            "name": "EXIT U PALICE",
+            "releaseDate": "2026-06-17"
+          },
+          "durationMs": 223000,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b45257149b0523dae2939820"
+        },
+        {
+          "position": 22,
+          "id": "levyra-e2fb7ff2caa8b0160954",
+          "title": "The One That Got Away",
+          "artists": [
+            {
+              "name": "Katy Perry"
+            }
+          ],
+          "album": {
+            "name": "Teenage Dream",
+            "releaseDate": "2010-01-01"
+          },
+          "durationMs": 227333,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021d955011a3ed477dc77865ad"
+        },
+        {
+          "position": 23,
+          "id": "levyra-3f721023b7bbcc9b60d4",
+          "title": "WTF",
+          "artists": [
+            {
+              "name": "Yzomandias"
+            },
+            {
+              "name": "P T K"
+            }
+          ],
+          "album": {
+            "name": "EXIT U PALICE",
+            "releaseDate": "2026-06-17"
+          },
+          "durationMs": 139000,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b45257149b0523dae2939820"
+        },
+        {
+          "position": 24,
+          "id": "levyra-75a39a111f20c684d681",
+          "title": "Pistácie (feat. Sofian Medjmedj)",
+          "artists": [
+            {
+              "name": "Calin"
+            },
+            {
+              "name": "Sofian Medjmedj"
+            }
+          ],
+          "album": {
+            "name": "Bieber Fever Tour Life",
+            "releaseDate": "2024-12-06"
+          },
+          "durationMs": 174117,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "y9fwZvB84r8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCwiGKkQcOlzMpXOc1xHFoeg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0234decaa12d2f70bd4ba21cf7"
+        },
+        {
+          "position": 25,
+          "id": "levyra-cbd9b811cf35f9fd810a",
+          "title": "Luana",
+          "artists": [
+            {
+              "name": "Calin"
+            }
+          ],
+          "album": {
+            "name": "Toxic Love",
+            "releaseDate": "2026-07-30"
+          },
+          "durationMs": 161584,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "P6s4mfIEmOw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCwiGKkQcOlzMpXOc1xHFoeg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0257c283d6ab94a1f048b0fff4"
+        },
+        {
+          "position": 26,
+          "id": "levyra-125ea7b7545575a3409f",
+          "title": "Painkillers",
+          "artists": [
+            {
+              "name": "Yzomandias"
+            },
+            {
+              "name": "P T K"
+            },
+            {
+              "name": "Luca Brassi10x"
+            },
+            {
+              "name": "Le Winter"
+            }
+          ],
+          "album": {
+            "name": "Painkillers",
+            "releaseDate": "2024-11-22"
+          },
+          "durationMs": 216363,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "KeUo1aE0L34",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCiCzfnkK0faixAEzTMKphDQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024a0b35724fb8436637671263"
+        },
+        {
+          "position": 27,
+          "id": "levyra-a9b8576a2fa18a7f2377",
+          "title": "Na ostří nože",
+          "artists": [
+            {
+              "name": "Ewa Farna"
+            }
+          ],
+          "album": {
+            "name": "Best Of",
+            "releaseDate": "2016-11-18"
+          },
+          "durationMs": 223426,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cbb0024450f19e6c8ef3daa4"
+        },
+        {
+          "position": 28,
+          "id": "levyra-8b6ac2a09931de472dcf",
+          "title": "ONLY WAY OUT IS THROUGH THE SHITS 2",
+          "artists": [
+            {
+              "name": "P T K"
+            }
+          ],
+          "album": {
+            "name": "KARAKORAM",
+            "releaseDate": "2025-10-08"
+          },
+          "durationMs": 146922,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023681741a458805af84c5df7c"
+        },
+        {
+          "position": 29,
+          "id": "levyra-d6b04d9d7938bf8a831c",
+          "title": "Svaz českých bohémů",
+          "artists": [
+            {
+              "name": "Wohnout"
+            }
+          ],
+          "album": {
+            "name": "Našim klientům",
+            "releaseDate": "2011-06-16"
+          },
+          "durationMs": 256720,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024d5f8f3f698e04be1fb03634"
+        },
+        {
+          "position": 30,
+          "id": "levyra-a0e0c0d8c6ff3bb04ac4",
+          "title": "milujou mě nenávidět",
+          "artists": [
+            {
+              "name": "Yzomandias"
+            }
+          ],
+          "album": {
+            "name": "EXIT U PALICE",
+            "releaseDate": "2026-06-17"
+          },
+          "durationMs": 185416,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "CRWBJj7dAaw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCiCzfnkK0faixAEzTMKphDQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b45257149b0523dae2939820"
+        },
+        {
+          "position": 31,
+          "id": "levyra-d43d31dade0c776df2b4",
+          "title": "Danza Kuduro - Version MTO",
+          "artists": [
+            {
+              "name": "Lucenzo"
+            },
+            {
+              "name": "Don Omar"
+            }
+          ],
+          "album": {
+            "name": "Emigrante Del Mundo (Remastered)",
+            "releaseDate": "2011-12-19"
+          },
+          "durationMs": 216352,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dd6b19d30e8b2531c625fbc4"
+        },
+        {
+          "position": 32,
+          "id": "levyra-8d52dd5a928cec18a91f",
+          "title": "Lush Life",
+          "artists": [
+            {
+              "name": "Zara Larsson"
+            }
+          ],
+          "album": {
+            "name": "So Good",
+            "releaseDate": "2017-03-17"
+          },
+          "durationMs": 200646,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "RG-D4bcg54s",
+            "audioConfidence": 100,
+            "videoId": "tD4HCZe-tew",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCB-GmTOjewVU2F_7S4ZFmEA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02401bf6103d4b7f5230a21582"
+        },
+        {
+          "position": 33,
+          "id": "levyra-2e25f3290321b2c73a69",
+          "title": "Sunset",
+          "artists": [
+            {
+              "name": "Separ"
+            },
+            {
+              "name": "Jerry Lee"
+            },
+            {
+              "name": "P T K"
+            }
+          ],
+          "album": {
+            "name": "FLOWDEMORT",
+            "releaseDate": "2023-03-31"
+          },
+          "durationMs": 155520,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cb08eb80723fa9a0e9d02f4d"
+        },
+        {
+          "position": 34,
+          "id": "levyra-e9d5970bfbbf4fa7f71a",
+          "title": "Síla Starejch Vín",
+          "artists": [
+            {
+              "name": "ŠKWOR"
+            }
+          ],
+          "album": {
+            "name": "Sliby & Lži",
+            "releaseDate": "2013-09-27"
+          },
+          "durationMs": 174666,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e4fb100068f72b0e7244aabd"
+        },
+        {
+          "position": 35,
+          "id": "levyra-4435724e8934201fe429",
+          "title": "misery.",
+          "artists": [
+            {
+              "name": "pupsies"
+            }
+          ],
+          "album": {
+            "name": "misery.",
+            "releaseDate": "2026-03-18"
+          },
+          "durationMs": 166401,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qJKcADiAuAw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCp3AZ2_EV0KOSEL33IC1YWw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02316b7fde50dfbf4be72735c2"
+        },
+        {
+          "position": 36,
+          "id": "levyra-398b2ca4b3fc8d25f97f",
+          "title": "Mr. Brightside",
+          "artists": [
+            {
+              "name": "The Killers"
+            }
+          ],
+          "album": {
+            "name": "Hot Fuss",
+            "releaseDate": "2004"
+          },
+          "durationMs": 222973,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "m2zUrruKjDQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCneQ7UWyu9USLDgMya6T7IA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ccdddd46119a4ff53eaf1f5d"
+        },
+        {
+          "position": 37,
+          "id": "levyra-9d3e530cd74574baf20a",
+          "title": "Babydoll",
+          "artists": [
+            {
+              "name": "Dominic Fike"
+            }
+          ],
+          "album": {
+            "name": "Don't Forget About Me, Demos",
+            "releaseDate": "2018-10-16"
+          },
+          "durationMs": 97960,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "UnuEzP1rDLY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCsWqHrJvOU_uukQCU92VEvw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b1b6f41c1645af9757d5616"
+        },
+        {
+          "position": 38,
+          "id": "levyra-2adde94e118c9ecb6a98",
+          "title": "french tip nails",
+          "artists": [
+            {
+              "name": "Yzomandias"
+            },
+            {
+              "name": "Calin"
+            },
+            {
+              "name": "Luca Brassi10x"
+            },
+            {
+              "name": "Raphael"
+            },
+            {
+              "name": "NobodyListen"
+            }
+          ],
+          "album": {
+            "name": "EXIT U PALICE",
+            "releaseDate": "2026-06-17"
+          },
+          "durationMs": 158000,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b45257149b0523dae2939820"
+        },
+        {
+          "position": 39,
+          "id": "levyra-0ccb64868625783f0662",
+          "title": "On The Floor",
+          "artists": [
+            {
+              "name": "Jennifer Lopez"
+            },
+            {
+              "name": "Pitbull"
+            }
+          ],
+          "album": {
+            "name": "Love?",
+            "releaseDate": "2011-04-29"
+          },
+          "durationMs": 284866,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d7b2aa3834b82b1cbe899a48"
+        },
+        {
+          "position": 40,
+          "id": "levyra-4ace0c853964d01a1372",
+          "title": "Talk2me",
+          "artists": [
+            {
+              "name": "Sara Rikas"
+            },
+            {
+              "name": "Yzomandias"
+            }
+          ],
+          "album": {
+            "name": "Ja, Sára",
+            "releaseDate": "2025-04-23"
+          },
+          "durationMs": 163209,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "T7SyQUzjU8Q",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7Jy_p35sz63TAYfgh32oaQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0203ccd9623130ad06aeca8e71"
+        },
+        {
+          "position": 41,
+          "id": "levyra-b0195e34016593daa643",
+          "title": "HIP THRUST",
+          "artists": [
+            {
+              "name": "Yzomandias"
+            }
+          ],
+          "album": {
+            "name": "TYPE BEAT / HIP THRUST",
+            "releaseDate": "2026-02-25"
+          },
+          "durationMs": 100377,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "DrWgYK2rPrA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCiCzfnkK0faixAEzTMKphDQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02419ba9b3ce79a0d64722ad90"
+        },
+        {
+          "position": 42,
+          "id": "levyra-5a726f6152cfa7e4c4f7",
+          "title": "Givenchy",
+          "artists": [
+            {
+              "name": "Robin Zoot"
+            }
+          ],
+          "album": {
+            "name": "PONYA",
+            "releaseDate": "2024-01-12"
+          },
+          "durationMs": 181224,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "zEfM0w7n6XQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCumucBkBKYHg42bdnSLhDfg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cf5ad35919ef8c3960d6a38c"
+        },
+        {
+          "position": 43,
+          "id": "levyra-ddfcf51978a627fb4bf0",
+          "title": "Legendary Lovers",
+          "artists": [
+            {
+              "name": "Katy Perry"
+            }
+          ],
+          "album": {
+            "name": "PRISM",
+            "releaseDate": "2013-01-01"
+          },
+          "durationMs": 224216,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021e9a057052d59004caf47e22"
+        },
+        {
+          "position": 44,
+          "id": "levyra-a475f54e33ee41bae6c8",
+          "title": "že nechci tě tady",
+          "artists": [
+            {
+              "name": "Yzomandias"
+            },
+            {
+              "name": "Calin"
+            },
+            {
+              "name": "Hasan"
+            }
+          ],
+          "album": {
+            "name": "EXIT U PALICE",
+            "releaseDate": "2026-06-17"
+          },
+          "durationMs": 158000,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b45257149b0523dae2939820"
+        },
+        {
+          "position": 45,
+          "id": "levyra-9095bac7086a1d981168",
+          "title": "S&M",
+          "artists": [
+            {
+              "name": "Rihanna"
+            }
+          ],
+          "album": {
+            "name": "Loud",
+            "releaseDate": "2010-01-01"
+          },
+          "durationMs": 243600,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "q_MtePol92o",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCvWtix2TtWGe9kffqnwdaMw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0231548865f7c729290b96c794"
+        },
+        {
+          "position": 46,
+          "id": "levyra-5209b7cb1850ce3685b3",
+          "title": "Strach",
+          "artists": [
+            {
+              "name": "BUKA"
+            }
+          ],
+          "album": {
+            "name": "Já, mé druhé já a Kristýna",
+            "releaseDate": "2025-11-12"
+          },
+          "durationMs": 205048,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f700d9fa6b9429546f99fbbb"
+        },
+        {
+          "position": 47,
+          "id": "levyra-c36566a5131abf6155be",
+          "title": "Modrá",
+          "artists": [
+            {
+              "name": "Jana Kirschner"
+            }
+          ],
+          "album": {
+            "name": "16 naj pesničiek",
+            "releaseDate": "2015-11-06"
+          },
+          "durationMs": 252880,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cb125c594cfcdab1994095df"
+        },
+        {
+          "position": 48,
+          "id": "levyra-a5a017fba38add2b0e35",
+          "title": "Zakazane uvolneni",
+          "artists": [
+            {
+              "name": "Michal Hruza"
+            }
+          ],
+          "album": {
+            "name": "Den",
+            "releaseDate": "2014-05-12"
+          },
+          "durationMs": 217426,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f9746344a77524a78facd986"
+        },
+        {
+          "position": 49,
+          "id": "levyra-5b2bb7f7fe509bd09cf7",
+          "title": "Ona je se mnou",
+          "artists": [
+            {
+              "name": "Hard Rico"
+            },
+            {
+              "name": "P T K"
+            }
+          ],
+          "album": {
+            "name": "Focus",
+            "releaseDate": "2026-06-26"
+          },
+          "durationMs": 209491,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c1941e670b1ba79538221580"
+        },
+        {
+          "position": 50,
+          "id": "levyra-7381202fbbe9f4c990c4",
+          "title": "Pátky",
+          "artists": [
+            {
+              "name": "Viktor Sheen"
+            }
+          ],
+          "album": {
+            "name": "Impostor syndrom",
+            "releaseDate": "2024-11-08"
+          },
+          "durationMs": 188571,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "sXf02hCe6fc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCqZZxzg69-ITB4WSrJhXHfQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ba29643468657ddaefffa149"
+        }
+      ]
+    },
+    {
+      "id": "top-50-ua",
+      "kind": "chart",
+      "market": "UA",
+      "title": "Top 50 Україна",
+      "description": "Ucraina: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-fb8662c2388e77298991",
+          "title": "целоваться",
+          "artists": [
+            {
+              "name": "lightprey"
+            }
+          ],
+          "album": {
+            "name": "целоваться",
+            "releaseDate": "2026-04-03"
+          },
+          "durationMs": 114580,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0273b3aff431b889e2e7126d48"
+        },
+        {
+          "position": 2,
+          "id": "levyra-6b3c91c110811077956a",
+          "title": "Маргарита",
+          "artists": [
+            {
+              "name": "Анна Трінчер"
+            }
+          ],
+          "album": {
+            "name": "Маргарита",
+            "releaseDate": "2026-07-15"
+          },
+          "durationMs": 211874,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0282f7d3c1e10540493d02eceb"
+        },
+        {
+          "position": 3,
+          "id": "levyra-e711ca2ff498c71f098b",
+          "title": "Червоний мак",
+          "artists": [
+            {
+              "name": "Kolibri"
+            },
+            {
+              "name": "Zlata Ko"
+            }
+          ],
+          "album": {
+            "name": "Червоний мак",
+            "releaseDate": "2026-05-18"
+          },
+          "durationMs": 243216,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f11c6591539f00f15400e828"
+        },
+        {
+          "position": 4,
+          "id": "levyra-2b5045a0575099435bfc",
+          "title": "ДИНАСТИЯ",
+          "artists": [
+            {
+              "name": "VILLIAN"
+            },
+            {
+              "name": "madk1d"
+            }
+          ],
+          "album": {
+            "name": "Красивое Зло",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 150425,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f49aca7a14ea9f19f664a7ca"
+        },
+        {
+          "position": 5,
+          "id": "levyra-165c8746074267b95c78",
+          "title": "Фанат",
+          "artists": [
+            {
+              "name": "Alena Omargalieva"
+            }
+          ],
+          "album": {
+            "name": "Фанат",
+            "releaseDate": "2026-04-01"
+          },
+          "durationMs": 198774,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dd600f8f778c89b9a05cb923"
+        },
+        {
+          "position": 6,
+          "id": "levyra-c6c6cebe5489ecb5c9a1",
+          "title": "Не Пʼяна - Закохана - за участі ансамблю «Кралиця»",
+          "artists": [
+            {
+              "name": "Alena Omargalieva"
+            }
+          ],
+          "album": {
+            "name": "Не Пʼяна - Закохана (за участі ансамблю «Кралиця»)",
+            "releaseDate": "2025-11-14"
+          },
+          "durationMs": 223255,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c84ebb523f01ae60be355e90"
+        },
+        {
+          "position": 7,
+          "id": "levyra-630593b120a48c87c98d",
+          "title": "КРИЛА ЛЕЛЕКИ",
+          "artists": [
+            {
+              "name": "Нікіта Кісельов"
+            }
+          ],
+          "album": {
+            "name": "КРИЛА ЛЕЛЕКИ",
+            "releaseDate": "2026-06-19"
+          },
+          "durationMs": 198000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e5f8f7a9cb6a2fecb6d84dfe"
+        },
+        {
+          "position": 8,
+          "id": "levyra-b2d1cde8bf2b0b4eac6e",
+          "title": "Енкарапіста",
+          "artists": [
+            {
+              "name": "Drevo"
+            }
+          ],
+          "album": {
+            "name": "Енкарапіста",
+            "releaseDate": "2025-12-26"
+          },
+          "durationMs": 178421,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cb1a86c448c3c4905597cd49"
+        },
+        {
+          "position": 9,
+          "id": "levyra-d415e1d52c5d2aa373e9",
+          "title": "Не складається",
+          "artists": [
+            {
+              "name": "MAX BARSKIH"
+            }
+          ],
+          "album": {
+            "name": "Не складається",
+            "releaseDate": "2025-12-12"
+          },
+          "durationMs": 211500,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024ed7f37f2a83c0b787a3ebec"
+        },
+        {
+          "position": 10,
+          "id": "levyra-cd450acc86db882fc09b",
+          "title": "Вівтар",
+          "artists": [
+            {
+              "name": "Нікіта Кісельов"
+            }
+          ],
+          "album": {
+            "name": "Вівтар",
+            "releaseDate": "2026-04-23"
+          },
+          "durationMs": 260181,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ed029ca5e4109e1ab508262a"
+        },
+        {
+          "position": 11,
+          "id": "levyra-ed4584c2cf66d0cfc4d4",
+          "title": "Афини",
+          "artists": [
+            {
+              "name": "FIЇNKA"
+            }
+          ],
+          "album": {
+            "name": "Афини",
+            "releaseDate": "2025-07-31"
+          },
+          "durationMs": 202333,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02316460844c634c81e145d54a"
+        },
+        {
+          "position": 12,
+          "id": "levyra-9ea6c7b17bf5d96337e0",
+          "title": "На нашій вулиці",
+          "artists": [
+            {
+              "name": "MamaRika"
+            }
+          ],
+          "album": {
+            "name": "На нашій вулиці",
+            "releaseDate": "2026-07-15"
+          },
+          "durationMs": 171488,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02869cac657b0a72712cf0a648"
+        },
+        {
+          "position": 13,
+          "id": "levyra-32dcb3a8358aeddedcf9",
+          "title": "спокуслива",
+          "artists": [
+            {
+              "name": "Nikow"
+            }
+          ],
+          "album": {
+            "name": "спокуслива",
+            "releaseDate": "2026-05-22"
+          },
+          "durationMs": 142184,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0298c398a7ef375dcf4427e7b1"
+        },
+        {
+          "position": 14,
+          "id": "levyra-e4b90184bd00f315b3ca",
+          "title": "Контракт",
+          "artists": [
+            {
+              "name": "Poshlaya Molly"
+            }
+          ],
+          "album": {
+            "name": "Контракт",
+            "releaseDate": "2021-03-12"
+          },
+          "durationMs": 204756,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02418e072993fc456293ccc7c5"
+        },
+        {
+          "position": 15,
+          "id": "levyra-b27de6ac8c2f3816086d",
+          "title": "священная война",
+          "artists": [
+            {
+              "name": "урал гайсин"
+            }
+          ],
+          "album": {
+            "name": "саундклауд пак",
+            "releaseDate": "2025-06-06"
+          },
+          "durationMs": 102258,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f7f0aec4fe68585319d0ecb7"
+        },
+        {
+          "position": 16,
+          "id": "levyra-9d3e530cd74574baf20a",
+          "title": "Babydoll",
+          "artists": [
+            {
+              "name": "Dominic Fike"
+            }
+          ],
+          "album": {
+            "name": "Don't Forget About Me, Demos",
+            "releaseDate": "2018-10-16"
+          },
+          "durationMs": 97960,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "UnuEzP1rDLY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCsWqHrJvOU_uukQCU92VEvw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b1b6f41c1645af9757d5616"
+        },
+        {
+          "position": 17,
+          "id": "levyra-aab4b79ce135e5852061",
+          "title": "Смарагдове небо",
+          "artists": [
+            {
+              "name": "Drevo"
+            }
+          ],
+          "album": {
+            "name": "Смарагдове небо",
+            "releaseDate": "2025-05-23"
+          },
+          "durationMs": 186827,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02568d5935eebee2be42445db8"
+        },
+        {
+          "position": 18,
+          "id": "levyra-2f7a1c1b7bceb923f67c",
+          "title": "Loser",
+          "artists": [
+            {
+              "name": "Tame Impala"
+            }
+          ],
+          "album": {
+            "name": "Deadbeat",
+            "releaseDate": "2025-10-17"
+          },
+          "durationMs": 223069,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "MX7FSAnRPug",
+            "audioConfidence": 100,
+            "videoId": "s3a4OQR-10M",
+            "videoConfidence": 97,
+            "confidence": 100,
+            "artistBrowseId": "UCGz-eguN8tcic5kUG4s1ZgA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02208500450dcd0fd294d7bd3b"
+        },
+        {
+          "position": 19,
+          "id": "levyra-0ad5a79db31c94c1df70",
+          "title": "type london",
+          "artists": [
+            {
+              "name": "ONDA ANDAR"
+            }
+          ],
+          "album": {
+            "name": "type london",
+            "releaseDate": "2025-10-03"
+          },
+          "durationMs": 103529,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028f3c50379840f6bfa28ef0d9"
+        },
+        {
+          "position": 20,
+          "id": "levyra-4435724e8934201fe429",
+          "title": "misery.",
+          "artists": [
+            {
+              "name": "pupsies"
+            }
+          ],
+          "album": {
+            "name": "misery.",
+            "releaseDate": "2026-03-18"
+          },
+          "durationMs": 166401,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qJKcADiAuAw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCp3AZ2_EV0KOSEL33IC1YWw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02316b7fde50dfbf4be72735c2"
+        },
+        {
+          "position": 21,
+          "id": "levyra-ddbfdd111697ae6ab174",
+          "title": "Лампочки",
+          "artists": [
+            {
+              "name": "ARTIK & ASTI"
+            }
+          ],
+          "album": {
+            "name": "Миллениум Х",
+            "releaseDate": "2021-07-22"
+          },
+          "durationMs": 195789,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0238898009d002b12da70ea103"
+        },
+        {
+          "position": 22,
+          "id": "levyra-b4d429c53a3f9c261546",
+          "title": "Монополия",
+          "artists": [
+            {
+              "name": "Monetochka"
+            }
+          ],
+          "album": {
+            "name": "Молитвы. Анекдоты. Тосты.",
+            "releaseDate": "2024-05-24"
+          },
+          "durationMs": 217607,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0270ebd1b40be2fa37d043ee14"
+        },
+        {
+          "position": 23,
+          "id": "levyra-b8c13f3104bc78523dda",
+          "title": "8 миля",
+          "artists": [
+            {
+              "name": "madk1d"
+            },
+            {
+              "name": "VILLIAN"
+            }
+          ],
+          "album": {
+            "name": "8 миля",
+            "releaseDate": "2026-02-20"
+          },
+          "durationMs": 115200,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026c37e2df7d6a120e0b4dcc69"
+        },
+        {
+          "position": 24,
+          "id": "levyra-83fbaf60c49b2084d245",
+          "title": "ІКОНА",
+          "artists": [
+            {
+              "name": "IVAN LIULENOV"
+            }
+          ],
+          "album": {
+            "name": "ІКОНА",
+            "releaseDate": "2026-04-16"
+          },
+          "durationMs": 188475,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b41506d6a733f519c4e6a942"
+        },
+        {
+          "position": 25,
+          "id": "levyra-ed8c853c6caece264e3a",
+          "title": "якщо це не по-справжньому",
+          "artists": [
+            {
+              "name": "Nikow"
+            }
+          ],
+          "album": {
+            "name": "живу-відстукує",
+            "releaseDate": "2025-08-15"
+          },
+          "durationMs": 191815,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021a7c7cccfeaa7945ee07c7d3"
+        },
+        {
+          "position": 26,
+          "id": "levyra-b31eb5e60513bbd613b7",
+          "title": "Billie Jean",
+          "artists": [
+            {
+              "name": "Michael Jackson"
+            }
+          ],
+          "album": {
+            "name": "Thriller",
+            "releaseDate": "1982-11-30"
+          },
+          "durationMs": 293802,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0232a7d87248d1b75463483df5"
+        },
+        {
+          "position": 27,
+          "id": "levyra-b744d4fcfd44f36ebacf",
+          "title": "ток",
+          "artists": [
+            {
+              "name": "zhanulka"
+            }
+          ],
+          "album": {
+            "name": "новый альбом про любовь",
+            "releaseDate": "2024-03-01"
+          },
+          "durationMs": 173272,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02636adab1214fa22eebf73a01"
+        },
+        {
+          "position": 28,
+          "id": "levyra-3f2dcb748a0d34c72f83",
+          "title": "Self Aware",
+          "artists": [
+            {
+              "name": "Temper City"
+            }
+          ],
+          "album": {
+            "name": "Self Aware",
+            "releaseDate": "2026-02-15"
+          },
+          "durationMs": 180740,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "R-hYM3BqTbA",
+            "audioConfidence": 100,
+            "videoId": "mh4AQkw4Jjc",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCpWebSe88U-TOiO8YfKnTgg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d6c26d2ae723f7ab553d64cc"
+        },
+        {
+          "position": 29,
+          "id": "levyra-35d06ec654a14999ae9a",
+          "title": "Врубай",
+          "artists": [
+            {
+              "name": "Parfeniuk"
+            }
+          ],
+          "album": {
+            "name": "Врубай",
+            "releaseDate": "2024-11-28"
+          },
+          "durationMs": 150583,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02756c56762021fd8e600be358"
+        },
+        {
+          "position": 30,
+          "id": "levyra-62d5f362fe507f6a9413",
+          "title": "Зійшла Зоря",
+          "artists": [
+            {
+              "name": "Alena Omargalieva"
+            }
+          ],
+          "album": {
+            "name": "Зійшла Зоря",
+            "releaseDate": "2026-06-24"
+          },
+          "durationMs": 207333,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02014e16a3286f312c67ebee06"
+        },
+        {
+          "position": 31,
+          "id": "levyra-28147e0d6dcb709138f7",
+          "title": "Нагадай",
+          "artists": [
+            {
+              "name": "Domiy"
+            }
+          ],
+          "album": {
+            "name": "Нагадай",
+            "releaseDate": "2023-12-16"
+          },
+          "durationMs": 152184,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a0cbc5f07d3a807b85fafe55"
+        },
+        {
+          "position": 32,
+          "id": "levyra-6f158ed3d9270eccfb54",
+          "title": "Кольє",
+          "artists": [
+            {
+              "name": "MAX BARSKIH"
+            }
+          ],
+          "album": {
+            "name": "Кольє",
+            "releaseDate": "2026-06-19"
+          },
+          "durationMs": 201714,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c99b3986af5dcd004aa7021d"
+        },
+        {
+          "position": 33,
+          "id": "levyra-d0b59fddf0f4c45ea1f5",
+          "title": "так похуй",
+          "artists": [
+            {
+              "name": "madk1d"
+            }
+          ],
+          "album": {
+            "name": "sexyswag",
+            "releaseDate": "2025-03-21"
+          },
+          "durationMs": 108000,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02486d56969b1223a6a610e7be"
+        },
+        {
+          "position": 34,
+          "id": "levyra-18153eb46e94985d37b5",
+          "title": "Прикуті",
+          "artists": [
+            {
+              "name": "Kristonko"
+            }
+          ],
+          "album": {
+            "name": "Прикуті",
+            "releaseDate": "2026-04-23"
+          },
+          "durationMs": 145000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02608f4b9d2d77484614ae2c5a"
+        },
+        {
+          "position": 35,
+          "id": "levyra-64bbb4fda296ff87a852",
+          "title": "Тому що…",
+          "artists": [
+            {
+              "name": "MONATIK"
+            }
+          ],
+          "album": {
+            "name": "Тому що…",
+            "releaseDate": "2026-06-17"
+          },
+          "durationMs": 177000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02809322f8bfef4232f6f16cdc"
+        },
+        {
+          "position": 36,
+          "id": "levyra-ae787ea39fbeda4f683b",
+          "title": "Юра, Юра",
+          "artists": [
+            {
+              "name": "CUPSIZE"
+            }
+          ],
+          "album": {
+            "name": "Как испортить вечеринку?",
+            "releaseDate": "2023-12-22"
+          },
+          "durationMs": 128764,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c8e66353eab8e2fbd88615f7"
+        },
+        {
+          "position": 37,
+          "id": "levyra-47bb054a825ec75f01ee",
+          "title": "Malo 2.0",
+          "artists": [
+            {
+              "name": "Egor Kreed"
+            },
+            {
+              "name": "OG Buda"
+            },
+            {
+              "name": "Toxi$"
+            },
+            {
+              "name": "Мэйби Бэйби"
+            },
+            {
+              "name": "Baby Cute"
+            },
+            {
+              "name": "Дора"
+            },
+            {
+              "name": "madk1d"
+            },
+            {
+              "name": "тёмный принц"
+            }
+          ],
+          "album": {
+            "name": "Malo 2.0",
+            "releaseDate": "2026-07-03"
+          },
+          "durationMs": 326076,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c19a363e6e4de6eb2e297cc7"
+        },
+        {
+          "position": 38,
+          "id": "levyra-b2361cb3034b416dc872",
+          "title": "RMB (Ring My Bell)",
+          "artists": [
+            {
+              "name": "Aitch"
+            }
+          ],
+          "album": {
+            "name": "RMB (Ring My Bell)",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 174222,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "QY7ZblrGc8k",
+            "audioConfidence": 100,
+            "videoId": "3uUHZlEBQ6A",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCdbasYA6lUSImvxdqS1RuZQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026b31df00eabe45483ec9974b"
+        },
+        {
+          "position": 39,
+          "id": "levyra-a12fe96c2caa5e598a66",
+          "title": "БІТ ТРЕМБІТ",
+          "artists": [
+            {
+              "name": "Нікіта Кісельов"
+            }
+          ],
+          "album": {
+            "name": "БІТ ТРЕМБІТ",
+            "releaseDate": "2026-05-22"
+          },
+          "durationMs": 217468,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0224bc9de409a2bfd3a8925200"
+        },
+        {
+          "position": 40,
+          "id": "levyra-9b64b8f18d153449686b",
+          "title": "Твоя мама",
+          "artists": [
+            {
+              "name": "Анна Трінчер"
+            }
+          ],
+          "album": {
+            "name": "Твоя мама",
+            "releaseDate": "2026-05-21"
+          },
+          "durationMs": 159374,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02fec1085e75a21017917abfbf"
+        },
+        {
+          "position": 41,
+          "id": "levyra-695d750a1bbc08ee91c4",
+          "title": "ШОВКОВИЦЯ",
+          "artists": [
+            {
+              "name": "IVAN LIULENOV"
+            },
+            {
+              "name": "DAMNITSKYI"
+            }
+          ],
+          "album": {
+            "name": "ШОВКОВИЦЯ",
+            "releaseDate": "2025-05-28"
+          },
+          "durationMs": 185061,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0240559bb92fc394baaa75f3aa"
+        },
+        {
+          "position": 42,
+          "id": "levyra-08248e7fa041403e1d8f",
+          "title": "Forever Young",
+          "artists": [
+            {
+              "name": "FACE"
+            }
+          ],
+          "album": {
+            "name": "VLONE",
+            "releaseDate": "2016-03-07"
+          },
+          "durationMs": 191921,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e60e2c60cf249b222adda5af"
+        },
+        {
+          "position": 43,
+          "id": "levyra-b78107e0dabeee79a12a",
+          "title": "З якого ти поверху неба?",
+          "artists": [
+            {
+              "name": "Jerry Heil"
+            },
+            {
+              "name": "YARMAK"
+            }
+          ],
+          "album": {
+            "name": "АРХЕТИПИ",
+            "releaseDate": "2025-05-02"
+          },
+          "durationMs": 196817,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a3f20e74f56e539245e5ed04"
+        },
+        {
+          "position": 44,
+          "id": "levyra-66d26b9c701d4a8f11d7",
+          "title": "Beat It",
+          "artists": [
+            {
+              "name": "Michael Jackson"
+            }
+          ],
+          "album": {
+            "name": "Thriller",
+            "releaseDate": "1982-11-30"
+          },
+          "durationMs": 258296,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "kOn-HdEg6AQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCoIOOL7QKuBhQHVKL8y7BEQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0232a7d87248d1b75463483df5"
+        },
+        {
+          "position": 45,
+          "id": "levyra-defa1ad7bfb0db625168",
+          "title": "Ну и чё?",
+          "artists": [
+            {
+              "name": "BLAZER 993"
+            }
+          ],
+          "album": {
+            "name": "LIFESTYLE",
+            "releaseDate": "2025-02-14"
+          },
+          "durationMs": 134188,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dd014cb3cdc0f97d108ee872"
+        },
+        {
+          "position": 46,
+          "id": "levyra-a44429210f76b6e45437",
+          "title": "Не ходи",
+          "artists": [
+            {
+              "name": "Alena Omargalieva"
+            },
+            {
+              "name": "MamaRika"
+            }
+          ],
+          "album": {
+            "name": "Не ходи",
+            "releaseDate": "2025-10-01"
+          },
+          "durationMs": 160972,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021f0298e0e54aa0268f8501dc"
+        },
+        {
+          "position": 47,
+          "id": "levyra-dd97ab0526572874a745",
+          "title": "TAMAM",
+          "artists": [
+            {
+              "name": "YG IMMA"
+            }
+          ],
+          "album": {
+            "name": "TAMAM",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 107906,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d19674c075ea250ed80e5dc1"
+        },
+        {
+          "position": 48,
+          "id": "levyra-56e21ea2fd07d5c8c327",
+          "title": "Сльози",
+          "artists": [
+            {
+              "name": "MAX BARSKIH"
+            }
+          ],
+          "album": {
+            "name": "Сльози",
+            "releaseDate": "2026-03-13"
+          },
+          "durationMs": 226000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027ba49cc74bc128334ea1df26"
+        },
+        {
+          "position": 49,
+          "id": "levyra-502a077c4127e7e00eb3",
+          "title": "Супермаркет",
+          "artists": [
+            {
+              "name": "Poshlaya Molly"
+            }
+          ],
+          "album": {
+            "name": "8 способов как бросить...",
+            "releaseDate": "2017-02-24"
+          },
+          "durationMs": 214418,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0272ef05a73eb103693ffff352"
+        },
+        {
+          "position": 50,
+          "id": "levyra-10f0e87fbd2a1519b6e8",
+          "title": "Очі",
+          "artists": [
+            {
+              "name": "Kalush Orchestra"
+            },
+            {
+              "name": "melos"
+            }
+          ],
+          "album": {
+            "name": "Очі",
+            "releaseDate": "2026-07-08"
+          },
+          "durationMs": 174399,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023a6b03c4a69dac7d0dfc198e"
+        }
+      ]
+    },
+    {
+      "id": "top-50-tr",
+      "kind": "chart",
+      "market": "TR",
+      "title": "Top 50 Türkiye",
+      "description": "Turchia: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-61205dff8f129403bdf1",
+          "title": "Sebebi Yar",
+          "artists": [
+            {
+              "name": "BLOK3"
+            }
+          ],
+          "album": {
+            "name": "KAYIP PERSONA",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 186475,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "WQvqf1lLQws",
+            "audioConfidence": 100,
+            "videoId": "69L-nKRY3ac",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCZpmeLoLLb3vmxgscRyLPgw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0229728fe23025da14d5695ddb"
+        },
+        {
+          "position": 2,
+          "id": "levyra-4f6896cd3ee5d4352b66",
+          "title": "CRUSH!",
+          "artists": [
+            {
+              "name": "CRUSH"
+            }
+          ],
+          "album": {
+            "name": "CRUSH!",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 148363,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025fd811e0b5320163d644d22d"
+        },
+        {
+          "position": 3,
+          "id": "levyra-3f587abd629e06d48cf8",
+          "title": "pVg - Manifest Live Remix",
+          "artists": [
+            {
+              "name": "manifest"
+            },
+            {
+              "name": "Motive"
+            },
+            {
+              "name": "Pango"
+            }
+          ],
+          "album": {
+            "name": "pVg (Manifest Live Remix)",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 245669,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0265529d64da7ebede606463ae"
+        },
+        {
+          "position": 4,
+          "id": "levyra-e1b0d24f3fed0795535a",
+          "title": "Toz Pembe",
+          "artists": [
+            {
+              "name": "manifest"
+            }
+          ],
+          "album": {
+            "name": "Toz Pembe",
+            "releaseDate": "2026-07-03"
+          },
+          "durationMs": 160998,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "h1Zn0aHceVM",
+            "audioConfidence": 100,
+            "videoId": "0pg0raFMNIU",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCavTTSUSD6aYPeF-F3ND9Yg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02872e8421fdd7c0e50c76060f"
+        },
+        {
+          "position": 5,
+          "id": "levyra-ed18ca134717d824f435",
+          "title": "Bana Ne Bu Sevdalardan",
+          "artists": [
+            {
+              "name": "Ezhel"
+            }
+          ],
+          "album": {
+            "name": "Bana Ne Bu Sevdalardan",
+            "releaseDate": "2026-07-10"
+          },
+          "durationMs": 137512,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "9gZuXeLLttg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCKyS9imZeKupw7aVr6GCI5w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0206da62a59d59d82344a7d5ee"
+        },
+        {
+          "position": 6,
+          "id": "levyra-3f521210612c356f2668",
+          "title": "Hileli",
+          "artists": [
+            {
+              "name": "manifest"
+            },
+            {
+              "name": "Ajda Pekkan"
+            }
+          ],
+          "album": {
+            "name": "Hileli",
+            "releaseDate": "2026-05-08"
+          },
+          "durationMs": 202431,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "XyiTiiXSpZs",
+            "audioConfidence": 100,
+            "videoId": "kXKhNI4DLHM",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCavTTSUSD6aYPeF-F3ND9Yg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0268bf830b9d954889967c81b2"
+        },
+        {
+          "position": 7,
+          "id": "levyra-ed1fe3021cfd83b018aa",
+          "title": "Kırgınım",
+          "artists": [
+            {
+              "name": "BLOK3"
+            }
+          ],
+          "album": {
+            "name": "KAYIP PERSONA",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 160639,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "OfAtAceHQTI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCZpmeLoLLb3vmxgscRyLPgw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0229728fe23025da14d5695ddb"
+        },
+        {
+          "position": 8,
+          "id": "levyra-1e8dbbf819a603e24d05",
+          "title": "Kayıp Kalp",
+          "artists": [
+            {
+              "name": "BLOK3"
+            }
+          ],
+          "album": {
+            "name": "KAYIP PERSONA",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 153230,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "nKHGXOdJlNc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCZpmeLoLLb3vmxgscRyLPgw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0229728fe23025da14d5695ddb"
+        },
+        {
+          "position": 9,
+          "id": "levyra-ff786c5cd98edebae1b7",
+          "title": "Çok Güzel Gülüyorsun",
+          "artists": [
+            {
+              "name": "BLOK3"
+            },
+            {
+              "name": "Poizi"
+            }
+          ],
+          "album": {
+            "name": "KAYIP PERSONA",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 240782,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "aQ6TGi2m88A",
+            "audioConfidence": 100,
+            "videoId": "q2IMrkhSjSA",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCZpmeLoLLb3vmxgscRyLPgw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0229728fe23025da14d5695ddb"
+        },
+        {
+          "position": 10,
+          "id": "levyra-d720ffe895f33f293caa",
+          "title": "TAMPONTAMPONA",
+          "artists": [
+            {
+              "name": "Ati242"
+            }
+          ],
+          "album": {
+            "name": "TAMPONTAMPONA",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 196800,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "EXkYU-kH870",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCJjP9Yna08Zq5_TimlS429w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021acf4b69070878efdb4354a2"
+        },
+        {
+          "position": 11,
+          "id": "levyra-cb64b74ff5820e1690c9",
+          "title": "Ara Beni",
+          "artists": [
+            {
+              "name": "Hadise"
+            }
+          ],
+          "album": {
+            "name": "H.",
+            "releaseDate": "2026-05-08"
+          },
+          "durationMs": 144374,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "EJRnE1M97wk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCUBIH6SiAP4nVxD1m8o0rlw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02823d7f1b81fa6ec46000c43c"
+        },
+        {
+          "position": 12,
+          "id": "levyra-95302b8c6a5a759941ab",
+          "title": "Daha İyi",
+          "artists": [
+            {
+              "name": "manifest"
+            }
+          ],
+          "album": {
+            "name": "Daha İyi",
+            "releaseDate": "2026-04-03"
+          },
+          "durationMs": 198595,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "WjGeH0BBrVs",
+            "audioConfidence": 100,
+            "videoId": "vso1LpaQRbo",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCavTTSUSD6aYPeF-F3ND9Yg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d929de2276b676e8e4772e4e"
+        },
+        {
+          "position": 13,
+          "id": "levyra-c58f162a301fafb1e872",
+          "title": "Başımda Belalar",
+          "artists": [
+            {
+              "name": "Poizi"
+            }
+          ],
+          "album": {
+            "name": "Başımda Belalar",
+            "releaseDate": "2026-07-10"
+          },
+          "durationMs": 170641,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "iEibj0RhX0Q",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC5fDzy6g0T-zwzQxbpcFjvw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a5a68d5e1d7115826c3f2ca7"
+        },
+        {
+          "position": 14,
+          "id": "levyra-82d854bf191e4b0df2ac",
+          "title": "İhtimal",
+          "artists": [
+            {
+              "name": "KARM6"
+            }
+          ],
+          "album": {
+            "name": "Serotonin",
+            "releaseDate": "2026-06-26"
+          },
+          "durationMs": 146470,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a9caf7c9c9b47c440dcf64b2"
+        },
+        {
+          "position": 15,
+          "id": "levyra-940e5408a8d787053ab9",
+          "title": "YIN YANG",
+          "artists": [
+            {
+              "name": "Motive"
+            }
+          ],
+          "album": {
+            "name": "PASAJ",
+            "releaseDate": "2026-06-19"
+          },
+          "durationMs": 180923,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "jwItOVMFP2s",
+            "audioConfidence": 100,
+            "videoId": "lDpXhLzJQsA",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCkQ6jNdLeiwqUdMIY7QiXUg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d55cc116abf2fe8ab2e0d227"
+        },
+        {
+          "position": 16,
+          "id": "levyra-5ee2fa927ac83a3d4f5e",
+          "title": "Yangın Yeri",
+          "artists": [
+            {
+              "name": "Elif Buse Doğan"
+            }
+          ],
+          "album": {
+            "name": "Yangın Yeri",
+            "releaseDate": "2026-05-08"
+          },
+          "durationMs": 151318,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Z8e121pTmjU",
+            "audioConfidence": 100,
+            "videoId": "WgoVgSOuReY",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCsADIvvzA4YLvQEwuuHn44g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d2a65fe2b7d42e5f9f31863c"
+        },
+        {
+          "position": 17,
+          "id": "levyra-47e4565e5d7c21fd8b6d",
+          "title": "İki Tas Çorba - Mustafa Sandal Saygı 1",
+          "artists": [
+            {
+              "name": "Mela Bedel"
+            },
+            {
+              "name": "Mustafa Sandal"
+            }
+          ],
+          "album": {
+            "name": "İki Tas Çorba (Mustafa Sandal Saygı 1)",
+            "releaseDate": "2026-05-18"
+          },
+          "durationMs": 191079,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02df5b131c2dc3e3a4f3f8e825"
+        },
+        {
+          "position": 18,
+          "id": "levyra-461c4b6af2bf35696635",
+          "title": "pVg",
+          "artists": [
+            {
+              "name": "Motive"
+            }
+          ],
+          "album": {
+            "name": "pVg",
+            "releaseDate": "2024-01-19"
+          },
+          "durationMs": 243779,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "sWQS9lRrxnk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCkQ6jNdLeiwqUdMIY7QiXUg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cac3fbecf899c1cb6cefb7dc"
+        },
+        {
+          "position": 19,
+          "id": "levyra-570f48af286e63a7b87e",
+          "title": "Başa Bela",
+          "artists": [
+            {
+              "name": "Ezhel"
+            }
+          ],
+          "album": {
+            "name": "Başa Bela",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 154081,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7IPOu5aUhK8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCKyS9imZeKupw7aVr6GCI5w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c81ac96228f4e6c9c8e947e6"
+        },
+        {
+          "position": 20,
+          "id": "levyra-b066632e218f3c0adf66",
+          "title": "Eller Üzer",
+          "artists": [
+            {
+              "name": "Serkan Nişancı"
+            }
+          ],
+          "album": {
+            "name": "Unutacağım",
+            "releaseDate": "2026-06-19"
+          },
+          "durationMs": 198910,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Q5v3aQ_6sgI",
+            "audioConfidence": 100,
+            "videoId": "XScahAwKYHU",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCHw_izpwqDl2yGRY2oYzLIQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a6d171324a48786be46c4f31"
+        },
+        {
+          "position": 21,
+          "id": "levyra-c68bed7f6207d7a74f75",
+          "title": "KIYAMAM",
+          "artists": [
+            {
+              "name": "Sibel Can"
+            },
+            {
+              "name": "Eypio"
+            }
+          ],
+          "album": {
+            "name": "KIYAMAM",
+            "releaseDate": "2026-07-10"
+          },
+          "durationMs": 146262,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "up1F8Cl8Kbc",
+            "audioConfidence": 100,
+            "videoId": "qgSVE71wNec",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCcKuHJnofB8QOWWshLAoVwg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a58e866faca37fe36fe38473"
+        },
+        {
+          "position": 22,
+          "id": "levyra-3cbd6f6080c0cb5cd748",
+          "title": "Snap",
+          "artists": [
+            {
+              "name": "manifest"
+            }
+          ],
+          "album": {
+            "name": "manifestival",
+            "releaseDate": "2025-06-13"
+          },
+          "durationMs": 149711,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "PauIcvh7cfY",
+            "audioConfidence": 100,
+            "videoId": "KyQCrV-z4_A",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCavTTSUSD6aYPeF-F3ND9Yg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02be1b34819d010b15ea80f518"
+        },
+        {
+          "position": 23,
+          "id": "levyra-d6754aaad63c6d139067",
+          "title": "Diva",
+          "artists": [
+            {
+              "name": "Burak Bulut"
+            }
+          ],
+          "album": {
+            "name": "Diva",
+            "releaseDate": "2026-07-03"
+          },
+          "durationMs": 127000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "or7cG9BdsT4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCMqXgeP9E7wfhfDZMMuEF0Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0234c43e446c063dba3e169fda"
+        },
+        {
+          "position": 24,
+          "id": "levyra-3bf7605b8d5a1cb1f7dd",
+          "title": "TSS",
+          "artists": [
+            {
+              "name": "KAVAK"
+            },
+            {
+              "name": "BAKAN"
+            }
+          ],
+          "album": {
+            "name": "VAKKO",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 118736,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "ouHRWWOkhhs",
+            "audioConfidence": 100,
+            "videoId": "JYlS1xRrpAg",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCHbqxwhmDWZdKA8SqkJcyUA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0278ff92663d249460c37aca0d"
+        },
+        {
+          "position": 25,
+          "id": "levyra-1d6984bb68fbd6c16ba2",
+          "title": "Gidişat",
+          "artists": [
+            {
+              "name": "Tan Taşçı"
+            }
+          ],
+          "album": {
+            "name": "Gidişat",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 225570,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Q4rf6aq_m6Q",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCWb1cSMKnn8Bj-mTYPtFqew"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028d96380fafbb2db6edb012d9"
+        },
+        {
+          "position": 26,
+          "id": "levyra-bbb256114d279b29f9af",
+          "title": "Sakin Ol Champ",
+          "artists": [
+            {
+              "name": "BLOK3"
+            }
+          ],
+          "album": {
+            "name": "KAYIP PERSONA",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 106105,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0229728fe23025da14d5695ddb"
+        },
+        {
+          "position": 27,
+          "id": "levyra-8430e3cfa7f37cf1da7c",
+          "title": "Akşamüstü",
+          "artists": [
+            {
+              "name": "Yalın"
+            }
+          ],
+          "album": {
+            "name": "Akşamüstü",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 172000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "CUFw_Gs_cF4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCzJ9YDydxiTUdHAax7YfAGA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020345877482911e3c54f3e87d"
+        },
+        {
+          "position": 28,
+          "id": "levyra-f4dddc69ea3efe48f5f3",
+          "title": "Maraton",
+          "artists": [
+            {
+              "name": "Ati242"
+            }
+          ],
+          "album": {
+            "name": "Maraton",
+            "releaseDate": "2025-12-26"
+          },
+          "durationMs": 213906,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "gCAMQm--CZA",
+            "audioConfidence": 100,
+            "videoId": "aQb_uxNfcGk",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCJjP9Yna08Zq5_TimlS429w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ef515a24ca4190ad477b3363"
+        },
+        {
+          "position": 29,
+          "id": "levyra-360a6fcab3d80e75e482",
+          "title": "Amatör",
+          "artists": [
+            {
+              "name": "manifest"
+            }
+          ],
+          "album": {
+            "name": "Amatör",
+            "releaseDate": "2025-12-05"
+          },
+          "durationMs": 163809,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "4MlZDSTUu5w",
+            "audioConfidence": 100,
+            "videoId": "JzH6uWBtC3I",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCavTTSUSD6aYPeF-F3ND9Yg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ccb96d4a469a73aff0706316"
+        },
+        {
+          "position": 30,
+          "id": "levyra-e85b1c9f45b0733b7bd5",
+          "title": "UYUYAMADIN DİMİ?",
+          "artists": [
+            {
+              "name": "Poizi"
+            }
+          ],
+          "album": {
+            "name": "PARDON MUTLULUKLAR",
+            "releaseDate": "2026-04-17"
+          },
+          "durationMs": 158779,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "FL3Bjjq38Wo",
+            "audioConfidence": 100,
+            "videoId": "eG79aUWKkKo",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC5fDzy6g0T-zwzQxbpcFjvw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a9972b9ad89b3ae386e13755"
+        },
+        {
+          "position": 31,
+          "id": "levyra-7691b0b2fa70f1ce5f98",
+          "title": "Ömrüm",
+          "artists": [
+            {
+              "name": "Eypio"
+            }
+          ],
+          "album": {
+            "name": "Ömrüm",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 174545,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "791Qe2oF-eY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7xB-aD79YD7hHKs34knVLQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e12ee3039a1e0ec5e93d9fe5"
+        },
+        {
+          "position": 32,
+          "id": "levyra-31d6cca23322d4be2957",
+          "title": "KUSURA BAKMA",
+          "artists": [
+            {
+              "name": "BLOK3"
+            }
+          ],
+          "album": {
+            "name": "KAYIP PERSONA",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 157800,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "4tBnjRrPSDI",
+            "audioConfidence": 100,
+            "videoId": "Y9AXKgqGwN4",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCZpmeLoLLb3vmxgscRyLPgw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0229728fe23025da14d5695ddb"
+        },
+        {
+          "position": 33,
+          "id": "levyra-4b2c440f76637d5ad45b",
+          "title": "KTS",
+          "artists": [
+            {
+              "name": "manifest"
+            }
+          ],
+          "album": {
+            "name": "manifestival",
+            "releaseDate": "2025-06-13"
+          },
+          "durationMs": 146517,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "YKO78iqqtDE",
+            "audioConfidence": 100,
+            "videoId": "yRqJ6gbkBA0",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCavTTSUSD6aYPeF-F3ND9Yg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02be1b34819d010b15ea80f518"
+        },
+        {
+          "position": 34,
+          "id": "levyra-61ad527b2e3506083579",
+          "title": "yanılmışım",
+          "artists": [
+            {
+              "name": "Yung Ouzo"
+            },
+            {
+              "name": "Tanerman"
+            }
+          ],
+          "album": {
+            "name": "valiz",
+            "releaseDate": "2026-04-24"
+          },
+          "durationMs": 125538,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0280d1ae960a5413a88d133952"
+        },
+        {
+          "position": 35,
+          "id": "levyra-f9b260f20938df65a660",
+          "title": "Yaşanacaksa",
+          "artists": [
+            {
+              "name": "manifest"
+            }
+          ],
+          "album": {
+            "name": "manifestival",
+            "releaseDate": "2025-06-13"
+          },
+          "durationMs": 166425,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "B42fXNlLxvQ",
+            "audioConfidence": 100,
+            "videoId": "zuP6l1oA3Ro",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCavTTSUSD6aYPeF-F3ND9Yg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02be1b34819d010b15ea80f518"
+        },
+        {
+          "position": 36,
+          "id": "levyra-2775f7a8dd6df90a497e",
+          "title": "Makina",
+          "artists": [
+            {
+              "name": "Emir"
+            }
+          ],
+          "album": {
+            "name": "Ateşten Bi Rüzgar",
+            "releaseDate": "2012-04-06"
+          },
+          "durationMs": 205191,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a75372c02e373dbb019555a5"
+        },
+        {
+          "position": 37,
+          "id": "levyra-675dfbb8eeb5ecedc0bc",
+          "title": "Aklın Hep Bende",
+          "artists": [
+            {
+              "name": "UZI"
+            },
+            {
+              "name": "Motive"
+            },
+            {
+              "name": "FT Kings"
+            }
+          ],
+          "album": {
+            "name": "Kan II",
+            "releaseDate": "2026-07-10"
+          },
+          "durationMs": 195917,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qM5yHPwQvjQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC2tJgRViTA66CnPtCxDfKaQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0232c7d367a48e3147a0b899a9"
+        },
+        {
+          "position": 38,
+          "id": "levyra-1c8812a2ac5e38046dbc",
+          "title": "GEL GEL GEL",
+          "artists": [
+            {
+              "name": "Lvbel C5"
+            },
+            {
+              "name": "DYSTINCT"
+            }
+          ],
+          "album": {
+            "name": "GEL GEL GEL",
+            "releaseDate": "2026-05-21"
+          },
+          "durationMs": 160087,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "3Wq3YAlG8u4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCmduBlHIIX98XCRP2bJIoSQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f79d417fbcb6bcda4bdd00c5"
+        },
+        {
+          "position": 39,
+          "id": "levyra-14249afedae850dcb65d",
+          "title": "Geri Ver",
+          "artists": [
+            {
+              "name": "Wegh"
+            }
+          ],
+          "album": {
+            "name": "CURCUNA",
+            "releaseDate": "2026-02-20"
+          },
+          "durationMs": 169411,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "vHD83B_iTZM",
+            "audioConfidence": 100,
+            "videoId": "4-6En3bf5TY",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCNVTeurSES3zFPGe6dRvRFQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0257a8fe9eac772817bdce0c47"
+        },
+        {
+          "position": 40,
+          "id": "levyra-5b40423c6ba984f54e46",
+          "title": "napıyosun mesela ?",
+          "artists": [
+            {
+              "name": "BLOK3"
+            }
+          ],
+          "album": {
+            "name": "KAYIP PERSONA",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 185216,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "FpRC6QYiQ3I",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCZpmeLoLLb3vmxgscRyLPgw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0229728fe23025da14d5695ddb"
+        },
+        {
+          "position": 41,
+          "id": "levyra-9417ce58febf610c4dbe",
+          "title": "A Canım",
+          "artists": [
+            {
+              "name": "Mabel Matiz"
+            }
+          ],
+          "album": {
+            "name": "Maya",
+            "releaseDate": "2018-06-20"
+          },
+          "durationMs": 263799,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "nzB15DkJ8v4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCeHch28L__s_rBqZAqKa0zA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ce11b6aa0971b9bc60946b3a"
+        },
+        {
+          "position": 42,
+          "id": "levyra-c07f893ff7752ad0558a",
+          "title": "Değiştiremezsin Yazılmışsa",
+          "artists": [
+            {
+              "name": "BLOK3"
+            }
+          ],
+          "album": {
+            "name": "KAYIP PERSONA",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 155024,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7A58WJikeyE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCZpmeLoLLb3vmxgscRyLPgw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0229728fe23025da14d5695ddb"
+        },
+        {
+          "position": 43,
+          "id": "levyra-87fff3a352b8d7a6eb70",
+          "title": "git",
+          "artists": [
+            {
+              "name": "BLOK3"
+            }
+          ],
+          "album": {
+            "name": "KAYIP PERSONA",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 158774,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Xh55tq-T1eE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCZpmeLoLLb3vmxgscRyLPgw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0229728fe23025da14d5695ddb"
+        },
+        {
+          "position": 44,
+          "id": "levyra-29daecc0b0f4d63f6d6a",
+          "title": "Gamsız Hayat",
+          "artists": [
+            {
+              "name": "Candan Erçetin"
+            }
+          ],
+          "album": {
+            "name": "Neden",
+            "releaseDate": "2002-04-17"
+          },
+          "durationMs": 231800,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "6B6t_wmk-KY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC5uno6D44aNZ4L57DeVRkQQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bb0356a01d01ef3abb4d3010"
+        },
+        {
+          "position": 45,
+          "id": "levyra-736e577b530b5d4dffb6",
+          "title": "Zamansızdık",
+          "artists": [
+            {
+              "name": "manifest"
+            }
+          ],
+          "album": {
+            "name": "manifestival",
+            "releaseDate": "2025-06-13"
+          },
+          "durationMs": 169822,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "2Xw-W9h-l0g",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCavTTSUSD6aYPeF-F3ND9Yg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02be1b34819d010b15ea80f518"
+        },
+        {
+          "position": 46,
+          "id": "levyra-4f2795509600875b7617",
+          "title": "Zehir - Motive Remix",
+          "artists": [
+            {
+              "name": "manifest"
+            },
+            {
+              "name": "Motive"
+            },
+            {
+              "name": "Pango"
+            }
+          ],
+          "album": {
+            "name": "manifestival (deluxe)",
+            "releaseDate": "2025-09-05"
+          },
+          "durationMs": 232215,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02566c01a04238f0c00f1982e1"
+        },
+        {
+          "position": 47,
+          "id": "levyra-9058d44b4e9a0d7e482b",
+          "title": "Arıyo",
+          "artists": [
+            {
+              "name": "manifest"
+            }
+          ],
+          "album": {
+            "name": "manifestival",
+            "releaseDate": "2025-06-13"
+          },
+          "durationMs": 133090,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "-Ti_L7lG_io",
+            "audioConfidence": 100,
+            "videoId": "yQ9lXHfv9Yg",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCavTTSUSD6aYPeF-F3ND9Yg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02be1b34819d010b15ea80f518"
+        },
+        {
+          "position": 48,
+          "id": "levyra-cf91be914249b8a9588d",
+          "title": "Allah Allah ?",
+          "artists": [
+            {
+              "name": "BLOK3"
+            }
+          ],
+          "album": {
+            "name": "KAYIP PERSONA",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 158158,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "jMqpGNdicnU",
+            "audioConfidence": 100,
+            "videoId": "jAB-LwRoiOU",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCZpmeLoLLb3vmxgscRyLPgw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0229728fe23025da14d5695ddb"
+        },
+        {
+          "position": 49,
+          "id": "levyra-8f225630a7f7498d97c4",
+          "title": "Son Aşkım - Remastered",
+          "artists": [
+            {
+              "name": "Yalın"
+            }
+          ],
+          "album": {
+            "name": "Ellerine Sağlık (Remastered)",
+            "releaseDate": "2004"
+          },
+          "durationMs": 291866,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ea483c6cc4dc4a5f97e04f3d"
+        },
+        {
+          "position": 50,
+          "id": "levyra-b108f877a24a1cc98ac6",
+          "title": "Şarkılar Sokaklara Ait",
+          "artists": [
+            {
+              "name": "UZI"
+            },
+            {
+              "name": "Motive"
+            }
+          ],
+          "album": {
+            "name": "Mortal Kombat",
+            "releaseDate": "2026-01-23"
+          },
+          "durationMs": 175143,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "YiJAxtSdeTw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC2tJgRViTA66CnPtCxDfKaQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f28269ed4bbcd8ebc756d198"
+        }
+      ]
+    },
+    {
+      "id": "top-50-sa",
+      "kind": "chart",
+      "market": "SA",
+      "title": "Top 50 السعودية",
+      "description": "Arabia Saudita: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-f970c12c11cd1a08b53e",
+          "title": "عفتني",
+          "artists": [
+            {
+              "name": "Sabah Mahmod"
+            }
+          ],
+          "album": {
+            "name": "عفتني",
+            "releaseDate": "2011-06-12"
+          },
+          "durationMs": 404035,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0229caa468e671a1c1f5f125a9"
+        },
+        {
+          "position": 2,
+          "id": "levyra-4435724e8934201fe429",
+          "title": "misery.",
+          "artists": [
+            {
+              "name": "pupsies"
+            }
+          ],
+          "album": {
+            "name": "misery.",
+            "releaseDate": "2026-03-18"
+          },
+          "durationMs": 166401,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qJKcADiAuAw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCp3AZ2_EV0KOSEL33IC1YWw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02316b7fde50dfbf4be72735c2"
+        },
+        {
+          "position": 3,
+          "id": "levyra-e1c46fadf597e525d128",
+          "title": "ارجع علينا",
+          "artists": [
+            {
+              "name": "علي حاتم"
+            }
+          ],
+          "album": {
+            "name": "ارجع علينا",
+            "releaseDate": "2013-05-03"
+          },
+          "durationMs": 287216,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b5454d0ead182b4b1ccd620"
+        },
+        {
+          "position": 4,
+          "id": "levyra-7e487b0abcfa0b133f38",
+          "title": "Kelma",
+          "artists": [
+            {
+              "name": "Ramy Sabry"
+            }
+          ],
+          "album": {
+            "name": "Ghammadt Einy",
+            "releaseDate": "2008-11-03"
+          },
+          "durationMs": 250320,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0269b28bfb4c6131ca48f8218a"
+        },
+        {
+          "position": 5,
+          "id": "levyra-157bd040ad14b22b5395",
+          "title": "Rouh W Nsani",
+          "artists": [
+            {
+              "name": "Yasmeen"
+            }
+          ],
+          "album": {
+            "name": "Rouh W Nsani",
+            "releaseDate": "2020-03-04"
+          },
+          "durationMs": 225959,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "u7X4fPZ_jsc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCxujwWdnXrQuTYtN8W1ChEA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0239b5585cb4fc5f6b6e5d55e3"
+        },
+        {
+          "position": 6,
+          "id": "levyra-268bff0e7fc44c19286b",
+          "title": "العمر راح - النسخة الأصلية",
+          "artists": [
+            {
+              "name": "Nasrat Al Badr"
+            }
+          ],
+          "album": {
+            "name": "العمر راح (النسخة الأصلية)",
+            "releaseDate": "2017-06-11"
+          },
+          "durationMs": 271441,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02958df4f61488e46d95935e18"
+        },
+        {
+          "position": 7,
+          "id": "levyra-6e3c4fb8d151eb90a09d",
+          "title": "ميت اني",
+          "artists": [
+            {
+              "name": "Sabah Mahmod"
+            }
+          ],
+          "album": {
+            "name": "ميت اني",
+            "releaseDate": "2014-03-03"
+          },
+          "durationMs": 246021,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ff0d12ba4a289e44c5af0072"
+        },
+        {
+          "position": 8,
+          "id": "levyra-0d4a5bb42c1ef05f1eef",
+          "title": "الحب عيبنا",
+          "artists": [
+            {
+              "name": "Ramy Sabry"
+            }
+          ],
+          "album": {
+            "name": "الحب عيبنا",
+            "releaseDate": "2025-03-07"
+          },
+          "durationMs": 236000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0206b3b8e76373d4569a7f833d"
+        },
+        {
+          "position": 9,
+          "id": "levyra-f93852bf8b9f8d444b31",
+          "title": "Almahzala",
+          "artists": [
+            {
+              "name": "Nasrat Al Badr"
+            }
+          ],
+          "album": {
+            "name": "Almahzala",
+            "releaseDate": "2021-11-08"
+          },
+          "durationMs": 262345,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "ubkYBvPBFXI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCIpfqF-PEl2ca1zBqPXW4Eg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0268fe0e7a534a805de94d9496"
+        },
+        {
+          "position": 10,
+          "id": "levyra-cc625226a82e6ac297d2",
+          "title": "Tayeh Fel Amaken",
+          "artists": [
+            {
+              "name": "Nabil"
+            }
+          ],
+          "album": {
+            "name": "Tayeh Fel Amaken",
+            "releaseDate": "2025-12-03"
+          },
+          "durationMs": 229040,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "ZD7hSAjfqKM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC-wIOenYywGgsphYQ6xvfTQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026a14b2b88b3cb603208f4b4f"
+        },
+        {
+          "position": 11,
+          "id": "levyra-ed228a8306a1526fecfd",
+          "title": "اوعدك",
+          "artists": [
+            {
+              "name": "Ayed"
+            }
+          ],
+          "album": {
+            "name": "ثمان الام",
+            "releaseDate": "2018-01-19"
+          },
+          "durationMs": 246832,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c048ccb4c26a2d2418513bf0"
+        },
+        {
+          "position": 12,
+          "id": "levyra-e2fb7ff2caa8b0160954",
+          "title": "The One That Got Away",
+          "artists": [
+            {
+              "name": "Katy Perry"
+            }
+          ],
+          "album": {
+            "name": "Teenage Dream",
+            "releaseDate": "2010-01-01"
+          },
+          "durationMs": 227333,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021d955011a3ed477dc77865ad"
+        },
+        {
+          "position": 13,
+          "id": "levyra-89effa5a49744feb5d5c",
+          "title": "يا ناس",
+          "artists": [
+            {
+              "name": "مامون النطاح"
+            },
+            {
+              "name": "Osama Naji"
+            }
+          ],
+          "album": {
+            "name": "أتركني أحبك",
+            "releaseDate": "2015-08-10"
+          },
+          "durationMs": 301055,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b057b18fd01c8eee341bd127"
+        },
+        {
+          "position": 14,
+          "id": "levyra-7c7627f8aa65f97ad968",
+          "title": "One Day (feat. Helena) - Radio Edit",
+          "artists": [
+            {
+              "name": "Arash"
+            },
+            {
+              "name": "Helena"
+            }
+          ],
+          "album": {
+            "name": "SUPERMAN",
+            "releaseDate": "2014-11-04"
+          },
+          "durationMs": 213146,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0299066c4b98aa2ab8252a47bc"
+        },
+        {
+          "position": 15,
+          "id": "levyra-2231e1f9ac96caa19d66",
+          "title": "Bring Me To Life",
+          "artists": [
+            {
+              "name": "Evanescence"
+            }
+          ],
+          "album": {
+            "name": "Fallen",
+            "releaseDate": "2003-03-04"
+          },
+          "durationMs": 235893,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "-eGM0IJc70Y",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC1ObIyFsDJn62iAZYLWcNxA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0225f49ab23f0ec6332efef432"
+        },
+        {
+          "position": 16,
+          "id": "levyra-cb5592a1a61f6d267657",
+          "title": "هذا دمعك",
+          "artists": [
+            {
+              "name": "Tayseer Al Safeer"
+            }
+          ],
+          "album": {
+            "name": "هذا دمعك",
+            "releaseDate": "2013-12-28"
+          },
+          "durationMs": 291657,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "ygmNeFO6hdU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCAfpf6LYDQ13cWCeWmuv6ug"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02624262e72f24b331c58f1abf"
+        },
+        {
+          "position": 17,
+          "id": "levyra-6f0ba1270c9e26ff0c17",
+          "title": "ضاعت دروبي",
+          "artists": [
+            {
+              "name": "مشاري بن نافل"
+            }
+          ],
+          "album": {
+            "name": "ضاعت دروبي",
+            "releaseDate": "2026-01-31"
+          },
+          "durationMs": 204149,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021bdac84c4f27edacf9c346a6"
+        },
+        {
+          "position": 18,
+          "id": "levyra-d8e7bad935fab9e6f04f",
+          "title": "Hbnah Antaha",
+          "artists": [
+            {
+              "name": "Mohamad Abdel Jabar"
+            },
+            {
+              "name": "Ali Bader"
+            }
+          ],
+          "album": {
+            "name": "Hbnah Antaha",
+            "releaseDate": "2015-05-29"
+          },
+          "durationMs": 400320,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f3ffc181969572dd2b958eb8"
+        },
+        {
+          "position": 19,
+          "id": "levyra-93683240d111e7825d3f",
+          "title": "hate that i made you love me",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 197949,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7CUz7Ec7cWc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 20,
+          "id": "levyra-9aa6985d9985f1b7e01e",
+          "title": "Love Me Not",
+          "artists": [
+            {
+              "name": "Ravyn Lenae"
+            }
+          ],
+          "album": {
+            "name": "Bird's Eye",
+            "releaseDate": "2024-08-09"
+          },
+          "durationMs": 213466,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "HfpR4tAmI7E",
+            "audioConfidence": 100,
+            "videoId": "cswfR85D7jM",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCN8pGtbprga7vJL5B4dhXrg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020e62daaea2c7b94053e1c142"
+        },
+        {
+          "position": 21,
+          "id": "levyra-47764fdde285bb5be11a",
+          "title": "Beauty And A Beat",
+          "artists": [
+            {
+              "name": "Justin Bieber"
+            },
+            {
+              "name": "Nicki Minaj"
+            }
+          ],
+          "album": {
+            "name": "Believe",
+            "releaseDate": "2012-01-01"
+          },
+          "durationMs": 227986,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f1d02a6cec967f8b6b78f76e"
+        },
+        {
+          "position": 22,
+          "id": "levyra-411ee215adfe5f5c97c7",
+          "title": "Animal",
+          "artists": [
+            {
+              "name": "KATSEYE"
+            }
+          ],
+          "album": {
+            "name": "Animal",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 158494,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "vOfyxPRunFM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCX9kfYB9t0tnd6DYUC2iuKg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029e8d48f27391ce383862b8e8"
+        },
+        {
+          "position": 23,
+          "id": "levyra-502ec119fbfeb45c0983",
+          "title": "Ya Helou",
+          "artists": [
+            {
+              "name": "Adam"
+            }
+          ],
+          "album": {
+            "name": "Ya Helou",
+            "releaseDate": "2025-07-11"
+          },
+          "durationMs": 185495,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "LzHgq3LcoTE",
+            "audioConfidence": 100,
+            "videoId": "GEucCNFsr84",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UC06hTV4etv99Jnf1exPpSlg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028facebae3fed1b911dc33f30"
+        },
+        {
+          "position": 24,
+          "id": "levyra-ffec91f9709839cde3ad",
+          "title": "Sailor Song",
+          "artists": [
+            {
+              "name": "Gigi Perez"
+            }
+          ],
+          "album": {
+            "name": "At The Beach, In Every Life",
+            "releaseDate": "2025-04-25"
+          },
+          "durationMs": 211978,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "wPY6dOC-MDA",
+            "audioConfidence": 100,
+            "videoId": "1lrFsXkT_rM",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCobE63bvA-2tK_HZ2LbP8cQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0249c26270052e1671add569c1"
+        },
+        {
+          "position": 25,
+          "id": "levyra-33e727b985a62c7c03e9",
+          "title": "TQBL Kol",
+          "artists": [
+            {
+              "name": "Hussain Ghazal"
+            },
+            {
+              "name": "حسين غزال"
+            }
+          ],
+          "album": {
+            "name": "TQBL Kol",
+            "releaseDate": "2018-06-12"
+          },
+          "durationMs": 277707,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0221b1188088192e0cb437c648"
+        },
+        {
+          "position": 26,
+          "id": "levyra-25bf3eaafe644d8ccbb4",
+          "title": "شلون بية",
+          "artists": [
+            {
+              "name": "Aws Al Saber"
+            }
+          ],
+          "album": {
+            "name": "شلون بية",
+            "releaseDate": "2022-01-25"
+          },
+          "durationMs": 360055,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0295813b722aa2fa5ff9dc32ef"
+        },
+        {
+          "position": 27,
+          "id": "levyra-62c90b4af13ccbc9f4cd",
+          "title": "back to friends",
+          "artists": [
+            {
+              "name": "sombr"
+            }
+          ],
+          "album": {
+            "name": "I Barely Know Her",
+            "releaseDate": "2025-08-22"
+          },
+          "durationMs": 199032,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "c-8abSPAPOU",
+            "audioConfidence": 100,
+            "videoId": "c8zq4kAn_O0",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCyI0V6RmULLsRxegMTCmkWQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024229702de91cb3d3a4383302"
+        },
+        {
+          "position": 28,
+          "id": "levyra-4a8f3d180ce3d0b76564",
+          "title": "Earrings",
+          "artists": [
+            {
+              "name": "Malcolm Todd"
+            }
+          ],
+          "album": {
+            "name": "Sweet Boy",
+            "releaseDate": "2024-04-05"
+          },
+          "durationMs": 151500,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "BI9HQCzpDgQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCRLE_fwmN2CQw1vuWPwo6eA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022c1f34ecc1929fb59908aad1"
+        },
+        {
+          "position": 29,
+          "id": "levyra-5eaeece4a8314ec56b5e",
+          "title": "باعني وراح",
+          "artists": [
+            {
+              "name": "Sabah Mahmod"
+            }
+          ],
+          "album": {
+            "name": "باعني وراح",
+            "releaseDate": "2025-11-16"
+          },
+          "durationMs": 321689,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024cbad3534fe9231343c02751"
+        },
+        {
+          "position": 30,
+          "id": "levyra-e2926fcb77ba07b05d31",
+          "title": "اريدك",
+          "artists": [
+            {
+              "name": "Louay Adnan"
+            }
+          ],
+          "album": {
+            "name": "اريدك",
+            "releaseDate": "2017-07-05"
+          },
+          "durationMs": 251768,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "bZ0a54DPQqA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC38PzHIYsgDt3vRbscJIk2w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c2817167c99e53dfb9e898c7"
+        },
+        {
+          "position": 31,
+          "id": "levyra-9d3e530cd74574baf20a",
+          "title": "Babydoll",
+          "artists": [
+            {
+              "name": "Dominic Fike"
+            }
+          ],
+          "album": {
+            "name": "Don't Forget About Me, Demos",
+            "releaseDate": "2018-10-16"
+          },
+          "durationMs": 97960,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "UnuEzP1rDLY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCsWqHrJvOU_uukQCU92VEvw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b1b6f41c1645af9757d5616"
+        },
+        {
+          "position": 32,
+          "id": "levyra-a298dc98ce6762c75044",
+          "title": "Garee2a Awy - A COLORS SHOW",
+          "artists": [
+            {
+              "name": "TUL8TE"
+            },
+            {
+              "name": "COLORS"
+            }
+          ],
+          "album": {
+            "name": "Garee2a Awy - A COLORS SHOW",
+            "releaseDate": "2026-07-06"
+          },
+          "durationMs": 158502,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0273aa5127d0871a45c130ea55"
+        },
+        {
+          "position": 33,
+          "id": "levyra-86006382838522ff2827",
+          "title": "WILDFLOWER",
+          "artists": [
+            {
+              "name": "Billie Eilish"
+            }
+          ],
+          "album": {
+            "name": "HIT ME HARD AND SOFT",
+            "releaseDate": "2024-05-17"
+          },
+          "durationMs": 261466,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "O1PkZaFy61Y",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCERrDZ8oN0U_n9MphMKERcg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0271d62ea7ea8a5be92d3c1f62"
+        },
+        {
+          "position": 34,
+          "id": "levyra-f2400a9c007b1ad2eaea",
+          "title": "Apocalypse",
+          "artists": [
+            {
+              "name": "Cigarettes After Sex"
+            }
+          ],
+          "album": {
+            "name": "Cigarettes After Sex",
+            "releaseDate": "2017-06-09"
+          },
+          "durationMs": 290146,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "DdI598gKkKw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCIMuwfTAzgZ5Dg84TmYxYkA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dfed999f959177dfc4f33cdc"
+        },
+        {
+          "position": 35,
+          "id": "levyra-7d92d2cd170bad2fe1bb",
+          "title": "Runaway",
+          "artists": [
+            {
+              "name": "AURORA"
+            }
+          ],
+          "album": {
+            "name": "All My Demons Greeting Me As A Friend (Deluxe)",
+            "releaseDate": "2016-03-11"
+          },
+          "durationMs": 248826,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c379325088c2845fe85cd70a"
+        },
+        {
+          "position": 36,
+          "id": "levyra-e2356a371c2d3c340055",
+          "title": "Zombie - 2025 Remastered",
+          "artists": [
+            {
+              "name": "The Cranberries"
+            }
+          ],
+          "album": {
+            "name": "No Need To Argue (2025 Remastered)",
+            "releaseDate": "1994"
+          },
+          "durationMs": 305626,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0220a28883cdd0fc7d5f85a9a9"
+        },
+        {
+          "position": 37,
+          "id": "levyra-8111af2eb81fe2ba446f",
+          "title": "Aaouf El Denia",
+          "artists": [
+            {
+              "name": "Mohamed AlSalim"
+            }
+          ],
+          "album": {
+            "name": "Ana Al Basma",
+            "releaseDate": "2017-03-05"
+          },
+          "durationMs": 226853,
+          "explicit": false
+        },
+        {
+          "position": 38,
+          "id": "levyra-f123c95b9d77f3733ff6",
+          "title": "Baraka Ya Albi",
+          "artists": [
+            {
+              "name": "Yesa ekha putri"
+            }
+          ],
+          "album": {
+            "name": "Baraka Ya Albi",
+            "releaseDate": "2024-11-26"
+          },
+          "durationMs": 244248,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "aW1XLiER45c",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCpnq-Xab0dMdD0zLKxMZTyA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a61475640e3a514c9dbd63a4"
+        },
+        {
+          "position": 39,
+          "id": "levyra-3bba25d8ea5814eb102f",
+          "title": "Heseeny",
+          "artists": [
+            {
+              "name": "TUL8TE"
+            }
+          ],
+          "album": {
+            "name": "Narein",
+            "releaseDate": "2025-07-31"
+          },
+          "durationMs": 213838,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "bcMIr1xhXQI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCv6OuuEWKGkqtRPkg9xbLvA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022e50096092c24bd9acb0749d"
+        },
+        {
+          "position": 40,
+          "id": "levyra-fe44bb7f3a371bb83750",
+          "title": "No One Noticed",
+          "artists": [
+            {
+              "name": "The Marías"
+            }
+          ],
+          "album": {
+            "name": "Submarine",
+            "releaseDate": "2024-05-31"
+          },
+          "durationMs": 236906,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "oodQMZLjoBU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCVV5M4OEFsKnB9HBhwOhHbA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028aa339341a0b0c813909c831"
+        },
+        {
+          "position": 41,
+          "id": "levyra-98349a571204b2f4073a",
+          "title": "petal",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 184248,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "4mQyEqbaUOU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 42,
+          "id": "levyra-4752c1f2ef25959136fb",
+          "title": "جريدة بلا خبر",
+          "artists": [
+            {
+              "name": "Almas"
+            },
+            {
+              "name": "خالد الحنين"
+            }
+          ],
+          "album": {
+            "name": "جريدة بلا خبر",
+            "releaseDate": "2026-02-11"
+          },
+          "durationMs": 217082,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d4d504ab5bb2a72840679fbc"
+        },
+        {
+          "position": 43,
+          "id": "levyra-3f2dcb748a0d34c72f83",
+          "title": "Self Aware",
+          "artists": [
+            {
+              "name": "Temper City"
+            }
+          ],
+          "album": {
+            "name": "Self Aware",
+            "releaseDate": "2026-02-15"
+          },
+          "durationMs": 180740,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "R-hYM3BqTbA",
+            "audioConfidence": 100,
+            "videoId": "mh4AQkw4Jjc",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCpWebSe88U-TOiO8YfKnTgg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d6c26d2ae723f7ab553d64cc"
+        },
+        {
+          "position": 44,
+          "id": "levyra-9d0b06800b1f28aa3479",
+          "title": "Sweater Weather",
+          "artists": [
+            {
+              "name": "The Neighbourhood"
+            }
+          ],
+          "album": {
+            "name": "I Love You.",
+            "releaseDate": "2013-04-22"
+          },
+          "durationMs": 240400,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028265a736a1eb838ad5a0b921"
+        },
+        {
+          "position": 45,
+          "id": "levyra-94dd6692a2a5d3ff09bc",
+          "title": "Ya Nas",
+          "artists": [
+            {
+              "name": "Ma’moun Alnatah"
+            },
+            {
+              "name": "Osama Naji"
+            }
+          ],
+          "album": {
+            "name": "Ya Nas",
+            "releaseDate": "2015-03-10"
+          },
+          "durationMs": 297000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020221675bcc7451247c89ee50"
+        },
+        {
+          "position": 46,
+          "id": "levyra-3f16285d709fb0eb3316",
+          "title": "وين صرتي",
+          "artists": [
+            {
+              "name": "رعد وميثاق"
+            }
+          ],
+          "album": {
+            "name": "وين صرتي",
+            "releaseDate": "2016-06-23"
+          },
+          "durationMs": 348003,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ac868317ebe8b5258a6fc1d6"
+        },
+        {
+          "position": 47,
+          "id": "levyra-b31eb5e60513bbd613b7",
+          "title": "Billie Jean",
+          "artists": [
+            {
+              "name": "Michael Jackson"
+            }
+          ],
+          "album": {
+            "name": "Thriller",
+            "releaseDate": "1982-11-30"
+          },
+          "durationMs": 293802,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0232a7d87248d1b75463483df5"
+        },
+        {
+          "position": 48,
+          "id": "levyra-2f7a1c1b7bceb923f67c",
+          "title": "Loser",
+          "artists": [
+            {
+              "name": "Tame Impala"
+            }
+          ],
+          "album": {
+            "name": "Deadbeat",
+            "releaseDate": "2025-10-17"
+          },
+          "durationMs": 223069,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "MX7FSAnRPug",
+            "audioConfidence": 100,
+            "videoId": "s3a4OQR-10M",
+            "videoConfidence": 97,
+            "confidence": 100,
+            "artistBrowseId": "UCGz-eguN8tcic5kUG4s1ZgA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02208500450dcd0fd294d7bd3b"
+        },
+        {
+          "position": 49,
+          "id": "levyra-1e075596e47edf8666d7",
+          "title": "Habibi Howa",
+          "artists": [
+            {
+              "name": "Mahmoud Al Turky"
+            }
+          ],
+          "album": {
+            "name": "Habibi Howa",
+            "releaseDate": "2015-05-27"
+          },
+          "durationMs": 295157,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020509f9b14997cfcdd0af3dc0"
+        },
+        {
+          "position": 50,
+          "id": "levyra-2638864ca0a06d605e8e",
+          "title": "Maool",
+          "artists": [
+            {
+              "name": "Fadel Chaker"
+            }
+          ],
+          "album": {
+            "name": "Maool",
+            "releaseDate": "2020-06-06"
+          },
+          "durationMs": 235368,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "aB1VEVv2oRc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCTbl3DkhJIa5MB0uHFEQwtw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025914b01bce659a39ad7216ea"
+        }
+      ]
+    },
+    {
+      "id": "top-50-jp",
+      "kind": "chart",
+      "market": "JP",
+      "title": "Top 50 日本",
+      "description": "Giappone: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-63519ad348662b144f32",
+          "title": "Brand New",
+          "artists": [
+            {
+              "name": "Mrs. GREEN APPLE"
+            }
+          ],
+          "album": {
+            "name": "Brand New",
+            "releaseDate": "2026-07-12"
+          },
+          "durationMs": 211666,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "UZ4an60Zmvc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCFB0qxwNwayGQ4Ksj8QpCXg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028bc6d0a539486bdb1a9f2968"
+        },
+        {
+          "position": 2,
+          "id": "levyra-209c18db738d71d72cfe",
+          "title": "高嶺の花子さん",
+          "artists": [
+            {
+              "name": "back number"
+            }
+          ],
+          "album": {
+            "name": "ラブストーリー",
+            "releaseDate": "2014-03-26"
+          },
+          "durationMs": 294813,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02783ed3c2af46af7ab7c671c0"
+        },
+        {
+          "position": 3,
+          "id": "levyra-d7982e33818186ba0441",
+          "title": "花束",
+          "artists": [
+            {
+              "name": "back number"
+            }
+          ],
+          "album": {
+            "name": "スーパースター",
+            "releaseDate": "2011-10-26"
+          },
+          "durationMs": 286053,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024951a4f5f9d719dfa4ef3d75"
+        },
+        {
+          "position": 4,
+          "id": "levyra-9562cf3e488f30935ecc",
+          "title": "青と夏",
+          "artists": [
+            {
+              "name": "Mrs. GREEN APPLE"
+            }
+          ],
+          "album": {
+            "name": "Attitude",
+            "releaseDate": "2019-10-01"
+          },
+          "durationMs": 270026,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0281f55cd879e9480e3ed313df"
+        },
+        {
+          "position": 5,
+          "id": "levyra-c67a483f76da489a695d",
+          "title": "Sukisugite METSU!",
+          "artists": [
+            {
+              "name": "M!LK"
+            }
+          ],
+          "album": {
+            "name": "Sukisugite METSU!",
+            "releaseDate": "2025-10-27"
+          },
+          "durationMs": 212400,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "14cxcH1eiPc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UChbU0n7P86fWdZtlzCNCeGg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0209fb0acaaf2416132c914eb5"
+        },
+        {
+          "position": 6,
+          "id": "levyra-400d2fe94e4789e4e913",
+          "title": "It's Me",
+          "artists": [
+            {
+              "name": "ILLIT"
+            }
+          ],
+          "album": {
+            "name": "MAMIHLAPINATAPAI",
+            "releaseDate": "2026-04-30"
+          },
+          "durationMs": 138284,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "XDzGoMtSqZA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCNVIo0UJXTdEnsRkCB9Q03w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0261eea484e31bca065904f1c6"
+        },
+        {
+          "position": 7,
+          "id": "levyra-7a806b6bb775ac9bf27b",
+          "title": "Tsumi to Batsu to Ame to Kiss (Hayato Sano & Jinto Yoshida)",
+          "artists": [
+            {
+              "name": "M!LK"
+            }
+          ],
+          "album": {
+            "name": "Tsumi to Batsu to Ame to Kiss (Hayato Sano & Jinto Yoshida)",
+            "releaseDate": "2026-08-03"
+          },
+          "durationMs": 222293,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "oFzP7YKS5gM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UChbU0n7P86fWdZtlzCNCeGg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0244c48f55cbea9422c30f0f64"
+        },
+        {
+          "position": 8,
+          "id": "levyra-3b1481ef506663cbfe67",
+          "title": "ブルーアンバー",
+          "artists": [
+            {
+              "name": "back number"
+            }
+          ],
+          "album": {
+            "name": "ブルーアンバー",
+            "releaseDate": "2025-04-28"
+          },
+          "durationMs": 207845,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a58f0d10db6a676c3b422fda"
+        },
+        {
+          "position": 9,
+          "id": "levyra-1359a9f71e6e9ca752a9",
+          "title": "点描の唄",
+          "artists": [
+            {
+              "name": "Mrs. GREEN APPLE"
+            },
+            {
+              "name": "Sonoko Inoue"
+            }
+          ],
+          "album": {
+            "name": "青と夏",
+            "releaseDate": "2018-07-31"
+          },
+          "durationMs": 307066,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b68755a98268d7aa297549d5"
+        },
+        {
+          "position": 10,
+          "id": "levyra-f40ad16f6513af4712f4",
+          "title": "ライラック",
+          "artists": [
+            {
+              "name": "Mrs. GREEN APPLE"
+            }
+          ],
+          "album": {
+            "name": "10",
+            "releaseDate": "2025-07-06"
+          },
+          "durationMs": 289506,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02232b48311e311ba914af2811"
+        },
+        {
+          "position": 11,
+          "id": "levyra-b2f4e5660b8c4ebfaadc",
+          "title": "夜の踊り子",
+          "artists": [
+            {
+              "name": "sakanaction"
+            }
+          ],
+          "album": {
+            "name": "sakanaction",
+            "releaseDate": "2013-03-13"
+          },
+          "durationMs": 302920,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026dd4b6207e6e3780e50a24d6"
+        },
+        {
+          "position": 12,
+          "id": "levyra-5bdee3d9d83c7598beee",
+          "title": "Bakuretsu Aishiteru",
+          "artists": [
+            {
+              "name": "M!LK"
+            }
+          ],
+          "album": {
+            "name": "Bakuretsu Aishiteru",
+            "releaseDate": "2026-02-09"
+          },
+          "durationMs": 205333,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "20bYUQZOAeQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UChbU0n7P86fWdZtlzCNCeGg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023307c09719bde062177f93c7"
+        },
+        {
+          "position": 13,
+          "id": "levyra-12f716366faa609a1252",
+          "title": "Don’t Say You Love Me",
+          "artists": [
+            {
+              "name": "Jin"
+            }
+          ],
+          "album": {
+            "name": "Echo",
+            "releaseDate": "2025-05-16"
+          },
+          "durationMs": 180716,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "DdJFbCBiggE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCkX4rp22PPv7V6PKXD7zZFg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0289228504f700641956e29f5d"
+        },
+        {
+          "position": 14,
+          "id": "levyra-3716d295cfbcc1e578e1",
+          "title": "烏 - Raven",
+          "artists": [
+            {
+              "name": "Kenshi Yonezu"
+            }
+          ],
+          "album": {
+            "name": "烏 - Raven",
+            "releaseDate": "2026-06-15"
+          },
+          "durationMs": 248494,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026587e9ae2e13c8bd69c0bf7e"
+        },
+        {
+          "position": 15,
+          "id": "levyra-3d922c15f941e0993b73",
+          "title": "IRIS OUT",
+          "artists": [
+            {
+              "name": "Kenshi Yonezu"
+            }
+          ],
+          "album": {
+            "name": "IRIS OUT",
+            "releaseDate": "2025-09-15"
+          },
+          "durationMs": 151573,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Cb0JZhdmjtg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCC_OGcKdYY-aWFvVMFVGbzw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026d1d4e875e2424cdd07f3232"
+        },
+        {
+          "position": 16,
+          "id": "levyra-6be56da60a06a920ca00",
+          "title": "Marigold",
+          "artists": [
+            {
+              "name": "Aimyon"
+            }
+          ],
+          "album": {
+            "name": "Momentary Sixth Sense",
+            "releaseDate": "2019-02-13"
+          },
+          "durationMs": 306626,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023bc8c5a65f225815fa3844e1"
+        },
+        {
+          "position": 17,
+          "id": "levyra-dc41334e36c7865708be",
+          "title": "ハッピーエンド",
+          "artists": [
+            {
+              "name": "back number"
+            }
+          ],
+          "album": {
+            "name": "ハッピーエンド",
+            "releaseDate": "2016-11-16"
+          },
+          "durationMs": 314280,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e09353d6028fda18c3699085"
+        },
+        {
+          "position": 18,
+          "id": "levyra-f13dfed69bbb3814b889",
+          "title": "水平線",
+          "artists": [
+            {
+              "name": "back number"
+            }
+          ],
+          "album": {
+            "name": "ユーモア",
+            "releaseDate": "2023-01-17"
+          },
+          "durationMs": 288013,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02fd363d834b815375814ae78e"
+        },
+        {
+          "position": 19,
+          "id": "levyra-23825e7b712492ee4401",
+          "title": "Blue Jeans",
+          "artists": [
+            {
+              "name": "HANA"
+            }
+          ],
+          "album": {
+            "name": "HANA",
+            "releaseDate": "2026-02-23"
+          },
+          "durationMs": 207200,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "u8aBtdeb68Q",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCVznsJmPM4qyjLYyORcu0Tg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c175a1d89c39c1cd297cb669"
+        },
+        {
+          "position": 20,
+          "id": "levyra-f945a03099453da34fba",
+          "title": "BUGS LIFE",
+          "artists": [
+            {
+              "name": "Number_i"
+            }
+          ],
+          "album": {
+            "name": "BUGS LIFE",
+            "releaseDate": "2026-07-13"
+          },
+          "durationMs": 179361,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "kNUfjGWIRD8",
+            "audioConfidence": 100,
+            "videoId": "qFhspt7zsXg",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCx4Eo-GGs-O4LgJSryyWdZQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02425a1d2feed9239e8214a609"
+        },
+        {
+          "position": 21,
+          "id": "levyra-c24f729006a4eda997bc",
+          "title": "3XL",
+          "artists": [
+            {
+              "name": "Number_i"
+            }
+          ],
+          "album": {
+            "name": "3XL",
+            "releaseDate": "2026-01-26"
+          },
+          "durationMs": 165454,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "RpqFhbu9wCI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCx4Eo-GGs-O4LgJSryyWdZQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02633ad0881110110829018a69"
+        },
+        {
+          "position": 22,
+          "id": "levyra-fb8bc394a787eacd458d",
+          "title": "Soranji",
+          "artists": [
+            {
+              "name": "Mrs. GREEN APPLE"
+            }
+          ],
+          "album": {
+            "name": "ANTENNA",
+            "releaseDate": "2023-07-04"
+          },
+          "durationMs": 343253,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7Ze7MDQjXS0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCFB0qxwNwayGQ4Ksj8QpCXg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d482c602732da71e7cdf04c3"
+        },
+        {
+          "position": 23,
+          "id": "levyra-ef805e2d4dcb899b7700",
+          "title": "You!Joy!Parade!",
+          "artists": [
+            {
+              "name": "M!LK"
+            }
+          ],
+          "album": {
+            "name": "You!Joy!Parade!",
+            "releaseDate": "2026-07-17"
+          },
+          "durationMs": 181693,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lx3KDeBoLMM",
+            "audioConfidence": 100,
+            "videoId": "3C0EOqt7sqA",
+            "videoConfidence": 97,
+            "confidence": 100,
+            "artistBrowseId": "UChbU0n7P86fWdZtlzCNCeGg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020c91cd279b5581517a3eb578"
+        },
+        {
+          "position": 24,
+          "id": "levyra-8154e4ab1264247cae19",
+          "title": "愛を伝えたいだとか",
+          "artists": [
+            {
+              "name": "Aimyon"
+            }
+          ],
+          "album": {
+            "name": "青春のエキサイトメント",
+            "releaseDate": "2017-09-12"
+          },
+          "durationMs": 235240,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0233c05e1d08fec494a30bd240"
+        },
+        {
+          "position": 25,
+          "id": "levyra-974b67dda63f431fc5d5",
+          "title": "GO GHOST",
+          "artists": [
+            {
+              "name": "King Gnu"
+            }
+          ],
+          "album": {
+            "name": "GO GHOST",
+            "releaseDate": "2026-07-29"
+          },
+          "durationMs": 170100,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0289f64a56f9c086a08fcac39d"
+        },
+        {
+          "position": 26,
+          "id": "levyra-91177e7d96591d31bfcf",
+          "title": "夢中",
+          "artists": [
+            {
+              "name": "BE:FIRST"
+            }
+          ],
+          "album": {
+            "name": "夢中",
+            "releaseDate": "2025-04-25"
+          },
+          "durationMs": 189640,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02530e4b27e7f9281ee1ad4ee6"
+        },
+        {
+          "position": 27,
+          "id": "levyra-2fa4404e0a96d9e64732",
+          "title": "ケセラセラ",
+          "artists": [
+            {
+              "name": "Mrs. GREEN APPLE"
+            }
+          ],
+          "album": {
+            "name": "ANTENNA",
+            "releaseDate": "2023-07-04"
+          },
+          "durationMs": 272226,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d482c602732da71e7cdf04c3"
+        },
+        {
+          "position": 28,
+          "id": "levyra-4177296dc91027387556",
+          "title": "lulu.",
+          "artists": [
+            {
+              "name": "Mrs. GREEN APPLE"
+            }
+          ],
+          "album": {
+            "name": "lulu.",
+            "releaseDate": "2026-01-11"
+          },
+          "durationMs": 270626,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "4REuyY89tfw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCFB0qxwNwayGQ4Ksj8QpCXg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029f3b4070433475c017120dec"
+        },
+        {
+          "position": 29,
+          "id": "levyra-9b4781a13185a8538fb6",
+          "title": "君はロックを聴かない",
+          "artists": [
+            {
+              "name": "Aimyon"
+            }
+          ],
+          "album": {
+            "name": "青春のエキサイトメント",
+            "releaseDate": "2017-09-12"
+          },
+          "durationMs": 246306,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0233c05e1d08fec494a30bd240"
+        },
+        {
+          "position": 30,
+          "id": "levyra-37ea43f12bc8c2fdec7a",
+          "title": "Yes! 東京",
+          "artists": [
+            {
+              "name": "EBiDAN (恵比寿学園男子部)"
+            },
+            {
+              "name": "chotokkyu"
+            },
+            {
+              "name": "M!LK"
+            },
+            {
+              "name": "原因は自分にある。"
+            },
+            {
+              "name": "SUPER★DRAGON"
+            },
+            {
+              "name": "Sakurashimeji"
+            },
+            {
+              "name": "ONE N' ONLY"
+            },
+            {
+              "name": "BUDDiiS"
+            },
+            {
+              "name": "ICEx"
+            },
+            {
+              "name": "Lienel"
+            }
+          ],
+          "album": {
+            "name": "Yes! 東京",
+            "releaseDate": "2026-07-02"
+          },
+          "durationMs": 220466,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02902e640490a6decd6dcebef8"
+        },
+        {
+          "position": 31,
+          "id": "levyra-bb08f9048dee557271d4",
+          "title": "Missing",
+          "artists": [
+            {
+              "name": "BE:FIRST"
+            }
+          ],
+          "album": {
+            "name": "Missing",
+            "releaseDate": "2026-07-01"
+          },
+          "durationMs": 172466,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022cd4bda9ecd034c7bacf2838"
+        },
+        {
+          "position": 32,
+          "id": "levyra-adcd20c56930008824a2",
+          "title": "ダーリン",
+          "artists": [
+            {
+              "name": "Mrs. GREEN APPLE"
+            }
+          ],
+          "album": {
+            "name": "10",
+            "releaseDate": "2025-07-06"
+          },
+          "durationMs": 278506,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02232b48311e311ba914af2811"
+        },
+        {
+          "position": 33,
+          "id": "levyra-efc7fd66d2e5c7ba1c33",
+          "title": "愛をこめて花束を",
+          "artists": [
+            {
+              "name": "Superfly"
+            }
+          ],
+          "album": {
+            "name": "Superfly",
+            "releaseDate": "2007-04-04"
+          },
+          "durationMs": 295600,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f4ba4f68c6906e2cd85fd54a"
+        },
+        {
+          "position": 34,
+          "id": "levyra-e97bc979884c40c508ed",
+          "title": "夜鷹 - Yodaka",
+          "artists": [
+            {
+              "name": "Kenshi Yonezu"
+            }
+          ],
+          "album": {
+            "name": "夜鷹 - Yodaka",
+            "releaseDate": "2026-07-13"
+          },
+          "durationMs": 198050,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "dgN0JbJfzFA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCC_OGcKdYY-aWFvVMFVGbzw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0262249e32fd6ee1ce0b34640b"
+        },
+        {
+          "position": 35,
+          "id": "levyra-ab3c91c84841b690f3ca",
+          "title": "恋",
+          "artists": [
+            {
+              "name": "back number"
+            }
+          ],
+          "album": {
+            "name": "blues",
+            "releaseDate": "2012-11-21"
+          },
+          "durationMs": 253306,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0203808f76fad28ce8523f5ac6"
+        },
+        {
+          "position": 36,
+          "id": "levyra-e7a0fe7a4fb42c6f4b03",
+          "title": "君の恋人になったら",
+          "artists": [
+            {
+              "name": "back number"
+            }
+          ],
+          "album": {
+            "name": "ハッピーエンド",
+            "releaseDate": "2016-11-16"
+          },
+          "durationMs": 244066,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e09353d6028fda18c3699085"
+        },
+        {
+          "position": 37,
+          "id": "levyra-df68c95e9b768506a1fc",
+          "title": "ただ君に晴れ",
+          "artists": [
+            {
+              "name": "ヨルシカ"
+            }
+          ],
+          "album": {
+            "name": "負け犬にアンコールはいらない",
+            "releaseDate": "2018-05-09"
+          },
+          "durationMs": 198971,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0228b535c92629e3c8d20ec242"
+        },
+        {
+          "position": 38,
+          "id": "levyra-7df46b15e1328c2a8b81",
+          "title": "Kaiju no Hanauta",
+          "artists": [
+            {
+              "name": "Vaundy"
+            }
+          ],
+          "album": {
+            "name": "strobo",
+            "releaseDate": "2020-05-27"
+          },
+          "durationMs": 224804,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "ENQANfv2ANQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC8_Ag6BVp43Vmrx6eillK9g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cf855f0c6dee3a4b541b48e7"
+        },
+        {
+          "position": 39,
+          "id": "levyra-7b0b3bbe44ac0be4143f",
+          "title": "IDOLPOWER",
+          "artists": [
+            {
+              "name": "M!LK"
+            }
+          ],
+          "album": {
+            "name": "IDOLPOWER",
+            "releaseDate": "2026-04-27"
+          },
+          "durationMs": 230453,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "d1d9cz3LcJ4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UChbU0n7P86fWdZtlzCNCeGg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020147cecbbbc8b8237ed95dc9"
+        },
+        {
+          "position": 40,
+          "id": "levyra-559cd864f8d50298347b",
+          "title": "幸せ",
+          "artists": [
+            {
+              "name": "back number"
+            }
+          ],
+          "album": {
+            "name": "スーパースター",
+            "releaseDate": "2011-10-26"
+          },
+          "durationMs": 397280,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024951a4f5f9d719dfa4ef3d75"
+        },
+        {
+          "position": 41,
+          "id": "levyra-f223ccda4e6dc1754204",
+          "title": "Kaiju",
+          "artists": [
+            {
+              "name": "sakanaction"
+            }
+          ],
+          "album": {
+            "name": "Kaiju",
+            "releaseDate": "2025-02-20"
+          },
+          "durationMs": 252722,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "ukYEgbe2QPw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCtHYsFMAI733Qy6Es3wDU6g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022337f03620420d4561c7e6c9"
+        },
+        {
+          "position": 42,
+          "id": "levyra-20275428c50e9f9ecb36",
+          "title": "僕のこと",
+          "artists": [
+            {
+              "name": "Mrs. GREEN APPLE"
+            }
+          ],
+          "album": {
+            "name": "Attitude",
+            "releaseDate": "2019-10-01"
+          },
+          "durationMs": 321306,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0281f55cd879e9480e3ed313df"
+        },
+        {
+          "position": 43,
+          "id": "levyra-357cc33100e4fcde75a5",
+          "title": "HAPPY BIRTHDAY",
+          "artists": [
+            {
+              "name": "back number"
+            }
+          ],
+          "album": {
+            "name": "MAGIC",
+            "releaseDate": "2019-03-27"
+          },
+          "durationMs": 258333,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ce51ffc5c742ed217779cb9d"
+        },
+        {
+          "position": 44,
+          "id": "levyra-48bb9003bd64406f91ee",
+          "title": "革命道中 - On The Way",
+          "artists": [
+            {
+              "name": "AiNA THE END"
+            }
+          ],
+          "album": {
+            "name": "革命道中 - On The Way",
+            "releaseDate": "2025-07-02"
+          },
+          "durationMs": 197668,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "ntRVm85--b4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCr_slw4yAD3LI3KQrmnRD8Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029df9218f742e792bcbd711d3"
+        },
+        {
+          "position": 45,
+          "id": "levyra-59575680f1d33b58fafb",
+          "title": "恋人ごっこ",
+          "artists": [
+            {
+              "name": "Macaroni Empitsu"
+            }
+          ],
+          "album": {
+            "name": "hope",
+            "releaseDate": "2020-04-01"
+          },
+          "durationMs": 200219,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ad388532d6600cc70e57139d"
+        },
+        {
+          "position": 46,
+          "id": "levyra-83a17a57a33835e0ba61",
+          "title": "奏(かなで)",
+          "artists": [
+            {
+              "name": "Sukima Switch"
+            }
+          ],
+          "album": {
+            "name": "夏雲ノイズ",
+            "releaseDate": "2004-06-23"
+          },
+          "durationMs": 328626,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a716d5aa6f08492ad5bdae37"
+        },
+        {
+          "position": 47,
+          "id": "levyra-ed9de9f75286af94d7bb",
+          "title": "ROSE",
+          "artists": [
+            {
+              "name": "HANA"
+            }
+          ],
+          "album": {
+            "name": "HANA",
+            "releaseDate": "2026-02-23"
+          },
+          "durationMs": 165520,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "ODunwHoX5Ag",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCVznsJmPM4qyjLYyORcu0Tg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c175a1d89c39c1cd297cb669"
+        },
+        {
+          "position": 48,
+          "id": "levyra-e7365b803094d593f1ab",
+          "title": "ヒロイン",
+          "artists": [
+            {
+              "name": "back number"
+            }
+          ],
+          "album": {
+            "name": "シャンデリア",
+            "releaseDate": "2015-12-09"
+          },
+          "durationMs": 269786,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0259a14a1d53eb5610f84c8382"
+        },
+        {
+          "position": 49,
+          "id": "levyra-5636e272029b9f2fec46",
+          "title": "AIZO",
+          "artists": [
+            {
+              "name": "King Gnu"
+            }
+          ],
+          "album": {
+            "name": "AIZO",
+            "releaseDate": "2026-01-09"
+          },
+          "durationMs": 215858,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "wQiz17AKhjM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC9tx_HmhNISUR39M29r9a8A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02120734724ff398a2d812f982"
+        },
+        {
+          "position": 50,
+          "id": "levyra-a4b5907d0191f2891e8d",
+          "title": "Five",
+          "artists": [
+            {
+              "name": "ARASHI"
+            }
+          ],
+          "album": {
+            "name": "Five",
+            "releaseDate": "2026-03-04"
+          },
+          "durationMs": 267600,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "_G4zEwk18YI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCFK3iAGAFy6q8lS8NspImrQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d4223a5dd64fe336dd9951e2"
+        }
+      ]
+    },
+    {
+      "id": "top-50-kr",
+      "kind": "chart",
+      "market": "KR",
+      "title": "Top 50 대한민국",
+      "description": "Corea del Sud: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-768c8c9f8c1c77b2a1aa",
+          "title": "REDRED",
+          "artists": [
+            {
+              "name": "CORTIS"
+            }
+          ],
+          "album": {
+            "name": "REDRED",
+            "releaseDate": "2026-04-20"
+          },
+          "durationMs": 163001,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0224ace1518851b27e9983f739"
+        },
+        {
+          "position": 2,
+          "id": "levyra-690a7a566ce4f6da4592",
+          "title": "LOVE ATTACK",
+          "artists": [
+            {
+              "name": "RESCENE"
+            }
+          ],
+          "album": {
+            "name": "SCENEDROME",
+            "releaseDate": "2024-08-27"
+          },
+          "durationMs": 181560,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "1uDzUPzS2w8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCM9SwoeOLtalqxyuZXIGe2Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02831c0d124fc7c7a3ad0618ab"
+        },
+        {
+          "position": 3,
+          "id": "levyra-22648abc2ff62e105ada",
+          "title": "Less than a Lover",
+          "artists": [
+            {
+              "name": "JENNIE"
+            }
+          ],
+          "album": {
+            "name": "Less than a Lover",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 145680,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021568796289f10031724bc780"
+        },
+        {
+          "position": 4,
+          "id": "levyra-d4f71f7f55e0567df657",
+          "title": "Pretty Girl",
+          "artists": [
+            {
+              "name": "RESCENE"
+            }
+          ],
+          "album": {
+            "name": "Pretty Girl - Special Single",
+            "releaseDate": "2026-07-08"
+          },
+          "durationMs": 210000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "YVjcmz9sBIs",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCM9SwoeOLtalqxyuZXIGe2Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0277d32118586f2e1053262fce"
+        },
+        {
+          "position": 5,
+          "id": "levyra-611ad4be3bc21026abd7",
+          "title": "LEMONADE",
+          "artists": [
+            {
+              "name": "aespa"
+            }
+          ],
+          "album": {
+            "name": "LEMONADE - The 2nd Album (NINGNING Special Version)",
+            "releaseDate": "2026-05-28"
+          },
+          "durationMs": 187000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e19de393db31cdad2ce36b6c"
+        },
+        {
+          "position": 6,
+          "id": "levyra-72b2520a3b38bc47ad5a",
+          "title": "Who",
+          "artists": [
+            {
+              "name": "Jimin"
+            }
+          ],
+          "album": {
+            "name": "MUSE",
+            "releaseDate": "2024-07-19"
+          },
+          "durationMs": 170887,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "sEcvQvftOQY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCE6l2NHQkpgF_P96isfOu4Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f02c451189a709b9a952aaec"
+        },
+        {
+          "position": 7,
+          "id": "levyra-400d2fe94e4789e4e913",
+          "title": "It's Me",
+          "artists": [
+            {
+              "name": "ILLIT"
+            }
+          ],
+          "album": {
+            "name": "MAMIHLAPINATAPAI",
+            "releaseDate": "2026-04-30"
+          },
+          "durationMs": 138284,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "XDzGoMtSqZA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCNVIo0UJXTdEnsRkCB9Q03w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0261eea484e31bca065904f1c6"
+        },
+        {
+          "position": 8,
+          "id": "levyra-b5d32486e28326733eef",
+          "title": "Lemon Tang",
+          "artists": [
+            {
+              "name": "Hearts2Hearts"
+            }
+          ],
+          "album": {
+            "name": "Lemon Tang - The 2nd Mini Album",
+            "releaseDate": "2026-06-22"
+          },
+          "durationMs": 163000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02391fce8d3ef22f778a8c5c54"
+        },
+        {
+          "position": 9,
+          "id": "levyra-9f5eb53b9a32cbbe3a59",
+          "title": "Sunflower - Spider-Man: Into the Spider-Verse",
+          "artists": [
+            {
+              "name": "Post Malone"
+            },
+            {
+              "name": "Swae Lee"
+            }
+          ],
+          "album": {
+            "name": "Hollywood's Bleeding",
+            "releaseDate": "2019-09-06"
+          },
+          "durationMs": 157560,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029478c87599550dd73bfa7e02"
+        },
+        {
+          "position": 10,
+          "id": "levyra-a9115bf86a99ec972387",
+          "title": "BAD",
+          "artists": [
+            {
+              "name": "ATEEZ"
+            }
+          ],
+          "album": {
+            "name": "GOLDEN HOUR : Part.5",
+            "releaseDate": "2026-06-26"
+          },
+          "durationMs": 156034,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "3F9jlnANW08",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCmWwbZ-8SngcUzRAD8rCVvw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027e77585ffef632e51313b3e0"
+        },
+        {
+          "position": 11,
+          "id": "levyra-52364addd1d592646d83",
+          "title": "0+0",
+          "artists": [
+            {
+              "name": "HANRORO"
+            }
+          ],
+          "album": {
+            "name": "JAMONG SALGU CLUB",
+            "releaseDate": "2025-08-04"
+          },
+          "durationMs": 192000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "sgxwL8V39Lc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCz3jIN2-AvbR71j_4nVgFpA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02afda752d5db59e06d3f86e3b"
+        },
+        {
+          "position": 12,
+          "id": "levyra-5a6bf51193a253265288",
+          "title": "Deja Vu",
+          "artists": [
+            {
+              "name": "RESCENE"
+            }
+          ],
+          "album": {
+            "name": "Dearest",
+            "releaseDate": "2025-07-02"
+          },
+          "durationMs": 184000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "_1juftZumOQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCM9SwoeOLtalqxyuZXIGe2Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022d3d7a09566b6d612c890824"
+        },
+        {
+          "position": 13,
+          "id": "levyra-c9e40119b038bdd41988",
+          "title": "Landing in Love",
+          "artists": [
+            {
+              "name": "HANRORO"
+            }
+          ],
+          "album": {
+            "name": "Take-off",
+            "releaseDate": "2023-08-29"
+          },
+          "durationMs": 165000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Snyan1_jGWc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCz3jIN2-AvbR71j_4nVgFpA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02041c2df6c6417db26f4133d4"
+        },
+        {
+          "position": 14,
+          "id": "levyra-c3df00c3dfd6b9d6d5ae",
+          "title": "RUDE!",
+          "artists": [
+            {
+              "name": "Hearts2Hearts"
+            }
+          ],
+          "album": {
+            "name": "RUDE!",
+            "releaseDate": "2026-02-20"
+          },
+          "durationMs": 200000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d505bec2fbfee5857725d333"
+        },
+        {
+          "position": 15,
+          "id": "levyra-1f71413d04a9cc3e05e5",
+          "title": "Suddenly",
+          "artists": [
+            {
+              "name": "I.O.I"
+            }
+          ],
+          "album": {
+            "name": "I.O.I 3rd MINI ALBUM [I.O.I : LOOP]",
+            "releaseDate": "2026-05-19"
+          },
+          "durationMs": 195000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "R5By6ms2a3Y",
+            "audioConfidence": 100,
+            "videoId": "gmjZf_Nxlec",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCXYVQ1uTq-KQbPk6IQlXHnA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02244aed7ce852aedf2097fed9"
+        },
+        {
+          "position": 16,
+          "id": "levyra-2df3154ae731579fc34a",
+          "title": "Vitamin ME",
+          "artists": [
+            {
+              "name": "fromis_9"
+            }
+          ],
+          "album": {
+            "name": "Glow ME",
+            "releaseDate": "2026-07-21"
+          },
+          "durationMs": 190000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Cbs8h6nJWBc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC3M9MRdZz-WWtAQos94_h6w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025e0c6f72c2e7d712f34b01e2"
+        },
+        {
+          "position": 17,
+          "id": "levyra-c86bc4c00ae864d1ec44",
+          "title": "404 (New Era)",
+          "artists": [
+            {
+              "name": "KiiiKiii"
+            }
+          ],
+          "album": {
+            "name": "Delulu Pack",
+            "releaseDate": "2026-01-26"
+          },
+          "durationMs": 179586,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "MUny_GDYIDM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCfCiP0obFQZOB6fJqN-eF8A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020cc65398388cbc486fa4fff7"
+        },
+        {
+          "position": 18,
+          "id": "levyra-5fa420ceec6d53bf84c3",
+          "title": "Let Me Love My Youth",
+          "artists": [
+            {
+              "name": "HANRORO"
+            }
+          ],
+          "album": {
+            "name": "Let Me Love My Youth",
+            "releaseDate": "2022-03-14"
+          },
+          "durationMs": 248407,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "I0Hu7PRF4j0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCz3jIN2-AvbR71j_4nVgFpA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0226a40856fec5db78306ba3c0"
+        },
+        {
+          "position": 19,
+          "id": "levyra-6ea3f0d1f05b3f383665",
+          "title": "Drowning",
+          "artists": [
+            {
+              "name": "WOODZ"
+            }
+          ],
+          "album": {
+            "name": "OO-LI",
+            "releaseDate": "2023-04-26"
+          },
+          "durationMs": 244986,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e87a41550ee1b24be3e6e1fb"
+        },
+        {
+          "position": 20,
+          "id": "levyra-d2278f14e9491e3a1538",
+          "title": "Seven (feat. Latto) (Explicit Ver.)",
+          "artists": [
+            {
+              "name": "Jung Kook"
+            },
+            {
+              "name": "Latto"
+            }
+          ],
+          "album": {
+            "name": "GOLDEN",
+            "releaseDate": "2023-11-03"
+          },
+          "durationMs": 183550,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02741fd4807f442af3f7359316"
+        },
+        {
+          "position": 21,
+          "id": "levyra-a98e4e673937b84a9d5d",
+          "title": "Catch Catch",
+          "artists": [
+            {
+              "name": "YENA"
+            }
+          ],
+          "album": {
+            "name": "LOVE CATCHER",
+            "releaseDate": "2026-03-11"
+          },
+          "durationMs": 180000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "sjtyqmA-pH4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC4mOLela441MNvGJNy6h8bg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029687ef1de31954cfdeac2f5a"
+        },
+        {
+          "position": 22,
+          "id": "levyra-aa090f0a8dd7aeff2e12",
+          "title": "If I have you only (My love X Nerd Connection)",
+          "artists": [
+            {
+              "name": "Nerd Connection"
+            }
+          ],
+          "album": {
+            "name": "If I have you only (My love X Nerd Connection)",
+            "releaseDate": "2023-08-15"
+          },
+          "durationMs": 250573,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0220daf4f9c25cbe0bc384e606"
+        },
+        {
+          "position": 23,
+          "id": "levyra-12f716366faa609a1252",
+          "title": "Don’t Say You Love Me",
+          "artists": [
+            {
+              "name": "Jin"
+            }
+          ],
+          "album": {
+            "name": "Echo",
+            "releaseDate": "2025-05-16"
+          },
+          "durationMs": 180716,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "DdJFbCBiggE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCkX4rp22PPv7V6PKXD7zZFg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0289228504f700641956e29f5d"
+        },
+        {
+          "position": 24,
+          "id": "levyra-b9b109db4fd567de0eea",
+          "title": "SWIM",
+          "artists": [
+            {
+              "name": "BTS"
+            }
+          ],
+          "album": {
+            "name": "ARIRANG",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 159007,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qZTVU04UOO4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC9vrvNSL3xcWGSkV86REBSg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dfa17fad7f190c901603270e"
+        },
+        {
+          "position": 25,
+          "id": "levyra-9f5f9fa675f8fa7f0e76",
+          "title": "Forever Has Always Been",
+          "artists": [
+            {
+              "name": "Redoor"
+            }
+          ],
+          "album": {
+            "name": "Forever Has Always Been",
+            "releaseDate": "2021-01-09"
+          },
+          "durationMs": 237160,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02149023dcdf178cffc8b994c3"
+        },
+        {
+          "position": 26,
+          "id": "levyra-98e1dc1f30d599210ef4",
+          "title": "Pretender",
+          "artists": [
+            {
+              "name": "OFFICIAL HIGE DANDISM"
+            }
+          ],
+          "album": {
+            "name": "Traveler",
+            "releaseDate": "2019-08-31"
+          },
+          "durationMs": 326842,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "37W7Y2RRyiM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC84Rm0a3gimYXPtqp5O_JRw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029c4ba827e585fabd3cfd90f2"
+        },
+        {
+          "position": 27,
+          "id": "levyra-8f28707fc5056b6750e7",
+          "title": "Heavy Serenade",
+          "artists": [
+            {
+              "name": "NMIXX"
+            }
+          ],
+          "album": {
+            "name": "Heavy Serenade",
+            "releaseDate": "2026-05-11"
+          },
+          "durationMs": 180000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "hGqYdubpcCM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC_Cx288SDUD9liYn7CiJLAA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d179b01c0b9baac10170d1ad"
+        },
+        {
+          "position": 28,
+          "id": "levyra-39fe6f83d3fa7c7d690b",
+          "title": "for lovers who hesitate",
+          "artists": [
+            {
+              "name": "JANNABI"
+            }
+          ],
+          "album": {
+            "name": "LEGEND",
+            "releaseDate": "2019-03-13"
+          },
+          "durationMs": 265000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f694adfa02990eaca79fec1b"
+        },
+        {
+          "position": 29,
+          "id": "levyra-1844cf8a831a64adc25d",
+          "title": "Bansanka",
+          "artists": [
+            {
+              "name": "TAEYEON"
+            }
+          ],
+          "album": {
+            "name": "J-POP REMAKE Vol.1",
+            "releaseDate": "2026-06-29"
+          },
+          "durationMs": 219000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "UOKLtaE2U90",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCwzCuKxyMY_sT7hr1E8G1XA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ec70b6ceac2050be19c87cfb"
+        },
+        {
+          "position": 30,
+          "id": "levyra-99a7ffb27361e42be6d4",
+          "title": "Runaway",
+          "artists": [
+            {
+              "name": "RESCENE"
+            }
+          ],
+          "album": {
+            "name": "Runaway",
+            "releaseDate": "2026-04-08"
+          },
+          "durationMs": 182000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e5fd56cd91d38d69aec9a5a2"
+        },
+        {
+          "position": 31,
+          "id": "levyra-2052d22d04a415acde90",
+          "title": "Love Love Love",
+          "artists": [
+            {
+              "name": "Epik High"
+            }
+          ],
+          "album": {
+            "name": "Remapping the Human Soul",
+            "releaseDate": "2007-01-24"
+          },
+          "durationMs": 231093,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024c71e80a8f580184ba910222"
+        },
+        {
+          "position": 32,
+          "id": "levyra-35247be087f21e2934cf",
+          "title": "Please Summer!",
+          "artists": [
+            {
+              "name": "BOL4"
+            }
+          ],
+          "album": {
+            "name": "Please Summer!",
+            "releaseDate": "2026-07-22"
+          },
+          "durationMs": 229000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "_cSciVF1FpY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCa5qWh5TRLCVFkCO67_gOtw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02224571aa7884b5c07ed1e790"
+        },
+        {
+          "position": 33,
+          "id": "levyra-9a7c0ee12485d861a618",
+          "title": "We Are",
+          "artists": [
+            {
+              "name": "Woo"
+            },
+            {
+              "name": "Loco"
+            },
+            {
+              "name": "GRAY"
+            }
+          ],
+          "album": {
+            "name": "We Are",
+            "releaseDate": "2017-09-04"
+          },
+          "durationMs": 196020,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0280af1bc4fa047ba0e2f17c04"
+        },
+        {
+          "position": 34,
+          "id": "levyra-853c9116e5f0f1147d5d",
+          "title": "FOCUS",
+          "artists": [
+            {
+              "name": "Hearts2Hearts"
+            }
+          ],
+          "album": {
+            "name": "FOCUS - The 1st Mini Album",
+            "releaseDate": "2025-10-20"
+          },
+          "durationMs": 177052,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027c887828b1a67202f0219857"
+        },
+        {
+          "position": 35,
+          "id": "levyra-49e3bd25d616f1f762fa",
+          "title": "STYLE",
+          "artists": [
+            {
+              "name": "Hearts2Hearts"
+            }
+          ],
+          "album": {
+            "name": "STYLE",
+            "releaseDate": "2025-06-18"
+          },
+          "durationMs": 209671,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "D3tUvbqOAAY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCC3Hg75KxQk4VTrBSphEbGw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02610f16f9c84e85158baa0384"
+        },
+        {
+          "position": 36,
+          "id": "levyra-474ed0a867295a5f7053",
+          "title": "yours",
+          "artists": [
+            {
+              "name": "데이먼스 이어 Damons year"
+            }
+          ],
+          "album": {
+            "name": "yours",
+            "releaseDate": "2019-04-10"
+          },
+          "durationMs": 165229,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cccd0bf2843a65a3d45ea190"
+        },
+        {
+          "position": 37,
+          "id": "levyra-eac94f06a99e02b32903",
+          "title": "Surfin' Boy",
+          "artists": [
+            {
+              "name": "Red Velvet"
+            }
+          ],
+          "album": {
+            "name": "Velvet Summer - Summer Mini Album",
+            "releaseDate": "2026-08-03"
+          },
+          "durationMs": 168466,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "obP2P15pO5w",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCHmZYTfdTyVKQEJicLiXEOg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023df160174c379ca0f9bb7c18"
+        },
+        {
+          "position": 38,
+          "id": "levyra-aa6dc76058c1b09f2cf5",
+          "title": "Paradise of Rumors",
+          "artists": [
+            {
+              "name": "AKMU"
+            }
+          ],
+          "album": {
+            "name": "FLOWERING",
+            "releaseDate": "2026-04-07"
+          },
+          "durationMs": 218480,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "6Xa1VDLACPo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC-IG_h142pRnsilk8TkoZxA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bd15713cf9824b7842bcd290"
+        },
+        {
+          "position": 39,
+          "id": "levyra-15c885108cedc67d7483",
+          "title": "晩餐歌 - Bansanka",
+          "artists": [
+            {
+              "name": "tuki."
+            }
+          ],
+          "album": {
+            "name": "15",
+            "releaseDate": "2025-01-08"
+          },
+          "durationMs": 217760,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "p1tsL0YmNqU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCtrbtNbdI4jwRQPG35Mtn2A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022d68ffbcaeaa5e6fbe102202"
+        },
+        {
+          "position": 40,
+          "id": "levyra-93683240d111e7825d3f",
+          "title": "hate that i made you love me",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 197949,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7CUz7Ec7cWc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 41,
+          "id": "levyra-1c836cd56c0655b4fcde",
+          "title": "FLYING HIGH WITH U",
+          "artists": [
+            {
+              "name": "VINXEN"
+            }
+          ],
+          "album": {
+            "name": "FLYING HIGH WITH U",
+            "releaseDate": "2021-03-09"
+          },
+          "durationMs": 207186,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "1jtban6rFAA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCmb1h6hIQHKxzfUbebHD60w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024c013b35958a8538181b41c4"
+        },
+        {
+          "position": 42,
+          "id": "levyra-3ca6cc8c455c561fd8c7",
+          "title": "‎Good Night Good Dream",
+          "artists": [
+            {
+              "name": "Nerd Connection"
+            }
+          ],
+          "album": {
+            "name": "‎Good Night Good Dream",
+            "releaseDate": "2020-03-23"
+          },
+          "durationMs": 265983,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "XfzE8ku3TCI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCCaBM8AtUiqVwJQZHbtua2w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024d082eca2a31873a3622408e"
+        },
+        {
+          "position": 43,
+          "id": "levyra-cdec864e1881d842fbf2",
+          "title": "GO!",
+          "artists": [
+            {
+              "name": "CORTIS"
+            }
+          ],
+          "album": {
+            "name": "COLOR OUTSIDE THE LINES",
+            "releaseDate": "2025-09-08"
+          },
+          "durationMs": 170880,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7wJsfALKRR8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCraxhuo4vXXMMgXJ6Gil4Eg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024b56a34b0c2b3798fd46f855"
+        },
+        {
+          "position": 44,
+          "id": "levyra-e7501a08b03d04425f3c",
+          "title": "Magnetic",
+          "artists": [
+            {
+              "name": "ILLIT"
+            }
+          ],
+          "album": {
+            "name": "SUPER REAL ME",
+            "releaseDate": "2024-03-25"
+          },
+          "durationMs": 160688,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "HBqH4uJS0PU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCNVIo0UJXTdEnsRkCB9Q03w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f037c5fb9de6c78726cb8e2c"
+        },
+        {
+          "position": 45,
+          "id": "levyra-26eb27af44717f1da8de",
+          "title": "Eternal Moment",
+          "artists": [
+            {
+              "name": "Lim Young Woong"
+            }
+          ],
+          "album": {
+            "name": "IM HERO 2",
+            "releaseDate": "2025-08-29"
+          },
+          "durationMs": 208000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "AmaYHBbQl8w",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCo-E2lz4uU7adqktpJFKnvw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f207933160e8018901f665b2"
+        },
+        {
+          "position": 46,
+          "id": "levyra-2eb84d54c5a79c6d5a7d",
+          "title": "ACAI",
+          "artists": [
+            {
+              "name": "CORTIS"
+            }
+          ],
+          "album": {
+            "name": "GREENGREEN",
+            "releaseDate": "2026-05-04"
+          },
+          "durationMs": 173947,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "3G0A03PFMg0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCraxhuo4vXXMMgXJ6Gil4Eg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027a702a4c3a18c1439fdc29ff"
+        },
+        {
+          "position": 47,
+          "id": "levyra-411ee215adfe5f5c97c7",
+          "title": "Animal",
+          "artists": [
+            {
+              "name": "KATSEYE"
+            }
+          ],
+          "album": {
+            "name": "Animal",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 158494,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "vOfyxPRunFM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCX9kfYB9t0tnd6DYUC2iuKg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029e8d48f27391ce383862b8e8"
+        },
+        {
+          "position": 48,
+          "id": "levyra-1b1d0d7070cf2c50f63b",
+          "title": "Endangered Love",
+          "artists": [
+            {
+              "name": "LEE CHANHYUK"
+            }
+          ],
+          "album": {
+            "name": "EROS",
+            "releaseDate": "2025-07-14"
+          },
+          "durationMs": 220202,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "bLahVNBGdLQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCpdaQTi9fxu4t76aFK6iFWQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c675edee6479e3f798d90716"
+        },
+        {
+          "position": 49,
+          "id": "levyra-535d547ed2b8800b377d",
+          "title": "KISS KISS KISS (Feat. SUNWOO (THE BOYZ)) (Prod. by Hukky Shibaseki)",
+          "artists": [
+            {
+              "name": "NOWIMYOUNG"
+            },
+            {
+              "name": "Royal 44"
+            },
+            {
+              "name": "SUNWOO"
+            }
+          ],
+          "album": {
+            "name": "Show Me The Money 12 Episode 2",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 218796,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026ac4312a155a95bb06fc6532"
+        },
+        {
+          "position": 50,
+          "id": "levyra-47764fdde285bb5be11a",
+          "title": "Beauty And A Beat",
+          "artists": [
+            {
+              "name": "Justin Bieber"
+            },
+            {
+              "name": "Nicki Minaj"
+            }
+          ],
+          "album": {
+            "name": "Believe",
+            "releaseDate": "2012-01-01"
+          },
+          "durationMs": 227986,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f1d02a6cec967f8b6b78f76e"
+        }
+      ]
+    },
+    {
+      "id": "top-50-in",
+      "kind": "chart",
+      "market": "IN",
+      "title": "Top 50 भारत",
+      "description": "India: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-8a7880903ff0644c92b7",
+          "title": "Arz Kiya Hai | Coke Studio Bharat",
+          "artists": [
+            {
+              "name": "Anuv Jain"
+            }
+          ],
+          "album": {
+            "name": "Arz Kiya Hai | Coke Studio Bharat",
+            "releaseDate": "2025-08-20"
+          },
+          "durationMs": 294500,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "-BJt4fCAtZE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCo36OSM_dp0KynQ02zibnsQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0225fa2d19b2363a9520a34409"
+        },
+        {
+          "position": 2,
+          "id": "levyra-386b2346aa49691cd75a",
+          "title": "Bairan",
+          "artists": [
+            {
+              "name": "Banjaare"
+            }
+          ],
+          "album": {
+            "name": "Bairan",
+            "releaseDate": "2026-01-23"
+          },
+          "durationMs": 150857,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "kyqJ_FId-_w",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCumzZjVz0BQCWYFzrqoezTA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cdce9a38222807fa703b4396"
+        },
+        {
+          "position": 3,
+          "id": "levyra-aed2c88371f863a0250f",
+          "title": "Khat",
+          "artists": [
+            {
+              "name": "Navjot Ahuja"
+            }
+          ],
+          "album": {
+            "name": "Khat",
+            "releaseDate": "2025-12-03"
+          },
+          "durationMs": 296222,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "KrJ5c-Egz-U",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCqi9QQgLNdZVTXmvzR8-uxg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d421c37d9cf4bbee71844c24"
+        },
+        {
+          "position": 4,
+          "id": "levyra-f35a93003f6718c327f8",
+          "title": "KALYANI (with Shreya Ghoshal) - Remix",
+          "artists": [
+            {
+              "name": "ARJN"
+            },
+            {
+              "name": "KDS"
+            },
+            {
+              "name": "FIFTY4"
+            },
+            {
+              "name": "Shreya Ghoshal"
+            }
+          ],
+          "album": {
+            "name": "KALYANI (with Shreya Ghoshal) [Remix]",
+            "releaseDate": "2026-07-01"
+          },
+          "durationMs": 269387,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029aa819fdf84c78fc1976391d"
+        },
+        {
+          "position": 5,
+          "id": "levyra-abdbd4e6ab32796475db",
+          "title": "Barsaat",
+          "artists": [
+            {
+              "name": "Banjaare"
+            },
+            {
+              "name": "Roni"
+            }
+          ],
+          "album": {
+            "name": "Barsaat",
+            "releaseDate": "2026-07-09"
+          },
+          "durationMs": 185294,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "IaLk90h1-oo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCumzZjVz0BQCWYFzrqoezTA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a0b110307ee3dc10a74e3562"
+        },
+        {
+          "position": 6,
+          "id": "levyra-659eed5aa39eef03dc7f",
+          "title": "Gehra Hua",
+          "artists": [
+            {
+              "name": "Shashwat Sachdev"
+            },
+            {
+              "name": "Arijit Singh"
+            },
+            {
+              "name": "Irshad Kamil"
+            },
+            {
+              "name": "Armaan Khan"
+            }
+          ],
+          "album": {
+            "name": "Dhurandhar",
+            "releaseDate": "2025-12-05"
+          },
+          "durationMs": 362400,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027838ccbef3fb712228e23fc5"
+        },
+        {
+          "position": 7,
+          "id": "levyra-265cc1fa59c9c6710c6f",
+          "title": "Mann Mera",
+          "artists": [
+            {
+              "name": "Gajendra Verma"
+            }
+          ],
+          "album": {
+            "name": "Table No. 21 (Original Motion Picture Soundtrack)",
+            "releaseDate": "2013-04-01"
+          },
+          "durationMs": 200120,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "s_GR_TDK07I",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCRUq1Vg289WgemqAEP-slBg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f2d0db770d8cd316f760a2f2"
+        },
+        {
+          "position": 8,
+          "id": "levyra-36dff872a923461924d3",
+          "title": "Tum Ho Toh (From \"Saiyaara\")",
+          "artists": [
+            {
+              "name": "Vishal Mishra"
+            },
+            {
+              "name": "Hansika Pareek"
+            },
+            {
+              "name": "Raj Shekhar"
+            }
+          ],
+          "album": {
+            "name": "Tum Ho Toh (From \"Saiyaara\")",
+            "releaseDate": "2025-06-17"
+          },
+          "durationMs": 318217,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d998c880f085f08c7ddeeafc"
+        },
+        {
+          "position": 9,
+          "id": "levyra-fd5cae6e79b96f278c4e",
+          "title": "Finding Her",
+          "artists": [
+            {
+              "name": "Kushagra"
+            },
+            {
+              "name": "Bharath"
+            },
+            {
+              "name": "Saaheal"
+            }
+          ],
+          "album": {
+            "name": "Finding Her",
+            "releaseDate": "2025-01-29"
+          },
+          "durationMs": 207000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "PZtSnQBsBW0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC9DK_HcsnfaPLdYYYpSfZpg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02292341cd3e621d7f9171331f"
+        },
+        {
+          "position": 10,
+          "id": "levyra-721abddf5dd0b67f9933",
+          "title": "Sahiba",
+          "artists": [
+            {
+              "name": "Aditya Rikhari"
+            }
+          ],
+          "album": {
+            "name": "Sahiba",
+            "releaseDate": "2023-12-19"
+          },
+          "durationMs": 190098,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "tNc2coVC2aw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC4pXWqeKDSIWEvlLLTYWmXQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020a47bbe7141fdfe0eb2cdba7"
+        },
+        {
+          "position": 11,
+          "id": "levyra-e017cf10ab6333a681fe",
+          "title": "Samjhawan",
+          "artists": [
+            {
+              "name": "Jawad Ahmad"
+            },
+            {
+              "name": "Shaarib Toshi"
+            },
+            {
+              "name": "Arijit Singh"
+            },
+            {
+              "name": "Shreya Ghoshal"
+            }
+          ],
+          "album": {
+            "name": "Samjhawan",
+            "releaseDate": "2014-06-19"
+          },
+          "durationMs": 269184,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028a7ae7092464f6685355dc3c"
+        },
+        {
+          "position": 12,
+          "id": "levyra-13d08c1f277f9b39804d",
+          "title": "Darkhaast",
+          "artists": [
+            {
+              "name": "Mithoon"
+            },
+            {
+              "name": "Arijit Singh"
+            },
+            {
+              "name": "Sunidhi Chauhan"
+            },
+            {
+              "name": "Sayeed Quadri"
+            }
+          ],
+          "album": {
+            "name": "Shivaay",
+            "releaseDate": "2016-10-07"
+          },
+          "durationMs": 374205,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e7fe7d656750737e8d369f95"
+        },
+        {
+          "position": 13,
+          "id": "levyra-48fe9522afca8e2c478a",
+          "title": "Tere Liye",
+          "artists": [
+            {
+              "name": "Atif Aslam"
+            },
+            {
+              "name": "Shreya Ghoshal"
+            },
+            {
+              "name": "Sachin Gupta"
+            },
+            {
+              "name": "Sameer Anjaan"
+            }
+          ],
+          "album": {
+            "name": "Best of Romance: Atif Aslam",
+            "releaseDate": "2023-04-20"
+          },
+          "durationMs": 279826,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "5U5Ru0nTiUM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCVGomUS__PL0c4jDXa0QwXA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02af932ac943c7afa6b74659f7"
+        },
+        {
+          "position": 14,
+          "id": "levyra-b046068d36871a396870",
+          "title": "Jo Tum Mere Ho",
+          "artists": [
+            {
+              "name": "Anuv Jain"
+            }
+          ],
+          "album": {
+            "name": "Jo Tum Mere Ho",
+            "releaseDate": "2024-08-02"
+          },
+          "durationMs": 251813,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "usvVGXFIpTM",
+            "audioConfidence": 100,
+            "videoId": "ilNt2bikxDI",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCo36OSM_dp0KynQ02zibnsQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0272a77d038887cdc425f5ee55"
+        },
+        {
+          "position": 15,
+          "id": "levyra-d01e346e085a39cd9371",
+          "title": "Barbaad (From \"Saiyaara\")",
+          "artists": [
+            {
+              "name": "The Rish"
+            },
+            {
+              "name": "Jubin Nautiyal"
+            }
+          ],
+          "album": {
+            "name": "Barbaad (From \"Saiyaara\")",
+            "releaseDate": "2025-06-10"
+          },
+          "durationMs": 357127,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02148a06ae24e68c088d8d2954"
+        },
+        {
+          "position": 16,
+          "id": "levyra-89934d47fd8c140487de",
+          "title": "Udi Udi",
+          "artists": [
+            {
+              "name": "Aneesh"
+            },
+            {
+              "name": "Sarkar"
+            },
+            {
+              "name": "Hruday"
+            }
+          ],
+          "album": {
+            "name": "Udi Udi",
+            "releaseDate": "2026-02-26"
+          },
+          "durationMs": 161250,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0221d6e1053df28c5a33208c1a"
+        },
+        {
+          "position": 17,
+          "id": "levyra-8005c45013b41db92de9",
+          "title": "Ishq",
+          "artists": [
+            {
+              "name": "Faheem Abdullah"
+            },
+            {
+              "name": "Rauhan Malik"
+            },
+            {
+              "name": "Amir Ameer"
+            }
+          ],
+          "album": {
+            "name": "Lost;Found",
+            "releaseDate": "2024-05-25"
+          },
+          "durationMs": 224842,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020de04fd2c7c3bdc0a1d765f5"
+        },
+        {
+          "position": 18,
+          "id": "levyra-d50a8a4401ea835611c2",
+          "title": "Sheesha - Aakhya Mai Aakh Ghali Jo Bairan",
+          "artists": [
+            {
+              "name": "Mitta Ror"
+            },
+            {
+              "name": "Swara Verma"
+            }
+          ],
+          "album": {
+            "name": "Sheesha (Aakhya Mai Aakh Ghali Jo Bairan)",
+            "releaseDate": "2024-09-10"
+          },
+          "durationMs": 196253,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "JPfoLgd3uKg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCi0PPmXjjwIVTNU5BCU8XHw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02190b5b394a6fc5574ceea4da"
+        },
+        {
+          "position": 19,
+          "id": "levyra-d3eb887e4fe98b9cc131",
+          "title": "Ishq de Fanniyar - Female Version",
+          "artists": [
+            {
+              "name": "Jyotica Tangri"
+            },
+            {
+              "name": "Shaarib Toshi"
+            },
+            {
+              "name": "Kumaar"
+            }
+          ],
+          "album": {
+            "name": "Bollywood Love Lounge Vol 1",
+            "releaseDate": "2026-07-30"
+          },
+          "durationMs": 177893,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02003336d02e4fb8741a203315"
+        },
+        {
+          "position": 20,
+          "id": "levyra-786ab9b9042b042201f1",
+          "title": "Boyfriend",
+          "artists": [
+            {
+              "name": "Karan Aujla"
+            },
+            {
+              "name": "Ikky"
+            }
+          ],
+          "album": {
+            "name": "P-POP CULTURE",
+            "releaseDate": "2025-08-22"
+          },
+          "durationMs": 160796,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "tIjUfo30r4M",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCSmK5WX5U4gdtebWjoL81og"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0289e8f71cb6f3b6cc60944858"
+        },
+        {
+          "position": 21,
+          "id": "levyra-323ccf4ab0421f869de5",
+          "title": "Pavazha Malli - From \"Think Indie\"",
+          "artists": [
+            {
+              "name": "Sai Abhyankkar"
+            },
+            {
+              "name": "Shruti Haasan"
+            },
+            {
+              "name": "Vivek"
+            }
+          ],
+          "album": {
+            "name": "Pavazha Malli (From \"Think Indie\")",
+            "releaseDate": "2026-03-05"
+          },
+          "durationMs": 252569,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "tOaizzQG8Cw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCJPuVnth4cFX-2QJ6HxciaA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f5f2a6705dfe3c2fe11028c8"
+        },
+        {
+          "position": 22,
+          "id": "levyra-e9c3bd49d263aa8046eb",
+          "title": "For A Reason",
+          "artists": [
+            {
+              "name": "Karan Aujla"
+            },
+            {
+              "name": "Ikky"
+            }
+          ],
+          "album": {
+            "name": "P-POP CULTURE",
+            "releaseDate": "2025-08-22"
+          },
+          "durationMs": 180000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "cWIGUPQqnSk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCSmK5WX5U4gdtebWjoL81og"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0289e8f71cb6f3b6cc60944858"
+        },
+        {
+          "position": 23,
+          "id": "levyra-ead14a1d73c9746cc527",
+          "title": "Dooron Dooron",
+          "artists": [
+            {
+              "name": "Paresh Pahuja"
+            },
+            {
+              "name": "Shiv Tandan"
+            },
+            {
+              "name": "Meghdeep Bose"
+            }
+          ],
+          "album": {
+            "name": "Dooron Dooron",
+            "releaseDate": "2022-01-18"
+          },
+          "durationMs": 215946,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "U_nAFr9tLYg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCwrJU40lfjs6WW5bj_301iA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029fd839ed5ae2fd87ee8ac923"
+        },
+        {
+          "position": 24,
+          "id": "levyra-11dc455fd0bea9383d44",
+          "title": "Boom Shaka",
+          "artists": [
+            {
+              "name": "KR$NA"
+            },
+            {
+              "name": "Dhanda Nyoliwala"
+            }
+          ],
+          "album": {
+            "name": "Boom Shaka",
+            "releaseDate": "2026-04-28"
+          },
+          "durationMs": 218769,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "0zmIgxfZz0M",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCfp03WF5o4epbVJpSIr4Rag"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0213dcb5da9470852eb67f1783"
+        },
+        {
+          "position": 25,
+          "id": "levyra-85227b238978a8abad7e",
+          "title": "Tu Thodi Der Aur Thehar Ja - From \"Half Girlfriend\"",
+          "artists": [
+            {
+              "name": "Shreya Ghoshal"
+            },
+            {
+              "name": "Farhan Saeed"
+            },
+            {
+              "name": "Kumaar"
+            }
+          ],
+          "album": {
+            "name": "Tu Thodi Der Aur Thehar Ja (From \"Half Girlfriend\")",
+            "releaseDate": "2026-07-01"
+          },
+          "durationMs": 296377,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02fdfdfb32ce2dae56c62c8ac7"
+        },
+        {
+          "position": 26,
+          "id": "levyra-025cca452738700c9e78",
+          "title": "Saiyaara",
+          "artists": [
+            {
+              "name": "Tanishk Bagchi"
+            },
+            {
+              "name": "Faheem Abdullah"
+            },
+            {
+              "name": "Arslan Nizami"
+            },
+            {
+              "name": "Irshad Kamil"
+            }
+          ],
+          "album": {
+            "name": "Saiyaara",
+            "releaseDate": "2025-07-04"
+          },
+          "durationMs": 370875,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022fc1f0e56f80b5e7cc388b3c"
+        },
+        {
+          "position": 27,
+          "id": "levyra-b98d19571fb1afbcb8f4",
+          "title": "Inaam (Ft. Badshah)",
+          "artists": [
+            {
+              "name": "Jasleen Royal"
+            },
+            {
+              "name": "Badshah"
+            },
+            {
+              "name": "Ansh Chahal"
+            }
+          ],
+          "album": {
+            "name": "Inaam (Ft. Badshah)",
+            "releaseDate": "2026-04-06"
+          },
+          "durationMs": 178124,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02974c87c4d1b73970e0f45f70"
+        },
+        {
+          "position": 28,
+          "id": "levyra-ed39566c75e4cbfeb109",
+          "title": "Aarzu",
+          "artists": [
+            {
+              "name": "Noor"
+            },
+            {
+              "name": "Khan"
+            },
+            {
+              "name": "Madhurxo"
+            }
+          ],
+          "album": {
+            "name": "Aarzu",
+            "releaseDate": "2025-12-31"
+          },
+          "durationMs": 187567,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "1gcG6j_RD1k",
+            "audioConfidence": 100,
+            "videoId": "M5OCLifZK1w",
+            "videoConfidence": 97,
+            "confidence": 100,
+            "artistBrowseId": "UC5dYMu2kMBRgkQftc0EzAzA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020c28f02f30c669201ac4471d"
+        },
+        {
+          "position": 29,
+          "id": "levyra-868e41e8d3602b0577ce",
+          "title": "O Sanam",
+          "artists": [
+            {
+              "name": "Akhil Sachdeva"
+            }
+          ],
+          "album": {
+            "name": "O Sanam",
+            "releaseDate": "2023-01-17"
+          },
+          "durationMs": 265449,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Qsvga1oPoeE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC3Tod7_s2yD25gGvaqp77hA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a81f7cd4177159051ac9bbfc"
+        },
+        {
+          "position": 30,
+          "id": "levyra-318d53674eb637e178f3",
+          "title": "Sitaare (From \"Ikkis\")",
+          "artists": [
+            {
+              "name": "Arijit Singh"
+            },
+            {
+              "name": "Sachin-Jigar"
+            },
+            {
+              "name": "Amitabh Bhattacharya"
+            }
+          ],
+          "album": {
+            "name": "Sitaare (From \"Ikkis\")",
+            "releaseDate": "2025-12-03"
+          },
+          "durationMs": 242916,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dccd4f11c8ac8e1f2c8dfc51"
+        },
+        {
+          "position": 31,
+          "id": "levyra-a83cbb60ccd5340f23d6",
+          "title": "Zaalima",
+          "artists": [
+            {
+              "name": "Arijit Singh"
+            },
+            {
+              "name": "Harshdeep Kaur"
+            }
+          ],
+          "album": {
+            "name": "The Arijit Singh Collection",
+            "releaseDate": "2023-05-26"
+          },
+          "durationMs": 299333,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02627b5b17cb48f6e6956b842e"
+        },
+        {
+          "position": 32,
+          "id": "levyra-b9031873d1fb06e7e093",
+          "title": "Apna Bana Le",
+          "artists": [
+            {
+              "name": "Sachin-Jigar"
+            },
+            {
+              "name": "Arijit Singh"
+            },
+            {
+              "name": "Amitabh Bhattacharya"
+            }
+          ],
+          "album": {
+            "name": "Bhediya (Original Motion Picture Soundtrack)",
+            "releaseDate": "2022-12-06"
+          },
+          "durationMs": 261702,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b85b4e8fb6ba961aedfde386"
+        },
+        {
+          "position": 33,
+          "id": "levyra-5b8b8ed569a86f23bc91",
+          "title": "Jaiye Sajana",
+          "artists": [
+            {
+              "name": "Shashwat Sachdev"
+            },
+            {
+              "name": "Jasmine Sandlas"
+            },
+            {
+              "name": "Satinder Sartaaj"
+            }
+          ],
+          "album": {
+            "name": "Dhurandhar The Revenge",
+            "releaseDate": "2026-03-24"
+          },
+          "durationMs": 180004,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024c3eeb98521e02693a46d6db"
+        },
+        {
+          "position": 34,
+          "id": "levyra-271df9d8d572851610ce",
+          "title": "Mast Magan (From \"2 States)",
+          "artists": [
+            {
+              "name": "Arijit Singh"
+            },
+            {
+              "name": "Chinmayi"
+            }
+          ],
+          "album": {
+            "name": "Love Dose Arijit Singh",
+            "releaseDate": "2016-02-11"
+          },
+          "durationMs": 280161,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "SDQdGibJ9mE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCDxKh1gFWeYsqePvgVzmPoQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022d2263486e48ab1b41ae2466"
+        },
+        {
+          "position": 35,
+          "id": "levyra-d1eef08e14f0fd766bd3",
+          "title": "Hale Dil",
+          "artists": [
+            {
+              "name": "Harshit Saxena"
+            },
+            {
+              "name": "Sayeed Quadri"
+            }
+          ],
+          "album": {
+            "name": "Murder 2",
+            "releaseDate": "2011-05-30"
+          },
+          "durationMs": 346627,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "BLNHOgy_HCI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCw2F75fW5qMJTapieEiryFg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022432edc97b465e6db54d356b"
+        },
+        {
+          "position": 36,
+          "id": "levyra-5b812b66a6ba0d58aec2",
+          "title": "Agar Tum Saath Ho (From \"Tamasha\")",
+          "artists": [
+            {
+              "name": "Alka Yagnik"
+            },
+            {
+              "name": "Arijit Singh"
+            }
+          ],
+          "album": {
+            "name": "Love Wali Feeling: Valentine Special",
+            "releaseDate": "2017-02-10"
+          },
+          "durationMs": 341054,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0225f7621c3c70dd1f868b61bc"
+        },
+        {
+          "position": 37,
+          "id": "levyra-5dc5c4f00a5cd6be74e1",
+          "title": "Ehsaas",
+          "artists": [
+            {
+              "name": "Faheem Abdullah"
+            },
+            {
+              "name": "Duha Shah"
+            },
+            {
+              "name": "Vaibhav Pani"
+            },
+            {
+              "name": "Hyder Dar"
+            }
+          ],
+          "album": {
+            "name": "Ehsaas",
+            "releaseDate": "2025-04-09"
+          },
+          "durationMs": 233000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "8gq3S53aH3Y",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCal4gffnHGaQzcjNeN8pEhg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e80fd38e3f7025158e40a3ae"
+        },
+        {
+          "position": 38,
+          "id": "levyra-4b88560a30e73822f1dd",
+          "title": "Raanjhan (From \"Do Patti\")",
+          "artists": [
+            {
+              "name": "Sachet-Parampara"
+            },
+            {
+              "name": "Parampara Tandon"
+            },
+            {
+              "name": "Kausar Munir"
+            }
+          ],
+          "album": {
+            "name": "Raanjhan (From \"Do Patti\")",
+            "releaseDate": "2024-10-04"
+          },
+          "durationMs": 240066,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02773c5f60bcb309ef8802e4ef"
+        },
+        {
+          "position": 39,
+          "id": "levyra-016191aca6a56856d470",
+          "title": "Humsafar (From \"Badrinath Ki Dulhania\")",
+          "artists": [
+            {
+              "name": "Akhil Sachdeva"
+            },
+            {
+              "name": "Mansheel Gujral"
+            }
+          ],
+          "album": {
+            "name": "Best Of Akhil Sachdeva",
+            "releaseDate": "2019-09-03"
+          },
+          "durationMs": 268463,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dc9563139ebc2a5597254664"
+        },
+        {
+          "position": 40,
+          "id": "levyra-905db0ef216ef3bc841f",
+          "title": "Jo Tere Sang",
+          "artists": [
+            {
+              "name": "Jeet Gannguli"
+            },
+            {
+              "name": "Mustafa Zahid"
+            },
+            {
+              "name": "Sayeed Quadri"
+            }
+          ],
+          "album": {
+            "name": "Blood Money (Original Motion Picture Soundtrack)",
+            "releaseDate": "2012-02-14"
+          },
+          "durationMs": 306173,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "GeWnEyQRCUs",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC00SotJE71x-1F3ia2T3cvA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020ccca2f49bcdac5491e47b1a"
+        },
+        {
+          "position": 41,
+          "id": "levyra-cbd480a7a72b1a0611ae",
+          "title": "Chahun Main Ya Naa (From \"Aashiqui 2\")",
+          "artists": [
+            {
+              "name": "Palak Muchhal"
+            },
+            {
+              "name": "Arijit Singh"
+            }
+          ],
+          "album": {
+            "name": "Best Of Palak Muchhal",
+            "releaseDate": "2020-06-09"
+          },
+          "durationMs": 304899,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02808542d48ec7021a0577f4f5"
+        },
+        {
+          "position": 42,
+          "id": "levyra-9a9e5759fb24206ab7db",
+          "title": "LAAVAN",
+          "artists": [
+            {
+              "name": "Jasmine Sandlas"
+            },
+            {
+              "name": "Mofusion"
+            }
+          ],
+          "album": {
+            "name": "LAAVAN",
+            "releaseDate": "2024-12-11"
+          },
+          "durationMs": 185046,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "VgqxDYFhSng",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCnTpYy7WLMGu3NQxWydMd1A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0285b1cf1e8e5879a440eecf1f"
+        },
+        {
+          "position": 43,
+          "id": "levyra-fa5ba6eb355e4976de4e",
+          "title": "Ishq Bulaava",
+          "artists": [
+            {
+              "name": "Vishal-Shekhar"
+            },
+            {
+              "name": "Sanam Puri"
+            },
+            {
+              "name": "Shipra Goyal"
+            }
+          ],
+          "album": {
+            "name": "Hasee Toh Phasee (Original Motion Picture Soundtrack)",
+            "releaseDate": "2014-01-05"
+          },
+          "durationMs": 303640,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022025db071cd9dd7e8023e01e"
+        },
+        {
+          "position": 44,
+          "id": "levyra-11c1e594d6169cbd3957",
+          "title": "Aarzu (with Asim Azhar)",
+          "artists": [
+            {
+              "name": "Asim Azhar"
+            },
+            {
+              "name": "Noor"
+            },
+            {
+              "name": "Khan"
+            },
+            {
+              "name": "Madhurxo"
+            }
+          ],
+          "album": {
+            "name": "Aarzu (with Asim Azhar)",
+            "releaseDate": "2026-05-28"
+          },
+          "durationMs": 185142,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "9lvaV_DklFI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCZGYaSi1FXUP-4WKTRsqDPQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0223163367c297997eaa635b66"
+        },
+        {
+          "position": 45,
+          "id": "levyra-0ad1cd5554ca43d336f1",
+          "title": "Ye Tune Kya Kiya",
+          "artists": [
+            {
+              "name": "Pritam"
+            },
+            {
+              "name": "Javed Bashir"
+            },
+            {
+              "name": "Rajat Arora"
+            }
+          ],
+          "album": {
+            "name": "Once Upon Ay Time In Mumbai Dobaara !",
+            "releaseDate": "2013-07-22"
+          },
+          "durationMs": 314239,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02fe77bd21eb38ff74b5f21524"
+        },
+        {
+          "position": 46,
+          "id": "levyra-703d17b5948d67370b65",
+          "title": "Majboor",
+          "artists": [
+            {
+              "name": "Sheheryar Rehan"
+            },
+            {
+              "name": "Zoha Waseem"
+            }
+          ],
+          "album": {
+            "name": "Majboor",
+            "releaseDate": "2025-09-11"
+          },
+          "durationMs": 145333,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "OtWjS4I2ojU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCwsBq3_UL27sObt_rqHKpkw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ba7861fdb5826a0038078c23"
+        },
+        {
+          "position": 47,
+          "id": "levyra-0212b4c8036ae7ca6989",
+          "title": "Tere Bina",
+          "artists": [
+            {
+              "name": "A.R. Rahman"
+            },
+            {
+              "name": "Chinmayi"
+            },
+            {
+              "name": "Murtuza Khan"
+            },
+            {
+              "name": "Qadir Khan"
+            }
+          ],
+          "album": {
+            "name": "The Best of A.R. Rahman - Music and Magic from the Composer of Slumdog Millionaire",
+            "releaseDate": "2009-02-19"
+          },
+          "durationMs": 309640,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0280c96c6704190fa75a8b9860"
+        },
+        {
+          "position": 48,
+          "id": "levyra-efc9ead0183b9f0fa4da",
+          "title": "Shararat",
+          "artists": [
+            {
+              "name": "Shashwat Sachdev"
+            },
+            {
+              "name": "Madhubanti Bagchi"
+            },
+            {
+              "name": "Jasmine Sandlas"
+            }
+          ],
+          "album": {
+            "name": "Dhurandhar",
+            "releaseDate": "2025-12-05"
+          },
+          "durationMs": 224083,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027838ccbef3fb712228e23fc5"
+        },
+        {
+          "position": 49,
+          "id": "levyra-5966920c1cd928287aae",
+          "title": "Mashooqa - From “Cocktail 2”",
+          "artists": [
+            {
+              "name": "Pritam"
+            },
+            {
+              "name": "Mahmood"
+            },
+            {
+              "name": "Raghav Chaitanya"
+            },
+            {
+              "name": "Amitabh Bhattacharya"
+            },
+            {
+              "name": "Ruaa Kayy"
+            }
+          ],
+          "album": {
+            "name": "Cocktail 2 (Original Motion Picture Soundtrack)",
+            "releaseDate": "2026-06-25"
+          },
+          "durationMs": 230070,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "NwgOjWWTwyM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCCTN01plFzn4npREHKT2_9Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02adb1a15b21a4b9728285ca94"
+        },
+        {
+          "position": 50,
+          "id": "levyra-a79710b929807d62776a",
+          "title": "Mann Mera - Original Version",
+          "artists": [
+            {
+              "name": "Gajendra Verma"
+            }
+          ],
+          "album": {
+            "name": "Mann Mera (Original Version)",
+            "releaseDate": "2025-05-09"
+          },
+          "durationMs": 228000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020be94602b5b22cbe139a366b"
+        }
+      ]
+    },
+    {
+      "id": "top-50-id",
+      "kind": "chart",
+      "market": "ID",
+      "title": "Top 50 Indonesia",
+      "description": "Indonesia: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-6e78d16f499d0f5e4052",
+          "title": "Sesi Potret",
+          "artists": [
+            {
+              "name": "eńau"
+            },
+            {
+              "name": "Ari Lesmana"
+            }
+          ],
+          "album": {
+            "name": "Sesi Potret",
+            "releaseDate": "2026-01-29"
+          },
+          "durationMs": 243000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02172768978c7f929803ad7e8b"
+        },
+        {
+          "position": 2,
+          "id": "levyra-009cd17c902ccd248c99",
+          "title": "Teh Hijau",
+          "artists": [
+            {
+              "name": "Tulus"
+            }
+          ],
+          "album": {
+            "name": "Teh Hijau",
+            "releaseDate": "2026-06-30"
+          },
+          "durationMs": 212879,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "5F28ye50-Kc",
+            "audioConfidence": 100,
+            "videoId": "zyLmavBAY7k",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UC_DHlXllTSMB8pTC38_leFg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e4086e5f9d79cf18ed601015"
+        },
+        {
+          "position": 3,
+          "id": "levyra-9c6196cbfb3ca5b9cc42",
+          "title": "iqro'",
+          "artists": [
+            {
+              "name": "Raim Laode"
+            }
+          ],
+          "album": {
+            "name": "iqro'",
+            "releaseDate": "2026-04-24"
+          },
+          "durationMs": 234229,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Au_jz7Yd39I",
+            "audioConfidence": 100,
+            "videoId": "9WHWkEJLKJM",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UC2ArcMzVC3E4X_hTXpQNzlg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a9d1f9b5d3275b0625e13e79"
+        },
+        {
+          "position": 4,
+          "id": "levyra-a440c90e5b1f52316032",
+          "title": "Dunia Yang Nanti",
+          "artists": [
+            {
+              "name": "Raim Laode"
+            }
+          ],
+          "album": {
+            "name": "iqro'",
+            "releaseDate": "2026-04-24"
+          },
+          "durationMs": 202100,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "m91LMFkmpuI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC2ArcMzVC3E4X_hTXpQNzlg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a9d1f9b5d3275b0625e13e79"
+        },
+        {
+          "position": 5,
+          "id": "levyra-de408c4c61ed8dfc57d9",
+          "title": "Bersenja Gurau",
+          "artists": [
+            {
+              "name": "Raim Laode"
+            }
+          ],
+          "album": {
+            "name": "iqro'",
+            "releaseDate": "2026-04-24"
+          },
+          "durationMs": 194293,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "-07Xbws-LB4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC2ArcMzVC3E4X_hTXpQNzlg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a9d1f9b5d3275b0625e13e79"
+        },
+        {
+          "position": 6,
+          "id": "levyra-ac4ffc0767121ea8fb59",
+          "title": "Ini Abadi",
+          "artists": [
+            {
+              "name": "Perunggu"
+            }
+          ],
+          "album": {
+            "name": "Memorandum",
+            "releaseDate": "2022-03-10"
+          },
+          "durationMs": 232000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "ASBUp9jG6LI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCzP_EyHbxIc77ENSRrNNAyg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028555856b715d83c2fc867153"
+        },
+        {
+          "position": 7,
+          "id": "levyra-f89e898efc5778c8906d",
+          "title": "Jangan Paksa Rindu - Beda",
+          "artists": [
+            {
+              "name": "Ifan Seventeen"
+            }
+          ],
+          "album": {
+            "name": "Resonance",
+            "releaseDate": "2026-01-09"
+          },
+          "durationMs": 245226,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "D0fzGl640wE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCb_E36en08Yl0gB-oHWPXPg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b1f0e17d6a48da664cbdcbe5"
+        },
+        {
+          "position": 8,
+          "id": "levyra-4932d500157cf05fc463",
+          "title": "kota ini tak sama tanpamu",
+          "artists": [
+            {
+              "name": "Nadhif Basalamah"
+            }
+          ],
+          "album": {
+            "name": "Nadhif (laman berikutnya)",
+            "releaseDate": "2025-06-20"
+          },
+          "durationMs": 279649,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "R7mX714_QZs",
+            "audioConfidence": 100,
+            "videoId": "q0TFMtkTIR8",
+            "videoConfidence": 95,
+            "confidence": 100,
+            "artistBrowseId": "UCbwAI7LydeNSRU-bywK0EHw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f3e3f888fbfcc916ecce50a9"
+        },
+        {
+          "position": 9,
+          "id": "levyra-2cc656d038ff5aaada92",
+          "title": "Ada titik-titik di ujung doa",
+          "artists": [
+            {
+              "name": "Sal Priadi"
+            }
+          ],
+          "album": {
+            "name": "MARKERS AND SUCH PENS FLASHDISKS",
+            "releaseDate": "2024-04-30"
+          },
+          "durationMs": 305357,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lj-zKp2hLKU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCs1Iq1CQQDwTUUUtVhXmK6g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02686acaaa87bfc6ebb42b3bd2"
+        },
+        {
+          "position": 10,
+          "id": "levyra-2803557f9237a36b8fde",
+          "title": "everything u are",
+          "artists": [
+            {
+              "name": "Hindia"
+            }
+          ],
+          "album": {
+            "name": "Doves, '25 on Blank Canvas",
+            "releaseDate": "2025-02-24"
+          },
+          "durationMs": 236489,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Zq1Jg0H5fzc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCzhVLh7xVyH3MpqO_KY6SYg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0205898628baab6ef07a0a4d03"
+        },
+        {
+          "position": 11,
+          "id": "levyra-50313a79b15baa02a66b",
+          "title": "Monolog",
+          "artists": [
+            {
+              "name": "Pamungkas"
+            }
+          ],
+          "album": {
+            "name": "Walk the Talk",
+            "releaseDate": "2018-07-20"
+          },
+          "durationMs": 207216,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023e2cf96ce4558b8f2376b79a"
+        },
+        {
+          "position": 12,
+          "id": "levyra-9c096828dbdd76ef0c16",
+          "title": "bergema sampai selamanya",
+          "artists": [
+            {
+              "name": "Nadhif Basalamah"
+            }
+          ],
+          "album": {
+            "name": "Nadhif (laman berikutnya)",
+            "releaseDate": "2025-06-20"
+          },
+          "durationMs": 198567,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "bAoxY1jQnqo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCbwAI7LydeNSRU-bywK0EHw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f3e3f888fbfcc916ecce50a9"
+        },
+        {
+          "position": 13,
+          "id": "levyra-c45456634610cb7d1a57",
+          "title": "Bahagia Lagi",
+          "artists": [
+            {
+              "name": "Piche Kota"
+            }
+          ],
+          "album": {
+            "name": "Bahagia Lagi",
+            "releaseDate": "2025-10-23"
+          },
+          "durationMs": 227415,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "rouojv6Xu8Q",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCx8r4c5ZB_CpbYHTBLaNemw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025bd00b369e89c5cbc74d827b"
+        },
+        {
+          "position": 14,
+          "id": "levyra-728300af0a945c84423c",
+          "title": "Jatuh Suka",
+          "artists": [
+            {
+              "name": "Tulus"
+            }
+          ],
+          "album": {
+            "name": "Manusia",
+            "releaseDate": "2022-03-03"
+          },
+          "durationMs": 235000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qrnJL6P-QqQ",
+            "audioConfidence": 100,
+            "videoId": "NRGDT2UUlsk",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UC_DHlXllTSMB8pTC38_leFg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d34a0632f6861e8875d6899b"
+        },
+        {
+          "position": 15,
+          "id": "levyra-a470ada77f9b6a52e268",
+          "title": "Lesung Pipi",
+          "artists": [
+            {
+              "name": "Raim Laode"
+            }
+          ],
+          "album": {
+            "name": "iqro'",
+            "releaseDate": "2026-04-24"
+          },
+          "durationMs": 225153,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "G_EgkHCayU0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC2ArcMzVC3E4X_hTXpQNzlg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a9d1f9b5d3275b0625e13e79"
+        },
+        {
+          "position": 16,
+          "id": "levyra-f687cb1dcd2556635f44",
+          "title": "Berapa Kali Kita Akan Saling Memaafkan",
+          "artists": [
+            {
+              "name": "Pamungkas"
+            }
+          ],
+          "album": {
+            "name": "Berapa Kali Kita Akan Saling Memaafkan",
+            "releaseDate": "2026-04-08"
+          },
+          "durationMs": 284463,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "US8TFTvB0b0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCKsVGAgYj1seH6HLXr61ZJg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02867cbccc3fb739a46797ad04"
+        },
+        {
+          "position": 17,
+          "id": "levyra-3c8d4f83afa105a55e6c",
+          "title": "MMG (My Mine Gueh)",
+          "artists": [
+            {
+              "name": "Naykilla"
+            }
+          ],
+          "album": {
+            "name": "MMG (My Mine Gueh)",
+            "releaseDate": "2026-06-19"
+          },
+          "durationMs": 193090,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "THd_CGvnkvk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCtVjmGU8-P-gKsUYBEEENYw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02671059f40b6662d84ea412d9"
+        },
+        {
+          "position": 18,
+          "id": "levyra-e2fb7ff2caa8b0160954",
+          "title": "The One That Got Away",
+          "artists": [
+            {
+              "name": "Katy Perry"
+            }
+          ],
+          "album": {
+            "name": "Teenage Dream",
+            "releaseDate": "2010-01-01"
+          },
+          "durationMs": 227333,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021d955011a3ed477dc77865ad"
+        },
+        {
+          "position": 19,
+          "id": "levyra-c6aa2a30b53b3fb7aca1",
+          "title": "Astaga Bercanda",
+          "artists": [
+            {
+              "name": "Akbar Chalay"
+            },
+            {
+              "name": "Mingse"
+            }
+          ],
+          "album": {
+            "name": "Astaga Bercanda",
+            "releaseDate": "2026-05-08"
+          },
+          "durationMs": 166850,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "n5Mo9hC9d_Y",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCnHAGsl2PpcNqgmOwBz0hLQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02db45ed33946536fd099548b0"
+        },
+        {
+          "position": 20,
+          "id": "levyra-173ae5d28237f10608cd",
+          "title": "Titik Nadir (feat. Monita Tahalea)",
+          "artists": [
+            {
+              "name": "Kahitna"
+            },
+            {
+              "name": "Monita Tahalea"
+            }
+          ],
+          "album": {
+            "name": "Titik Nadir",
+            "releaseDate": "2025-06-24"
+          },
+          "durationMs": 245462,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "sYfzcAKzB3Y",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCWlxzIM_ruFSkraPvImck7Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025cfcb24701901b0e53ce4fae"
+        },
+        {
+          "position": 21,
+          "id": "levyra-0b7a4cf2021a065673e3",
+          "title": "Monokrom",
+          "artists": [
+            {
+              "name": "Tulus"
+            }
+          ],
+          "album": {
+            "name": "Monokrom",
+            "releaseDate": "2016-08-03"
+          },
+          "durationMs": 214567,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "1RrF6Ee_io0",
+            "audioConfidence": 100,
+            "videoId": "QqJ-Vp8mvbk",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UC_DHlXllTSMB8pTC38_leFg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0271c65edbeed32af70b900637"
+        },
+        {
+          "position": 22,
+          "id": "levyra-bed57e9e6e2d7c42d6e6",
+          "title": "33x",
+          "artists": [
+            {
+              "name": "Perunggu"
+            }
+          ],
+          "album": {
+            "name": "Memorandum",
+            "releaseDate": "2022-03-10"
+          },
+          "durationMs": 434759,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "_eVLDvD7lE8",
+            "audioConfidence": 100,
+            "videoId": "hbL5jQCw3As",
+            "videoConfidence": 97,
+            "confidence": 100,
+            "artistBrowseId": "UCzP_EyHbxIc77ENSRrNNAyg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028555856b715d83c2fc867153"
+        },
+        {
+          "position": 23,
+          "id": "levyra-b981f441978c1c41bac3",
+          "title": "Nina",
+          "artists": [
+            {
+              "name": ".Feast"
+            }
+          ],
+          "album": {
+            "name": "Membangun & Menghancurkan",
+            "releaseDate": "2024-08-30"
+          },
+          "durationMs": 277944,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "n2KBmgnXS_M",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCOaaWFF_QZrzbh-IO85UzNA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c800b90e2092a5328f699117"
+        },
+        {
+          "position": 24,
+          "id": "levyra-80863c26eaa90ab9d859",
+          "title": "Mangu",
+          "artists": [
+            {
+              "name": "Fourtwnty"
+            },
+            {
+              "name": "Charita Utami"
+            }
+          ],
+          "album": {
+            "name": "Nalar",
+            "releaseDate": "2023-04-18"
+          },
+          "durationMs": 261048,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0232ab17f5515e51490841f648"
+        },
+        {
+          "position": 25,
+          "id": "levyra-4e04e435343b33c99223",
+          "title": "Serana",
+          "artists": [
+            {
+              "name": "For Revenge"
+            }
+          ],
+          "album": {
+            "name": "Perayaan Patah Hati - Babak 1",
+            "releaseDate": "2022-09-06"
+          },
+          "durationMs": 250000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "ngam3hAnnYk",
+            "audioConfidence": 100,
+            "videoId": "nwNs_xzenFk",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UC-ER36426qLKgZAeEFagAtg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02322ce4ba8eb959ebee609fd8"
+        },
+        {
+          "position": 26,
+          "id": "levyra-6ebeb38b0d1bac5a7e6e",
+          "title": "Penyangkalan",
+          "artists": [
+            {
+              "name": "For Revenge"
+            }
+          ],
+          "album": {
+            "name": "Perayaan Patah Hati - Babak 2",
+            "releaseDate": "2025-12-11"
+          },
+          "durationMs": 240607,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "UUe2l3FoXuM",
+            "audioConfidence": 100,
+            "videoId": "yd1bQpQLcoY",
+            "videoConfidence": 97,
+            "confidence": 100,
+            "artistBrowseId": "UC-ER36426qLKgZAeEFagAtg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bf09e5d5661fe469bdf8e622"
+        },
+        {
+          "position": 27,
+          "id": "levyra-91a7f1ee382969f744c8",
+          "title": "Terpukau",
+          "artists": [
+            {
+              "name": "Astrid"
+            }
+          ],
+          "album": {
+            "name": "Terpukau",
+            "releaseDate": "2013-10-23"
+          },
+          "durationMs": 252093,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "tZNSzH2g06Q",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCOg-0UfMp81bEJn_tGJw8Vw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0205d8a1a7ebb27bdd2fbdc685"
+        },
+        {
+          "position": 28,
+          "id": "levyra-9217c6b8ef57581c746f",
+          "title": "Bertaut",
+          "artists": [
+            {
+              "name": "Nadin Amizah"
+            }
+          ],
+          "album": {
+            "name": "Selamat Ulang Tahun",
+            "releaseDate": "2020-05-28"
+          },
+          "durationMs": 315960,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026d57a5c60decaa8fb39d5afb"
+        },
+        {
+          "position": 29,
+          "id": "levyra-b9dc99513dc4dab175ae",
+          "title": "Rumah Ke Rumah",
+          "artists": [
+            {
+              "name": "Hindia"
+            }
+          ],
+          "album": {
+            "name": "Menari Dengan Bayangan",
+            "releaseDate": "2019-11-29"
+          },
+          "durationMs": 277457,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "xTQvdE1oOaw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCzhVLh7xVyH3MpqO_KY6SYg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d623688488865906052ef96b"
+        },
+        {
+          "position": 30,
+          "id": "levyra-446e3edf343a4eb5c259",
+          "title": "Cincin",
+          "artists": [
+            {
+              "name": "Hindia"
+            }
+          ],
+          "album": {
+            "name": "Lagipula Hidup Akan Berakhir",
+            "releaseDate": "2023-07-07"
+          },
+          "durationMs": 266330,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "RtK4E61x3Fs",
+            "audioConfidence": 100,
+            "videoId": "98hXjUqfqhE",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCzhVLh7xVyH3MpqO_KY6SYg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d58121433ea3e6c4822ac494"
+        },
+        {
+          "position": 31,
+          "id": "levyra-4d6c53e0e88158b73cf1",
+          "title": "Tarot",
+          "artists": [
+            {
+              "name": ".Feast"
+            }
+          ],
+          "album": {
+            "name": "Membangun & Menghancurkan",
+            "releaseDate": "2024-08-30"
+          },
+          "durationMs": 288981,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "iLOq3u5LH0U",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCOaaWFF_QZrzbh-IO85UzNA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c800b90e2092a5328f699117"
+        },
+        {
+          "position": 32,
+          "id": "levyra-e13adff4d1f189d67435",
+          "title": "penjaga hati",
+          "artists": [
+            {
+              "name": "Nadhif Basalamah"
+            }
+          ],
+          "album": {
+            "name": "Nadhif",
+            "releaseDate": "2024-06-21"
+          },
+          "durationMs": 260346,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "g6iIVyRfiUk",
+            "audioConfidence": 100,
+            "videoId": "jia3fhBQ8qI",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCbwAI7LydeNSRU-bywK0EHw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0225001f594384ffb7fb952347"
+        },
+        {
+          "position": 33,
+          "id": "levyra-159d9c9886b70ea1e318",
+          "title": "Kita usahakan rumah itu",
+          "artists": [
+            {
+              "name": "Sal Priadi"
+            }
+          ],
+          "album": {
+            "name": "MARKERS AND SUCH PENS FLASHDISKS",
+            "releaseDate": "2024-04-30"
+          },
+          "durationMs": 211244,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qkNHIcwrNxg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCs1Iq1CQQDwTUUUtVhXmK6g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02686acaaa87bfc6ebb42b3bd2"
+        },
+        {
+          "position": 34,
+          "id": "levyra-ba7cbea2c5242656f5af",
+          "title": "Hati-Hati di Jalan",
+          "artists": [
+            {
+              "name": "Tulus"
+            }
+          ],
+          "album": {
+            "name": "Manusia",
+            "releaseDate": "2022-03-03"
+          },
+          "durationMs": 242000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "E7kHvjvU6JY",
+            "audioConfidence": 100,
+            "videoId": "9II3OGZETo4",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UC_DHlXllTSMB8pTC38_leFg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d34a0632f6861e8875d6899b"
+        },
+        {
+          "position": 35,
+          "id": "levyra-dbfa6b60c535305a462c",
+          "title": "Masa ini, Nanti, dan Masa Indah Lainnya",
+          "artists": [
+            {
+              "name": "Nuca"
+            }
+          ],
+          "album": {
+            "name": "EUNOIA",
+            "releaseDate": "2025-11-26"
+          },
+          "durationMs": 275935,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0272efdd27a433732ba1ab6269"
+        },
+        {
+          "position": 36,
+          "id": "levyra-bfa79aa4311eb86d9a2e",
+          "title": "Dan...",
+          "artists": [
+            {
+              "name": "Sheila On 7"
+            }
+          ],
+          "album": {
+            "name": "Sheila On 7",
+            "releaseDate": "1999-07-14"
+          },
+          "durationMs": 288706,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "k1BfsO0mxWQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCoy8sTKrImqfSq6TYOSW81A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0254270208627aa8061a8abe21"
+        },
+        {
+          "position": 37,
+          "id": "levyra-a1de3654700d623645fd",
+          "title": "Selamat (Selamat Tinggal)",
+          "artists": [
+            {
+              "name": "Virgoun"
+            },
+            {
+              "name": "Audy"
+            }
+          ],
+          "album": {
+            "name": "Selamat (Selamat Tinggal)",
+            "releaseDate": "2019-06-17"
+          },
+          "durationMs": 313670,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dbd21bc0b35f4220357a1c66"
+        },
+        {
+          "position": 38,
+          "id": "levyra-291a3e6a311bc80b6fd9",
+          "title": "Foto kita blur",
+          "artists": [
+            {
+              "name": "Sal Priadi"
+            }
+          ],
+          "album": {
+            "name": "MARKERS AND SUCH PENS FLASHDISKS",
+            "releaseDate": "2024-04-30"
+          },
+          "durationMs": 271477,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "tW3KekLxXpg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCs1Iq1CQQDwTUUUtVhXmK6g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02686acaaa87bfc6ebb42b3bd2"
+        },
+        {
+          "position": 39,
+          "id": "levyra-550efd47fbe11463102b",
+          "title": "Shape of My Heart",
+          "artists": [
+            {
+              "name": "Backstreet Boys"
+            }
+          ],
+          "album": {
+            "name": "Black & Blue",
+            "releaseDate": "2000-11-21"
+          },
+          "durationMs": 230093,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "BLhIcQMaaTI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCQsJi7L4_zXzYRN2X0Fw3Zg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cf871e6326e334bfa92cff20"
+        },
+        {
+          "position": 40,
+          "id": "levyra-5fdfed88ec3816f855ea",
+          "title": "Komang",
+          "artists": [
+            {
+              "name": "Raim Laode"
+            }
+          ],
+          "album": {
+            "name": "iqro'",
+            "releaseDate": "2026-04-24"
+          },
+          "durationMs": 222706,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a9d1f9b5d3275b0625e13e79"
+        },
+        {
+          "position": 41,
+          "id": "levyra-7afe7b0162499b1dfacd",
+          "title": "Nanti Kita Seperti Ini",
+          "artists": [
+            {
+              "name": "Batas Senja"
+            }
+          ],
+          "album": {
+            "name": "Nanti Kita Seperti Ini",
+            "releaseDate": "2022-09-27"
+          },
+          "durationMs": 209647,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "V697wAtn6cI",
+            "audioConfidence": 100,
+            "videoId": "s6H6ffS6zJI",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCuO6wlFQ04dArFZeZdxwtRQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c6092bd9b2579479e5fa9891"
+        },
+        {
+          "position": 42,
+          "id": "levyra-ff023e505b21929079c0",
+          "title": "1000X",
+          "artists": [
+            {
+              "name": "Ghea Indrawari"
+            }
+          ],
+          "album": {
+            "name": "RASI BINTANG",
+            "releaseDate": "2026-06-05"
+          },
+          "durationMs": 252249,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "NcbxQom0Jpk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCWoBKSc1j2KkPd5j_f8Qfaw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0214814de2da42fd2273d0fcff"
+        },
+        {
+          "position": 43,
+          "id": "levyra-002f2a2ec315ea5906ca",
+          "title": "Sedia Aku Sebelum Hujan",
+          "artists": [
+            {
+              "name": "Idgitaf"
+            }
+          ],
+          "album": {
+            "name": "Berusaha di Bawah Hujan",
+            "releaseDate": "2026-05-15"
+          },
+          "durationMs": 230130,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "MODbh7nKWmQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCM32L34TXX4f_l7f4tn6KGg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ac44521bc2da938d92b422f9"
+        },
+        {
+          "position": 44,
+          "id": "levyra-dfeccc791b92fc8c8633",
+          "title": "Lantas",
+          "artists": [
+            {
+              "name": "Juicy Luicy"
+            }
+          ],
+          "album": {
+            "name": "Sentimental",
+            "releaseDate": "2020-11-06"
+          },
+          "durationMs": 234204,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "M4YpWWj_IWs",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCYBtTmBP2QgHgalgsv2v5LA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b1d3ef29ee15a18842973471"
+        },
+        {
+          "position": 45,
+          "id": "levyra-a906d007445d79dd7edf",
+          "title": "Treat You Better",
+          "artists": [
+            {
+              "name": "Shawn Mendes"
+            }
+          ],
+          "album": {
+            "name": "Illuminate",
+            "releaseDate": "2017-04-20"
+          },
+          "durationMs": 187973,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qSay_8xzijg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC6ZjlLJhqP79nqGr3Ic6Adg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021376b4b16f4bfcba02dc571b"
+        },
+        {
+          "position": 46,
+          "id": "levyra-76e62b7666fb626ff602",
+          "title": "Dirimu Yang Dulu",
+          "artists": [
+            {
+              "name": "Anggis Devaki"
+            }
+          ],
+          "album": {
+            "name": "Devaki",
+            "releaseDate": "2025-09-26"
+          },
+          "durationMs": 240800,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d7105ffabf2ff9ddd265eab1"
+        },
+        {
+          "position": 47,
+          "id": "levyra-48619e7749b9a9bd6dad",
+          "title": "About You",
+          "artists": [
+            {
+              "name": "The 1975"
+            }
+          ],
+          "album": {
+            "name": "Being Funny In A Foreign Language",
+            "releaseDate": "2022-10-14"
+          },
+          "durationMs": 326490,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "4PgOJwUCdIc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCNrTdctAV0JMT7RBQvpA5lw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0200702474f8e0e2b6155d48e3"
+        },
+        {
+          "position": 48,
+          "id": "levyra-21a79f6979f4e7de84dd",
+          "title": "Terbuang Dalam Waktu",
+          "artists": [
+            {
+              "name": "Barasuara"
+            }
+          ],
+          "album": {
+            "name": "Jalaran Sadrah",
+            "releaseDate": "2024-06-21"
+          },
+          "durationMs": 281173,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "60gOh6eCrkw",
+            "audioConfidence": 100,
+            "videoId": "X-EK60rmcQs",
+            "videoConfidence": 97,
+            "confidence": 100,
+            "artistBrowseId": "UCA36OMMsSium2rOWHdo7gsA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0295688e1f59ae3fc4951d41ff"
+        },
+        {
+          "position": 49,
+          "id": "levyra-2cae16bebfb9bd3a29cf",
+          "title": "Aku Milikmu",
+          "artists": [
+            {
+              "name": "Dewa 19"
+            }
+          ],
+          "album": {
+            "name": "Format Masa Depan",
+            "releaseDate": "1994-06-16"
+          },
+          "durationMs": 332733,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "5a0EkeqWNBs",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCn0hl0XZ3bFREX2SCBZK3Pw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bfc7fa507f4bc822cabe7bde"
+        },
+        {
+          "position": 50,
+          "id": "levyra-01ccbad0d9418ce59af4",
+          "title": "Lihat Kebunku (Taman Bunga)",
+          "artists": [
+            {
+              "name": "Aku Jeje"
+            }
+          ],
+          "album": {
+            "name": "Lihat Kebunku (Taman Bunga)",
+            "releaseDate": "2025-09-19"
+          },
+          "durationMs": 189897,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Qb8vgvtEuEs",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC-Dj9iE3_fDqL7Pz_X70U_w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0223a15d3a2c0fc3d9bb6c5911"
+        }
+      ]
+    },
+    {
+      "id": "top-50-vn",
+      "kind": "chart",
+      "market": "VN",
+      "title": "Top 50 Việt Nam",
+      "description": "Vietnam: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-7ebd34c3b949902751e3",
+          "title": "Tìm Em (feat. Bảo Anh)",
+          "artists": [
+            {
+              "name": "Hngle"
+            },
+            {
+              "name": "Bảo Anh"
+            }
+          ],
+          "album": {
+            "name": "Tìm Em (feat. Bảo Anh)",
+            "releaseDate": "2026-06-18"
+          },
+          "durationMs": 274589,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "PnGk00MuNM4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCZzzKGVP9wqbVOtjK0nCSFA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0216d614a859798e628354b232"
+        },
+        {
+          "position": 2,
+          "id": "levyra-d2278f14e9491e3a1538",
+          "title": "Seven (feat. Latto) (Explicit Ver.)",
+          "artists": [
+            {
+              "name": "Jung Kook"
+            },
+            {
+              "name": "Latto"
+            }
+          ],
+          "album": {
+            "name": "GOLDEN",
+            "releaseDate": "2023-11-03"
+          },
+          "durationMs": 183550,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02741fd4807f442af3f7359316"
+        },
+        {
+          "position": 3,
+          "id": "levyra-f588b284e5cd9a4c39fd",
+          "title": "xương rồng (intro)",
+          "artists": [
+            {
+              "name": "Dangrangto"
+            },
+            {
+              "name": "DONAL"
+            }
+          ],
+          "album": {
+            "name": "trái tim băng bó",
+            "releaseDate": "2026-06-17"
+          },
+          "durationMs": 245040,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "skvHQIt-XyI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCkQdT9u47dM1nJ4i0qB1SXA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f5ccda42421dd2d34cef2480"
+        },
+        {
+          "position": 4,
+          "id": "levyra-15c3fc1c55adb2b03ba2",
+          "title": "Không Buông",
+          "artists": [
+            {
+              "name": "Hngle"
+            },
+            {
+              "name": "Ari"
+            }
+          ],
+          "album": {
+            "name": "Không Buông",
+            "releaseDate": "2025-08-25"
+          },
+          "durationMs": 174866,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "5008LmjAq-g",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCZzzKGVP9wqbVOtjK0nCSFA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028e2436033be92c06e4afee32"
+        },
+        {
+          "position": 5,
+          "id": "levyra-339dc2688fa4ba0cc151",
+          "title": "dự báo thời tiết hôm nay mưa",
+          "artists": [
+            {
+              "name": "GREY D"
+            }
+          ],
+          "album": {
+            "name": "dự báo thời tiết hôm nay mưa – Maxi Single",
+            "releaseDate": "2022-11-22"
+          },
+          "durationMs": 281493,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "i7ZyZHIY2Jw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCxqXDmjSpeNuScT5OPRZStQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0212a6bd687aec4105bc06fcdf"
+        },
+        {
+          "position": 6,
+          "id": "levyra-2dba70689aef29add351",
+          "title": "vết thương",
+          "artists": [
+            {
+              "name": "Fishy"
+            }
+          ],
+          "album": {
+            "name": "vết thương",
+            "releaseDate": "2023-06-29"
+          },
+          "durationMs": 261617,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "vfztsrjPneo",
+            "audioConfidence": 100,
+            "videoId": "LIKOvbJ-DZg",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UC-iRwJlS3Xw7KPKy8nytYqw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cb2a3066584a339e09508520"
+        },
+        {
+          "position": 7,
+          "id": "levyra-b9b109db4fd567de0eea",
+          "title": "SWIM",
+          "artists": [
+            {
+              "name": "BTS"
+            }
+          ],
+          "album": {
+            "name": "ARIRANG",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 159007,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qZTVU04UOO4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC9vrvNSL3xcWGSkV86REBSg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dfa17fad7f190c901603270e"
+        },
+        {
+          "position": 8,
+          "id": "levyra-bcd373bfd3789c50feb6",
+          "title": "SSD",
+          "artists": [
+            {
+              "name": "W/N"
+            },
+            {
+              "name": "267"
+            },
+            {
+              "name": "PAR SG"
+            },
+            {
+              "name": "Nguyenn"
+            }
+          ],
+          "album": {
+            "name": "SSD",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 420000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02107694dd2971e8b166c9f57d"
+        },
+        {
+          "position": 9,
+          "id": "levyra-267c6662f971053de1fd",
+          "title": "Exit Sign",
+          "artists": [
+            {
+              "name": "HIEUTHUHAI"
+            },
+            {
+              "name": "marzuz"
+            }
+          ],
+          "album": {
+            "name": "Ai Cũng Phải Bắt Đầu Từ Đâu Đó",
+            "releaseDate": "2023-10-16"
+          },
+          "durationMs": 201589,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Fwsl_XS4sYQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC-FbBvrUwI1CmCnurnJlc6Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c006b0181a3846c1c63e178f"
+        },
+        {
+          "position": 10,
+          "id": "levyra-cde75f5f6c2e5a01aaa4",
+          "title": "THẾ GIỚI CỦA ANH (feat. Dương Domic, WEAN, CONGB, buitruonglinh & Van Toan)",
+          "artists": [
+            {
+              "name": "TINH HÀ \"SAY HI\""
+            },
+            {
+              "name": "Dương Domic"
+            },
+            {
+              "name": "WEAN"
+            },
+            {
+              "name": "CONGB"
+            },
+            {
+              "name": "buitruonglinh"
+            },
+            {
+              "name": "Van Toan"
+            }
+          ],
+          "album": {
+            "name": "TINH HÀ \"SAY HI\", TẬP 4",
+            "releaseDate": "2026-07-25"
+          },
+          "durationMs": 257595,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ecbec3da3fc21b7b720f652e"
+        },
+        {
+          "position": 11,
+          "id": "levyra-2a43ee7ec3df7c0c0876",
+          "title": "Người Im Lặng Gặp Người Hay Nói",
+          "artists": [
+            {
+              "name": "HIEUTHUHAI"
+            }
+          ],
+          "album": {
+            "name": "Mắt Nhắm Mắt Mở",
+            "releaseDate": "2026-04-22"
+          },
+          "durationMs": 256000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "IlVAy_wTG_s",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC-FbBvrUwI1CmCnurnJlc6Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029786a600b159da21312fb356"
+        },
+        {
+          "position": 12,
+          "id": "levyra-9136242599b58c6b3336",
+          "title": "Em (feat. SOOBIN)",
+          "artists": [
+            {
+              "name": "Binz"
+            },
+            {
+              "name": "SOOBIN"
+            }
+          ],
+          "album": {
+            "name": "Gặp Lại",
+            "releaseDate": "2026-05-24"
+          },
+          "durationMs": 296983,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "J0Jdd3Tz8kU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCuVwM-xqo_3H3vjQc-ZwNpA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02113b4bb24fa0898ce579d19c"
+        },
+        {
+          "position": 13,
+          "id": "levyra-baa713c7b7cbf4ec1cc8",
+          "title": "Và Thế Giới Đã Mất Đi Một Người Cô Đơn",
+          "artists": [
+            {
+              "name": "marzuz"
+            },
+            {
+              "name": "Changg"
+            }
+          ],
+          "album": {
+            "name": "Và Thế Giới Đã Mất Đi Một Người Cô Đơn",
+            "releaseDate": "2024-05-18"
+          },
+          "durationMs": 201176,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02634fee188263a0d6bd8d822d"
+        },
+        {
+          "position": 14,
+          "id": "levyra-aa1233ffcb0d1868682c",
+          "title": "MVP (MƯA VỘI PHÓNG) (feat. Wren Evans, Ali Hoàng Dương, CODYNAMVO, HYO & 2pillz)",
+          "artists": [
+            {
+              "name": "TINH HÀ \"SAY HI\""
+            },
+            {
+              "name": "Wren Evans"
+            },
+            {
+              "name": "Ali Hoàng Dương"
+            },
+            {
+              "name": "CODYNAMVO"
+            },
+            {
+              "name": "HYO"
+            },
+            {
+              "name": "2Pillz"
+            }
+          ],
+          "album": {
+            "name": "TINH HÀ \"SAY HI\", TẬP 4",
+            "releaseDate": "2026-07-25"
+          },
+          "durationMs": 221800,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ecbec3da3fc21b7b720f652e"
+        },
+        {
+          "position": 15,
+          "id": "levyra-73306409169821f01bd5",
+          "title": "In Love",
+          "artists": [
+            {
+              "name": "Low G"
+            },
+            {
+              "name": "JustaTee"
+            }
+          ],
+          "album": {
+            "name": "L2K",
+            "releaseDate": "2025-10-21"
+          },
+          "durationMs": 200923,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "x8cz2E_nutc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCz4mnp3cgm4e82lIBH5ZGaA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0223cf61113b6f831989e68725"
+        },
+        {
+          "position": 16,
+          "id": "levyra-c3ecac908903cdd1be02",
+          "title": "Ngày Rời Chuyến Bay",
+          "artists": [
+            {
+              "name": "Minh Huy"
+            },
+            {
+              "name": "Pinny"
+            }
+          ],
+          "album": {
+            "name": "Ngày Rời Chuyến Bay",
+            "releaseDate": "2026-03-14"
+          },
+          "durationMs": 229385,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "kBz22YS1eeQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCg8HKFU3QJMSw79YfcGjjsw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026710f4e7e1be806c3e31a67d"
+        },
+        {
+          "position": 17,
+          "id": "levyra-9a8301a85b198ceb4a18",
+          "title": "Nếu Ngày Ấy",
+          "artists": [
+            {
+              "name": "SOOBIN"
+            }
+          ],
+          "album": {
+            "name": "Nếu Ngày Ấy",
+            "releaseDate": "2019-07-22"
+          },
+          "durationMs": 292757,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "xBLe8hb2eTU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCbB39VCJGo7ZASuDAX5vTIA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0294bae292aed83118570ea86a"
+        },
+        {
+          "position": 18,
+          "id": "levyra-e55d65411725badc040c",
+          "title": "Nếu Như Ta Chẳng Còn (feat. A$AP Ướt Mi)",
+          "artists": [
+            {
+              "name": "RPT MCK"
+            },
+            {
+              "name": "A$AP Ướt Mi"
+            }
+          ],
+          "album": {
+            "name": "HVL",
+            "releaseDate": "2026-06-17"
+          },
+          "durationMs": 317972,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "a_QfIGr4tfg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCDRWYq4se6zr4MCLBorlVZg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a2907cc0804151b77ca8667d"
+        },
+        {
+          "position": 19,
+          "id": "levyra-87059dfc9bb8d36861da",
+          "title": "Vùng An Toàn",
+          "artists": [
+            {
+              "name": "B Ray"
+            },
+            {
+              "name": "V#"
+            }
+          ],
+          "album": {
+            "name": "Cho Bảo",
+            "releaseDate": "2025-07-08"
+          },
+          "durationMs": 265954,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "9tRqGdP1c2M",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCcyy_mCsUzX2q4ht-atRmng"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024e1566cecfa3c836f48f80f6"
+        },
+        {
+          "position": 20,
+          "id": "levyra-91bca96466b5957ddbfd",
+          "title": "She Neva Knows",
+          "artists": [
+            {
+              "name": "JustaTee"
+            }
+          ],
+          "album": {
+            "name": "She Neva Knows",
+            "releaseDate": "2012-01-21"
+          },
+          "durationMs": 293000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "GJgyNpBkiqg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCz3Q1vuUWCX5aFide-RS-qA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023ecc6ca902daf3617c75d336"
+        },
+        {
+          "position": 21,
+          "id": "levyra-009079c49575da6b1335",
+          "title": "Mơ",
+          "artists": [
+            {
+              "name": "VCT"
+            }
+          ],
+          "album": {
+            "name": "Mơ",
+            "releaseDate": "2016-01-01"
+          },
+          "durationMs": 262191,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Rmun4-dd2xQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCRR908cRMgRkekWQXpk31sA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028b40ad72aa86e76099297d7b"
+        },
+        {
+          "position": 22,
+          "id": "levyra-27d7a689c29e860fe5ae",
+          "title": "NORMAL",
+          "artists": [
+            {
+              "name": "BTS"
+            }
+          ],
+          "album": {
+            "name": "ARIRANG",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 181649,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dfa17fad7f190c901603270e"
+        },
+        {
+          "position": 23,
+          "id": "levyra-757f3521fcd7ef6dce5e",
+          "title": "id 072019",
+          "artists": [
+            {
+              "name": "W/N"
+            }
+          ],
+          "album": {
+            "name": "id 072019",
+            "releaseDate": "2023-07-31"
+          },
+          "durationMs": 271704,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "GheFGLpNh44",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCx8-BfCPgvsE8rAVlzpJTFQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dc031e2429585e32b4ccb69b"
+        },
+        {
+          "position": 24,
+          "id": "levyra-fc9c28ab3f3f8b475e42",
+          "title": "Chuyện Đôi Ta (feat. Muộii)",
+          "artists": [
+            {
+              "name": "Emcee L (Da LAB)"
+            },
+            {
+              "name": "Da LAB"
+            },
+            {
+              "name": "Muộii (Starry Night)"
+            }
+          ],
+          "album": {
+            "name": "Chuyện Đôi Ta (feat. Muộii)",
+            "releaseDate": "2021-12-01"
+          },
+          "durationMs": 208048,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a400211178f6d590d875f2da"
+        },
+        {
+          "position": 25,
+          "id": "levyra-af97a15ccc3de093ec5c",
+          "title": "50 CUỘC GỌI NHỠ (feat. CoolKid, Quang Hùng MasterD, Jaysonlei & CODYNAMVO)",
+          "artists": [
+            {
+              "name": "TINH HÀ \"SAY HI\""
+            },
+            {
+              "name": "CoolKid"
+            },
+            {
+              "name": "Quang Hùng MasterD"
+            },
+            {
+              "name": "Jaysonlei"
+            },
+            {
+              "name": "CODYNAMVO"
+            }
+          ],
+          "album": {
+            "name": "TINH HÀ \"SAY HI\", TẬP 2",
+            "releaseDate": "2026-07-11"
+          },
+          "durationMs": 240000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c823e4437a4a00db2855f94b"
+        },
+        {
+          "position": 26,
+          "id": "levyra-04de3738158a7a90ba68",
+          "title": "Vết Mưa",
+          "artists": [
+            {
+              "name": "VCT"
+            }
+          ],
+          "album": {
+            "name": "Giải Mã",
+            "releaseDate": "2014-01-01"
+          },
+          "durationMs": 210067,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "FpL-aKcV940",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCRR908cRMgRkekWQXpk31sA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024992bf290fe8c9f82a0e66e4"
+        },
+        {
+          "position": 27,
+          "id": "levyra-ce8dc78454e9222ad5a2",
+          "title": "bình yên",
+          "artists": [
+            {
+              "name": "Vũ."
+            },
+            {
+              "name": "Binz"
+            }
+          ],
+          "album": {
+            "name": "Bảo Tàng Của Nuối Tiếc",
+            "releaseDate": "2024-09-27"
+          },
+          "durationMs": 195974,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "PkgYe-QMXIo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCtmovuboAb2Yi_bD0wqLP0Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026f76636916ae7d5d930b1656"
+        },
+        {
+          "position": 28,
+          "id": "levyra-ef8f92607f0a0a22b439",
+          "title": "chẳng phải tình đầu sao đau đến thế",
+          "artists": [
+            {
+              "name": "MIN"
+            },
+            {
+              "name": "Dangrangto"
+            },
+            {
+              "name": "antransax"
+            }
+          ],
+          "album": {
+            "name": "Dear Min",
+            "releaseDate": "2025-10-22"
+          },
+          "durationMs": 283333,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "nGa6UaPxQ_w",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCxz2csaZmtzHCW_HLKXgJ-g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e1b3669f2b8eba5bb7b10b3b"
+        },
+        {
+          "position": 29,
+          "id": "levyra-e2053fbbfe629c69b6ff",
+          "title": "Âm Thầm Bên Em",
+          "artists": [
+            {
+              "name": "Sơn Tùng M-TP"
+            }
+          ],
+          "album": {
+            "name": "m-tp M-TP",
+            "releaseDate": "2017-04-01"
+          },
+          "durationMs": 293112,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "cnHHCR7EW10",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC3muIvzjhubNpJ4Pn_0kCQw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02794744c57c9f35db88249842"
+        },
+        {
+          "position": 30,
+          "id": "levyra-355fe94958ba1e27cb8a",
+          "title": "2AM",
+          "artists": [
+            {
+              "name": "JustaTee"
+            },
+            {
+              "name": "BigDaddy"
+            }
+          ],
+          "album": {
+            "name": "2AM",
+            "releaseDate": "2022-05-10"
+          },
+          "durationMs": 258281,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lz3v23n_pzo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCz3Q1vuUWCX5aFide-RS-qA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020b97a73cab024885e9819a9e"
+        },
+        {
+          "position": 31,
+          "id": "levyra-6e21e7beaff2c17931cd",
+          "title": "Đã Lỡ Yêu Em Nhiều",
+          "artists": [
+            {
+              "name": "JustaTee"
+            }
+          ],
+          "album": {
+            "name": "Đã Lỡ Yêu Em Nhiều",
+            "releaseDate": "2022-07-11"
+          },
+          "durationMs": 261105,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Pc1CD6sDuPc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCz3Q1vuUWCX5aFide-RS-qA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02636bd3e9f31e1ea1e7bb389e"
+        },
+        {
+          "position": 32,
+          "id": "levyra-c8e18777cc73f8549b4a",
+          "title": "Thằng Điên",
+          "artists": [
+            {
+              "name": "JustaTee"
+            },
+            {
+              "name": "Phương Ly"
+            }
+          ],
+          "album": {
+            "name": "Thằng Điên",
+            "releaseDate": "2022-07-11"
+          },
+          "durationMs": 234000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0202dc41ad81138aa3c53d2b98"
+        },
+        {
+          "position": 33,
+          "id": "levyra-fc8126aa338e63030c17",
+          "title": "Dạo Này",
+          "artists": [
+            {
+              "name": "Obito"
+            }
+          ],
+          "album": {
+            "name": "Dạo Này",
+            "releaseDate": "2025-12-24"
+          },
+          "durationMs": 284288,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "HkqQyXFp5jk",
+            "audioConfidence": 100,
+            "videoId": "Bb5Qb7ziIig",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCibICXbasq8ego6sGoKGAVA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025ec4c60ff0fc01236d2653b0"
+        },
+        {
+          "position": 34,
+          "id": "levyra-bb9e5eaa2f89ed1abe95",
+          "title": "Bạn Đời",
+          "artists": [
+            {
+              "name": "Karik"
+            },
+            {
+              "name": "GDucky"
+            }
+          ],
+          "album": {
+            "name": "421",
+            "releaseDate": "2024-07-11"
+          },
+          "durationMs": 306477,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "gfCpgk6IOqs",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCkfDU6zGNelhdPjGgxCV41A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b37fa6ada1fe1a79194db5a0"
+        },
+        {
+          "position": 35,
+          "id": "levyra-e22aff5602b573207e7c",
+          "title": "Nguyễn Văn Mười",
+          "artists": [
+            {
+              "name": "RPT MCK"
+            }
+          ],
+          "album": {
+            "name": "HVL",
+            "releaseDate": "2026-06-17"
+          },
+          "durationMs": 242144,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "6tPO2QrCeIw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCDRWYq4se6zr4MCLBorlVZg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a2907cc0804151b77ca8667d"
+        },
+        {
+          "position": 36,
+          "id": "levyra-c5eb8a7671b5eb7d538d",
+          "title": "một đời",
+          "artists": [
+            {
+              "name": "14 Casper"
+            },
+            {
+              "name": "Bon Nghiêm"
+            },
+            {
+              "name": "buitruonglinh"
+            }
+          ],
+          "album": {
+            "name": "SỐ KHÔNG",
+            "releaseDate": "2023-03-03"
+          },
+          "durationMs": 328240,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0270cb943c9a67b7eda3414366"
+        },
+        {
+          "position": 37,
+          "id": "levyra-232618b9d312fec3b63a",
+          "title": "Có Em",
+          "artists": [
+            {
+              "name": "Madihu"
+            },
+            {
+              "name": "Low G"
+            }
+          ],
+          "album": {
+            "name": "Có em",
+            "releaseDate": "2022-04-22"
+          },
+          "durationMs": 218512,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "8BVsIRMG7GI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCL1WryAjTA3pNwsWuUqxT-A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02556e7b75fb148c696f99a709"
+        },
+        {
+          "position": 38,
+          "id": "levyra-eb4caf463e72adde87f6",
+          "title": "Mắt Môi Tay Chân (feat. Tage)",
+          "artists": [
+            {
+              "name": "RPT MCK"
+            },
+            {
+              "name": "Tage"
+            }
+          ],
+          "album": {
+            "name": "HVL",
+            "releaseDate": "2026-06-17"
+          },
+          "durationMs": 192485,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "6Dt9ch2UJ8M",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCDRWYq4se6zr4MCLBorlVZg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a2907cc0804151b77ca8667d"
+        },
+        {
+          "position": 39,
+          "id": "levyra-487efcd866d65d2d29f4",
+          "title": "Tình Mình Lạ Kì",
+          "artists": [
+            {
+              "name": "Lil Zpoet"
+            }
+          ],
+          "album": {
+            "name": "Tình Mình Lạ Kì",
+            "releaseDate": "2021-07-11"
+          },
+          "durationMs": 300750,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02921051f4f50a3d20946afb16"
+        },
+        {
+          "position": 40,
+          "id": "levyra-06a76e5421576082d89e",
+          "title": "Nắng có mang em về",
+          "artists": [
+            {
+              "name": "Shartnuss"
+            },
+            {
+              "name": "Phankeo"
+            },
+            {
+              "name": "Tr.D"
+            }
+          ],
+          "album": {
+            "name": "Luv",
+            "releaseDate": "2023-10-21"
+          },
+          "durationMs": 254304,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "nnJNidtX5fE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCKIUnMQUGyejxcF8Jn2Zu7w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029e8842387d1017cf5581c4cc"
+        },
+        {
+          "position": 41,
+          "id": "levyra-4a8f3d180ce3d0b76564",
+          "title": "Earrings",
+          "artists": [
+            {
+              "name": "Malcolm Todd"
+            }
+          ],
+          "album": {
+            "name": "Sweet Boy",
+            "releaseDate": "2024-04-05"
+          },
+          "durationMs": 151500,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "BI9HQCzpDgQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCRLE_fwmN2CQw1vuWPwo6eA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022c1f34ecc1929fb59908aad1"
+        },
+        {
+          "position": 42,
+          "id": "levyra-f994421003d079d2ef87",
+          "title": "vaicaunoicokhiennguoithaydoi",
+          "artists": [
+            {
+              "name": "GREY D"
+            },
+            {
+              "name": "tlinh"
+            }
+          ],
+          "album": {
+            "name": "vaicaunoicokhiennguoithaydoi",
+            "releaseDate": "2022-06-20"
+          },
+          "durationMs": 225862,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0294df376aa7f0890380ea4688"
+        },
+        {
+          "position": 43,
+          "id": "levyra-9670a9300e0627c82f5a",
+          "title": "Sinh Ra Đã Là Thứ Đối Lập Nhau (feat. Badbies)",
+          "artists": [
+            {
+              "name": "Emcee L (Da LAB)"
+            },
+            {
+              "name": "Da LAB"
+            },
+            {
+              "name": "Badbies"
+            }
+          ],
+          "album": {
+            "name": "Sinh Ra Đã Là Thứ Đối Lập Nhau (feat. Badbies)",
+            "releaseDate": "2020-12-29"
+          },
+          "durationMs": 234168,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "5q906vfrzyY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCjhtSjcSCUWbfFAWrp8Ow6w"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d6ebd978c7c460eaf3f75f85"
+        },
+        {
+          "position": 44,
+          "id": "levyra-dcd2f89649b4ef04f9bf",
+          "title": "Không Thể Say",
+          "artists": [
+            {
+              "name": "HIEUTHUHAI"
+            }
+          ],
+          "album": {
+            "name": "Ai Cũng Phải Bắt Đầu Từ Đâu Đó",
+            "releaseDate": "2023-10-16"
+          },
+          "durationMs": 228413,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "r96eaATJWW8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC-FbBvrUwI1CmCnurnJlc6Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c006b0181a3846c1c63e178f"
+        },
+        {
+          "position": 45,
+          "id": "levyra-2458cfe7577bf71d8ad9",
+          "title": "NỢ EM CẢ BẦU TRỜI",
+          "artists": [
+            {
+              "name": "Anh Trai Vượt Ngàn Chông Gai"
+            },
+            {
+              "name": "THỎ (Da LAB)"
+            },
+            {
+              "name": "Hoàng Tôn"
+            },
+            {
+              "name": "Osad"
+            },
+            {
+              "name": "Hồ Đông Quan"
+            },
+            {
+              "name": "Hà An Huy"
+            }
+          ],
+          "album": {
+            "name": "CÔNG DIỄN 1 (Anh Trai Vượt Ngàn Chông Gai 2026)",
+            "releaseDate": "2026-07-25"
+          },
+          "durationMs": 305852,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022970a90780d33bc31f885bd3"
+        },
+        {
+          "position": 46,
+          "id": "levyra-1e1037373c18114574cd",
+          "title": "Ai Ngoài Anh",
+          "artists": [
+            {
+              "name": "VSTRA"
+            },
+            {
+              "name": "Tyronee"
+            }
+          ],
+          "album": {
+            "name": "Triệu (Phase 1 of 3)",
+            "releaseDate": "2025-12-20"
+          },
+          "durationMs": 199000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "5atn7vD-1OQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCxsmbg2r2RMDuimB1zHuWWw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021e3ae4d328b0937f13e52c9f"
+        },
+        {
+          "position": 47,
+          "id": "levyra-700260dd752512bb9821",
+          "title": "ex's hate me, Pt.2",
+          "artists": [
+            {
+              "name": "AMEE"
+            }
+          ],
+          "album": {
+            "name": "dreaAMEE",
+            "releaseDate": "2020-06-20"
+          },
+          "durationMs": 216500,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "L7py6QJyERE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7zM1_Wnhl75Hh_SPa1DuRw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02819219f4ea0ad1e11cb78411"
+        },
+        {
+          "position": 48,
+          "id": "levyra-22648abc2ff62e105ada",
+          "title": "Less than a Lover",
+          "artists": [
+            {
+              "name": "JENNIE"
+            }
+          ],
+          "album": {
+            "name": "Less than a Lover",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 145680,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021568796289f10031724bc780"
+        },
+        {
+          "position": 49,
+          "id": "levyra-915769fea25774a56c46",
+          "title": "Wrong Times",
+          "artists": [
+            {
+              "name": "Puppy"
+            },
+            {
+              "name": "Dangrangto"
+            }
+          ],
+          "album": {
+            "name": "Wrong Times",
+            "releaseDate": "2023"
+          },
+          "durationMs": 211200,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "ZWut57wYBd8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCx8yA865hC060Ju99sB-q7Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02566178ff844ca2b57f959374"
+        },
+        {
+          "position": 50,
+          "id": "levyra-aa8ef7e118c2f6a12ecf",
+          "title": "nếu lúc đó",
+          "artists": [
+            {
+              "name": "tlinh"
+            },
+            {
+              "name": "2Pillz"
+            }
+          ],
+          "album": {
+            "name": "ái",
+            "releaseDate": "2023-08-16"
+          },
+          "durationMs": 263752,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "27Q74nknDyk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC1sk5IAQQC3B5fK8CJznIpQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02484c56addba0e4dad8be48c9"
+        }
+      ]
+    },
+    {
+      "id": "top-50-th",
+      "kind": "chart",
+      "market": "TH",
+      "title": "Top 50 ประเทศไทย",
+      "description": "Thailandia: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-b9b109db4fd567de0eea",
+          "title": "SWIM",
+          "artists": [
+            {
+              "name": "BTS"
+            }
+          ],
+          "album": {
+            "name": "ARIRANG",
+            "releaseDate": "2026-03-20"
+          },
+          "durationMs": 159007,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qZTVU04UOO4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC9vrvNSL3xcWGSkV86REBSg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dfa17fad7f190c901603270e"
+        },
+        {
+          "position": 2,
+          "id": "levyra-c7026031fce15256caf6",
+          "title": "If You Don’t Mean It (ถ้าไม่คิด อย่าทำให้คิด)",
+          "artists": [
+            {
+              "name": "TEN"
+            }
+          ],
+          "album": {
+            "name": "If You Don’t Mean It (ถ้าไม่คิด อย่าทำให้คิด)",
+            "releaseDate": "2026-07-27"
+          },
+          "durationMs": 232534,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "3Nm6MINXVks",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCJOXMxI99o8azJ_uV7qEZdA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c28e386522dea30cf757654c"
+        },
+        {
+          "position": 3,
+          "id": "levyra-3c778f6a5f97adf42119",
+          "title": "เมื่อไหร่จะมี (มีใจให้กัน)",
+          "artists": [
+            {
+              "name": "BLVCKHEART"
+            }
+          ],
+          "album": {
+            "name": "เมื่อไหร่จะมี (มีใจให้กัน)",
+            "releaseDate": "2026-05-06"
+          },
+          "durationMs": 214883,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "WmlGzY1iWAc",
+            "audioConfidence": 100,
+            "videoId": "HTjkVCSsKv8",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCz8kusd-P42WEfu71ObB-aw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02867017bcc32c6a32fa7d94b3"
+        },
+        {
+          "position": 4,
+          "id": "levyra-b8c1b2637270b6e060b1",
+          "title": "นาฬิกาทราย (sign)",
+          "artists": [
+            {
+              "name": "BOWKYLION"
+            }
+          ],
+          "album": {
+            "name": "นาฬิกาทราย (sign)",
+            "releaseDate": "2026-07-06"
+          },
+          "durationMs": 255466,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "kqgrMG2st7s",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCH37fMa51kuvqaHjQyPUbQw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02730b2376db7c593147c5f870"
+        },
+        {
+          "position": 5,
+          "id": "levyra-3e4d7313624ac122a3d2",
+          "title": "ขึ้นใจ (3am call)",
+          "artists": [
+            {
+              "name": "Mirrr"
+            },
+            {
+              "name": "BLVCKHEART"
+            }
+          ],
+          "album": {
+            "name": "ขึ้นใจ (3am call)",
+            "releaseDate": "2026-07-23"
+          },
+          "durationMs": 261785,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c94c223bcd576d2ca2c02a6e"
+        },
+        {
+          "position": 6,
+          "id": "levyra-d8186c988f8a586d9177",
+          "title": "ขี้แง (Boys Don't Cry)",
+          "artists": [
+            {
+              "name": "PROXIE"
+            }
+          ],
+          "album": {
+            "name": "ขี้แง (Boys Don't Cry)",
+            "releaseDate": "2026-06-18"
+          },
+          "durationMs": 255000,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "D0fXmn2KewI",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCXgJrYoy796xjr7sYHhX01g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02eb508df0affe01b473e70300"
+        },
+        {
+          "position": 7,
+          "id": "levyra-629b6547f2be7c22df28",
+          "title": "Living Death",
+          "artists": [
+            {
+              "name": "PUN"
+            }
+          ],
+          "album": {
+            "name": "Living Death",
+            "releaseDate": "2025-04-24"
+          },
+          "durationMs": 258823,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02fa0eba8392217e6b1d061791"
+        },
+        {
+          "position": 8,
+          "id": "levyra-1bdee5fd99ca9689b0d6",
+          "title": "กลัวว่าฉันจะไม่เสียใจ (Fear)",
+          "artists": [
+            {
+              "name": "PURPEECH"
+            }
+          ],
+          "album": {
+            "name": "กลัวว่าฉันจะไม่เสียใจ (Fear)",
+            "releaseDate": "2025-04-09"
+          },
+          "durationMs": 287000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "gkHr6A_d2Qc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC36-XFRzxOhgi3DCk8Kz2Ug"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d40ab8c072495fa960817cdd"
+        },
+        {
+          "position": 9,
+          "id": "levyra-e7f10a934b604ba0ccb2",
+          "title": "ดาวตก (Wish) [feat. Z9]",
+          "artists": [
+            {
+              "name": "WANYAi"
+            },
+            {
+              "name": "Z9"
+            }
+          ],
+          "album": {
+            "name": "ดาวตก (Wish) [feat. Z9]",
+            "releaseDate": "2025-10-01"
+          },
+          "durationMs": 241250,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "YFTkUkfaxbU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCwgobGDBV3jvJMzGk5S4xdw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b82d5332a7a169def634827f"
+        },
+        {
+          "position": 10,
+          "id": "levyra-d1b593b4c6af14e7f30f",
+          "title": "คืนจันทร์",
+          "artists": [
+            {
+              "name": "Loso"
+            }
+          ],
+          "album": {
+            "name": "Rock & Roll",
+            "releaseDate": "1999-10-07"
+          },
+          "durationMs": 235946,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021b26cfd1418671d9131c3634"
+        },
+        {
+          "position": 11,
+          "id": "levyra-0e745b506c401ccb0fa7",
+          "title": "ได้แค่เดินมาส่ง (The Last Walk)",
+          "artists": [
+            {
+              "name": "GAVIN:D"
+            },
+            {
+              "name": "BLVCKHEART"
+            }
+          ],
+          "album": {
+            "name": "ROOM101",
+            "releaseDate": "2026-03-12"
+          },
+          "durationMs": 227785,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dff3f8fad5c3c0a439f14547"
+        },
+        {
+          "position": 12,
+          "id": "levyra-954c0b2b98cf4ff3e1cc",
+          "title": "รักให้เธอได้รู้ (Proof.)",
+          "artists": [
+            {
+              "name": "PUN"
+            }
+          ],
+          "album": {
+            "name": "รักให้เธอได้รู้ (Proof.)",
+            "releaseDate": "2026-04-23"
+          },
+          "durationMs": 202105,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "TPfaQ2-MgO0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC_FFKwisPiEXk5EH_ipTHcA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02aa8d481dd7dc1824b900dd67"
+        },
+        {
+          "position": 13,
+          "id": "levyra-6bb9173ffd342384230a",
+          "title": "รักมือสอง",
+          "artists": [
+            {
+              "name": "Bedroom Audio"
+            }
+          ],
+          "album": {
+            "name": "Album",
+            "releaseDate": "2021-09-10"
+          },
+          "durationMs": 200170,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c4437eb590c34989f940374d"
+        },
+        {
+          "position": 14,
+          "id": "levyra-87c93543b9893107d1a8",
+          "title": "กลัวความเสียใจ",
+          "artists": [
+            {
+              "name": "Saran"
+            },
+            {
+              "name": "Pearpilincys"
+            }
+          ],
+          "album": {
+            "name": "กลัวความเสียใจ",
+            "releaseDate": "2025-12-12"
+          },
+          "durationMs": 291000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028cef18173b59380b5129b23c"
+        },
+        {
+          "position": 15,
+          "id": "levyra-996792f555572efe808f",
+          "title": "Winter Ahead (with PARK HYO SHIN)",
+          "artists": [
+            {
+              "name": "V"
+            },
+            {
+              "name": "Park Hyo Shin"
+            }
+          ],
+          "album": {
+            "name": "Winter Ahead (with PARK HYO SHIN)",
+            "releaseDate": "2024-11-29"
+          },
+          "durationMs": 234895,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0216ba2a3622bd0d0d985e3234"
+        },
+        {
+          "position": 16,
+          "id": "levyra-5c8dcef69617918920bd",
+          "title": "รักมักยาก (Lover Loser)",
+          "artists": [
+            {
+              "name": "BUS"
+            }
+          ],
+          "album": {
+            "name": "รักมักยาก (Lover Loser)",
+            "releaseDate": "2026-07-08"
+          },
+          "durationMs": 253764,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "utYweBJoQe0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UChsjnej-sOxXgK3ndMSadTw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028c6014e2a87c000ad1de4234"
+        },
+        {
+          "position": 17,
+          "id": "levyra-ce9fc109d2c6633b0f55",
+          "title": "คำยินดี",
+          "artists": [
+            {
+              "name": "KLEAR"
+            }
+          ],
+          "album": {
+            "name": "The Storyteller",
+            "releaseDate": "2012-05-17"
+          },
+          "durationMs": 266813,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e44a6c1b09844f232da0872b"
+        },
+        {
+          "position": 18,
+          "id": "levyra-482a49fed0e66560c803",
+          "title": "FRI(END)S",
+          "artists": [
+            {
+              "name": "V"
+            }
+          ],
+          "album": {
+            "name": "FRI(END)S",
+            "releaseDate": "2024-03-15"
+          },
+          "durationMs": 148082,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "HDMRTsPgSDU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCFqldK305KOVQXbAIGi-flg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02377ee031d0a3da40db19ccf4"
+        },
+        {
+          "position": 19,
+          "id": "levyra-09283a8fa7ad450e0338",
+          "title": "ขอแค่นี้ (Forever n ever)",
+          "artists": [
+            {
+              "name": "PUN"
+            }
+          ],
+          "album": {
+            "name": "While I'm away",
+            "releaseDate": "2026-06-11"
+          },
+          "durationMs": 219047,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "y-MdBVdMg7o",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC_FFKwisPiEXk5EH_ipTHcA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02556a0b3b538f6d7cf5a5b057"
+        },
+        {
+          "position": 20,
+          "id": "levyra-296e30ade67693f00441",
+          "title": "ความรัก",
+          "artists": [
+            {
+              "name": "Bodyslam"
+            }
+          ],
+          "album": {
+            "name": "คราม",
+            "releaseDate": "2010-08-12"
+          },
+          "durationMs": 291557,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029a7514703bbd3b230399d942"
+        },
+        {
+          "position": 21,
+          "id": "levyra-2223c4c8d3ec3052be98",
+          "title": "กอดไม่ได้",
+          "artists": [
+            {
+              "name": "Bedroom Audio"
+            }
+          ],
+          "album": {
+            "name": "2014 Extended Play",
+            "releaseDate": "2014-01-01"
+          },
+          "durationMs": 286191,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02420440a036c4a1a64e7eb421"
+        },
+        {
+          "position": 22,
+          "id": "levyra-b097d6b07ca3d27c479a",
+          "title": "จากกันโดยสมบูรณ์",
+          "artists": [
+            {
+              "name": "guncharlie"
+            }
+          ],
+          "album": {
+            "name": "Like You Never Left",
+            "releaseDate": "2025-07-01"
+          },
+          "durationMs": 206416,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02afbae55931618ecd661b6db0"
+        },
+        {
+          "position": 23,
+          "id": "levyra-d3f44e92742a6a5cefa9",
+          "title": "อยากจะกอดเธอนาน ๆ (HAVE A GOOD TIME)",
+          "artists": [
+            {
+              "name": "BLVCKHEART"
+            }
+          ],
+          "album": {
+            "name": "อยากจะกอดเธอนาน ๆ (HAVE A GOOD TIME)",
+            "releaseDate": "2025-05-16"
+          },
+          "durationMs": 219428,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "mhnsWEJlE3s",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCz8kusd-P42WEfu71ObB-aw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02dc679b969c81ebc604b1e7da"
+        },
+        {
+          "position": 24,
+          "id": "levyra-168758e63a77d5010f5c",
+          "title": "ที่คั่นหนังสือ (Sometimes)",
+          "artists": [
+            {
+              "name": "BOWKYLION"
+            },
+            {
+              "name": "NONT TANONT"
+            }
+          ],
+          "album": {
+            "name": "ที่คั่นหนังสือ (Sometimes)",
+            "releaseDate": "2025-04-25"
+          },
+          "durationMs": 292500,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0293078ffbe895d3504ccd9881"
+        },
+        {
+          "position": 25,
+          "id": "levyra-4a8f3d180ce3d0b76564",
+          "title": "Earrings",
+          "artists": [
+            {
+              "name": "Malcolm Todd"
+            }
+          ],
+          "album": {
+            "name": "Sweet Boy",
+            "releaseDate": "2024-04-05"
+          },
+          "durationMs": 151500,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "BI9HQCzpDgQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCRLE_fwmN2CQw1vuWPwo6eA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022c1f34ecc1929fb59908aad1"
+        },
+        {
+          "position": 26,
+          "id": "levyra-1c5c7105e82df9b8e4a5",
+          "title": "9 นาฬิกา",
+          "artists": [
+            {
+              "name": "SPF"
+            }
+          ],
+          "album": {
+            "name": "9 นาฬิกา",
+            "releaseDate": "2015-05-11"
+          },
+          "durationMs": 242181,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025fed9088f057bcec9ef9f25a"
+        },
+        {
+          "position": 27,
+          "id": "levyra-93683240d111e7825d3f",
+          "title": "hate that i made you love me",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 197949,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7CUz7Ec7cWc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 28,
+          "id": "levyra-a209a54b1dab1fa15078",
+          "title": "Rain Zone",
+          "artists": [
+            {
+              "name": "Maiyarap"
+            },
+            {
+              "name": "Z9"
+            }
+          ],
+          "album": {
+            "name": "Rain Zone",
+            "releaseDate": "2026-02-05"
+          },
+          "durationMs": 185210,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0290518e881786f10df122a475"
+        },
+        {
+          "position": 29,
+          "id": "levyra-fc1af818e8d8c1f1b69f",
+          "title": "สายไป",
+          "artists": [
+            {
+              "name": "9tokyo"
+            },
+            {
+              "name": "BLVCKHEART"
+            }
+          ],
+          "album": {
+            "name": "สายไป",
+            "releaseDate": "2025-05-24"
+          },
+          "durationMs": 198461,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "S_-DiJ3CPSc",
+            "audioConfidence": 100,
+            "videoId": "DXvtelMvUy8",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCi20r6dnEOtYLThuIKwHicw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02904c18125aeb753e3aeb8d87"
+        },
+        {
+          "position": 30,
+          "id": "levyra-ea162aa8b252ac95f59e",
+          "title": "ลบไม่ได้ช่วยให้ลืม (LIVE SESSION)",
+          "artists": [
+            {
+              "name": "BILLKIN"
+            },
+            {
+              "name": "Ink Waruntorn"
+            }
+          ],
+          "album": {
+            "name": "ลบไม่ได้ช่วยให้ลืม (LIVE SESSION)",
+            "releaseDate": "2021-03-05"
+          },
+          "durationMs": 276315,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "pKZ1sraf-Eo",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCTKJyum8atjrmRTi5OXxTyw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ba88f47523d8dfe21480e45e"
+        },
+        {
+          "position": 31,
+          "id": "levyra-f2106b030370f3bc3369",
+          "title": "เจิดจรัส",
+          "artists": [
+            {
+              "name": "YOUNGOHM"
+            }
+          ],
+          "album": {
+            "name": "ไฟกลางคืน",
+            "releaseDate": "2025-10-25"
+          },
+          "durationMs": 261948,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0289010986807175896f24855e"
+        },
+        {
+          "position": 32,
+          "id": "levyra-1bef340ed7aca636c9e9",
+          "title": "รู้ตัวอีกที",
+          "artists": [
+            {
+              "name": "Sexski"
+            },
+            {
+              "name": "2T FLOW"
+            }
+          ],
+          "album": {
+            "name": "รู้ตัวอีกที",
+            "releaseDate": "2025-12-28"
+          },
+          "durationMs": 190476,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ee931143f33a710ca40c3236"
+        },
+        {
+          "position": 33,
+          "id": "levyra-fd3562e9cee03650345d",
+          "title": "ที่เดิม",
+          "artists": [
+            {
+              "name": "PUN"
+            }
+          ],
+          "album": {
+            "name": "PUN",
+            "releaseDate": "2024-09-19"
+          },
+          "durationMs": 236062,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "yBV8KpxIlHU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC_FFKwisPiEXk5EH_ipTHcA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cc05ec584ca006c1a29e54f0"
+        },
+        {
+          "position": 34,
+          "id": "levyra-453bbe886662a9ca0270",
+          "title": "ฝากให้เขารัก",
+          "artists": [
+            {
+              "name": "Yes'sir Days"
+            }
+          ],
+          "album": {
+            "name": "ฝากให้เขารัก",
+            "releaseDate": "2025-07-09"
+          },
+          "durationMs": 256946,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b324274fba21a713c650259f"
+        },
+        {
+          "position": 35,
+          "id": "levyra-f5c74842d35ef047f7a0",
+          "title": "บทสรุปสุดท้าย",
+          "artists": [
+            {
+              "name": "Z9"
+            }
+          ],
+          "album": {
+            "name": "บทสรุปสุดท้าย",
+            "releaseDate": "2025-03-22"
+          },
+          "durationMs": 264960,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "JrW1p-UJ9Ag",
+            "audioConfidence": 100,
+            "videoId": "DXvtelMvUy8",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCWBOZt9HgUzjvkrNPdT0aJg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0205c3fb79c77c600a45e9c992"
+        },
+        {
+          "position": 36,
+          "id": "levyra-0821a1182f91664bdf45",
+          "title": "รักใครไม่ไหว",
+          "artists": [
+            {
+              "name": "Three Man Down"
+            }
+          ],
+          "album": {
+            "name": "III",
+            "releaseDate": "2025-06-24"
+          },
+          "durationMs": 250232,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b665b01883c990a870e2a99c"
+        },
+        {
+          "position": 37,
+          "id": "levyra-4ff3ccc27797cfc1fe5d",
+          "title": "ก่อนตาย",
+          "artists": [
+            {
+              "name": "Big Ass"
+            }
+          ],
+          "album": {
+            "name": "XL",
+            "releaseDate": "2015"
+          },
+          "durationMs": 257133,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0252e0c225cf0eb353812294c7"
+        },
+        {
+          "position": 38,
+          "id": "levyra-022bc399bc8748650a43",
+          "title": "ใจบาง",
+          "artists": [
+            {
+              "name": "LUMMUN"
+            }
+          ],
+          "album": {
+            "name": "ใจบาง",
+            "releaseDate": "2025-08-26"
+          },
+          "durationMs": 221049,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "rtfaauniRw0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC10h2Lxjfv1yoQGcruB1L6A"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0270048701303d388430a9977f"
+        },
+        {
+          "position": 39,
+          "id": "levyra-30744aacd7e039c74991",
+          "title": "ใจฉันตามเธอไป",
+          "artists": [
+            {
+              "name": "YOUNGOHM"
+            }
+          ],
+          "album": {
+            "name": "ไฟกลางคืน",
+            "releaseDate": "2025-10-25"
+          },
+          "durationMs": 264000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0289010986807175896f24855e"
+        },
+        {
+          "position": 40,
+          "id": "levyra-284e6fb2dec87d62a592",
+          "title": "ความทรงจำ",
+          "artists": [
+            {
+              "name": "Musketeers"
+            }
+          ],
+          "album": {
+            "name": "Left Right And Something",
+            "releaseDate": "2015-12-16"
+          },
+          "durationMs": 258973,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b0f744fa9ec23266c747a606"
+        },
+        {
+          "position": 41,
+          "id": "levyra-7b5d2778ce8477588bac",
+          "title": "One Of My Life",
+          "artists": [
+            {
+              "name": "BLVCKHEART"
+            },
+            {
+              "name": "K6Y"
+            }
+          ],
+          "album": {
+            "name": "One Of My Life",
+            "releaseDate": "2024-12-16"
+          },
+          "durationMs": 216000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024574863ddb40a0a5c9941ed1"
+        },
+        {
+          "position": 42,
+          "id": "levyra-dd6b5d29212403211490",
+          "title": "DAY ONE",
+          "artists": [
+            {
+              "name": "PUN"
+            }
+          ],
+          "album": {
+            "name": "PUN",
+            "releaseDate": "2024-09-19"
+          },
+          "durationMs": 271500,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "JUlggsOTXvE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC_FFKwisPiEXk5EH_ipTHcA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cc05ec584ca006c1a29e54f0"
+        },
+        {
+          "position": 43,
+          "id": "levyra-22648abc2ff62e105ada",
+          "title": "Less than a Lover",
+          "artists": [
+            {
+              "name": "JENNIE"
+            }
+          ],
+          "album": {
+            "name": "Less than a Lover",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 145680,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021568796289f10031724bc780"
+        },
+        {
+          "position": 44,
+          "id": "levyra-87001d94004b0dba37bc",
+          "title": "ผมมีหัวใจจริงๆ (For The Girl...)",
+          "artists": [
+            {
+              "name": "T!NE"
+            }
+          ],
+          "album": {
+            "name": "ผมมีหัวใจจริงๆ (For The Girl...)",
+            "releaseDate": "2026-04-03"
+          },
+          "durationMs": 211066,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "OO2ENHdR-O8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCAYHnoXfxEc0WpkIJoOFlsQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0260f235eab5f77c9176c0715d"
+        },
+        {
+          "position": 45,
+          "id": "levyra-07e746d817e2d9ca6eba",
+          "title": "PLEASE",
+          "artists": [
+            {
+              "name": "atom chanakan"
+            }
+          ],
+          "album": {
+            "name": "CYANTIST",
+            "releaseDate": "2017-12-07"
+          },
+          "durationMs": 284583,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0225d799cdc59ad352e6d7e7ae"
+        },
+        {
+          "position": 46,
+          "id": "levyra-4d9557adc905eb9d6bb4",
+          "title": "สาธุ (Sathu) [feat. ปลาย กนกพร]",
+          "artists": [
+            {
+              "name": "ASIA7"
+            },
+            {
+              "name": "ปลาย กนกพร"
+            }
+          ],
+          "album": {
+            "name": "DEEPMIND",
+            "releaseDate": "2025-09-02"
+          },
+          "durationMs": 218400,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b563a468b0dde8b8fbecdc2a"
+        },
+        {
+          "position": 47,
+          "id": "levyra-1001b1d184079bf5f3ba",
+          "title": "ซาโยนาระ",
+          "artists": [
+            {
+              "name": "Mild"
+            }
+          ],
+          "album": {
+            "name": "MI4D",
+            "releaseDate": "2018-09-14"
+          },
+          "durationMs": 293500,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028e104724f24489a06887b626"
+        },
+        {
+          "position": 48,
+          "id": "levyra-682f17ccaf0e525015ec",
+          "title": "เมื่อถูกค้นพบ (Finally She Found.)",
+          "artists": [
+            {
+              "name": "FREEHAND"
+            }
+          ],
+          "album": {
+            "name": "เมื่อถูกค้นพบ (Finally She Found.)",
+            "releaseDate": "2026-05-06"
+          },
+          "durationMs": 239770,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "KQQ5YszMNfc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCnsvZoTQmhrVwal5PKZpbQA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c57a351eb9777e70862c2b9a"
+        },
+        {
+          "position": 49,
+          "id": "levyra-72b2520a3b38bc47ad5a",
+          "title": "Who",
+          "artists": [
+            {
+              "name": "Jimin"
+            }
+          ],
+          "album": {
+            "name": "MUSE",
+            "releaseDate": "2024-07-19"
+          },
+          "durationMs": 170887,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "sEcvQvftOQY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCE6l2NHQkpgF_P96isfOu4Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f02c451189a709b9a952aaec"
+        },
+        {
+          "position": 50,
+          "id": "levyra-327940993f9ba0496a20",
+          "title": "ไกล",
+          "artists": [
+            {
+              "name": "Musketeers"
+            }
+          ],
+          "album": {
+            "name": "Left Right And Something",
+            "releaseDate": "2015-12-16"
+          },
+          "durationMs": 273493,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b0f744fa9ec23266c747a606"
+        }
+      ]
+    },
+    {
+      "id": "top-50-ph",
+      "kind": "chart",
+      "market": "PH",
+      "title": "Top 50 Pilipinas",
+      "description": "Filippine: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-c896143ac631ed22f037",
+          "title": "Kalapastangan",
+          "artists": [
+            {
+              "name": "fitterkarma"
+            }
+          ],
+          "album": {
+            "name": "Kalapastangan",
+            "releaseDate": "2023-11-24"
+          },
+          "durationMs": 276000,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "FpJxPzveHzA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCVZoM1H-jFwni_C4nogarjw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0201cb2e736602194466522135"
+        },
+        {
+          "position": 2,
+          "id": "levyra-c8e16bd57117ee27c4a1",
+          "title": "Panaginip",
+          "artists": [
+            {
+              "name": "nicole"
+            }
+          ],
+          "album": {
+            "name": "Panaginip",
+            "releaseDate": "2025-05-10"
+          },
+          "durationMs": 317077,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "tHJyXh5z1A8",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCKJOobV0GEsdFnP2DneFWYg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b24fad04acb0e57d8042ca26"
+        },
+        {
+          "position": 3,
+          "id": "levyra-82f2f6177c97ebf30571",
+          "title": "Libu-Libong Buwan (Uuwian)",
+          "artists": [
+            {
+              "name": "Kyle Raphael"
+            }
+          ],
+          "album": {
+            "name": "Libu-Libong Buwan (Uuwian)",
+            "releaseDate": "2025-08-22"
+          },
+          "durationMs": 178488,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lJZaI_SQPK4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCjMQnOnjslv-aCgREphr8Mw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0271784b412d5d984fb1cfd880"
+        },
+        {
+          "position": 4,
+          "id": "levyra-b6dd3ab3dee066e8af5e",
+          "title": "Pag-Ibig ay Kanibalismo II",
+          "artists": [
+            {
+              "name": "fitterkarma"
+            }
+          ],
+          "album": {
+            "name": "Pag-Ibig ay Kanibalismo II",
+            "releaseDate": "2025-02-14"
+          },
+          "durationMs": 207314,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "cb9gPI11ZL0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCVZoM1H-jFwni_C4nogarjw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02796442914fd83d47da3242a9"
+        },
+        {
+          "position": 5,
+          "id": "levyra-4acfb9d8b8b98a89e87d",
+          "title": "Since Day One",
+          "artists": [
+            {
+              "name": "Skusta Clee"
+            },
+            {
+              "name": "Flow G"
+            }
+          ],
+          "album": {
+            "name": "Since Day One",
+            "releaseDate": "2026-02-01"
+          },
+          "durationMs": 191375,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02fcf257c309992480a08120c6"
+        },
+        {
+          "position": 6,
+          "id": "levyra-93683240d111e7825d3f",
+          "title": "hate that i made you love me",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 197949,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7CUz7Ec7cWc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 7,
+          "id": "levyra-b57f355fbe936134b142",
+          "title": "Kabisado",
+          "artists": [
+            {
+              "name": "IV OF SPADES"
+            }
+          ],
+          "album": {
+            "name": "Andalucia",
+            "releaseDate": "2025-11-05"
+          },
+          "durationMs": 207920,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "D0k3n4ugaX0",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCDXTJp6GlR2jDTy_M09ym3Q"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0214708b669227cf0b2c458946"
+        },
+        {
+          "position": 8,
+          "id": "levyra-6fbd2e88f9a9717e85ba",
+          "title": "Multo",
+          "artists": [
+            {
+              "name": "Cup of Joe"
+            }
+          ],
+          "album": {
+            "name": "Silakbo",
+            "releaseDate": "2025-01-17"
+          },
+          "durationMs": 237692,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "2cL2LkST4a4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCgz-JXAkpKjIli7OTg_QM5g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0285a7fd707d00e5d255807add"
+        },
+        {
+          "position": 9,
+          "id": "levyra-583973de9d68ba755357",
+          "title": "Lifetime (Reimagined)",
+          "artists": [
+            {
+              "name": "Ben&Ben"
+            }
+          ],
+          "album": {
+            "name": "Lifetime (Reimagined)",
+            "releaseDate": "2026-03-31"
+          },
+          "durationMs": 277894,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "dWEvz2tzRuk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCJP1ja0mfMvS5y_3V_PIaiw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029649c1885cfb1052f6637464"
+        },
+        {
+          "position": 10,
+          "id": "levyra-b4f504fa8c526b5a3826",
+          "title": "Isa lang",
+          "artists": [
+            {
+              "name": "Arthur Nery"
+            }
+          ],
+          "album": {
+            "name": "Isa lang",
+            "releaseDate": "2021-12-17"
+          },
+          "durationMs": 269256,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "ZqE0cyZ3ZAs",
+            "audioConfidence": 100,
+            "videoId": "6m-ZuVb1tK4",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCnV3y1lEw750nsOcXhh4nlw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026e17e9e8ed7d466c6d3281fd"
+        },
+        {
+          "position": 11,
+          "id": "levyra-eee106ffa7fa3b6eb4fb",
+          "title": "Halik Sobrang Diin Pt. 2",
+          "artists": [
+            {
+              "name": "Gat Putch"
+            },
+            {
+              "name": "Louie Grammz"
+            },
+            {
+              "name": "Mi'Kel"
+            }
+          ],
+          "album": {
+            "name": "Halik Sobrang Diin Pt. 2",
+            "releaseDate": "2025-10-01"
+          },
+          "durationMs": 213529,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "O8FdYL6zyWk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCQT34JghsmSnkc9apQCQZcA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0212fc73f7a20f65645d538927"
+        },
+        {
+          "position": 12,
+          "id": "levyra-91777c9ec00e13fea045",
+          "title": "Pahintulot",
+          "artists": [
+            {
+              "name": "shirebound"
+            }
+          ],
+          "album": {
+            "name": "For Princesses, By Thieves (O Mga Awit ng Hiraya Para sa Guni-guning Sinta)",
+            "releaseDate": "2019-08-02"
+          },
+          "durationMs": 297508,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "0g7aHsV_zzs",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCbX-jaeXuh0vcX13WgVJclQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0205607a2aa0f351108ff921d9"
+        },
+        {
+          "position": 13,
+          "id": "levyra-6c914f93848f8fb511de",
+          "title": "Tahanan",
+          "artists": [
+            {
+              "name": "El Manu"
+            }
+          ],
+          "album": {
+            "name": "Tahanan",
+            "releaseDate": "2025-11-14"
+          },
+          "durationMs": 195428,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "XoBuaGgV80Y",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC7llhk76kGE6jeB3_FZDjbA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029568b0205dda7e2b8d7465ee"
+        },
+        {
+          "position": 14,
+          "id": "levyra-419823547dad4e1fadc7",
+          "title": "Summer Crush",
+          "artists": [
+            {
+              "name": "HELLMERRY"
+            }
+          ],
+          "album": {
+            "name": "Summer Crush",
+            "releaseDate": "2026-05-23"
+          },
+          "durationMs": 194887,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "YMUsAAwd8GA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCVJJot2WTh-OLjiKpxzU-bw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c3857d4eec0e38b496b06ef8"
+        },
+        {
+          "position": 15,
+          "id": "levyra-e196d9339419cf1fb639",
+          "title": "Mundo",
+          "artists": [
+            {
+              "name": "IV OF SPADES"
+            }
+          ],
+          "album": {
+            "name": "Mundo",
+            "releaseDate": "2018-02-14"
+          },
+          "durationMs": 349750,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021aaed2d9bea791b5488e08a2"
+        },
+        {
+          "position": 16,
+          "id": "levyra-e2fb7ff2caa8b0160954",
+          "title": "The One That Got Away",
+          "artists": [
+            {
+              "name": "Katy Perry"
+            }
+          ],
+          "album": {
+            "name": "Teenage Dream",
+            "releaseDate": "2010-01-01"
+          },
+          "durationMs": 227333,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021d955011a3ed477dc77865ad"
+        },
+        {
+          "position": 17,
+          "id": "levyra-eebf508778c820320fff",
+          "title": "Dominga",
+          "artists": [
+            {
+              "name": "Nateman"
+            },
+            {
+              "name": "La Mave"
+            }
+          ],
+          "album": {
+            "name": "Dominga",
+            "releaseDate": "2025-06-27"
+          },
+          "durationMs": 227619,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "XHez_iYD60Q",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCQwnhPZOvjAvZAJAQg7NYMQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02768834ced010a03f7c11a666"
+        },
+        {
+          "position": 18,
+          "id": "levyra-255841206a15acb611ad",
+          "title": "Risk It All",
+          "artists": [
+            {
+              "name": "Bruno Mars"
+            }
+          ],
+          "album": {
+            "name": "The Romantic",
+            "releaseDate": "2026-02-27"
+          },
+          "durationMs": 204068,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "BF2_ipR1OI0",
+            "audioConfidence": 100,
+            "videoId": "lY5V4hSLWY8",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCZn4r7heNOPY-C43YIywnVA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023eb8dc748f7efb1470f74395"
+        },
+        {
+          "position": 19,
+          "id": "levyra-7b286b042f765ebe5549",
+          "title": "Rosas",
+          "artists": [
+            {
+              "name": "Yuridope"
+            },
+            {
+              "name": "Skusta Clee"
+            }
+          ],
+          "album": {
+            "name": "Rosas",
+            "releaseDate": "2025-12-17"
+          },
+          "durationMs": 250058,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02b8bae6553d170668a5202696"
+        },
+        {
+          "position": 20,
+          "id": "levyra-903d9b5ddc07eb9639a3",
+          "title": "Janice",
+          "artists": [
+            {
+              "name": "Dilaw"
+            }
+          ],
+          "album": {
+            "name": "Janice",
+            "releaseDate": "2021-07-01"
+          },
+          "durationMs": 235161,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "GT0tn6U2JVE",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCmu6s82eBTMnYc8xMyhSvDQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022c8c45af3062943f1ce7af81"
+        },
+        {
+          "position": 21,
+          "id": "levyra-a4f028bc520cad1f04b6",
+          "title": "The Man Who Can't Be Moved",
+          "artists": [
+            {
+              "name": "The Script"
+            }
+          ],
+          "album": {
+            "name": "The Script",
+            "releaseDate": "2008-07-14"
+          },
+          "durationMs": 241373,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f33a9f529c12f79b116eb218"
+        },
+        {
+          "position": 22,
+          "id": "levyra-48619e7749b9a9bd6dad",
+          "title": "About You",
+          "artists": [
+            {
+              "name": "The 1975"
+            }
+          ],
+          "album": {
+            "name": "Being Funny In A Foreign Language",
+            "releaseDate": "2022-10-14"
+          },
+          "durationMs": 326490,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "4PgOJwUCdIc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCNrTdctAV0JMT7RBQvpA5lw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0200702474f8e0e2b6155d48e3"
+        },
+        {
+          "position": 23,
+          "id": "levyra-411ee215adfe5f5c97c7",
+          "title": "Animal",
+          "artists": [
+            {
+              "name": "KATSEYE"
+            }
+          ],
+          "album": {
+            "name": "Animal",
+            "releaseDate": "2026-07-24"
+          },
+          "durationMs": 158494,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "vOfyxPRunFM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCX9kfYB9t0tnd6DYUC2iuKg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029e8d48f27391ce383862b8e8"
+        },
+        {
+          "position": 24,
+          "id": "levyra-72f83dc4dd00e40a904f",
+          "title": "Pahina",
+          "artists": [
+            {
+              "name": "Cup of Joe"
+            }
+          ],
+          "album": {
+            "name": "Silakbo",
+            "releaseDate": "2025-01-17"
+          },
+          "durationMs": 249375,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0285a7fd707d00e5d255807add"
+        },
+        {
+          "position": 25,
+          "id": "levyra-4a8f3d180ce3d0b76564",
+          "title": "Earrings",
+          "artists": [
+            {
+              "name": "Malcolm Todd"
+            }
+          ],
+          "album": {
+            "name": "Sweet Boy",
+            "releaseDate": "2024-04-05"
+          },
+          "durationMs": 151500,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "BI9HQCzpDgQ",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCRLE_fwmN2CQw1vuWPwo6eA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022c1f34ecc1929fb59908aad1"
+        },
+        {
+          "position": 26,
+          "id": "levyra-2979bce3e70d75dbd128",
+          "title": "Palayo Sa Mundo",
+          "artists": [
+            {
+              "name": "Jolianne"
+            },
+            {
+              "name": "Arthur Nery"
+            }
+          ],
+          "album": {
+            "name": "Palayo Sa Mundo",
+            "releaseDate": "2025-10-10"
+          },
+          "durationMs": 268571,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "qaDbTVnfWqc",
+            "audioConfidence": 100,
+            "videoId": "173SbLSn620",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCkFdlfd2prj9o442hMDETZg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0236558a5c77443a73d1e1254b"
+        },
+        {
+          "position": 27,
+          "id": "levyra-ed1d6f052a4e1808c5f4",
+          "title": "Tadhana",
+          "artists": [
+            {
+              "name": "Up Dharma Down"
+            }
+          ],
+          "album": {
+            "name": "Capacities",
+            "releaseDate": "2012-12-07"
+          },
+          "durationMs": 222446,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "aM1chZsrlNk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCczexwGX6z87RN5qZ9sYyTA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c37604dd465e90d386feb4bf"
+        },
+        {
+          "position": 28,
+          "id": "levyra-1bcef17c13a5fa801cdb",
+          "title": "the cure",
+          "artists": [
+            {
+              "name": "Olivia Rodrigo"
+            }
+          ],
+          "album": {
+            "name": "you seem pretty sad for a girl so in love",
+            "releaseDate": "2026-06-12"
+          },
+          "durationMs": 297090,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "cmzCwz4NkOA",
+            "audioConfidence": 100,
+            "videoId": "B402rKl4bUg",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCE5XNpliPM-SmyFEp61tL_g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025cf234eeb7a2edf44bf64a46"
+        },
+        {
+          "position": 29,
+          "id": "levyra-7632ef25d1699abbf369",
+          "title": "Backburner",
+          "artists": [
+            {
+              "name": "NIKI"
+            }
+          ],
+          "album": {
+            "name": "Nicole",
+            "releaseDate": "2022-08-12"
+          },
+          "durationMs": 236533,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "BIAlNtIhajM",
+            "audioConfidence": 100,
+            "videoId": "BBpIV9A1PXc",
+            "videoConfidence": 97,
+            "confidence": 100,
+            "artistBrowseId": "UCFeCzD2Fqr3jlMcGTt0Jnlg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0289aa3d00d339b8948374782b"
+        },
+        {
+          "position": 30,
+          "id": "levyra-62c90b4af13ccbc9f4cd",
+          "title": "back to friends",
+          "artists": [
+            {
+              "name": "sombr"
+            }
+          ],
+          "album": {
+            "name": "I Barely Know Her",
+            "releaseDate": "2025-08-22"
+          },
+          "durationMs": 199032,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "c-8abSPAPOU",
+            "audioConfidence": 100,
+            "videoId": "c8zq4kAn_O0",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCyI0V6RmULLsRxegMTCmkWQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024229702de91cb3d3a4383302"
+        },
+        {
+          "position": 31,
+          "id": "levyra-98349a571204b2f4073a",
+          "title": "petal",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 184248,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "4mQyEqbaUOU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 32,
+          "id": "levyra-28082485462ce002493e",
+          "title": "drop dead",
+          "artists": [
+            {
+              "name": "Olivia Rodrigo"
+            }
+          ],
+          "album": {
+            "name": "you seem pretty sad for a girl so in love",
+            "releaseDate": "2026-06-11"
+          },
+          "durationMs": 224998,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "wLmLB4Zzyiw",
+            "audioConfidence": 100,
+            "videoId": "78wrful9cVU",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCE5XNpliPM-SmyFEp61tL_g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e026949b83f85d782b21ce70583"
+        },
+        {
+          "position": 33,
+          "id": "levyra-3e3a6408b5f1f06e2b4c",
+          "title": "Thinking Of You",
+          "artists": [
+            {
+              "name": "Katy Perry"
+            }
+          ],
+          "album": {
+            "name": "One Of The Boys",
+            "releaseDate": "2008-06-17"
+          },
+          "durationMs": 246410,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Gp5wVTNYmjk",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC_7s69e1mDS3lgcTMJEPjCg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023f97d4244eff5852477d9ee0"
+        },
+        {
+          "position": 34,
+          "id": "levyra-851b992e6042d5f96b4b",
+          "title": "Unti-Unti",
+          "artists": [
+            {
+              "name": "Up Dharma Down"
+            }
+          ],
+          "album": {
+            "name": "Unti-Unti",
+            "releaseDate": "2017-02-14"
+          },
+          "durationMs": 283825,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "g2t7utfVD50",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCczexwGX6z87RN5qZ9sYyTA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029f4a8c5a148b760d5d86e433"
+        },
+        {
+          "position": 35,
+          "id": "levyra-eaf1f7360e544324ef1b",
+          "title": "Burnout",
+          "artists": [
+            {
+              "name": "Sugarfree"
+            }
+          ],
+          "album": {
+            "name": "Sa Wakas",
+            "releaseDate": "2003-01-27"
+          },
+          "durationMs": 209480,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "d0n3vgtsnzY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCj9zcZK6FSiDsQYkevHS2Ig"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02089ce120f5b4f793f4fd5ce7"
+        },
+        {
+          "position": 36,
+          "id": "levyra-c40c7c1dc0da3e4a3c34",
+          "title": "Ayoko Maging Kaibigan",
+          "artists": [
+            {
+              "name": "kiddotin"
+            }
+          ],
+          "album": {
+            "name": "Ayoko Maging Kaibigan",
+            "releaseDate": "2026-05-22"
+          },
+          "durationMs": 166129,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "O2gHGfDi7dA",
+            "audioConfidence": 100,
+            "videoId": "Y9tzuMsQago",
+            "videoConfidence": 98,
+            "confidence": 100,
+            "artistBrowseId": "UCP0KmTcvKT9a6fmUl1qL6cQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e376ed67aa5fce7c06539a41"
+        },
+        {
+          "position": 37,
+          "id": "levyra-e7a14944ccf9687952a6",
+          "title": "Sino",
+          "artists": [
+            {
+              "name": "Unique Salonga"
+            }
+          ],
+          "album": {
+            "name": "Grandma",
+            "releaseDate": "2018-08-06"
+          },
+          "durationMs": 280426,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "LX-GMt1WMgw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCMlsliADnEfb4zHfp_TxfZA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028366d95c69868480c944f63c"
+        },
+        {
+          "position": 38,
+          "id": "levyra-9824cf7c6204b58ac7c7",
+          "title": "Iris",
+          "artists": [
+            {
+              "name": "The Goo Goo Dolls"
+            }
+          ],
+          "album": {
+            "name": "Dizzy up the Girl",
+            "releaseDate": "1998"
+          },
+          "durationMs": 289533,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02eda9478c39a21e1cdc6609ca"
+        },
+        {
+          "position": 39,
+          "id": "levyra-6159bd5a29ce993285c8",
+          "title": "Who Knows",
+          "artists": [
+            {
+              "name": "Daniel Caesar"
+            }
+          ],
+          "album": {
+            "name": "Son Of Spergy",
+            "releaseDate": "2025-10-24"
+          },
+          "durationMs": 226283,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "Wzn4BLtE73o",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCcbtSIy5DlnpVIxW8hIvxBw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022bad6e56e77d5bef0aa3f2dc"
+        },
+        {
+          "position": 40,
+          "id": "levyra-d47696557df2d7c7b403",
+          "title": "Saksi Ang Langit",
+          "artists": [
+            {
+              "name": "December Avenue"
+            }
+          ],
+          "album": {
+            "name": "Saksi Ang Langit",
+            "releaseDate": "2022-11-25"
+          },
+          "durationMs": 259058,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7x_ojZzYlcY",
+            "audioConfidence": 100,
+            "videoId": "9MmT13mCLOE",
+            "videoConfidence": 97,
+            "confidence": 100,
+            "artistBrowseId": "UCt8mVrdKyR0JvkuXs2HOmvg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027060277073fc2ae384281296"
+        },
+        {
+          "position": 41,
+          "id": "levyra-fcf7ce8cfb0a21b0149b",
+          "title": "TAKE ALL THE LOVE",
+          "artists": [
+            {
+              "name": "Arthur Nery"
+            }
+          ],
+          "album": {
+            "name": "TAKE ALL THE LOVE",
+            "releaseDate": "2021-04-23"
+          },
+          "durationMs": 206181,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "iXy0hfEpwFU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCnV3y1lEw750nsOcXhh4nlw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e029092f7a0dff311a64f44345d"
+        },
+        {
+          "position": 42,
+          "id": "levyra-9ebde4dbbb67b7d23d39",
+          "title": "Vibrate",
+          "artists": [
+            {
+              "name": "La Mave"
+            }
+          ],
+          "album": {
+            "name": "Vibrate",
+            "releaseDate": "2025-09-03"
+          },
+          "durationMs": 166400,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "-jSuAJDqc7k",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCQwnhPZOvjAvZAJAQg7NYMQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028c092bc6407fa7691370b976"
+        },
+        {
+          "position": 43,
+          "id": "levyra-debe1eb5c5ccad18bd44",
+          "title": "Pangako",
+          "artists": [
+            {
+              "name": "Kyle Echarri"
+            }
+          ],
+          "album": {
+            "name": "Kyle Echarri",
+            "releaseDate": "2018-10-13"
+          },
+          "durationMs": 247960,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "ksTPa_XEyXM",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCC8LBoXd2qCw1UOk5SF_A4g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a49fe0d9eda4d458fab598c1"
+        },
+        {
+          "position": 44,
+          "id": "levyra-f67c0dca26d1a544faf7",
+          "title": "Waltz of Four Left Feet",
+          "artists": [
+            {
+              "name": "shirebound"
+            }
+          ],
+          "album": {
+            "name": "For Princesses, By Thieves (O Mga Awit ng Hiraya Para sa Guni-guning Sinta)",
+            "releaseDate": "2019-08-02"
+          },
+          "durationMs": 337580,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0205607a2aa0f351108ff921d9"
+        },
+        {
+          "position": 45,
+          "id": "levyra-968fbdce8ce0b188b42f",
+          "title": "TORPE",
+          "artists": [
+            {
+              "name": "JAO"
+            }
+          ],
+          "album": {
+            "name": "TORPE",
+            "releaseDate": "2025-01-30"
+          },
+          "durationMs": 173500,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "nxVAqU1TZ2A",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCyebRtbyS2OULawHBdRR-wA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ac59428c15b6c233d9bd0c33"
+        },
+        {
+          "position": 46,
+          "id": "levyra-cea1b46d4de234bf5c19",
+          "title": "Para Sa Streets",
+          "artists": [
+            {
+              "name": "Hev Abi"
+            }
+          ],
+          "album": {
+            "name": "Para Sa Streets",
+            "releaseDate": "2022-09-02"
+          },
+          "durationMs": 194020,
+          "explicit": true,
+          "youtubeMusic": {
+            "audioVideoId": "dizWDK6puwc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCY8t9eIdFhUBNgrUR6czXqQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02cb8dd4cef799c3a8d3853dbe"
+        },
+        {
+          "position": 47,
+          "id": "levyra-01a75be05ca1e0bd603f",
+          "title": "Nang Iwan",
+          "artists": [
+            {
+              "name": "This Band"
+            }
+          ],
+          "album": {
+            "name": "Nang Iwan",
+            "releaseDate": "2019-07-26"
+          },
+          "durationMs": 367889,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "jEYKsCD8zmU",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC1vxvk_KcZf1wZ6CY2STGkw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02a8ae5a1119f570f90d05e372"
+        },
+        {
+          "position": 48,
+          "id": "levyra-08da0a293c1ea7f3a370",
+          "title": "Sa Susunod Na Lang",
+          "artists": [
+            {
+              "name": "PDL"
+            },
+            {
+              "name": "Skusta Clee"
+            },
+            {
+              "name": "Yuridope"
+            }
+          ],
+          "album": {
+            "name": "Sa Susunod Na Lang",
+            "releaseDate": "2018-09-26"
+          },
+          "durationMs": 214606,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "YJNk1SIlg74",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCN6W8gG58Akw-7rYMAhoJmA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ba5c65f95bce8e0282df79f9"
+        },
+        {
+          "position": 49,
+          "id": "levyra-de2cf0aa252b54a0d4e0",
+          "title": "Just the Way You Are",
+          "artists": [
+            {
+              "name": "Bruno Mars"
+            }
+          ],
+          "album": {
+            "name": "Doo-Wops & Hooligans",
+            "releaseDate": "2010-05-11"
+          },
+          "durationMs": 220734,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "GnUW4AF1LZo",
+            "audioConfidence": 100,
+            "videoId": "LjhCEhWiKXk",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCZn4r7heNOPY-C43YIywnVA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028a9eb5a1f701d1d367a5ea10"
+        },
+        {
+          "position": 50,
+          "id": "levyra-0ea788d074b3da5a1f97",
+          "title": "4:AM",
+          "artists": [
+            {
+              "name": "HELLMERRY"
+            }
+          ],
+          "album": {
+            "name": "4:AM",
+            "releaseDate": "2023-09-09"
+          },
+          "durationMs": 228571,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "NNtMnerQsUw",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCVJJot2WTh-OLjiKpxzU-bw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027dc2965600ea32042cd0b8a9"
+        }
+      ]
+    },
+    {
+      "id": "top-50-il",
+      "kind": "chart",
+      "market": "IL",
+      "title": "Top 50 ישראל",
+      "description": "Israele: il tuo aggiornamento quotidiano sui brani più ascoltati in questo momento.",
+      "totalSourceItems": 50,
+      "tracks": [
+        {
+          "position": 1,
+          "id": "levyra-a1445e365b51eb83532e",
+          "title": "איך שהיא רוקדת",
+          "artists": [
+            {
+              "name": "Eden Hason"
+            },
+            {
+              "name": "אופק אדנק"
+            },
+            {
+              "name": "Agam Buhbut"
+            }
+          ],
+          "album": {
+            "name": "איך שהיא רוקדת",
+            "releaseDate": "2026-05-19"
+          },
+          "durationMs": 157959,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e021f50eee9553ec21741a42c38"
+        },
+        {
+          "position": 2,
+          "id": "levyra-c058e4165820304cc97c",
+          "title": "יוצאת מן הכלל",
+          "artists": [
+            {
+              "name": "ליעד מאיר"
+            },
+            {
+              "name": "אופק אדנק"
+            }
+          ],
+          "album": {
+            "name": "יוצאת מן הכלל",
+            "releaseDate": "2026-06-04"
+          },
+          "durationMs": 150588,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e025ccb2d3fb2272bc06d345661"
+        },
+        {
+          "position": 3,
+          "id": "levyra-186aca48a7050b60d357",
+          "title": "אבי הטחול",
+          "artists": [
+            {
+              "name": "רואי אדם"
+            }
+          ],
+          "album": {
+            "name": "אבי הטחול",
+            "releaseDate": "2026-06-23"
+          },
+          "durationMs": 211034,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f69a9a7a027d972c4a94ad36"
+        },
+        {
+          "position": 4,
+          "id": "levyra-0a3bf1daf0c3a4fe558d",
+          "title": "כולם גנבים",
+          "artists": [
+            {
+              "name": "Osher Cohen"
+            }
+          ],
+          "album": {
+            "name": "Life Lately",
+            "releaseDate": "2026-02-16"
+          },
+          "durationMs": 241935,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0292dd40f2b1fbdc24e72f2b71"
+        },
+        {
+          "position": 5,
+          "id": "levyra-03364643133e0b3f8926",
+          "title": "עשר רמות מעליו",
+          "artists": [
+            {
+              "name": "אודיה"
+            }
+          ],
+          "album": {
+            "name": "השם יעזור",
+            "releaseDate": "2026-05-17"
+          },
+          "durationMs": 160000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02c5917e386343b63b1bdac4e3"
+        },
+        {
+          "position": 6,
+          "id": "levyra-5cc3ec156ee82aab8122",
+          "title": "03",
+          "artists": [
+            {
+              "name": "Itay Levi"
+            }
+          ],
+          "album": {
+            "name": "13",
+            "releaseDate": "2026-03-31"
+          },
+          "durationMs": 184883,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0244d94f8ffd83da40a609a875"
+        },
+        {
+          "position": 7,
+          "id": "levyra-f674afb669329d8834ea",
+          "title": "הלוואי",
+          "artists": [
+            {
+              "name": "פאר טסי"
+            },
+            {
+              "name": "חנן בן ארי"
+            }
+          ],
+          "album": {
+            "name": "הלוואי",
+            "releaseDate": "2026-04-04"
+          },
+          "durationMs": 229166,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0280fa77b60ee538b066c48c79"
+        },
+        {
+          "position": 8,
+          "id": "levyra-4500512f5aa38edfe312",
+          "title": "Dai Dai",
+          "artists": [
+            {
+              "name": "Shakira"
+            },
+            {
+              "name": "Burna Boy"
+            }
+          ],
+          "album": {
+            "name": "Dai Dai",
+            "releaseDate": "2026-05-14"
+          },
+          "durationMs": 223448,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "lFQdcPTTzSg",
+            "audioConfidence": 100,
+            "videoId": "fcnDmrtj6Sk",
+            "videoConfidence": 99,
+            "confidence": 100,
+            "artistBrowseId": "UCo6JijJGA3IvIiPsawDK3Ww"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0203cadf1b3fe324c1dc710ed4"
+        },
+        {
+          "position": 9,
+          "id": "levyra-2f76d593898f5b9e08e5",
+          "title": "אהבת חיי",
+          "artists": [
+            {
+              "name": "רואי אדם"
+            }
+          ],
+          "album": {
+            "name": "אהבת חיי",
+            "releaseDate": "2026-02-10"
+          },
+          "durationMs": 181500,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023a2be1bfe2d85903267d341a"
+        },
+        {
+          "position": 10,
+          "id": "levyra-da93f23328298ea748f9",
+          "title": "06",
+          "artists": [
+            {
+              "name": "Itay Levi"
+            }
+          ],
+          "album": {
+            "name": "13",
+            "releaseDate": "2026-03-31"
+          },
+          "durationMs": 200853,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0244d94f8ffd83da40a609a875"
+        },
+        {
+          "position": 11,
+          "id": "levyra-cae339ef8dad4ab288c2",
+          "title": "ריו דה ז'נרו",
+          "artists": [
+            {
+              "name": "Omer Adam"
+            }
+          ],
+          "album": {
+            "name": "חלק מהנצח",
+            "releaseDate": "2026-02-19"
+          },
+          "durationMs": 203437,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022b17e1a552e595e62027c79b"
+        },
+        {
+          "position": 12,
+          "id": "levyra-c3589ab63b3795420beb",
+          "title": "רולקס וקסקט",
+          "artists": [
+            {
+              "name": "Eden Ben Zaken"
+            }
+          ],
+          "album": {
+            "name": "רולקס וקסקט",
+            "releaseDate": "2026-01-06"
+          },
+          "durationMs": 192828,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02427a2c6eefc3469fa63d9c78"
+        },
+        {
+          "position": 13,
+          "id": "levyra-705958a6131d43e7f035",
+          "title": "תקופה חרא",
+          "artists": [
+            {
+              "name": "Omer Adam"
+            }
+          ],
+          "album": {
+            "name": "חלק מהנצח",
+            "releaseDate": "2026-02-19"
+          },
+          "durationMs": 243257,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "R0CaWsIkH2s",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCZF1s9c5bnnzDXqH7MN_IDg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022b17e1a552e595e62027c79b"
+        },
+        {
+          "position": 14,
+          "id": "levyra-68eb91d43e86bf0a8f46",
+          "title": "אם את כבר הולכת",
+          "artists": [
+            {
+              "name": "נדב חנציס"
+            }
+          ],
+          "album": {
+            "name": "אם את כבר הולכת",
+            "releaseDate": "2025-05-19"
+          },
+          "durationMs": 205000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022fb40cd8617a531cbde15b00"
+        },
+        {
+          "position": 15,
+          "id": "levyra-5a6e8052ead09d327d76",
+          "title": "אהבת השם",
+          "artists": [
+            {
+              "name": "בן צור"
+            }
+          ],
+          "album": {
+            "name": "חלק א' - הוויה",
+            "releaseDate": "2026-02-24"
+          },
+          "durationMs": 135480,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d0e0d3fedb7f9152d66376a6"
+        },
+        {
+          "position": 16,
+          "id": "levyra-eb31cb64ebaa4c859c94",
+          "title": "לב לבן",
+          "artists": [
+            {
+              "name": "Shuli Rand"
+            }
+          ],
+          "album": {
+            "name": "לב לבן",
+            "releaseDate": "2026-01-12"
+          },
+          "durationMs": 184000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023e326294af14fcd1b6db2992"
+        },
+        {
+          "position": 17,
+          "id": "levyra-fc2522bc9f3b42345f45",
+          "title": "השיר שאת אהבת",
+          "artists": [
+            {
+              "name": "Omer Adam"
+            }
+          ],
+          "album": {
+            "name": "תסמינים של פרידה",
+            "releaseDate": "2025-06-10"
+          },
+          "durationMs": 218100,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0212d961970aa13291d9720f8b"
+        },
+        {
+          "position": 18,
+          "id": "levyra-2e4d92479f17d910e699",
+          "title": "מלכת הדור",
+          "artists": [
+            {
+              "name": "Omer Adam"
+            }
+          ],
+          "album": {
+            "name": "תסמינים של פרידה",
+            "releaseDate": "2025-06-10"
+          },
+          "durationMs": 183031,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0212d961970aa13291d9720f8b"
+        },
+        {
+          "position": 19,
+          "id": "levyra-30c108e6dfeb68fb71a3",
+          "title": "איש הפלא",
+          "artists": [
+            {
+              "name": "בן צור"
+            }
+          ],
+          "album": {
+            "name": "איש הפלא",
+            "releaseDate": "2025-12-15"
+          },
+          "durationMs": 190000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0256c8d59fbc316464977c228e"
+        },
+        {
+          "position": 20,
+          "id": "levyra-74c022f1f8308cf58918",
+          "title": "אהבה ראשונה",
+          "artists": [
+            {
+              "name": "נדב חנציס"
+            }
+          ],
+          "album": {
+            "name": "שירים בפתקים",
+            "releaseDate": "2026-02-04"
+          },
+          "durationMs": 181395,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0277b3169c18a0eb22a4110a43"
+        },
+        {
+          "position": 21,
+          "id": "levyra-3229aaf9bbddd74ff7ca",
+          "title": "נווה הדרים",
+          "artists": [
+            {
+              "name": "ששון איפרם שאולוב"
+            }
+          ],
+          "album": {
+            "name": "נווה הדרים",
+            "releaseDate": "2026-05-05"
+          },
+          "durationMs": 191470,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0230345d471123fc466cf032a1"
+        },
+        {
+          "position": 22,
+          "id": "levyra-92d8a321017c5a5469de",
+          "title": "מחזיק לך את היד",
+          "artists": [
+            {
+              "name": "Eyal Golan"
+            }
+          ],
+          "album": {
+            "name": "30 - חלק א'",
+            "releaseDate": "2026-03-23"
+          },
+          "durationMs": 247135,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0217af412678d4182db21f0b11"
+        },
+        {
+          "position": 23,
+          "id": "levyra-f955bc22f77c11c58c92",
+          "title": "עוף מוזר",
+          "artists": [
+            {
+              "name": "פאר טסי"
+            }
+          ],
+          "album": {
+            "name": "רדיו שטח 3",
+            "releaseDate": "2025-06-28"
+          },
+          "durationMs": 208000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022252eded849d7d25553fb74d"
+        },
+        {
+          "position": 24,
+          "id": "levyra-76263413f382576a5448",
+          "title": "אבא",
+          "artists": [
+            {
+              "name": "בן צור"
+            }
+          ],
+          "album": {
+            "name": "אבא",
+            "releaseDate": "2024-02-05"
+          },
+          "durationMs": 202408,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028bde762c7c90b97522742609"
+        },
+        {
+          "position": 25,
+          "id": "levyra-de1f723762d4cd54a98c",
+          "title": "לא קונה אותי",
+          "artists": [
+            {
+              "name": "Mor"
+            }
+          ],
+          "album": {
+            "name": "MOR 6FM",
+            "releaseDate": "2026-05-26"
+          },
+          "durationMs": 175265,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02464ef299a4fdfd05342e9642"
+        },
+        {
+          "position": 26,
+          "id": "levyra-3f2dcb748a0d34c72f83",
+          "title": "Self Aware",
+          "artists": [
+            {
+              "name": "Temper City"
+            }
+          ],
+          "album": {
+            "name": "Self Aware",
+            "releaseDate": "2026-02-15"
+          },
+          "durationMs": 180740,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "R-hYM3BqTbA",
+            "audioConfidence": 100,
+            "videoId": "mh4AQkw4Jjc",
+            "videoConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCpWebSe88U-TOiO8YfKnTgg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d6c26d2ae723f7ab553d64cc"
+        },
+        {
+          "position": 27,
+          "id": "levyra-c21537a28a4490b24f33",
+          "title": "בית ביפו",
+          "artists": [
+            {
+              "name": "Dudu Tassa"
+            }
+          ],
+          "album": {
+            "name": "אי",
+            "releaseDate": "2026-02-11"
+          },
+          "durationMs": 196200,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0280b0b61e82ed5e5803779528"
+        },
+        {
+          "position": 28,
+          "id": "levyra-a7816a614bf40a5e92b5",
+          "title": "שחור לבן",
+          "artists": [
+            {
+              "name": "young buta"
+            }
+          ],
+          "album": {
+            "name": "שחור לבן",
+            "releaseDate": "2026-06-30"
+          },
+          "durationMs": 202500,
+          "explicit": true,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0223107a9ad314e4f69111544c"
+        },
+        {
+          "position": 29,
+          "id": "levyra-ecd375610f044454bc54",
+          "title": "מונולוג",
+          "artists": [
+            {
+              "name": "סטילה"
+            },
+            {
+              "name": "Ness"
+            }
+          ],
+          "album": {
+            "name": "מונולוג",
+            "releaseDate": "2026-07-26"
+          },
+          "durationMs": 223413,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "p4tK9P6sPJA",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC3OMAWYYZlwDLBVnGm2qnkQ"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0216db8e42761733deec2b68be"
+        },
+        {
+          "position": 30,
+          "id": "levyra-3b0618e240e38916f49d",
+          "title": "בן 32",
+          "artists": [
+            {
+              "name": "Omer Adam"
+            }
+          ],
+          "album": {
+            "name": "חלק מהנצח",
+            "releaseDate": "2026-02-19"
+          },
+          "durationMs": 210138,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "a2v7fM9B_h4",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCZF1s9c5bnnzDXqH7MN_IDg"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022b17e1a552e595e62027c79b"
+        },
+        {
+          "position": 31,
+          "id": "levyra-89d5d986ad784e5573cd",
+          "title": "ילדה מטורפת",
+          "artists": [
+            {
+              "name": "Bar Tzabary"
+            }
+          ],
+          "album": {
+            "name": "ילדה מטורפת",
+            "releaseDate": "2025-11-04"
+          },
+          "durationMs": 214545,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023d1b316e04f7e544ae12408e"
+        },
+        {
+          "position": 32,
+          "id": "levyra-c9015406eb3ab8c496bb",
+          "title": "Michelle",
+          "artists": [
+            {
+              "name": "Noam Bettan"
+            },
+            {
+              "name": "כאן - תאגיד השידור הישראלי"
+            }
+          ],
+          "album": {
+            "name": "Michelle",
+            "releaseDate": "2026-03-05"
+          },
+          "durationMs": 180517,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02d1743e3c1b8cf51b4cb57731"
+        },
+        {
+          "position": 33,
+          "id": "levyra-360d420dd3625daabf80",
+          "title": "אתה חי בחלום",
+          "artists": [
+            {
+              "name": "הגר יפת"
+            }
+          ],
+          "album": {
+            "name": "אתה חי בחלום",
+            "releaseDate": "2020-07-02"
+          },
+          "durationMs": 200260,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e023cc7b9b7ffa90fd33ffcf8f6"
+        },
+        {
+          "position": 34,
+          "id": "levyra-95ae48d3e3eb2ba39c5f",
+          "title": "אין מילים איתך",
+          "artists": [
+            {
+              "name": "Full Trunk"
+            }
+          ],
+          "album": {
+            "name": "אין מילים איתך",
+            "releaseDate": "2026-01-16"
+          },
+          "durationMs": 249002,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02bbd53cf2f9be57abe335431a"
+        },
+        {
+          "position": 35,
+          "id": "levyra-fa70f6ce3cc65a8dc95c",
+          "title": "באמת של האמת",
+          "artists": [
+            {
+              "name": "Osher Cohen"
+            }
+          ],
+          "album": {
+            "name": "אוגוסט דאמפ",
+            "releaseDate": "2025-08-04"
+          },
+          "durationMs": 183750,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020202dab8650665de78debfa3"
+        },
+        {
+          "position": 36,
+          "id": "levyra-8c01b2a9867a057d14f6",
+          "title": "כבר לא שמח",
+          "artists": [
+            {
+              "name": "נדב חנציס"
+            },
+            {
+              "name": "אופק אדנק"
+            }
+          ],
+          "album": {
+            "name": "כבר לא שמח",
+            "releaseDate": "2026-07-30"
+          },
+          "durationMs": 158727,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02ce8a1ca48a54236cb10f8fc7"
+        },
+        {
+          "position": 37,
+          "id": "levyra-c354b5d57ba0206724af",
+          "title": "נשמות צמאות",
+          "artists": [
+            {
+              "name": "בן צור"
+            }
+          ],
+          "album": {
+            "name": "נשמות צמאות",
+            "releaseDate": "2025-08-04"
+          },
+          "durationMs": 179047,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e024b47364311ebf15debf5c306"
+        },
+        {
+          "position": 38,
+          "id": "levyra-bb8af83d98384197e9f4",
+          "title": "אביצ'י",
+          "artists": [
+            {
+              "name": "נדב חנציס"
+            }
+          ],
+          "album": {
+            "name": "אופוריה",
+            "releaseDate": "2026-06-02"
+          },
+          "durationMs": 188702,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0254c09c52bf24727a71ab7716"
+        },
+        {
+          "position": 39,
+          "id": "levyra-147d6512595cad99517b",
+          "title": "המבט בעיניך",
+          "artists": [
+            {
+              "name": "Agam Buhbut"
+            }
+          ],
+          "album": {
+            "name": "21",
+            "releaseDate": "2025-08-24"
+          },
+          "durationMs": 188591,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "jJ8fPgsiwvg",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCNsMksDl9za5N9R7hyYa97g"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02759a0f224bec949bf7218a2d"
+        },
+        {
+          "position": 40,
+          "id": "levyra-f5c635431fd76946a2e0",
+          "title": "01",
+          "artists": [
+            {
+              "name": "Itay Levi"
+            }
+          ],
+          "album": {
+            "name": "13",
+            "releaseDate": "2026-03-31"
+          },
+          "durationMs": 200800,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0244d94f8ffd83da40a609a875"
+        },
+        {
+          "position": 41,
+          "id": "levyra-833532a3b49da12b42b4",
+          "title": "Jamaican (Bam Bam)",
+          "artists": [
+            {
+              "name": "HUGEL"
+            },
+            {
+              "name": "SOLTO (FR)"
+            }
+          ],
+          "album": {
+            "name": "Jamaican (Bam Bam)",
+            "releaseDate": "2025-11-07"
+          },
+          "durationMs": 156393,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02450a730dd72f3bf49882ae9d"
+        },
+        {
+          "position": 42,
+          "id": "levyra-9ad6f07db58d87205f92",
+          "title": "היא לא יודעת למה",
+          "artists": [
+            {
+              "name": "פאר טסי"
+            }
+          ],
+          "album": {
+            "name": "רדיו שטח 3",
+            "releaseDate": "2025-06-28"
+          },
+          "durationMs": 237000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e022252eded849d7d25553fb74d"
+        },
+        {
+          "position": 43,
+          "id": "levyra-93683240d111e7825d3f",
+          "title": "hate that i made you love me",
+          "artists": [
+            {
+              "name": "Ariana Grande"
+            }
+          ],
+          "album": {
+            "name": "petal",
+            "releaseDate": "2026-07-31"
+          },
+          "durationMs": 197949,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "7CUz7Ec7cWc",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UC0076UMUgEng8HORUw_MYHA"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e028baf677ee2d8dda6cc9fcbd7"
+        },
+        {
+          "position": 44,
+          "id": "levyra-e4ac43aa4ecb67eb36ce",
+          "title": "כל עכבה לטובה",
+          "artists": [
+            {
+              "name": "בן צור"
+            }
+          ],
+          "album": {
+            "name": "כל עכבה לטובה",
+            "releaseDate": "2025-06-23"
+          },
+          "durationMs": 162088,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02e19c486ff981719e2254e5bb"
+        },
+        {
+          "position": 45,
+          "id": "levyra-b6684d9e3371a980ad78",
+          "title": "סחרחורות",
+          "artists": [
+            {
+              "name": "Mor"
+            }
+          ],
+          "album": {
+            "name": "MOR 4FM",
+            "releaseDate": "2025-11-07"
+          },
+          "durationMs": 190517,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e020b0729fd3d2fcffeb4db3b27"
+        },
+        {
+          "position": 46,
+          "id": "levyra-47764fdde285bb5be11a",
+          "title": "Beauty And A Beat",
+          "artists": [
+            {
+              "name": "Justin Bieber"
+            },
+            {
+              "name": "Nicki Minaj"
+            }
+          ],
+          "album": {
+            "name": "Believe",
+            "releaseDate": "2012-01-01"
+          },
+          "durationMs": 227986,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02f1d02a6cec967f8b6b78f76e"
+        },
+        {
+          "position": 47,
+          "id": "levyra-1f2e4b8bf8880a438390",
+          "title": "תאהב אותי ככה",
+          "artists": [
+            {
+              "name": "Mor"
+            }
+          ],
+          "album": {
+            "name": "MOR 6FM",
+            "releaseDate": "2026-05-26"
+          },
+          "durationMs": 164884,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e02464ef299a4fdfd05342e9642"
+        },
+        {
+          "position": 48,
+          "id": "levyra-91e151cd0002d4502b4b",
+          "title": "08",
+          "artists": [
+            {
+              "name": "Itay Levi"
+            }
+          ],
+          "album": {
+            "name": "13",
+            "releaseDate": "2026-03-31"
+          },
+          "durationMs": 208888,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0244d94f8ffd83da40a609a875"
+        },
+        {
+          "position": 49,
+          "id": "levyra-59b31ca4a2835a286250",
+          "title": "מה יהיה מחר",
+          "artists": [
+            {
+              "name": "פאר טסי"
+            }
+          ],
+          "album": {
+            "name": "רדיו שטח 2",
+            "releaseDate": "2024-05-26"
+          },
+          "durationMs": 188000,
+          "explicit": false,
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e0264262898e2dc5b99349e5b15"
+        },
+        {
+          "position": 50,
+          "id": "levyra-9d3e530cd74574baf20a",
+          "title": "Babydoll",
+          "artists": [
+            {
+              "name": "Dominic Fike"
+            }
+          ],
+          "album": {
+            "name": "Don't Forget About Me, Demos",
+            "releaseDate": "2018-10-16"
+          },
+          "durationMs": 97960,
+          "explicit": false,
+          "youtubeMusic": {
+            "audioVideoId": "UnuEzP1rDLY",
+            "audioConfidence": 100,
+            "confidence": 100,
+            "artistBrowseId": "UCsWqHrJvOU_uukQCU92VEvw"
+          },
+          "artworkUrl": "https://i.scdn.co/image/ab67616d00001e027b1b6f41c1645af9757d5616"
+        }
+      ]
+    }
+  ]
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/SpotifyChartBootstrapProvider.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/SpotifyChartBootstrapProvider.kt
@@ -1,0 +1,93 @@
+package com.luc4n3x.levyra.data
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import android.util.AtomicFile
+import android.util.Log
+import org.json.JSONObject
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+
+/**
+ * Seeds the on-device editorial cache before [com.luc4n3x.levyra.LevyraApplication] starts.
+ *
+ * A fresh installation can therefore render Spotify's ordered Top 50 immediately from the APK,
+ * while [EditorialChartsRepository] refreshes the same catalog from the network in the background.
+ * The normal YouTube Music and Apple Music fallbacks remain untouched and are used when neither a
+ * valid cached/remote Spotify catalog nor this bundled bootstrap is available.
+ */
+class SpotifyChartBootstrapProvider : ContentProvider() {
+
+    override fun onCreate(): Boolean {
+        val appContext = context?.applicationContext ?: return false
+        runCatching {
+            val target = File(appContext.filesDir, CACHE_RELATIVE_PATH)
+            if (target.isFile && target.length() in 1..MAX_CATALOG_BYTES.toLong()) return@runCatching
+
+            val bundled = appContext.assets.open(ASSET_PATH).bufferedReader(StandardCharsets.UTF_8).use {
+                it.readText()
+            }
+            if (bundled.toByteArray(StandardCharsets.UTF_8).size !in 1..MAX_CATALOG_BYTES) {
+                return@runCatching
+            }
+
+            val root = JSONObject(bundled)
+            if (root.optInt("schemaVersion", -1) != SUPPORTED_SCHEMA_VERSION) return@runCatching
+            if (root.optJSONArray("collections")?.length()?.let { it > 0 } != true) return@runCatching
+
+            // The bundled snapshot is a first-paint cache, not a claim that its generation time is now.
+            // Refreshing the timestamp only makes the existing cache eligibility rules accept it while
+            // the repository starts a real Spotify refresh immediately in the background.
+            root.put("generatedAt", Instant.now().toString())
+            val payload = root.toString().toByteArray(StandardCharsets.UTF_8)
+            if (payload.size !in 1..MAX_CATALOG_BYTES) return@runCatching
+
+            target.parentFile?.mkdirs()
+            val atomicFile = AtomicFile(target)
+            val stream = atomicFile.startWrite()
+            try {
+                stream.write(payload)
+                stream.fd.sync()
+                atomicFile.finishWrite(stream)
+            } catch (error: Throwable) {
+                atomicFile.failWrite(stream)
+                throw error
+            }
+        }.onFailure { error ->
+            Log.w(TAG, "Unable to install bundled Spotify chart bootstrap", error)
+        }
+        return true
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?
+    ): Cursor? = null
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?
+    ): Int = 0
+
+    private companion object {
+        const val TAG = "SpotifyChartBootstrap"
+        const val ASSET_PATH = "editorial/spotify-bootstrap.json"
+        const val CACHE_RELATIVE_PATH = "editorial/charts-v2.json"
+        const val SUPPORTED_SCHEMA_VERSION = 1
+        const val MAX_CATALOG_BYTES = 2 * 1024 * 1024
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/SpotifyChartBootstrapProvider.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/SpotifyChartBootstrapProvider.kt
@@ -2,14 +2,18 @@ package com.luc4n3x.levyra.data
 
 import android.content.ContentProvider
 import android.content.ContentValues
+import android.content.Context
 import android.database.Cursor
 import android.net.Uri
 import android.util.AtomicFile
 import android.util.Log
+import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
 import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import java.time.Instant
+import java.util.Locale
 
 /**
  * Seeds the on-device editorial cache before [com.luc4n3x.levyra.LevyraApplication] starts.
@@ -23,43 +27,146 @@ class SpotifyChartBootstrapProvider : ContentProvider() {
 
     override fun onCreate(): Boolean {
         val appContext = context?.applicationContext ?: return false
-        runCatching {
-            val target = File(appContext.filesDir, CACHE_RELATIVE_PATH)
-            if (target.isFile && target.length() in 1..MAX_CATALOG_BYTES.toLong()) return@runCatching
-
-            val bundled = appContext.assets.open(ASSET_PATH).bufferedReader(StandardCharsets.UTF_8).use {
-                it.readText()
+        runCatching { installIfNeeded(appContext) }
+            .onFailure { error ->
+                Log.w(TAG, "Unable to install bundled Spotify chart bootstrap", error)
             }
-            if (bundled.toByteArray(StandardCharsets.UTF_8).size !in 1..MAX_CATALOG_BYTES) {
-                return@runCatching
-            }
-
-            val root = JSONObject(bundled)
-            if (root.optInt("schemaVersion", -1) != SUPPORTED_SCHEMA_VERSION) return@runCatching
-            if (root.optJSONArray("collections")?.length()?.let { it > 0 } != true) return@runCatching
-
-            // The bundled snapshot is a first-paint cache, not a claim that its generation time is now.
-            // Refreshing the timestamp only makes the existing cache eligibility rules accept it while
-            // the repository starts a real Spotify refresh immediately in the background.
-            root.put("generatedAt", Instant.now().toString())
-            val payload = root.toString().toByteArray(StandardCharsets.UTF_8)
-            if (payload.size !in 1..MAX_CATALOG_BYTES) return@runCatching
-
-            target.parentFile?.mkdirs()
-            val atomicFile = AtomicFile(target)
-            val stream = atomicFile.startWrite()
-            try {
-                stream.write(payload)
-                stream.fd.sync()
-                atomicFile.finishWrite(stream)
-            } catch (error: Throwable) {
-                atomicFile.failWrite(stream)
-                throw error
-            }
-        }.onFailure { error ->
-            Log.w(TAG, "Unable to install bundled Spotify chart bootstrap", error)
-        }
         return true
+    }
+
+    private fun installIfNeeded(appContext: Context) {
+        val target = File(appContext.filesDir, CACHE_RELATIVE_PATH)
+        val marker = appContext.getSharedPreferences(BOOTSTRAP_STATE, Context.MODE_PRIVATE)
+        val cachePresent = target.isFile && target.length() in 1..MAX_CATALOG_BYTES.toLong()
+        if (cachePresent && marker.getInt(KEY_BOOTSTRAP_VERSION, 0) >= BOOTSTRAP_VERSION) return
+
+        val bundled = appContext.assets.open(ASSET_PATH).bufferedReader(StandardCharsets.UTF_8).use {
+            it.readText()
+        }
+        if (bundled.toByteArray(StandardCharsets.UTF_8).size !in 1..MAX_CATALOG_BYTES) return
+
+        val root = JSONObject(bundled)
+        if (root.optInt("schemaVersion", -1) != SUPPORTED_SCHEMA_VERSION) return
+        if (root.optJSONArray("collections")?.length()?.let { it > 0 } != true) return
+
+        val now = System.currentTimeMillis()
+        if (!cachePresent) {
+            // The bundled snapshot is a first-paint cache, not a claim that its source was generated now.
+            // Refreshing this local timestamp only makes the existing cache eligibility rules accept it;
+            // the real Spotify catalog refresh still starts immediately in the background.
+            root.put("generatedAt", Instant.ofEpochMilli(now).toString())
+            writeCatalog(target, root.toString().toByteArray(StandardCharsets.UTF_8))
+        }
+
+        seedArtworkCache(appContext, root, now)
+        marker.edit().putInt(KEY_BOOTSTRAP_VERSION, BOOTSTRAP_VERSION).apply()
+    }
+
+    private fun writeCatalog(target: File, payload: ByteArray) {
+        if (payload.size !in 1..MAX_CATALOG_BYTES) return
+        target.parentFile?.mkdirs()
+        val atomicFile = AtomicFile(target)
+        val stream = atomicFile.startWrite()
+        try {
+            stream.write(payload)
+            stream.fd.sync()
+            atomicFile.finishWrite(stream)
+        } catch (error: Throwable) {
+            atomicFile.failWrite(stream)
+            throw error
+        }
+    }
+
+    /**
+     * The chart rows already ship with Spotify artwork and normalized metadata. Priming the resolver's
+     * cache prevents its first-install enrichment pass from spending several seconds re-looking-up
+     * those same 50 covers before Home can render.
+     */
+    private fun seedArtworkCache(appContext: Context, root: JSONObject, now: Long) {
+        val collection = preferredCollection(root.optJSONArray("collections")) ?: return
+        val tracks = collection.optJSONArray("tracks") ?: return
+        val editor = appContext
+            .getSharedPreferences(ARTWORK_CACHE_NAME, Context.MODE_PRIVATE)
+            .edit()
+
+        for (index in 0 until tracks.length()) {
+            val item = tracks.optJSONObject(index) ?: continue
+            val title = item.optString("title").trim()
+            val artist = parseArtists(item.optJSONArray("artists"))
+            val artwork = item.optString("artworkUrl").trim()
+            if (title.isBlank() || artist.isBlank() || !artwork.startsWith("https://")) continue
+
+            val album = item.optJSONObject("album")
+            val releaseDate = album?.optString("releaseDate").orEmpty().trim()
+            val year = releaseDate.take(4).takeIf { value ->
+                value.length == 4 && value.all(Char::isDigit)
+            }.orEmpty()
+            val provider = if (item.optJSONObject("youtubeMusic") != null) {
+                "Levyra Editorial + YouTube Music"
+            } else {
+                "Levyra Editorial"
+            }
+            val cached = JSONObject()
+                .put("thumbnailUrl", artwork)
+                .put("largeThumbnailUrl", artwork)
+                .put("album", album?.optString("name").orEmpty().trim())
+                .put("provider", provider)
+                .put("canonicalAlbumUrl", "")
+                .put("releaseDate", releaseDate)
+                .put("year", year)
+                .put("trackNumber", 0)
+                .put("discNumber", 0)
+                .put("explicit", item.optBoolean("explicit", false))
+                .put("isrc", item.optString("isrc").trim())
+                .put("upc", "")
+                .put("score", 500)
+                .put("cachedAt", now)
+            editor.putString("artwork.${artworkIdentity(title, artist)}", cached.toString())
+        }
+        // apply() updates the process-local SharedPreferences snapshot synchronously, so the resolver
+        // sees these entries immediately while the disk flush happens off the startup path.
+        editor.apply()
+    }
+
+    private fun preferredCollection(collections: JSONArray?): JSONObject? {
+        if (collections == null) return null
+        val deviceMarket = Locale.getDefault().country
+            .trim()
+            .uppercase(Locale.ROOT)
+            .takeIf { it.length == 2 }
+            ?: DEFAULT_MARKET
+        var italy: JSONObject? = null
+        var firstChart: JSONObject? = null
+        for (index in 0 until collections.length()) {
+            val collection = collections.optJSONObject(index) ?: continue
+            if (!collection.optString("kind").equals("chart", ignoreCase = true)) continue
+            if (firstChart == null) firstChart = collection
+            val market = collection.optString("market").trim().uppercase(Locale.ROOT)
+            if (market == deviceMarket) return collection
+            if (market == DEFAULT_MARKET) italy = collection
+        }
+        return italy ?: firstChart
+    }
+
+    private fun parseArtists(items: JSONArray?): String {
+        if (items == null) return ""
+        return buildList {
+            for (index in 0 until items.length()) {
+                val name = items.optJSONObject(index)?.optString("name").orEmpty().trim()
+                if (name.isNotBlank()) add(name)
+            }
+        }.distinct().joinToString(", ")
+    }
+
+    private fun artworkIdentity(title: String, artist: String): String {
+        val normalized = listOf(
+            ChartFeedParser.normalizeMusicText(title),
+            ChartFeedParser.normalizeMusicText(artist)
+        ).joinToString("|")
+        return MessageDigest.getInstance("SHA-256")
+            .digest(normalized.toByteArray(StandardCharsets.UTF_8))
+            .take(12)
+            .joinToString("") { byte -> "%02x".format(byte) }
     }
 
     override fun query(
@@ -87,6 +194,11 @@ class SpotifyChartBootstrapProvider : ContentProvider() {
         const val TAG = "SpotifyChartBootstrap"
         const val ASSET_PATH = "editorial/spotify-bootstrap.json"
         const val CACHE_RELATIVE_PATH = "editorial/charts-v2.json"
+        const val ARTWORK_CACHE_NAME = "levyra_chart_official_artwork"
+        const val BOOTSTRAP_STATE = "levyra_spotify_chart_bootstrap"
+        const val KEY_BOOTSTRAP_VERSION = "version"
+        const val BOOTSTRAP_VERSION = 1
+        const val DEFAULT_MARKET = "IT"
         const val SUPPORTED_SCHEMA_VERSION = 1
         const val MAX_CATALOG_BYTES = 2 * 1024 * 1024
     }


### PR DESCRIPTION
## Obiettivo
Mantenere la sezione come **Top 50 Spotify reale**, con Spotify come fonte primaria e la catena YouTube Music → Apple Music invariata quando non esiste più un catalogo Spotify utilizzabile.

## Problema
Su un'installazione pulita non esiste ancora il file di cache editoriale. La Home può quindi aspettare il primo download oppure entrare subito nei fallback. Inoltre il primo passaggio dell'artwork resolver può ripetere lookup già inutili, nonostante il catalogo Spotify contenga copertine ufficiali.

## Soluzione
- mantiene il limite originale di **50 brani** e non modifica `ChartsRepository`;
- include nell'APK l'ultimo catalogo editoriale Spotify validato, preservando ordine e posizioni ufficiali;
- registra un `ContentProvider` non esportato che viene inizializzato prima dell'Application;
- su installazione pulita copia atomicamente il catalogo Spotify nella cache già usata da `EditorialChartsRepository`;
- aggiorna esclusivamente il timestamp locale di eleggibilità, mentre il refresh Spotify reale parte comunque subito in background;
- pre-carica per il mercato del dispositivo le copertine Spotify nel resolver, evitando il costoso re-lookup delle 50 righe al primo avvio;
- non mostra dati inventati o placeholder.

## Ordine delle fonti
1. catalogo Spotify remoto o cache Spotify reale;
2. snapshot Spotify reale incluso nell'APK per il primo rendering;
3. YouTube Music se Spotify non è più utilizzabile;
4. Apple Music come ultimo fallback.

## File
- `app/src/main/AndroidManifest.xml`
- `app/src/main/java/com/luc4n3x/levyra/data/SpotifyChartBootstrapProvider.kt`
- `app/src/main/assets/editorial/spotify-bootstrap.json`

## Verifiche
- build Android;
- installazione pulita e apertura Home senza attendere la rete;
- presenza immediata di 50 righe nell'ordine Spotify;
- refresh remoto silenzioso;
- fallback esistenti ancora funzionanti con asset/cache non disponibili.

Nessun merge automatico.