### PR TITLE
fix(ai): persist OpenClaw evidence runtime

### DIFF
--- a/scripts/openclaw/configure-evidence-runtime.sh
+++ b/scripts/openclaw/configure-evidence-runtime.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+agent_index() {
+  local agent="$1"
+  openclaw config get agents.list --json | python3 -c '
+import json, sys
+agent = sys.argv[1]
+value = json.load(sys.stdin)
+if isinstance(value, dict):
+    value = value.get("list", value.get("agents", value.get("items", [])))
+for index, item in enumerate(value if isinstance(value, list) else []):
+    if isinstance(item, dict) and item.get("id") == agent:
+        print(index)
+        raise SystemExit(0)
+raise SystemExit(1)
+' "$agent"
+}
+
+effective_model() {
+  local index="$1"
+  openclaw config get agents --json | python3 -c '
+import json, sys
+index = int(sys.argv[1])
+value = json.load(sys.stdin)
+agents = value.get("list", value.get("agents", value.get("items", []))) if isinstance(value, dict) else []
+defaults = value.get("defaults", {}) if isinstance(value, dict) else {}
+
+def primary(model):
+    if isinstance(model, str):
+        return model
+    if isinstance(model, dict):
+        return model.get("primary")
+    return None
+
+if not isinstance(agents, list) or index >= len(agents) or not isinstance(agents[index], dict):
+    raise SystemExit(1)
+model = primary(agents[index].get("model")) or primary(defaults.get("model"))
+if not isinstance(model, str) or not model:
+    raise SystemExit(1)
+print(model)
+' "$index"
+}
+
+configure_agent() {
+  local agent="$1"
+  local index model runtime_json
+  index="$(agent_index "$agent")"
+  model="$(effective_model "$index")"
+  runtime_json="$(python3 -c 'import json, sys; print(json.dumps({sys.argv[1]: {"agentRuntime": {"id": "openclaw"}}}, separators=(",", ":")))' "$model")"
+
+  openclaw config set "agents.list[$index].models" "$runtime_json" --strict-json --merge
+  openclaw config set "agents.list[$index].tools.exec.mode" '"allowlist"' --strict-json
+}
+
+configure_agent levyra-reviewer
+configure_agent levyra-ci
+openclaw config validate

--- a/scripts/setup-openclaw-levyra-pr-only-openclaw.sh
+++ b/scripts/setup-openclaw-levyra-pr-only-openclaw.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+bash "$ROOT/scripts/setup-openclaw-levyra-pr-only.sh"
+bash "$ROOT/scripts/openclaw/configure-evidence-runtime.sh"


### PR DESCRIPTION
## Summary

- persist the tested `agentRuntime.id = openclaw` override for `levyra-reviewer` and `levyra-ci`
- restore `tools.exec.mode = allowlist` for those evidence agents so execution stays behind the host wrapper policy
- resolve the effective model from either the agent entry or inherited defaults before applying the runtime override
- add a PR-only bootstrap wrapper that runs the existing publication policy setup first, then applies the evidence runtime override
- do not enable Codex `networkProxy`, do not broaden host allowlists, and do not change merge/release/deploy permissions

## Verified on VPS

The live smoke test showed both specialist agents using `agentRuntime.id = openclaw`. `levyra-ci` then completed `actions-sha` and `run-list` for the exact SHA successfully, reporting the three matching GitHub Actions runs with `toolSummary.failures = 0`. The same GitHub queries had previously failed from the Codex app-server runtime with `error connecting to api.github.com` while host `gh api` and `curl https://api.github.com` were healthy.

## Scope

Only OpenClaw bootstrap/runtime helper scripts are added. No Android/Desktop source, workflow, secret, repository setting, release, deployment, or merge behavior is changed.