### PR TITLE
Fix OpenClaw agent role validation

### DIFF
--- a/scripts/tests/test_ai_quality_gate.py
+++ b/scripts/tests/test_ai_quality_gate.py
@@ -9,6 +9,7 @@ from scripts.ai_quality_gate import (
     gradle_wrapper,
     scan_added_lines,
 )
+from scripts.validate_agent_config import DOCUMENTED_AGENT_IDS
 
 
 class AiQualityGateTest(unittest.TestCase):
@@ -94,6 +95,12 @@ class AiQualityGateTest(unittest.TestCase):
         )
 
         self.assertEqual(2, len(findings))
+
+    def test_openclaw_agent_ids_are_not_native_skill_requirements(self) -> None:
+        self.assertEqual(
+            {"levyra-ci", "levyra-reviewer", "levyra-worker"},
+            DOCUMENTED_AGENT_IDS,
+        )
 
     def test_full_android_profile_adds_tests_lint_and_compile(self) -> None:
         commands, blocked = build_commands(

--- a/scripts/tests/test_ai_quality_gate.py
+++ b/scripts/tests/test_ai_quality_gate.py
@@ -9,7 +9,7 @@ from scripts.ai_quality_gate import (
     gradle_wrapper,
     scan_added_lines,
 )
-from scripts.validate_agent_config import DOCUMENTED_AGENT_IDS
+from scripts.validate_agent_config import missing_skill_references
 
 
 class AiQualityGateTest(unittest.TestCase):
@@ -98,8 +98,17 @@ class AiQualityGateTest(unittest.TestCase):
 
     def test_openclaw_agent_ids_are_not_native_skill_requirements(self) -> None:
         self.assertEqual(
-            {"levyra-ci", "levyra-reviewer", "levyra-worker"},
-            DOCUMENTED_AGENT_IDS,
+            [],
+            missing_skill_references(
+                {"levyra-ci", "levyra-reviewer", "levyra-worker"},
+                set(),
+            ),
+        )
+
+    def test_unknown_documented_skill_still_fails_validation(self) -> None:
+        self.assertEqual(
+            ["levyra-missing-skill"],
+            missing_skill_references({"levyra-missing-skill"}, set()),
         )
 
     def test_full_android_profile_adds_tests_lint_and_compile(self) -> None:

--- a/scripts/validate_agent_config.py
+++ b/scripts/validate_agent_config.py
@@ -140,6 +140,13 @@ def parse_front_matter(path: Path) -> dict[str, str]:
     return metadata
 
 
+def missing_skill_references(
+    referenced_skills: set[str],
+    actual_skills: set[str],
+) -> list[str]:
+    return sorted(referenced_skills - actual_skills - DOCUMENTED_AGENT_IDS)
+
+
 def require_skill_references(
     errors: list[str],
     relative_path: str,
@@ -415,9 +422,7 @@ def main() -> int:
         except (OSError, UnicodeError) as exc:
             errors.append(f"{relative_path}: cannot read file: {exc}")
 
-    missing_skills = sorted(
-        referenced_skills - actual_skills - DOCUMENTED_AGENT_IDS
-    )
+    missing_skills = missing_skill_references(referenced_skills, actual_skills)
     for name in missing_skills:
         errors.append(f"documented skill does not exist: {name}")
 

--- a/scripts/validate_agent_config.py
+++ b/scripts/validate_agent_config.py
@@ -100,6 +100,11 @@ CLAUDE_CANONICAL_BRIDGES = (
 
 SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 SKILL_REFERENCE_RE = re.compile(r"`(levyra-[a-z0-9-]+)`")
+DOCUMENTED_AGENT_IDS = {
+    "levyra-ci",
+    "levyra-reviewer",
+    "levyra-worker",
+}
 
 
 def read_text(relative_path: str) -> str:
@@ -410,7 +415,9 @@ def main() -> int:
         except (OSError, UnicodeError) as exc:
             errors.append(f"{relative_path}: cannot read file: {exc}")
 
-    missing_skills = sorted(referenced_skills - actual_skills)
+    missing_skills = sorted(
+        referenced_skills - actual_skills - DOCUMENTED_AGENT_IDS
+    )
     for name in missing_skills:
         errors.append(f"documented skill does not exist: {name}")
 


### PR DESCRIPTION
## Causa
Il validatore raccoglieva ogni identificatore backtick `levyra-*` dalla documentazione e lo trattava come nome di skill nativa. La nuova guida OpenClaw documenta invece tre ID di agenti (`levyra-worker`, `levyra-reviewer`, `levyra-ci`), causando il fallimento del gate su `main` prima di compilazione e test.

## Impatto
`PR Check` falliva nello step **AI Quality Gate** con tre falsi positivi “documented skill does not exist”, bloccando tutta la validazione Android/F-Droid successiva.

## Modifica
- distingue esplicitamente gli ID degli agenti OpenClaw dai nomi delle skill native;
- mantiene invariata la validazione di tutte le altre referenze `levyra-*`;
- aggiunge una regressione test per il confine agent/skill.

## File
- `scripts/validate_agent_config.py`
- `scripts/tests/test_ai_quality_gate.py`

## Verifiche
- `levyra-worker verify`: superato;
- Android regex compatibility scan: superato;
- validatori e script unit test inclusi nel wrapper: superati.

## Rischi
Bassi. L'eccezione è limitata a tre ID agent documentati e non riduce i controlli sulle skill reali mancanti. Nessun workflow, dipendenza, sorgente applicativo, segreto o release viene modificato.

## Comportamento precedente
La guida OpenClaw valida faceva fallire il gate perché gli agenti venivano scambiati per skill.

## Comportamento atteso
Gli agenti OpenClaw documentati sono accettati come agenti; una qualsiasi altra skill `levyra-*` inesistente continua a far fallire il validatore.
