### PR TITLE
fix(desktop): compile shared localization catalog

### DIFF
--- a/desktop/app/build.gradle.kts
+++ b/desktop/app/build.gradle.kts
@@ -46,6 +46,10 @@ tasks.named<ProcessResources>("processResources") {
 kotlin {
     sourceSets.named("main") {
         kotlin.srcDir(rootProject.file("../app/src/main/java/com/luc4n3x/levyra/ui/i18n"))
+        kotlin.exclude(
+            "**/LevyraFeatureStrings.kt",
+            "**/PlaylistImportStatusStrings.kt"
+        )
     }
 }
 

--- a/desktop/app/build.gradle.kts
+++ b/desktop/app/build.gradle.kts
@@ -1,5 +1,6 @@
 import java.util.Properties
 import org.gradle.language.jvm.tasks.ProcessResources
+import org.gradle.api.tasks.Sync
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 
 plugins {
@@ -28,7 +29,7 @@ require(levyraDesktopVersion.matches(Regex("^[0-9]+\\.[0-9]+\\.[0-9]+([-.+][0-9A
 }
 
 val generatedVersionResources = layout.buildDirectory.dir("generated/resources/desktopVersion")
-val generateDesktopVersionResource by tasks.registering {
+val generateDesktopVersionResource = tasks.register("generateDesktopVersionResource") {
     inputs.property("levyraDesktopVersion", levyraDesktopVersion)
     outputs.dir(generatedVersionResources)
     doLast {
@@ -45,12 +46,23 @@ tasks.named<ProcessResources>("processResources") {
 
 kotlin {
     sourceSets.named("main") {
-        kotlin.srcDir(rootProject.file("../app/src/main/java/com/luc4n3x/levyra/ui/i18n"))
-        kotlin.exclude(
-            "**/LevyraFeatureStrings.kt",
-            "**/PlaylistImportStatusStrings.kt"
-        )
+        val sharedAndroidSources = objects.sourceDirectorySet(
+            "sharedAndroidSources",
+            "Android sources shared with Levyra Desktop"
+        ).apply {
+            srcDir(rootProject.file("../app/src/main/java"))
+            include("com/luc4n3x/levyra/ui/i18n/**/*.kt")
+            include("com/luc4n3x/levyra/domain/LevyraAudio.kt")
+            include("com/luc4n3x/levyra/domain/PlaylistImportFailureKind.kt")
+        }
+        kotlin.source(sharedAndroidSources)
     }
+}
+
+val generatedComposeResources = layout.buildDirectory.dir("generated/composeResources/main")
+val prepareComposeResources = tasks.register<Sync>("prepareComposeResources") {
+    from(layout.projectDirectory.file("src/main/resources/icons/levyra.png"))
+    into(generatedComposeResources.map { it.dir("drawable") })
 }
 
 dependencies {
@@ -58,9 +70,10 @@ dependencies {
     implementation(project(":player"))
 
     implementation(compose.desktop.currentOs)
-    implementation(compose.material3)
-    implementation(compose.foundation)
-    implementation(compose.ui)
+    implementation(libs.compose.material3)
+    implementation(libs.compose.foundation)
+    implementation(libs.compose.ui)
+    implementation(libs.compose.resources)
 
     implementation(libs.kotlinx.coroutines.swing)
     implementation(libs.kotlinx.serialization.json)
@@ -77,6 +90,12 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+}
+
+compose.resources {
+    publicResClass = true
+    packageOfResClass = "com.luc4n3x.levyra.desktop.app.generated.resources"
+    customDirectory("main", prepareComposeResources.map { generatedComposeResources.get() })
 }
 
 compose.desktop {


### PR DESCRIPTION
## Causa

`desktop/app/src/main/kotlin/.../ui/i18n/Strings.kt` importa `com.luc4n3x.levyra.ui.i18n.LevyraStrings`, ma il modulo `desktop:app` non compilava la directory sorgente condivisa Android che contiene quella classe. La compilazione Desktop falliva quindi con riferimenti non risolti al catalogo condiviso.

## Impatto

Il progetto Desktop Windows non poteva completare la verifica/build dopo il riuso del catalogo di localizzazione comune.

## Modifica

- aggiunta `app/src/main/java/com/luc4n3x/levyra/ui/i18n` al source set Kotlin di `desktop:app`;
- esclusi i due file Android-specifici che dipendono da classi non disponibili nel modulo Desktop (`LevyraFeatureStrings.kt` e `PlaylistImportStatusStrings.kt`).

## File

- `desktop/app/build.gradle.kts`

## Verifica

`levyra-worker verify` superato, incluse le verifiche Android, Desktop e di compatibilità regex.

## Rischi

Bassi. Non vengono copiate né forkate traduzioni: il modulo Desktop compila direttamente il catalogo condiviso. Le esclusioni sono esplicite e limitate ai file con dipendenze Android/domain non presenti nel grafo Desktop.

## Comportamento precedente

Il sorgente Desktop importava il catalogo condiviso senza includerlo nel proprio source set, causando errori di compilazione.
