### PR TITLE
feat(extractor): unify YouTube client identity and add content-aware fallback

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -7,6 +7,11 @@ import com.luc4n3x.levyra.BuildConfig
 import com.luc4n3x.levyra.data.security.GoogleApiKeyHeaders
 import com.luc4n3x.levyra.data.local.LevyraDatabase
 import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
+import com.luc4n3x.levyra.data.network.YoutubeClientProfile
+import com.luc4n3x.levyra.data.network.YoutubeClientRanking
+import com.luc4n3x.levyra.data.network.YoutubeClientRegistry
+import com.luc4n3x.levyra.data.network.YoutubeContentAwareClientSelector
+import com.luc4n3x.levyra.data.network.YoutubeContentHints
 import com.luc4n3x.levyra.domain.LevyraContentLocales
 import com.luc4n3x.levyra.domain.PlaybackDeliveryMethod
 import com.luc4n3x.levyra.domain.PlaybackStreamDescriptor
@@ -86,6 +91,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         private const val YOUTUBE_VIDEO_ID_PATTERN = "[A-Za-z0-9_-]{11}"
         private const val LEVYRA_EXTRACTOR_PROVIDER = "LevyraExtractor"
         private const val LEVYRA_EXTRACTOR_HLS_PROVIDER = "LevyraExtractor HLS"
+        private const val MAX_CONTENT_HINT_ENTRIES = 256
         private val youtubeVideoIdRegex = Regex(YOUTUBE_VIDEO_ID_PATTERN)
         private val youtubeVideoUrlRegex = Regex("(?:v=|/shorts/|/embed/|/live/|youtu\\.be/)($YOUTUBE_VIDEO_ID_PATTERN)")
         private val youtubeSearchResultVideoIdRegex = Regex("""\\?["]videoId\\?["]\s*:\s*\\?["]($YOUTUBE_VIDEO_ID_PATTERN)\\?["]""")
