### PR TITLE
fix(playback): always resolve the official music video in native-video mode

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
@@ -81,6 +81,18 @@ object NewPipeRuntime {
         }
     }
 
+    /**
+     * `Accept-Language` for extractor requests. NewPipe builds its request headers from the
+     * extractor's own localization and never emits this header, so the downloader has to supply it
+     * from the language the user selected instead of pinning one language for every user.
+     */
+    fun acceptLanguageHeader(): String {
+        val locale = LevyraContentLocales.forLanguage(appliedLanguage.ifBlank { requestedLanguage })
+        val english = locale.hl.equals("en", ignoreCase = true)
+        return "${locale.hl}-${locale.gl},${locale.hl};q=0.9" +
+            if (english) "" else ",en-US;q=0.8,en;q=0.7"
+    }
+
     private fun applyRequestedLocalization() = synchronized(this) {
         val requested = requestedLanguage
         if (requested.isBlank() || requested == appliedLanguage) return
@@ -273,7 +285,7 @@ private class OkHttpNewPipeDownloader : Downloader() {
             builder.header("Accept", "*/*")
         }
         if (headers["Accept-Language"].isNullOrBlank()) {
-            builder.header("Accept-Language", "it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7")
+            builder.header("Accept-Language", NewPipeRuntime.acceptLanguageHeader())
         }
 
         return builder.build()

--- a/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
@@ -81,11 +81,6 @@ object NewPipeRuntime {
         }
     }
 
-    /**
-     * `Accept-Language` for extractor requests. NewPipe builds its request headers from the
-     * extractor's own localization and never emits this header, so the downloader has to supply it
-     * from the language the user selected instead of pinning one language for every user.
-     */
     fun acceptLanguageHeader(): String {
         val locale = LevyraContentLocales.forLanguage(appliedLanguage.ifBlank { requestedLanguage })
         val english = locale.hl.equals("en", ignoreCase = true)

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
@@ -18,6 +18,7 @@ import com.luc4n3x.levyra.domain.releaseTypeFromProviderLabel
 import com.luc4n3x.levyra.domain.Track
 import com.luc4n3x.levyra.domain.artistIdentityKey
 import com.luc4n3x.levyra.domain.primaryArtistSegment
+import com.luc4n3x.levyra.domain.parseCompactViewCount
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -2307,7 +2308,14 @@ class YoutubeMusicRepository(private val context: Context? = null) {
             source = "YouTube Music",
             albumBrowseId = albumReference.second,
             artistBrowseIds = artistReferences.map { it.browseId },
-            videoType = findStringUnderKey(renderer, "musicVideoType").orEmpty()
+            videoType = findStringUnderKey(renderer, "musicVideoType").orEmpty(),
+            // The view count is published only as a localized label, and which subtitle token
+            // carries it moves with the language. Take the first token that parses as a count;
+            // parseCompactViewCount rejects durations and bare years.
+            youtubeViewCount = tokens.asSequence()
+                .map(::parseCompactViewCount)
+                .firstOrNull { it >= 0L }
+                ?: -1L
         )
     }
 
