### PR TITLE
fix(android): open Home video cards in native video mode

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -5949,10 +5949,10 @@ private fun HomeScreen(
                     HomeMusicVideoShelf(
                         title = strings.video,
                         tracks = homeVideoTracks,
-                        currentId = state.currentTrack?.id,
+                        currentId = state.currentTrack?.id?.takeIf { state.isVideoMode },
                         isPlaying = state.isPlaying,
                         isResolving = state.isResolving,
-                        onPlay = { track -> viewModel.playFrom(homeVideoTracks, track) },
+                        onPlay = { track -> viewModel.playVideoFrom(homeVideoTracks, track) },
                         onToggleCurrent = viewModel::togglePlay
                     )
                 }

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -109,10 +109,19 @@ class HomeViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::homeP
     fun refreshHomeArtists() = root.refreshHomeArtists()
     fun playAll(tracks: List<Track>) = root.playAll(tracks)
     fun playFrom(list: List<Track>, track: Track, loopOnCompletion: Boolean = false) {
-        if (root.state.value.currentTrack?.id == track.id) {
+        val current = root.state.value
+        if (!current.isVideoMode && current.currentTrack?.id == track.id) {
             root.togglePlay()
         } else {
-            root.playFrom(list, track, loopOnCompletion)
+            root.playAudioFrom(list, track, loopOnCompletion)
+        }
+    }
+    fun playVideoFrom(list: List<Track>, track: Track, loopOnCompletion: Boolean = false) {
+        val current = root.state.value
+        if (current.isVideoMode && current.currentTrack?.id == track.id) {
+            root.togglePlay()
+        } else {
+            root.playVideoFrom(list, track, loopOnCompletion)
         }
     }
     fun searchNow() = root.searchNow()
@@ -751,6 +760,7 @@ private data class HomeProjection(
     val isLoadingHome: Boolean,
     val isPlaying: Boolean,
     val isResolving: Boolean,
+    val isVideoMode: Boolean,
     val languageCode: String,
     val moods: List<Mood>,
     val personalOrbitTracks: List<Track>,
@@ -787,6 +797,7 @@ private fun homeProjection(state: LevyraUiState): HomeProjection = HomeProjectio
     isLoadingHome = state.isLoadingHome,
     isPlaying = state.isPlaying,
     isResolving = state.isResolving,
+    isVideoMode = state.isVideoMode,
     languageCode = state.languageCode,
     moods = state.moods,
     personalOrbitTracks = state.personalOrbitTracks,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -193,6 +193,10 @@ internal fun shouldStartPlaybackPaused(
     activeRequestId: Long
 ): Boolean = request.id == activeRequestId && request.startPaused
 
+internal fun LevyraUiState.withExplicitPlaybackMode(videoMode: Boolean): LevyraUiState =
+    if (isVideoMode == videoMode && pendingVideoMode == null) this
+    else copy(isVideoMode = videoMode, pendingVideoMode = null)
+
 internal fun prioritizeNewReleasesForUser(
     releases: List<AlbumHit>,
     preferredArtists: List<String>,
@@ -4544,6 +4548,18 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         queueEngine.replace(list, index, keepPlaybackModes = true, radioEnabled = queueEngine.state.value.radioEnabled)
         queueIndex = index
         startResolve(list.getOrElse(index) { track })
+    }
+
+    fun playAudioFrom(list: List<Track>, track: Track, loopOnCompletion: Boolean = false) {
+        if (list.isEmpty()) return
+        _state.update { current -> current.withExplicitPlaybackMode(videoMode = false) }
+        playFrom(list, track, loopOnCompletion)
+    }
+
+    fun playVideoFrom(list: List<Track>, track: Track, loopOnCompletion: Boolean = false) {
+        if (list.isEmpty()) return
+        _state.update { current -> current.withExplicitPlaybackMode(videoMode = true) }
+        playFrom(list, track, loopOnCompletion)
     }
 
     fun beginSamplesPlayback() {

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/HomeVideoPlaybackIntentTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/HomeVideoPlaybackIntentTest.kt
@@ -1,0 +1,38 @@
+package com.luc4n3x.levyra.viewmodel
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HomeVideoPlaybackIntentTest {
+    @Test
+    fun explicitVideoPlaybackModeEnablesVideoAndClearsPendingSwitch() {
+        val state = LevyraUiState(isVideoMode = false, pendingVideoMode = false)
+
+        val updated = state.withExplicitPlaybackMode(videoMode = true)
+
+        assertTrue(updated.isVideoMode)
+        assertNull(updated.pendingVideoMode)
+    }
+
+    @Test
+    fun explicitAudioPlaybackModeLeavesVideoAndClearsPendingSwitch() {
+        val state = LevyraUiState(isVideoMode = true, pendingVideoMode = true)
+
+        val updated = state.withExplicitPlaybackMode(videoMode = false)
+
+        assertFalse(updated.isVideoMode)
+        assertNull(updated.pendingVideoMode)
+    }
+
+    @Test
+    fun settledPlaybackModeDoesNotPublishANewState() {
+        val videoState = LevyraUiState(isVideoMode = true, pendingVideoMode = null)
+        val audioState = LevyraUiState(isVideoMode = false, pendingVideoMode = null)
+
+        assertSame(videoState, videoState.withExplicitPlaybackMode(videoMode = true))
+        assertSame(audioState, audioState.withExplicitPlaybackMode(videoMode = false))
+    }
+}


### PR DESCRIPTION
## Summary

Fixes Home playback intent so the selected card determines the playback mode instead of leaving the previous mode sticky.

- Home **Video** cards explicitly start Levyra native-video playback.
- Home **song/track** cards explicitly return to audio/song playback, even after a video was playing.

## What changed

- route Home video cards through a dedicated `playVideoFrom(...)` intent
- route normal Home track cards through a dedicated `playAudioFrom(...)` intent
- switch the playback mode before stream resolution starts
- clear any pending mode switch when an explicit audio or video intent is selected
- if the same recording is playing as video and the user taps its song card, switch to audio instead of toggling the video
- if the same recording is already playing in the matching mode, keep the normal play/pause toggle behavior
- include `isVideoMode` in the Home projection so the shelf reflects the actual playback mode
- add focused regression coverage for both explicit video and explicit audio mode transitions

## Validation

Passed on GitHub Actions after rebasing onto current `main`:

- focused `HomeVideoPlaybackIntentTest`
- `:app:compileDebugKotlin`
- Levyra AI quality gate `fast`
- Levyra AI quality gate `full`
- `git diff --check`

Physical-device Home → Video → song playback remains to be verified manually.

## Scope

Android Home playback only. No dependency changes, version changes, Room migrations, Desktop changes, releases, tags, or merge actions.