### PR TITLE
docs: align README toolchain versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ desktop:
 * Android Studio with Android Gradle Plugin 9.3.1 support
 * Java Development Kit (JDK) 17
 * Android SDK Platform 37 (`compileSdk = 37`, `targetSdk = 37`)
-* Gradle 9.6.1 through the repository Gradle Wrapper
+* Gradle 9.7.0 through the repository Gradle Wrapper
 
 ### Android build and install
 
@@ -339,7 +339,7 @@ levyraVersionName=2.3.19
 levyraVersionCode=2031900
 
 # Windows — desktop/version.properties
-levyraDesktopVersion=1.1.0
+levyraDesktopVersion=1.2.0
 ```
 
 Android publishes `v<version>` releases and remains the repository's **Latest** channel. Windows publishes immutable `desktop-v<version>` releases with MSI, EXE, portable ZIP and SHA-256 files. Increasing the Android version never starts or publishes the Desktop build, and increasing the Desktop version never modifies Android or F-Droid releases.


### PR DESCRIPTION
## Causa

Il README non era stato aggiornato insieme al Gradle Wrapper e alla versione indipendente del client Windows: dichiarava Gradle 9.6.1 e Desktop 1.1.0, mentre i file sorgente correnti impostano rispettivamente 9.7.0 e 1.2.0.

## Impatto

I prerequisiti di build e l'esempio di versioning risultavano incoerenti con il repository, con rischio di confondere chi compila Android o verifica la versione Desktop.

## Modifica

- allinea il prerequisito Gradle del README a 9.7.0;
- allinea l'esempio `levyraDesktopVersion` a 1.2.0.

## File

- `README.md`

## Verifiche

- `levyra-worker verify`: superato;
- compatibility scan Android: superato;
- confronto diretto con `gradle/wrapper/gradle-wrapper.properties` e `desktop/version.properties`.

## Rischi

Bassi: modifica esclusivamente documentale, senza cambi a build, dipendenze, workflow o runtime.

## Comportamento precedente

Il README riportava versioni obsolete rispetto ai file autorevoli del repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented Gradle wrapper version to 9.7.0.
  * Updated the documented Windows desktop version to 1.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->