### PR TITLE
feat(update): install GitHub releases in app

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -158,6 +158,30 @@ jobs:
             exit 1
           fi
 
+          APK_ANALYZER="${ANDROID_HOME}/cmdline-tools/latest/bin/apkanalyzer"
+          test -x "${APK_ANALYZER}"
+          "${APK_ANALYZER}" manifest print "${FDROID_APK}" > /tmp/levyra-fdroid-manifest.xml
+          python3 - <<'PY'
+          import xml.etree.ElementTree as ET
+
+          manifest = ET.parse('/tmp/levyra-fdroid-manifest.xml').getroot()
+          android = '{http://schemas.android.com/apk/res/android}'
+          permissions = {
+              item.get(android + 'name')
+              for item in manifest.findall('uses-permission')
+          }
+          if 'android.permission.REQUEST_INSTALL_PACKAGES' in permissions:
+              raise SystemExit('F-Droid APK must not request REQUEST_INSTALL_PACKAGES')
+
+          authorities = 'com.luc4n3x.levyra.update-files'
+          providers = [
+              item for item in manifest.findall('.//provider')
+              if item.get(android + 'authorities') == authorities
+          ]
+          if len(providers) != 1 or providers[0].get(android + 'enabled', 'true') != 'false':
+              raise SystemExit('F-Droid APK must keep the GitHub update provider disabled')
+          PY
+
       - name: Collect Reports
         if: always()
         shell: bash

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -127,7 +127,8 @@ jobs:
             --tests 'com.luc4n3x.levyra.data.LyricsParsingTest' \
             --tests 'com.luc4n3x.levyra.ui.i18n.LevyraStringsTest' \
             --tests 'com.luc4n3x.levyra.viewmodel.AudioSettingsPersistenceCoordinatorTest' \
-            --tests 'com.luc4n3x.levyra.player.LevyraDspAudioProcessorTest'
+            --tests 'com.luc4n3x.levyra.player.LevyraDspAudioProcessorTest' \
+            --tests 'com.luc4n3x.levyra.update.AppUpdateInstallerTest'
 
       - name: Release Compile
         run: ./gradlew --no-daemon --no-configuration-cache assembleRelease

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -133,6 +133,36 @@ jobs:
       - name: Release Compile
         run: ./gradlew --no-daemon --no-configuration-cache assembleRelease
 
