### PR TITLE
fix(home): tighten mobile spacing and always show section subtitles

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -792,7 +792,7 @@ private fun HomeSectionHeader(
 
     Row(
         modifier = modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
+        verticalAlignment = if (displaySubtitle.isBlank()) Alignment.CenterVertically else Alignment.Top,
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         Column(
@@ -815,9 +815,7 @@ private fun HomeSectionHeader(
                     color = LevyraMuted,
                     fontSize = 12.5.sp,
                     lineHeight = 16.sp,
-                    fontWeight = FontWeight.Medium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    fontWeight = FontWeight.Medium
                 )
             }
         }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraHomeEditorialStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraHomeEditorialStrings.kt
@@ -57,7 +57,7 @@ Disponibile da oggi
 Uscito questa settimana
 Tra i brani in classifica
 Levyra Collections
-Playlist curate per ogni momento, costruite intorno alla musica che ami
+Playlist curate intorno alla musica che ami
 Novità del momento
 Essenziali locali
 Energia per allenarti

--- a/app/src/main/java/com/luc4n3x/levyra/ui/theme/HomeDesign.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/theme/HomeDesign.kt
@@ -21,8 +21,8 @@ object LevyraHomeDesign {
     val HeaderBorderLight: Color = Color(0x1811131F)
 
     val HorizontalInset: Dp = 18.dp
-    val SectionGap: Dp = 28.dp
-    val SectionGapCompact: Dp = 18.dp
+    val SectionGap: Dp = 18.dp
+    val SectionGapCompact: Dp = 14.dp
     val HeaderCorner: Dp = 20.dp
     val HeaderPadding: Dp = 14.dp
     val SettingsControlHeight: Dp = 48.dp


### PR DESCRIPTION
## Obiettivo
Rifinire la Home su smartphone mantenendo questa modifica separata dalle ottimizzazioni di avvio della PR #309.

## Modifiche
- riduce lo spazio verticale tra le intestazioni e i relativi caroselli;
- avvicina “Album per te” alle copertine;
- permette ai sottotitoli delle sezioni di andare a capo naturalmente, senza `…` e senza limite a una sola riga;
- corregge quindi anche “La tua orbita”, “Voci che risuonano” e tutte le altre sezioni che usano lo stesso header;
- accorcia il sottotitolo italiano di “Levyra Collections” mantenendone il significato;
- allinea in alto il pulsante “Riproduci tutto” quando il sottotitolo occupa più righe;
- non modifica cataloghi, playback, networking o logica delle raccomandazioni.

## File modificati
- `app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt`
- `app/src/main/java/com/luc4n3x/levyra/ui/theme/HomeDesign.kt`
- `app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraHomeEditorialStrings.kt`

## Verifiche
- confronto con `main`: soltanto 3 file dell’app;
- workflow temporanei rimossi dalla diff;
- PR mergeabile;
- build e controlli GitHub Actions in esecuzione.

CodeRabbit ha sospeso la review per esaurimento della quota gratuita, non per un errore del codice.

PR separata dalla #309. Nessun merge automatico.