### PR TITLE
Fix NewPipeRuntime Kotlin return-type warning

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/NewPipeRuntime.kt
@@ -88,12 +88,14 @@ object NewPipeRuntime {
             if (english) "" else ",en-US;q=0.8,en;q=0.7"
     }
 
-    private fun applyRequestedLocalization() = synchronized(this) {
-        val requested = requestedLanguage
-        if (requested.isBlank() || requested == appliedLanguage) return
-        val locale = LevyraContentLocales.forLanguage(requested)
-        NewPipe.setupLocalization(Localization(locale.hl, locale.gl), ContentCountry(locale.gl))
-        appliedLanguage = locale.languageCode
+    private fun applyRequestedLocalization() {
+        synchronized(this) {
+            val requested = requestedLanguage
+            if (requested.isBlank() || requested == appliedLanguage) return
+            val locale = LevyraContentLocales.forLanguage(requested)
+            NewPipe.setupLocalization(Localization(locale.hl, locale.gl), ContentCountry(locale.gl))
+            appliedLanguage = locale.languageCode
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the expression-bodied `applyRequestedLocalization()` with a block-bodied function
- preserve the existing synchronized localization flow and early-return behavior
- remove the Kotlin warning that will become an error with language version 2.5

## Scope
- only `NewPipeRuntime.kt` is changed
- no playback, networking, localization, or UI behavior is intentionally modified

## Validation
- verified the diff is limited to the function-body form change