+      - name: Upstream updater manifest contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          UPSTREAM_APK="app/build/outputs/apk/release/app-release.apk"
+          APK_ANALYZER="${ANDROID_HOME}/cmdline-tools/latest/bin/apkanalyzer"
+          test -f "${UPSTREAM_APK}"
+          test -x "${APK_ANALYZER}"
+          "${APK_ANALYZER}" manifest print "${UPSTREAM_APK}" > /tmp/levyra-upstream-manifest.xml
+          python3 - <<'PY'
+          import xml.etree.ElementTree as ET
+
+          manifest = ET.parse('/tmp/levyra-upstream-manifest.xml').getroot()
+          android = '{http://schemas.android.com/apk/res/android}'
+          permissions = {
+              item.get(android + 'name')
+              for item in manifest.findall('uses-permission')
+          }
+          if 'android.permission.REQUEST_INSTALL_PACKAGES' not in permissions:
+              raise SystemExit('Upstream APK must request REQUEST_INSTALL_PACKAGES')
+
+          authorities = 'com.luc4n3x.levyra.update-files'
+          providers = [
+              item for item in manifest.findall('.//provider')
+              if item.get(android + 'authorities') == authorities
+          ]
+          if len(providers) != 1 or providers[0].get(android + 'enabled', 'true') != 'true':
+              raise SystemExit('Upstream APK must keep the GitHub update provider enabled')
+          PY
+
       - name: Setup Java 21 for F-Droid
         uses: actions/setup-java@v5
         with:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,6 +126,7 @@ android {
         versionCode = levyraVersionCode
         versionName = levyraVersionName
         vectorDrawables.useSupportLibrary = true
+        manifestPlaceholders["upstreamInstallPermissionNode"] = if (isFdroidBuild) "remove" else "merge"
         buildConfigField("String", "UPDATE_REPOSITORY", "\"LUC4N3X/Levyra-deepsound\"")
         buildConfigField("String", "UPDATE_LATEST_URL", "\"https://api.github.com/repos/LUC4N3X/Levyra-deepsound/releases/latest\"")
         buildConfigField("boolean", "UPSTREAM_UPDATES_ENABLED", (!isFdroidBuild).toString())

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -131,6 +131,7 @@ android {
         } else {
             "android.permission.REQUEST_INSTALL_PACKAGES"
         }
+        manifestPlaceholders["upstreamUpdatesEnabled"] = (!isFdroidBuild).toString()
         buildConfigField("String", "UPDATE_REPOSITORY", "\"LUC4N3X/Levyra-deepsound\"")
         buildConfigField("String", "UPDATE_LATEST_URL", "\"https://api.github.com/repos/LUC4N3X/Levyra-deepsound/releases/latest\"")
         buildConfigField("boolean", "UPSTREAM_UPDATES_ENABLED", (!isFdroidBuild).toString())

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,7 +126,11 @@ android {
         versionCode = levyraVersionCode
         versionName = levyraVersionName
         vectorDrawables.useSupportLibrary = true
-        manifestPlaceholders["upstreamInstallPermissionNode"] = if (isFdroidBuild) "remove" else "merge"
+        manifestPlaceholders["upstreamInstallPermission"] = if (isFdroidBuild) {
+            "android.permission.INTERNET"
+        } else {
+            "android.permission.REQUEST_INSTALL_PACKAGES"
+        }
         buildConfigField("String", "UPDATE_REPOSITORY", "\"LUC4N3X/Levyra-deepsound\"")
         buildConfigField("String", "UPDATE_LATEST_URL", "\"https://api.github.com/repos/LUC4N3X/Levyra-deepsound/releases/latest\"")
         buildConfigField("boolean", "UPSTREAM_UPDATES_ENABLED", (!isFdroidBuild).toString())

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" tools:node="${upstreamInstallPermissionNode}" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
     <uses-permission android:name="androidx.car.app.MEDIA_TEMPLATES" />
@@ -35,6 +36,16 @@
             android:initOrder="100" />
 
         <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.update-files"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/update_file_paths" />
+        </provider>
+
+        <provider
             android:name=".data.AutomaticBackupDocumentsProvider"
             android:authorities="${applicationId}.automatic-backups"
             android:exported="true"
@@ -54,6 +65,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:resizeableActivity="true"
             android:supportsPictureInPicture="true"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
@@ -72,6 +84,14 @@
                 <action android:name="android.intent.action.SEND_MULTIPLE" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data
+                    android:scheme="levyra"
+                    android:host="updates"
+                    android:path="/install" />
             </intent-filter>
             <intent-filter android:autoVerify="false">
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,7 @@
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.update-files"
+            android:enabled="${upstreamUpdatesEnabled}"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data
@@ -65,7 +66,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:launchMode="singleTop"
             android:resizeableActivity="true"
             android:supportsPictureInPicture="true"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
@@ -84,14 +84,6 @@
                 <action android:name="android.intent.action.SEND_MULTIPLE" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/*" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data
-                    android:scheme="levyra"
-                    android:host="updates"
-                    android:path="/install" />
             </intent-filter>
             <intent-filter android:autoVerify="false">
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
-    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" tools:node="${upstreamInstallPermissionNode}" />
+    <uses-permission android:name="${upstreamInstallPermission}" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
     <uses-permission android:name="androidx.car.app.MEDIA_TEMPLATES" />

--- a/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
@@ -2,25 +2,34 @@ package com.luc4n3x.levyra
 
 import android.Manifest
 import android.app.PictureInPictureParams
+import android.content.ClipData
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.SystemClock
+import android.provider.Settings
 import android.util.Rational
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
@@ -28,28 +37,40 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import com.luc4n3x.levyra.data.LevyraArtworkCache
 import com.luc4n3x.levyra.domain.LevyraFontPreset
 import com.luc4n3x.levyra.player.LevyraPipBridge
 import com.luc4n3x.levyra.ui.LevyraApp
+import com.luc4n3x.levyra.ui.i18n.LevyraStrings
 import com.luc4n3x.levyra.ui.support.RemoteAnnouncementGate
 import com.luc4n3x.levyra.ui.support.RemoteAnnouncementPromptPolicy
 import com.luc4n3x.levyra.ui.support.SupportLevyraSettingsCard
 import com.luc4n3x.levyra.ui.theme.LevyraTheme
 import com.luc4n3x.levyra.ui.theme.LevyraThemeController
 import com.luc4n3x.levyra.ui.theme.LevyraThemes
+import com.luc4n3x.levyra.update.AppUpdateContract
+import com.luc4n3x.levyra.update.AppUpdateInstaller
+import com.luc4n3x.levyra.update.PreparedAppUpdate
 import com.luc4n3x.levyra.viewmodel.LevyraUiState
 import com.luc4n3x.levyra.viewmodel.LevyraViewModel
 import kotlin.math.roundToInt
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import timber.log.Timber
 
 private data class MainActivityUiSlice(
     val fontPreset: LevyraFontPreset,
@@ -69,9 +90,25 @@ private fun LevyraUiState.toMainActivityUiSlice(): MainActivityUiSlice = MainAct
     recentListenCount = recentListens.size
 )
 
+private sealed interface InAppUpdateUiState {
+    data object Idle : InAppUpdateUiState
+    data class Downloading(
+        val versionName: String,
+        val progress: Int?
+    ) : InAppUpdateUiState
+}
+
 class MainActivity : ComponentActivity() {
     private val pipMode = mutableStateOf(false)
     private val viewModel: LevyraViewModel by viewModels()
+    private val updateUiState = mutableStateOf<InAppUpdateUiState>(InAppUpdateUiState.Idle)
+    private val updateInstaller by lazy { AppUpdateInstaller(applicationContext) }
+    private var updateJob: Job? = null
+    private var pendingUpdate: PreparedAppUpdate? = null
+
+    private val unknownSourcesLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        resumePendingUpdateInstall()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -87,7 +124,9 @@ class MainActivity : ComponentActivity() {
             isAppearanceLightStatusBars = startPalette.isLight
             isAppearanceLightNavigationBars = startPalette.isLight
         }
-        LevyraLaunchActions.consumeFrom(intent)
+        if (!handleInAppUpdateIntent(intent)) {
+            LevyraLaunchActions.consumeFrom(intent)
+        }
         if (Build.VERSION.SDK_INT >= 28) {
             val params = window.attributes
             params.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
@@ -146,6 +185,10 @@ class MainActivity : ComponentActivity() {
                         listenedPlaybackMs = listenedPlaybackMs
                     )
                 )
+                InAppUpdateDialog(
+                    state = updateUiState.value,
+                    strings = LevyraStrings.forCode(activityUiState.languageCode)
+                )
             }
         }
     }
@@ -153,7 +196,9 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-        LevyraLaunchActions.consumeFrom(intent)
+        if (!handleInAppUpdateIntent(intent)) {
+            LevyraLaunchActions.consumeFrom(intent)
+        }
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
@@ -176,8 +221,93 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun onDestroy() {
+        updateJob?.cancel()
         LevyraPipBridge.unbind()
         super.onDestroy()
+    }
+
+    private fun handleInAppUpdateIntent(intent: Intent?): Boolean {
+        if (!AppUpdateContract.matches(intent)) return false
+        if (intent?.getBooleanExtra(AppUpdateContract.EXTRA_CONSUMED, false) == true) return true
+        intent?.putExtra(AppUpdateContract.EXTRA_CONSUMED, true)
+        if (BuildConfig.UPSTREAM_UPDATES_ENABLED) beginInAppUpdate()
+        return true
+    }
+
+    private fun beginInAppUpdate() {
+        if (updateJob?.isActive == true) return
+        updateJob = lifecycleScope.launch {
+            try {
+                val prepared = updateInstaller.prepareLatestUpdate { versionName, progress ->
+                    runOnUiThread {
+                        updateUiState.value = InAppUpdateUiState.Downloading(versionName, progress)
+                    }
+                }
+                pendingUpdate = prepared
+                updateUiState.value = InAppUpdateUiState.Idle
+                requestPackageInstall(prepared)
+            } catch (cancelled: CancellationException) {
+                updateUiState.value = InAppUpdateUiState.Idle
+                throw cancelled
+            } catch (error: Throwable) {
+                Timber.w(error, "In-app update failed")
+                pendingUpdate = null
+                updateUiState.value = InAppUpdateUiState.Idle
+                viewModel.checkForUpdates(silent = false)
+            } finally {
+                updateJob = null
+            }
+        }
+    }
+
+    private fun requestPackageInstall(prepared: PreparedAppUpdate) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !packageManager.canRequestPackageInstalls()) {
+            pendingUpdate = prepared
+            val settingsIntent = Intent(
+                Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+                Uri.parse("package:$packageName")
+            )
+            runCatching { unknownSourcesLauncher.launch(settingsIntent) }
+                .onFailure {
+                    Timber.w(it, "Unable to open unknown-source settings")
+                    pendingUpdate = null
+                    viewModel.checkForUpdates(silent = false)
+                }
+            return
+        }
+        launchPackageInstaller(prepared)
+    }
+
+    private fun resumePendingUpdateInstall() {
+        val prepared = pendingUpdate ?: return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !packageManager.canRequestPackageInstalls()) {
+            pendingUpdate = null
+            viewModel.checkForUpdates(silent = false)
+            return
+        }
+        launchPackageInstaller(prepared)
+    }
+
+    private fun launchPackageInstaller(prepared: PreparedAppUpdate) {
+        val apkUri = runCatching {
+            FileProvider.getUriForFile(this, "$packageName.update-files", prepared.apkFile)
+        }.getOrElse {
+            Timber.w(it, "Unable to expose update APK")
+            pendingUpdate = null
+            viewModel.checkForUpdates(silent = false)
+            return
+        }
+        val installIntent = Intent(Intent.ACTION_INSTALL_PACKAGE).apply {
+            data = apkUri
+            clipData = ClipData.newRawUri("Levyra update", apkUri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        runCatching { startActivity(installIntent) }
+            .onFailure {
+                Timber.w(it, "Unable to launch Android package installer")
+                viewModel.checkForUpdates(silent = false)
+            }
+        pendingUpdate = null
     }
 
     private fun enterPictureInPicture(): Boolean {
@@ -242,4 +372,35 @@ class MainActivity : ComponentActivity() {
     private fun configureFastImageLoader() {
         LevyraArtworkCache.configure(this)
     }
+}
+
+@Composable
+private fun InAppUpdateDialog(
+    state: InAppUpdateUiState,
+    strings: LevyraStrings
+) {
+    val downloading = state as? InAppUpdateUiState.Downloading ?: return
+    AlertDialog(
+        onDismissRequest = {},
+        confirmButton = {},
+        title = {
+            Text(
+                text = downloading.versionName.ifBlank { strings.updates }.let { version ->
+                    if (version == strings.updates) version else "LEVYRA $version"
+                },
+                fontWeight = FontWeight.Bold
+            )
+        },
+        text = {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(14.dp)
+            ) {
+                CircularProgressIndicator()
+                Text(
+                    text = downloading.progress?.let { "${strings.update} · $it%" } ?: strings.updateDescription
+                )
+            }
+        }
+    )
 }

--- a/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
@@ -276,10 +276,14 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun resumePendingUpdateInstall() {
-        val prepared = pendingUpdate ?: return
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !packageManager.canRequestPackageInstalls()) {
             pendingUpdate = null
             showUpdateFailure()
+            return
+        }
+        val prepared = pendingUpdate
+        if (prepared == null) {
+            if (BuildConfig.UPSTREAM_UPDATES_ENABLED) beginInAppUpdate()
             return
         }
         launchPackageInstaller(prepared)

--- a/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
@@ -16,6 +16,7 @@ import android.os.SystemClock
 import android.provider.Settings
 import android.util.Rational
 import android.view.WindowManager
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
@@ -124,9 +125,7 @@ class MainActivity : ComponentActivity() {
             isAppearanceLightStatusBars = startPalette.isLight
             isAppearanceLightNavigationBars = startPalette.isLight
         }
-        if (!handleInAppUpdateIntent(intent)) {
-            LevyraLaunchActions.consumeFrom(intent)
-        }
+        LevyraLaunchActions.consumeFrom(intent)
         if (Build.VERSION.SDK_INT >= 28) {
             val params = window.attributes
             params.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
@@ -196,9 +195,15 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-        if (!handleInAppUpdateIntent(intent)) {
-            LevyraLaunchActions.consumeFrom(intent)
+        LevyraLaunchActions.consumeFrom(intent)
+    }
+
+    override fun startActivity(intent: Intent) {
+        if (AppUpdateContract.matches(intent)) {
+            if (BuildConfig.UPSTREAM_UPDATES_ENABLED) beginInAppUpdate()
+            return
         }
+        super.startActivity(intent)
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
@@ -226,16 +231,8 @@ class MainActivity : ComponentActivity() {
         super.onDestroy()
     }
 
-    private fun handleInAppUpdateIntent(intent: Intent?): Boolean {
-        if (!AppUpdateContract.matches(intent)) return false
-        if (intent?.getBooleanExtra(AppUpdateContract.EXTRA_CONSUMED, false) == true) return true
-        intent?.putExtra(AppUpdateContract.EXTRA_CONSUMED, true)
-        if (BuildConfig.UPSTREAM_UPDATES_ENABLED) beginInAppUpdate()
-        return true
-    }
-
     private fun beginInAppUpdate() {
-        if (updateJob?.isActive == true) return
+        if (!BuildConfig.UPSTREAM_UPDATES_ENABLED || updateJob?.isActive == true) return
         updateJob = lifecycleScope.launch {
             try {
                 val prepared = updateInstaller.prepareLatestUpdate { versionName, progress ->
@@ -253,7 +250,7 @@ class MainActivity : ComponentActivity() {
                 Timber.w(error, "In-app update failed")
                 pendingUpdate = null
                 updateUiState.value = InAppUpdateUiState.Idle
-                viewModel.checkForUpdates(silent = false)
+                showUpdateFailure()
             } finally {
                 updateJob = null
             }
@@ -271,7 +268,7 @@ class MainActivity : ComponentActivity() {
                 .onFailure {
                     Timber.w(it, "Unable to open unknown-source settings")
                     pendingUpdate = null
-                    viewModel.checkForUpdates(silent = false)
+                    showUpdateFailure()
                 }
             return
         }
@@ -282,7 +279,7 @@ class MainActivity : ComponentActivity() {
         val prepared = pendingUpdate ?: return
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !packageManager.canRequestPackageInstalls()) {
             pendingUpdate = null
-            viewModel.checkForUpdates(silent = false)
+            showUpdateFailure()
             return
         }
         launchPackageInstaller(prepared)
@@ -294,7 +291,7 @@ class MainActivity : ComponentActivity() {
         }.getOrElse {
             Timber.w(it, "Unable to expose update APK")
             pendingUpdate = null
-            viewModel.checkForUpdates(silent = false)
+            showUpdateFailure()
             return
         }
         val installIntent = Intent(Intent.ACTION_INSTALL_PACKAGE).apply {
@@ -305,9 +302,14 @@ class MainActivity : ComponentActivity() {
         runCatching { startActivity(installIntent) }
             .onFailure {
                 Timber.w(it, "Unable to launch Android package installer")
-                viewModel.checkForUpdates(silent = false)
+                showUpdateFailure()
             }
         pendingUpdate = null
+    }
+
+    private fun showUpdateFailure() {
+        val strings = LevyraStrings.forCode(viewModel.state.value.languageCode)
+        Toast.makeText(this, strings.cannotOpenDownload, Toast.LENGTH_LONG).show()
     }
 
     private fun enterPictureInPicture(): Boolean {

--- a/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -186,7 +187,8 @@ class MainActivity : ComponentActivity() {
                 )
                 InAppUpdateDialog(
                     state = updateUiState.value,
-                    strings = LevyraStrings.forCode(activityUiState.languageCode)
+                    strings = LevyraStrings.forCode(activityUiState.languageCode),
+                    onCancel = ::cancelInAppUpdate
                 )
             }
         }
@@ -199,11 +201,19 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun startActivity(intent: Intent) {
-        if (AppUpdateContract.matches(intent)) {
-            if (BuildConfig.UPSTREAM_UPDATES_ENABLED) beginInAppUpdate()
-            return
-        }
+        if (handleInAppUpdateIntent(intent)) return
         super.startActivity(intent)
+    }
+
+    override fun startActivity(intent: Intent, options: Bundle?) {
+        if (handleInAppUpdateIntent(intent)) return
+        super.startActivity(intent, options)
+    }
+
+    private fun handleInAppUpdateIntent(intent: Intent): Boolean {
+        if (!AppUpdateContract.matches(intent)) return false
+        if (BuildConfig.UPSTREAM_UPDATES_ENABLED) beginInAppUpdate()
+        return true
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
@@ -233,7 +243,8 @@ class MainActivity : ComponentActivity() {
 
     private fun beginInAppUpdate() {
         if (!BuildConfig.UPSTREAM_UPDATES_ENABLED || updateJob?.isActive == true) return
-        updateJob = lifecycleScope.launch {
+        lateinit var job: Job
+        job = lifecycleScope.launch {
             try {
                 val prepared = updateInstaller.prepareLatestUpdate { versionName, progress ->
                     runOnUiThread {
@@ -252,9 +263,18 @@ class MainActivity : ComponentActivity() {
                 updateUiState.value = InAppUpdateUiState.Idle
                 showUpdateFailure()
             } finally {
-                updateJob = null
+                if (updateJob === job) updateJob = null
             }
         }
+        updateJob = job
+    }
+
+    private fun cancelInAppUpdate() {
+        val job = updateJob
+        updateJob = null
+        pendingUpdate = null
+        updateUiState.value = InAppUpdateUiState.Idle
+        job?.cancel()
     }
 
     private fun requestPackageInstall(prepared: PreparedAppUpdate) {
@@ -383,12 +403,17 @@ class MainActivity : ComponentActivity() {
 @Composable
 private fun InAppUpdateDialog(
     state: InAppUpdateUiState,
-    strings: LevyraStrings
+    strings: LevyraStrings,
+    onCancel: () -> Unit
 ) {
     val downloading = state as? InAppUpdateUiState.Downloading ?: return
     AlertDialog(
         onDismissRequest = {},
-        confirmButton = {},
+        confirmButton = {
+            TextButton(onClick = onCancel) {
+                Text(strings.cancel)
+            }
+        },
         title = {
             Text(
                 text = downloading.versionName.ifBlank { strings.updates }.let { version ->

--- a/app/src/main/java/com/luc4n3x/levyra/data/AppUpdateRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/AppUpdateRepository.kt
@@ -68,7 +68,7 @@ class AppUpdateRepository(context: Context) {
         )
         val assetDownloadUrl = selected?.downloadUrl.orEmpty()
         val directApk = selected?.isApk == true && assetDownloadUrl.isNotBlank()
-        val downloadUrl = if (directApk) {
+        val downloadUrl = if (directApk && BuildConfig.UPSTREAM_UPDATES_ENABLED) {
             AppUpdateContract.INSTALL_URI
         } else {
             assetDownloadUrl.ifBlank { releaseUrl }

--- a/app/src/main/java/com/luc4n3x/levyra/data/AppUpdateRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/AppUpdateRepository.kt
@@ -8,15 +8,35 @@ import com.luc4n3x.levyra.domain.AppUpdateInfo
 import com.luc4n3x.levyra.nexus.update.LevyraUpdateArtifact
 import com.luc4n3x.levyra.nexus.update.LevyraUpdateSelector
 import com.luc4n3x.levyra.nexus.update.LevyraVersionComparator
+import com.luc4n3x.levyra.update.AppUpdateContract
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Request
 import org.json.JSONObject
 
+internal data class InstallableAppUpdate(
+    val info: AppUpdateInfo,
+    val assetDownloadUrl: String,
+    val assetSizeBytes: Long
+)
+
 class AppUpdateRepository(context: Context) {
     private val client = LevyraHttpClientFactory.general(context.applicationContext)
 
     suspend fun latest(): AppUpdateInfo = withContext(Dispatchers.IO) {
+        parseLatestRelease(fetchLatestRelease()).info
+    }
+
+    internal suspend fun latestInstallable(): InstallableAppUpdate = withContext(Dispatchers.IO) {
+        val update = parseLatestRelease(fetchLatestRelease())
+        if (!update.info.isNewer) throw IllegalStateException("No newer Levyra release is available")
+        if (!update.info.directApk || update.assetDownloadUrl.isBlank()) {
+            throw IllegalStateException("The latest Levyra release has no installable APK")
+        }
+        update
+    }
+
+    private fun fetchLatestRelease(): JSONObject {
         val request = Request.Builder()
             .url(BuildConfig.UPDATE_LATEST_URL)
             .header("Accept", "application/vnd.github+json")
@@ -32,11 +52,11 @@ class AppUpdateRepository(context: Context) {
                 }
                 throw IllegalStateException(message)
             }
-            parseLatestRelease(JSONObject(body))
+            return JSONObject(body)
         }
     }
 
-    private fun parseLatestRelease(root: JSONObject): AppUpdateInfo {
+    private fun parseLatestRelease(root: JSONObject): InstallableAppUpdate {
         val latestTag = root.optString("tag_name").ifBlank { root.optString("name") }
         val latestVersion = normalizeDisplayVersion(latestTag)
         val releaseUrl = root.optString("html_url")
@@ -46,12 +66,18 @@ class AppUpdateRepository(context: Context) {
             sdk = Build.VERSION.SDK_INT,
             supportedAbis = Build.SUPPORTED_ABIS.orEmpty().toList()
         )
-        val downloadUrl = selected?.downloadUrl?.ifBlank { releaseUrl } ?: releaseUrl
+        val assetDownloadUrl = selected?.downloadUrl.orEmpty()
+        val directApk = selected?.isApk == true && assetDownloadUrl.isNotBlank()
+        val downloadUrl = if (directApk) {
+            AppUpdateContract.INSTALL_URI
+        } else {
+            assetDownloadUrl.ifBlank { releaseUrl }
+        }
         val assetName = selected?.name.orEmpty()
         val releaseTitle = root.optString("name").ifBlank { "LEVYRA $latestVersion" }
         val notes = root.optString("body").trim()
         val current = BuildConfig.VERSION_NAME
-        return AppUpdateInfo(
+        val info = AppUpdateInfo(
             currentVersionName = current,
             latestVersionName = latestVersion,
             latestTag = latestTag.ifBlank { latestVersion },
@@ -59,10 +85,15 @@ class AppUpdateRepository(context: Context) {
             releaseNotes = notes,
             publishedAt = root.optString("published_at"),
             downloadUrl = downloadUrl,
-            releaseUrl = releaseUrl.ifBlank { downloadUrl },
+            releaseUrl = releaseUrl.ifBlank { assetDownloadUrl },
             assetName = assetName,
-            directApk = selected?.isApk == true,
+            directApk = directApk,
             isNewer = LevyraVersionComparator.compare(latestVersion, current) > 0
+        )
+        return InstallableAppUpdate(
+            info = info,
+            assetDownloadUrl = assetDownloadUrl,
+            assetSizeBytes = selected?.sizeBytes?.coerceAtLeast(0L) ?: 0L
         )
     }
 

--- a/app/src/main/java/com/luc4n3x/levyra/update/AppUpdateInstaller.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/update/AppUpdateInstaller.kt
@@ -30,11 +30,12 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 
 internal object AppUpdateContract {
-    const val INSTALL_URI = "levyra://updates/install"
-    const val EXTRA_CONSUMED = "levyra.update_intent_consumed"
+    const val INSTALL_URI = "levyra-internal://updates/install"
 
-    fun matches(intent: Intent?): Boolean =
-        intent?.action == Intent.ACTION_VIEW && intent.data?.toString() == INSTALL_URI
+    fun matches(action: String?, uri: String?): Boolean =
+        action == Intent.ACTION_VIEW && uri == INSTALL_URI
+
+    fun matches(intent: Intent?): Boolean = matches(intent?.action, intent?.dataString)
 }
 
 internal data class PreparedAppUpdate(
@@ -139,10 +140,13 @@ internal class AppUpdateInstaller(
         .connectTimeout(10, TimeUnit.SECONDS)
         .readTimeout(30, TimeUnit.SECONDS)
         .writeTimeout(10, TimeUnit.SECONDS)
-        .callTimeout(45, TimeUnit.SECONDS)
+        .callTimeout(0, TimeUnit.MILLISECONDS)
         .build()
 
     suspend fun prepareLatestUpdate(onProgress: (String, Int?) -> Unit): PreparedAppUpdate = withContext(Dispatchers.IO) {
+        if (!BuildConfig.UPSTREAM_UPDATES_ENABLED) {
+            throw IllegalStateException("Upstream updates are disabled")
+        }
         val update = repository.latestInstallable()
         val versionName = update.info.latestVersionName
         if (update.assetSizeBytes > MAX_UPDATE_APK_BYTES) throw IOException("Update APK is too large")

--- a/app/src/main/java/com/luc4n3x/levyra/update/AppUpdateInstaller.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/update/AppUpdateInstaller.kt
@@ -142,8 +142,9 @@ internal class AppUpdateInstaller(
         .callTimeout(45, TimeUnit.SECONDS)
         .build()
 
-    suspend fun prepareLatestUpdate(onProgress: (Int?) -> Unit): PreparedAppUpdate = withContext(Dispatchers.IO) {
+    suspend fun prepareLatestUpdate(onProgress: (String, Int?) -> Unit): PreparedAppUpdate = withContext(Dispatchers.IO) {
         val update = repository.latestInstallable()
+        val versionName = update.info.latestVersionName
         if (update.assetSizeBytes > MAX_UPDATE_APK_BYTES) throw IOException("Update APK is too large")
 
         val directory = File(appContext.cacheDir, "updates")
@@ -155,8 +156,10 @@ internal class AppUpdateInstaller(
         if (finalFile.isFile) {
             try {
                 verifyDownloadedApk(finalFile, update)
-                onProgress(100)
-                return@withContext PreparedAppUpdate(update.info.latestVersionName, finalFile)
+                onProgress(versionName, 100)
+                return@withContext PreparedAppUpdate(versionName, finalFile)
+            } catch (cancelled: CancellationException) {
+                throw cancelled
             } catch (_: Throwable) {
                 finalFile.delete()
             }
@@ -164,19 +167,22 @@ internal class AppUpdateInstaller(
 
         val initialUrl = validateLevyraUpdateUrl(update.assetDownloadUrl, initial = true)
             ?: throw IOException("Invalid Levyra update URL")
-        downloadToFile(initialUrl, update, partFile, onProgress)
+        downloadToFile(initialUrl, update, partFile) { progress -> onProgress(versionName, progress) }
         if (!partFile.renameTo(finalFile)) {
             partFile.delete()
             throw IOException("Unable to finalize update APK")
         }
         try {
             verifyDownloadedApk(finalFile, update)
+        } catch (cancelled: CancellationException) {
+            finalFile.delete()
+            throw cancelled
         } catch (error: Throwable) {
             finalFile.delete()
             throw error
         }
-        onProgress(100)
-        PreparedAppUpdate(update.info.latestVersionName, finalFile)
+        onProgress(versionName, 100)
+        PreparedAppUpdate(versionName, finalFile)
     }
 
     private suspend fun downloadToFile(
@@ -201,8 +207,10 @@ internal class AppUpdateInstaller(
             }
             val response = try {
                 call.execute()
-            } finally {
-                if (call.isCanceled()) cancellation.dispose()
+            } catch (error: Throwable) {
+                cancellation.dispose()
+                destination.delete()
+                throw error
             }
             try {
                 if (response.code in UPDATE_REDIRECT_CODES) {
@@ -259,6 +267,9 @@ internal class AppUpdateInstaller(
                     throw IOException("Downloaded update is incomplete")
                 }
                 return
+            } catch (cancelled: CancellationException) {
+                destination.delete()
+                throw cancelled
             } catch (error: Throwable) {
                 destination.delete()
                 throw error

--- a/app/src/main/java/com/luc4n3x/levyra/update/AppUpdateInstaller.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/update/AppUpdateInstaller.kt
@@ -1,0 +1,357 @@
+package com.luc4n3x.levyra.update
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.content.pm.Signature
+import android.os.Build
+import com.luc4n3x.levyra.BuildConfig
+import com.luc4n3x.levyra.data.AppUpdateRepository
+import com.luc4n3x.levyra.data.InstallableAppUpdate
+import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
+import com.luc4n3x.levyra.nexus.update.LevyraVersionComparator
+import java.io.File
+import java.io.IOException
+import java.net.InetAddress
+import java.net.UnknownHostException
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.job
+import kotlinx.coroutines.withContext
+import okhttp3.Dns
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+internal object AppUpdateContract {
+    const val INSTALL_URI = "levyra://updates/install"
+    const val EXTRA_CONSUMED = "levyra.update_intent_consumed"
+
+    fun matches(intent: Intent?): Boolean =
+        intent?.action == Intent.ACTION_VIEW && intent.data?.toString() == INSTALL_URI
+}
+
+internal data class PreparedAppUpdate(
+    val versionName: String,
+    val apkFile: File
+)
+
+internal const val MAX_UPDATE_APK_BYTES = 250L * 1024L * 1024L
+private const val MAX_UPDATE_REDIRECTS = 5
+private const val UPDATE_APK_FILE = "levyra-update.apk"
+private const val UPDATE_APK_PART_FILE = "levyra-update.apk.part"
+private const val LEVYRA_RELEASE_PATH_PREFIX = "/LUC4N3X/Levyra-deepsound/releases/download/"
+private val UPDATE_REDIRECT_CODES = setOf(301, 302, 303, 307, 308)
+
+internal fun validateLevyraUpdateUrl(value: String, initial: Boolean): HttpUrl? {
+    val url = value.trim().toHttpUrlOrNull() ?: return null
+    if (!url.isHttps || url.port != 443) return null
+    if (url.username.isNotEmpty() || url.password.isNotEmpty() || url.fragment != null) return null
+    val host = url.host.lowercase(Locale.ROOT)
+    if (!isAllowedUpdateHost(host)) return null
+    if (initial && (host != "github.com" || !url.encodedPath.startsWith(LEVYRA_RELEASE_PATH_PREFIX))) return null
+    return url
+}
+
+internal fun updateApkContentTypeAccepted(value: String?): Boolean {
+    val mime = value
+        ?.substringBefore(';')
+        ?.trim()
+        ?.lowercase(Locale.ROOT)
+        .orEmpty()
+    return mime.isBlank() || mime == "application/vnd.android.package-archive" ||
+        mime == "application/octet-stream" || mime == "binary/octet-stream"
+}
+
+internal fun isPublicUpdateAddress(address: InetAddress): Boolean {
+    if (
+        address.isAnyLocalAddress ||
+        address.isLoopbackAddress ||
+        address.isLinkLocalAddress ||
+        address.isSiteLocalAddress ||
+        address.isMulticastAddress
+    ) return false
+
+    val bytes = address.address
+    val ipv4 = when {
+        bytes.size == 4 -> bytes
+        bytes.size == 16 && bytes.take(10).all { it.toInt() == 0 } &&
+            bytes[10].toInt() == -1 && bytes[11].toInt() == -1 -> bytes.copyOfRange(12, 16)
+        else -> null
+    }
+    if (ipv4 != null) {
+        val a = ipv4[0].toInt() and 0xff
+        val b = ipv4[1].toInt() and 0xff
+        val c = ipv4[2].toInt() and 0xff
+        if (a == 0 || a == 10 || a == 127 || a >= 224) return false
+        if (a == 100 && b in 64..127) return false
+        if (a == 169 && b == 254) return false
+        if (a == 172 && b in 16..31) return false
+        if (a == 192 && b == 168) return false
+        if (a == 192 && b == 0 && c in 0..2) return false
+        if (a == 198 && b in 18..19) return false
+        if (a == 198 && b == 51 && c == 100) return false
+        if (a == 203 && b == 0 && c == 113) return false
+        return true
+    }
+
+    if (bytes.size == 16) {
+        val first = bytes[0].toInt() and 0xff
+        if (first and 0xfe == 0xfc) return false
+        if (
+            first == 0x20 && (bytes[1].toInt() and 0xff) == 0x01 &&
+            (bytes[2].toInt() and 0xff) == 0x0d && (bytes[3].toInt() and 0xff) == 0xb8
+        ) return false
+    }
+    return true
+}
+
+private fun isAllowedUpdateHost(host: String): Boolean =
+    host == "github.com" || host == "githubusercontent.com" || host.endsWith(".githubusercontent.com")
+
+internal class AppUpdateInstaller(
+    context: Context,
+    private val repository: AppUpdateRepository = AppUpdateRepository(context.applicationContext),
+    httpClient: OkHttpClient = LevyraHttpClientFactory.general(context.applicationContext)
+) {
+    private val appContext = context.applicationContext
+    private val baseDns = httpClient.dns
+    private val downloadClient = httpClient.newBuilder()
+        .dns(object : Dns {
+            override fun lookup(hostname: String): List<InetAddress> {
+                val host = hostname.lowercase(Locale.ROOT)
+                if (!isAllowedUpdateHost(host)) throw UnknownHostException("Update host not allowed")
+                val addresses = baseDns.lookup(hostname)
+                if (addresses.isEmpty() || addresses.any { !isPublicUpdateAddress(it) }) {
+                    throw UnknownHostException("Update destination is not public")
+                }
+                return addresses
+            }
+        })
+        .followRedirects(false)
+        .followSslRedirects(false)
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(10, TimeUnit.SECONDS)
+        .callTimeout(45, TimeUnit.SECONDS)
+        .build()
+
+    suspend fun prepareLatestUpdate(onProgress: (Int?) -> Unit): PreparedAppUpdate = withContext(Dispatchers.IO) {
+        val update = repository.latestInstallable()
+        if (update.assetSizeBytes > MAX_UPDATE_APK_BYTES) throw IOException("Update APK is too large")
+
+        val directory = File(appContext.cacheDir, "updates")
+        if (!directory.exists() && !directory.mkdirs()) throw IOException("Unable to create update cache")
+        val finalFile = File(directory, UPDATE_APK_FILE)
+        val partFile = File(directory, UPDATE_APK_PART_FILE)
+        partFile.delete()
+
+        if (finalFile.isFile) {
+            try {
+                verifyDownloadedApk(finalFile, update)
+                onProgress(100)
+                return@withContext PreparedAppUpdate(update.info.latestVersionName, finalFile)
+            } catch (_: Throwable) {
+                finalFile.delete()
+            }
+        }
+
+        val initialUrl = validateLevyraUpdateUrl(update.assetDownloadUrl, initial = true)
+            ?: throw IOException("Invalid Levyra update URL")
+        downloadToFile(initialUrl, update, partFile, onProgress)
+        if (!partFile.renameTo(finalFile)) {
+            partFile.delete()
+            throw IOException("Unable to finalize update APK")
+        }
+        try {
+            verifyDownloadedApk(finalFile, update)
+        } catch (error: Throwable) {
+            finalFile.delete()
+            throw error
+        }
+        onProgress(100)
+        PreparedAppUpdate(update.info.latestVersionName, finalFile)
+    }
+
+    private suspend fun downloadToFile(
+        initialUrl: HttpUrl,
+        update: InstallableAppUpdate,
+        destination: File,
+        onProgress: (Int?) -> Unit
+    ) {
+        var currentUrl = initialUrl
+        var redirects = 0
+        while (true) {
+            currentCoroutineContext().ensureActive()
+            val request = Request.Builder()
+                .url(currentUrl)
+                .header("Accept", "application/vnd.android.package-archive, application/octet-stream;q=0.9")
+                .header("User-Agent", "LEVYRA/${BuildConfig.VERSION_NAME}")
+                .header("Cache-Control", "no-cache")
+                .build()
+            val call = downloadClient.newCall(request)
+            val cancellation = currentCoroutineContext().job.invokeOnCompletion { cause ->
+                if (cause is CancellationException) call.cancel()
+            }
+            val response = try {
+                call.execute()
+            } finally {
+                if (call.isCanceled()) cancellation.dispose()
+            }
+            try {
+                if (response.code in UPDATE_REDIRECT_CODES) {
+                    if (redirects >= MAX_UPDATE_REDIRECTS) throw IOException("Too many update redirects")
+                    val location = response.header("Location") ?: throw IOException("Update redirect has no location")
+                    val next = currentUrl.resolve(location)?.toString().orEmpty()
+                    currentUrl = validateLevyraUpdateUrl(next, initial = false)
+                        ?: throw IOException("Unsafe update redirect")
+                    redirects++
+                    continue
+                }
+                if (!response.isSuccessful) throw IOException("Update download failed (${response.code})")
+                if (!updateApkContentTypeAccepted(response.header("Content-Type"))) {
+                    throw IOException("Unexpected update content type")
+                }
+                val body = response.body
+                val declaredLength = body.contentLength().takeIf { it >= 0L } ?: 0L
+                if (declaredLength > MAX_UPDATE_APK_BYTES) throw IOException("Update APK is too large")
+                if (update.assetSizeBytes > 0L && declaredLength > 0L && declaredLength != update.assetSizeBytes) {
+                    throw IOException("Update size does not match release metadata")
+                }
+
+                val expectedLength = update.assetSizeBytes.takeIf { it > 0L } ?: declaredLength
+                var total = 0L
+                var lastProgress = -1
+                if (expectedLength <= 0L) onProgress(null)
+                body.byteStream().use { input ->
+                    destination.outputStream().buffered().use { output ->
+                        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                        while (true) {
+                            currentCoroutineContext().ensureActive()
+                            val count = input.read(buffer)
+                            if (count < 0) break
+                            if (count == 0) continue
+                            total += count
+                            if (total > MAX_UPDATE_APK_BYTES) throw IOException("Update APK exceeded size limit")
+                            output.write(buffer, 0, count)
+                            if (expectedLength > 0L) {
+                                val progress = ((total * 100L) / expectedLength).toInt().coerceIn(0, 99)
+                                if (progress != lastProgress) {
+                                    lastProgress = progress
+                                    onProgress(progress)
+                                }
+                            }
+                        }
+                        output.flush()
+                    }
+                }
+                if (total < 4_096L) throw IOException("Downloaded update is not a valid APK")
+                if (update.assetSizeBytes > 0L && total != update.assetSizeBytes) {
+                    throw IOException("Downloaded update size does not match release metadata")
+                }
+                if (declaredLength > 0L && total != declaredLength) {
+                    throw IOException("Downloaded update is incomplete")
+                }
+                return
+            } catch (error: Throwable) {
+                destination.delete()
+                throw error
+            } finally {
+                response.close()
+                cancellation.dispose()
+            }
+        }
+    }
+
+    private fun verifyDownloadedApk(file: File, update: InstallableAppUpdate) {
+        if (!file.isFile || file.length() < 4_096L || file.length() > MAX_UPDATE_APK_BYTES) {
+            throw IOException("Update APK is invalid")
+        }
+        if (update.assetSizeBytes > 0L && file.length() != update.assetSizeBytes) {
+            throw IOException("Update APK size does not match release metadata")
+        }
+
+        val packageManager = appContext.packageManager
+        val installed = installedPackageInfo(packageManager)
+        val archive = archivePackageInfo(packageManager, file)
+            ?: throw IOException("Unable to inspect update APK")
+        if (archive.packageName != appContext.packageName) throw IOException("Update package name mismatch")
+
+        val installedVersionCode = packageVersionCode(installed)
+        val archiveVersionCode = packageVersionCode(archive)
+        if (archiveVersionCode <= installedVersionCode) throw IOException("Update APK is not newer")
+        val archiveVersionName = archive.versionName.orEmpty()
+        if (
+            archiveVersionName.isNotBlank() &&
+            LevyraVersionComparator.compare(archiveVersionName, update.info.latestVersionName) != 0
+        ) {
+            throw IOException("Update APK version does not match release metadata")
+        }
+        if (!hasTrustedSigningLineage(installed, archive)) throw IOException("Update signing certificate mismatch")
+    }
+
+    @Suppress("DEPRECATION")
+    private fun installedPackageInfo(packageManager: PackageManager): PackageInfo {
+        val flags = signingFlags()
+        return if (Build.VERSION.SDK_INT >= 33) {
+            packageManager.getPackageInfo(
+                appContext.packageName,
+                PackageManager.PackageInfoFlags.of(flags.toLong())
+            )
+        } else {
+            packageManager.getPackageInfo(appContext.packageName, flags)
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun archivePackageInfo(packageManager: PackageManager, file: File): PackageInfo? {
+        val flags = signingFlags()
+        return if (Build.VERSION.SDK_INT >= 33) {
+            packageManager.getPackageArchiveInfo(
+                file.absolutePath,
+                PackageManager.PackageInfoFlags.of(flags.toLong())
+            )
+        } else {
+            packageManager.getPackageArchiveInfo(file.absolutePath, flags)
+        }
+    }
+
+    private fun signingFlags(): Int =
+        if (Build.VERSION.SDK_INT >= 28) PackageManager.GET_SIGNING_CERTIFICATES else PackageManager.GET_SIGNATURES
+
+    @Suppress("DEPRECATION")
+    private fun packageVersionCode(info: PackageInfo): Long =
+        if (Build.VERSION.SDK_INT >= 28) info.longVersionCode else info.versionCode.toLong()
+
+    @Suppress("DEPRECATION")
+    private fun hasTrustedSigningLineage(installed: PackageInfo, archive: PackageInfo): Boolean {
+        val installedSigners = if (Build.VERSION.SDK_INT >= 28) {
+            installed.signingInfo?.apkContentsSigners.orEmpty()
+        } else {
+            installed.signatures.orEmpty()
+        }
+        val archiveLineage = if (Build.VERSION.SDK_INT >= 28) {
+            val signingInfo = archive.signingInfo ?: return false
+            if (signingInfo.hasPastSigningCertificates()) {
+                signingInfo.signingCertificateHistory
+            } else {
+                signingInfo.apkContentsSigners
+            }.orEmpty()
+        } else {
+            archive.signatures.orEmpty()
+        }
+        if (installedSigners.isEmpty() || archiveLineage.isEmpty()) return false
+        return installedSigners.all { installedSigner ->
+            archiveLineage.any { archiveSigner -> signaturesEqual(installedSigner, archiveSigner) }
+        }
+    }
+
+    private fun signaturesEqual(left: Signature, right: Signature): Boolean =
+        left.toByteArray().contentEquals(right.toByteArray())
+}

--- a/app/src/main/res/xml/update_file_paths.xml
+++ b/app/src/main/res/xml/update_file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path
+        name="update_apk"
+        path="updates/" />
+</paths>

--- a/app/src/test/java/com/luc4n3x/levyra/update/AppUpdateInstallerTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/update/AppUpdateInstallerTest.kt
@@ -22,6 +22,7 @@ class AppUpdateInstallerTest {
         assertNull(validateLevyraUpdateUrl("https://github.com:8443/LUC4N3X/Levyra-deepsound/releases/download/v2.3.20/app.apk", true))
         assertNull(validateLevyraUpdateUrl("https://github.com/other/project/releases/download/v1/app.apk", true))
         assertNull(validateLevyraUpdateUrl("https://example.com/LUC4N3X/Levyra-deepsound/releases/download/v2.3.20/app.apk", true))
+        assertNull(validateLevyraUpdateUrl("https://github.com/LUC4N3X/Levyra-deepsound/releases/download/../../../other/app.apk", true))
     }
 
     @Test
@@ -29,6 +30,11 @@ class AppUpdateInstallerTest {
         assertNotNull(validateLevyraUpdateUrl("https://release-assets.githubusercontent.com/github-production-release-asset/file.apk", false))
         assertNotNull(validateLevyraUpdateUrl("https://github.com/LUC4N3X/Levyra-deepsound/releases/download/v2.3.20/app.apk", false))
         assertNull(validateLevyraUpdateUrl("https://example.com/app.apk", false))
+        assertNull(validateLevyraUpdateUrl("https://release-assets.githubusercontent.com:8443/file.apk", false))
+        assertNull(validateLevyraUpdateUrl("https://user:pass@release-assets.githubusercontent.com/file.apk", false))
+        assertNull(validateLevyraUpdateUrl("https://release-assets.githubusercontent.com/file.apk#frag", false))
+        assertNull(validateLevyraUpdateUrl("http://release-assets.githubusercontent.com/file.apk", false))
+        assertNull(validateLevyraUpdateUrl("https://evil.githubusercontent.com.attacker.test/file.apk", false))
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/update/AppUpdateInstallerTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/update/AppUpdateInstallerTest.kt
@@ -41,6 +41,14 @@ class AppUpdateInstallerTest {
     }
 
     @Test
+    fun `internal install handoff only matches the private update URI`() {
+        assertTrue(AppUpdateContract.matches("android.intent.action.VIEW", AppUpdateContract.INSTALL_URI))
+        assertFalse(AppUpdateContract.matches("android.intent.action.SEND", AppUpdateContract.INSTALL_URI))
+        assertFalse(AppUpdateContract.matches("android.intent.action.VIEW", "levyra://updates/install"))
+        assertFalse(AppUpdateContract.matches("android.intent.action.VIEW", "https://github.com/LUC4N3X/Levyra-deepsound"))
+    }
+
+    @Test
     fun `private and special destinations are rejected`() {
         assertFalse(isPublicUpdateAddress(InetAddress.getByName("10.0.0.1")))
         assertFalse(isPublicUpdateAddress(InetAddress.getByName("100.64.0.1")))

--- a/app/src/test/java/com/luc4n3x/levyra/update/AppUpdateInstallerTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/update/AppUpdateInstallerTest.kt
@@ -1,0 +1,52 @@
+package com.luc4n3x.levyra.update
+
+import java.net.InetAddress
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppUpdateInstallerTest {
+    @Test
+    fun `official release asset URL is accepted`() {
+        val url = "https://github.com/LUC4N3X/Levyra-deepsound/releases/download/v2.3.20/levyra-release.apk"
+
+        assertNotNull(validateLevyraUpdateUrl(url, initial = true))
+    }
+
+    @Test
+    fun `initial update URL rejects unsafe or unrelated sources`() {
+        assertNull(validateLevyraUpdateUrl("http://github.com/LUC4N3X/Levyra-deepsound/releases/download/v2.3.20/app.apk", true))
+        assertNull(validateLevyraUpdateUrl("https://user:pass@github.com/LUC4N3X/Levyra-deepsound/releases/download/v2.3.20/app.apk", true))
+        assertNull(validateLevyraUpdateUrl("https://github.com:8443/LUC4N3X/Levyra-deepsound/releases/download/v2.3.20/app.apk", true))
+        assertNull(validateLevyraUpdateUrl("https://github.com/other/project/releases/download/v1/app.apk", true))
+        assertNull(validateLevyraUpdateUrl("https://example.com/LUC4N3X/Levyra-deepsound/releases/download/v2.3.20/app.apk", true))
+    }
+
+    @Test
+    fun `redirects stay on GitHub managed hosts`() {
+        assertNotNull(validateLevyraUpdateUrl("https://release-assets.githubusercontent.com/github-production-release-asset/file.apk", false))
+        assertNotNull(validateLevyraUpdateUrl("https://github.com/LUC4N3X/Levyra-deepsound/releases/download/v2.3.20/app.apk", false))
+        assertNull(validateLevyraUpdateUrl("https://example.com/app.apk", false))
+    }
+
+    @Test
+    fun `APK response types are constrained`() {
+        assertTrue(updateApkContentTypeAccepted("application/vnd.android.package-archive"))
+        assertTrue(updateApkContentTypeAccepted("application/octet-stream"))
+        assertTrue(updateApkContentTypeAccepted(null))
+        assertFalse(updateApkContentTypeAccepted("text/html"))
+        assertFalse(updateApkContentTypeAccepted("application/zip"))
+    }
+
+    @Test
+    fun `private and special destinations are rejected`() {
+        assertFalse(isPublicUpdateAddress(InetAddress.getByName("10.0.0.1")))
+        assertFalse(isPublicUpdateAddress(InetAddress.getByName("100.64.0.1")))
+        assertFalse(isPublicUpdateAddress(InetAddress.getByName("203.0.113.1")))
+        assertFalse(isPublicUpdateAddress(InetAddress.getByName("fc00::1")))
+        assertTrue(isPublicUpdateAddress(InetAddress.getByName("8.8.8.8")))
+        assertTrue(isPublicUpdateAddress(InetAddress.getByName("2606:4700:4700::1111")))
+    }
+}


### PR DESCRIPTION
## What changed

- keep the existing GitHub release check and ABI-aware APK selection for upstream/GitHub builds, but route direct APK updates back into Levyra instead of opening the browser
- download the selected release APK inside the app with visible progress and hand the verified file directly to Android's package installer
- remove the externally registered update deep link; the update handoff is internal to the running app
- open Android's per-app unknown-source settings only when needed, then resume the install; if the activity is recreated while settings are open, Levyra safely reuses and re-verifies the cached APK
- expose only `cache/updates/` through a dedicated `FileProvider`
- remove the 45-second whole-call timeout so a healthy but slow APK download can continue while retaining connection/read/write timeout protection
- show a real failure message instead of looping back into another update check

## GitHub build vs F-Droid

The in-app installer is an **upstream/GitHub distribution feature only**.

- upstream builds request `REQUEST_INSTALL_PACKAGES` and enable the update `FileProvider`
- F-Droid builds do **not** request `REQUEST_INSTALL_PACKAGES`, keep the GitHub update provider disabled, and keep `UPSTREAM_UPDATES_ENABLED=false`
- that flag disables only Levyra's own GitHub self-updater in the F-Droid build; it does **not** disable app updates through F-Droid
- F-Droid remains responsible for detecting and installing newer Levyra versions through the normal F-Droid client/repository flow
- PR Check inspects the built F-Droid APK and fails if `REQUEST_INSTALL_PACKAGES` is present or the GitHub update provider is enabled

## Update integrity

The downloader does not trust an arbitrary release URL. It:

- requires the initial asset to be an HTTPS GitHub release URL for `LUC4N3X/Levyra-deepsound`
- disables automatic redirects and validates every redirect hop against GitHub-managed hosts and public network destinations
- rejects credentials, non-443 ports, private/special IP ranges, unexpected MIME types, oversized responses, incomplete files and release-size mismatches
- writes to a fixed `.part` file and promotes it to the cached APK only after the download completes
- verifies the APK package name, newer version code, release version and signing-certificate lineage before handing it to Android

## User experience

For a GitHub-installed build:

`Aggiorna -> download inside Levyra -> Android installer`

No GitHub Releases page is opened for a normal direct APK update. Android still owns the final installation confirmation, as required for a regular non-privileged app.

For an F-Droid-installed build, updates remain managed by F-Droid as usual.

## Files

- `.github/workflows/pr-check.yml`
- `app/build.gradle.kts`
- `app/src/main/AndroidManifest.xml`
- `app/src/main/java/com/luc4n3x/levyra/MainActivity.kt`
- `app/src/main/java/com/luc4n3x/levyra/data/AppUpdateRepository.kt`
- `app/src/main/java/com/luc4n3x/levyra/update/AppUpdateInstaller.kt`
- `app/src/main/res/xml/update_file_paths.xml`
- `app/src/test/java/com/luc4n3x/levyra/update/AppUpdateInstallerTest.kt`

## Validation

All CI checks on head `84c98ea` pass:

- Release Guard
- Dependency Review
- APK Size Report
- APK Artifact: signed release APK built, verified and uploaded
- PR Check
  - agent/F-Droid contract validation
  - extractor tests
  - Android Lint
  - updater URL/redirect/MIME/private-network/internal-handoff tests plus the existing regression suite
  - release compile
  - F-Droid release compile
  - final F-Droid APK manifest check proving `REQUEST_INSTALL_PACKAGES` is absent and the GitHub update provider is disabled

A physical-device smoke test of the Android package-installer handoff remains manual, especially the first-run `Install unknown apps` permission flow.

## Preserved behavior

- no Android version change
- no release/tag/signing configuration change
- no playback, database, download-library or user-data changes
- F-Droid's normal store-managed update flow remains unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added in-app update downloads and installation with progress tracking.
  - Update files are securely validated before installation.
  - Added support for resuming downloads from cached APK files.
  - Update failures now provide localized feedback.

- **Bug Fixes**
  - Improved update compatibility checks to prevent invalid, outdated, or unrelated APKs from being installed.

- **F-Droid**
  - F-Droid builds no longer request permission to install packages or enable upstream update providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->