### PR TITLE
fix(playback): resolve the selected official video instead of its art track

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
@@ -2,6 +2,7 @@ package com.luc4n3x.levyra.data
 
 import android.content.Context
 import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
+import com.luc4n3x.levyra.domain.LevyraContentLocales
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
@@ -31,12 +32,40 @@ object NewPipeRuntime {
     @Volatile
     private var applicationContext: Context? = null
 
+    @Volatile
+    private var requestedLanguage: String = ""
+
+    @Volatile
+    private var appliedLanguage: String = ""
+
+    /**
+     * Publishes the language the user selected in Levyra. The value is pushed instead of read here
+     * so extraction never blocks on the preferences DataStore during playback.
+     */
+    fun setLanguage(languageCode: String) {
+        val locale = LevyraContentLocales.forLanguage(languageCode)
+        requestedLanguage = locale.languageCode
+        if (initialized.get()) applyRequestedLocalization()
+    }
+
     fun ensure(context: Context? = null) {
         context?.applicationContext?.let { applicationContext = it }
 
         if (initialized.compareAndSet(false, true)) {
-            NewPipe.init(OkHttpNewPipeDownloader(), Localization("it", "IT"), ContentCountry("IT"))
+            val locale = LevyraContentLocales.forLanguage(requestedLanguage)
+            try {
+                NewPipe.init(
+                    OkHttpNewPipeDownloader(),
+                    Localization(locale.hl, locale.gl),
+                    ContentCountry(locale.gl)
+                )
+                appliedLanguage = locale.languageCode
+            } catch (error: Throwable) {
+                initialized.set(false)
+                throw error
+            }
         }
+        applyRequestedLocalization()
 
         val appContext = applicationContext ?: return
         if (providerInstalled.compareAndSet(false, true)) {
@@ -49,6 +78,14 @@ object NewPipeRuntime {
                 throw error
             }
         }
+    }
+
+    private fun applyRequestedLocalization() {
+        val requested = requestedLanguage
+        if (requested.isBlank() || requested == appliedLanguage) return
+        val locale = LevyraContentLocales.forLanguage(requested)
+        NewPipe.setupLocalization(Localization(locale.hl, locale.gl), ContentCountry(locale.gl))
+        appliedLanguage = locale.languageCode
     }
 }
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
@@ -3,6 +3,7 @@ package com.luc4n3x.levyra.data
 import android.content.Context
 import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
 import com.luc4n3x.levyra.domain.LevyraContentLocales
+import com.luc4n3x.levyra.domain.LevyraLanguageCatalog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
@@ -33,7 +34,7 @@ object NewPipeRuntime {
     private var applicationContext: Context? = null
 
     @Volatile
-    private var requestedLanguage: String = ""
+    private var requestedLanguage: String = LevyraLanguageCatalog.deviceDefault()
 
     @Volatile
     private var appliedLanguage: String = ""
@@ -80,7 +81,7 @@ object NewPipeRuntime {
         }
     }
 
