### PR TITLE
Strengthen Levyra agent engineering workflows

### DIFF
--- a/.agents/rules/levyra-workspace.md
+++ b/.agents/rules/levyra-workspace.md
@@ -47,6 +47,32 @@ contract. Before investigating, editing, reviewing, or running commands:
 17. keep implementation, validation, review, publication, merge, and release as
     separate states.
 
+## Automatic task-to-skill routing
+
+Codex, Antigravity, OpenCode, OpenClaw, and any other compatible runtime using
+this workspace must select matching skills from the task itself. Never require
+the owner to name a skill, type a slash command, or remind the agent to use one.
+Load multiple skills when several rows apply.
+
+- bugs, regressions, test/build failures, races, crashes, or unexpected behavior
+  that need investigation -> `levyra-real-engineering` plus the affected domain
+  skill; use its hypothesis-driven debugging lane before speculative fixes;
+- Compose jank, scrolling, recomposition, state projection, Layout Inspector,
+  Perfetto, accessibility, TalkBack, semantics, touch targets, RTL, or UI work ->
+  `levyra-compose`;
+- GitHub Actions, CI, F-Droid, Gradle, AGP, Kotlin, KSP, configuration/build
+  cache, build speed, artifacts, or workflow automation ->
+  `levyra-ci-workflows`; also load `levyra-context-efficiency` when command
+  output is expected to be noisy;
+- emulator/device smoke tests, `adb` runtime verification, pre-merge evidence,
+  signing, APK/package checks, or release validation -> `levyra-release-check`;
+- branch, commit, diff, or pull-request review -> `levyra-pr-review` plus any
+  matching domain/security skill.
+
+These automatic routes activate the repository-local workflows that incorporate
+curated practices from the reviewed external skill sources. External packages
+are not required at runtime for these Levyra-native behaviors.
+
 For real-engineering work, follow
 `../../.agents/skills/levyra-real-engineering/SKILL.md`. When the upstream Matt
 Pocock package is available, load the exact stage skill selected by that adapter

--- a/.agents/skills/levyra-ci-workflows/SKILL.md
+++ b/.agents/skills/levyra-ci-workflows/SKILL.md
@@ -46,6 +46,20 @@ Levyra-specific rules:
 
 These guardrails intentionally take the useful AGP 9 compatibility checks from JetBrains' Kotlin agent skill while keeping Levyra's existing architecture authoritative.
 
+## Gradle build-performance work
+
+Treat build-speed changes as performance engineering, not a bag of `gradle.properties` toggles.
+
+1. Measure a representative baseline first, including the build mode that is actually slow (clean, incremental, CI, Android, or Desktop).
+2. Determine whether the time is dominated by configuration, dependency resolution, compilation/processing, execution, packaging, or cache misses before choosing a fix.
+3. Inspect existing configuration-cache/build-cache behavior, task inputs/outputs, eager task creation, configuration-time I/O, KSP work, repository resolution, and JDK/toolchain consistency before adding new infrastructure.
+4. Apply one material optimization at a time, rerun the same measured path, and keep the change only when the evidence shows an improvement without weakening correctness or reproducibility.
+5. Prefer lazy Gradle APIs and Providers when they solve a demonstrated configuration-time problem; do not rewrite working build logic solely to match a generic optimization checklist.
+6. Do not add remote caches, Develocity/Build Scan publishing, third-party analytics, new CI services, or data-uploading plugins merely for diagnostics. Any external upload or persistent service requires an explicit task plus privacy, credential, supply-chain, and maintenance review.
+7. Do not skip tests/lint in CI to make a timing number look better unless the repository already has a safe path-based job design that preserves the mandatory quality gate.
+
+Record the before/after command, environment-relevant differences, and timing or task evidence when claiming a build-performance improvement. SimpMusic's Gradle performance skill is useful here for its baseline -> isolate phase -> one change -> remeasure discipline; its generic flags and services are not Levyra defaults.
+
 ## Validation
 
-Validate YAML structure, expressions, event filters, permissions, matrix behavior, shell quoting, paths, conditions, output propagation, artifact retention, and secret availability. Compare the workflow with the corresponding local Gradle command. For build-tooling changes, also verify the affected plugin graph, wrapper/version compatibility, and the narrowest relevant Android or Desktop build task. Report job-log evidence, checks not reproducible locally, and any manual release verification still required.
+Validate YAML structure, expressions, event filters, permissions, matrix behavior, shell quoting, paths, conditions, output propagation, artifact retention, and secret availability. Compare the workflow with the corresponding local Gradle command. For build-tooling changes, also verify the affected plugin graph, wrapper/version compatibility, and the narrowest relevant Android or Desktop build task. For performance changes, rerun the same representative build used for the baseline and report measured evidence rather than an assumed speedup. Report job-log evidence, checks not reproducible locally, and any manual release verification still required.

--- a/.agents/skills/levyra-ci-workflows/SKILL.md
+++ b/.agents/skills/levyra-ci-workflows/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: levyra-ci-workflows
-description: Implement, debug, or review Levyra GitHub Actions, CI checks, Android and Desktop builds, artifact handling, release automation, F-Droid, configuration sync, permissions, and workflow security.
+description: Implement, debug, or review Levyra GitHub Actions, CI checks, Android and Desktop builds, artifact handling, release automation, F-Droid, configuration sync, permissions, workflow security, and Kotlin/Gradle/AGP build-tooling compatibility.
 ---
 
 # Levyra CI and workflow workflow
@@ -24,6 +24,28 @@ description: Implement, debug, or review Levyra GitHub Actions, CI checks, Andro
 - Ensure caches use safe, deterministic keys and cannot substitute untrusted executable output across trust boundaries.
 - Make no-change, skipped, cancelled, and failed outcomes visible and semantically distinct.
 
