### PR TITLE
Add anti-slop guardrails for AI-assisted development

### DIFF
--- a/.agents/rules/levyra-workspace.md
+++ b/.agents/rules/levyra-workspace.md
@@ -8,28 +8,39 @@ contract. Before investigating, editing, reviewing, or running commands:
 1. apply the nearest path-specific `AGENTS.md` files for every file in scope;
 2. read only relevant approved planning material under `docs/project/`;
 3. discover and load every matching `levyra-*` skill under `.agents/skills/`;
-4. automatically load `levyra-context-efficiency` for builds, tests, lint,
+4. read `../../docs/ai/AI_ENGINEERING_GUARDRAILS.md` before production-code
+   implementation or broad review and apply its architecture-first, reuse-first,
+   complexity-budget, scope-checkpoint, and diff-quality rules;
+5. automatically load `levyra-context-efficiency` for builds, tests, lint,
    logs, broad searches, dependencies, Git/GitHub, CI, CodeRabbit, setup, or any
    command expected to produce large repetitive output;
-5. automatically load `levyra-security-review` for vulnerability scans,
+6. automatically load `levyra-security-review` for vulnerability scans,
    attacker-controlled input, trust-boundary changes, authentication, secrets,
    permissions, privacy, dependency risk, update integrity, or security-related
    pull requests;
-6. when RTK is available, use it selectively for noisy supported commands,
+7. when RTK is available, use it selectively for noisy supported commands,
    verify exit status and success/failure markers, and rerun the exact command
    raw whenever compact output hides required evidence;
-7. keep exploit evidence, security validation, hashes, signatures, secret scans,
+8. keep exploit evidence, security validation, hashes, signatures, secret scans,
    signing, and exact reproduction output raw;
-8. inspect current code, tests, architecture, build files, dependencies, and
+9. inspect current code, tests, architecture, build files, dependencies, and
    workflows before relying on memory or previous agent output;
-9. for security work, follow threat model, identification, safe validation,
-   minimal remediation, human review, and revalidation;
-10. make the smallest coherent change and preserve unrelated behavior;
-11. run focused validation first, then
+10. for security work, follow threat model, identification, safe validation,
+    minimal remediation, human review, and revalidation;
+11. identify the current architecture owner and expected production files before
+    editing, then make the smallest coherent change and preserve unrelated
+    behavior;
+12. if the implementation crosses an AI guardrail scope checkpoint, re-evaluate
+    and split the work instead of expanding autonomously unless the owner
+    explicitly approves the larger scope;
+13. run focused validation first, then
     `python3 scripts/ai_quality_gate.py --profile fast` before commit and
     `python3 scripts/ai_quality_gate.py --profile full` before push or PR;
-12. treat every blocked or skipped required gate check as not passed;
-13. keep implementation, validation, review, publication, merge, and release as
+14. inspect final diff statistics and the complete diff for unnecessary code
+    growth, duplicate ownership, speculative abstractions, generated churn, and
+    unrelated edits;
+15. treat every blocked or skipped required gate check as not passed;
+16. keep implementation, validation, review, publication, merge, and release as
     separate states.
 
 RTK reduces command output; it is not validation authority and its savings are
@@ -43,4 +54,5 @@ the exact action and scope.
 
 This lightweight bridge gives Codex, Antigravity, OpenCode, OpenClaw, and other
 compatible workspaces one source of truth while discovering Levyra's context-
-efficiency and security-review workflows automatically.
+efficiency, AI engineering guardrails, and security-review workflows
+automatically.

