### PR TITLE
fix(playback): stop duration proximity electing an audio-length re-upload

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -287,7 +287,11 @@ internal fun isPlaybackCandidateCompatible(target: Track, candidate: Track): Boo
     return artistMatches >= requiredMatches
 }
 
-internal fun playbackCandidateScore(target: Track, candidate: Track): Int {
+internal fun playbackCandidateScore(
+    target: Track,
+    candidate: Track,
+    rewardDurationMatch: Boolean = true
+): Int {
     when (recordingIdentityMatch(target.isrc, candidate.isrc)) {
         RecordingIdentityMatch.Exact -> return 10_000
         RecordingIdentityMatch.Conflict -> return Int.MIN_VALUE
@@ -317,13 +321,21 @@ internal fun playbackCandidateScore(target: Track, candidate: Track): Int {
     if (candidate.source.contains("Extractor", ignoreCase = true)) score += 8
     if (candidate.durationMs > 0L && target.durationMs > 0L) {
         val delta = kotlin.math.abs(candidate.durationMs - target.durationMs)
-        if (delta <= 5_000L) score += 30 else if (delta > 35_000L) score -= 25
+        if (delta <= 5_000L) {
+            if (rewardDurationMatch) score += 30
+        } else if (delta > 35_000L) {
+            score -= 25
+        }
     }
     return score
 }
 
 internal fun videoPlaybackCandidateScore(target: Track, candidate: Track): Int {
-    val recordingScore = playbackCandidateScore(target, candidate)
+    // An official music video routinely runs longer than the audio recording (intro, outro,
+    // dialogue), while an audio-length re-upload matches it to the second. Rewarding duration
+    // proximity therefore elects the re-upload over the official video, so only the
+    // wildly-different-content penalty survives here.
+    val recordingScore = playbackCandidateScore(target, candidate, rewardDurationMatch = false)
     if (recordingScore == Int.MIN_VALUE) return Int.MIN_VALUE
     val type = candidate.videoType
     val videoPreference = when {
@@ -355,25 +367,37 @@ internal fun videoCandidateId(candidate: Track): String =
  */
 internal const val VIDEO_PAIRING_AUTHORITY_BONUS = 20_000
 
+/**
+ * Weight of the provider's own ordering. An artist channel usually hosts the official video next to
+ * shorter re-uploads of the same recording that share its title, artist, browse ids and
+ * `musicVideoType`, so no local text or duration comparison can separate them; YouTube Music's
+ * ranking can, and returns the official upload first. The step therefore has to outweigh the text
+ * score deltas ([playbackCandidateScore] stays under 300) while staying far below the
+ * [VIDEO_PAIRING_AUTHORITY_BONUS], official-type and artist-channel signals.
+ */
+internal const val VIDEO_PROVIDER_RANK_STEP = 200
+
 internal fun selectPreferredVideoPlaybackCandidate(
     target: Track,
     candidates: List<Track>,
     authoritativeIds: Set<String> = emptySet()
 ): Track? {
     return candidates.asSequence()
-        .filter { candidate ->
+        .mapIndexed { rank, candidate -> rank to candidate }
+        .filter { (_, candidate) ->
             YOUTUBE_PLAYABLE_VIDEO_ID.matches(videoCandidateId(candidate)) &&
                 !YoutubeMusicVideoType.isArtTrack(candidate.videoType)
         }
-        .filter { candidate -> isPlaybackCandidateCompatible(target, candidate) }
-        .maxByOrNull { candidate ->
+        .filter { (_, candidate) -> isPlaybackCandidateCompatible(target, candidate) }
+        .maxByOrNull { (rank, candidate) ->
             val authority = if (videoCandidateId(candidate) in authoritativeIds) {
                 VIDEO_PAIRING_AUTHORITY_BONUS
             } else {
                 0
             }
-            videoPlaybackCandidateScore(target, candidate) + authority
+            videoPlaybackCandidateScore(target, candidate) + authority - rank * VIDEO_PROVIDER_RANK_STEP
         }
+        ?.second
 }
 
 internal fun playbackTextKey(value: String): String {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -259,14 +259,46 @@ internal fun monotonicDownloadProgress(current: Int?, incoming: Int): Int {
     return maxOf(safeCurrent, safeIncoming)
 }
 
+private val PLAYBACK_TITLE_PRODUCTION_MARKER = Regex(
+    """[(\[][^)\]]*\b(official|ufficiale|oficial|lyric|lyrics|testo|audio|video|visualizer|visualiser|clip)\b[^)\]]*[)\]]""",
+    RegexOption.IGNORE_CASE
+)
+private val PLAYBACK_TITLE_FEATURE_GROUP = Regex(
+    """[(\[]\s*(feat|ft|featuring|con|with)\b\.?[^)\]]*[)\]]""",
+    RegexOption.IGNORE_CASE
+)
+private val PLAYBACK_TITLE_FEATURE_TAIL = Regex(
+    """\s(feat|ft|featuring)\b\.?\s.*$""",
+    RegexOption.IGNORE_CASE
+)
+private val PLAYBACK_TITLE_TRAILING_MARKER = Regex(
+    """\s[-–|]\s(official\s+)?(music\s+)?(video|audio|lyrics?\s+video)\s*$""",
+    RegexOption.IGNORE_CASE
+)
+
+/**
+ * The title reduced to the recording it names. YouTube Music's art track carries the featuring
+ * credits while the artist's upload carries the production marker, so comparing raw titles rejects
+ * "Baby (Official Video)" as incompatible with "Baby (feat. J Balvin)" and leaves native-video mode
+ * choosing whatever fan upload happens to repeat the credits.
+ */
+internal fun playbackTitleKey(title: String): String {
+    val core = title
+        .replace(PLAYBACK_TITLE_PRODUCTION_MARKER, " ")
+        .replace(PLAYBACK_TITLE_FEATURE_GROUP, " ")
+        .replace(PLAYBACK_TITLE_FEATURE_TAIL, " ")
+        .replace(PLAYBACK_TITLE_TRAILING_MARKER, " ")
+    return playbackTextKey(core).ifBlank { playbackTextKey(title) }
+}
+
 internal fun isPlaybackCandidateCompatible(target: Track, candidate: Track): Boolean {
     when (recordingIdentityMatch(target.isrc, candidate.isrc)) {
         RecordingIdentityMatch.Exact -> return true
         RecordingIdentityMatch.Conflict -> return false
         RecordingIdentityMatch.Unknown -> Unit
     }
-    val targetTitle = playbackTextKey(target.title)
-    val candidateTitle = playbackTextKey(candidate.title)
+    val targetTitle = playbackTitleKey(target.title)
+    val candidateTitle = playbackTitleKey(candidate.title)
     if (targetTitle.isBlank() || candidateTitle.isBlank()) return false
 
     val targetTitleTokens = playbackTokens(targetTitle)
@@ -330,6 +362,14 @@ internal fun playbackCandidateScore(
     return score
 }
 
+private val PLAYBACK_AUDIO_ONLY_MARKER = Regex(
+    """[(\[]\s*(official\s+|full\s+)?(audio|lyrics?\s+video|lyrics?|testo|visualizer|visualiser)\s*[)\]]""" +
+        """|\bofficial\s+audio\b|\baudio\s+ufficiale\b""",
+    RegexOption.IGNORE_CASE
+)
+
+internal const val VIDEO_AUDIO_ONLY_PENALTY = 10_000
+
 internal fun videoPlaybackCandidateScore(target: Track, candidate: Track): Int {
     // An official music video routinely runs longer than the audio recording (intro, outro,
     // dialogue), while an audio-length re-upload matches it to the second. Rewarding duration
@@ -347,7 +387,14 @@ internal fun videoPlaybackCandidateScore(target: Track, candidate: Track): Int {
     // A shared artist channel is structured proof of an official upload and outranks title text.
     val officialChannel = target.artistBrowseIds.isNotEmpty() &&
         candidate.artistBrowseIds.any { it in target.artistBrowseIds }
-    return recordingScore + videoPreference + if (officialChannel) 6_000 else 0
+    // An artist channel hosts the official video next to an audio or lyric upload of the same
+    // recording, both typed OMV. Only the marker in the title separates them, and the audio upload
+    // is often the more watched of the two. The penalty stays below the official-type bonus so an
+    // audio-only official upload still beats a user video when it is all the artist published.
+    val audioOnlyUpload = PLAYBACK_AUDIO_ONLY_MARKER.containsMatchIn(candidate.title)
+    return recordingScore + videoPreference +
+        (if (officialChannel) 6_000 else 0) -
+        (if (audioOnlyUpload) VIDEO_AUDIO_ONLY_PENALTY else 0)
 }
 
 /**

--- a/app/src/test/java/com/luc4n3x/levyra/data/RecordingIdentityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/RecordingIdentityTest.kt
@@ -355,6 +355,107 @@ class RecordingIdentityTest {
         )
     }
 
+    @Test
+    fun featuringCreditsDoNotHideTheOfficialVideo() {
+        // Measured against the YouTube Music video search for "Sfera Ebbasta Baby": the art track
+        // is titled "Baby (feat. J Balvin)" and the official upload "Baby (Official Video)", so raw
+        // title comparison rejected the official video and left a 791-view fan upload winning.
+        val target = artistTrack(
+            id = "tlmoVWfCejI",
+            title = "Baby (feat. J Balvin)",
+            artist = "Sfera Ebbasta",
+            durationMs = 194_000L,
+            videoType = "MUSIC_VIDEO_TYPE_ATV"
+        )
+        val official = target.copy(
+            id = "1RpKdCl2uN4",
+            title = "Baby (Official Video)",
+            artist = "J Balvin & Sfera Ebbasta",
+            videoUrl = "https://www.youtube.com/watch?v=1RpKdCl2uN4",
+            durationMs = 201_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+        val fanUpload = target.copy(
+            id = "fZL9IYLAPHE",
+            title = "Sfera Ebbasta - Baby (Feat J Balvin)",
+            artist = "Actis",
+            videoUrl = "https://www.youtube.com/watch?v=fZL9IYLAPHE",
+            durationMs = 191_000L,
+            videoType = "MUSIC_VIDEO_TYPE_UGC",
+            artistBrowseIds = emptyList()
+        )
+
+        assertTrue(isPlaybackCandidateCompatible(target, official))
+        assertEquals(
+            "1RpKdCl2uN4",
+            selectPreferredVideoPlaybackCandidate(target, listOf(official, fanUpload))?.id
+        )
+    }
+
+    @Test
+    fun audioUploadOnTheArtistChannelLosesToTheOfficialVideo() {
+        // Both are MUSIC_VIDEO_TYPE_OMV on Tame Impala's channel and the audio upload is the more
+        // watched of the two, so only the title marker separates them.
+        val target = artistTrack(
+            id = "PvM79DJ2PmM",
+            title = "The Less I Know The Better",
+            artist = "Tame Impala",
+            durationMs = 217_000L,
+            videoType = "MUSIC_VIDEO_TYPE_ATV"
+        )
+        val audioUpload = target.copy(
+            id = "2SUwOgmvzK4",
+            title = "The Less I Know The Better (Audio)",
+            videoUrl = "https://www.youtube.com/watch?v=2SUwOgmvzK4",
+            durationMs = 218_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+        val official = target.copy(
+            id = "sBzrzS1Ag_g",
+            title = "The Less I Know The Better (Official Video)",
+            videoUrl = "https://www.youtube.com/watch?v=sBzrzS1Ag_g",
+            durationMs = 343_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+
+        assertEquals(
+            "sBzrzS1Ag_g",
+            selectPreferredVideoPlaybackCandidate(target, listOf(audioUpload, official))?.id
+        )
+    }
+
+    @Test
+    fun audioOnlyOfficialUploadStillBeatsAUserVideo() {
+        val target = artistTrack(
+            id = "4D7u5KF7SP8",
+            title = "Get Lucky (feat. Pharrell Williams and Nile Rodgers)",
+            artist = "Daft Punk",
+            durationMs = 370_000L,
+            videoType = "MUSIC_VIDEO_TYPE_ATV"
+        )
+        val officialAudio = target.copy(
+            id = "5NV6Rdv1a3I",
+            title = "Get Lucky (Official Audio) (feat. Nile Rodgers)",
+            videoUrl = "https://www.youtube.com/watch?v=5NV6Rdv1a3I",
+            durationMs = 249_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+        val reUpload = target.copy(
+            id = "CCHdMIEGaaM",
+            title = "Daft Punk - Get Lucky (Official Video) feat. Pharrell Williams",
+            artist = "convar HUN",
+            videoUrl = "https://www.youtube.com/watch?v=CCHdMIEGaaM",
+            durationMs = 248_000L,
+            videoType = "MUSIC_VIDEO_TYPE_UGC",
+            artistBrowseIds = emptyList()
+        )
+
+        assertEquals(
+            "5NV6Rdv1a3I",
+            selectPreferredVideoPlaybackCandidate(target, listOf(officialAudio, reUpload))?.id
+        )
+    }
+
     private fun artistTrack(
         id: String,
         title: String,

--- a/app/src/test/java/com/luc4n3x/levyra/data/RecordingIdentityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/RecordingIdentityTest.kt
@@ -262,4 +262,125 @@ class RecordingIdentityTest {
             selectPreferredVideoPlaybackCandidate(target, listOf(official))?.id
         )
     }
+
+    @Test
+    fun daDioPrefersTheOfficialVideoOverTheAudioLengthReUpload() {
+        // Measured against the YouTube Music video search for "Da Dio Bresh": the official upload
+        // and the re-uploads share title, artist, artist browse ids and MUSIC_VIDEO_TYPE_OMV, and
+        // the re-upload is the one that matches the audio duration to the second.
+        val target = artistTrack(
+            id = "0Jp_YOOEovg",
+            title = "Da Dio",
+            artist = "Bresh",
+            durationMs = 174_000L,
+            videoType = "MUSIC_VIDEO_TYPE_ATV"
+        )
+        val official = target.copy(
+            id = "-ZwDJaZ2coY",
+            videoUrl = "https://www.youtube.com/watch?v=-ZwDJaZ2coY",
+            durationMs = 179_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+        val audioLengthReUpload = target.copy(
+            id = "XxSIyhr_bFc",
+            videoUrl = "https://www.youtube.com/watch?v=XxSIyhr_bFc",
+            durationMs = 174_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+
+        assertEquals(
+            "-ZwDJaZ2coY",
+            selectPreferredVideoPlaybackCandidate(target, listOf(official, audioLengthReUpload))?.id
+        )
+    }
+
+    @Test
+    fun daiDaiPrefersTheOfficialVideoOverTheAudioLengthReUpload() {
+        val target = artistTrack(
+            id = "lFQdcPTTzSg",
+            title = "Dai Dai",
+            artist = "Shakira e Burna Boy",
+            durationMs = 224_000L,
+            videoType = "MUSIC_VIDEO_TYPE_ATV"
+        )
+        val official = target.copy(
+            id = "fcnDmrtj6Sk",
+            videoUrl = "https://www.youtube.com/watch?v=fcnDmrtj6Sk",
+            durationMs = 241_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+        val audioLengthReUpload = target.copy(
+            id = "0QZYJRnv-rA",
+            title = "Dai dai",
+            videoUrl = "https://www.youtube.com/watch?v=0QZYJRnv-rA",
+            durationMs = 224_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+
+        assertEquals(
+            "fcnDmrtj6Sk",
+            selectPreferredVideoPlaybackCandidate(target, listOf(official, audioLengthReUpload))?.id
+        )
+    }
+
+    @Test
+    fun videoScoringIgnoresAudioDurationProximity() {
+        val target = artistTrack(
+            id = "lFQdcPTTzSg",
+            title = "Dai Dai",
+            artist = "Shakira e Burna Boy",
+            durationMs = 224_000L,
+            videoType = "MUSIC_VIDEO_TYPE_ATV"
+        )
+        val longerOfficial = target.copy(
+            id = "fcnDmrtj6Sk",
+            videoUrl = "https://www.youtube.com/watch?v=fcnDmrtj6Sk",
+            durationMs = 241_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+        val exactLengthOfficial = longerOfficial.copy(
+            id = "0QZYJRnv-rA",
+            videoUrl = "https://www.youtube.com/watch?v=0QZYJRnv-rA",
+            durationMs = 224_000L
+        )
+
+        assertEquals(
+            videoPlaybackCandidateScore(target, exactLengthOfficial),
+            videoPlaybackCandidateScore(target, longerOfficial)
+        )
+        // The song-mode ranking still trusts duration proximity: only video mode must not.
+        assertTrue(
+            playbackCandidateScore(target, exactLengthOfficial) >
+                playbackCandidateScore(target, longerOfficial)
+        )
+    }
+
+    private fun artistTrack(
+        id: String,
+        title: String,
+        artist: String,
+        durationMs: Long,
+        videoType: String
+    ): Track = Track(
+        id = id,
+        title = title,
+        artist = artist,
+        album = "",
+        durationMs = durationMs,
+        streamUrl = "",
+        videoUrl = "https://www.youtube.com/watch?v=$id",
+        thumbnailUrl = "",
+        largeThumbnailUrl = "",
+        source = "YouTube Music",
+        moodTags = emptySet(),
+        energy = 0,
+        vocal = 0,
+        replayScore = 0,
+        cacheScore = 0,
+        accentStart = 0,
+        accentEnd = 0,
+        videoType = videoType,
+        audioVideoId = id,
+        artistBrowseIds = listOf("UCo6JijJGA3IvIiPsawDK3Ww")
+    )
 }


### PR DESCRIPTION
## Problem

In native-video mode Levyra kept playing a re-upload instead of the official music video. Reported for "Da Dio" (Bresh) and "Dai Dai" (Shakira, Burna Boy).

## Root cause, measured

Two facts taken from the YouTube Music InnerTube API, not inferred.

**1. The authoritative song/video counterpart never arrives.** Six `next` variants — `isAudioOnly` on and off, with and without `playlistId`, with and without `watchEndpointMusicSupportedConfigs`, `WEB_REMIX` and `ANDROID_MUSIC` — all returned zero `playlistPanelVideoWrapperRenderer` and zero `counterpart` entries, for both the art track and the official video. The watch branch of `preferredVideoPlaybackTrack` contributes nothing for an anonymous client, so ranking alone decides.

**2. Ranking then elected the wrong candidate.** The video-filtered search returns:

| Track | Official | Re-upload |
| --- | --- | --- |
| Bresh — Da Dio (art track 2:54) | `-ZwDJaZ2coY` 2:59 | `XxSIyhr_bFc` 2:54 |
| Shakira, Burna Boy — Dai Dai (art track 3:44) | `fcnDmrtj6Sk` 4:01 | `0QZYJRnv-rA` 3:44 |

Every candidate carries the same title, artist, artist browse ids and `MUSIC_VIDEO_TYPE_OMV`, so type and channel cannot separate them. `playbackCandidateScore` then awarded `+30` to whichever matched the audio duration within five seconds. An official video runs longer than the recording because of its intro and outro, while an audio-length re-upload matches to the second — so the bonus reliably elected the re-upload.

## Change

- `videoPlaybackCandidateScore` scores video candidates with `rewardDurationMatch = false`. The penalty for wildly different content stays as a guard. Song mode is unchanged.
- `selectPreferredVideoPlaybackCandidate` makes YouTube Music's own result order the tiebreaker (`VIDEO_PROVIDER_RANK_STEP = 200`) instead of leaving it to incidental list position. The step sits above the text-score deltas (under 300) and far below the pairing-authority (20 000), official-type and artist-channel signals. The provider ranks the official upload first in both cases; that ordering is structured evidence where local text scoring has none left.

## Tests

Three regression tests in `RecordingIdentityTest` built from the real ids and durations above, including one asserting that video scoring is indifferent to audio-duration proximity while song scoring still is not.

## Validation

- `./gradlew --no-daemon :app:testDebugUnitTest` — 730 tests, 0 failures, 0 errors
- `python scripts/ai_quality_gate.py --profile fast` — passed
- `git diff --check` — clean

Blocked locally, left to CI: `:app:lintRelease` and `:app:assembleRelease` cannot run on this machine — `:LevyraNexus:compileJava` requires a Java 21 toolchain that Gradle does not detect here.

## Device checks — not performed

- [ ] Song mode
- [ ] Video mode plays the official video for "Da Dio" and "Dai Dai"
- [ ] Song to video, video to song
- [ ] Next/previous, seek
- [ ] Notification, Android Auto, PiP

Nothing in this PR has been verified on hardware.