+## Kotlin and AGP 9 guardrails
+
+Levyra currently uses AGP 9.x and built-in Kotlin support in the Android application module. Treat build-tooling edits as compatibility work, not routine cleanup.
+
+Before changing AGP, Kotlin, KSP, Gradle, Compose tooling, source sets, compiler options, or module plugins:
+
+1. inspect `settings.gradle.kts`, root and affected module `build.gradle.kts` files, `gradle/libs.versions.toml`, `gradle/wrapper/gradle-wrapper.properties`, and `gradle.properties`;
+2. classify the affected module from its actual plugins instead of inferring KMP merely because the repository also contains a Desktop client;
+3. compare the proposed change with the current official Kotlin/Android Gradle guidance when behavior is version-sensitive;
+4. keep the change limited to the migration or compatibility issue that actually exists.
+
+Levyra-specific rules:
+
+- Do not reintroduce `org.jetbrains.kotlin.android` into the AGP 9 Android app; AGP provides built-in Kotlin support for the Android application plugin.
+- Keep annotation processing on KSP where supported. Do not introduce `org.jetbrains.kotlin.kapt` as a convenience workaround; any legacy-kapt fallback requires an explicit task and compatibility justification.
+- When compiler options must change, use the current Kotlin compiler DSL rather than reviving deprecated `android.kotlinOptions` configuration.
+- Do not restructure Android and Desktop into a shared KMP application merely because a generic migration guide recommends that layout. Levyra's Android and Desktop products remain independently versioned and released unless the owner approves an architectural change.
+- Do not upgrade AGP, Kotlin, KSP, Gradle, JDK, SDK tools, or Compose dependencies as collateral cleanup in an unrelated CI/build fix.
+- If the official `Kotlin/kotlin-agent-skills` package is available, use `kotlin-tooling-agp9-migration` as an additional reference for AGP 9 migration work, then adapt it to Levyra's real module graph and repository rules rather than copying its target structure wholesale.
+
+These guardrails intentionally take the useful AGP 9 compatibility checks from JetBrains' Kotlin agent skill while keeping Levyra's existing architecture authoritative.
+
 ## Validation
 
-Validate YAML structure, expressions, event filters, permissions, matrix behavior, shell quoting, paths, conditions, output propagation, artifact retention, and secret availability. Compare the workflow with the corresponding local Gradle command. Report job-log evidence, checks not reproducible locally, and any manual release verification still required.
+Validate YAML structure, expressions, event filters, permissions, matrix behavior, shell quoting, paths, conditions, output propagation, artifact retention, and secret availability. Compare the workflow with the corresponding local Gradle command. For build-tooling changes, also verify the affected plugin graph, wrapper/version compatibility, and the narrowest relevant Android or Desktop build task. Report job-log evidence, checks not reproducible locally, and any manual release verification still required.

--- a/.agents/skills/levyra-ci-workflows/SKILL.md
+++ b/.agents/skills/levyra-ci-workflows/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: levyra-ci-workflows
-description: Implement, debug, or review Levyra GitHub Actions, CI checks, Android and Desktop builds, artifact handling, release automation, F-Droid, configuration sync, permissions, workflow security, and Kotlin/Gradle/AGP build-tooling compatibility.
+description: Automatically use for Levyra GitHub Actions, CI, F-Droid, Gradle/AGP/Kotlin/KSP compatibility, build performance, configuration/build cache, artifacts, release automation, workflow security, or configuration-sync work.
 ---
 
 # Levyra CI and workflow workflow

--- a/.agents/skills/levyra-compose/SKILL.md
+++ b/.agents/skills/levyra-compose/SKILL.md
@@ -33,6 +33,34 @@ Before editing, identify:
 - Add localization entries for every user-facing string; do not hardcode visible text.
 - Avoid broad visual rewrites when a focused state or layout correction is sufficient.
 
+## Compose performance diagnosis
+
+For jank, slow scrolling, frame drops, or suspected recomposition problems, measure before redesigning the UI.
+
+1. Start with the affected code and trace the state reads that can invalidate it.
+2. Inspect stable identity in lazy layouts, broad state collection, work performed during composition, allocation churn, image sizing/loading, subcomposition, and expensive layout/intrinsic measurement.
+3. Compare against a nearby smooth screen or component when one exists before introducing a new pattern.
+4. If code inspection is not enough, gather direct evidence with the narrowest useful tool: Layout Inspector/recomposition counts, System Trace or Perfetto for frame timing, and the existing benchmark/baseline-profile infrastructure when a repeatable metric is appropriate.
+5. Diagnose release-like behavior for performance claims. Debug-only jank or timings are evidence about the debug build, not proof of release performance.
+6. Change one material performance variable at a time and remeasure. Do not cargo-cult `remember`, `derivedStateOf`, `@Stable`, `@Immutable`, persistent collections, or a new dependency without showing that it fixes the measured invalidation/allocation/layout problem.
+
+Performance findings must distinguish code-review suspicion from measured evidence. Report the before/after metric when one was actually collected.
+
+## Accessibility review
+
+For changed interactive UI, verify semantics as behavior rather than merely checking that a property exists.
+
+- Actionable controls should expose a meaningful accessible label describing the action or purpose; purely decorative images/icons should not create redundant announcements.
+- Preserve logical focus/traversal order and group descendants only when the combined announcement is clearer than separate controls.
+- Expose selected/checked/expanded/loading or other custom state through standard semantics or an appropriate state description when the visual state would otherwise be hidden from assistive technology.
+- Keep interactive touch targets at least 48dp where platform behavior does not already enforce the minimum.
+- Use heading semantics for real section headings when they improve navigation, not for decorative typography.
+- Validate large font scale, long translations, RTL, contrast, and TalkBack/screen-reader behavior when the change affects them.
+
+Do not add duplicate spoken labels around controls that already expose correct semantics through their standard component behavior.
+
 ## Validation
 
 Test recomposition-sensitive paths, state restoration, rapid navigation, background/foreground transitions, long translations, RTL, large font scale, empty/error states, and accessibility semantics when applicable. Run focused UI or ViewModel tests before broader Android checks.
+
+For performance work, include direct profiling/benchmark evidence when available and state clearly when performance remains code-review-only. For accessibility-sensitive changes, distinguish static semantics review from an actual TalkBack/device check.

--- a/.agents/skills/levyra-real-engineering/SKILL.md
+++ b/.agents/skills/levyra-real-engineering/SKILL.md
@@ -25,6 +25,21 @@ Do not run the full pipeline for a typo, one-line build fix, obvious null check,
 
 For non-trivial work:
 