@@ -145,15 +151,12 @@ class PlaybackResolver private constructor(private val context: Context) {
     @Volatile
     private var lastNetworkWarmAt = 0L
 
-    private val profiles = listOf(
-        ClientProfile("ANDROID_VR", "1.65.10", "Android VR", "com.google.android.apps.youtube.vr.oculus/1.65.10 (Linux; U; Android 12L; Quest 3 Build/SQ3A.220605.009.A1) gzip", true, 0L, 0, false),
-        ClientProfile("ANDROID_MUSIC", "8.10.52", "Android Music", "Mozilla/5.0 (Linux; Android 15; Pixel 8 Pro) AppleWebKit/537.36 (KHTML, like Gecko) com.google.android.apps.youtube.music/8.10.52", true, 0L, 1, false),
-        ClientProfile("ANDROID", "19.44.38", "Android", "com.google.android.youtube/19.44.38 (Linux; U; Android 15)", true, 0L, 2, false),
-        ClientProfile("IOS", "20.10.4", "iOS", "com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3 like Mac OS X; it_IT)", false, 0L, 3, false),
-        ClientProfile("WEB_REMIX", "1.20260423.01.00", "YouTube Music Web", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36", false, 0L, 4, true),
-        ClientProfile("WEB", "2.20260630.01.00", "YouTube Web", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36", false, 0L, 5, true),
-        ClientProfile("WEB_EMBEDDED_PLAYER", "1.20260423.01.00", "Embedded Player", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36", false, 0L, 6, false)
-    )
+    private val profiles = YoutubeClientRegistry.playbackProfiles
+    private val contentHintsLock = Any()
+    private val contentHints = object : LinkedHashMap<String, YoutubeContentHints>(64, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, YoutubeContentHints>): Boolean =
+            size > MAX_CONTENT_HINT_ENTRIES
+    }
 
     init {
         restoreCache()
@@ -973,7 +976,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         isVideoMode: Boolean,
         audioQuality: String
     ): DirectStream? {
-        val ladder = orderedProfiles().map { profile ->
+        val ladder = orderedProfiles(contentHints(track)).map { profile ->
             listOf(
                 suspend {
                     runCatchingPreservingCancellation { resolveWithInnerTube(track, profile, isVideoMode, false, audioQuality) }
@@ -1017,7 +1020,7 @@ class PlaybackResolver private constructor(private val context: Context) {
     ): DirectStream? = coroutineScope {
         val winner = CompletableDeferred<DirectStream?>()
         val fallback = AtomicReference<DirectStream?>(null)
-        val workers = orderedProfiles().mapIndexed { index, profile ->
+        val workers = orderedProfiles(contentHints(track)).mapIndexed { index, profile ->
             launch {
                 val dynamicDelay = profile.delayMs + index * 20L
                 if (dynamicDelay > 0L) delay(dynamicDelay)
@@ -1048,32 +1051,52 @@ class PlaybackResolver private constructor(private val context: Context) {
         result
     }
 
-    private fun profileFromSource(source: String): ClientProfile? {
+    private fun profileFromSource(source: String): YoutubeClientProfile? {
         val normalized = source.lowercase()
         return profiles.firstOrNull { profile ->
             normalized.contains(profile.label.lowercase()) || normalized.contains(profile.clientName.lowercase())
         }
     }
 
-    private fun orderedProfiles(): List<ClientProfile> {
-        val now = System.currentTimeMillis()
-        val available = profiles.filter { profile -> (clientHealth[profile.clientName]?.blockedUntilMs ?: 0L) <= now }
-        val candidates = if (available.isNotEmpty()) available else profiles
-        val sorted = candidates.sortedWith(
-            compareByDescending<ClientProfile> { profile -> clientHealth[profile.clientName]?.score ?: 50.0 }
-                .thenBy { profile -> clientHealth[profile.clientName]?.averageLatencyMs ?: Long.MAX_VALUE }
-                .thenBy { it.tier }
-        )
-        val vr = sorted.firstOrNull { it.clientName == "ANDROID_VR" } ?: return sorted
-        val best = sorted.firstOrNull() ?: return sorted
-        val vrHealth = clientHealth[vr.clientName]
-        val bestScore = clientHealth[best.clientName]?.score ?: 50.0
-        val vrScore = vrHealth?.score ?: 50.0
-        val keepVrPrimary = vrHealth?.consecutiveFailures.orZero() == 0 && vrScore >= bestScore - 12.0
-        return if (keepVrPrimary) listOf(vr) + sorted.filterNot { it === vr } else sorted
+    private fun orderedProfiles(hints: YoutubeContentHints): List<YoutubeClientProfile> {
+        return YoutubeContentAwareClientSelector.order(
+            profiles = profiles,
+            hints = hints,
+            nowMs = System.currentTimeMillis()
+        ) { profile ->
+            clientHealth[profile.clientName]?.let { health ->
+                YoutubeClientRanking(
+                    score = health.score,
+                    averageLatencyMs = health.averageLatencyMs,
+                    consecutiveFailures = health.consecutiveFailures,
+                    blockedUntilMs = health.blockedUntilMs
+                )
+            }
+        }
     }
 
-    private fun recordClientSuccess(profile: ClientProfile, latencyMs: Long) {
+    private fun contentHints(track: Track): YoutubeContentHints {
+        val metadata = YoutubeContentHints.fromMetadata(track.videoType)
+        val videoId = PlaybackSourceIdentity.sourceVideoId(track).takeIf { it.isNotBlank() }
+            ?: return metadata
+        val observed = synchronized(contentHintsLock) { contentHints[videoId] } ?: return metadata
+        return metadata.mergedWith(observed)
+    }
+
+    private fun playerResponseHints(root: JSONObject): YoutubeContentHints {
+        val details = root.optJSONObject("videoDetails") ?: return YoutubeContentHints.NONE
+        val live = details.optBoolean("isLiveContent", false) || details.optBoolean("isLive", false)
+        return YoutubeContentHints(isLive = true.takeIf { live })
+    }
+
+    private fun observeContentHints(videoId: String, observed: YoutubeContentHints) {
+        if (videoId.isBlank() || observed == YoutubeContentHints.NONE) return
+        synchronized(contentHintsLock) {
+            contentHints[videoId] = contentHints[videoId]?.mergedWith(observed) ?: observed
+        }
+    }
+
+    private fun recordClientSuccess(profile: YoutubeClientProfile, latencyMs: Long) {
         clientHealth.compute(profile.clientName) { name, current ->
             val previous = current ?: ClientHealth()
             val samples = (previous.successes + 1).coerceAtMost(10_000)
@@ -1092,7 +1115,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         }
     }
 
-    private fun recordClientFailure(profile: ClientProfile, latencyMs: Long?, error: Throwable) {
+    private fun recordClientFailure(profile: YoutubeClientProfile, latencyMs: Long?, error: Throwable) {
         if (!hasValidatedInternet()) {
             clearTransientClientPenalties()
             return
@@ -1346,7 +1369,7 @@ class PlaybackResolver private constructor(private val context: Context) {
 
     private suspend fun resolveWithInnerTube(
         track: Track,
-        profile: ClientProfile,
+        profile: YoutubeClientProfile,
         isVideoMode: Boolean = false,
         preferMp4Audio: Boolean = false,
         audioQuality: String = selectedAudioQuality
@@ -1385,7 +1408,7 @@ class PlaybackResolver private constructor(private val context: Context) {
 
     private suspend fun resolveWithInnerTubeOnce(
         track: Track,
-        profile: ClientProfile,
+        profile: YoutubeClientProfile,
         isVideoMode: Boolean,
         preferMp4Audio: Boolean,
         audioQuality: String
@@ -1400,7 +1423,7 @@ class PlaybackResolver private constructor(private val context: Context) {
             playbackSecurity.cachedSession()
         }
         val poTokens = if (profile.requiresPoToken) playbackSecurity.poTokensForPlayback(sourceVideoId, session) else null
-        val signatureTimestamp = if (profile.clientName.startsWith("WEB")) {
+        val signatureTimestamp = if (profile.useSignatureTimestamp) {
             runCatchingPreservingCancellation {
                 YoutubeJavaScriptPlayerManager.getSignatureTimestamp(sourceVideoId)
             }.getOrNull()
@@ -1420,15 +1443,15 @@ class PlaybackResolver private constructor(private val context: Context) {
             .post(body.toRequestBody(jsonMediaType))
             .header("Content-Type", "application/json")
             .header("Accept", "application/json")
-            .header("Origin", if (profile.clientName == "WEB_REMIX") "https://music.youtube.com" else "https://www.youtube.com")
-            .header("Referer", if (profile.clientName == "WEB_EMBEDDED_PLAYER") "https://www.youtube.com/embed/$sourceVideoId" else sourceVideoUrl)
+            .header("Origin", profile.origin.ifBlank { "https://www.youtube.com" })
+            .header("Referer", if (profile.isEmbedded) "https://www.youtube.com/embed/$sourceVideoId" else sourceVideoUrl)
             .header("User-Agent", profile.userAgent)
             .header("X-Youtube-Client-Name", profile.clientHeaderName)
             .header("X-Youtube-Client-Version", profile.clientVersion)
         session.visitorData.takeIf { it.isNotBlank() }?.let {
             requestBuilder.header("X-Goog-Visitor-Id", it)
         }
-        if (profile.clientName == "ANDROID_VR") {
+        if (profile.useApiFormatVersion2) {
             requestBuilder.header("X-Goog-Api-Format-Version", "2")
         }
         val request = GoogleApiKeyHeaders.applyTo(requestBuilder, context).build()
@@ -1443,12 +1466,15 @@ class PlaybackResolver private constructor(private val context: Context) {
                 ?.optString("visitorData")
                 ?.takeIf { it.isNotBlank() }
                 ?.let(playbackSecurity::observeVisitorData)
+            observeContentHints(sourceVideoId, playerResponseHints(root))
             val playability = root.optJSONObject("playabilityStatus")
             val status = playability?.optString("status").orEmpty()
             if (status.isNotBlank() && status != "OK") {
                 val reason = playability?.optString("reason").orEmpty()
                 val subreason = playability?.optJSONObject("errorScreen")?.toString().orEmpty()
-                throw YoutubePlayerRequestException(null, reason.ifBlank { subreason.ifBlank { status } })
+                val diagnostic = reason.ifBlank { subreason.ifBlank { status } }
+                observeContentHints(sourceVideoId, YoutubeContentHints.fromPlayabilityReason(diagnostic))
+                throw YoutubePlayerRequestException(null, diagnostic)
             }
             val streamingData = root.optJSONObject("streamingData")
                 ?: throw YoutubePlayerRequestException(null, "Nessun blocco streamingData")
@@ -1484,7 +1510,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 val url = format.resolveFormatUrl(
                     videoId = sourceVideoId,
                     streamingPoToken = poTokens?.streamingToken,
-                    transformThrottling = profile.clientName.startsWith("WEB")
+                    transformThrottling = profile.deciphersStreamUrls
                 )
                 if (url.isBlank() || isPlaybackUrlBlocked(url)) continue
                 bestAudioUrl = url
@@ -1498,7 +1524,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                     for (i in 0 until adaptiveFormats.length()) {
                         val format = adaptiveFormats.optJSONObject(i) ?: continue
                         val mime = format.optString("mimeType")
-                        val url = format.resolveFormatUrl(sourceVideoId, poTokens?.streamingToken, profile.clientName.startsWith("WEB"))
+                        val url = format.resolveFormatUrl(sourceVideoId, poTokens?.streamingToken, profile.deciphersStreamUrls)
                         if (!mime.startsWith("video/", true) || url.isBlank()) continue
                         add(
                             LevyraVideoCandidate(
@@ -1520,7 +1546,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                     for (i in 0 until muxedFormats.length()) {
                         val format = muxedFormats.optJSONObject(i) ?: continue
                         val mime = format.optString("mimeType")
-                        val url = format.resolveFormatUrl(sourceVideoId, poTokens?.streamingToken, profile.clientName.startsWith("WEB"))
+                        val url = format.resolveFormatUrl(sourceVideoId, poTokens?.streamingToken, profile.deciphersStreamUrls)
                         if (!mime.startsWith("video/", true) || url.isBlank()) continue
                         add(
                             LevyraVideoCandidate(
@@ -1547,7 +1573,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 val hlsUrl = if (selection == null) {
                     streamingData.optString("hlsManifestUrl")
                         .takeIf { it.isNotBlank() }
-                        ?.let { it.finalizeStreamingUrl(sourceVideoId, poTokens?.streamingToken, profile.clientName.startsWith("WEB")) }
+                        ?.let { it.finalizeStreamingUrl(sourceVideoId, poTokens?.streamingToken, profile.deciphersStreamUrls) }
                         ?.takeIf { !isPlaybackUrlBlocked(it) && isVerifiedHlsManifest(it) }
                         .orEmpty()
                 } else {
@@ -2013,7 +2039,7 @@ class PlaybackResolver private constructor(private val context: Context) {
 
     private fun buildPlayerBody(
         videoId: String,
-        profile: ClientProfile,
+        profile: YoutubeClientProfile,
         visitorData: String,
         playerPoToken: String?,
         signatureTimestamp: Int?
@@ -2027,25 +2053,15 @@ class PlaybackResolver private constructor(private val context: Context) {
             .put("utcOffsetMinutes", 0)
             .put("timeZone", "UTC")
         visitorData.takeIf { it.isNotBlank() }?.let { client.put("visitorData", it) }
-        if (profile.android) {
-            val vr = profile.clientName == "ANDROID_VR"
-            client.put("androidSdkVersion", if (vr) 32 else 35)
-                .put("osName", "Android")
-                .put("osVersion", if (vr) "12L" else "15")
-                .put("platform", "MOBILE")
-            if (vr) {
-                client.put("deviceMake", "Oculus")
-                    .put("deviceModel", "Quest 3")
-            }
+        if (profile.osName.isNotBlank()) {
+            client.put("osName", profile.osName)
+                .put("osVersion", profile.osVersion)
+                .put("platform", profile.platform)
         }
-        if (profile.clientName == "IOS") {
-            client.put("deviceMake", "Apple")
-                .put("deviceModel", "iPhone16,2")
-                .put("osName", "iPhone")
-                .put("osVersion", "18.3")
-                .put("platform", "MOBILE")
-        }
-        if (profile.clientName == "WEB_EMBEDDED_PLAYER") {
+        if (profile.androidSdkVersion > 0) client.put("androidSdkVersion", profile.androidSdkVersion)
+        if (profile.deviceMake.isNotBlank()) client.put("deviceMake", profile.deviceMake)
+        if (profile.deviceModel.isNotBlank()) client.put("deviceModel", profile.deviceModel)
+        if (profile.isEmbedded) {
             client.put("clientScreen", "EMBED")
                 .put("thirdParty", JSONObject().put("embedUrl", "https://www.youtube.com/embed/$videoId"))
         }
@@ -2249,8 +2265,6 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 }
 
-private fun Int?.orZero(): Int = this ?: 0
-
 private fun Throwable.playbackDiagnostic(): String {
     val messages = generateSequence(this) { it.cause }
         .mapNotNull { cause -> cause.message?.trim()?.takeIf { it.isNotBlank() } }
@@ -2260,29 +2274,6 @@ private fun Throwable.playbackDiagnostic(): String {
 }
 
 class PlaybackBlockedException(message: String) : IllegalStateException(message)
-
-private data class ClientProfile(
-    val clientName: String,
-    val clientVersion: String,
-    val label: String,
-    val userAgent: String,
-    val android: Boolean,
-    val delayMs: Long,
-    val tier: Int,
-    val requiresPoToken: Boolean
-) {
-    val clientHeaderName: String
-        get() = when (clientName) {
-            "ANDROID" -> "3"
-            "ANDROID_MUSIC" -> "21"
-            "ANDROID_VR" -> "28"
-            "IOS" -> "5"
-            "WEB_REMIX" -> "67"
-            "WEB" -> "1"
-            "WEB_EMBEDDED_PLAYER" -> "56"
-            else -> "1"
-        }
-}
 
 private data class ClientHealth(
     val successes: Int = 0,

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
@@ -2,6 +2,7 @@ package com.luc4n3x.levyra.data
 
 import android.content.Context
 import com.luc4n3x.levyra.BuildConfig
+import com.luc4n3x.levyra.data.network.YoutubeClientRegistry
 import com.luc4n3x.levyra.data.security.GoogleApiKeyHeaders
 import com.luc4n3x.levyra.domain.AlbumHit
 import com.luc4n3x.levyra.domain.AlbumRecommendationSeed
@@ -355,7 +356,7 @@ private fun matchingArtistSignalIndex(artist: String, signals: List<String>): In
 
 class YoutubeMusicRepository(private val context: Context? = null) {
     private val apiKey = BuildConfig.YOUTUBE_INNERTUBE_API_KEY
-    private val clientVersion = "1.20260423.01.00"
+    private val clientVersion = YoutubeClientRegistry.WEB_REMIX_VERSION
     private val memory = LinkedHashMap<String, Track>()
     private val watchRepository = YoutubeMusicWatchRepository(context)
     private val resilienceClient = YoutubeMusicResilienceClient(context, apiKey, clientVersion)

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicResilienceClient.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicResilienceClient.kt
@@ -2,6 +2,8 @@ package com.luc4n3x.levyra.data
 
 import android.content.Context
 import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
+import com.luc4n3x.levyra.data.network.YoutubeClientProfile
+import com.luc4n3x.levyra.data.network.YoutubeClientRegistry
 import com.luc4n3x.levyra.data.security.GoogleApiKeyHeaders
 import com.luc4n3x.levyra.domain.LevyraContentLocales
 import okhttp3.MediaType.Companion.toMediaType
@@ -37,71 +39,7 @@ internal class YoutubeMusicResilienceClient(
     private val responseCache = LinkedHashMap<String, YoutubeMusicCacheEntry>(32, 0.75f, true)
     private var responseCacheBytes = 0L
 
-    private val profiles = listOf(
-        YoutubeMusicClientProfile(
-            id = "web-remix",
-            clientName = "WEB_REMIX",
-            clientVersion = webRemixVersion,
-            clientHeaderName = "67",
-            userAgent = WEB_USER_AGENT,
-            host = "https://music.youtube.com",
-            origin = "https://music.youtube.com",
-            platform = "DESKTOP",
-            priority = 0
-        ),
-        YoutubeMusicClientProfile(
-            id = "android-music",
-            clientName = "ANDROID_MUSIC",
-            clientVersion = "8.10.52",
-            clientHeaderName = "21",
-            userAgent = ANDROID_MUSIC_USER_AGENT,
-            host = "https://youtubei.googleapis.com",
-            origin = "",
-            platform = "MOBILE",
-            priority = 1,
-            androidSdkVersion = 35,
-            osName = "Android",
-            osVersion = "15"
-        ),
-        YoutubeMusicClientProfile(
-            id = "android",
-            clientName = "ANDROID",
-            clientVersion = "19.44.38",
-            clientHeaderName = "3",
-            userAgent = ANDROID_USER_AGENT,
-            host = "https://youtubei.googleapis.com",
-            origin = "",
-            platform = "MOBILE",
-            priority = 2,
-            androidSdkVersion = 35,
-            osName = "Android",
-            osVersion = "15"
-        ),
-        YoutubeMusicClientProfile(
-            id = "ios",
-            clientName = "IOS",
-            clientVersion = "20.10.4",
-            clientHeaderName = "5",
-            userAgent = IOS_USER_AGENT,
-            host = "https://youtubei.googleapis.com",
-            origin = "",
-            platform = "MOBILE",
-            priority = 3,
-            osName = "iOS",
-            osVersion = "18.3"
-        ),
-        YoutubeMusicClientProfile(
-            id = "web",
-            clientName = "WEB",
-            clientVersion = "2.20260630.01.00",
-            clientHeaderName = "1",
-            userAgent = WEB_USER_AGENT,
-            host = "https://www.youtube.com",
-            origin = "https://www.youtube.com",
-            platform = "DESKTOP",
-            priority = 4
-        )
-    )
+    private val profiles = YoutubeClientRegistry.browseProfiles(webRemixVersion)
 
     fun search(query: String, languageCode: String, params: String = ""): JSONObject? {
         val clean = query.trim()
@@ -296,7 +234,7 @@ internal class YoutubeMusicResilienceClient(
     }
 
     private fun payload(
-        profile: YoutubeMusicClientProfile,
+        profile: YoutubeClientProfile,
         kind: YoutubeMusicRequestKind,
         languageCode: String,
         browseId: String,
@@ -331,17 +269,17 @@ internal class YoutubeMusicResilienceClient(
         return root
     }
 
-    private fun orderedProfiles(now: Long): List<YoutubeMusicClientProfile> {
+    private fun orderedProfiles(now: Long): List<YoutubeClientProfile> {
         val available = profiles.filter { (health[it.id]?.blockedUntilMs ?: 0L) <= now }
         if (available.isEmpty()) return emptyList()
         return available.sortedWith(
-            compareByDescending<YoutubeMusicClientProfile> {
+            compareByDescending<YoutubeClientProfile> {
                 health[it.id]?.score ?: DEFAULT_PROFILE_SCORE
-            }.thenBy { it.priority }
+            }.thenBy { it.tier }
         )
     }
 
-    private fun recordSuccess(profile: YoutubeMusicClientProfile, latencyMs: Long, now: Long) {
+    private fun recordSuccess(profile: YoutubeClientProfile, latencyMs: Long, now: Long) {
         health.compute(profile.id) { _, current ->
             val previous = current ?: YoutubeMusicClientHealth()
             val samples = (previous.successes + 1).coerceAtMost(MAX_HEALTH_SAMPLES)
@@ -362,7 +300,7 @@ internal class YoutubeMusicResilienceClient(
     }
 
     private fun recordFailure(
-        profile: YoutubeMusicClientProfile,
+        profile: YoutubeClientProfile,
         statusCode: Int?,
         reason: String,
         latencyMs: Long?,
@@ -501,14 +439,6 @@ internal class YoutubeMusicResilienceClient(
         const val LONG_BLOCK_MS = 2L * 60L * 1_000L
         const val HARD_BLOCK_MS = 10L * 60L * 1_000L
         const val DEFAULT_PROFILE_SCORE = 50.0
-        const val WEB_USER_AGENT =
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
-        const val ANDROID_MUSIC_USER_AGENT =
-            "com.google.android.apps.youtube.music/8.10.52 (Linux; U; Android 15; Pixel 8 Pro Build/AP3A.241105.007) gzip"
-        const val ANDROID_USER_AGENT =
-            "com.google.android.youtube/19.44.38 (Linux; U; Android 15; Pixel 8 Pro Build/AP3A.241105.007) gzip"
-        const val IOS_USER_AGENT =
-            "com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3 like Mac OS X)"
 
         val SEARCH_MARKERS = arrayOf(
             "musicResponsiveListItemRenderer",
@@ -538,7 +468,7 @@ internal fun interface YoutubeMusicTransport {
 internal data class YoutubeMusicTransportRequest(
     val path: String,
     val apiKey: String,
-    val profile: YoutubeMusicClientProfile,
+    val profile: YoutubeClientProfile,
     val payload: String,
     val referer: String,
     val visitorData: String,
@@ -549,21 +479,6 @@ internal data class YoutubeMusicTransportResponse(
     val code: Int,
     val body: String,
     val latencyMs: Long
-)
-
-internal data class YoutubeMusicClientProfile(
-    val id: String,
-    val clientName: String,
-    val clientVersion: String,
-    val clientHeaderName: String,
-    val userAgent: String,
-    val host: String,
-    val origin: String,
-    val platform: String,
-    val priority: Int,
-    val androidSdkVersion: Int = 0,
-    val osName: String = "",
-    val osVersion: String = ""
 )
 
 internal data class YoutubeMusicClientHealth(
@@ -598,7 +513,7 @@ private data class YoutubeMusicCacheEntry(
 )
 
 private data class YoutubeMusicDeferredFailure(
-    val profile: YoutubeMusicClientProfile,
+    val profile: YoutubeClientProfile,
     val statusCode: Int?,
     val reason: String,
     val latencyMs: Long?,
@@ -673,7 +588,7 @@ private class OkHttpYoutubeMusicTransport(context: Context?) : YoutubeMusicTrans
             .header("X-Youtube-Client-Name", request.profile.clientHeaderName)
             .header("X-Youtube-Client-Version", request.profile.clientVersion)
         if (request.profile.origin.isNotBlank()) builder.header("Origin", request.profile.origin)
-        if (request.profile.androidSdkVersion > 0) builder.header("X-Goog-Api-Format-Version", "2")
+        if (request.profile.useApiFormatVersion2) builder.header("X-Goog-Api-Format-Version", "2")
         request.visitorData.takeIf(String::isNotBlank)?.let { builder.header("X-Goog-Visitor-Id", it) }
 
         val httpRequest = GoogleApiKeyHeaders.applyTo(builder, appContext).build()

--- a/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeClientIdentityInterceptor.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeClientIdentityInterceptor.kt
@@ -16,13 +16,13 @@ internal object YoutubeClientIdentityInterceptor : Interceptor {
     private const val HEADER_REFERER = "Referer"
     private const val HEADER_USER_AGENT = "User-Agent"
 
-    private const val CLIENT_WEB = "1"
-    private const val CLIENT_ANDROID = "3"
-    private const val CLIENT_IOS = "5"
-    private const val CLIENT_ANDROID_MUSIC = "21"
-    private const val CLIENT_ANDROID_VR = "28"
-    private const val CLIENT_WEB_EMBEDDED = "56"
-    private const val CLIENT_WEB_REMIX = "67"
+    private const val CLIENT_WEB = YoutubeClientRegistry.CLIENT_ID_WEB
+    private const val CLIENT_ANDROID = YoutubeClientRegistry.CLIENT_ID_ANDROID
+    private const val CLIENT_IOS = YoutubeClientRegistry.CLIENT_ID_IOS
+    private const val CLIENT_ANDROID_MUSIC = YoutubeClientRegistry.CLIENT_ID_ANDROID_MUSIC
+    private const val CLIENT_ANDROID_VR = YoutubeClientRegistry.CLIENT_ID_ANDROID_VR
+    private const val CLIENT_WEB_EMBEDDED = YoutubeClientRegistry.CLIENT_ID_WEB_EMBEDDED
+    private const val CLIENT_WEB_REMIX = YoutubeClientRegistry.CLIENT_ID_WEB_REMIX
 
     private val nativeClientNames = setOf(
         CLIENT_ANDROID,

--- a/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeClientRegistry.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeClientRegistry.kt
@@ -1,0 +1,203 @@
+package com.luc4n3x.levyra.data.network
+
+internal data class YoutubeClientProfile(
+    val id: String,
+    val clientName: String,
+    val clientVersion: String,
+    val clientHeaderName: String,
+    val label: String,
+    val userAgent: String,
+    val host: String,
+    val origin: String,
+    val platform: String,
+    val tier: Int,
+    val delayMs: Long = 0L,
+    val osName: String = "",
+    val osVersion: String = "",
+    val deviceMake: String = "",
+    val deviceModel: String = "",
+    val androidSdkVersion: Int = 0,
+    val requiresPoToken: Boolean = false,
+    val useSignatureTimestamp: Boolean = false,
+    val deciphersStreamUrls: Boolean = false,
+    val isEmbedded: Boolean = false,
+    val useApiFormatVersion2: Boolean = false,
+    val supportsLive: Boolean = true,
+    val supportsUserUploads: Boolean = true,
+    val supportsAgeRestricted: Boolean = false
+)
+
+internal object YoutubeClientRegistry {
+    const val WEB_REMIX_VERSION = "1.20260423.01.00"
+    const val WEB_VERSION = "2.20260630.01.00"
+    const val ANDROID_VERSION = "19.44.38"
+    const val ANDROID_MUSIC_VERSION = "8.10.52"
+    const val ANDROID_VR_VERSION = "1.65.10"
+    const val IOS_VERSION = "20.10.4"
+
+    const val CLIENT_ID_WEB = "1"
+    const val CLIENT_ID_ANDROID = "3"
+    const val CLIENT_ID_IOS = "5"
+    const val CLIENT_ID_ANDROID_MUSIC = "21"
+    const val CLIENT_ID_ANDROID_VR = "28"
+    const val CLIENT_ID_WEB_EMBEDDED = "56"
+    const val CLIENT_ID_WEB_REMIX = "67"
+
+    const val WEB_USER_AGENT =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+            "(KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
+
+    private const val HOST_YOUTUBE = "https://www.youtube.com"
+    private const val HOST_YOUTUBE_MUSIC = "https://music.youtube.com"
+    private const val HOST_YOUTUBEI = "https://youtubei.googleapis.com"
+
+    /**
+     * Serves adaptive audio without a PoToken but refuses live streams and user uploads.
+     */
+    val ANDROID_VR = YoutubeClientProfile(
+        id = "android-vr",
+        clientName = "ANDROID_VR",
+        clientVersion = ANDROID_VR_VERSION,
+        clientHeaderName = CLIENT_ID_ANDROID_VR,
+        label = "Android VR",
+        userAgent = "com.google.android.apps.youtube.vr.oculus/$ANDROID_VR_VERSION " +
+            "(Linux; U; Android 12L; Quest 3 Build/SQ3A.220605.009.A1) gzip",
+        host = HOST_YOUTUBEI,
+        origin = "",
+        platform = "MOBILE",
+        tier = 0,
+        osName = "Android",
+        osVersion = "12L",
+        deviceMake = "Oculus",
+        deviceModel = "Quest 3",
+        androidSdkVersion = 32,
+        useApiFormatVersion2 = true,
+        supportsLive = false,
+        supportsUserUploads = false
+    )
+
+    val ANDROID_MUSIC = YoutubeClientProfile(
+        id = "android-music",
+        clientName = "ANDROID_MUSIC",
+        clientVersion = ANDROID_MUSIC_VERSION,
+        clientHeaderName = CLIENT_ID_ANDROID_MUSIC,
+        label = "Android Music",
+        userAgent = "com.google.android.apps.youtube.music/$ANDROID_MUSIC_VERSION " +
+            "(Linux; U; Android 15; Pixel 8 Pro Build/AP3A.241105.007) gzip",
+        host = HOST_YOUTUBEI,
+        origin = "",
+        platform = "MOBILE",
+        tier = 1,
+        osName = "Android",
+        osVersion = "15",
+        androidSdkVersion = 35,
+        useApiFormatVersion2 = true,
+        supportsUserUploads = false
+    )
+
+    val ANDROID = YoutubeClientProfile(
+        id = "android",
+        clientName = "ANDROID",
+        clientVersion = ANDROID_VERSION,
+        clientHeaderName = CLIENT_ID_ANDROID,
+        label = "Android",
+        userAgent = "com.google.android.youtube/$ANDROID_VERSION " +
+            "(Linux; U; Android 15; Pixel 8 Pro Build/AP3A.241105.007) gzip",
+        host = HOST_YOUTUBEI,
+        origin = "",
+        platform = "MOBILE",
+        tier = 2,
+        osName = "Android",
+        osVersion = "15",
+        androidSdkVersion = 35,
+        useApiFormatVersion2 = true
+    )
+
+    val IOS = YoutubeClientProfile(
+        id = "ios",
+        clientName = "IOS",
+        clientVersion = IOS_VERSION,
+        clientHeaderName = CLIENT_ID_IOS,
+        label = "iOS",
+        userAgent = "com.google.ios.youtube/$IOS_VERSION (iPhone16,2; U; CPU iOS 18_3 like Mac OS X)",
+        host = HOST_YOUTUBEI,
+        origin = "",
+        platform = "MOBILE",
+        tier = 3,
+        osName = "iPhone",
+        osVersion = "18.3",
+        deviceMake = "Apple",
+        deviceModel = "iPhone16,2"
+    )
+
+    val WEB_REMIX = YoutubeClientProfile(
+        id = "web-remix",
+        clientName = "WEB_REMIX",
+        clientVersion = WEB_REMIX_VERSION,
+        clientHeaderName = CLIENT_ID_WEB_REMIX,
+        label = "YouTube Music Web",
+        userAgent = WEB_USER_AGENT,
+        host = HOST_YOUTUBE_MUSIC,
+        origin = HOST_YOUTUBE_MUSIC,
+        platform = "DESKTOP",
+        tier = 4,
+        requiresPoToken = true,
+        useSignatureTimestamp = true,
+        deciphersStreamUrls = true
+    )
+
+    val WEB = YoutubeClientProfile(
+        id = "web",
+        clientName = "WEB",
+        clientVersion = WEB_VERSION,
+        clientHeaderName = CLIENT_ID_WEB,
+        label = "YouTube Web",
+        userAgent = WEB_USER_AGENT,
+        host = HOST_YOUTUBE,
+        origin = HOST_YOUTUBE,
+        platform = "DESKTOP",
+        tier = 5,
+        requiresPoToken = true,
+        useSignatureTimestamp = true,
+        deciphersStreamUrls = true
+    )
+
+    /**
+     * Embedded surface kept last: it is the only Levyra client able to negotiate
+     * age-restricted playback when every other candidate is denied.
+     */
+    val WEB_EMBEDDED_PLAYER = YoutubeClientProfile(
+        id = "web-embedded",
+        clientName = "WEB_EMBEDDED_PLAYER",
+        clientVersion = WEB_REMIX_VERSION,
+        clientHeaderName = CLIENT_ID_WEB_EMBEDDED,
+        label = "Embedded Player",
+        userAgent = WEB_USER_AGENT,
+        host = HOST_YOUTUBE,
+        origin = HOST_YOUTUBE,
+        platform = "DESKTOP",
+        tier = 6,
+        isEmbedded = true,
+        useSignatureTimestamp = true,
+        deciphersStreamUrls = true,
+        supportsAgeRestricted = true
+    )
+
+    val playbackProfiles: List<YoutubeClientProfile> = listOf(
+        ANDROID_VR,
+        ANDROID_MUSIC,
+        ANDROID,
+        IOS,
+        WEB_REMIX,
+        WEB,
+        WEB_EMBEDDED_PLAYER
+    )
+
+    fun browseProfiles(webRemixVersion: String): List<YoutubeClientProfile> = listOf(
+        WEB_REMIX.copy(clientVersion = webRemixVersion.ifBlank { WEB_REMIX_VERSION }, tier = 0),
+        ANDROID_MUSIC.copy(tier = 1),
+        ANDROID.copy(tier = 2),
+        IOS.copy(tier = 3, osName = "iOS"),
+        WEB.copy(tier = 4)
+    )
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeContentAwareClientSelector.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeContentAwareClientSelector.kt
@@ -1,0 +1,103 @@
+package com.luc4n3x.levyra.data.network
+
+import java.util.Locale
+
+internal data class YoutubeContentHints(
+    val isLive: Boolean? = null,
+    val isUserUpload: Boolean? = null,
+    val isAgeRestricted: Boolean? = null
+) {
+    fun mergedWith(other: YoutubeContentHints): YoutubeContentHints = YoutubeContentHints(
+        isLive = other.isLive ?: isLive,
+        isUserUpload = other.isUserUpload ?: isUserUpload,
+        isAgeRestricted = other.isAgeRestricted ?: isAgeRestricted
+    )
+
+    companion object {
+        val NONE = YoutubeContentHints()
+
+        private val AGE_RESTRICTION_MARKERS = listOf(
+            "confirm your age",
+            "age-restricted",
+            "age restricted",
+            "inappropriate for some users"
+        )
+
+        fun fromMetadata(videoType: String): YoutubeContentHints = YoutubeContentHints(
+            isUserUpload = true.takeIf { videoType.uppercase(Locale.ROOT).contains("UGC") }
+        )
+
+        fun fromPlayabilityReason(reason: String): YoutubeContentHints {
+            val normalized = reason.lowercase(Locale.ROOT)
+            return YoutubeContentHints(
+                isAgeRestricted = true.takeIf { AGE_RESTRICTION_MARKERS.any(normalized::contains) }
+            )
+        }
+    }
+}
+
+internal data class YoutubeClientRanking(
+    val score: Double,
+    val averageLatencyMs: Long,
+    val consecutiveFailures: Int,
+    val blockedUntilMs: Long
+)
+
+/**
+ * Orders playback clients by content compatibility first and observed health second.
+ *
+ * A client is excluded only when it provably cannot serve the content, and only while at least one
+ * compatible candidate remains, so a conservative hint can never strand playback. Age restriction is
+ * handled as a promotion instead of an exclusion because the other clients may still succeed.
+ */
+internal object YoutubeContentAwareClientSelector {
+    const val DEFAULT_SCORE = 50.0
+    private const val VR_PRIMARY_SCORE_TOLERANCE = 12.0
+
+    private fun supports(profile: YoutubeClientProfile, hints: YoutubeContentHints): Boolean {
+        if (hints.isLive == true && !profile.supportsLive) return false
+        if (hints.isUserUpload == true && !profile.supportsUserUploads) return false
+        return true
+    }
+
+    fun order(
+        profiles: List<YoutubeClientProfile>,
+        hints: YoutubeContentHints,
+        nowMs: Long,
+        ranking: (YoutubeClientProfile) -> YoutubeClientRanking?
+    ): List<YoutubeClientProfile> {
+        if (profiles.isEmpty()) return emptyList()
+        val compatible = profiles.filter { supports(it, hints) }.ifEmpty { profiles }
+        val unblocked = compatible.filter { (ranking(it)?.blockedUntilMs ?: 0L) <= nowMs }
+        val sorted = unblocked.ifEmpty { compatible }.sortedWith(
+            compareByDescending<YoutubeClientProfile> { ranking(it)?.score ?: DEFAULT_SCORE }
+                .thenBy { ranking(it)?.averageLatencyMs ?: Long.MAX_VALUE }
+                .thenBy { it.tier }
+        )
+        if (hints.isAgeRestricted == true) {
+            return promote(sorted) { it.supportsAgeRestricted }
+        }
+        if (!keepVrPrimary(sorted, ranking)) return sorted
+        return promote(sorted) { it.clientName == YoutubeClientRegistry.ANDROID_VR.clientName }
+    }
+
+    private fun keepVrPrimary(
+        sorted: List<YoutubeClientProfile>,
+        ranking: (YoutubeClientProfile) -> YoutubeClientRanking?
+    ): Boolean {
+        val vr = sorted.firstOrNull { it.clientName == YoutubeClientRegistry.ANDROID_VR.clientName }
+            ?: return false
+        val vrRanking = ranking(vr)
+        val bestScore = sorted.firstOrNull()?.let { ranking(it)?.score } ?: DEFAULT_SCORE
+        return (vrRanking?.consecutiveFailures ?: 0) == 0 &&
+            (vrRanking?.score ?: DEFAULT_SCORE) >= bestScore - VR_PRIMARY_SCORE_TOLERANCE
+    }
+
+    private fun promote(
+        sorted: List<YoutubeClientProfile>,
+        predicate: (YoutubeClientProfile) -> Boolean
+    ): List<YoutubeClientProfile> {
+        val (promoted, rest) = sorted.partition(predicate)
+        return if (promoted.isEmpty()) sorted else promoted + rest
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/network/YoutubeClientRegistryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/network/YoutubeClientRegistryTest.kt
@@ -1,0 +1,88 @@
+package com.luc4n3x.levyra.data.network
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class YoutubeClientRegistryTest {
+    @Test
+    fun playbackProfilesExposeStableIdentities() {
+        val profiles = YoutubeClientRegistry.playbackProfiles
+
+        assertEquals(profiles.size, profiles.map { it.id }.toSet().size)
+        assertEquals(profiles.size, profiles.map { it.clientName }.toSet().size)
+        assertEquals(profiles.indices.toList(), profiles.map { it.tier })
+        assertTrue(profiles.all { it.clientHeaderName.toIntOrNull() != null })
+        assertTrue(profiles.all { it.clientVersion.isNotBlank() && it.userAgent.isNotBlank() })
+    }
+
+    @Test
+    fun onlyDecipheringClientsRequestASignatureTimestamp() {
+        val profiles = YoutubeClientRegistry.playbackProfiles
+
+        assertEquals(
+            profiles.filter { it.deciphersStreamUrls }.map { it.clientName },
+            profiles.filter { it.useSignatureTimestamp }.map { it.clientName }
+        )
+    }
+
+    @Test
+    fun poTokenIsOnlyRequiredByWebSurfaces() {
+        val required = YoutubeClientRegistry.playbackProfiles
+            .filter { it.requiresPoToken }
+            .map { it.clientName }
+
+        assertEquals(listOf("WEB_REMIX", "WEB"), required)
+    }
+
+    @Test
+    fun androidVrIsTheOnlyClientThatCannotServeLiveStreams() {
+        val restricted = YoutubeClientRegistry.playbackProfiles
+            .filterNot { it.supportsLive }
+            .map { it.clientName }
+
+        assertEquals(listOf("ANDROID_VR"), restricted)
+    }
+
+    @Test
+    fun musicOnlySurfacesDeclineUserUploads() {
+        val restricted = YoutubeClientRegistry.playbackProfiles
+            .filterNot { it.supportsUserUploads }
+            .map { it.clientName }
+
+        assertEquals(listOf("ANDROID_VR", "ANDROID_MUSIC"), restricted)
+    }
+
+    @Test
+    fun embeddedSurfaceIsTheOnlyAgeRestrictionCandidate() {
+        val embedded = YoutubeClientRegistry.playbackProfiles.filter { it.isEmbedded }
+
+        assertEquals(listOf("WEB_EMBEDDED_PLAYER"), embedded.map { it.clientName })
+        assertEquals(YoutubeClientRegistry.playbackProfiles.last(), embedded.single())
+        assertEquals(
+            embedded,
+            YoutubeClientRegistry.playbackProfiles.filter { it.supportsAgeRestricted }
+        )
+    }
+
+    @Test
+    fun browseProfilesReuseTheRegistryAndHonourTheSyncedRemixVersion() {
+        val profiles = YoutubeClientRegistry.browseProfiles("1.99999999.99.99")
+
+        assertEquals(
+            listOf("web-remix", "android-music", "android", "ios", "web"),
+            profiles.map { it.id }
+        )
+        assertEquals("1.99999999.99.99", profiles.first().clientVersion)
+        assertEquals(profiles.indices.toList(), profiles.map { it.tier })
+        assertFalse(profiles.any { it.isEmbedded })
+    }
+
+    @Test
+    fun blankRemixVersionFallsBackToTheRegistryDefault() {
+        val profiles = YoutubeClientRegistry.browseProfiles("")
+
+        assertEquals(YoutubeClientRegistry.WEB_REMIX_VERSION, profiles.first().clientVersion)
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/network/YoutubeContentAwareClientSelectorTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/network/YoutubeContentAwareClientSelectorTest.kt
@@ -1,0 +1,163 @@
+package com.luc4n3x.levyra.data.network
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class YoutubeContentAwareClientSelectorTest {
+    private val profiles = YoutubeClientRegistry.playbackProfiles
+
+    @Test
+    fun liveContentExcludesClientsThatCannotServeIt() {
+        val ordered = order(YoutubeContentHints(isLive = true))
+
+        assertFalse(ordered.any { it.clientName == "ANDROID_VR" })
+        assertTrue(ordered.any { it.clientName == "WEB_REMIX" })
+    }
+
+    @Test
+    fun userUploadExcludesTheMusicOnlyClients() {
+        val ordered = order(YoutubeContentHints(isUserUpload = true))
+
+        assertEquals(
+            listOf("ANDROID", "IOS", "WEB_REMIX", "WEB", "WEB_EMBEDDED_PLAYER"),
+            ordered.map { it.clientName }
+        )
+    }
+
+    @Test
+    fun ageRestrictionPromotesTheEmbeddedSurfaceWithoutDroppingCandidates() {
+        val ordered = order(YoutubeContentHints(isAgeRestricted = true))
+
+        assertEquals("WEB_EMBEDDED_PLAYER", ordered.first().clientName)
+        assertEquals(profiles.size, ordered.size)
+    }
+
+    @Test
+    fun parentalAdvisoryAloneNeverChangesTheClientLadder() {
+        val ordered = order(YoutubeContentHints.fromMetadata("MUSIC_VIDEO_TYPE_ATV"))
+
+        assertEquals(order(YoutubeContentHints.NONE).map { it.clientName }, ordered.map { it.clientName })
+        assertEquals("ANDROID_VR", ordered.first().clientName)
+    }
+
+    @Test
+    fun emptyHintsKeepEveryClientAndPromoteAndroidVr() {
+        val ordered = order(YoutubeContentHints.NONE)
+
+        assertEquals(profiles.size, ordered.size)
+        assertEquals("ANDROID_VR", ordered.first().clientName)
+    }
+
+    @Test
+    fun healthyClientIsPreferredOverPenalizedOne() {
+        val ordered = order(
+            hints = YoutubeContentHints(isLive = true),
+            ranking = mapOf(
+                "WEB_REMIX" to ranking(score = 10.0, consecutiveFailures = 3),
+                "IOS" to ranking(score = 95.0)
+            )
+        )
+
+        assertEquals("IOS", ordered.first().clientName)
+    }
+
+    @Test
+    fun temporarilyBlockedClientIsSkipped() {
+        val ordered = order(
+            hints = YoutubeContentHints.NONE,
+            nowMs = 1_000L,
+            ranking = mapOf("ANDROID_VR" to ranking(score = 99.0, blockedUntilMs = 5_000L))
+        )
+
+        assertFalse(ordered.any { it.clientName == "ANDROID_VR" })
+        assertEquals(profiles.size - 1, ordered.size)
+    }
+
+    @Test
+    fun everyBlockedClientStillProducesCandidates() {
+        val blocked = profiles.associate { it.clientName to ranking(blockedUntilMs = 5_000L) }
+
+        val ordered = order(YoutubeContentHints.NONE, nowMs = 1_000L, ranking = blocked)
+
+        assertEquals(profiles.size, ordered.size)
+    }
+
+    @Test
+    fun incompatibleHintsNeverStrandPlayback() {
+        val ordered = YoutubeContentAwareClientSelector.order(
+            profiles = listOf(YoutubeClientRegistry.ANDROID_VR),
+            hints = YoutubeContentHints(isLive = true),
+            nowMs = 0L
+        ) { null }
+
+        assertEquals(listOf("ANDROID_VR"), ordered.map { it.clientName })
+    }
+
+    @Test
+    fun androidVrLosesPrimarySlotAfterConsecutiveFailures() {
+        val ordered = order(
+            hints = YoutubeContentHints.NONE,
+            ranking = mapOf(
+                "ANDROID_VR" to ranking(score = 60.0, consecutiveFailures = 1),
+                "ANDROID_MUSIC" to ranking(score = 90.0)
+            )
+        )
+
+        assertEquals("ANDROID_MUSIC", ordered.first().clientName)
+    }
+
+    @Test
+    fun metadataHintsDetectUserUploadsOnly() {
+        val upload = YoutubeContentHints.fromMetadata("MUSIC_VIDEO_TYPE_UGC")
+        assertEquals(true, upload.isUserUpload)
+        assertNull(upload.isAgeRestricted)
+
+        val artTrack = YoutubeContentHints.fromMetadata("MUSIC_VIDEO_TYPE_ATV")
+        assertNull(artTrack.isUserUpload)
+    }
+
+    @Test
+    fun playabilityReasonsClassifyAgeRestriction() {
+        assertEquals(
+            true,
+            YoutubeContentHints.fromPlayabilityReason("Sign in to confirm your age").isAgeRestricted
+        )
+        assertEquals(
+            true,
+            YoutubeContentHints.fromPlayabilityReason(
+                "This video may be inappropriate for some users."
+            ).isAgeRestricted
+        )
+        assertNull(
+            YoutubeContentHints.fromPlayabilityReason("Video unavailable").isAgeRestricted
+        )
+    }
+
+    @Test
+    fun observedHintsDoNotClearKnownMetadata() {
+        val merged = YoutubeContentHints(isUserUpload = true)
+            .mergedWith(YoutubeContentHints(isLive = true))
+
+        assertEquals(YoutubeContentHints(isLive = true, isUserUpload = true), merged)
+    }
+
+    private fun order(
+        hints: YoutubeContentHints,
+        nowMs: Long = 0L,
+        ranking: Map<String, YoutubeClientRanking> = emptyMap()
+    ): List<YoutubeClientProfile> = YoutubeContentAwareClientSelector.order(
+        profiles = profiles,
+        hints = hints,
+        nowMs = nowMs
+    ) { ranking[it.clientName] }
+
+    private fun ranking(
+        score: Double = YoutubeContentAwareClientSelector.DEFAULT_SCORE,
+        averageLatencyMs: Long = Long.MAX_VALUE,
+        consecutiveFailures: Int = 0,
+        blockedUntilMs: Long = 0L
+    ) = YoutubeClientRanking(score, averageLatencyMs, consecutiveFailures, blockedUntilMs)
+}


### PR DESCRIPTION
## Summary

Levyra maintained **three independent copies** of the InnerTube client catalogue — the playback ladder in `PlaybackResolver`, the browse/search ladder in `YoutubeMusicResilienceClient`, and the numeric client ids in `YoutubeClientIdentityInterceptor` — with drifting versions and user agents, and every per-client behaviour decided by string matching on the client name (`clientName.startsWith("WEB")`, `clientName == "ANDROID_VR"`, …).

This PR introduces a single authoritative client registry with an explicit capability model, and folds Metrolist's content-aware fallback concept into Levyra's existing health-scored resolver instead of replacing it.


## Improvements

**`YoutubeClientRegistry` — single source of truth.** Owns client name, version, numeric id, user agent, host/origin, OS and device context, and capability flags. Adapted from Metrolist's `YouTubeClient` capability model (`useSignatureTimestamp`, `isEmbedded`, `requirePoToken`, `loginSupported`, …), reduced to the flags Levyra actually consumes:

| flag | meaning |
| --- | --- |
| `requiresPoToken` | client needs a PoToken session |
| `useSignatureTimestamp` | player body carries `signatureTimestamp` |
| `deciphersStreamUrls` | stream URLs need local `n`/signature transformation |
| `isEmbedded` | embedded surface (embed referer + `clientScreen: EMBED` + `thirdParty.embedUrl`) |
| `useApiFormatVersion2` | sends `X-Goog-Api-Format-Version: 2` |
| `supportsLive` / `supportsUserUploads` / `supportsAgeRestricted` | content compatibility |

**`YoutubeContentAwareClientSelector`** — adapted from `ContentAwareFallbackStrategy`, but **fused with** Levyra's health scoring rather than replacing it with static lists:

1. filter clients that provably cannot serve the content (live, user upload);
2. drop temporarily blocked clients;
3. rank the survivors by Levyra health score → average latency → tier;
4. promote the age-restriction-capable surface when an age restriction was observed, otherwise keep the existing Android VR primary bias.

Every filtering step is skipped when it would leave no candidate, so a hint can never strand playback.

**Capability-driven request building.** `resolveWithInnerTubeOnce` and `buildPlayerBody` now read profile capabilities instead of re-deriving them from the client name. `buildPlayerBody` lost three hardcoded per-client blocks in favour of registry fields.

**Removed duplication.** Deleted the private `ClientProfile` (incl. its `clientHeaderName` `when` block), the duplicated `YoutubeMusicClientProfile`, four duplicated user-agent constants, the duplicated `WEB_REMIX` version string in `YoutubeMusicRepository`, the seven duplicated numeric client ids in the interceptor, and the now-unused `Int?.orZero()` helper.

## Levyra behavior preserved

Nothing was replaced by a Metrolist equivalent where Levyra was already stronger:

- persistent client health scoring, failure penalties and temporary blocks (`levyra_innertube_client_health` keys unchanged);
- Android VR primary bias with its consecutive-failure guard;
- hedged and raced resolution, single-flight, stream cache, resolver latency budgets;
- `PlaybackResilienceEngine`, `PlaybackSourceMatchStore` (`profile.label` strings kept **byte-identical** so persisted source matches stay valid);
- `YoutubePlaybackSecurity` PoToken lifecycle, `YoutubeLocalDecoder`, NewPipe fallback order;
- Song/Video mode, audio quality selection, video stream selection, queue, MediaSession, Android Auto — untouched.

## Architecture

```
Track
  |
  v
content hints  (metadata already held + signals observed on player responses)
  |
  v
capability filter        <- YoutubeContentAwareClientSelector
  |
  v
blocked-client filter    <- existing client health
  |
  v
health / latency / tier ranking
  |
  v
age-restriction or Android VR promotion
  |
  v
hedged InnerTube attempt -> security repair -> alternate client -> NewPipe fallback
```

`YoutubeClientRegistry` is the only place declaring client identity and capabilities; the playback ladder, the browse ladder and the HTTP identity interceptor all derive from it.

## Playback impact

- Clients that provably cannot serve the content are no longer attempted, so the ladder wastes fewer round trips on live streams and user uploads.
- `signatureTimestamp` is now requested strictly by `useSignatureTimestamp` clients. The previous `clientName.startsWith("WEB")` test selected the same three clients, so there is no change in JS work today, but the intent is now explicit and cannot drift when a client is added.
- Age restriction is handled as a **promotion, not an exclusion**: after a client reports an age-restricted playability reason, the embedded surface moves to the front on the next attempt while every other candidate stays in the ladder.
- No new network call is introduced. Content hints come from `Track.videoType` and from `videoDetails` / `playabilityStatus` already parsed in the player response.

## Search / metadata

No parser change in this PR. Metrolist's structured page parsers were studied but deliberately not ported — see *Not ported*.

## Reliability

- Content-aware filtering removes attempts that were structurally doomed instead of relying on the health score to learn the failure after the fact.
- Age-restriction detection turns a repeated hard failure into a targeted retry on the one client able to negotiate it.
- Observed hints are cached per video id in a bounded access-ordered LRU (256 entries) under an explicit lock, and a hint is only ever *set*, never cleared, so a client that hides a flag cannot erase a real signal.

## Performance

- Critical path unchanged in shape: cache/source match → hedged InnerTube → repair → NewPipe.
- Capability filtering runs before any request, on an in-memory list of 7 profiles.
- The `explicit` metadata flag is deliberately **not** used for filtering: YouTube Music's explicit badge is parental advisory, not age restriction, and excluding the tier-0 no-PoToken Android VR client for that share of the catalogue would have been a latency regression.

## Tests

Commands actually executed, with results:

| command | result |
| --- | --- |
| `./gradlew :app:compileDebugKotlin` | **passed** |
| `./gradlew :app:testDebugUnitTest` | **passed** — 120 suites, 792 tests, 0 failures, 0 errors |
| `./gradlew :app:lintDebug` | **passed** |
| `python scripts/ai_quality_gate.py --profile full` → agent config, AI efficiency, claude-mem, F-Droid review contract, Android runtime compatibility, all Android unit tests | **passed** |
| `python scripts/ai_quality_gate.py --profile full` → *Run repository script tests* | **pre-existing failure**, not caused by this change — 17 errors, identical on a pristine `origin/main` worktree. The tests spawn the `.sh` hooks and fail with `FileNotFoundError: [WinError 2]` on this Windows host. |
| `python scripts/ai_quality_gate.py --profile full` → *Android release lint* and *unsigned F-Droid release compile* | **blocked, not run.** Both abort at `app/build.gradle.kts:68` with `Missing YOUTUBE_INNERTUBE_API_KEY`. Per `AGENTS.md` this value must never be committed locally, so these two stages are left to CI. |

New tests (21):

- `YoutubeClientRegistryTest` (8) — stable identities, signature-timestamp/decipher coherence, PoToken scope, live and user-upload restrictions, embedded/age-restriction surface, browse profiles honouring the synced remix version and its blank fallback.
- `YoutubeContentAwareClientSelectorTest` (13) — live exclusion, user-upload exclusion, age-restriction promotion, parental advisory changing nothing, healthy vs penalised client, blocked client skipped, all-blocked still producing candidates, incompatible hints never stranding playback, Android VR losing its primary slot, metadata and playability-reason hint derivation, hint merging.

Not performed: device installation, real playback, Android Auto, notification and download checks.

## Files changed

| file | change |
| --- | --- |
| `data/network/YoutubeClientRegistry.kt` | **new** — authoritative client + capability catalogue |
| `data/network/YoutubeContentAwareClientSelector.kt` | **new** — content hints and capability-aware ordering |
| `data/PlaybackResolver.kt` | consumes the registry and selector; capability-driven request building; hint observation; `ClientProfile` and `orZero` removed |
| `data/YoutubeMusicResilienceClient.kt` | consumes `browseProfiles`; duplicated profile type and user-agent constants removed |
| `data/network/YoutubeClientIdentityInterceptor.kt` | numeric client ids sourced from the registry |
| `data/YoutubeMusicRepository.kt` | `WEB_REMIX` version sourced from the registry |
| `test/.../YoutubeClientRegistryTest.kt` | **new** |
| `test/.../YoutubeContentAwareClientSelectorTest.kt` | **new** |

## Dependencies

**None added, changed or removed.** Metrolist's InnerTube module is built on Ktor over OkHttp; Levyra keeps its own OkHttp stack through `LevyraHttpClientFactory`, which already provides HTTP/2, a tuned connection pool, Brotli, bounded per-surface timeouts and the shared DNS/event-listener intelligence. Adding Ktor would have meant a second HTTP stack for no capability gain.

## Attribution

Metrolist is GPL-3.0. No Metrolist source file was copied. Two ideas were reimplemented against Levyra's own types:

- the capability-per-client model of `innertube/models/YouTubeClient.kt` — reimplemented as `YoutubeClientProfile` with only the flags Levyra consumes, over Levyra's existing profile fields;
- the content-to-client mapping of `innertube/strategy/ContentAwareFallbackStrategy.kt` — reimplemented as capability filtering layered on Levyra's health ranking, rather than Metrolist's static per-content client lists.

Both files carry a short comment describing the behaviour, not adapted Metrolist code, so no GPL header was added. Metrolist stays credited as the analysed reference in this PR and in the commit message.

## Not ported

- **Ktor / `NetworkConfig.kt`** — would add a second HTTP stack. Its useful parts (HTTP/2, connection pool, gzip, bounded timeouts) already exist in `LevyraHttpClientFactory`, and its 30 s connect / 60 s read timeouts are browse-shaped and far looser than Levyra's playback budgets.
- **`InnerTube.withRetry`** (3 attempts, exponential backoff on `IOException`) — Levyra already recovers through the hedged multi-client ladder. Adding blind per-request retries would multiply traffic and delay the fallback to the next client, against the resolver latency budget.
- **Account surface** — login, cookies, `SAPISID` hashing, `dataSyncId`, `onBehalfOfUser`, remote like/subscribe/playlist editing, `AccountMenuResponse`. Out of scope and outside Levyra's privacy contract.
- **Extra client profiles** (`TVHTML5`, `TVHTML5_SIMPLY`, `VISIONOS`, `IPADOS`, `ANDROID_CREATOR`, the four `ANDROID_VR` version variants) — Levyra's seven profiles already cover the same content classes. Adding untested clients lengthens the ladder and slows the failure path.
- **Structured page parsers / DTO layer** (`pages/*`, `models/response/*`) — a genuinely valuable direction, but it is a separate vertical: it would rewrite Levyra's `JSONObject` parsing across search, artist, album, playlist, next and continuations, and it does not belong in a client-identity change. Left for a follow-up so this PR stays reviewable.
- **`pages/NewPipe.kt`** — Levyra's `NewPipeRuntime` is already hardened (bounded responses, init safety, cancellation, downloader hardening) beyond the Metrolist version.
- **Proxy configuration and telemetry hooks** — no Levyra requirement.

## Risks

1. **Unified user agents for the native clients.** `ANDROID` and `IOS` now send the browse-side user agents (`…/19.44.38 (Linux; U; Android 15; Pixel 8 Pro Build/AP3A.241105.007) gzip`, and the iOS string without a hardcoded `it_IT` locale) on the playback path too. `ANDROID_MUSIC` and the three WEB clients are unaffected because `YoutubeClientIdentityInterceptor` already overwrites their user agent. The change is small but real and is only exercised against live YouTube.
2. **`X-Goog-Api-Format-Version: 2` on playback for `ANDROID_MUSIC` and `ANDROID`.** Previously sent only by `ANDROID_VR` on playback, and by both of these on browse. Aligned on what the genuine Android clients send; if a client regresses, flipping `useApiFormatVersion2` in the registry is a one-line revert.
3. **Live detection is observation-based.** A track is only known to be live after a player response exposes `videoDetails.isLiveContent`, so the very first resolution of a live stream still tries Android VR. Subsequent resolutions skip it. No pre-emptive network call was added to close this gap.
4. **Release lint and the F-Droid release compile were not run locally** (missing API key, see *Tests*). CI must confirm both.
