### PR TITLE
Refine R8 keep rules for NewPipe and WebView

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,6 +1,15 @@
 -keep class org.mozilla.javascript.** { *; }
 -keep class org.mozilla.classfile.** { *; }
--keep class org.schabi.newpipe.extractor.** { *; }
+
+# Keep only the NewPipe pieces that rely on stable generated/runtime classes.
+-keep class org.schabi.newpipe.extractor.services.youtube.protos.** { *; }
+-keep class org.schabi.newpipe.extractor.timeago.patterns.** { *; }
+
+# WebView calls these methods by name from JavaScript.
+-keepclassmembers class * {
+    @android.webkit.JavascriptInterface public <methods>;
+}
+
 -dontwarn java.beans.**
 -dontwarn javax.script.**
 -dontwarn jdk.dynalink.**


### PR DESCRIPTION
## What changed

- replace the broad `-keep class org.schabi.newpipe.extractor.** { *; }` rule with targeted keeps for the YouTube protobuf and timeago runtime classes
- preserve methods annotated with `@JavascriptInterface` so the WebView PoToken/BotGuard bridge remains callable after R8 shrinking and obfuscation
- keep the existing Rhino, warning suppression and Kotlin Serialization rules unchanged

## Why

Levyra enables R8 minification and resource shrinking for release builds. Keeping the entire NewPipe Extractor package prevents R8 from optimizing a large dependency surface. The narrower rules keep the runtime-sensitive parts while allowing unused NewPipe code to be optimized.

The explicit `@JavascriptInterface` member rule protects Levyra's JavaScript bridge without keeping unrelated WebView or application classes.

## Impact

This should reduce unnecessary R8 retention without changing runtime behavior. The main area to verify is release playback/PoToken generation and NewPipe-backed extraction.

## Validation

- branch is based on current `main`
- diff contains only `app/proguard-rules.pro`
- no broad keep rules were added for Media3, Room, Coil, DataStore or WorkManager

A release build and playback smoke test should be used as the final validation before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-build compatibility for YouTube playback and extraction.
  * Preserved JavaScript interface functionality and time-related display behavior when code shrinking is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->