### PR TITLE
fix: cancel blocked in-app update downloads

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/update/AppUpdateInstaller.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/update/AppUpdateInstaller.kt
@@ -18,10 +18,14 @@ import java.net.UnknownHostException
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.Dns
 import okhttp3.HttpUrl
@@ -112,6 +116,15 @@ internal fun isPublicUpdateAddress(address: InetAddress): Boolean {
     }
     return true
 }
+
+internal fun CoroutineScope.launchUpdateCallCancellationWatcher(cancelCall: () -> Unit): Job =
+    launch(Dispatchers.Default, start = CoroutineStart.UNDISPATCHED) {
+        try {
+            awaitCancellation()
+        } finally {
+            cancelCall()
+        }
+    }
 
 private fun isAllowedUpdateHost(host: String): Boolean =
     host == "github.com" || host == "githubusercontent.com" || host.endsWith(".githubusercontent.com")
@@ -206,14 +219,14 @@ internal class AppUpdateInstaller(
                 .header("Cache-Control", "no-cache")
                 .build()
             val call = downloadClient.newCall(request)
-            val cancellation = currentCoroutineContext().job.invokeOnCompletion { cause ->
-                if (cause is CancellationException) call.cancel()
-            }
+            val cancellationWatcher = CoroutineScope(currentCoroutineContext())
+                .launchUpdateCallCancellationWatcher(call::cancel)
             val response = try {
-                call.execute()
+                call.execute().also { currentCoroutineContext().ensureActive() }
             } catch (error: Throwable) {
-                cancellation.dispose()
+                cancellationWatcher.cancel()
                 destination.delete()
+                currentCoroutineContext().ensureActive()
                 throw error
             }
             try {
@@ -276,10 +289,11 @@ internal class AppUpdateInstaller(
                 throw cancelled
             } catch (error: Throwable) {
                 destination.delete()
+                currentCoroutineContext().ensureActive()
                 throw error
             } finally {
                 response.close()
-                cancellation.dispose()
+                cancellationWatcher.cancel()
             }
         }
     }

--- a/app/src/test/java/com/luc4n3x/levyra/update/AppUpdateInstallerTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/update/AppUpdateInstallerTest.kt
@@ -1,10 +1,19 @@
 package com.luc4n3x.levyra.update
 
 import java.net.InetAddress
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 class AppUpdateInstallerTest {
@@ -62,5 +71,33 @@ class AppUpdateInstallerTest {
         assertFalse(isPublicUpdateAddress(InetAddress.getByName("fc00::1")))
         assertTrue(isPublicUpdateAddress(InetAddress.getByName("8.8.8.8")))
         assertTrue(isPublicUpdateAddress(InetAddress.getByName("2606:4700:4700::1111")))
+    }
+
+    @Test
+    fun `cancelling update work interrupts a blocking call`() = runBlocking {
+        val enteredCall = CountDownLatch(1)
+        val cancelledCall = CountDownLatch(1)
+        val worker = async(Dispatchers.IO) {
+            val watcher = CoroutineScope(currentCoroutineContext())
+                .launchUpdateCallCancellationWatcher(cancelledCall::countDown)
+            try {
+                enteredCall.countDown()
+                check(cancelledCall.await(2, TimeUnit.SECONDS)) {
+                    "Blocking update call was not interrupted"
+                }
+            } finally {
+                watcher.cancel()
+            }
+        }
+
+        assertTrue(enteredCall.await(2, TimeUnit.SECONDS))
+        worker.cancel()
+        try {
+            worker.await()
+            fail("Cancelled update work must not complete successfully")
+        } catch (_: CancellationException) {
+            // Expected.
+        }
+        assertTrue(cancelledCall.await(2, TimeUnit.SECONDS))
     }
 }


### PR DESCRIPTION
## Causa

Il download in-app registrava `Call.cancel()` con `Job.invokeOnCompletion`. Il callback standard viene eseguito quando il job completa, ma una `call.execute()` o una lettura del body bloccata può impedire quel completamento. Inoltre il callback veniva rimosso subito dopo la ricezione degli header, prima della lettura completa dell'APK.

## Impatto

Premendo **Annulla**, uscendo dall'Activity o cancellando il lifecycle job durante una rete lenta/bloccata, il download poteva restare attivo fino al timeout o alla ripresa della socket. Il job e l'Activity potevano quindi trattenere lavoro e risorse più a lungo del previsto.

## Modifica

- aggiunto un watcher figlio che resta attivo per l'intera richiesta e chiama immediatamente `Call.cancel()` alla cancellazione del job;
- mantenuto il watcher fino alla chiusura del response body;
- ripristinata la `CancellationException` quando OkHttp traduce la cancellazione della socket in un errore I/O;
- aggiunto un test deterministico che dimostra lo sblocco di una chiamata bloccante quando il lavoro viene cancellato.

## File

- `app/src/main/java/com/luc4n3x/levyra/update/AppUpdateInstaller.kt`
- `app/src/test/java/com/luc4n3x/levyra/update/AppUpdateInstallerTest.kt`

## Verifica

`levyra-worker verify` superato, inclusi test, lint/controlli locali e compatibilità regex Android.

## Rischi

Bassi. La modifica non cambia URL, validazione APK, firma, redirect o flusso del package installer. Su completamento normale il watcher viene chiuso dopo il response; `Call.cancel()` a response già chiusa è idempotente.

## Comportamento precedente

La cancellazione era collegata al completamento finale del job e non copriva la lettura del body, quindi non poteva interrompere in modo affidabile la stessa operazione bloccante che ritardava il completamento.
