### PR TITLE
docs(ai): add execution-first policy for all coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,10 @@
 
 ## Purpose and hierarchy
 
-This file is the repository-wide operating contract for coding agents. Codex,
-Google Antigravity, OpenClaw, and compatible runtimes should read it from the
-Git root, then apply any nearer `AGENTS.md` for the files in scope.
+This file is the repository-wide operating contract for coding agents. Claude
+Code, Codex, ChatGPT when operating through a repository-capable runtime,
+Google Antigravity, OpenCode, OpenClaw, and compatible runtimes should read it
+from the Git root, then apply any nearer `AGENTS.md` for the files in scope.
 
 Instruction order:
 
@@ -69,6 +70,42 @@ complexity-budget, and diff-quality rules.
 Runtime-specific discovery must not create separate sources of truth. This file,
 nearest scoped instructions, approved planning, matching skills, and current
 repository evidence remain the shared hierarchy.
+
+## Execution-first operating mode
+
+This policy is shared by every supported coding runtime. It is not a
+Claude-specific preference.
+
+- When the owner asks to `fix`, `update`, `address`, `implement`, `refactor`, or
+  otherwise change code, execute the requested work directly inside the
+  authorized scope. Do not turn an implementation request into an unsolicited
+  design discussion, tutorial, list of alternatives, or approval pause.
+- Do not ask routine confirmation questions when the requested outcome,
+  repository evidence, and existing architecture already determine the next
+  safe action.
+- Ask only when an indispensable input is missing, materially different
+  interpretations would produce meaningfully different results, or the next
+  action is destructive, irreversible, security-sensitive, or outside the
+  owner's existing authorization.
+- If the requested approach conflicts with current repository evidence,
+  security, data integrity, compatibility, product invariants, or deterministic
+  validation, surface the conflict briefly and choose the smallest safe
+  correction when it remains inside scope. Never silently execute a known-bad
+  approach merely to appear compliant.
+- For code-bearing work: inspect the current owner and nearby tests, make the
+  smallest coherent change, run focused validation, fix regressions introduced
+  by the change, inspect the final diff, then report the result, files changed,
+  checks run, and any real blocker.
+- Treat `only this`, `solo questo`, and equivalent wording as a hard scope
+  boundary. Do not perform opportunistic refactors, unrelated cleanup,
+  dependency churn, version changes, or speculative architecture work.
+- Prefer execution over commentary. Explain decisions only when they materially
+  affect correctness, safety, compatibility, validation, or the owner's next
+  action.
+- Execution-first behavior never grants permission to commit, push, open or
+  merge a pull request, tag, publish, release, deploy, change repository
+  settings, bypass approvals, weaken sandboxing, or skip required validation.
+  Those actions keep their existing owner-controlled authorization rules.
 
 ## Always-on context budget
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Claude-specific preference.
   validation, surface the conflict briefly and choose the smallest safe
   correction when it remains inside scope. Never silently execute a known-bad
   approach merely to appear compliant.
-- For code-bearing work: inspect the current owner and nearby tests, make the
+- For code-bearing work: inspect the current implementation and nearby tests, make the
   smallest coherent change, run focused validation, fix regressions introduced
   by the change, inspect the final diff, then report the result, files changed,
   checks run, and any real blocker.


### PR DESCRIPTION
## Summary

- make the root `AGENTS.md` explicitly cover Claude Code, Codex, ChatGPT repository runtimes, Antigravity, OpenCode, OpenClaw, and compatible agents
- add a shared execution-first operating mode so implementation requests are executed directly instead of becoming unnecessary discussions or approval pauses
- keep safety, scope, validation, and owner-controlled publication boundaries intact

## Behavior

The new policy tells supported runtimes to:

- execute `fix` / `update` / `address` / `implement` / `refactor` requests directly within the authorized scope
- avoid routine confirmation questions and unsolicited alternatives
- ask only when indispensable information is missing, interpretations materially diverge, or the action is destructive/security-sensitive/outside authorization
- flag genuinely unsafe or incompatible requests instead of blindly following them
- treat `only this` / `solo questo` as a hard scope boundary
- make the smallest coherent change, validate it, inspect the final diff, and report the result

Publication, merge, release, repository settings, approval bypasses, sandbox weakening, and skipped validation remain explicitly owner-controlled.

## Files changed

- `AGENTS.md`

## Validation

- final commit diff inspected: only `AGENTS.md` changed (`+40 / -3`)
- repository quality gates were not run locally because this ChatGPT runtime does not have a runnable repository checkout
- CI/PR checks remain the validation authority; no unrun check is claimed as passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository guidance to support Claude Code and ChatGPT workflows.
  * Clarified implementation practices, confirmation requirements, scope control, validation steps, and restrictions on publishing or changing repository settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->