+### 0. Evidence and reuse before invention
+
+Before adding a new abstraction, helper, dependency, workflow, cache, store, controller, parser, or architectural layer:
+
+- search Levyra first for the existing owner, working pattern, nearby implementation, or reusable primitive;
+- compare the broken/new path with at least one working local path when one exists;
+- when behavior depends on a versioned external API, library, plugin, or platform rule, verify current primary documentation instead of trusting remembered behavior;
+- prefer adapting a proven local implementation over importing a generic framework pattern;
+- treat third-party repositories and skill catalogs as evidence and inspiration, never as authority over Levyra's codebase;
+- add a dependency only when the existing stack cannot reasonably satisfy the requirement and the maintenance, security, binary-size, and compatibility cost is justified.
+
+Do not turn this into mandatory broad web research for trivial work. The goal is to prevent needless reinvention and stale assumptions, not to add ceremony.
+
+This step incorporates the useful research-and-reuse discipline from ECC while deliberately rejecting its generic stack assumptions and fixed coverage/style thresholds.
+
 ### 1. Ambiguous product or architecture: `grill-with-docs`
 
 Use when the requested behavior, trade-offs, ownership, compatibility, or user-visible outcome is genuinely unclear.
@@ -75,6 +90,22 @@ Implement one ticket or one reviewable phase at a time.
 - Do not force artificial tests around trivial declarative changes; still validate the narrowest relevant behavior.
 - Make the smallest coherent change and avoid unrelated cleanup.
 
+#### Hypothesis-driven debugging
+
+For a bug, test failure, build failure, race, playback regression, or other unexpected behavior, do not stack speculative fixes.
+
+1. Reproduce or capture the failing path and read the complete relevant error/evidence.
+2. Trace the bad state or value backward across the actual component boundaries until the first incorrect assumption, mutation, stale value, or failed contract is identified.
+3. Compare with a nearby working path and list the material differences.
+4. State one concrete root-cause hypothesis and the evidence supporting it.
+5. Test that hypothesis with the smallest possible experiment or change.
+6. If it fails, revert/discard the speculative change and form a new hypothesis from the new evidence; do not pile fixes on top of one another.
+7. Once the cause is supported, add the smallest regression test or deterministic reproduction that proves the failure, then implement the fix and rerun the relevant broader checks.
+
+If three materially different fix hypotheses fail, stop treating the issue as a local patch problem. Reassess the ownership boundary or architecture before attempting another fix and surface that change in direction to the owner.
+
+This keeps the strongest part of the AAS `systematic-debugging` workflow—root-cause tracing and single-variable experiments—without importing its full catalog or rigid ceremony into every tiny defect.
+
 ### 6. Review: `code-review` + `levyra-pr-review`
 
 Matt's code review is supplementary to Levyra's repository review contract.
@@ -101,12 +132,17 @@ Do not assume one skill can invoke another across every runtime. Codex, ChatGPT,
 
 If the external package is unavailable, follow this Levyra adapter rather than blocking ordinary work, and report that the upstream skill body was not available.
 
-## Context discipline
+## Context and handoff discipline
 
 - Keep the current ticket/phase small enough to review.
-- Prefer fresh context between independent tickets.
-- Carry forward the approved spec, domain vocabulary, ADRs, exact ticket, and direct validation evidence; do not carry stale exploratory chatter as authority.
-- Current repository evidence always overrides remembered conversation context.
+- Prefer fresh context between independent tickets and use an independent context for final review when the runtime supports it.
+- Carry forward only the approved spec/ticket, relevant architecture/invariants, exact changed files or diff/commit, direct validation evidence, and unresolved blockers.
+- Prefer durable existing artifacts (`docs/project/TASKS.md` for the active approved phase, an existing issue/PR, or a scoped implementation handoff) over burying important state in chat history.
+- Do not create `MEMORY.md`, `recap.md`, duplicate PRDs, duplicate task ledgers, or another persistent source of truth only to help an agent survive context compaction.
+- When a session must compact or restart, summarize verified facts and open decisions, not exploratory chatter, guesses, or superseded hypotheses.
+- Current repository evidence always overrides remembered conversation context or an older handoff.
+
+This adapts the artifact-first/fresh-context ideas from `KhazP/vibe-coding-prompt-template` and current Claude Code skill practices without duplicating Levyra's existing planning system.
 
 ## Publication and quality gates
 

--- a/.agents/skills/levyra-real-engineering/SKILL.md
+++ b/.agents/skills/levyra-real-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: levyra-real-engineering
-description: Route non-trivial Levyra engineering through the Matt Pocock real-engineering workflow: clarify ambiguous work, build shared domain language, create a spec, split large work into vertical tickets, implement with focused tests, then independently review. Use for features, architectural changes, unclear bugs, multi-step work, or requests that risk AI slop; skip the ceremony for tiny obvious edits.
+description: Route non-trivial Levyra engineering through the Matt Pocock real-engineering workflow. Use automatically for features, architectural changes, bugs, test/build failures, regressions, unexpected behavior, multi-step work, or requests that risk AI slop when root-cause investigation, specification, focused implementation, or independent review is useful; skip the ceremony for tiny obvious edits.
 ---
 
 # Levyra real-engineering workflow

--- a/.agents/skills/levyra-release-check/SKILL.md
+++ b/.agents/skills/levyra-release-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: levyra-release-check
-description: Validate Levyra before merge or release, including Android and Desktop versions, signing, builds, packaging, artifacts, checksums, workflows, secrets, and truthful manual verification.
+description: Automatically use for Levyra pre-merge/pre-release validation, Android emulator or physical-device runtime verification, versions, signing, builds, packaging, artifacts, checksums, workflows, secrets, and truthful manual evidence.
 ---
 
 # Levyra release validation workflow

--- a/.agents/skills/levyra-release-check/SKILL.md
+++ b/.agents/skills/levyra-release-check/SKILL.md
@@ -33,6 +33,20 @@ Never update one platform's version merely because the other platform is releasi
 - verify package names, filenames, checksums, update metadata, release tags, and expected output paths;
 - distinguish CI evidence, local evidence, emulator/device evidence, and unperformed checks.
 
+## Android emulator and device evidence
+
+When an Android change needs runtime verification, prefer semantic, reproducible interaction over screen-coordinate automation.
+
+- Confirm `adb`, the intended SDK/JDK, the connected target, and the exact app/build variant before testing.
+- If more than one device or emulator is connected, select the serial explicitly; never assume the first target is correct.
+- Separate build, install, launch, interaction, log inspection, and final-state evidence so a successful earlier step is not mistaken for end-to-end success.
+- Prefer UI hierarchy, resource IDs, visible text, and accessibility/content descriptions for navigation and assertions. Use raw coordinates only when no stable semantic target exists, and record that limitation.
+- Capture focused logcat for the app/process around the reproduction window. Compact repetitive success noise when useful, but keep complete failure, crash, stacktrace, security, and exact-reproduction evidence available raw.
+- For playback changes, verify the exact affected path (song/audio mode, native-video mode, queue transition, background/foreground, notification, or other relevant behavior) rather than treating a successful app launch as playback validation.
+- Emulator success does not prove physical-device, Android Auto, notification, Bluetooth/media-key, battery, OEM, or hardware-decoder behavior. Report each category separately.
+
+This adopts the strongest idea from SimpMusic's Android emulator workflow: semantic navigation and structured evidence instead of brittle pixel automation, without vendoring its helper scripts into Levyra.
+
 ## Reporting
 
 List every command/check with its result. A blocked or skipped check is not a pass. Report manual playback, Android Auto, notification, PiP, Windows installer, update, protocol, media-key, and native VLC checks as unverified unless actually performed.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -56,22 +56,24 @@ Release tasks require the inputs documented in `app/build.gradle.kts` and mirror
  
 ## Specialized guidance
  
