### PR TITLE
fix(ai): keep Codex evidence agents executable

### DIFF
--- a/scripts/setup-openclaw-levyra-pr-only.sh
+++ b/scripts/setup-openclaw-levyra-pr-only.sh
@@ -124,7 +124,7 @@ configure_evidence_exec() {
   set_agent_json "$agent" tools.allow '["read","exec","process"]'
   set_agent_json "$agent" tools.deny '["write","edit","apply_patch","browser","gateway","cron"]'
   set_agent_json "$agent" tools.exec.host '"gateway"'
-  set_agent_json "$agent" tools.exec.mode '"allowlist"'
+  set_agent_json "$agent" tools.exec.mode '"auto"'
   set_agent_json "$agent" tools.exec.strictInlineEval true
   set_agent_json "$agent" tools.fs.workspaceOnly true
   set_agent_json "$agent" tools.elevated.enabled false

--- a/scripts/tests/test_openclaw_pr_only_policy.py
+++ b/scripts/tests/test_openclaw_pr_only_policy.py
@@ -110,6 +110,21 @@ class OpenClawPrOnlyPolicyTest(unittest.TestCase):
         ):
             self.assertIn(term, setup)
 
+    def test_codex_evidence_agents_use_auto_exec_with_wrapper_allowlists(self) -> None:
+        setup = SETUP.read_text(encoding="utf-8")
+        primary_block = setup.split("configure_primary_exec()", 1)[1].split(
+            "configure_evidence_exec()", 1
+        )[0]
+        evidence_block = setup.split("configure_evidence_exec()", 1)[1].split(
+            "append_policy()", 1
+        )[0]
+
+        self.assertIn("tools.exec.mode '\"allowlist\"'", primary_block)
+        self.assertIn("tools.exec.mode '\"auto\"'", evidence_block)
+        self.assertNotIn("tools.exec.mode '\"allowlist\"'", evidence_block)
+        self.assertIn("ensure_allowlist_pattern levyra-reviewer", setup)
+        self.assertIn("ensure_allowlist_pattern levyra-ci", setup)
+
     def test_worker_has_no_merge_release_or_direct_main_publication_command(self) -> None:
         worker = WORKER.read_text(encoding="utf-8")
 


### PR DESCRIPTION
Fix the OpenClaw PR-only bootstrap so Codex-backed reviewer and CI agents use `tools.exec.mode=auto` while keeping their existing per-agent `levyra-evidence` allowlists and read-only tool policy. The primary worker remains on `allowlist`. Adds focused regression coverage. No merge, release, deploy, workflow, secret, or repository-setting changes.