### PR TITLE
fix: preserve audio tuning across backup restore

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraBackupManager.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraBackupManager.kt
@@ -287,37 +287,11 @@ class LevyraBackupManager(private val context: Context) {
         }
     }
 
-    private fun audioSettingsToJson(value: LevyraAudioSettings): JSONObject = JSONObject()
-        .put("equalizerEnabled", value.equalizerEnabled)
-        .put("presetId", value.presetId)
-        .put("bandLevels", JSONArray(value.bandLevels))
-        .put("bassBoost", value.bassBoost)
-        .put("virtualizer", value.virtualizer)
-        .put("crossfadeSeconds", value.crossfadeSeconds)
-        .put("djSoftMode", value.djSoftMode)
-        .put("replayGainEnabled", value.replayGainEnabled)
-        .put("playbackSpeed", value.playbackSpeed.toDouble())
-        .put("pitch", value.pitch.toDouble())
-        .put("gaplessEnabled", value.gaplessEnabled)
+    private fun audioSettingsToJson(value: LevyraAudioSettings): JSONObject =
+        backupAudioSettingsToJson(value)
 
-    private fun parseAudioSettings(json: JSONObject?): LevyraAudioSettings {
-        if (json == null) return LevyraAudioSettings()
-        val levelsArray = json.optJSONArray("bandLevels") ?: JSONArray()
-        val levels = buildList { for (index in 0 until levelsArray.length()) add(levelsArray.optInt(index)) }
-        return LevyraAudioSettings(
-            equalizerEnabled = json.optBoolean("equalizerEnabled"),
-            presetId = json.optString("presetId"),
-            bandLevels = levels,
-            bassBoost = json.optInt("bassBoost"),
-            virtualizer = json.optInt("virtualizer"),
-            crossfadeSeconds = json.optInt("crossfadeSeconds"),
-            djSoftMode = json.optBoolean("djSoftMode"),
-            replayGainEnabled = json.optBoolean("replayGainEnabled"),
-            playbackSpeed = json.optDouble("playbackSpeed", 1.0).toFloat(),
-            pitch = json.optDouble("pitch", 1.0).toFloat(),
-            gaplessEnabled = json.optBoolean("gaplessEnabled", true)
-        ).normalized()
-    }
+    private fun parseAudioSettings(json: JSONObject?): LevyraAudioSettings =
+        backupAudioSettingsFromJson(json)
 
     private fun interfaceSettingsToJson(value: LevyraInterfaceSettings): JSONObject = JSONObject()
         .put("compactHome", value.compactHome)
@@ -528,6 +502,42 @@ class LevyraBackupManager(private val context: Context) {
         const val AUTOMATIC_BACKUP_PREFIX = "levyra-auto-backup-"
         val REQUIRED_ENTRIES = setOf(MANIFEST_ENTRY, PAYLOAD_ENTRY)
     }
+}
+
+internal fun backupAudioSettingsToJson(value: LevyraAudioSettings): JSONObject = JSONObject()
+    .put("equalizerEnabled", value.equalizerEnabled)
+    .put("presetId", value.presetId)
+    .put("bandLevels", JSONArray(value.bandLevels))
+    .put("bassBoost", value.bassBoost)
+    .put("virtualizer", value.virtualizer)
+    .put("preampDb", value.preampDb.toDouble())
+    .put("limiterEnabled", value.limiterEnabled)
+    .put("crossfadeSeconds", value.crossfadeSeconds)
+    .put("djSoftMode", value.djSoftMode)
+    .put("replayGainEnabled", value.replayGainEnabled)
+    .put("playbackSpeed", value.playbackSpeed.toDouble())
+    .put("pitch", value.pitch.toDouble())
+    .put("gaplessEnabled", value.gaplessEnabled)
+
+internal fun backupAudioSettingsFromJson(json: JSONObject?): LevyraAudioSettings {
+    if (json == null) return LevyraAudioSettings()
+    val levelsArray = json.optJSONArray("bandLevels") ?: JSONArray()
+    val levels = buildList { for (index in 0 until levelsArray.length()) add(levelsArray.optInt(index)) }
+    return LevyraAudioSettings(
+        equalizerEnabled = json.optBoolean("equalizerEnabled"),
+        presetId = json.optString("presetId"),
+        bandLevels = levels,
+        bassBoost = json.optInt("bassBoost"),
+        virtualizer = json.optInt("virtualizer"),
+        preampDb = json.optDouble("preampDb", 0.0).toFloat(),
+        limiterEnabled = json.optBoolean("limiterEnabled", true),
+        crossfadeSeconds = json.optInt("crossfadeSeconds"),
+        djSoftMode = json.optBoolean("djSoftMode"),
+        replayGainEnabled = json.optBoolean("replayGainEnabled"),
+        playbackSpeed = json.optDouble("playbackSpeed", 1.0).toFloat(),
+        pitch = json.optDouble("pitch", 1.0).toFloat(),
+        gaplessEnabled = json.optBoolean("gaplessEnabled", true)
+    ).normalized()
 }
 
 internal fun automaticBackupFilesToDelete(fileNames: List<String>, retentionCount: Int): List<String> = fileNames