-Rules under `.claude/rules/` load automatically from their `paths:` frontmatter. Skills do not load themselves. Invoke the matching skill with the Skill tool **before reading widely or editing**, without waiting to be asked.
+Rules under `.claude/rules/` load automatically from their `paths:` frontmatter. Skills do not load themselves. Invoke every matching skill with the Skill tool **automatically before reading widely, editing, or running a large command**, without waiting for the owner to name the skill or type a slash command.
 
 | The task touches | Invoke |
 | --- | --- |
-| Non-trivial feature, architectural change, unclear defect, specification/ticket split, or multi-step engineering | `levyra-real-engineering` |
+| Non-trivial feature, architecture, bug/regression, test/build failure, unexpected behavior, specification/ticket split, or multi-step engineering | `levyra-real-engineering` |
 | Playback, queue, Media3, MediaSession, notification, Android Auto, prefetch, audio/video mode | `levyra-player` |
 | InnerTube, extractor, stream resolution, player-config sync, tokens, network fallback | `levyra-extractor` |
 | Room entities, DAOs, migrations, schema, caches, stores, backup | `levyra-database` |
-| Compose screens, state projections, animation, lifecycle, accessibility, localization | `levyra-compose` |
+| Compose screens, state projections, jank/scrolling/recomposition, Layout Inspector/Perfetto, animation, lifecycle, accessibility/TalkBack/semantics, RTL, localization | `levyra-compose` |
 | Decorative motion artwork | `levyra-motion-artwork` |
+| GitHub Actions, CI, F-Droid, Gradle/AGP/Kotlin/KSP, build performance/cache, artifacts, or workflow automation | `levyra-ci-workflows` |
+| Builds, tests, lint, logs, broad searches, dependencies, Git/GitHub, CI, CodeRabbit, setup, or other noisy command output | `levyra-context-efficiency` |
 | Secrets, remote URLs, redirects, SSRF, MIME confusion, permissions, privacy, workflow exposure | `levyra-security-review` |
-| Reviewing the current diff before merge | `levyra-pr-review` |
-| Pre-merge or pre-release validation, `levyraVersionName`/`levyraVersionCode`, signing, APK output | `levyra-release-check` |
+| Reviewing a branch, commit, diff, or pull request | `levyra-pr-review` |
+| Emulator/device runtime verification, pre-merge/pre-release validation, `levyraVersionName`/`levyraVersionCode`, signing, APK/package output | `levyra-release-check` |
 
-When several rows match, invoke each of them. A player change that also touches the extractor is both. If a skill turns out not to apply once read, say so in one line and continue rather than silently skipping it.
+When several rows match, invoke each of them. A slow Gradle build normally uses both `levyra-ci-workflows` and `levyra-context-efficiency`; a playback bug uses `levyra-real-engineering` plus `levyra-player`; a Compose jank issue uses `levyra-real-engineering` plus `levyra-compose`; a PR review uses `levyra-pr-review` plus all affected domain/security skills. If a skill turns out not to apply once read, say so in one line and continue rather than silently skipping it.
 
-`levyra-real-engineering` is a thin bridge to the canonical adapter under `.agents/skills/`. Use only the stages needed: clarify genuine ambiguity, resolve a large decision map when necessary, write a spec only after intent is settled, split oversized work into reviewable tickets, implement one ticket at a time, and finish with independent review. Skip this ceremony for tiny, already-unambiguous changes. When the project-enabled `mattpocock-skills` plugin is available, invoke the exact upstream stage named by the bridge instead of paraphrasing it from memory. Levyra's architecture, focused domain skills, tests, quality gates, and publication rules always win on conflicts.
+`levyra-real-engineering` is a thin bridge to the canonical adapter under `.agents/skills/`. Use only the stages needed: clarify genuine ambiguity, resolve a large decision map when necessary, write a spec only after intent is settled, split oversized work into reviewable tickets, implement one ticket at a time, and finish with independent review. Skip this ceremony for tiny, already-unambiguous changes. For bugs, regressions, test/build failures, races, crashes, and unexpected behavior, use its hypothesis-driven debugging lane before stacking speculative fixes. When the project-enabled `mattpocock-skills` plugin is available, invoke the exact upstream stage named by the bridge instead of paraphrasing it from memory. Levyra's architecture, focused domain skills, tests, quality gates, and publication rules always win on conflicts.
 
 A `UserPromptSubmit` hook restates the matching rows for each request, so this table is enforced rather than merely documented. The table remains authoritative if that hook is unavailable.

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -44,6 +44,7 @@ if [ -f local.properties ]; then
 fi
 
 sdk_root=""
+sdk_platform=""
 sdk_partial=""
 for candidate in "${candidates[@]}"; do
   if [ -z "$candidate" ] || [ ! -d "$candidate" ]; then
@@ -51,19 +52,36 @@ for candidate in "${candidates[@]}"; do
   fi
 
   missing=""
+  found_platform=""
   if [ -n "$compile_sdk" ]; then
-    if [ ! -f "$candidate/platforms/android-$compile_sdk/android.jar" ]; then
-      missing="platforms;android-$compile_sdk"
+    # Recent SDK Manager releases store the base minor SDK as android-<api>.0
+    # (for example API 37 as android-37.0), while older installations may still
+    # use android-<api>. Accept both, but do not treat a later minor SDK such as
+    # android-37.1 as satisfying compileSdk = 37.
+    for platform_path in \
+      "$candidate/platforms/android-$compile_sdk" \
+      "$candidate/platforms/android-$compile_sdk.0"; do
+      if [ -f "$platform_path/android.jar" ]; then
+        found_platform="${platform_path##*/}"
+        break
+      fi
+    done
+    if [ -z "$found_platform" ]; then
+      missing="platforms;android-$compile_sdk (or platforms;android-$compile_sdk.0)"
     fi
   elif ! compgen -G "$candidate/platforms/android-*/android.jar" >/dev/null 2>&1; then
     missing="an android-<compileSdk> platform"
   fi
