### PR TITLE
fix(ai): pin spawned evidence wrappers to specialist workspaces

### DIFF
--- a/scripts/setup-openclaw-levyra-pr-only.sh
+++ b/scripts/setup-openclaw-levyra-pr-only.sh
@@ -141,6 +141,37 @@ append_policy() {
   fi
 }
 
+upsert_policy() {
+  local path="$1"
+  local heading="$2"
+  shift 2
+  python3 - "$path" "$heading" "$@" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+heading = sys.argv[2]
+body = list(sys.argv[3:])
+text = path.read_text(encoding="utf-8") if path.exists() else ""
+lines = text.splitlines()
+section = [heading, "", *body]
+start = next((index for index, line in enumerate(lines) if line == heading), None)
+if start is None:
+    if lines and lines[-1] != "":
+        lines.append("")
+    lines.extend(section)
+else:
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("## "):
+            end = index
+            break
+    lines[start:end] = section + ([""] if end < len(lines) else [])
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+PY
+}
+
 require_command openclaw
 require_command python3
 require_command git
@@ -181,12 +212,19 @@ append_policy "$PRIMARY_WORKSPACE/AGENTS.md" "## Levyra PR-only publication poli
   "The only publication path is: work branch -> commit -> push that branch -> open a Pull Request against main." \
   "Never push directly to main/master, merge a PR, create a tag or release, deploy, or bypass the wrapper with raw Git/GitHub shell commands."
 
-append_policy "$REVIEW_WORKSPACE/AGENTS.md" "## Levyra evidence command policy" \
-  "Use \`./bin/levyra-evidence\` for Git and GitHub evidence, including show/diff/fetch and exact-SHA Actions queries." \
+upsert_policy "$PRIMARY_WORKSPACE/AGENTS.md" "## Levyra specialist evidence paths" \
+  "When delegating to levyra-reviewer, require the absolute wrapper \`$REVIEW_EVIDENCE\`; do not hand the child \`./bin/levyra-evidence\`." \
+  "When delegating to levyra-ci, require the absolute wrapper \`$CI_EVIDENCE\`; do not hand the child \`./bin/levyra-evidence\`." \
+  "A spawned specialist may inherit the requester working directory, so relative wrapper paths are not valid evidence roots."
+
+upsert_policy "$REVIEW_WORKSPACE/AGENTS.md" "## Levyra evidence command policy" \
+  "Use \`$REVIEW_EVIDENCE\` for Git and GitHub evidence, including show/diff/fetch and exact-SHA Actions queries." \
+  "Use that absolute wrapper path even when spawnedCwd points at the requester workspace; do not invoke \`./bin/levyra-evidence\`." \
   "Do not use raw Git or gh commands and do not modify the checkout beyond fetch metadata."
 
-append_policy "$CI_WORKSPACE/AGENTS.md" "## Levyra evidence command policy" \
-  "Use \`./bin/levyra-evidence\` for Git and GitHub evidence, especially \`actions-sha <sha>\` or \`run-list <sha>\` before concluding that CI is absent." \
+upsert_policy "$CI_WORKSPACE/AGENTS.md" "## Levyra evidence command policy" \
+  "Use \`$CI_EVIDENCE\` for Git and GitHub evidence, especially \`actions-sha <sha>\` or \`run-list <sha>\` before concluding that CI is absent." \
+  "Use that absolute wrapper path even when spawnedCwd points at the requester workspace; do not invoke \`./bin/levyra-evidence\`." \
   "Do not use raw Git or gh commands and do not modify source, workflows, or repository state."
 
 openclaw config validate

--- a/scripts/tests/test_openclaw_pr_only_policy.py
+++ b/scripts/tests/test_openclaw_pr_only_policy.py
@@ -125,6 +125,28 @@ class OpenClawPrOnlyPolicyTest(unittest.TestCase):
         self.assertIn("ensure_allowlist_pattern levyra-reviewer", setup)
         self.assertIn("ensure_allowlist_pattern levyra-ci", setup)
 
+    def test_spawned_evidence_agents_receive_absolute_role_paths(self) -> None:
+        setup = SETUP.read_text(encoding="utf-8")
+
+        for term in (
+            "upsert_policy()",
+            "Levyra specialist evidence paths",
+            "require the absolute wrapper \\`$REVIEW_EVIDENCE\\`",
+            "require the absolute wrapper \\`$CI_EVIDENCE\\`",
+            "spawnedCwd",
+            "do not invoke \\`./bin/levyra-evidence\\`",
+        ):
+            self.assertIn(term, setup)
+
+        self.assertIn(
+            'upsert_policy "$REVIEW_WORKSPACE/AGENTS.md" "## Levyra evidence command policy"',
+            setup,
+        )
+        self.assertIn(
+            'upsert_policy "$CI_WORKSPACE/AGENTS.md" "## Levyra evidence command policy"',
+            setup,
+        )
+
     def test_worker_has_no_merge_release_or_direct_main_publication_command(self) -> None:
         worker = WORKER.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- make the PR-only bootstrap upsert specialist evidence instructions instead of leaving stale relative paths
- tell the primary Levyra orchestrator the exact absolute reviewer and CI wrapper paths
- require spawned reviewer/CI agents to invoke their own absolute `levyra-evidence` wrapper even when `spawnedCwd` points at the requester workspace
- keep existing Codex `tools.exec.mode=auto`, role-specific host allowlists, and read-only reviewer/CI boundaries unchanged
- add focused regression coverage for the spawned-path contract

## Why

Direct `levyra-reviewer` execution succeeds, while spawned reviewer and CI sessions finish with their bash tool calls in error. Runtime metadata shows the spawned sessions inherit the requester cwd, so `./bin/levyra-evidence` can resolve against the primary workspace instead of the specialist workspace. The host allowlist intentionally permits only each specialist's own absolute wrapper.

No merge, release, deploy, workflow, secret, or repository-setting changes are included.