--- a/app/src/test/java/com/luc4n3x/levyra/data/LevyraPreferencesDefaultsTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/LevyraPreferencesDefaultsTest.kt
@@ -1,5 +1,9 @@
 package com.luc4n3x.levyra.data
 
+import com.luc4n3x.levyra.domain.LevyraAudioSettings
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import com.luc4n3x.levyra.viewmodel.LevyraUiState
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -9,5 +13,25 @@ class LevyraPreferencesDefaultsTest {
     fun sponsorBlockIsEnabledByDefault() {
         assertTrue(DEFAULT_SPONSORBLOCK_ENABLED)
         assertTrue(LevyraUiState().sponsorBlockEnabled)
+    }
+
+    @Test
+    fun backupRoundTripPreservesPreampAndLimiterSettings() {
+        val restored = backupAudioSettingsFromJson(
+            backupAudioSettingsToJson(
+                LevyraAudioSettings(preampDb = -4.5f, limiterEnabled = false)
+            )
+        )
+
+        assertEquals(-4.5f, restored.preampDb, 0f)
+        assertFalse(restored.limiterEnabled)
+    }
+
+    @Test
+    fun legacyBackupKeepsPreampAndLimiterDefaults() {
+        val restored = backupAudioSettingsFromJson(JSONObject())
+
+        assertEquals(0f, restored.preampDb, 0f)
+        assertTrue(restored.limiterEnabled)
     }
 }


### PR DESCRIPTION
## Cause

`LevyraBackupManager` serialized most `LevyraAudioSettings` fields but omitted `preampDb` and `limiterEnabled`. Restore therefore replaced a user's preamp with `0 dB` and re-enabled the limiter through constructor defaults.

## Impact

Both manual and automatic backup restores silently changed two persisted audio-tuning choices. This could alter loudness/headroom and DSP behavior after a restore even though the backup completed successfully.

## Change

- include `preampDb` and `limiterEnabled` in the backup audio-settings payload;
- preserve backward compatibility by using the historical defaults for older archives where those keys are absent;
- route serialization through testable internal helpers;
- add focused round-trip and legacy-payload regression tests to `LevyraPreferencesDefaultsTest`, which is already selected by PR Check.

## Files

- `app/src/main/java/com/luc4n3x/levyra/data/LevyraBackupManager.kt`
- `app/src/test/java/com/luc4n3x/levyra/data/LevyraPreferencesDefaultsTest.kt`

## Verification

- `levyra-worker verify`: passed.
- Regression coverage verifies non-default preamp/limiter round-trip and defaults for legacy backup JSON.

## Risks

Low. The ZIP schema version and existing keys are unchanged; two optional JSON fields are added. Older backups remain readable, and newer backups preserve settings that were previously lost. No workflow, dependency, Room, version, signing, release, Desktop, or F-Droid metadata change is included.

## Previous behavior

Restoring any backup reset `preampDb` to `0f` and `limiterEnabled` to `true`, regardless of the values configured when the backup was created.
