### PR TITLE
fix(build): remove deprecations and restore cross-platform checks

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,17 +126,17 @@ android {
         versionCode = levyraVersionCode
         versionName = levyraVersionName
         vectorDrawables.useSupportLibrary = true
-        manifestPlaceholders["upstreamInstallPermission"] = if (isFdroidBuild) {
-            "android.permission.INTERNET"
-        } else {
-            "android.permission.REQUEST_INSTALL_PACKAGES"
-        }
         manifestPlaceholders["upstreamUpdatesEnabled"] = (!isFdroidBuild).toString()
         buildConfigField("String", "UPDATE_REPOSITORY", "\"LUC4N3X/Levyra-deepsound\"")
         buildConfigField("String", "UPDATE_LATEST_URL", "\"https://api.github.com/repos/LUC4N3X/Levyra-deepsound/releases/latest\"")
         buildConfigField("boolean", "UPSTREAM_UPDATES_ENABLED", (!isFdroidBuild).toString())
         buildConfigField("boolean", "REMOTE_ANNOUNCEMENTS_ENABLED", (!isFdroidBuild).toString())
         buildConfigField("String", "YOUTUBE_INNERTUBE_API_KEY", buildConfigString(youtubeInnertubeApiKey))
+    }
+
+    if (isFdroidBuild) {
+        sourceSets.getByName("debug").manifest.srcFile("src/fdroid/AndroidManifest.xml")
+        sourceSets.getByName("release").manifest.srcFile("src/fdroid/AndroidManifest.xml")
     }
 
     signingConfigs {

--- a/app/src/fdroid/AndroidManifest.xml
+++ b/app/src/fdroid/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission
+        android:name="android.permission.REQUEST_INSTALL_PACKAGES"
+        tools:node="remove" />
+</manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
-    <uses-permission android:name="${upstreamInstallPermission}" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
     <uses-permission android:name="androidx.car.app.MEDIA_TEMPLATES" />

--- a/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
@@ -318,8 +318,8 @@ class MainActivity : ComponentActivity() {
             showUpdateFailure()
             return
         }
-        val installIntent = Intent(Intent.ACTION_INSTALL_PACKAGE).apply {
-            data = apkUri
+        val installIntent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(apkUri, "application/vnd.android.package-archive")
             clipData = ClipData.newRawUri("Levyra update", apkUri)
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }

--- a/app/src/main/java/com/luc4n3x/levyra/data/UniversalPlaylistImporter.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/UniversalPlaylistImporter.kt
@@ -650,9 +650,9 @@ class UniversalPlaylistImporter(
         val call = spotifyHttpClient.newCall(request)
         continuation.invokeOnCancellation { call.cancel() }
         call.enqueue(object : Callback {
-            override fun onFailure(call: Call, error: IOException) {
+            override fun onFailure(call: Call, e: IOException) {
                 if (continuation.isActive) {
-                    continuation.resumeWithException(error)
+                    continuation.resumeWithException(e)
                 }
             }
 

--- a/app/src/main/java/com/luc4n3x/levyra/player/car/LevyraCarAppService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/car/LevyraCarAppService.kt
@@ -154,8 +154,7 @@ private class LevyraCarSession : Session() {
                 if (response.resultCode != SessionResult.RESULT_SUCCESS || token == null) {
                     throw IllegalStateException("Playback token unavailable")
                 }
-                (carContext.getCarService(CarContext.MEDIA_PLAYBACK_SERVICE) as MediaPlaybackManager)
-                    .registerMediaPlaybackToken(MediaSessionCompat.Token.fromToken(token))
+                registerPlatformPlaybackToken(token)
                 playbackTokenRegistered = true
                 reconnectAttempts = 0
                 invalidatePlaybackScreen()
@@ -167,6 +166,13 @@ private class LevyraCarSession : Session() {
                 scheduleReconnect()
             }
         }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun registerPlatformPlaybackToken(sessionToken: android.media.session.MediaSession.Token) {
+        // AndroidX Car App 1.9.0-alpha01 still accepts only MediaSessionCompat.Token.
+        (carContext.getCarService(CarContext.MEDIA_PLAYBACK_SERVICE) as MediaPlaybackManager)
+            .registerMediaPlaybackToken(MediaSessionCompat.Token.fromToken(sessionToken))
     }
 
     private fun handleDisconnected(controller: MediaController) {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -11956,35 +11956,6 @@ private fun PlayerScreen(
                                 shape = RoundedCornerShape(artCorner)
                             )
                     )
-                    Surface(
-                        color = Color.Black.copy(alpha = 0.72f),
-                        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.18f)),
-                        shape = CircleShape,
-                        modifier = Modifier
-                            .align(Alignment.TopStart)
-                            .padding(18.dp)
-                            .zIndex(40f)
-                            .pressable(onClick = viewModel::toggleVideoMode)
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = 13.dp, vertical = 8.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(7.dp)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Rounded.MusicNote,
-                                contentDescription = null,
-                                tint = Color.White,
-                                modifier = Modifier.size(17.dp)
-                            )
-                            Text(
-                                text = strings.song,
-                                color = Color.White,
-                                fontSize = 12.sp,
-                                fontWeight = FontWeight.Bold
-                            )
-                        }
-                    }
                 } else {
                     PlayerArtworkCanvas(
                         track = activeTrack,

--- a/app/src/main/java/com/luc4n3x/levyra/update/AppUpdateInstaller.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/update/AppUpdateInstaller.kt
@@ -351,6 +351,7 @@ internal class AppUpdateInstaller(
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun signingFlags(): Int =
         if (Build.VERSION.SDK_INT >= 28) PackageManager.GET_SIGNING_CERTIFICATES else PackageManager.GET_SIGNATURES
 

--- a/desktop/app/build.gradle.kts
+++ b/desktop/app/build.gradle.kts
@@ -1,5 +1,6 @@
 import java.util.Properties
 import org.gradle.language.jvm.tasks.ProcessResources
+import org.gradle.api.tasks.Sync
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 
 plugins {
@@ -28,7 +29,7 @@ require(levyraDesktopVersion.matches(Regex("^[0-9]+\\.[0-9]+\\.[0-9]+([-.+][0-9A
 }
 
 val generatedVersionResources = layout.buildDirectory.dir("generated/resources/desktopVersion")
-val generateDesktopVersionResource by tasks.registering {
+val generateDesktopVersionResource = tasks.register("generateDesktopVersionResource") {
     inputs.property("levyraDesktopVersion", levyraDesktopVersion)
     outputs.dir(generatedVersionResources)
     doLast {
@@ -45,8 +46,23 @@ tasks.named<ProcessResources>("processResources") {
 
 kotlin {
     sourceSets.named("main") {
-        kotlin.srcDir(rootProject.file("../app/src/main/java/com/luc4n3x/levyra/ui/i18n"))
+        val sharedAndroidSources = objects.sourceDirectorySet(
+            "sharedAndroidSources",
+            "Android sources shared with Levyra Desktop"
+        ).apply {
+            srcDir(rootProject.file("../app/src/main/java"))
+            include("com/luc4n3x/levyra/ui/i18n/**/*.kt")
+            include("com/luc4n3x/levyra/domain/LevyraAudio.kt")
+            include("com/luc4n3x/levyra/domain/PlaylistImportFailureKind.kt")
+        }
+        kotlin.source(sharedAndroidSources)
     }
+}
+
+val generatedComposeResources = layout.buildDirectory.dir("generated/composeResources/main")
+val prepareComposeResources = tasks.register<Sync>("prepareComposeResources") {
+    from(layout.projectDirectory.file("src/main/resources/icons/levyra.png"))
+    into(generatedComposeResources.map { it.dir("drawable") })
 }
 
 dependencies {
@@ -54,9 +70,10 @@ dependencies {
     implementation(project(":player"))
 
     implementation(compose.desktop.currentOs)
-    implementation(compose.material3)
-    implementation(compose.foundation)
-    implementation(compose.ui)
+    implementation(libs.compose.material3)
+    implementation(libs.compose.foundation)
+    implementation(libs.compose.ui)
+    implementation(libs.compose.resources)
 
     implementation(libs.kotlinx.coroutines.swing)
     implementation(libs.kotlinx.serialization.json)
@@ -73,6 +90,12 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+}
+
+compose.resources {
+    publicResClass = true
+    packageOfResClass = "com.luc4n3x.levyra.desktop.app.generated.resources"
+    customDirectory("main", prepareComposeResources.map { generatedComposeResources.get() })
 }
 
 compose.desktop {

--- a/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/Main.kt
+++ b/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/Main.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isSpecified
@@ -36,6 +35,7 @@ import com.luc4n3x.levyra.desktop.app.state.PlaybackUiState
 import com.luc4n3x.levyra.desktop.app.ui.DesktopUpdateDialogHost
 import com.luc4n3x.levyra.desktop.app.ui.LevyraRoot
 import com.luc4n3x.levyra.desktop.app.ui.components.TextInputFocus
+import com.luc4n3x.levyra.desktop.app.ui.components.levyraIconPainter
 import com.luc4n3x.levyra.desktop.app.ui.i18n.LevyraStrings
 import com.luc4n3x.levyra.desktop.app.ui.i18n.stringsFor
 import com.luc4n3x.levyra.desktop.app.ui.player.MiniPlayerWindow
@@ -181,7 +181,7 @@ fun main(args: Array<String>) {
             state = windowState,
             visible = windowVisible,
             title = strings.appName,
-            icon = painterResource(APP_ICON),
+            icon = levyraIconPainter(),
             onKeyEvent = { event ->
                 val action = DesktopShortcuts.resolve(event, TextInputFocus.active)
                 if (action == null) {
@@ -281,7 +281,7 @@ private fun ApplicationScope.LevyraTray(
     onQuit: () -> Unit
 ) {
     Tray(
-        icon = painterResource(APP_ICON),
+        icon = levyraIconPainter(),
         tooltip = trackTooltip?.let { "${strings.appName} · $it" } ?: strings.appName,
         onAction = onShow,
         menu = {
@@ -376,7 +376,6 @@ private fun PlaybackUiState.withoutTransientUiTicks(): PlaybackUiState = copy(
     sleepRemainingMs = 0L
 )
 
-private const val APP_ICON = "icons/levyra.png"
 private const val ARTWORK_CACHE_BYTES = 512L * 1024L * 1024L
 private const val MIN_WINDOW_WIDTH = 960
 private const val MIN_WINDOW_HEIGHT = 640

--- a/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/ui/components/LevyraDesktopResources.kt
+++ b/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/ui/components/LevyraDesktopResources.kt
@@ -1,0 +1,10 @@
+package com.luc4n3x.levyra.desktop.app.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.painter.Painter
+import com.luc4n3x.levyra.desktop.app.generated.resources.Res
+import com.luc4n3x.levyra.desktop.app.generated.resources.levyra
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+fun levyraIconPainter(): Painter = painterResource(Res.drawable.levyra)

--- a/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/ui/components/navigation/LevyraSidebar.kt
+++ b/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/ui/components/navigation/LevyraSidebar.kt
@@ -40,12 +40,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.luc4n3x.levyra.desktop.app.state.Destination
 import com.luc4n3x.levyra.desktop.app.ui.i18n.LocalStrings
+import com.luc4n3x.levyra.desktop.app.ui.components.levyraIconPainter
 import com.luc4n3x.levyra.desktop.app.ui.icons.LevyraIcons
 import com.luc4n3x.levyra.desktop.app.ui.icons.OfflineIcons
 import com.luc4n3x.levyra.desktop.app.ui.theme.LevyraMotion
@@ -216,7 +216,7 @@ private fun SidebarBrand(
                 contentAlignment = Alignment.Center
             ) {
                 Image(
-                    painter = painterResource("icons/levyra.png"),
+                    painter = levyraIconPainter(),
                     contentDescription = appName,
                     modifier = Modifier.size(36.dp)
                 )

--- a/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/ui/player/MiniPlayerWindow.kt
+++ b/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/ui/player/MiniPlayerWindow.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpSize
@@ -48,6 +47,7 @@ import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.WindowState
 import com.luc4n3x.levyra.desktop.app.state.PlaybackUiState
 import com.luc4n3x.levyra.desktop.app.ui.components.Artwork
+import com.luc4n3x.levyra.desktop.app.ui.components.levyraIconPainter
 import com.luc4n3x.levyra.desktop.app.ui.i18n.LevyraStrings
 import com.luc4n3x.levyra.desktop.app.ui.i18n.LocalStrings
 import com.luc4n3x.levyra.desktop.app.ui.icons.LevyraIcons
@@ -106,7 +106,7 @@ fun MiniPlayerWindow(
         onCloseRequest = onClose,
         state = windowState,
         title = "Levyra · Mini ${strings.navNowPlaying}",
-        icon = painterResource("icons/levyra.png"),
+        icon = levyraIconPainter(),
         alwaysOnTop = true,
         undecorated = true,
         transparent = true,

--- a/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/ui/screens/OnboardingScreen.kt
+++ b/desktop/app/src/main/kotlin/com/luc4n3x/levyra/desktop/app/ui/screens/OnboardingScreen.kt
@@ -46,7 +46,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.LayoutDirection
@@ -55,6 +54,7 @@ import androidx.compose.ui.unit.sp
 import com.luc4n3x.levyra.desktop.app.ui.catalog.CountryOption
 import com.luc4n3x.levyra.desktop.app.ui.catalog.LocaleCatalog
 import com.luc4n3x.levyra.desktop.app.ui.components.CountryFlag
+import com.luc4n3x.levyra.desktop.app.ui.components.levyraIconPainter
 import com.luc4n3x.levyra.desktop.app.ui.components.tracksTextInputFocus
 import com.luc4n3x.levyra.desktop.app.ui.i18n.LocalStrings
 import com.luc4n3x.levyra.desktop.app.ui.i18n.stringsFor
@@ -258,7 +258,7 @@ private fun OnboardingRail(
                 horizontalArrangement = Arrangement.spacedBy(13.dp)
             ) {
                 Image(
-                    painter = painterResource("icons/levyra.png"),
+                    painter = levyraIconPainter(),
                     contentDescription = strings.appName,
                     modifier = Modifier.size(50.dp)
                 )

--- a/desktop/gradle/libs.versions.toml
+++ b/desktop/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.4.10"
 compose = "1.11.1"
-composeMaterial3 = "1.9.0"
+composeMaterial3 = "1.11.0-alpha07"
 coroutines = "1.11.0"
 serialization = "1.11.0"
 okhttp = "5.4.0"

--- a/desktop/gradle/libs.versions.toml
+++ b/desktop/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "2.4.10"
 compose = "1.11.1"
+composeMaterial3 = "1.9.0"
 coroutines = "1.11.0"
 serialization = "1.11.0"
 okhttp = "5.4.0"
@@ -31,6 +32,10 @@ slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4
 json = { group = "org.json", name = "json", version.ref = "json" }
 levyra-extractor = { group = "com.github.LUC4N3X", name = "LevyraExtractor", version.ref = "levyraExtractor" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+compose-material3 = { group = "org.jetbrains.compose.material3", name = "material3", version.ref = "composeMaterial3" }
+compose-foundation = { group = "org.jetbrains.compose.foundation", name = "foundation", version.ref = "compose" }
+compose-ui = { group = "org.jetbrains.compose.ui", name = "ui", version.ref = "compose" }
+compose-resources = { group = "org.jetbrains.compose.components", name = "components-resources", version.ref = "compose" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
-distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionSha256Sum=84fbba45c7f4c64abc77460e1c00f541e9f960e3c7ed2538f1ede19eacd873ae
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,82 @@
+@rem
+@rem Copyright 2015 the original author or authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem      https://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
+@rem SPDX-License-Identifier: Apache-2.0
+@rem
+
+@if "%DEBUG%"=="" @echo off
+@rem ##########################################################################
+@rem
+@rem  gradlew startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables, and ensure extensions are enabled
+setlocal EnableExtensions
+
+set DIRNAME=%~dp0
+if "%DIRNAME%"=="" set DIRNAME=.
+@rem This is normally unused
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Resolve any "." and ".." in APP_HOME to make it shorter.
+for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if %ERRORLEVEL% equ 0 goto execute
+
+echo. 1>&2
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
+
+"%COMSPEC%" /c exit 1
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto execute
+
+echo. 1>&2
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
+
+"%COMSPEC%" /c exit 1
+
+:execute
+@rem Setup the command line
+
+
+
+@rem Execute gradlew
+@rem endlocal doesn't take effect until after the line is parsed and variables are expanded
+@rem which allows us to clear the local environment before executing the java command
+endlocal & "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -jar "%APP_HOME%\gradle\wrapper\gradle-wrapper.jar" %* & call :exitWithErrorLevel
+
+:exitWithErrorLevel
+@rem Use "%COMSPEC%" /c exit to allow operators to work properly in scripts
+"%COMSPEC%" /c exit %ERRORLEVEL%

--- a/scripts/ai_quality_gate.py
+++ b/scripts/ai_quality_gate.py
@@ -307,6 +307,7 @@ def gradle_wrapper(directory: str = ".") -> str:
 def build_commands(
     paths: set[str], profile: str, python: str | None = None
 ) -> tuple[list[GateCommand], list[str]]:
+    """Build the validation commands selected by changed paths and gate profile."""
     python = python or sys.executable
     kinds = classify_changes(paths)
     commands = [

--- a/scripts/ai_quality_gate.py
+++ b/scripts/ai_quality_gate.py
@@ -425,7 +425,7 @@ def build_commands(
             commands.append(
                 GateCommand(
                     "Run Desktop checks and assembly",
-                    (gradle_wrapper("desktop"), "check", "assemble"),
+                    (gradle_wrapper("desktop"), "-p", "desktop", "check", "assemble"),
                     timeout_seconds=3600,
                 )
             )

--- a/scripts/tests/test_ai_quality_gate.py
+++ b/scripts/tests/test_ai_quality_gate.py
@@ -6,6 +6,7 @@ from scripts.ai_quality_gate import (
     build_commands,
     classify_changes,
     forbidden_path_findings,
+    gradle_wrapper,
     scan_added_lines,
 )
 
@@ -130,6 +131,7 @@ class AiQualityGateTest(unittest.TestCase):
         )
 
         self.assertEqual([], blocked)
+        self.assertEqual(gradle_wrapper("desktop"), desktop_command.argv[0])
         self.assertEqual(("-p", "desktop", "check", "assemble"), desktop_command.argv[-4:])
 
 

--- a/scripts/tests/test_ai_quality_gate.py
+++ b/scripts/tests/test_ai_quality_gate.py
@@ -119,6 +119,19 @@ class AiQualityGateTest(unittest.TestCase):
         self.assertEqual([], blocked)
         self.assertNotIn("Run all Android unit tests", labels)
 
+    def test_full_desktop_profile_uses_desktop_project_directory(self) -> None:
+        commands, blocked = build_commands(
+            {"desktop/app/src/main/kotlin/example.kt"},
+            "full",
+            python="python",
+        )
+        desktop_command = next(
+            command for command in commands if command.label == "Run Desktop checks and assembly"
+        )
+
+        self.assertEqual([], blocked)
+        self.assertEqual(("-p", "desktop", "check", "assemble"), desktop_command.argv[-4:])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_ai_quality_gate.py
+++ b/scripts/tests/test_ai_quality_gate.py
@@ -121,6 +121,7 @@ class AiQualityGateTest(unittest.TestCase):
         self.assertNotIn("Run all Android unit tests", labels)
 
     def test_full_desktop_profile_uses_desktop_project_directory(self) -> None:
+        """The full gate must invoke the Desktop wrapper in the Desktop project."""
         commands, blocked = build_commands(
             {"desktop/app/src/main/kotlin/example.kt"},
             "full",

--- a/third_party/LevyraExtractor/build.gradle
+++ b/third_party/LevyraExtractor/build.gradle
@@ -31,7 +31,7 @@ allprojects {
         mavenCentral()
         google()
         maven {
-            url "https://jitpack.io"
+            url = uri("https://jitpack.io")
         }
     }
 

--- a/third_party/LevyraExtractor/gradle/wrapper/gradle-wrapper.properties
+++ b/third_party/LevyraExtractor/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionSha256Sum=84fbba45c7f4c64abc77460e1c00f541e9f960e3c7ed2538f1ede19eacd873ae
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/third_party/LevyraExtractor/settings.gradle
+++ b/third_party/LevyraExtractor/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
         mavenCentral()
         google()
         maven {
-            url "https://jitpack.io"
+            url = uri("https://jitpack.io")
         }
     }
 }
@@ -15,7 +15,7 @@ dependencyResolutionManagement {
         mavenCentral()
         google()
         maven {
-            url "https://jitpack.io"
+            url = uri("https://jitpack.io")
         }
     }
 }


### PR DESCRIPTION
## Summary

This fixes the compiler and Gradle warnings reported by Android and Desktop CI, replaces the broken Gradle 9.7 update from #336 with a binary-safe wrapper update, and removes the redundant **Brano** badge drawn over native video. The result keeps audio/video mode behavior intact while restoring clean cross-platform builds.

## What changed

- Replaced supported deprecated Android APIs and narrowly documented the two compatibility fallbacks that still require deprecated platform types.
- Removed the duplicate **Brano** overlay while preserving the header Brano/Video mode switch.
- Upgraded root and extractor Gradle distribution metadata to 9.7.0 with the official SHA-256 checksum, without changing wrapper JAR binaries.
- Added the missing root Windows wrapper and corrected the full quality gate so Desktop tasks run in the Desktop project.
- Restored Desktop shared-source compilation and migrated icon loading to Compose resources.
- Aligned Material3 `1.11.0-alpha07` with Compose Multiplatform `1.11.1` after CodeRabbit review.
- Removed the duplicate F-Droid `INTERNET` manifest warning while keeping `REQUEST_INSTALL_PACKAGES` out of F-Droid builds.
- Strengthened the quality-gate regression test to verify both the Desktop wrapper and `-p desktop` project arguments.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor or maintenance
- [x] UI or UX change
- [ ] Localization or accessibility
- [x] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android / Windows Desktop / Shared infrastructure
- **Area:** UI / System integration / Build and release

## Validation

### Automated checks

- [x] Android: full quality gate ran unit tests, release lint, and unsigned F-Droid release assembly
- [x] Desktop: `gradlew.bat -p desktop check assemble`
- [x] Targeted tests were added or updated
- [x] Extractor tests completed through the full quality gate
- [x] `python scripts/ai_quality_gate.py --profile fast`
- [x] `python scripts/ai_quality_gate.py --profile full`
- [x] `git diff --check`
- [x] Material3 dependency insight resolves `material3` and `material3-desktop` to `1.11.0-alpha07`
- [x] Merged-manifest verification: upstream keeps `INTERNET` and `REQUEST_INSTALL_PACKAGES`; F-Droid keeps one `INTERNET` and removes `REQUEST_INSTALL_PACKAGES`

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Windows 11, JDK 21 | Desktop dependency resolution, tests, and assembly | Passed |
| Android device/emulator | Visual confirmation of the removed in-video badge | Not run; no device or emulator was used |

## Risk and compatibility

- **Risk level:** Medium
- **Compatibility or migration notes:** No data, database, preference, download, queue, or version migration. Android and Desktop release versions remain unchanged.
- **Known limitations:** Native Android UI behavior was not manually exercised on a device.
- **Rollback plan:** Revert this PR.

## Reviewer notes

- The AndroidX Car App 1.9.0-alpha01 API still accepts only `MediaSessionCompat.Token`; its deprecation suppression is intentionally limited to one helper.
- `GET_SIGNATURES` remains only in the pre-API 28 compatibility branch.
- The wrapper upgrade changes distribution metadata only; both existing wrapper JARs remain untouched.
- CodeRabbit findings for Material3 alignment and Desktop-wrapper test coverage were fixed in `d52da194` and both threads were confirmed addressed.
- The CodeRabbit docstring metric is covered for the two changed Python callables; no unrelated documentation churn was added.

## Release note

The native video player no longer shows the redundant **Brano** badge, and Android/Desktop builds use cleaner, compatible tooling.

## Related issues

- Supersedes #336
- Related to #336

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [x] Local full validation is green; GitHub CI is rerunning for the latest commit