-  if ! compgen -G "$candidate/build-tools/*/aapt2" >/dev/null 2>&1; then
+
+  # Build-tools binaries are extensionless on Unix and use .exe on Windows.
+  if ! compgen -G "$candidate/build-tools/*/aapt2" >/dev/null 2>&1 && \
+     ! compgen -G "$candidate/build-tools/*/aapt2.exe" >/dev/null 2>&1; then
     missing="${missing:+$missing and }build-tools"
   fi
 
   if [ -z "$missing" ]; then
     sdk_root="$candidate"
+    sdk_platform="$found_platform"
     break
   fi
   if [ -z "$sdk_partial" ]; then
@@ -73,7 +91,7 @@ done
 
 sdk_unusable_advice="Do not attempt them, and do not report them as passing or as skipped-by-choice: say the Android SDK is unusable in this environment and that CI (.github/workflows/pr-check.yml) is the authority."
 if [ -n "$sdk_root" ]; then
-  lines+=("Android SDK: $sdk_root, with platform android-${compile_sdk:-unknown} and build-tools present. ':app:' Gradle tasks should configure. That is a precondition, not a result: still run the task and report only what actually ran.")
+  lines+=("Android SDK: $sdk_root, with platform ${sdk_platform:-android-${compile_sdk:-unknown}} and build-tools present. ':app:' Gradle tasks should configure. That is a precondition, not a result: still run the task and report only what actually ran.")
 elif [ -n "$sdk_partial" ]; then
   lines+=("Android SDK: incomplete - $sdk_partial. Every ':app:' Gradle task (testDebugUnitTest, lintRelease, assembleRelease) still fails at configuration time until those packages are installed via sdkmanager. $sdk_unusable_advice")
 else