@@ -2406,6 +2414,7 @@ class YoutubeMusicRepository(private val context: Context? = null) {
         artistBrowseIds: List<String> = emptyList(),
         counterpartVideoId: String = "",
         videoType: String = "",
+        youtubeViewCount: Long = -1L,
         trackNumber: Int = 0,
         discNumber: Int = 0
     ): Track {
@@ -2446,6 +2455,7 @@ class YoutubeMusicRepository(private val context: Context? = null) {
             artistBrowseIds = artistBrowseIds,
             counterpartVideoId = counterpartVideoId,
             videoType = videoType,
+            youtubeViewCount = youtubeViewCount,
             trackNumber = trackNumber,
             discNumber = discNumber
         )

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
@@ -2309,9 +2309,6 @@ class YoutubeMusicRepository(private val context: Context? = null) {
             albumBrowseId = albumReference.second,
             artistBrowseIds = artistReferences.map { it.browseId },
             videoType = findStringUnderKey(renderer, "musicVideoType").orEmpty(),
-            // The view count is published only as a localized label, and which subtitle token
-            // carries it moves with the language. Take the first token that parses as a count;
-            // parseCompactViewCount rejects durations and bare years.
             youtubeViewCount = tokens.asSequence()
                 .map(::parseCompactViewCount)
                 .firstOrNull { it >= 0L }

--- a/app/src/main/java/com/luc4n3x/levyra/domain/VideoPlaybackContract.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/VideoPlaybackContract.kt
@@ -27,6 +27,71 @@ internal object YoutubeMusicVideoType {
     }
 }
 
+private val COMPACT_COUNT_LEADING_NUMBER = Regex("""^[0-9][0-9.,  ]*""")
+private val COMPACT_COUNT_DURATION = Regex("""^[0-9]+(:[0-9]{2})+$""")
+
+/**
+ * Compact view-count multipliers as YouTube Music writes them per language. Matching is exact so
+ * Spanish and Portuguese "mil" (thousand) never collides with Portuguese "mi" or English "M"
+ * (million). An unlisted token leaves the plain number, which under-rates rather than over-rates.
+ */
+private val COMPACT_COUNT_MULTIPLIERS = mapOf(
+    "k" to 1_000L, "tys" to 1_000L, "tis" to 1_000L, "mil" to 1_000L, "тыс" to 1_000L, "тис" to 1_000L,
+    "m" to 1_000_000L, "mi" to 1_000_000L, "mln" to 1_000_000L, "mio" to 1_000_000L, "млн" to 1_000_000L,
+    "b" to 1_000_000_000L, "bn" to 1_000_000_000L, "mld" to 1_000_000_000L, "mrd" to 1_000_000_000L,
+    "млрд" to 1_000_000_000L,
+    "万" to 10_000L, "萬" to 10_000L, "만" to 10_000L,
+    "億" to 100_000_000L, "亿" to 100_000_000L, "억" to 100_000_000L
+)
+
+/**
+ * Reads a YouTube Music view-count label such as "772 Mln di visualizzazioni", "772M views" or
+ * "7,7億 回視聴". InnerTube publishes no numeric view count in this renderer, only the localized
+ * label, so the count has to be recovered from it. Returns `-1` when the label is not a count, so
+ * an unparsed value never becomes a misleading zero.
+ */
+internal fun parseCompactViewCount(label: String): Long {
+    val text = label.trim()
+    if (text.isEmpty() || COMPACT_COUNT_DURATION.matches(text)) return -1L
+    if (text.none(Char::isLetter)) return -1L
+    val numberPart = COMPACT_COUNT_LEADING_NUMBER.find(text)?.value?.trim() ?: return -1L
+
+    val suffix = text.removePrefix(numberPart).trimStart()
+    val magnitude = suffix.takeWhile { !it.isWhitespace() }
+        .trimEnd('.')
+        .lowercase(Locale.ROOT)
+    val multiplier = COMPACT_COUNT_MULTIPLIERS[magnitude]
+
+    return if (multiplier == null) {
+        // No magnitude token: the separators group digits, they are not a decimal point.
+        numberPart.filter(Char::isDigit).toLongOrNull() ?: -1L
+    } else {
+        val scalar = numberPart.replace(',', '.').filterNot(Char::isWhitespace)
+        val value = scalar.toDoubleOrNull() ?: return -1L
+        (value * multiplier).toLong()
+    }
+}
+
+internal const val VIDEO_VIEW_COUNT_STEP = 500
+
+/**
+ * Order of magnitude of [views] as a bounded ranking bonus. The canonical upload of a recording
+ * outruns its re-uploads by two or three orders of magnitude while sharing their title, artist,
+ * browse ids and `musicVideoType`, so this is the only local signal that separates them. It is
+ * deliberately coarse and capped below the artist-channel bonus, so it breaks ties without ever
+ * outvoting the official-type, artist-channel or pairing-authority evidence.
+ */
+internal fun videoViewCountBonus(views: Long): Int {
+    if (views <= 0L) return 0
+    var digits = 0
+    var remaining = views
+    while (remaining > 0L) {
+        digits += 1
+        remaining /= 10L
+    }
+    return digits.coerceAtMost(10) * VIDEO_VIEW_COUNT_STEP
+}
+
 internal fun Track.hasVerifiedYoutubeMusicVideoPairing(): Boolean {
     val audio = audioVideoId.trim()
     val video = counterpartVideoId.trim()

--- a/app/src/main/java/com/luc4n3x/levyra/domain/VideoPlaybackContract.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/VideoPlaybackContract.kt
@@ -30,11 +30,6 @@ internal object YoutubeMusicVideoType {
 private val COMPACT_COUNT_LEADING_NUMBER = Regex("""^[0-9][0-9.,  ]*""")
 private val COMPACT_COUNT_DURATION = Regex("""^[0-9]+(:[0-9]{2})+$""")
 
-/**
- * Compact view-count multipliers as YouTube Music writes them per language. Matching is exact so
- * Spanish and Portuguese "mil" (thousand) never collides with Portuguese "mi" or English "M"
- * (million). An unlisted token leaves the plain number, which under-rates rather than over-rates.
- */
 private val COMPACT_COUNT_MULTIPLIERS = mapOf(
     "k" to 1_000L, "tys" to 1_000L, "tis" to 1_000L, "mil" to 1_000L, "тыс" to 1_000L, "тис" to 1_000L,
     "m" to 1_000_000L, "mi" to 1_000_000L, "mln" to 1_000_000L, "mio" to 1_000_000L, "млн" to 1_000_000L,
@@ -44,12 +39,6 @@ private val COMPACT_COUNT_MULTIPLIERS = mapOf(
     "億" to 100_000_000L, "亿" to 100_000_000L, "억" to 100_000_000L
 )
 
-/**
- * Reads a YouTube Music view-count label such as "772 Mln di visualizzazioni", "772M views" or
- * "7,7億 回視聴". InnerTube publishes no numeric view count in this renderer, only the localized
- * label, so the count has to be recovered from it. Returns `-1` when the label is not a count, so
- * an unparsed value never becomes a misleading zero.
- */
 internal fun parseCompactViewCount(label: String): Long {
     val text = label.trim()
     if (text.isEmpty() || COMPACT_COUNT_DURATION.matches(text)) return -1L
@@ -63,7 +52,6 @@ internal fun parseCompactViewCount(label: String): Long {
     val multiplier = COMPACT_COUNT_MULTIPLIERS[magnitude]
 
     return if (multiplier == null) {
-        // No magnitude token: the separators group digits, they are not a decimal point.
         numberPart.filter(Char::isDigit).toLongOrNull() ?: -1L
     } else {
         val scalar = numberPart.replace(',', '.').filterNot(Char::isWhitespace)
@@ -74,13 +62,6 @@ internal fun parseCompactViewCount(label: String): Long {
 
 internal const val VIDEO_VIEW_COUNT_STEP = 500
 
-/**
- * Order of magnitude of [views] as a bounded ranking bonus. The canonical upload of a recording
- * outruns its re-uploads by two or three orders of magnitude while sharing their title, artist,
- * browse ids and `musicVideoType`, so this is the only local signal that separates them. It is
- * deliberately coarse and capped below the artist-channel bonus, so it breaks ties without ever
- * outvoting the official-type, artist-channel or pairing-authority evidence.
- */
 internal fun videoViewCountBonus(views: Long): Int {
     if (views <= 0L) return 0
     var digits = 0

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -287,7 +287,11 @@ internal fun isPlaybackCandidateCompatible(target: Track, candidate: Track): Boo
     return artistMatches >= requiredMatches
 }
 
-internal fun playbackCandidateScore(target: Track, candidate: Track): Int {
+internal fun playbackCandidateScore(
+    target: Track,
+    candidate: Track,
+    rewardDurationMatch: Boolean = true
+): Int {
     when (recordingIdentityMatch(target.isrc, candidate.isrc)) {
         RecordingIdentityMatch.Exact -> return 10_000
         RecordingIdentityMatch.Conflict -> return Int.MIN_VALUE
@@ -317,13 +321,21 @@ internal fun playbackCandidateScore(target: Track, candidate: Track): Int {
     if (candidate.source.contains("Extractor", ignoreCase = true)) score += 8
     if (candidate.durationMs > 0L && target.durationMs > 0L) {
         val delta = kotlin.math.abs(candidate.durationMs - target.durationMs)
-        if (delta <= 5_000L) score += 30 else if (delta > 35_000L) score -= 25
+        if (delta <= 5_000L) {
+            if (rewardDurationMatch) score += 30
+        } else if (delta > 35_000L) {
+            score -= 25
+        }
     }
     return score
 }
 
 internal fun videoPlaybackCandidateScore(target: Track, candidate: Track): Int {
-    val recordingScore = playbackCandidateScore(target, candidate)
+    // An official music video routinely runs longer than the audio recording (intro, outro,
+    // dialogue), while an audio-length re-upload matches it to the second. Rewarding duration
+    // proximity therefore elects the re-upload over the official video, so only the
+    // wildly-different-content penalty survives here.
+    val recordingScore = playbackCandidateScore(target, candidate, rewardDurationMatch = false)
     if (recordingScore == Int.MIN_VALUE) return Int.MIN_VALUE
     val type = candidate.videoType
     val videoPreference = when {
@@ -355,25 +367,37 @@ internal fun videoCandidateId(candidate: Track): String =
  */
 internal const val VIDEO_PAIRING_AUTHORITY_BONUS = 20_000
 
+/**
+ * Weight of the provider's own ordering. An artist channel usually hosts the official video next to
+ * shorter re-uploads of the same recording that share its title, artist, browse ids and
+ * `musicVideoType`, so no local text or duration comparison can separate them; YouTube Music's
+ * ranking can, and returns the official upload first. The step therefore has to outweigh the text
+ * score deltas ([playbackCandidateScore] stays under 300) while staying far below the
+ * [VIDEO_PAIRING_AUTHORITY_BONUS], official-type and artist-channel signals.
+ */
+internal const val VIDEO_PROVIDER_RANK_STEP = 200
+
 internal fun selectPreferredVideoPlaybackCandidate(
     target: Track,
     candidates: List<Track>,
     authoritativeIds: Set<String> = emptySet()
 ): Track? {
     return candidates.asSequence()
-        .filter { candidate ->
+        .mapIndexed { rank, candidate -> rank to candidate }
+        .filter { (_, candidate) ->
             YOUTUBE_PLAYABLE_VIDEO_ID.matches(videoCandidateId(candidate)) &&
                 !YoutubeMusicVideoType.isArtTrack(candidate.videoType)
         }
-        .filter { candidate -> isPlaybackCandidateCompatible(target, candidate) }
-        .maxByOrNull { candidate ->
+        .filter { (_, candidate) -> isPlaybackCandidateCompatible(target, candidate) }
+        .maxByOrNull { (rank, candidate) ->
             val authority = if (videoCandidateId(candidate) in authoritativeIds) {
                 VIDEO_PAIRING_AUTHORITY_BONUS
             } else {
                 0
             }
-            videoPlaybackCandidateScore(target, candidate) + authority
+            videoPlaybackCandidateScore(target, candidate) + authority - rank * VIDEO_PROVIDER_RANK_STEP
         }
+        ?.second
 }
 
 internal fun playbackTextKey(value: String): String {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -259,14 +259,46 @@ internal fun monotonicDownloadProgress(current: Int?, incoming: Int): Int {
     return maxOf(safeCurrent, safeIncoming)
 }
 
+private val PLAYBACK_TITLE_PRODUCTION_MARKER = Regex(
+    """[(\[][^)\]]*\b(official|ufficiale|oficial|lyric|lyrics|testo|audio|video|visualizer|visualiser|clip)\b[^)\]]*[)\]]""",
+    RegexOption.IGNORE_CASE
+)
+private val PLAYBACK_TITLE_FEATURE_GROUP = Regex(
+    """[(\[]\s*(feat|ft|featuring|con|with)\b\.?[^)\]]*[)\]]""",
+    RegexOption.IGNORE_CASE
+)
+private val PLAYBACK_TITLE_FEATURE_TAIL = Regex(
+    """\s(feat|ft|featuring)\b\.?\s.*$""",
+    RegexOption.IGNORE_CASE
+)
+private val PLAYBACK_TITLE_TRAILING_MARKER = Regex(
+    """\s[-–|]\s(official\s+)?(music\s+)?(video|audio|lyrics?\s+video)\s*$""",
+    RegexOption.IGNORE_CASE
+)
+
+/**
+ * The title reduced to the recording it names. YouTube Music's art track carries the featuring
+ * credits while the artist's upload carries the production marker, so comparing raw titles rejects
+ * "Baby (Official Video)" as incompatible with "Baby (feat. J Balvin)" and leaves native-video mode
+ * choosing whatever fan upload happens to repeat the credits.
+ */
+internal fun playbackTitleKey(title: String): String {
+    val core = title
+        .replace(PLAYBACK_TITLE_PRODUCTION_MARKER, " ")
+        .replace(PLAYBACK_TITLE_FEATURE_GROUP, " ")
+        .replace(PLAYBACK_TITLE_FEATURE_TAIL, " ")
+        .replace(PLAYBACK_TITLE_TRAILING_MARKER, " ")
+    return playbackTextKey(core).ifBlank { playbackTextKey(title) }
+}
+
 internal fun isPlaybackCandidateCompatible(target: Track, candidate: Track): Boolean {
     when (recordingIdentityMatch(target.isrc, candidate.isrc)) {
         RecordingIdentityMatch.Exact -> return true
         RecordingIdentityMatch.Conflict -> return false
         RecordingIdentityMatch.Unknown -> Unit
     }
-    val targetTitle = playbackTextKey(target.title)
-    val candidateTitle = playbackTextKey(candidate.title)
+    val targetTitle = playbackTitleKey(target.title)
+    val candidateTitle = playbackTitleKey(candidate.title)
     if (targetTitle.isBlank() || candidateTitle.isBlank()) return false
 
     val targetTitleTokens = playbackTokens(targetTitle)
@@ -330,6 +362,14 @@ internal fun playbackCandidateScore(
     return score
 }
 
+private val PLAYBACK_AUDIO_ONLY_MARKER = Regex(
+    """[(\[]\s*(official\s+|full\s+)?(audio|lyrics?\s+video|lyrics?|testo|visualizer|visualiser)\s*[)\]]""" +
+        """|\bofficial\s+audio\b|\baudio\s+ufficiale\b""",
+    RegexOption.IGNORE_CASE
+)
+
+internal const val VIDEO_AUDIO_ONLY_PENALTY = 10_000
+
 internal fun videoPlaybackCandidateScore(target: Track, candidate: Track): Int {
     // An official music video routinely runs longer than the audio recording (intro, outro,
     // dialogue), while an audio-length re-upload matches it to the second. Rewarding duration
@@ -347,7 +387,14 @@ internal fun videoPlaybackCandidateScore(target: Track, candidate: Track): Int {
     // A shared artist channel is structured proof of an official upload and outranks title text.
     val officialChannel = target.artistBrowseIds.isNotEmpty() &&
         candidate.artistBrowseIds.any { it in target.artistBrowseIds }
-    return recordingScore + videoPreference + if (officialChannel) 6_000 else 0
+    // An artist channel hosts the official video next to an audio or lyric upload of the same
+    // recording, both typed OMV. Only the marker in the title separates them, and the audio upload
+    // is often the more watched of the two. The penalty stays below the official-type bonus so an
+    // audio-only official upload still beats a user video when it is all the artist published.
+    val audioOnlyUpload = PLAYBACK_AUDIO_ONLY_MARKER.containsMatchIn(candidate.title)
+    return recordingScore + videoPreference +
+        (if (officialChannel) 6_000 else 0) -
+        (if (audioOnlyUpload) VIDEO_AUDIO_ONLY_PENALTY else 0)
 }
 
 /**

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -104,6 +104,7 @@ import com.luc4n3x.levyra.domain.YoutubeMusicVideoType
 import com.luc4n3x.levyra.domain.YoutubeComment
 import com.luc4n3x.levyra.domain.YoutubeCommentsState
 import com.luc4n3x.levyra.domain.YoutubeEngagementState
+import com.luc4n3x.levyra.domain.videoViewCountBonus
 import com.luc4n3x.levyra.feature.motion.MotionArtworkEngine
 import com.luc4n3x.levyra.feature.motion.MotionArtworkIdentityKey
 import com.luc4n3x.levyra.feature.providers.CachedPlaybackProvider
@@ -394,7 +395,8 @@ internal fun videoPlaybackCandidateScore(target: Track, candidate: Track): Int {
     val audioOnlyUpload = PLAYBACK_AUDIO_ONLY_MARKER.containsMatchIn(candidate.title)
     return recordingScore + videoPreference +
         (if (officialChannel) 6_000 else 0) -
-        (if (audioOnlyUpload) VIDEO_AUDIO_ONLY_PENALTY else 0)
+        (if (audioOnlyUpload) VIDEO_AUDIO_ONLY_PENALTY else 0) +
+        videoViewCountBonus(candidate.youtubeViewCount)
 }
 
 /**

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -277,12 +277,6 @@ private val PLAYBACK_TITLE_TRAILING_MARKER = Regex(
     RegexOption.IGNORE_CASE
 )
 
-/**
- * The title reduced to the recording it names. YouTube Music's art track carries the featuring
- * credits while the artist's upload carries the production marker, so comparing raw titles rejects
- * "Baby (Official Video)" as incompatible with "Baby (feat. J Balvin)" and leaves native-video mode
- * choosing whatever fan upload happens to repeat the credits.
- */
 internal fun playbackTitleKey(title: String): String {
     val core = title
         .replace(PLAYBACK_TITLE_PRODUCTION_MARKER, " ")
@@ -372,10 +366,6 @@ private val PLAYBACK_AUDIO_ONLY_MARKER = Regex(
 internal const val VIDEO_AUDIO_ONLY_PENALTY = 10_000
 
 internal fun videoPlaybackCandidateScore(target: Track, candidate: Track): Int {
-    // An official music video routinely runs longer than the audio recording (intro, outro,
-    // dialogue), while an audio-length re-upload matches it to the second. Rewarding duration
-    // proximity therefore elects the re-upload over the official video, so only the
-    // wildly-different-content penalty survives here.
     val recordingScore = playbackCandidateScore(target, candidate, rewardDurationMatch = false)
     if (recordingScore == Int.MIN_VALUE) return Int.MIN_VALUE
     val type = candidate.videoType
@@ -388,10 +378,6 @@ internal fun videoPlaybackCandidateScore(target: Track, candidate: Track): Int {
     // A shared artist channel is structured proof of an official upload and outranks title text.
     val officialChannel = target.artistBrowseIds.isNotEmpty() &&
         candidate.artistBrowseIds.any { it in target.artistBrowseIds }
-    // An artist channel hosts the official video next to an audio or lyric upload of the same
-    // recording, both typed OMV. Only the marker in the title separates them, and the audio upload
-    // is often the more watched of the two. The penalty stays below the official-type bonus so an
-    // audio-only official upload still beats a user video when it is all the artist published.
     val audioOnlyUpload = PLAYBACK_AUDIO_ONLY_MARKER.containsMatchIn(candidate.title)
     return recordingScore + videoPreference +
         (if (officialChannel) 6_000 else 0) -
@@ -416,14 +402,6 @@ internal fun videoCandidateId(candidate: Track): String =
  */
 internal const val VIDEO_PAIRING_AUTHORITY_BONUS = 20_000
 
-/**
- * Weight of the provider's own ordering. An artist channel usually hosts the official video next to
- * shorter re-uploads of the same recording that share its title, artist, browse ids and
- * `musicVideoType`, so no local text or duration comparison can separate them; YouTube Music's
- * ranking can, and returns the official upload first. The step therefore has to outweigh the text
- * score deltas ([playbackCandidateScore] stays under 300) while staying far below the
- * [VIDEO_PAIRING_AUTHORITY_BONUS], official-type and artist-channel signals.
- */
 internal const val VIDEO_PROVIDER_RANK_STEP = 200
 
 internal fun selectPreferredVideoPlaybackCandidate(

--- a/app/src/test/java/com/luc4n3x/levyra/data/NewPipeAcceptLanguageTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/NewPipeAcceptLanguageTest.kt
@@ -1,0 +1,21 @@
+package com.luc4n3x.levyra.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NewPipeAcceptLanguageTest {
+    @Test
+    fun acceptLanguageFollowsTheSelectedLanguage() {
+        NewPipeRuntime.setLanguage("es")
+        assertEquals("es-ES,es;q=0.9,en-US;q=0.8,en;q=0.7", NewPipeRuntime.acceptLanguageHeader())
+
+        NewPipeRuntime.setLanguage("it")
+        assertEquals("it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7", NewPipeRuntime.acceptLanguageHeader())
+    }
+
+    @Test
+    fun englishDoesNotRepeatItselfAsItsOwnFallback() {
+        NewPipeRuntime.setLanguage("en")
+        assertEquals("en-US,en;q=0.9", NewPipeRuntime.acceptLanguageHeader())
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/RecordingIdentityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/RecordingIdentityTest.kt
@@ -1,6 +1,8 @@
 package com.luc4n3x.levyra.data
 
 import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.domain.parseCompactViewCount
+import com.luc4n3x.levyra.domain.videoViewCountBonus
 import com.luc4n3x.levyra.viewmodel.isPlaybackCandidateCompatible
 import com.luc4n3x.levyra.viewmodel.playbackCandidateScore
 import com.luc4n3x.levyra.viewmodel.selectPreferredVideoPlaybackCandidate
@@ -453,6 +455,97 @@ class RecordingIdentityTest {
         assertEquals(
             "5NV6Rdv1a3I",
             selectPreferredVideoPlaybackCandidate(target, listOf(officialAudio, reUpload))?.id
+        )
+    }
+
+    @Test
+    fun compactViewCountsAreReadInEveryPublishedLabelShape() {
+        assertEquals(772_000_000L, parseCompactViewCount("772 Mln di visualizzazioni"))
+        assertEquals(772_000_000L, parseCompactViewCount("772M views"))
+        assertEquals(2_600_000L, parseCompactViewCount("2,6 Mln di visualizzazioni"))
+        assertEquals(2_600_000L, parseCompactViewCount("2.6M views"))
+        assertEquals(74_000L, parseCompactViewCount("74K views"))
+        assertEquals(772_000_000L, parseCompactViewCount("772 Mio. Aufrufe"))
+        assertEquals(1_200L, parseCompactViewCount("1,2 mil visualizações"))
+        assertEquals(791L, parseCompactViewCount("791 visualizzazioni"))
+        // A duration, a bare year and an empty label are not counts.
+        assertEquals(-1L, parseCompactViewCount("4:01"))
+        assertEquals(-1L, parseCompactViewCount("2023"))
+        assertEquals(-1L, parseCompactViewCount(""))
+    }
+
+    @Test
+    fun viewCountBonusStaysBelowTheArtistChannelSignal() {
+        assertEquals(0, videoViewCountBonus(-1L))
+        assertEquals(0, videoViewCountBonus(0L))
+        assertTrue(videoViewCountBonus(772_000_000L) > videoViewCountBonus(2_600_000L))
+        assertTrue(videoViewCountBonus(Long.MAX_VALUE) < 6_000)
+    }
+
+    @Test
+    fun viewCountSeparatesTheOfficialVideoFromReUploadsOnTheSameChannel() {
+        // The Top 50 entry for "Dai Dai" reaches playback without a YouTube Music mapping, so it
+        // carries no browse ids and no pairing. Three candidates then share type, channel, artist
+        // and title, and the official upload is not the first one returned.
+        val target = artistTrack(
+            id = "levyra-4500512f5aa38edfe312",
+            title = "Dai Dai",
+            artist = "Shakira, Burna Boy",
+            durationMs = 223_448L,
+            videoType = ""
+        ).copy(artistBrowseIds = emptyList())
+        val reUpload = target.copy(
+            id = "ux255_NUR2o",
+            title = "Dai dai",
+            artist = "Shakira e Burna Boy",
+            videoUrl = "https://www.youtube.com/watch?v=ux255_NUR2o",
+            durationMs = 220_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV",
+            youtubeViewCount = 2_600_000L
+        )
+        val official = reUpload.copy(
+            id = "fcnDmrtj6Sk",
+            title = "Dai Dai",
+            videoUrl = "https://www.youtube.com/watch?v=fcnDmrtj6Sk",
+            durationMs = 241_000L,
+            youtubeViewCount = 772_000_000L
+        )
+
+        assertEquals(
+            "fcnDmrtj6Sk",
+            selectPreferredVideoPlaybackCandidate(target, listOf(reUpload, official))?.id
+        )
+    }
+
+    @Test
+    fun viewCountNeverPromotesAnAudioUploadOverTheOfficialVideo() {
+        // SZA's "Kill Bill (Official Audio)" outruns the official video on views.
+        val target = artistTrack(
+            id = "AdEKgwUqPKI",
+            title = "Kill Bill",
+            artist = "SZA",
+            durationMs = 154_000L,
+            videoType = "MUSIC_VIDEO_TYPE_ATV"
+        )
+        val officialAudio = target.copy(
+            id = "SQnc1QibapQ",
+            title = "Kill Bill (Official Audio)",
+            videoUrl = "https://www.youtube.com/watch?v=SQnc1QibapQ",
+            durationMs = 156_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV",
+            youtubeViewCount = 167_000_000L
+        )
+        val official = officialAudio.copy(
+            id = "MSRcC626prw",
+            title = "Kill Bill (Official Video)",
+            videoUrl = "https://www.youtube.com/watch?v=MSRcC626prw",
+            durationMs = 276_000L,
+            youtubeViewCount = 142_000_000L
+        )
+
+        assertEquals(
+            "MSRcC626prw",
+            selectPreferredVideoPlaybackCandidate(target, listOf(officialAudio, official))?.id
         )
     }
 

--- a/app/src/test/java/com/luc4n3x/levyra/data/RecordingIdentityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/RecordingIdentityTest.kt
@@ -355,6 +355,107 @@ class RecordingIdentityTest {
         )
     }
 
+    @Test
+    fun featuringCreditsDoNotHideTheOfficialVideo() {
+        // Measured against the YouTube Music video search for "Sfera Ebbasta Baby": the art track
+        // is titled "Baby (feat. J Balvin)" and the official upload "Baby (Official Video)", so raw
+        // title comparison rejected the official video and left a 791-view fan upload winning.
+        val target = artistTrack(
+            id = "tlmoVWfCejI",
+            title = "Baby (feat. J Balvin)",
+            artist = "Sfera Ebbasta",
+            durationMs = 194_000L,
+            videoType = "MUSIC_VIDEO_TYPE_ATV"
+        )
+        val official = target.copy(
+            id = "1RpKdCl2uN4",
+            title = "Baby (Official Video)",
+            artist = "J Balvin & Sfera Ebbasta",
+            videoUrl = "https://www.youtube.com/watch?v=1RpKdCl2uN4",
+            durationMs = 201_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+        val fanUpload = target.copy(
+            id = "fZL9IYLAPHE",
+            title = "Sfera Ebbasta - Baby (Feat J Balvin)",
+            artist = "Actis",
+            videoUrl = "https://www.youtube.com/watch?v=fZL9IYLAPHE",
+            durationMs = 191_000L,
+            videoType = "MUSIC_VIDEO_TYPE_UGC",
+            artistBrowseIds = emptyList()
+        )
+
+        assertTrue(isPlaybackCandidateCompatible(target, official))
+        assertEquals(
+            "1RpKdCl2uN4",
+            selectPreferredVideoPlaybackCandidate(target, listOf(official, fanUpload))?.id
+        )
+    }
+
+    @Test
+    fun audioUploadOnTheArtistChannelLosesToTheOfficialVideo() {
+        // Both are MUSIC_VIDEO_TYPE_OMV on Tame Impala's channel and the audio upload is the more
+        // watched of the two, so only the title marker separates them.
+        val target = artistTrack(
+            id = "PvM79DJ2PmM",
+            title = "The Less I Know The Better",
+            artist = "Tame Impala",
+            durationMs = 217_000L,
+            videoType = "MUSIC_VIDEO_TYPE_ATV"
+        )
+        val audioUpload = target.copy(
+            id = "2SUwOgmvzK4",
+            title = "The Less I Know The Better (Audio)",
+            videoUrl = "https://www.youtube.com/watch?v=2SUwOgmvzK4",
+            durationMs = 218_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+        val official = target.copy(
+            id = "sBzrzS1Ag_g",
+            title = "The Less I Know The Better (Official Video)",
+            videoUrl = "https://www.youtube.com/watch?v=sBzrzS1Ag_g",
+            durationMs = 343_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+
+        assertEquals(
+            "sBzrzS1Ag_g",
+            selectPreferredVideoPlaybackCandidate(target, listOf(audioUpload, official))?.id
+        )
+    }
+
+    @Test
+    fun audioOnlyOfficialUploadStillBeatsAUserVideo() {
+        val target = artistTrack(
+            id = "4D7u5KF7SP8",
+            title = "Get Lucky (feat. Pharrell Williams and Nile Rodgers)",
+            artist = "Daft Punk",
+            durationMs = 370_000L,
+            videoType = "MUSIC_VIDEO_TYPE_ATV"
+        )
+        val officialAudio = target.copy(
+            id = "5NV6Rdv1a3I",
+            title = "Get Lucky (Official Audio) (feat. Nile Rodgers)",
+            videoUrl = "https://www.youtube.com/watch?v=5NV6Rdv1a3I",
+            durationMs = 249_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+        val reUpload = target.copy(
+            id = "CCHdMIEGaaM",
+            title = "Daft Punk - Get Lucky (Official Video) feat. Pharrell Williams",
+            artist = "convar HUN",
+            videoUrl = "https://www.youtube.com/watch?v=CCHdMIEGaaM",
+            durationMs = 248_000L,
+            videoType = "MUSIC_VIDEO_TYPE_UGC",
+            artistBrowseIds = emptyList()
+        )
+
+        assertEquals(
+            "5NV6Rdv1a3I",
+            selectPreferredVideoPlaybackCandidate(target, listOf(officialAudio, reUpload))?.id
+        )
+    }
+
     private fun artistTrack(
         id: String,
         title: String,

--- a/app/src/test/java/com/luc4n3x/levyra/data/RecordingIdentityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/RecordingIdentityTest.kt
@@ -262,4 +262,125 @@ class RecordingIdentityTest {
             selectPreferredVideoPlaybackCandidate(target, listOf(official))?.id
         )
     }
+
+    @Test
+    fun daDioPrefersTheOfficialVideoOverTheAudioLengthReUpload() {
+        // Measured against the YouTube Music video search for "Da Dio Bresh": the official upload
+        // and the re-uploads share title, artist, artist browse ids and MUSIC_VIDEO_TYPE_OMV, and
+        // the re-upload is the one that matches the audio duration to the second.
+        val target = artistTrack(
+            id = "0Jp_YOOEovg",
+            title = "Da Dio",
+            artist = "Bresh",
+            durationMs = 174_000L,
+            videoType = "MUSIC_VIDEO_TYPE_ATV"
+        )
+        val official = target.copy(
+            id = "-ZwDJaZ2coY",
+            videoUrl = "https://www.youtube.com/watch?v=-ZwDJaZ2coY",
+            durationMs = 179_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+        val audioLengthReUpload = target.copy(
+            id = "XxSIyhr_bFc",
+            videoUrl = "https://www.youtube.com/watch?v=XxSIyhr_bFc",
+            durationMs = 174_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+
+        assertEquals(
+            "-ZwDJaZ2coY",
+            selectPreferredVideoPlaybackCandidate(target, listOf(official, audioLengthReUpload))?.id
+        )
+    }
+
+    @Test
+    fun daiDaiPrefersTheOfficialVideoOverTheAudioLengthReUpload() {
+        val target = artistTrack(
+            id = "lFQdcPTTzSg",
+            title = "Dai Dai",
+            artist = "Shakira e Burna Boy",
+            durationMs = 224_000L,
+            videoType = "MUSIC_VIDEO_TYPE_ATV"
+        )
+        val official = target.copy(
+            id = "fcnDmrtj6Sk",
+            videoUrl = "https://www.youtube.com/watch?v=fcnDmrtj6Sk",
+            durationMs = 241_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+        val audioLengthReUpload = target.copy(
+            id = "0QZYJRnv-rA",
+            title = "Dai dai",
+            videoUrl = "https://www.youtube.com/watch?v=0QZYJRnv-rA",
+            durationMs = 224_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+
+        assertEquals(
+            "fcnDmrtj6Sk",
+            selectPreferredVideoPlaybackCandidate(target, listOf(official, audioLengthReUpload))?.id
+        )
+    }
+
+    @Test
+    fun videoScoringIgnoresAudioDurationProximity() {
+        val target = artistTrack(
+            id = "lFQdcPTTzSg",
+            title = "Dai Dai",
+            artist = "Shakira e Burna Boy",
+            durationMs = 224_000L,
+            videoType = "MUSIC_VIDEO_TYPE_ATV"
+        )
+        val longerOfficial = target.copy(
+            id = "fcnDmrtj6Sk",
+            videoUrl = "https://www.youtube.com/watch?v=fcnDmrtj6Sk",
+            durationMs = 241_000L,
+            videoType = "MUSIC_VIDEO_TYPE_OMV"
+        )
+        val exactLengthOfficial = longerOfficial.copy(
+            id = "0QZYJRnv-rA",
+            videoUrl = "https://www.youtube.com/watch?v=0QZYJRnv-rA",
+            durationMs = 224_000L
+        )
+
+        assertEquals(
+            videoPlaybackCandidateScore(target, exactLengthOfficial),
+            videoPlaybackCandidateScore(target, longerOfficial)
+        )
+        // The song-mode ranking still trusts duration proximity: only video mode must not.
+        assertTrue(
+            playbackCandidateScore(target, exactLengthOfficial) >
+                playbackCandidateScore(target, longerOfficial)
+        )
+    }
+
+    private fun artistTrack(
+        id: String,
+        title: String,
+        artist: String,
+        durationMs: Long,
+        videoType: String
+    ): Track = Track(
+        id = id,
+        title = title,
+        artist = artist,
+        album = "",
+        durationMs = durationMs,
+        streamUrl = "",
+        videoUrl = "https://www.youtube.com/watch?v=$id",
+        thumbnailUrl = "",
+        largeThumbnailUrl = "",
+        source = "YouTube Music",
+        moodTags = emptySet(),
+        energy = 0,
+        vocal = 0,
+        replayScore = 0,
+        cacheScore = 0,
+        accentStart = 0,
+        accentEnd = 0,
+        videoType = videoType,
+        audioVideoId = id,
+        artistBrowseIds = listOf("UCo6JijJGA3IvIiPsawDK3Ww")
+    )
 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/RecordingIdentityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/RecordingIdentityTest.kt
@@ -267,9 +267,6 @@ class RecordingIdentityTest {
 
     @Test
     fun daDioPrefersTheOfficialVideoOverTheAudioLengthReUpload() {
-        // Measured against the YouTube Music video search for "Da Dio Bresh": the official upload
-        // and the re-uploads share title, artist, artist browse ids and MUSIC_VIDEO_TYPE_OMV, and
-        // the re-upload is the one that matches the audio duration to the second.
         val target = artistTrack(
             id = "0Jp_YOOEovg",
             title = "Da Dio",
@@ -350,7 +347,6 @@ class RecordingIdentityTest {
             videoPlaybackCandidateScore(target, exactLengthOfficial),
             videoPlaybackCandidateScore(target, longerOfficial)
         )
-        // The song-mode ranking still trusts duration proximity: only video mode must not.
         assertTrue(
             playbackCandidateScore(target, exactLengthOfficial) >
                 playbackCandidateScore(target, longerOfficial)
@@ -359,9 +355,6 @@ class RecordingIdentityTest {
 
     @Test
     fun featuringCreditsDoNotHideTheOfficialVideo() {
-        // Measured against the YouTube Music video search for "Sfera Ebbasta Baby": the art track
-        // is titled "Baby (feat. J Balvin)" and the official upload "Baby (Official Video)", so raw
-        // title comparison rejected the official video and left a 791-view fan upload winning.
         val target = artistTrack(
             id = "tlmoVWfCejI",
             title = "Baby (feat. J Balvin)",
@@ -396,8 +389,6 @@ class RecordingIdentityTest {
 
     @Test
     fun audioUploadOnTheArtistChannelLosesToTheOfficialVideo() {
-        // Both are MUSIC_VIDEO_TYPE_OMV on Tame Impala's channel and the audio upload is the more
-        // watched of the two, so only the title marker separates them.
         val target = artistTrack(
             id = "PvM79DJ2PmM",
             title = "The Less I Know The Better",
@@ -468,7 +459,6 @@ class RecordingIdentityTest {
         assertEquals(772_000_000L, parseCompactViewCount("772 Mio. Aufrufe"))
         assertEquals(1_200L, parseCompactViewCount("1,2 mil visualizações"))
         assertEquals(791L, parseCompactViewCount("791 visualizzazioni"))
-        // A duration, a bare year and an empty label are not counts.
         assertEquals(-1L, parseCompactViewCount("4:01"))
         assertEquals(-1L, parseCompactViewCount("2023"))
         assertEquals(-1L, parseCompactViewCount(""))
@@ -484,9 +474,6 @@ class RecordingIdentityTest {
 
     @Test
     fun viewCountSeparatesTheOfficialVideoFromReUploadsOnTheSameChannel() {
-        // The Top 50 entry for "Dai Dai" reaches playback without a YouTube Music mapping, so it
-        // carries no browse ids and no pairing. Three candidates then share type, channel, artist
-        // and title, and the official upload is not the first one returned.
         val target = artistTrack(
             id = "levyra-4500512f5aa38edfe312",
             title = "Dai Dai",
@@ -519,7 +506,6 @@ class RecordingIdentityTest {
 
     @Test
     fun viewCountNeverPromotesAnAudioUploadOverTheOfficialVideo() {
-        // SZA's "Kill Bill (Official Audio)" outruns the official video on views.
         val target = artistTrack(
             id = "AdEKgwUqPKI",
             title = "Kill Bill",


### PR DESCRIPTION
Native-video mode picked the wrong video. Every claim below was measured against the YouTube Music InnerTube API for thirty tracks across Italian rap, Italian pop, international pop, Latin and catalogue rock — not inferred.

## 1. The authoritative song/video counterpart never arrives

Six `next` variants — `isAudioOnly` on and off, with and without `playlistId`, with and without `watchEndpointMusicSupportedConfigs`, `WEB_REMIX` and `ANDROID_MUSIC` — all returned zero `playlistPanelVideoWrapperRenderer` and zero `counterpart` entries. The watch branch of `preferredVideoPlaybackTrack` contributes nothing for an anonymous client, so ranking alone decides.

## 2. Duration proximity elected the audio-length re-upload

| Track | Official | Re-upload |
| --- | --- | --- |
| Bresh — Da Dio (art track 2:54) | `-ZwDJaZ2coY` 2:59 | `XxSIyhr_bFc` 2:54 |
| Shakira, Burna Boy — Dai Dai (art track 3:44) | `fcnDmrtj6Sk` 4:01 | `0QZYJRnv-rA` 3:44 |

Same title, artist, browse ids and `MUSIC_VIDEO_TYPE_OMV`. `playbackCandidateScore` awarded `+30` to whichever matched the audio duration within five seconds — and an official video runs longer because of its intro and outro, while a re-upload matches to the second.

Video candidates are now scored with `rewardDurationMatch = false`; the wildly-different-content penalty stays as a guard, and song mode is unchanged. YouTube Music's own result order becomes an explicit tiebreaker (`VIDEO_PROVIDER_RANK_STEP = 200`).

## 3. Featuring credits hid the official video

The art track of "Baby" is `Baby (feat. J Balvin)`, the artist upload `Baby (Official Video)`. `isPlaybackCandidateCompatible` compared `baby feat balvin` against `baby official video`, scored 0.33 token coverage against a 0.8 bar and **rejected the official video outright** — selection then fell to a fan upload with 791 views.

Titles are now compared reduced to the recording they name: production marker, parenthesised featuring group and trailing `- Official Video` suffix removed, with fallback to the raw key.

## 4. Audio uploads outranked the official video

An artist channel commonly hosts both, both `MUSIC_VIDEO_TYPE_OMV` under the same browse ids, and the audio upload is often the more watched: Adele's `Easy On Me (Official Lyric Video)` 505M against 429M, Tame Impala's `The Less I Know The Better (Audio)` 285M against 122M. A candidate whose title marks it audio, lyric or visualiser is demoted, with the penalty below the official-type bonus so an audio-only official upload still wins when it is all the artist published.

## 5. Top 50 entries had no signal left but the view count

A chart entry reaches playback through `EditorialChartsRepository`, and the published catalog carries no `youtubeMusic` block for several tracks. No `audioVideoId` means `getWatchPlaylist` returns immediately; no `artistBrowseId` means the artist-channel signal is gone. For "Dai Dai" three candidates then share type, channel, artist and title and all score 20193, separated only by the 200-point order step. Their view counts are 772M, 2.6M and 1.2M.

InnerTube publishes no numeric view count in `musicResponsiveListItemRenderer`, only a localized label, and a fixed-language lookup is not an option — the same query returns a different result order under `hl=it` and `hl=en`. `parseCompactViewCount` reads the label with exact-token multipliers per language, so Spanish and Portuguese "mil" (thousand) cannot collide with Portuguese "mi" or English "M" (million). An unrecognised token falls back to the plain number and an unparsable label yields `-1`, so the signal can only help. The bonus is the order of magnitude, capped at 5000 — below the 6000 artist-channel bonus, the 10000 audio-only penalty and the 20000 official-type and pairing-authority signals.

## 6. Accept-Language ignored the selected language

`NewPipeRuntime.setLanguage` already pushed the selected language into the extractor's `Localization`, but the downloader sent a literal `it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7` on every request, so non-Italian users still received Italian-biased responses. It is now derived from the applied locale. Italian is unchanged.

## Result

29 of 30 tracks resolve to an `OMV` on the artist's own channel. The one exception is Queen, where the art track is itself `Bohemian Rhapsody (Live Aid)` and selecting the Live Aid video is correct rather than a miss.

## Validation

- `./gradlew --no-daemon :app:testDebugUnitTest` — 739 tests, 0 failures, 0 errors
- `python scripts/ai_quality_gate.py --profile fast` — passed
- `python scripts/check_android_regex_compatibility.py` — passed
- `git diff --check` — clean

Blocked locally, left to CI: `:app:lintRelease` and `:app:assembleRelease` need a Java 21 toolchain that Gradle does not detect on this machine.

## Device checks — not performed

- [ ] Song mode
- [ ] Video mode plays the official video for "Da Dio", "Dai Dai" and "Baby"
- [ ] Same from the Top 50
- [ ] Song to video, video to song
- [ ] Next/previous, seek
- [ ] Notification, Android Auto, PiP
- [ ] Switch app language and confirm extractor results follow it

Nothing here has been verified on hardware.
