### PR TITLE
fix(extractor): send Accept-Language for the language the user selected

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
@@ -81,6 +81,18 @@ object NewPipeRuntime {
         }
     }
 
+    /**
+     * `Accept-Language` for extractor requests. NewPipe builds its request headers from the
+     * extractor's own localization and never emits this header, so the downloader has to supply it
+     * from the language the user selected instead of pinning one language for every user.
+     */
+    fun acceptLanguageHeader(): String {
+        val locale = LevyraContentLocales.forLanguage(appliedLanguage.ifBlank { requestedLanguage })
+        val english = locale.hl.equals("en", ignoreCase = true)
+        return "${locale.hl}-${locale.gl},${locale.hl};q=0.9" +
+            if (english) "" else ",en-US;q=0.8,en;q=0.7"
+    }
+
     private fun applyRequestedLocalization() = synchronized(this) {
         val requested = requestedLanguage
         if (requested.isBlank() || requested == appliedLanguage) return
@@ -273,7 +285,7 @@ private class OkHttpNewPipeDownloader : Downloader() {
             builder.header("Accept", "*/*")
         }
         if (headers["Accept-Language"].isNullOrBlank()) {
-            builder.header("Accept-Language", "it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7")
+            builder.header("Accept-Language", NewPipeRuntime.acceptLanguageHeader())
         }
 
         return builder.build()

--- a/app/src/test/java/com/luc4n3x/levyra/data/NewPipeAcceptLanguageTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/NewPipeAcceptLanguageTest.kt
@@ -1,0 +1,21 @@
+package com.luc4n3x.levyra.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NewPipeAcceptLanguageTest {
+    @Test
+    fun acceptLanguageFollowsTheSelectedLanguage() {
+        NewPipeRuntime.setLanguage("es")
+        assertEquals("es-ES,es;q=0.9,en-US;q=0.8,en;q=0.7", NewPipeRuntime.acceptLanguageHeader())
+
+        NewPipeRuntime.setLanguage("it")
+        assertEquals("it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7", NewPipeRuntime.acceptLanguageHeader())
+    }
+
+    @Test
+    fun englishDoesNotRepeatItselfAsItsOwnFallback() {
+        NewPipeRuntime.setLanguage("en")
+        assertEquals("en-US,en;q=0.9", NewPipeRuntime.acceptLanguageHeader())
+    }
+}


### PR DESCRIPTION
## Problem

`NewPipeRuntime.setLanguage` pushes the language the user selected in Levyra into the extractor's `Localization` and `ContentCountry`, but the downloader overrode that on the wire. Every request that did not already carry the header got a literal:

```kotlin
builder.header("Accept-Language", "it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7")
```

So a Spanish, German or English user still received Italian-biased responses from the NewPipe path, and the localization work only half applied.

## Change

NewPipe builds its request headers from the extractor's own localization and never emits `Accept-Language` itself, so the downloader has to supply it. `NewPipeRuntime.acceptLanguageHeader()` now derives it from the applied locale, and does not repeat English as its own fallback when English is the selected language.

| Selected language | Header |
| --- | --- |
| Italian | `it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7` |
| Spanish | `es-ES,es;q=0.9,en-US;q=0.8,en;q=0.7` |
| English | `en-US,en;q=0.9` |

Italian is unchanged, so no behaviour changes for the current default.

## Tests

`NewPipeAcceptLanguageTest` covers the language switch and the English case.

## Validation

- `./gradlew --no-daemon :app:testDebugUnitTest` — 735 tests, 0 failures, 0 errors
- `python scripts/ai_quality_gate.py --profile fast` — passed
- `git diff --check` — clean

Blocked locally, left to CI: `:app:lintRelease` and `:app:assembleRelease` need a Java 21 toolchain that Gradle does not detect on this machine.

## Device checks — not performed

- [ ] Switch the app language and confirm NewPipe-sourced results follow it

Not verified on hardware.