--- a/docs/ai/AI_ENGINEERING_GUARDRAILS.md
+++ b/docs/ai/AI_ENGINEERING_GUARDRAILS.md
@@ -1,0 +1,187 @@
+# Levyra AI Engineering Guardrails
+
+These rules exist to prevent AI-assisted work from making Levyra larger, harder
+to reason about, or less maintainable while still appearing to "work".
+
+They apply to ChatGPT, Codex, Claude Code, Google Antigravity, OpenCode,
+OpenClaw-delegated runtimes, and any other coding agent used on this repository.
+They supplement `AGENTS.md`; they do not replace repository architecture,
+path-specific instructions, tests, or owner decisions.
+
+## Core rule
+
+A successful AI change is not the change that produces the most code or the most
+features. It is the smallest reviewable change that solves the requested problem,
+fits the existing architecture, preserves unrelated behavior, and can be verified
+with direct evidence.
+
+Green compilation is necessary when applicable, but it is not proof that the
+architecture is sound.
+
+## Before implementation
+
+Before editing production code:
+
+1. state the exact requested outcome in one or two sentences;
+2. identify the current owner of the behavior in the existing architecture;
+3. list the expected production files or modules likely to change;
+4. identify existing clients, repositories, stores, caches, managers, services,
+   controllers, helpers, scopes, and abstractions that can be reused;
+5. state the behavior that must remain unchanged;
+6. choose focused validation that can prove the change.
+
+Do not start from a blank-slate design when Levyra already has an owner for the
+behavior.
+
+## Architecture-first rules
+
+- Reuse before creating.
+- Extend an existing owner before introducing a parallel owner.
+- Never add a second source of truth for playback, queue, persistence, cache,
+  settings, localization, update state, requirements, task state, or release
+  state.
+- A new `Manager`, `Repository`, `Cache`, `Service`, `Coordinator`, `Engine`,
+  wrapper, registry, event bus, or equivalent abstraction requires a concrete
+  reason why the existing owner cannot safely handle the responsibility.
+- Do not create abstractions for hypothetical future requirements.
+- Do not duplicate an existing flow merely because a new implementation is
+  easier for the agent to generate.
+- Prefer deleting or simplifying obsolete code when the new behavior genuinely
+  replaces it instead of keeping both implementations alive.
+- Do not hide architectural duplication behind compatibility wrappers unless a
+  real compatibility boundary requires them.
+
+## Scope and complexity budget
+
+One pull request should normally have one primary engineering outcome.
+
+Treat any of the following as a mandatory scope checkpoint before continuing:
+
+- the implementation needs production files well outside the originally
+  identified ownership path;
+- more than three unexpected production files become necessary;
+- the non-generated production diff approaches 1,000 added lines;
+- the change touches roughly 15 or more production files;
+- more than two new architectural abstractions are being introduced;
+- a requested feature starts turning into a platform-wide refactor;
+- an agent proposes a second cache, second state holder, second resolver,
+  parallel data path, or replacement architecture to avoid understanding the
+  existing one.
+
+At a scope checkpoint, do not keep expanding automatically. Re-evaluate the
+architecture and split the work into smaller reviewable phases unless the owner
+explicitly approves the larger scope with a concrete reason.
+
+Generated localization, schema snapshots, lock files, or other mechanically
+produced files may be excluded from the numeric heuristic, but they still require
+normal review for correctness and accidental churn.
+
+The thresholds above are review triggers, not permission to generate code up to
+the limit.
+
+## Large features and feature parity
+
+Do not implement broad "feature parity", "improve everything", or "make it like
+project X" requests as one giant autonomous patch.
+
+For large work:
+
+1. map the target behavior against Levyra's current architecture;
+2. separate required behavior from optional inspiration;
+3. divide the work into independently reviewable phases;
+4. implement one coherent phase at a time;
+5. inspect the complete diff and validation result before starting the next
+   phase;
+6. keep later phases free to change based on evidence from earlier ones.
+
+External projects are references, not architectures to copy wholesale. Import
+ideas selectively and adapt them to Levyra's existing ownership model.
+
+## Diff quality gate
+
+Before commit, push, or PR publication, inspect the complete diff and answer:
+
+- Does every changed production file contribute directly to the requested
+  outcome?
+- Did the change introduce a new owner for behavior that already had one?
+- Did any helper, wrapper, manager, cache, or layer appear only because it was
+  convenient to generate?
+- Is there dead, fallback, compatibility, or speculative code with no current
+  caller or acceptance criterion?
+- Could the same result be achieved with fewer moving parts?
+- Are failure, cancellation, lifecycle, concurrency, persistence, and security
+  semantics still explicit?
+- Are tests proving the requested behavior rather than only exercising the new
+  implementation?
+- Did generated output or formatting churn hide meaningful changes?
+
+If the answer reveals unnecessary complexity, simplify the diff before treating
+it as ready.
+
+## Agent delegation
+
+Multiple agents do not remove the need for one coherent architecture.
+
+When several agents or workers are used:
+
+- give each worker a narrow ownership boundary;
+- do not let different workers independently invent competing infrastructure;
+- reconcile shared types and ownership before merging their patches;
+- review the combined diff as a new artifact rather than assuming individually
+  valid patches compose safely;
+- require an independent review for broad or cross-domain changes.
+
+Agent count, token count, elapsed compute, generated line count, or number of
+implemented features are never quality metrics.
+
+## Validation discipline
+
+Use the existing Levyra quality gates from `AGENTS.md`.
+
+For AI-generated changes also record the final diff summary when possible:
+
+```bash
+git diff --stat <base>...HEAD
+git diff --numstat <base>...HEAD
+```
+
+Unexpected code growth is a reason to inspect the design, not a reason to praise
+productivity.
+
+A build that passes while the change duplicates ownership, leaks resources,
+creates unbounded work, or makes future maintenance unsafe is still a failed
+engineering result.
+
+## ChatGPT activation phrase
+
+When a ChatGPT conversation has access to this repository and the owner says
+"lavoriamo su Levyra", "work on Levyra", or an obvious equivalent, treat that as
+an instruction to enter Levyra engineering mode before technical work:
+
+1. open `LUC4N3X/Levyra-deepsound`;
+2. read the current root `AGENTS.md` and every nearer scoped instruction;
+3. read this guardrail document;
+4. load the relevant project planning, architecture, and native skills;
+5. inspect current repository evidence before relying on previous chat memory;
+6. apply the smallest-change and complexity-budget rules above.
+
+The activation phrase grants repository context only. It does not grant permission
+to commit, push, open or merge a PR, tag, release, publish, change versions, or
+modify repository settings.
+
+## Delivery
+
+For every substantial AI-assisted implementation, report:
+
+- requested outcome;
+- architecture owner reused or changed;
+- exact production files changed;
+- new abstractions introduced and why each is necessary;
+- diff size/statistics when available;
+- focused and broader validation performed;
+- blocked or unverified checks;
+- remaining risk;
+- publication state.
+
+Never present code volume, autonomous agent activity, or a green build alone as
+proof of a good change.

