### PR TITLE
fix: bound unknown-length artwork responses

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraArtworkCache.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraArtworkCache.kt
@@ -28,9 +28,26 @@ import kotlinx.coroutines.withContext
 import okhttp3.Request
 import okio.Path.Companion.toOkioPath
 import timber.log.Timber
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.InputStream
 import java.security.MessageDigest
 import java.nio.charset.StandardCharsets
+
+internal fun readBytesBounded(input: InputStream, maxBytes: Long): ByteArray? {
+    require(maxBytes > 0L)
+    val output = ByteArrayOutputStream(minOf(maxBytes, 16L * 1024L).toInt())
+    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+    var total = 0L
+    while (true) {
+        val read = input.read(buffer)
+        if (read < 0) break
+        total += read
+        if (total > maxBytes) return null
+        output.write(buffer, 0, read)
+    }
+    return output.toByteArray()
+}
 
 internal fun isLikelyArtworkBytes(bytes: ByteArray): Boolean {
     if (bytes.size >= 3 &&
@@ -274,7 +291,7 @@ object LevyraArtworkCache {
                         val body = response.body
                         val length = body.contentLength()
                         if (length > MAX_FILE_BYTES) return@use false
-                        val bytes = body.bytes()
+                        val bytes = readBytesBounded(body.byteStream(), MAX_FILE_BYTES) ?: return@use false
                         if (bytes.size < 512 || bytes.size.toLong() > MAX_FILE_BYTES || !isLikelyArtworkBytes(bytes)) return@use false
                         val temp = File(file.parentFile, "${file.name}.tmp")
                         temp.writeBytes(bytes)

--- a/app/src/test/java/com/luc4n3x/levyra/data/EditorialArtworkContinuityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/EditorialArtworkContinuityTest.kt
@@ -1,10 +1,27 @@
 package com.luc4n3x.levyra.data
 
 import com.luc4n3x.levyra.domain.Track
+import java.io.ByteArrayInputStream
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class EditorialArtworkContinuityTest {
+    @Test
+    fun boundedArtworkReaderAcceptsExactLimit() {
+        val bytes = ByteArray(32) { it.toByte() }
+
+        assertArrayEquals(bytes, readBytesBounded(ByteArrayInputStream(bytes), bytes.size.toLong()))
+    }
+
+    @Test
+    fun boundedArtworkReaderRejectsUnknownLengthBodyAboveLimit() {
+        val bytes = ByteArray(33) { it.toByte() }
+
+        assertNull(readBytesBounded(ByteArrayInputStream(bytes), 32L))
+    }
+
     @Test
     fun playerKeepsTheArtworkPresentedInTheTop50Row() {
         val presented = track(


### PR DESCRIPTION
## Cause

`LevyraArtworkCache.ensurePersistent` checked `ResponseBody.contentLength()` against the 6 MiB limit, then called `body.bytes()`. For chunked responses or responses without `Content-Length`, OkHttp reports `-1` and `bytes()` reads the complete body into memory before the later size check.

## Impact

A malformed or unexpectedly large artwork response could allocate an unbounded byte array during persistent artwork prefetch and cause memory pressure or process termination. The risk also applies when track metadata contains a remote artwork URL whose server omits the response length.

## Change

- read artwork bodies incrementally with a hard byte limit;
- reject the response as soon as it exceeds 6 MiB, including unknown-length responses;
- preserve exact-limit responses and all existing image signature validation;
- add focused regression coverage to the already selected `EditorialArtworkContinuityTest` CI class.

## Files

- `app/src/main/java/com/luc4n3x/levyra/data/LevyraArtworkCache.kt`
- `app/src/test/java/com/luc4n3x/levyra/data/EditorialArtworkContinuityTest.kt`

## Verification

- `levyra-worker verify`: passed.
- Regression cases cover an exact-limit stream and an unknown-length stream exceeding the limit.
- The focused test class is already executed by the existing PR Check workflow.

## Risks

Low. Valid artwork at or below 6 MiB is unchanged. Oversized or incomplete responses are treated as cache misses and the existing URL fallback/retry path continues. No network policy, workflow, dependency, version, signing, release, Room, Desktop, or F-Droid metadata changes are included.

## Previous behavior

Known-length responses above 6 MiB were rejected before reading, but unknown-length responses could be buffered without the configured bound.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artwork downloads to prevent excessive memory usage when receiving oversized responses.
  * Downloads exceeding the configured size limit are safely rejected.

* **Tests**
  * Added coverage for downloads at the exact allowed size.
  * Added coverage for oversized responses with unknown content length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->