-    private fun applyRequestedLocalization() {
+    private fun applyRequestedLocalization() = synchronized(this) {
         val requested = requestedLanguage
         if (requested.isBlank() || requested == appliedLanguage) return
         val locale = LevyraContentLocales.forLanguage(requested)

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSourceIdentity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSourceIdentity.kt
@@ -1,6 +1,7 @@
 package com.luc4n3x.levyra.data
 
 import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.domain.YoutubeMusicVideoType
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.util.Locale
@@ -43,9 +44,13 @@ object PlaybackSourceIdentity {
         val audioId = track.audioVideoId.trim().takeIf(youtubeIdPattern::matches).orEmpty()
         val selectedVideoId = extractYoutubeVideoId(track.videoUrl)
         val originalTrackId = track.id.trim().takeIf(youtubeIdPattern::matches).orEmpty()
-        val videoType = track.videoType.uppercase(Locale.ROOT)
+        // An explicit audio/video pairing is authoritative even when YouTube reports an art-track
+        // or empty musicVideoType, otherwise a selected official video silently resolves as audio.
+        val pairedVideoSelection = audioId.isNotBlank() &&
+            selectedVideoId != audioId &&
+            selectedVideoId == track.counterpartVideoId.trim()
         val confirmedVideoSelection = selectedVideoId.isNotBlank() &&
-            (videoType.contains("OMV") || videoType.contains("UGC"))
+            (YoutubeMusicVideoType.isVideo(track.videoType) || pairedVideoSelection)
 
         if (confirmedVideoSelection) return selectedVideoId
         if (audioId.isNotBlank()) return audioId

--- a/app/src/main/java/com/luc4n3x/levyra/domain/VideoPlaybackContract.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/VideoPlaybackContract.kt
@@ -1,7 +1,31 @@
 package com.luc4n3x.levyra.domain
 
+import java.util.Locale
+
 private val YOUTUBE_VIDEO_ID = Regex("^[A-Za-z0-9_-]{11}$")
 private val YOUTUBE_VIDEO_URL = Regex("(?:v=|/shorts/|/embed/|/live/|youtu\\.be/)([A-Za-z0-9_-]{11})")
+
+/**
+ * Shared reading of the YouTube Music `musicVideoType` metadata so playback identity and
+ * video-candidate selection classify the same string in the same way.
+ */
+internal object YoutubeMusicVideoType {
+    fun isArtTrack(videoType: String): Boolean = videoType.uppercase(Locale.ROOT).contains("ATV")
+
+    fun isOfficialVideo(videoType: String): Boolean {
+        if (isArtTrack(videoType)) return false
+        val type = videoType.uppercase(Locale.ROOT)
+        return type.contains("OMV") ||
+            type.contains("OFFICIAL_MUSIC_VIDEO") ||
+            type.contains("OFFICIAL_SOURCE_MUSIC")
+    }
+
+    fun isVideo(videoType: String): Boolean {
+        if (isOfficialVideo(videoType)) return true
+        if (isArtTrack(videoType)) return false
+        return videoType.uppercase(Locale.ROOT).contains("UGC")
+    }
+}
 
 internal fun Track.hasVerifiedYoutubeMusicVideoPairing(): Boolean {
     val audio = audioVideoId.trim()

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlaybackCacheKey.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlaybackCacheKey.kt
@@ -7,8 +7,13 @@ object LevyraPlaybackCacheKey {
     private val itagPattern = Regex("(?:[?&]|%26)itag(?:=|%3D)(\\d+)", RegexOption.IGNORE_CASE)
 
     fun stream(track: Track): String {
-        val id = stableId(track)
-        return "levyra:$id:stream:${variant(track.streamUrl)}"
+        // Keyed on the resolved source, not the catalog id: in native-video mode the audio stream
+        // belongs to the official video, so a catalog-id key collided with the art track whenever
+        // both used the same itag and Media3 replayed one recording's bytes for the other.
+        val id = PlaybackSourceIdentity.sourceVideoId(track)
+            .ifBlank { stableId(track) }
+            .replace(':', '_')
+        return "levyra:$id:stream-v2:${variant(track.streamUrl)}"
     }
 
     fun video(track: Track): String {

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -17,6 +17,7 @@ import android.os.SystemClock
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
@@ -1681,12 +1682,25 @@ private class LevyraMediaSourceFactory(
             return ProgressiveMediaSource.Factory(localDataSourceFactory).createMediaSource(localItem)
         }
         val uri = localUri?.toString().orEmpty()
+        // The declared MIME type wins over URL shape: a YouTube HLS audio manifest whose URL does
+        // not look like a playlist would otherwise reach the progressive extractor, which fails on
+        // the #EXTM3U header instead of playing.
+        val mimeType = mediaItem.localConfiguration?.mimeType.orEmpty()
         return when {
-            isHlsManifestUri(uri) -> HlsMediaSource.Factory(dataSourceFactory).createMediaSource(mediaItem)
-            isDashManifestUri(uri) -> DashMediaSource.Factory(dataSourceFactory).createMediaSource(mediaItem)
+            isHlsMimeType(mimeType) || isHlsManifestUri(uri) ->
+                HlsMediaSource.Factory(dataSourceFactory).createMediaSource(mediaItem)
+            isDashMimeType(mimeType) || isDashManifestUri(uri) ->
+                DashMediaSource.Factory(dataSourceFactory).createMediaSource(mediaItem)
             else -> ProgressiveMediaSource.Factory(dataSourceFactory).createMediaSource(mediaItem)
         }
     }
+
+    private fun isHlsMimeType(mimeType: String): Boolean =
+        mimeType.equals(MimeTypes.APPLICATION_M3U8, ignoreCase = true) ||
+            mimeType.equals("application/vnd.apple.mpegurl", ignoreCase = true)
+
+    private fun isDashMimeType(mimeType: String): Boolean =
+        mimeType.equals(MimeTypes.APPLICATION_MPD, ignoreCase = true)
 
     private fun isHlsManifestUri(uri: String): Boolean {
         val clean = uri.substringBefore('#').lowercase()

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -329,7 +329,7 @@ internal fun videoPlaybackCandidateScore(target: Track, candidate: Track): Int {
     val videoPreference = when {
         YoutubeMusicVideoType.isOfficialVideo(type) -> 20_000
         YoutubeMusicVideoType.isArtTrack(type) -> -20_000
-        type.uppercase().contains("UGC") || type.uppercase().contains("MUSIC_VIDEO") -> 1_000
+        YoutubeMusicVideoType.isVideo(type) -> 1_000
         else -> 0
     }
     // A shared artist channel is structured proof of an official upload and outranks title text.
@@ -338,15 +338,35 @@ internal fun videoPlaybackCandidateScore(target: Track, candidate: Track): Int {
     return recordingScore + videoPreference + if (officialChannel) 6_000 else 0
 }
 
-internal fun selectPreferredVideoPlaybackCandidate(target: Track, candidates: List<Track>): Track? {
+internal fun videoCandidateId(candidate: Track): String =
+    youtubeVideoId(candidate.videoUrl).ifBlank { candidate.id.trim() }
+
+/**
+ * YouTube Music's own song/video pairing is authoritative, so a candidate in [authoritativeIds]
+ * only loses to structurally stronger evidence such as an exact ISRC match. Without this a
+ * title-compatible official video of a *different* recording could replace the declared pairing.
+ */
+internal const val VIDEO_PAIRING_AUTHORITY_BONUS = 20_000
+
+internal fun selectPreferredVideoPlaybackCandidate(
+    target: Track,
+    candidates: List<Track>,
+    authoritativeIds: Set<String> = emptySet()
+): Track? {
     return candidates.asSequence()
         .filter { candidate ->
-            val videoId = youtubeVideoId(candidate.videoUrl).ifBlank { candidate.id.trim() }
-            YOUTUBE_PLAYABLE_VIDEO_ID.matches(videoId) &&
-                !candidate.videoType.contains("ATV", ignoreCase = true)
+            YOUTUBE_PLAYABLE_VIDEO_ID.matches(videoCandidateId(candidate)) &&
+                !YoutubeMusicVideoType.isArtTrack(candidate.videoType)
         }
         .filter { candidate -> isPlaybackCandidateCompatible(target, candidate) }
-        .maxByOrNull { candidate -> videoPlaybackCandidateScore(target, candidate) }
+        .maxByOrNull { candidate ->
+            val authority = if (videoCandidateId(candidate) in authoritativeIds) {
+                VIDEO_PAIRING_AUTHORITY_BONUS
+            } else {
+                0
+            }
+            videoPlaybackCandidateScore(target, candidate) + authority
+        }
 }
 
 internal fun playbackTextKey(value: String): String {
@@ -6659,9 +6679,15 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             related to search.await()
         }
 
-        // Rank every candidate together so a confirmed official video from search wins over a
-        // merely playable watch-playlist entry. Watch candidates come first and still win ties.
-        val selected = selectPreferredVideoPlaybackCandidate(track, watchCandidates + searchCandidates)
+        // Rank every candidate together so a confirmed official video from search can win, while
+        // YouTube Music's own pairing keeps authority unless the search hit proves a stronger
+        // identity (exact ISRC) rather than a merely title-compatible official video.
+        val authoritativeIds = watchCandidates.map(::videoCandidateId).filter { it.isNotBlank() }.toSet()
+        val selected = selectPreferredVideoPlaybackCandidate(
+            track,
+            watchCandidates + searchCandidates,
+            authoritativeIds
+        )
         if (selected != null) {
             verifiedVideoIdentityCache[cacheKey] = selected
             return track.withVerifiedVideoCandidate(selected, sourceId)

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -338,6 +338,13 @@ internal fun videoPlaybackCandidateScore(target: Track, candidate: Track): Int {
     return recordingScore + videoPreference + if (officialChannel) 6_000 else 0
 }
 
+/**
+ * Clears every stream artifact of the previous mode. Keeping the old [Track.playbackManifest] would
+ * carry the other mode's stream descriptors into the new resolution and its cache entry.
+ */
+internal fun Track.forModeResolution(): Track =
+    copy(streamUrl = "", videoStreamUrl = "", playbackManifest = null)
+
 internal fun videoCandidateId(candidate: Track): String =
     youtubeVideoId(candidate.videoUrl).ifBlank { candidate.id.trim() }
 
@@ -1721,7 +1728,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         modeSwitchJob = viewModelScope.launch {
             try {
                 val selectedSource = if (targetMode) preferredVideoPlaybackTrack(track) else youtubePlayableTrack(track)
-                val baseTrack = selectedSource?.copy(streamUrl = "", videoStreamUrl = "")
+                val baseTrack = selectedSource?.forModeResolution()
                     ?: throw IllegalStateException("Nessuna sorgente YouTube riproducibile per ${track.title}")
                 val resolved = withContext(Dispatchers.IO) {
                     resolver.cached(baseTrack, targetMode) ?: providerRouter.resolve(baseTrack, targetMode)
@@ -1791,8 +1798,8 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 } else {
                     youtubePlayableTrack(failedTrack)
                 }
-                val baseTrack = selectedSource?.copy(streamUrl = "", videoStreamUrl = "")
-                    ?: failedTrack.copy(streamUrl = "", videoStreamUrl = "")
+                val baseTrack = selectedSource?.forModeResolution()
+                    ?: failedTrack.forModeResolution()
                 val resolved = withContext(Dispatchers.IO) { providerRouter.resolve(baseTrack, videoMode) }
                 if (!isActive || transitionId != streamTransitionId) return@launch
                 val currentIndex = queueEngine.state.value.currentIndex
@@ -1835,7 +1842,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         alternateModePrefetchJob = viewModelScope.launch(Dispatchers.IO) {
             val targetVideoMode = !activeVideoMode
             val selectedSource = if (targetVideoMode) preferredVideoPlaybackTrack(track) else youtubePlayableTrack(track)
-            val cleanTrack = selectedSource?.copy(streamUrl = "", videoStreamUrl = "")
+            val cleanTrack = selectedSource?.forModeResolution()
                 ?: return@launch
             val resolved = resolver.prefetch(cleanTrack, targetVideoMode) ?: return@launch
             if (targetVideoMode) {
@@ -6995,7 +7002,11 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         private const val HOME_ARTIST_RESOLUTION_CONCURRENCY = 4
         private const val HOME_ARTIST_FAST_TIMEOUT_MS = 5_200L
         private const val HOME_ARTIST_TOTAL_TIMEOUT_MS = 18_000L
-        private const val VIDEO_IDENTITY_LOOKUP_TIMEOUT_MS = 3_000L
+        // Native-video mode is an explicit user request, so the authoritative YouTube Music lookup
+        // gets a real budget. At 3s both InnerTube calls routinely timed out on mobile networks,
+        // leaving no candidate at all and silently falling back to the catalog counterpart. The two
+        // lookups run in parallel, so this bounds added latency rather than doubling it.
+        private const val VIDEO_IDENTITY_LOOKUP_TIMEOUT_MS = 9_000L
         private const val VERIFIED_VIDEO_IDENTITY_CACHE_SIZE = 64
         private const val HOME_ARTIST_STARTUP_GRACE_MS = 850L
         private const val HOME_STARTUP_STREAM_PREFETCH_COUNT = 2

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -30,6 +30,7 @@ import com.luc4n3x.levyra.data.ListeningPulseStore
 import com.luc4n3x.levyra.data.OfficialArtworkRepository
 import com.luc4n3x.levyra.data.LyricsRepository
 import com.luc4n3x.levyra.data.PlaybackResolver
+import com.luc4n3x.levyra.data.NewPipeRuntime
 import com.luc4n3x.levyra.data.PlaybackSourceIdentity
 import com.luc4n3x.levyra.data.preserveEditorialArtwork
 import com.luc4n3x.levyra.data.ReturnYoutubeDislikeRepository
@@ -99,6 +100,7 @@ import com.luc4n3x.levyra.domain.OfflineDownloadTask
 import com.luc4n3x.levyra.domain.Playlist
 import com.luc4n3x.levyra.domain.RepeatMode
 import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.domain.YoutubeMusicVideoType
 import com.luc4n3x.levyra.domain.YoutubeComment
 import com.luc4n3x.levyra.domain.YoutubeCommentsState
 import com.luc4n3x.levyra.domain.YoutubeEngagementState
@@ -323,14 +325,17 @@ internal fun playbackCandidateScore(target: Track, candidate: Track): Int {
 internal fun videoPlaybackCandidateScore(target: Track, candidate: Track): Int {
     val recordingScore = playbackCandidateScore(target, candidate)
     if (recordingScore == Int.MIN_VALUE) return Int.MIN_VALUE
-    val type = candidate.videoType.uppercase()
+    val type = candidate.videoType
     val videoPreference = when {
-        type.contains("OMV") || type.contains("OFFICIAL_MUSIC_VIDEO") -> 20_000
-        type.contains("ATV") -> -20_000
-        type.contains("UGC") || type.contains("MUSIC_VIDEO") -> 1_000
+        YoutubeMusicVideoType.isOfficialVideo(type) -> 20_000
+        YoutubeMusicVideoType.isArtTrack(type) -> -20_000
+        type.uppercase().contains("UGC") || type.uppercase().contains("MUSIC_VIDEO") -> 1_000
         else -> 0
     }
-    return recordingScore + videoPreference
+    // A shared artist channel is structured proof of an official upload and outranks title text.
+    val officialChannel = target.artistBrowseIds.isNotEmpty() &&
+        candidate.artistBrowseIds.any { it in target.artistBrowseIds }
+    return recordingScore + videoPreference + if (officialChannel) 6_000 else 0
 }
 
 internal fun selectPreferredVideoPlaybackCandidate(target: Track, candidates: List<Track>): Track? {
@@ -2677,6 +2682,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     private fun applyLanguageContent(languageCode: String, refreshRemote: Boolean) {
+        NewPipeRuntime.setLanguage(languageCode)
         pendingHomeSectionsSnapshot.set(null)
         deferredHomeArtistsSnapshot.set(null)
         homeArtistsFingerprint = ""
@@ -6653,8 +6659,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             related to search.await()
         }
 
-        val selected = selectPreferredVideoPlaybackCandidate(track, watchCandidates)
-            ?: selectPreferredVideoPlaybackCandidate(track, searchCandidates)
+        // Rank every candidate together so a confirmed official video from search wins over a
+        // merely playable watch-playlist entry. Watch candidates come first and still win ties.
+        val selected = selectPreferredVideoPlaybackCandidate(track, watchCandidates + searchCandidates)
         if (selected != null) {
             verifiedVideoIdentityCache[cacheKey] = selected
             return track.withVerifiedVideoCandidate(selected, sourceId)
@@ -6677,7 +6684,10 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             videoUrl = "https://www.youtube.com/watch?v=$videoId",
             thumbnailUrl = thumbnailUrl.ifBlank { seed.thumbnailUrl },
             largeThumbnailUrl = thumbnailUrl.ifBlank { seed.largeThumbnailUrl },
-            videoType = videoType
+            videoType = videoType,
+            artistBrowseIds = artists.map { artist -> artist.browseId }
+                .filter { it.isNotBlank() }
+                .ifEmpty { seed.artistBrowseIds }
         )
     }
 

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackSourceIdentityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackSourceIdentityTest.kt
@@ -214,6 +214,48 @@ class PlaybackSourceIdentityTest {
         assertEquals("fcnDmrtj6Sk", PlaybackSourceIdentity.sourceVideoId(video))
     }
 
+    @Test
+    fun sourceVideoIdKeepsOfficialSourceMusicSelection() {
+        val video = track(
+            id = "catalog-recording-1",
+            videoUrl = "https://www.youtube.com/watch?v=fcnDmrtj6Sk"
+        ).copy(
+            audioVideoId = "lFQdcPTTzSg",
+            counterpartVideoId = "fcnDmrtj6Sk",
+            videoType = "MUSIC_VIDEO_TYPE_OFFICIAL_SOURCE_MUSIC"
+        )
+
+        assertEquals("fcnDmrtj6Sk", PlaybackSourceIdentity.sourceVideoId(video))
+    }
+
+    @Test
+    fun sourceVideoIdKeepsCounterpartSelectedForAnArtTrackInVideoMode() {
+        val artTrackWithSelectedVideo = track(
+            id = "catalog-recording-1",
+            videoUrl = "https://www.youtube.com/watch?v=fcnDmrtj6Sk"
+        ).copy(
+            audioVideoId = "lFQdcPTTzSg",
+            counterpartVideoId = "fcnDmrtj6Sk",
+            videoType = "MUSIC_VIDEO_TYPE_ATV"
+        )
+
+        assertEquals("fcnDmrtj6Sk", PlaybackSourceIdentity.sourceVideoId(artTrackWithSelectedVideo))
+    }
+
+    @Test
+    fun sourceVideoIdKeepsAudioIdentityWhenSongModeReusesTheSameId() {
+        val songMode = track(
+            id = "catalog-recording-1",
+            videoUrl = "https://www.youtube.com/watch?v=lFQdcPTTzSg"
+        ).copy(
+            audioVideoId = "lFQdcPTTzSg",
+            counterpartVideoId = "fcnDmrtj6Sk",
+            videoType = "MUSIC_VIDEO_TYPE_ATV"
+        )
+
+        assertEquals("lFQdcPTTzSg", PlaybackSourceIdentity.sourceVideoId(songMode))
+    }
+
     private fun track(
         id: String = "track-id",
         title: String = "Song Title",

--- a/app/src/test/java/com/luc4n3x/levyra/data/RecordingIdentityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/RecordingIdentityTest.kt
@@ -96,6 +96,55 @@ class RecordingIdentityTest {
     }
 
     @Test
+    fun officialSourceMusicOutranksUserUploadedVideo() {
+        val target = Track(
+            id = "catalog", title = "Song", artist = "Artist", album = "Album", durationMs = 180_000,
+            streamUrl = "", videoUrl = "", thumbnailUrl = "", largeThumbnailUrl = "", source = "Catalog",
+            moodTags = emptySet(), energy = 0, vocal = 0, replayScore = 0, cacheScore = 0,
+            accentStart = 0, accentEnd = 0
+        )
+        val fanUpload = target.copy(id = "ugc12345678", videoType = "MUSIC_VIDEO_TYPE_UGC")
+        val officialSource = target.copy(
+            id = "osm12345678",
+            videoType = "MUSIC_VIDEO_TYPE_OFFICIAL_SOURCE_MUSIC"
+        )
+
+        assertTrue(
+            videoPlaybackCandidateScore(target, officialSource) >
+                videoPlaybackCandidateScore(target, fanUpload)
+        )
+        assertEquals(
+            "osm12345678",
+            selectPreferredVideoPlaybackCandidate(target, listOf(fanUpload, officialSource))?.id
+        )
+    }
+
+    @Test
+    fun sharedArtistChannelOutranksAnUnrelatedChannelForTheSameVideoType() {
+        val target = Track(
+            id = "catalog", title = "Song", artist = "Artist", album = "Album", durationMs = 180_000,
+            streamUrl = "", videoUrl = "", thumbnailUrl = "", largeThumbnailUrl = "", source = "Catalog",
+            moodTags = emptySet(), energy = 0, vocal = 0, replayScore = 0, cacheScore = 0,
+            accentStart = 0, accentEnd = 0, artistBrowseIds = listOf("UCofficialchannel1")
+        )
+        val otherChannel = target.copy(
+            id = "other123456",
+            videoType = "MUSIC_VIDEO_TYPE_UGC",
+            artistBrowseIds = listOf("UCsomeoneelse999")
+        )
+        val artistChannel = target.copy(
+            id = "artist123456",
+            videoType = "MUSIC_VIDEO_TYPE_UGC",
+            artistBrowseIds = listOf("UCofficialchannel1")
+        )
+
+        assertTrue(
+            videoPlaybackCandidateScore(target, artistChannel) >
+                videoPlaybackCandidateScore(target, otherChannel)
+        )
+    }
+
+    @Test
     fun daDioAcceptsReportedOfficialVideoIdentity() {
         val target = Track(
             id = "audio123456",

--- a/app/src/test/java/com/luc4n3x/levyra/data/RecordingIdentityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/RecordingIdentityTest.kt
@@ -145,6 +145,90 @@ class RecordingIdentityTest {
     }
 
     @Test
+    fun authoritativePairingSurvivesAnOfficialVideoOfAnotherRecording() {
+        val target = Track(
+            id = "catalog", title = "Song Tonight", artist = "Artist", album = "Album",
+            durationMs = 180_000, streamUrl = "", videoUrl = "", thumbnailUrl = "",
+            largeThumbnailUrl = "", source = "Catalog", moodTags = emptySet(), energy = 0, vocal = 0,
+            replayScore = 0, cacheScore = 0, accentStart = 0, accentEnd = 0
+        )
+        val pairedLyricVideo = target.copy(
+            id = "pairedvid01",
+            videoUrl = "https://www.youtube.com/watch?v=pairedvid01",
+            videoType = "MUSIC_VIDEO_TYPE_UGC"
+        )
+        val otherSingleOfficial = target.copy(
+            id = "othersing01",
+            title = "Song Tonight Forever",
+            videoUrl = "https://www.youtube.com/watch?v=othersing01",
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+
+        val selected = selectPreferredVideoPlaybackCandidate(
+            target,
+            listOf(pairedLyricVideo, otherSingleOfficial),
+            setOf("pairedvid01")
+        )
+
+        assertEquals("pairedvid01", selected?.id)
+    }
+
+    @Test
+    fun exactIsrcOfficialVideoStillDisplacesTheAuthoritativePairing() {
+        val target = Track(
+            id = "catalog", title = "Song", artist = "Artist", album = "Album", durationMs = 180_000,
+            streamUrl = "", videoUrl = "", thumbnailUrl = "", largeThumbnailUrl = "",
+            source = "Catalog", moodTags = emptySet(), energy = 0, vocal = 0, replayScore = 0,
+            cacheScore = 0, accentStart = 0, accentEnd = 0, isrc = "ITB002000001"
+        )
+        val pairedLyricVideo = target.copy(
+            id = "pairedvid01",
+            videoUrl = "https://www.youtube.com/watch?v=pairedvid01",
+            videoType = "MUSIC_VIDEO_TYPE_UGC",
+            isrc = ""
+        )
+        val sameRecordingOfficial = target.copy(
+            id = "officialvid",
+            videoUrl = "https://www.youtube.com/watch?v=officialvid",
+            videoType = "MUSIC_VIDEO_TYPE_OMV",
+            isrc = "ITB002000001"
+        )
+
+        val selected = selectPreferredVideoPlaybackCandidate(
+            target,
+            listOf(pairedLyricVideo, sameRecordingOfficial),
+            setOf("pairedvid01")
+        )
+
+        assertEquals("officialvid", selected?.id)
+    }
+
+    @Test
+    fun equallyScoredCandidatesKeepTheFirstListedWatchEntry() {
+        val target = Track(
+            id = "catalog", title = "Song", artist = "Artist", album = "Album", durationMs = 180_000,
+            streamUrl = "", videoUrl = "", thumbnailUrl = "", largeThumbnailUrl = "",
+            source = "Catalog", moodTags = emptySet(), energy = 0, vocal = 0, replayScore = 0,
+            cacheScore = 0, accentStart = 0, accentEnd = 0
+        )
+        val watchEntry = target.copy(
+            id = "watchvideo1",
+            videoUrl = "https://www.youtube.com/watch?v=watchvideo1",
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+        val searchEntry = target.copy(
+            id = "searchvideo",
+            videoUrl = "https://www.youtube.com/watch?v=searchvideo",
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+
+        assertEquals(
+            "watchvideo1",
+            selectPreferredVideoPlaybackCandidate(target, listOf(watchEntry, searchEntry))?.id
+        )
+    }
+
+    @Test
     fun daDioAcceptsReportedOfficialVideoIdentity() {
         val target = Track(
             id = "audio123456",

--- a/app/src/test/java/com/luc4n3x/levyra/player/LevyraPlaybackCacheKeyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/LevyraPlaybackCacheKeyTest.kt
@@ -40,6 +40,25 @@ class LevyraPlaybackCacheKeyTest {
         assertTrue(LevyraPlaybackCacheKey.video(track).contains(":video-v5:itag-137"))
     }
 
+    @Test
+    fun artTrackAudioAndOfficialVideoAudioNeverShareAStreamKey() {
+        val songMode = track("https://rr.example/videoplayback?itag=140").copy(
+            audioVideoId = "lFQdcPTTzSg",
+            videoUrl = "https://www.youtube.com/watch?v=lFQdcPTTzSg"
+        )
+        val videoMode = songMode.copy(
+            videoUrl = "https://www.youtube.com/watch?v=fcnDmrtj6Sk",
+            counterpartVideoId = "fcnDmrtj6Sk",
+            videoType = "MUSIC_VIDEO_TYPE_OMV",
+            videoStreamUrl = "https://rr.example/videoplayback?itag=137"
+        )
+
+        assertNotEquals(
+            LevyraPlaybackCacheKey.stream(songMode),
+            LevyraPlaybackCacheKey.stream(videoMode)
+        )
+    }
+
     private fun track(streamUrl: String): Track = Track(
         id = "video-id",
         title = "Title",


### PR DESCRIPTION
## Problem

In native-video mode Levyra could silently play the **art track (audio)** instead of the official video it had just selected, and could prefer a non-official candidate when the official one was available.

Three separate defects:

1. **`NewPipeRuntime.ensure()` disabled itself permanently (P0).**
   `initialized.compareAndSet(false, true)` latched the flag *before* `NewPipe.init(...)`. If `init` threw (no network at startup, downloader not constructible), the flag stayed `true` and every later call skipped initialization, leaving the extractor broken for the whole process lifetime. The neighbouring `providerInstalled` block already restored its flag on failure — only `initialized` was inconsistent.

2. **Video mode resolved the audio id (P1).**
   `PlaybackSourceIdentity.sourceVideoId()` confirmed a selected video only for `OMV`/`UGC` `musicVideoType` values, then fell through to `audioVideoId`. That id is what `PlaybackResolver.resolveWithInnerTubeOnce()` sends to the player endpoint. Two real cases fell through:
   - `MUSIC_VIDEO_TYPE_OFFICIAL_SOURCE_MUSIC`, a legitimate YouTube Music type containing neither `OMV` nor `UGC`;
   - the documented fallback `youtubePlayableTrack(track, preferVideo = true)`, whose art-track branch returns the counterpart video while `videoType` is still `ATV`.

   The comment above that fallback says *"Never fall back to the ATV itself in native-video mode"* — which is exactly what happened, with no error surfaced.

3. **A non-official video could outrank the official one (P1).**
   `preferredVideoPlaybackTrack` chose by *list* rather than by quality:
   ```kotlin
   selectPreferredVideoPlaybackCandidate(track, watchCandidates)
       ?: selectPreferredVideoPlaybackCandidate(track, searchCandidates)
   ```
   A merely compatible UGC entry in the watch playlist won immediately, and the search list — which could hold the actual official music video — was never consulted. `OFFICIAL_SOURCE_MUSIC` also scored the same +1,000 as a fan upload, and `Track.artistBrowseIds` was populated but never used in ranking.

## Changes

- **`NewPipeRuntime.kt`** — restore `initialized` and rethrow when `NewPipe.init` fails, so a failure stays retryable. Added `setLanguage(code)` / `applyRequestedLocalization()`: extractor localization now follows the language the user selected instead of a hardcoded `it-IT`. The language is **pushed** from the ViewModel (mirroring `PlaybackResolver.setAudioQuality`) rather than read here, because `LevyraPreferences.read` uses `runBlocking(Dispatchers.IO)` on DataStore and reading it inside `ensure()` would put a blocking read on the playback critical path.
- **`VideoPlaybackContract.kt`** — added `internal object YoutubeMusicVideoType` (`isArtTrack` / `isOfficialVideo` / `isVideo`): one shared reading of `musicVideoType` for both playback identity and candidate selection. No new file, no new class, no second source of truth.
- **`PlaybackSourceIdentity.kt`** — confirm a selected video when the type is a video type **or** when an explicit pairing exists (`counterpartVideoId == selectedVideoId != audioVideoId`). This is a structural signal, not a text heuristic, and does not fire in song mode where `selectedVideoId == audioVideoId`.
- **`LevyraViewModel.kt`** — rank the **union** of watch and search candidates (watch entries come first so they still win ties via `maxByOrNull`); score `OFFICIAL_SOURCE_MUSIC` as official; add +6,000 for a shared artist `browseId`; propagate `artistBrowseIds` in `asVideoCandidate`; call `NewPipeRuntime.setLanguage` from `applyLanguageContent`.

The artist-channel signal is **positive only**. Penalising a mismatch risked demoting official videos published on VEVO channels whose id differs from the YouTube Music artist `browseId`; wrong artists are already rejected by `isPlaybackCandidateCompatible` and by ISRC conflict.

Resulting priority: exact ISRC → official type (+20,000) → shared artist channel (+6,000) → UGC (+1,000) → untyped (0) → art track (−20,000).

## Behaviour preserved

- Song mode is untouched: the pairing rule cannot fire there, and `sourceVideoIdKeepsAudioIdentityWhenSongModeReusesTheSameId` pins it.
- The existing catalog-counterpart fallback is unchanged — it now actually resolves the video instead of collapsing to audio.
- `MergingMediaSource(true, true, videoSource, audioSource)` was reviewed and **left as is**: `adjustPeriodTimeOffsets` + `clipDurations` is already the correct configuration for mismatched audio/video durations and timestamps. No reproducible `IllegalMergeException` was found, so nothing was changed there.

## Validation

| Check | Result |
|---|---|
| `./gradlew --no-daemon :app:compileDebugKotlin` | BUILD SUCCESSFUL |
| `./gradlew --no-daemon :app:testDebugUnitTest` | BUILD SUCCESSFUL — **723 tests, 0 failures, 0 errors, 0 skipped** |
| `./gradlew --no-daemon :app:assembleDebug` | BUILD SUCCESSFUL |
| `python3 scripts/ai_quality_gate.py --profile fast` | passed |
| `git diff --check` | clean |

Five new regression tests, all confirmed present in the JUnit XML reports:

- `sourceVideoIdKeepsOfficialSourceMusicSelection`
- `sourceVideoIdKeepsCounterpartSelectedForAnArtTrackInVideoMode`
- `sourceVideoIdKeepsAudioIdentityWhenSongModeReusesTheSameId`
- `officialSourceMusicOutranksUserUploadedVideo`
- `sharedArtistChannelOutranksAnUnrelatedChannelForTheSameVideoType`

## Not verified

- [ ] Device playback: Song, Video, Song→Video, Video→Song, next/previous, seek, expired URL, extractor failure, network failure, slightly mismatched audio/video durations
- [ ] Background/foreground, notification, Android Auto, PiP
- [ ] End-to-end official-video selection against live YouTube responses (covered only at the deterministic ranking/identity level)
- [ ] `lintRelease` / `assembleRelease` (release signing inputs not provided)
- [ ] `ai_quality_gate.py --profile full`

## Residual risk

- The structural pairing rule changes cache identity for art tracks with a selected counterpart: existing `PlaybackSourceMatchStore` entries for those tracks become a miss and are resolved once more. No data loss.
- The channel bonus depends on how consistently YouTube populates `artistBrowseIds`; where it is empty, ranking degrades to the previous behaviour.
- Before the ViewModel runs, `ensure()` initializes with the catalog default locale rather than forced Italian — worth confirming on device that the first-launch language is the expected one.
- `verifiedVideoIdentityCache` is a bounded LRU: already-cached video selections keep the previous candidate until eviction or restart.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime language selection and improved localization updates.
  * Improved music-video matching using video type, artist channels, and authoritative pairings.
  * Improved handling of HLS and DASH streams for more reliable playback.

* **Bug Fixes**
  * Prevented audio and music-video streams from sharing incorrect cache entries.
  * Improved recovery, prefetching, and video identity resolution.
  * Excluded unsuitable art-track candidates from video playback selection.

* **Tests**
  * Added coverage for video ranking, source identity, and playback cache separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->