--- a/docs/ai/CHATGPT_LEVYRA_TRIGGER.md
+++ b/docs/ai/CHATGPT_LEVYRA_TRIGGER.md
@@ -1,0 +1,69 @@
+# ChatGPT Levyra activation trigger
+
+Use this as the persistent ChatGPT instruction for Levyra conversations.
+
+## Trigger
+
+When the owner says **"lavoriamo su Levyra"**, **"work on Levyra"**, or an
+obvious equivalent, immediately switch to Levyra repository mode for the rest of
+the task.
+
+Do not require the owner to repeat the repository URL or the engineering rules.
+
+Repository: `LUC4N3X/Levyra-deepsound`
+
+## Automatic behavior
+
+When repository access is available:
+
+1. open the current `LUC4N3X/Levyra-deepsound` repository;
+2. read root `AGENTS.md` before technical conclusions or edits;
+3. read the nearest path-specific `AGENTS.md` files for the affected paths;
+4. read `docs/ai/AI_ENGINEERING_GUARDRAILS.md`;
+5. read only the relevant planning material in `docs/project/`;
+6. load every matching `levyra-*` skill under `.agents/skills/`;
+7. inspect current architecture, implementation, tests, build files, and
+   workflows before relying on remembered repository state;
+8. prefer the smallest coherent change that reuses existing ownership;
+9. stop and split work when an AI engineering scope checkpoint is crossed;
+10. validate with direct evidence and report what remains unverified.
+
+If repository access is unavailable, do not pretend that current files were
+inspected. Ask for or use the minimum repository material needed for the task,
+or clearly limit the answer to planning based on known context.
+
+## Anti-slop defaults
+
+Once the trigger is active:
+
+- code volume is not a success metric;
+- broad feature-parity work must be split into reviewable phases;
+- existing owners, repositories, stores, caches, clients, services, and flows
+  must be reused before creating new ones;
+- duplicate sources of truth and parallel infrastructure are prohibited unless
+  the owner explicitly approves a demonstrated architectural need;
+- unexpected diff growth triggers re-analysis instead of autonomous expansion;
+- speculative refactors, future-proof abstractions, unrelated cleanup,
+  dependency churn, and version changes are out of scope unless requested;
+- a green build does not override architectural problems found in the final
+  diff review.
+
+## Publication boundary
+
+The trigger grants context, not write authorization.
+
+Never infer permission to commit, push, open or merge a pull request, tag,
+release, publish, change versions, or modify repository settings. Those actions
+still require explicit authorization for the exact action and scope.
+
+## Suggested saved instruction
+
+For a general ChatGPT conversation, the persistent instruction can be kept
+compact:
+
+> When I say "lavoriamo su Levyra", use `LUC4N3X/Levyra-deepsound` as the current
+> project, inspect its current `AGENTS.md` and `docs/ai/AI_ENGINEERING_GUARDRAILS.md`
+> before technical work, reuse the existing architecture, keep changes small and
+> verifiable, and never publish or merge without my explicit approval.
+
+Repository evidence always overrides remembered implementation details.