--- a/.claude/hooks/user-prompt-submit.sh
+++ b/.claude/hooks/user-prompt-submit.sh
@@ -34,8 +34,8 @@ if any(marker in prompt for marker in AUTOMATED_MARKERS):
 ROUTES = [
     (
         "levyra-real-engineering",
-        "non-trivial requirements, architecture, or multi-step engineering",
-        r"new feature|nuova funzionalit|architecture|architett|refactor|riprogett|redesign|\bspec\b|specifica|roadmap|multi.?step|cross.?domain|pi[uù].*modul|across.*module|grill-with-docs|wayfinder|to-spec|to-tickets",
+        "non-trivial engineering, root-cause debugging, requirements, or architecture",
+        r"new feature|nuova funzionalit|architecture|architett|refactor|riprogett|redesign|\bspec\b|specifica|roadmap|multi.?step|cross.?domain|pi[uù].*modul|across.*module|grill-with-docs|wayfinder|to-spec|to-tickets|\bbug\b|regression|regressione|test failure|test fallit|build failure|build fallit|unexpected behavior|comportamento inaspett|\bcrash\b|race condition|concurrency bug",
     ),
     (
         "levyra-player",
@@ -54,13 +54,23 @@ ROUTES = [
     ),
     (
         "levyra-compose",
-        "Compose UI or state projection",
-        r"compose|composable|\bui\b|screen|schermat|theme|\btema\b|animation|animazion|layout|accessibilit|localizzazion|localization|string resource",
+        "Compose UI, performance, accessibility, or state projection",
+        r"compose|composable|\bui\b|screen|schermat|theme|\btema\b|animation|animazion|layout|jank|recomposition|ricompos|scroll|perfetto|layout inspector|talkback|semantics|semantic|touch target|accessibilit|rtl|localizzazion|localization|string resource",
     ),
     (
         "levyra-motion-artwork",
         "motion artwork",
         r"motion artwork|motion|artwork|copertin|cover art",
+    ),
+    (
+        "levyra-ci-workflows",
+        "CI, Gradle/Kotlin tooling, or build performance",
+        r"github actions|\bworkflow\b|\bci\b|fdroid|f-droid|\bgradle\b|\bagp\b|\bkotlin\b|\bksp\b|build performance|slow build|build lento|configuration cache|build cache|compile time|compilation time|build logic|gradle\.properties|artifact",
+    ),
+    (
+        "levyra-context-efficiency",
+        "noisy command output or broad repository diagnostics",
+        r"\bbuild\b|\bgradle\b|\btest\b|\blint\b|logcat|\blogs?\b|git diff|git log|git status|github|\bgh\b|coderabbit|dependencies|dependency tree|broad search|ricerca ampia|setup|installazione ai|agent setup",
     ),
     (
         "levyra-security-review",
@@ -69,13 +79,13 @@ ROUTES = [
     ),
     (
         "levyra-pr-review",
-        "reviewing the current diff",
-        r"review|revision|pull request|\bpr\b|merge|\bdiff\b|before merging|prima di merg",
+        "reviewing a branch, commit, diff, or pull request",
+        r"review|revision|pull request|\bpr\b|merge|\bdiff\b|commit review|branch review|before merging|prima di merg",
     ),
     (
         "levyra-release-check",
-        "release or version safety",
-        r"release|rilasci|versionname|versioncode|\bversion\b|versione|\bapk\b|signing|firma|tag\b|publish|pubblic",
+        "runtime, pre-merge, or release validation",
+        r"release|rilasci|versionname|versioncode|\bversion\b|versione|\bapk\b|signing|firma|tag\b|publish|pubblic|emulator|emulatore|physical device|device test|test dispositivo|\badb\b|connectedcheck|smoke test|runtime verification|runtime validation|verifica runtime|pre.?merge",
     ),
 ]
 
@@ -83,18 +93,21 @@ matched = [(skill, topic) for skill, topic, pattern in ROUTES if re.search(patte
 if not matched:
     sys.exit(0)
 
-lines = ["Levyra skill routing - this request matches project skills:", ""]
+lines = ["Levyra automatic skill routing - this request matches project skills:", ""]
 for skill, topic in matched:
     lines.append("- %s -> invoke the %s skill" % (topic, skill))
 lines += [
     "",
-    "Invoke each matching skill with the Skill tool BEFORE reading widely or editing, "
-    "and follow its procedure. Do not wait to be asked. For real-engineering work, "
-    "use the Matt Pocock stage skill selected by the Levyra bridge when the plugin is "
-    "available, and skip the full ceremony for tiny unambiguous changes. For security "
-    "work, preserve exact evidence and follow threat model, identification, safe "
-    "validation, minimal remediation, human review, and revalidation. If a skill turns "
-    "out not to apply once read, say so in one line and continue.",
+    "Invoke every matching skill with the Skill tool BEFORE reading widely, editing, "
+    "or running large commands. Do not wait for the owner to name a skill or type a "
+    "slash command. For real-engineering bugs/failures, use the hypothesis-driven "
+    "debugging lane before stacking speculative fixes. For CI/build-performance work, "
+    "measure before changing configuration and remeasure the same path afterward. For "
+    "Compose performance/accessibility work, require direct evidence where applicable. "
+    "For emulator/device validation, prefer semantic UI targets over raw coordinates. "
+    "For security work, preserve exact evidence and follow threat model, identification, "
+    "safe validation, minimal remediation, human review, and revalidation. If a skill "
+    "turns out not to apply once read, say so in one line and continue.",
 ]
 
 print(json.dumps({

--- a/.claude/skills/levyra-ci-workflows/SKILL.md
+++ b/.claude/skills/levyra-ci-workflows/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: Levyra CI Workflows
+description: Automatically use for Levyra GitHub Actions, CI, F-Droid, Gradle/AGP/Kotlin/KSP compatibility, build performance, caches, artifacts, release automation, workflow security, or configuration-sync work.
+---
+
+# Levyra CI workflow bridge
+
+Read and follow the canonical workflow at:
+
+```text
+.agents/skills/levyra-ci-workflows/SKILL.md
+```
+
+That file owns Levyra-specific Gradle/AGP/Kotlin/KSP compatibility rules, measured build-performance work, CI/workflow safety, validation, and architecture boundaries.
+
+Do not copy generic Gradle optimizations, add analytics/build-scan services, weaken checks, or restructure modules merely because an external skill recommends them. Root/path `AGENTS.md`, current build logic, and direct evidence remain authoritative.

--- a/.claude/skills/levyra-compose/SKILL.md
+++ b/.claude/skills/levyra-compose/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: Levyra Compose Change
-description: Implements or reviews Levyra Compose screens, state projections, animation, lifecycle, accessibility, and localization changes.
+description: Automatically use for Levyra Compose screens, state projections, jank, scrolling, recomposition, Layout Inspector/Perfetto analysis, animation, lifecycle, accessibility, TalkBack/semantics, RTL, and localization changes.
 ---
 
-# Levyra Compose workflow
+# Levyra Compose bridge
 
-1. Read `.claude/rules/compose-ui.md` and the affected composable, state, ViewModel, theme, and string files.
-2. Keep I/O and orchestration outside composables.
-3. Minimize the state observed by each screen and preserve stable lazy-list keys.
-4. Use correctly keyed effects and deterministic cleanup for listeners, callbacks, players, receivers, and surfaces.
-5. Keep cached/real content visible during refresh and provide a non-animated fallback.
-6. Respect animation preference, lifecycle, low-RAM, battery/data saver, RTL, accessibility, and touch targets.
-7. Add/update localization entries instead of hardcoding user-facing text.
-8. Check recomposition scope and test long text, state restoration, rapid navigation, and background/foreground behavior when applicable.
+Read and follow the canonical workflow at:
+
+```text
+.agents/skills/levyra-compose/SKILL.md
+```
+
+That file owns Levyra-specific Compose performance diagnosis, accessibility checks, state/lifecycle rules, localization, validation, and architecture boundaries.
+
+Do not substitute generic Compose recipes for repository evidence. Root/path `AGENTS.md`, current architecture, the affected implementation, and direct profiling/runtime evidence remain authoritative.

--- a/.claude/skills/levyra-context-efficiency/SKILL.md
+++ b/.claude/skills/levyra-context-efficiency/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: Levyra Context Efficiency
+description: Automatically use for noisy Levyra builds, tests, lint, logs, broad searches, dependencies, Git/GitHub, CI, CodeRabbit, setup, or other command-heavy work where RTK and focused context can reduce repetitive output without weakening evidence.
+---
+
+# Levyra context-efficiency bridge
+
+Read and follow the canonical workflow at:
+
+```text
+.agents/skills/levyra-context-efficiency/SKILL.md
+```
+
+Use it together with the matching domain skill. It controls context and command-output handling only; it never replaces tests, exact failure evidence, security validation, or the repository quality gate.

--- a/.claude/skills/levyra-pr-review/SKILL.md
+++ b/.claude/skills/levyra-pr-review/SKILL.md
@@ -3,6 +3,7 @@ name: Levyra PR Review
 description: Reviews the current Levyra diff before merge and produces prioritized, actionable findings plus a validation summary.
 context: fork
 agent: levyra-reviewer
+background: false
 ---
 
 # PR review procedure

--- a/.claude/skills/levyra-real-engineering/SKILL.md
+++ b/.claude/skills/levyra-real-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: levyra-real-engineering
-description: Use for non-trivial Levyra features, architectural changes, unclear bugs, multi-step work, or requests where requirements and implementation need to be separated before editing. Skip for tiny unambiguous fixes.
+description: Automatically use for non-trivial Levyra features, architecture, bugs, regressions, test/build failures, crashes, races, unexpected behavior, multi-step work, or requests needing root-cause investigation, specification, focused implementation, or independent review. Skip tiny unambiguous fixes.
 ---
 
 # Levyra real-engineering bridge

--- a/.claude/skills/levyra-release-check/SKILL.md
+++ b/.claude/skills/levyra-release-check/SKILL.md
@@ -1,18 +1,17 @@
 ---
 name: Levyra Release Check
-description: Runs the Levyra pre-merge or pre-release validation checklist and reports evidence without publishing or releasing anything. Use before merging or releasing, and whenever the task touches versionName, versionCode, signing, APK output, or release workflows.
+description: Automatically use for Levyra emulator/device runtime verification, pre-merge/pre-release validation, versionName/versionCode, signing, APK/package output, release workflows, artifacts, checksums, and truthful manual evidence.
 allowed-tools: Read, Grep, Glob, Bash
 ---
 
-# Levyra validation
+# Levyra validation bridge
 
-Do not publish, tag, release, merge, or change version values.
+Read and follow the canonical workflow at:
 
-1. Run `git status --short` and `git diff --check`.
-2. Inspect changed files for secrets, keystores, APKs, ZIPs, conflict markers, HTML pasted into source, and unrelated changes.
-3. Run the narrowest affected unit tests.
-4. Run `./gradlew --no-daemon :app:testDebugUnitTest` when available.
-5. Run `./gradlew --no-daemon :app:lintRelease` and `./gradlew --no-daemon --no-configuration-cache assembleRelease` only with the required release inputs available through the approved local/CI mechanism.
-6. Compare workflow changes against existing release, APK, extractor, config-sync, and duplicate guards.
-7. Verify `levyraVersionName` and `levyraVersionCode` changed only for an explicit release task.
-8. Report each command, exit result, and any skipped manual checks. Never convert a skipped or blocked check into a pass.
+```text
+.agents/skills/levyra-release-check/SKILL.md
+```
+
+That file owns semantic emulator/device validation, pre-merge/release checks, version/signing boundaries, artifact verification, and truthful evidence reporting.
+
+Do not publish, tag, release, merge, or change version values unless the owner separately authorizes that exact action. Prefer semantic UI targets over raw coordinates for Android runtime checks and report every unperformed device-only check as unverified.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,7 @@ skills over the general coordinator.
 | Windows Desktop, Compose Multiplatform, libvlc, downloads, mini player, deep links, updates, packaging | `levyra-desktop` |
 | Secrets, URLs, redirects, SSRF, MIME, permissions, privacy, update integrity | `levyra-security-review` |
 | GitHub Actions, CI, F-Droid, configuration sync, artifacts, build/release automation | `levyra-ci-workflows` |
+| Builds, tests, lint, logs, broad searches, dependency reports, Git/GitHub, CI diagnostics, or other noisy command output | `levyra-context-efficiency` |
 | Branch, commit, patch, or pull request review | `levyra-pr-review` |
 | Pre-merge or pre-release validation, versions, signing, checksums, packaging | `levyra-release-check` |
 | Genuine cross-domain work or initial architecture orientation | `levyra-engineering` |

--- a/scripts/validate_agent_config.py
+++ b/scripts/validate_agent_config.py
@@ -23,6 +23,14 @@ REQUIRED_FILES = (
     "docs/project/TASKS.md",
     ".agents/README.md",
     ".agents/rules/levyra-workspace.md",
+    ".claude/CLAUDE.md",
+    ".claude/hooks/user-prompt-submit.sh",
+    ".claude/skills/levyra-real-engineering/SKILL.md",
+    ".claude/skills/levyra-compose/SKILL.md",
+    ".claude/skills/levyra-ci-workflows/SKILL.md",
+    ".claude/skills/levyra-context-efficiency/SKILL.md",
+    ".claude/skills/levyra-release-check/SKILL.md",
+    ".claude/skills/levyra-pr-review/SKILL.md",
     "docs/ai/README.md",
     "docs/ai/WORKFLOW.md",
     "docs/ai/ANTIGRAVITY.md",
@@ -51,6 +59,25 @@ REFERENCE_FILES = (
 ANTIGRAVITY_RULE_PATH = ".agents/rules/levyra-workspace.md"
 ANTIGRAVITY_RULE_ROOT_REFERENCE = "@../../AGENTS.md"
 ANTIGRAVITY_SKILLS_PATH = ".agents/skills/"
+CLAUDE_INSTRUCTIONS_PATH = ".claude/CLAUDE.md"
+CLAUDE_ROUTER_PATH = ".claude/hooks/user-prompt-submit.sh"
+
+AUTOMATIC_ROUTED_SKILLS = (
+    "levyra-real-engineering",
+    "levyra-compose",
+    "levyra-ci-workflows",
+    "levyra-context-efficiency",
+    "levyra-pr-review",
+    "levyra-release-check",
+)
+
+CLAUDE_CANONICAL_BRIDGES = (
+    "levyra-real-engineering",
+    "levyra-compose",
+    "levyra-ci-workflows",
+    "levyra-context-efficiency",
+    "levyra-release-check",
+)
 
 SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 SKILL_REFERENCE_RE = re.compile(r"`(levyra-[a-z0-9-]+)`")
@@ -89,6 +116,20 @@ def parse_front_matter(path: Path) -> dict[str, str]:
     return metadata
 
 
+def require_skill_references(
+    errors: list[str],
+    relative_path: str,
+    text: str,
+    skills: tuple[str, ...],
+    runtime: str,
+) -> None:
+    for skill in skills:
+        if skill not in text:
+            errors.append(
+                f"{relative_path}: missing {runtime} automatic route for {skill}"
+            )
+
+
 def main() -> int:
     errors: list[str] = []
 
@@ -116,6 +157,13 @@ def main() -> int:
                     f"{ANTIGRAVITY_RULE_PATH}: missing canonical root reference "
                     f"{ANTIGRAVITY_RULE_ROOT_REFERENCE!r}"
                 )
+            require_skill_references(
+                errors,
+                ANTIGRAVITY_RULE_PATH,
+                antigravity_rule,
+                AUTOMATIC_ROUTED_SKILLS,
+                "shared workspace",
+            )
 
     antigravity_guide_path = ROOT / "docs/ai/ANTIGRAVITY.md"
     if antigravity_guide_path.is_file():
@@ -132,6 +180,68 @@ def main() -> int:
                 errors.append(
                     "docs/ai/ANTIGRAVITY.md: missing workspace rule reference"
                 )
+
+    codex_instructions_path = ROOT / "AGENTS.md"
+    if codex_instructions_path.is_file():
+        try:
+            codex_instructions = codex_instructions_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            errors.append(f"AGENTS.md: cannot read file: {exc}")
+        else:
+            require_skill_references(
+                errors,
+                "AGENTS.md",
+                codex_instructions,
+                AUTOMATIC_ROUTED_SKILLS,
+                "Codex",
+            )
+
+    claude_instructions_path = ROOT / CLAUDE_INSTRUCTIONS_PATH
+    if claude_instructions_path.is_file():
+        try:
+            claude_instructions = claude_instructions_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            errors.append(f"{CLAUDE_INSTRUCTIONS_PATH}: cannot read file: {exc}")
+        else:
+            require_skill_references(
+                errors,
+                CLAUDE_INSTRUCTIONS_PATH,
+                claude_instructions,
+                AUTOMATIC_ROUTED_SKILLS,
+                "Claude",
+            )
+
+    claude_router_path = ROOT / CLAUDE_ROUTER_PATH
+    if claude_router_path.is_file():
+        try:
+            claude_router = claude_router_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            errors.append(f"{CLAUDE_ROUTER_PATH}: cannot read file: {exc}")
+        else:
+            require_skill_references(
+                errors,
+                CLAUDE_ROUTER_PATH,
+                claude_router,
+                AUTOMATIC_ROUTED_SKILLS,
+                "Claude hook",
+            )
+
+    for skill in CLAUDE_CANONICAL_BRIDGES:
+        relative_path = f".claude/skills/{skill}/SKILL.md"
+        path = ROOT / relative_path
+        if not path.is_file():
+            continue
+        try:
+            bridge = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            errors.append(f"{relative_path}: cannot read file: {exc}")
+            continue
+
+        canonical_reference = f".agents/skills/{skill}/SKILL.md"
+        if canonical_reference not in bridge:
+            errors.append(
+                f"{relative_path}: missing canonical bridge to {canonical_reference}"
+            )
 
     skills_root = ROOT / ".agents" / "skills"
     skill_paths = sorted(skills_root.glob("*/SKILL.md"))
@@ -169,6 +279,10 @@ def main() -> int:
         if not description:
             errors.append(f"{relative_path}: missing front matter description")
 
+    missing_automatic_skills = sorted(set(AUTOMATIC_ROUTED_SKILLS) - actual_skills)
+    for name in missing_automatic_skills:
+        errors.append(f"automatic route points to missing native skill: {name}")
+
     referenced_skills: set[str] = set()
     for relative_path in REFERENCE_FILES:
         path = ROOT / relative_path
@@ -205,7 +319,8 @@ def main() -> int:
         f"{len(REQUIRED_FILES)} required files, "
         f"{len(actual_skills)} native skills, "
         f"{len(referenced_skills)} documented skill references, "
-        "Antigravity workspace bridge verified, "
+        f"{len(AUTOMATIC_ROUTED_SKILLS)} automatic cross-runtime routes, "
+        "Codex/Claude/Antigravity routing verified, "
         "no duplicate root planning files."
     )
     return 0


### PR DESCRIPTION
## Summary

Curates useful agent-engineering practices into Levyra and makes the resulting repository-native workflows **auto-routed across Codex, Claude Code, and Google Antigravity** without installing huge third-party skill catalogs or creating parallel sources of truth.

## What changed

- Strengthened `levyra-real-engineering` with research/reuse-before-invention, single-hypothesis debugging, root-cause tracing, cleaner context handoffs, and broader automatic matching for bugs/regressions/test or build failures.
- Added AGP 9 / built-in Kotlin guardrails and measured Gradle performance work to `levyra-ci-workflows`.
- Strengthened `levyra-compose` with evidence-driven Compose performance diagnosis and a concrete accessibility review contract.
- Strengthened `levyra-release-check` with semantic Android emulator/device validation using UI hierarchy, IDs, visible text, and accessibility semantics rather than brittle coordinate automation.
- Made Claude `levyra-pr-review` synchronous with `background: false` so the caller waits for the independent review result.
- Fixed Claude's `SessionStart` Android SDK probe so final minor SDK layouts such as `platforms/android-37.0` satisfy `compileSdk = 37`, while later minor SDKs such as `37.1` are not mistaken for the base SDK. The probe now also recognizes Windows `aapt2.exe` build-tools instead of falsely reporting them missing.

## Automatic cross-runtime routing

### Codex

- Uses the canonical root/path `AGENTS.md` contract plus `.agents/skills/*/SKILL.md` metadata.
- `.agents/rules/levyra-workspace.md` now explicitly requires automatic task-to-skill selection without the owner naming a skill or slash command.
- Bugs/failures, Compose performance/accessibility, CI/Gradle/Kotlin tooling, emulator/device validation, and PR review have explicit shared routes.

### Claude Code

- `.claude/CLAUDE.md` now requires automatic invocation of every matching skill.
- `.claude/hooks/user-prompt-submit.sh` routes each user request to matching skills automatically.
- Added thin Claude bridges for `levyra-ci-workflows` and `levyra-context-efficiency`.
- Converted Compose and release validation to thin bridges so Claude reads the same canonical `.agents/skills` procedures as Codex and Antigravity instead of stale duplicate copies.
- `.claude/hooks/session-start.sh` now validates Android SDK 37.0 correctly on Windows and reports the actual platform directory it found.

### Google Antigravity

- Uses the same canonical `.agents/skills` tree.
- The always-on `.agents/rules/levyra-workspace.md` now contains explicit automatic task-to-skill routing and does not require manual skill naming.

## Drift protection

`scripts/validate_agent_config.py` now verifies that:

- the key automatic routes exist for Codex (`AGENTS.md`), Claude (`CLAUDE.md` + `UserPromptSubmit`), and the shared Antigravity/workspace rule;
- every automatically routed native skill exists;
- required Claude bridge files exist;
- Claude bridges point back to the canonical `.agents/skills/<skill>/SKILL.md` source rather than becoming duplicate sources of truth.

## Sources deliberately adapted

Useful ideas were reviewed from:

- `affaan-m/ECC`
- `shanraisshan/claude-code-best-practice`
- `sickn33/agentic-awesome-skills`
- `KhazP/vibe-coding-prompt-template`
- `Kotlin/kotlin-agent-skills`
- `maxrave-dev/SimpMusic` `.claude` skills

The changes intentionally do **not** vendor or install those full collections. Generic architecture prescriptions, mandatory Hilt/Clean Architecture, Roborazzi, external emulator helper scripts, Crashlytics/Sentry defaults, remote Gradle analytics/cache services, and large skill catalogs remain excluded because they would add duplication, dependencies, context pressure, or conflict with Levyra's existing architecture.

## Impact

This remains agent/configuration-only. No Android/Desktop application behavior, application dependencies, versions, playback logic, or release configuration is changed.

## Validation

- Complete branch comparison against `main`: 16 changed files, all limited to agent instructions/skills/hooks and the agent-config validator.
- Current head `eedfb995`: Dependency Review passed; APK Size Report is in progress; PR Check and APK Artifact are pending at the time of this update.
- Required repository checks must still be judged from their actual results; pending/in-progress checks are not treated as passed.
- Relevant local commands remain:
  - `python3 scripts/validate_agent_config.py`
  - `python3 scripts/validate_ai_efficiency.py`
  - `python3 scripts/validate_matt_skills.py`
  - `python3 scripts/ai_quality_gate.py --profile fast`
  - `python3 scripts/ai_quality_gate.py --profile full`
