### PR TITLE
feat(ai): enforce PR-only OpenClaw publication

### DIFF
--- a/scripts/openclaw/levyra-evidence
+++ b/scripts/openclaw/levyra-evidence
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_SLUG="LUC4N3X/Levyra-deepsound"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+fail() {
+  echo "[blocked] $*" >&2
+  exit 2
+}
+
+resolve_repo() {
+  local candidate
+  for candidate in \
+    "${LEVYRA_REPO:-}" \
+    "$SCRIPT_DIR/../repo" \
+    "$PWD/repo" \
+    "$PWD"; do
+    [[ -n "$candidate" ]] || continue
+    if [[ -d "$candidate/.git" ]]; then
+      (cd "$candidate" && pwd -P)
+      return 0
+    fi
+  done
+  fail "Levyra repository checkout not found"
+}
+
+validate_ref() {
+  local ref="$1"
+  [[ "$ref" =~ ^[A-Za-z0-9][A-Za-z0-9._/@:+~^-]*$ ]] || fail "invalid git ref: $ref"
+}
+
+validate_number() {
+  local value="$1"
+  [[ "$value" =~ ^[0-9]+$ ]] || fail "expected a numeric id"
+}
+
+usage() {
+  cat <<'EOF'
+Usage: levyra-evidence <command> [args]
+
+Git evidence:
+  status
+  fetch
+  rev-parse <ref>
+  show <ref>
+  diff <base> <head>
+  log [ref] [count]
+
+GitHub evidence:
+  actions-sha <sha>
+  run-list <sha>
+  run-view <run-id>
+  job-log <job-id>
+  pr-view <number>
+  pr-diff <number>
+  pr-comments <number>
+EOF
+}
+
+REPO="$(resolve_repo)"
+COMMAND="${1:-}"
+shift || true
+
+case "$COMMAND" in
+  status)
+    git -C "$REPO" status --short --branch
+    ;;
+  fetch)
+    git -C "$REPO" fetch --prune origin
+    ;;
+  rev-parse)
+    [[ $# -eq 1 ]] || fail "rev-parse requires exactly one ref"
+    validate_ref "$1"
+    git -C "$REPO" rev-parse --verify "$1^{commit}"
+    ;;
+  show)
+    [[ $# -eq 1 ]] || fail "show requires exactly one ref"
+    validate_ref "$1"
+    git -C "$REPO" show --format=fuller --stat --patch "$1" --
+    ;;
+  diff)
+    [[ $# -eq 2 ]] || fail "diff requires base and head refs"
+    validate_ref "$1"
+    validate_ref "$2"
+    git -C "$REPO" diff --stat --patch "$1" "$2" --
+    ;;
+  log)
+    ref="${1:-HEAD}"
+    count="${2:-30}"
+    [[ $# -le 2 ]] || fail "log accepts at most ref and count"
+    validate_ref "$ref"
+    validate_number "$count"
+    git -C "$REPO" log --oneline --decorate -n "$count" "$ref"
+    ;;
+  actions-sha)
+    [[ $# -eq 1 ]] || fail "actions-sha requires one SHA"
+    validate_ref "$1"
+    gh api --method GET "repos/$REPO_SLUG/actions/runs" -f head_sha="$1" -f per_page=100
+    ;;
+  run-list)
+    [[ $# -eq 1 ]] || fail "run-list requires one SHA"
+    validate_ref "$1"
+    gh run list \
+      --repo "$REPO_SLUG" \
+      --commit "$1" \
+      --limit 100 \
+      --json databaseId,name,event,headSha,status,conclusion,createdAt,updatedAt,url
+    ;;
+  run-view)
+    [[ $# -eq 1 ]] || fail "run-view requires one run id"
+    validate_number "$1"
+    gh run view "$1" \
+      --repo "$REPO_SLUG" \
+      --json databaseId,name,event,headSha,status,conclusion,jobs,url
+    ;;
+  job-log)
+    [[ $# -eq 1 ]] || fail "job-log requires one job id"
+    validate_number "$1"
+    gh run view --repo "$REPO_SLUG" --job "$1" --log
+    ;;
+  pr-view)
+    [[ $# -eq 1 ]] || fail "pr-view requires one PR number"
+    validate_number "$1"
+    gh pr view "$1" \
+      --repo "$REPO_SLUG" \
+      --json number,title,state,isDraft,headRefName,headRefOid,baseRefName,mergeStateStatus,reviewDecision,statusCheckRollup,url
+    ;;
+  pr-diff)
+    [[ $# -eq 1 ]] || fail "pr-diff requires one PR number"
+    validate_number "$1"
+    gh pr diff "$1" --repo "$REPO_SLUG"
+    ;;
+  pr-comments)
+    [[ $# -eq 1 ]] || fail "pr-comments requires one PR number"
+    validate_number "$1"
+    gh pr view "$1" --repo "$REPO_SLUG" --comments
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    usage >&2
+    fail "unsupported evidence command: ${COMMAND:-<empty>}"
+    ;;
+esac

--- a/scripts/openclaw/levyra-worker
+++ b/scripts/openclaw/levyra-worker
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_SLUG="LUC4N3X/Levyra-deepsound"
+BASE_BRANCH="main"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EVIDENCE="$SCRIPT_DIR/levyra-evidence"
+
+fail() {
+  echo "[blocked] $*" >&2
+  exit 2
+}
+
+resolve_repo() {
+  local candidate
+  for candidate in \
+    "${LEVYRA_REPO:-}" \
+    "$SCRIPT_DIR/../repo" \
+    "$PWD/repo" \
+    "$PWD"; do
+    [[ -n "$candidate" ]] || continue
+    if [[ -d "$candidate/.git" ]]; then
+      (cd "$candidate" && pwd -P)
+      return 0
+    fi
+  done
+  fail "Levyra repository checkout not found"
+}
+
+current_branch() {
+  git -C "$REPO" symbolic-ref --quiet --short HEAD || true
+}
+
+validate_work_branch_name() {
+  local branch="$1"
+  [[ -n "$branch" ]] || fail "branch name is required"
+  git check-ref-format --branch "$branch" >/dev/null 2>&1 || fail "invalid branch name: $branch"
+  case "$branch" in
+    main|master)
+      fail "direct work on protected branch '$branch' is not allowed"
+      ;;
+  esac
+}
+
+require_work_branch() {
+  local branch
+  branch="$(current_branch)"
+  [[ -n "$branch" ]] || fail "detached HEAD is not a publishable work branch"
+  validate_work_branch_name "$branch"
+  printf '%s\n' "$branch"
+}
+
+validate_gradle_args() {
+  local arg lowered
+  for arg in "$@"; do
+    lowered="${arg,,}"
+    case "$lowered" in
+      *publish*|*upload*|*deploy*|*promote*)
+        fail "Gradle publication/deployment task is not allowed: $arg"
+        ;;
+    esac
+  done
+}
+
+usage() {
+  cat <<'EOF'
+Usage: levyra-worker <command> [args]
+
+Read/evidence commands:
+  status | fetch | rev-parse <ref> | show <ref> | diff <base> <head> | log [ref] [count]
+  actions-sha <sha> | run-list <sha> | run-view <id> | job-log <id>
+  pr-view <number> | pr-diff <number> | pr-comments <number>
+
+Work branch commands:
+  start <branch>
+  stage [path ...]
+  remove <path ...>
+  move <source> <destination>
+  restore <path ...>
+  commit <message>
+  push
+  pr-open <title> <body>
+  pr-status
+
+Validation commands:
+  quality <fast|full>
+  python-tests
+  gradle <args ...>
+  search <fixed-string> [path]
+
+This wrapper never pushes main/master, merges PRs, creates releases, tags,
+or exposes unrestricted gh/git shell access.
+EOF
+}
+
+REPO="$(resolve_repo)"
+COMMAND="${1:-}"
+shift || true
+
+case "$COMMAND" in
+  status|fetch|rev-parse|show|diff|log|actions-sha|run-list|run-view|job-log|pr-view|pr-diff|pr-comments)
+    [[ -x "$EVIDENCE" ]] || fail "read-only evidence wrapper not installed next to levyra-worker"
+    exec "$EVIDENCE" "$COMMAND" "$@"
+    ;;
+  start)
+    [[ $# -eq 1 ]] || fail "start requires one branch name"
+    branch="$1"
+    validate_work_branch_name "$branch"
+    git -C "$REPO" fetch --prune origin "$BASE_BRANCH"
+    if git -C "$REPO" show-ref --verify --quiet "refs/heads/$branch"; then
+      git -C "$REPO" switch "$branch"
+    elif git -C "$REPO" show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+      git -C "$REPO" switch --track -c "$branch" "origin/$branch"
+    else
+      git -C "$REPO" switch -c "$branch" "origin/$BASE_BRANCH"
+    fi
+    ;;
+  stage)
+    require_work_branch >/dev/null
+    if [[ $# -eq 0 ]]; then
+      git -C "$REPO" add -A
+    else
+      git -C "$REPO" add -- "$@"
+    fi
+    ;;
+  remove)
+    require_work_branch >/dev/null
+    [[ $# -ge 1 ]] || fail "remove requires at least one path"
+    git -C "$REPO" rm -- "$@"
+    ;;
+  move)
+    require_work_branch >/dev/null
+    [[ $# -eq 2 ]] || fail "move requires source and destination"
+    git -C "$REPO" mv -- "$1" "$2"
+    ;;
+  restore)
+    require_work_branch >/dev/null
+    [[ $# -ge 1 ]] || fail "restore requires at least one path"
+    git -C "$REPO" restore -- "$@"
+    ;;
+  commit)
+    require_work_branch >/dev/null
+    [[ $# -ge 1 ]] || fail "commit requires a message"
+    message="$*"
+    git -C "$REPO" commit -m "$message"
+    ;;
+  push)
+    branch="$(require_work_branch)"
+    git -C "$REPO" push --set-upstream origin "HEAD:refs/heads/$branch"
+    ;;
+  pr-open)
+    branch="$(require_work_branch)"
+    [[ $# -eq 2 ]] || fail "pr-open requires title and body"
+    title="$1"
+    body="$2"
+    existing="$(gh pr list --repo "$REPO_SLUG" --base "$BASE_BRANCH" --head "$branch" --state open --json url --jq '.[0].url // empty')"
+    if [[ -n "$existing" ]]; then
+      printf '%s\n' "$existing"
+      exit 0
+    fi
+    gh pr create \
+      --repo "$REPO_SLUG" \
+      --base "$BASE_BRANCH" \
+      --head "$branch" \
+      --title "$title" \
+      --body "$body"
+    ;;
+  pr-status)
+    branch="$(require_work_branch)"
+    gh pr view "$branch" \
+      --repo "$REPO_SLUG" \
+      --json number,title,state,isDraft,headRefName,headRefOid,baseRefName,mergeStateStatus,reviewDecision,statusCheckRollup,url
+    ;;
+  quality)
+    require_work_branch >/dev/null
+    [[ $# -eq 1 ]] || fail "quality requires fast or full"
+    case "$1" in
+      fast|full)
+        (cd "$REPO" && python3 scripts/ai_quality_gate.py --profile "$1")
+        ;;
+      *)
+        fail "quality profile must be fast or full"
+        ;;
+    esac
+    ;;
+  python-tests)
+    require_work_branch >/dev/null
+    [[ $# -eq 0 ]] || fail "python-tests takes no arguments"
+    (cd "$REPO" && python3 -m unittest discover -s scripts/tests)
+    ;;
+  gradle)
+    require_work_branch >/dev/null
+    [[ $# -ge 1 ]] || fail "gradle requires at least one task or option"
+    validate_gradle_args "$@"
+    (cd "$REPO" && ./gradlew "$@")
+    ;;
+  search)
+    [[ $# -ge 1 && $# -le 2 ]] || fail "search requires a fixed string and optional path"
+    pattern="$1"
+    path="${2:-.}"
+    (cd "$REPO" && rg --line-number --fixed-strings -- "$pattern" "$path")
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    usage >&2
+    fail "unsupported worker command: ${COMMAND:-<empty>}"
+    ;;
+esac

--- a/scripts/setup-openclaw-levyra-pr-only.sh
+++ b/scripts/setup-openclaw-levyra-pr-only.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+PRIMARY_WORKSPACE="${LEVYRA_OPENCLAW_WORKSPACE:-$STATE_DIR/workspace-levyra}"
+REVIEW_WORKSPACE="${LEVYRA_REVIEW_WORKSPACE:-$STATE_DIR/workspace-levyra-reviewer}"
+CI_WORKSPACE="${LEVYRA_CI_WORKSPACE:-$STATE_DIR/workspace-levyra-ci}"
+BASE_SETUP="$ROOT/scripts/setup-openclaw-levyra.sh"
+WORKER_SOURCE="$ROOT/scripts/openclaw/levyra-worker"
+EVIDENCE_SOURCE="$ROOT/scripts/openclaw/levyra-evidence"
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+agent_ids() {
+  openclaw agents list --json | python3 -c '
+import json, sys
+value = json.load(sys.stdin)
+if isinstance(value, dict):
+    value = value.get("agents", value.get("items", value.get("list", [])))
+for item in value if isinstance(value, list) else []:
+    if isinstance(item, dict) and item.get("id"):
+        print(item["id"])
+'
+}
+
+has_agent() {
+  agent_ids | grep -Fxq "$1"
+}
+
+choose_primary_agent() {
+  if [[ -n "${LEVYRA_OPENCLAW_AGENT:-}" ]]; then
+    printf '%s\n' "$LEVYRA_OPENCLAW_AGENT"
+  elif has_agent levyra-worker; then
+    printf '%s\n' levyra-worker
+  elif has_agent levyra; then
+    printf '%s\n' levyra
+  else
+    echo "No Levyra primary agent found. Run the base OpenClaw bootstrap first." >&2
+    exit 1
+  fi
+}
+
+agent_index() {
+  local agent="$1"
+  openclaw config get agents.list --json | python3 -c '
+import json, sys
+agent = sys.argv[1]
+value = json.load(sys.stdin)
+if isinstance(value, dict):
+    value = value.get("list", value.get("agents", value.get("items", [])))
+for index, item in enumerate(value if isinstance(value, list) else []):
+    if isinstance(item, dict) and item.get("id") == agent:
+        print(index)
+        raise SystemExit(0)
+raise SystemExit(1)
+' "$agent"
+}
+
+set_agent_json() {
+  local agent="$1"
+  local suffix="$2"
+  local value="$3"
+  local index
+  index="$(agent_index "$agent")"
+  openclaw config set "agents.list[$index].$suffix" "$value" --strict-json
+}
+
+install_tool() {
+  local source="$1"
+  local workspace="$2"
+  local name="$3"
+  local target="$workspace/bin/$name"
+  mkdir -p "$workspace/bin"
+  cp "$source" "$target"
+  chmod 700 "$target"
+  printf '%s\n' "$target"
+}
+
+has_allowlist_pattern() {
+  local agent="$1"
+  local pattern="$2"
+  openclaw approvals get --json | python3 -c '
+import json, sys
+agent, pattern = sys.argv[1], sys.argv[2]
+value = json.load(sys.stdin)
+entries = value.get("file", {}).get("agents", {}).get(agent, {}).get("allowlist", [])
+raise SystemExit(0 if any(isinstance(item, dict) and item.get("pattern") == pattern for item in entries) else 1)
+' "$agent" "$pattern"
+}
+
+ensure_allowlist_pattern() {
+  local agent="$1"
+  local pattern="$2"
+  if ! has_allowlist_pattern "$agent" "$pattern"; then
+    openclaw approvals allowlist add --agent "$agent" "$pattern"
+  fi
+}
+
+remove_allowlist_pattern() {
+  local agent="$1"
+  local pattern="$2"
+  if has_allowlist_pattern "$agent" "$pattern"; then
+    openclaw approvals allowlist remove --agent "$agent" "$pattern"
+  fi
+}
+
+configure_primary_exec() {
+  local agent="$1"
+  set_agent_json "$agent" tools.exec.host '"gateway"'
+  set_agent_json "$agent" tools.exec.mode '"allowlist"'
+  set_agent_json "$agent" tools.exec.strictInlineEval true
+  set_agent_json "$agent" tools.fs.workspaceOnly true
+  set_agent_json "$agent" tools.elevated.enabled false
+}
+
+configure_evidence_exec() {
+  local agent="$1"
+  set_agent_json "$agent" tools.allow '["read","exec","process"]'
+  set_agent_json "$agent" tools.deny '["write","edit","apply_patch","browser","gateway","cron"]'
+  set_agent_json "$agent" tools.exec.host '"gateway"'
+  set_agent_json "$agent" tools.exec.mode '"allowlist"'
+  set_agent_json "$agent" tools.exec.strictInlineEval true
+  set_agent_json "$agent" tools.fs.workspaceOnly true
+  set_agent_json "$agent" tools.elevated.enabled false
+}
+
+append_policy() {
+  local path="$1"
+  local heading="$2"
+  shift 2
+  touch "$path"
+  if ! grep -Fq "$heading" "$path"; then
+    printf '\n%s\n\n' "$heading" >> "$path"
+    printf '%s\n' "$@" >> "$path"
+  fi
+}
+
+require_command openclaw
+require_command python3
+require_command git
+require_command gh
+
+if [[ "${LEVYRA_PR_ONLY_SKIP_BASE_SETUP:-0}" != "1" ]]; then
+  bash "$BASE_SETUP"
+fi
+
+PRIMARY_AGENT="$(choose_primary_agent)"
+has_agent levyra-reviewer || { echo "Missing levyra-reviewer agent" >&2; exit 1; }
+has_agent levyra-ci || { echo "Missing levyra-ci agent" >&2; exit 1; }
+
+PRIMARY_WORKER="$(install_tool "$WORKER_SOURCE" "$PRIMARY_WORKSPACE" levyra-worker)"
+install_tool "$EVIDENCE_SOURCE" "$PRIMARY_WORKSPACE" levyra-evidence >/dev/null
+REVIEW_EVIDENCE="$(install_tool "$EVIDENCE_SOURCE" "$REVIEW_WORKSPACE" levyra-evidence)"
+CI_EVIDENCE="$(install_tool "$EVIDENCE_SOURCE" "$CI_WORKSPACE" levyra-evidence)"
+
+configure_primary_exec "$PRIMARY_AGENT"
+configure_evidence_exec levyra-reviewer
+configure_evidence_exec levyra-ci
+
+for agent in "$PRIMARY_AGENT" levyra-reviewer levyra-ci; do
+  for pattern in git gh /usr/bin/git /usr/bin/gh /bin/git /bin/gh; do
+    remove_allowlist_pattern "$agent" "$pattern"
+  done
+done
+remove_allowlist_pattern "$PRIMARY_AGENT" /usr/local/bin/levyra-worker
+remove_allowlist_pattern "$PRIMARY_AGENT" /usr/local/bin/levyra-release-main
+
+ensure_allowlist_pattern "$PRIMARY_AGENT" "$PRIMARY_WORKER"
+ensure_allowlist_pattern levyra-reviewer "$REVIEW_EVIDENCE"
+ensure_allowlist_pattern levyra-ci "$CI_EVIDENCE"
+
+append_policy "$PRIMARY_WORKSPACE/AGENTS.md" "## Levyra PR-only publication policy" \
+  "For Levyra implementation work, start or switch to a non-main work branch with \`./bin/levyra-worker start <branch>\` before editing." \
+  "Use normal workspace edit tools for code changes and \`./bin/levyra-worker\` for Git, validation, push, and PR operations." \
+  "The only publication path is: work branch -> commit -> push that branch -> open a Pull Request against main." \
+  "Never push directly to main/master, merge a PR, create a tag or release, deploy, or bypass the wrapper with raw Git/GitHub shell commands."
+
+append_policy "$REVIEW_WORKSPACE/AGENTS.md" "## Levyra evidence command policy" \
+  "Use \`./bin/levyra-evidence\` for Git and GitHub evidence, including show/diff/fetch and exact-SHA Actions queries." \
+  "Do not use raw Git or gh commands and do not modify the checkout beyond fetch metadata."
+
+append_policy "$CI_WORKSPACE/AGENTS.md" "## Levyra evidence command policy" \
+  "Use \`./bin/levyra-evidence\` for Git and GitHub evidence, especially \`actions-sha <sha>\` or \`run-list <sha>\` before concluding that CI is absent." \
+  "Do not use raw Git or gh commands and do not modify source, workflows, or repository state."
+
+openclaw config validate
+
+echo "OpenClaw Levyra PR-only policy ready."
+echo "Primary agent: $PRIMARY_AGENT"
+echo "Primary worker: $PRIMARY_WORKER"
+echo "Reviewer evidence: $REVIEW_EVIDENCE"
+echo "CI evidence: $CI_EVIDENCE"
+echo "Publication boundary: branch + Pull Request only; no direct main push, merge, release, or deploy."

--- a/scripts/tests/test_openclaw_pr_only_policy.py
+++ b/scripts/tests/test_openclaw_pr_only_policy.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKER = ROOT / "scripts" / "openclaw" / "levyra-worker"
+EVIDENCE = ROOT / "scripts" / "openclaw" / "levyra-evidence"
+SETUP = ROOT / "scripts" / "setup-openclaw-levyra-pr-only.sh"
+
+
+class OpenClawPrOnlyPolicyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.repo = self.root / "repo"
+        self.bin_dir = self.root / "bin"
+        self.repo.mkdir()
+        self.bin_dir.mkdir()
+
+        shutil.copy2(WORKER, self.bin_dir / "levyra-worker")
+        shutil.copy2(EVIDENCE, self.bin_dir / "levyra-evidence")
+        os.chmod(self.bin_dir / "levyra-worker", 0o700)
+        os.chmod(self.bin_dir / "levyra-evidence", 0o700)
+
+        self.run_git("init", "-b", "main")
+        self.run_git("config", "user.name", "Levyra Test")
+        self.run_git("config", "user.email", "levyra@example.invalid")
+        (self.repo / "sample.txt").write_text("one\n", encoding="utf-8")
+        self.run_git("add", "sample.txt")
+        self.run_git("commit", "-m", "initial")
+
+        self.env = os.environ.copy()
+        self.env["LEVYRA_REPO"] = str(self.repo)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def run_git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", "-C", str(self.repo), *args],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
+    def run_worker(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(self.bin_dir / "levyra-worker"), *args],
+            env=self.env,
+            text=True,
+            capture_output=True,
+        )
+
+    def run_evidence(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(self.bin_dir / "levyra-evidence"), *args],
+            env=self.env,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_shell_syntax(self) -> None:
+        for script in (WORKER, EVIDENCE, SETUP):
+            subprocess.run(["bash", "-n", str(script)], check=True, cwd=ROOT)
+
+    def test_worker_blocks_mutating_publication_from_main(self) -> None:
+        for command in (("commit", "blocked"), ("push",), ("pr-open", "Title", "Body")):
+            result = self.run_worker(*command)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("protected branch", result.stderr)
+
+    def test_evidence_reconstructs_commit_without_pull_request(self) -> None:
+        (self.repo / "sample.txt").write_text("one\ntwo\n", encoding="utf-8")
+        self.run_git("add", "sample.txt")
+        self.run_git("commit", "-m", "second")
+
+        show = self.run_evidence("show", "HEAD")
+        diff = self.run_evidence("diff", "HEAD^", "HEAD")
+
+        self.assertEqual(show.returncode, 0, show.stderr)
+        self.assertEqual(diff.returncode, 0, diff.stderr)
+        self.assertIn("second", show.stdout)
+        self.assertIn("+two", diff.stdout)
+
+    def test_worker_blocks_gradle_publication_tasks_on_work_branch(self) -> None:
+        self.run_git("switch", "-c", "agent/test")
+        result = self.run_worker("gradle", "publish")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("publication/deployment", result.stderr)
+
+    def test_policy_setup_replaces_legacy_exec_paths_with_role_wrappers(self) -> None:
+        setup = SETUP.read_text(encoding="utf-8")
+
+        for term in (
+            'tools.exec.mode',
+            "allowlist",
+            "/usr/local/bin/levyra-worker",
+            "/usr/local/bin/levyra-release-main",
+            "ensure_allowlist_pattern \"$PRIMARY_AGENT\" \"$PRIMARY_WORKER\"",
+            "ensure_allowlist_pattern levyra-reviewer \"$REVIEW_EVIDENCE\"",
+            "ensure_allowlist_pattern levyra-ci \"$CI_EVIDENCE\"",
+            "Levyra PR-only publication policy",
+            "branch + Pull Request only",
+        ):
+            self.assertIn(term, setup)
+
+    def test_worker_has_no_merge_release_or_direct_main_publication_command(self) -> None:
+        worker = WORKER.read_text(encoding="utf-8")
+
+        for forbidden in (
+            "gh pr merge",
+            "gh release create",
+            "git push origin main",
+            "git push origin master",
+        ):
+            self.assertNotIn(forbidden, worker)
+
+        for required in (
+            'git -C "$REPO" push --set-upstream origin "HEAD:refs/heads/$branch"',
+            "gh pr create",
+            "validate_work_branch_name",
+        ):
+            self.assertIn(required, worker)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a guarded `levyra-worker` wrapper that can inspect, edit through normal workspace tools, validate, stage, commit, push only the current non-main branch, and open a PR against `main`
- add a separate read-only `levyra-evidence` wrapper for reviewer/CI Git and GitHub evidence, including exact-SHA Actions queries
- add a PR-only OpenClaw policy bootstrap that switches exec to deterministic allowlists, removes legacy raw Git/gh and `levyra-release-main` approvals, and installs role-specific wrappers
- keep reviewer and CI agents read-only while giving the primary worker the practical branch workflow needed for implementation
- add regression coverage for protected-branch blocking, commit diff reconstruction, Gradle publication blocking, and policy wiring

## Publication boundary

The OpenClaw worker may work autonomously on a non-main branch and may push that branch and open a Pull Request. It cannot use the wrapper to push `main`/`master`, merge a PR, create a release/tag, deploy, or use unrestricted raw Git/GitHub shell commands.

GitHub currently reports `main` as unprotected, so this PR intentionally enforces the agent boundary in the OpenClaw execution policy instead of assuming server-side branch protection.

## Validation

- branch rebased to current `main`
- final diff reviewed: 4 new files, one commit, no unrelated Android/Desktop changes
- shell and policy regression tests added; CI is expected to run the repository quality gates on this PR

No merge, release, deploy, version, workflow, secret, or repository-setting changes are performed by this PR.