### PR DESCRIPTION
## Summary

Adds explicit anti-slop engineering guardrails for AI-assisted work on Levyra and a reusable ChatGPT activation trigger.

## What changed

- Added `docs/ai/AI_ENGINEERING_GUARDRAILS.md` with architecture-first and reuse-first rules, complexity/scope checkpoints, large-feature phase splitting, diff-quality review, multi-agent coordination constraints, and code-growth checks.
- Updated `.agents/rules/levyra-workspace.md` so compatible workspaces automatically route production-code work through the new guardrails and stop autonomous scope expansion when a checkpoint is crossed.
- Added `docs/ai/CHATGPT_LEVYRA_TRIGGER.md` defining `lavoriamo su Levyra` / `work on Levyra` as the project-context trigger when ChatGPT has repository access, while keeping commit/push/PR/merge/release permission separate.

## Why

AI-generated code can compile and appear functional while still duplicating ownership, creating parallel caches/state holders, adding speculative abstractions, or growing far beyond the requested scope. These rules make reviewability and architectural fit explicit quality requirements instead of treating code volume or agent activity as progress.

## Behavior preserved

- No Android or Desktop production code changed.
- Existing publication boundaries remain unchanged.
- Existing repository quality gates remain authoritative.
- Root `AGENTS.md` remains the canonical repository contract.

## Diff scope

Compared with `main`:

- 3 files changed
- `.agents/rules/levyra-workspace.md`: routing/guardrail integration only
- 2 new AI documentation files
- no production-code files

## Validation

Verified through the GitHub connector:

- branch is based directly on current `main`
- branch is 3 commits ahead and 0 behind at creation time
- final compare contains only the three intended files

Blocked in the current connector-only environment and therefore **not claimed as passed**:

```bash
python3 scripts/validate_agent_config.py
python3 scripts/validate_ai_efficiency.py
python3 scripts/ai_quality_gate.py --profile fast
python3 scripts/ai_quality_gate.py --profile full
```

CI and repository validators should be checked before merge.

## Manual review focus

- confirm the scope-checkpoint heuristics are strict enough to stop runaway AI patches without blocking legitimate large changes;
- confirm the ChatGPT trigger wording matches the desired owner workflow;
- confirm no runtime-specific bridge needs an additional explicit link to the new guardrail document.
