### PR TITLE
fix(android): recover empty album details and refine album error state

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
@@ -353,6 +353,39 @@ private fun matchingArtistSignalIndex(artist: String, signals: List<String>): In
     }
 }
 
+internal fun selectAlbumRecoveryCandidate(
+    album: AlbumHit,
+    candidates: List<AlbumHit>,
+    excludedBrowseIds: Set<String> = emptySet()
+): AlbumHit? {
+    val titleKey = albumRecommendationTextKey(album.title)
+    if (titleKey.isBlank()) return null
+
+    val artistKey = albumRecommendationTextKey(album.artist)
+    val primaryArtistKey = albumRecommendationTextKey(primaryArtistSegment(album.artist))
+    val artistBrowseId = album.artistBrowseId.trim()
+    val excluded = excludedBrowseIds
+        .map { it.trim().lowercase(Locale.ROOT) }
+        .filter(String::isNotBlank)
+        .toSet()
+
+    return candidates.asSequence()
+        .filter { candidate ->
+            val browseId = candidate.browseId.trim()
+            browseId.isNotBlank() && browseId.lowercase(Locale.ROOT) !in excluded
+        }
+        .filter { candidate ->
+            albumRecommendationTextKey(candidate.title) == titleKey
+        }
+        .firstOrNull { candidate ->
+            val candidateArtistKey = albumRecommendationTextKey(candidate.artist)
+            val candidatePrimaryArtistKey = albumRecommendationTextKey(primaryArtistSegment(candidate.artist))
+            (artistKey.isNotBlank() && candidateArtistKey == artistKey) ||
+                (primaryArtistKey.isNotBlank() && candidatePrimaryArtistKey == primaryArtistKey) ||
+                (artistBrowseId.isNotBlank() && candidate.artistBrowseId.equals(artistBrowseId, ignoreCase = true))
+        }
+}
+
 class YoutubeMusicRepository(private val context: Context? = null) {
     private val apiKey = BuildConfig.YOUTUBE_INNERTUBE_API_KEY
     private val clientVersion = "1.20260423.01.00"
@@ -870,71 +903,111 @@ class YoutubeMusicRepository(private val context: Context? = null) {
         }.distinctBy { it.id }
     }
 
-    suspend fun albumDetail(album: AlbumHit, languageCode: String = LevyraLanguageCatalog.deviceDefault()): AlbumDetail = withContext(Dispatchers.IO) {
-    val resolved = resolveAlbumHit(album, languageCode)
-    val root = resolved.browseId.takeIf { it.isNotBlank() }?.let { requestMusicBrowseRoot(languageCode, it) }
-    val headerAlbum = root?.let { parseAlbumHeader(it, resolved) } ?: resolved
-    val cover = headerAlbum.thumbnailUrl.ifBlank { resolved.thumbnailUrl }
-    val canonicalAudioPlaylistId = sequenceOf(
-        root?.let(::extractAudioPlaylistId).orEmpty(),
-        headerAlbum.audioPlaylistId,
-        resolved.audioPlaylistId,
-        album.audioPlaylistId
-    )
-        .map { it.trim().removePrefix("VL") }
-        .firstOrNull { it.startsWith("OLA") }
-        .orEmpty()
-    val playlistTracks = if (canonicalAudioPlaylistId.isNotBlank()) {
-        try {
-            playlist(canonicalAudioPlaylistId, languageCode, 60)?.tracks.orEmpty()
-        } catch (error: CancellationException) {
-            throw error
-        } catch (_: Throwable) {
+    suspend fun albumDetail(
+        album: AlbumHit,
+        languageCode: String = LevyraLanguageCatalog.deviceDefault()
+    ): AlbumDetail = withContext(Dispatchers.IO) {
+        val initial = loadAlbumDetailOnce(album, languageCode)
+        if (initial.tracks.isNotEmpty()) return@withContext initial
+
+        val attemptedBrowseIds = setOf(album.browseId, initial.album.browseId)
+            .map(String::trim)
+            .filter(String::isNotBlank)
+            .toSet()
+        val recovery = findAlbumRecoveryCandidate(
+            album = album,
+            languageCode = languageCode,
+            excludedBrowseIds = attemptedBrowseIds
+        ) ?: return@withContext initial
+
+        val recovered = loadAlbumDetailOnce(recovery, languageCode)
+        if (recovered.tracks.isNotEmpty()) recovered else initial
+    }
+
+    private suspend fun loadAlbumDetailOnce(album: AlbumHit, languageCode: String): AlbumDetail {
+        val resolved = resolveAlbumHit(album, languageCode)
+        val root = resolved.browseId.takeIf { it.isNotBlank() }
+            ?.let { requestMusicBrowseRoot(languageCode, it) }
+        val headerAlbum = root?.let { parseAlbumHeader(it, resolved) } ?: resolved
+        val cover = headerAlbum.thumbnailUrl.ifBlank { resolved.thumbnailUrl }
+        val canonicalAudioPlaylistId = sequenceOf(
+            root?.let(::extractAudioPlaylistId).orEmpty(),
+            headerAlbum.audioPlaylistId,
+            resolved.audioPlaylistId,
+            album.audioPlaylistId
+        )
+            .map { it.trim().removePrefix("VL") }
+            .firstOrNull { it.startsWith("OLA") }
+            .orEmpty()
+        val playlistTracks = if (canonicalAudioPlaylistId.isNotBlank()) {
+            try {
+                playlist(canonicalAudioPlaylistId, languageCode, 60)?.tracks.orEmpty()
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Throwable) {
+                emptyList()
+            }
+        } else {
             emptyList()
         }
-    } else {
-        emptyList()
-    }
-    val shelfTracks = if (playlistTracks.isEmpty()) {
-        root?.let { parseAlbumTracks(it, headerAlbum.copy(thumbnailUrl = cover)) }.orEmpty()
-    } else {
-        emptyList()
-    }
-    val finalTracks = (if (playlistTracks.isNotEmpty()) playlistTracks else shelfTracks)
-        .distinctBy { it.id.ifBlank { "${it.title.lowercase()}|${it.artist.lowercase()}" } }
-        .take(60)
-    val finalArtist = headerAlbum.artist.cleanAlbumArtistLabel()
-        .ifBlank { finalTracks.firstNotNullOfOrNull { it.artist.cleanAlbumArtistLabel().takeIf(String::isNotBlank) }.orEmpty() }
-        .ifBlank { resolved.artist.cleanAlbumArtistLabel() }
-    val finalAlbum = headerAlbum.copy(
-        artist = finalArtist,
-        thumbnailUrl = cover,
-        query = "${headerAlbum.title} $finalArtist".trim(),
-        browseId = headerAlbum.browseId.ifBlank { resolved.browseId },
-        audioPlaylistId = canonicalAudioPlaylistId,
-        explicit = root?.toString()?.contains("MUSIC_ITEM_BADGE_EXPLICIT") == true || headerAlbum.explicit
-    )
-    val enrichedTracks = finalTracks.map { track ->
-        track.copy(
-            album = finalAlbum.title,
-            albumBrowseId = finalAlbum.browseId,
-            year = track.year.ifBlank { finalAlbum.year },
-            explicit = track.explicit || finalAlbum.explicit,
-            thumbnailUrl = finalAlbum.thumbnailUrl.ifBlank { track.thumbnailUrl },
-            largeThumbnailUrl = finalAlbum.thumbnailUrl.ifBlank { track.largeThumbnailUrl.ifBlank { track.thumbnailUrl } }
+        val shelfTracks = if (playlistTracks.isEmpty()) {
+            root?.let { parseAlbumTracks(it, headerAlbum.copy(thumbnailUrl = cover)) }.orEmpty()
+        } else {
+            emptyList()
+        }
+        val finalTracks = (if (playlistTracks.isNotEmpty()) playlistTracks else shelfTracks)
+            .distinctBy { it.id.ifBlank { "${it.title.lowercase()}|${it.artist.lowercase()}" } }
+            .take(60)
+        val finalArtist = headerAlbum.artist.cleanAlbumArtistLabel()
+            .ifBlank {
+                finalTracks.firstNotNullOfOrNull {
+                    it.artist.cleanAlbumArtistLabel().takeIf(String::isNotBlank)
+                }.orEmpty()
+            }
+            .ifBlank { resolved.artist.cleanAlbumArtistLabel() }
+        val finalAlbum = headerAlbum.copy(
+            artist = finalArtist,
+            thumbnailUrl = cover,
+            query = "${headerAlbum.title} $finalArtist".trim(),
+            browseId = headerAlbum.browseId.ifBlank { resolved.browseId },
+            audioPlaylistId = canonicalAudioPlaylistId,
+            explicit = root?.toString()?.contains("MUSIC_ITEM_BADGE_EXPLICIT") == true || headerAlbum.explicit
+        )
+        val enrichedTracks = finalTracks.map { track ->
+            track.copy(
+                album = finalAlbum.title,
+                albumBrowseId = finalAlbum.browseId,
+                year = track.year.ifBlank { finalAlbum.year },
+                explicit = track.explicit || finalAlbum.explicit,
+                thumbnailUrl = finalAlbum.thumbnailUrl.ifBlank { track.thumbnailUrl },
+                largeThumbnailUrl = finalAlbum.thumbnailUrl.ifBlank {
+                    track.largeThumbnailUrl.ifBlank { track.thumbnailUrl }
+                }
+            )
+        }
+        enrichedTracks.forEach { memory[it.id] = it }
+        val description = root?.let { parseAlbumDescription(it) }.orEmpty()
+        return AlbumDetail(
+            album = finalAlbum,
+            description = description,
+            tracks = enrichedTracks,
+            otherVersions = root?.let { parseOtherAlbumVersions(it, finalAlbum) }.orEmpty(),
+            trackCount = enrichedTracks.size,
+            durationMs = enrichedTracks.sumOf { it.durationMs }
         )
     }
-    enrichedTracks.forEach { memory[it.id] = it }
-    val description = root?.let { parseAlbumDescription(it) }.orEmpty()
-    AlbumDetail(
-        album = finalAlbum,
-        description = description,
-        tracks = enrichedTracks,
-        otherVersions = root?.let { parseOtherAlbumVersions(it, finalAlbum) }.orEmpty(),
-        trackCount = enrichedTracks.size,
-        durationMs = enrichedTracks.sumOf { it.durationMs }
-    )
-}
+
+    private fun findAlbumRecoveryCandidate(
+        album: AlbumHit,
+        languageCode: String,
+        excludedBrowseIds: Set<String>
+    ): AlbumHit? {
+        if (!isPlausibleYoutubeMusicAlbumTitle(album.title)) return null
+        val query = album.query.ifBlank { "${album.title} ${album.artist}" }.trim()
+        if (query.length < 2) return null
+        val candidates = searchAlbumHits(query, languageCode, 12)
+        return selectAlbumRecoveryCandidate(album, candidates, excludedBrowseIds)
+    }
 
     suspend fun resolveAlbumDescription(
         detail: AlbumDetail,

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -1601,6 +1601,7 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
                     onFavorite = viewModel::toggleFavorite,
                     onDownload = viewModel::exportTrack,
                     onDownloadAlbum = viewModel::exportCurrentAlbum,
+                    onRetry = { state.albumDetail?.album?.let(viewModel::openAlbum) },
 
                     onAddToPlaylist = { playlistId, track -> viewModel.addToPlaylist(playlistId, track) },
                     onCreatePlaylistWithTrack = { name, track -> viewModel.createPlaylist(name, track) },
@@ -2047,6 +2048,7 @@ private fun AlbumOverlay(
     onFavorite: (Track) -> Unit,
     onDownload: (Track) -> Unit,
     onDownloadAlbum: () -> Unit,
+    onRetry: () -> Unit,
 
     onAddToPlaylist: (String, Track) -> Unit,
     onCreatePlaylistWithTrack: (String, Track) -> Unit,
@@ -2073,6 +2075,7 @@ private fun AlbumOverlay(
     val albumIsActive = albumCurrentTrack != null
     val albumIsPlaying = albumIsActive && state.isPlaying
     val albumIsResolving = albumIsActive && state.isResolving
+    val trackLoadFailed = album != null && tracks.isEmpty() && !state.albumLoading
     val albumBottomInset = animatedBottomContentInset(
         collapsed = 112.dp,
         expanded = 232.dp,
@@ -2112,7 +2115,7 @@ private fun AlbumOverlay(
                         color = Color.White.copy(alpha = 0.06f),
                         border = BorderStroke(1.dp, Color.White.copy(alpha = 0.10f)),
                         shape = CircleShape,
-                        modifier = Modifier.size(44.dp).pressable(onClick = onClose)
+                        modifier = Modifier.size(48.dp).pressable(onClick = onClose)
                     ) {
                         Box(contentAlignment = Alignment.Center) {
                             Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = strings.back, tint = LevyraText)
@@ -2123,7 +2126,7 @@ private fun AlbumOverlay(
                         color = Color.White.copy(alpha = 0.06f),
                         border = BorderStroke(1.dp, Color.White.copy(alpha = 0.10f)),
                         shape = CircleShape,
-                        modifier = Modifier.size(44.dp).pressable(onClick = {
+                        modifier = Modifier.size(48.dp).pressable(onClick = {
                             val query = listOf(album?.title.orEmpty(), album?.artist.orEmpty()).filter { it.isNotBlank() }.joinToString(" ")
                             if (query.isNotBlank()) openExternalUrl(context, "https://music.youtube.com/search?q=${java.net.URLEncoder.encode(query, "UTF-8")}", strings)
                         })
@@ -2152,6 +2155,7 @@ private fun AlbumOverlay(
                             cover = cover,
                             description = description,
                             trackCount = tracks.size,
+                            trackLoadFailed = trackLoadFailed,
                             isPlaying = albumIsPlaying,
                             isResolving = albumIsResolving,
                             accentStart = accentStart,
@@ -2160,6 +2164,7 @@ private fun AlbumOverlay(
                                 if (albumIsActive) onTogglePlayback() else onPlayAll()
                             },
                             onDownload = onDownloadAlbum,
+                            onRetry = onRetry,
                             onOpenArtist = onOpenAlbumArtist,
                             onShare = {
                                 val shareText = buildString {
@@ -2217,7 +2222,7 @@ private fun AlbumOverlay(
                         }
                     } else if (!state.albumLoading) {
                         item(key = "album-no-tracks") {
-                            GlassMessage(state.albumError ?: strings.albumTracksUnavailable, LevyraOrange)
+                            AlbumTracksUnavailableState(strings.albumTracksUnavailable)
                         }
                     }
                 }
@@ -2287,12 +2292,14 @@ private fun AlbumHeroCard(
     cover: String,
     description: String,
     trackCount: Int,
+    trackLoadFailed: Boolean,
     isPlaying: Boolean,
     isResolving: Boolean,
     accentStart: Color,
     accentEnd: Color,
     onPlayAll: () -> Unit,
     onDownload: () -> Unit,
+    onRetry: () -> Unit,
     onOpenArtist: () -> Unit,
     onShare: () -> Unit
 ) {
@@ -2356,19 +2363,22 @@ private fun AlbumHeroCard(
         }
 
         AlbumPrimaryPlayButton(
-            enabled = trackCount > 0,
-            isPlaying = isPlaying,
+            enabled = trackCount > 0 || trackLoadFailed,
+            isPlaying = isPlaying && !trackLoadFailed,
             isResolving = isResolving,
+            retry = trackLoadFailed,
             accentStart = accentStart,
             accentEnd = accentEnd,
-            onClick = onPlayAll
+            onClick = if (trackLoadFailed) onRetry else onPlayAll
         )
 
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(10.dp)
         ) {
-            AlbumSecondaryAction(icon = Icons.Rounded.Download, label = LocalLevyraStrings.current.offline, enabled = trackCount > 0, modifier = Modifier.weight(1f), onClick = onDownload)
+            if (trackCount > 0) {
+                AlbumSecondaryAction(icon = Icons.Rounded.Download, label = LocalLevyraStrings.current.offline, enabled = true, modifier = Modifier.weight(1f), onClick = onDownload)
+            }
             AlbumSecondaryAction(icon = Icons.Rounded.Person, label = LocalLevyraStrings.current.artistLabel, enabled = album.artist.isNotBlank(), modifier = Modifier.weight(1f), onClick = onOpenArtist)
             AlbumSecondaryAction(icon = Icons.Rounded.Share, label = LocalLevyraStrings.current.share, enabled = true, modifier = Modifier.weight(1f), onClick = onShare)
         }
@@ -2407,10 +2417,44 @@ private fun AlbumHeroCard(
 }
 
 @Composable
+private fun AlbumTracksUnavailableState(message: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp, vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(32.dp)
+                .background(LevyraOrange.copy(alpha = 0.12f), CircleShape),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.Info,
+                contentDescription = null,
+                tint = LevyraOrange,
+                modifier = Modifier.size(17.dp)
+            )
+        }
+        Text(
+            text = message,
+            color = LevyraMuted,
+            fontSize = 13.sp,
+            lineHeight = 18.sp,
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
 private fun AlbumPrimaryPlayButton(
     enabled: Boolean,
     isPlaying: Boolean,
     isResolving: Boolean,
+    retry: Boolean,
     accentStart: Color,
     accentEnd: Color,
     onClick: () -> Unit
@@ -2445,14 +2489,22 @@ private fun AlbumPrimaryPlayButton(
                 )
             } else {
                 Icon(
-                    if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+                    when {
+                        retry -> Icons.Rounded.Refresh
+                        isPlaying -> Icons.Rounded.Pause
+                        else -> Icons.Rounded.PlayArrow
+                    },
                     null,
                     tint = if (enabled) enabledContent else disabledContent,
                     modifier = Modifier.size(26.dp)
                 )
             }
             Text(
-                if (isPlaying) LocalLevyraStrings.current.playing else LocalLevyraStrings.current.play,
+                when {
+                    retry -> LocalLevyraStrings.current.exploreSamplesRetry
+                    isPlaying -> LocalLevyraStrings.current.playing
+                    else -> LocalLevyraStrings.current.play
+                },
                 color = if (enabled) enabledContent else disabledContent,
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Bold,
@@ -2475,7 +2527,7 @@ private fun AlbumSecondaryAction(
     val buttonShape = RoundedCornerShape(cornerRadius)
     Row(
         modifier = modifier
-            .height(46.dp)
+            .height(48.dp)
             .clip(buttonShape)
             .background(Color.White.copy(alpha = if (enabled) 0.06f else 0.03f))
             .border(BorderStroke(1.dp, Color.White.copy(alpha = if (enabled) 0.08f else 0.04f)), buttonShape)

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -3526,7 +3526,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 _state.update {
                     it.copy(
                         albumLoading = false,
-                        albumError = "Album non disponibile",
+                        albumError = LevyraStrings.forCode(it.languageCode).albumTracksUnavailable,
                         albumDetail = detail ?: AlbumDetail(album, "", emptyList())
                     )
                 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicRepositoryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.luc4n3x.levyra.data
 
+import com.luc4n3x.levyra.domain.AlbumHit
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -317,4 +318,75 @@ class YoutubeMusicRepositoryTest {
         assertEquals(emptyList<String>(), references.map { it.browseId })
     }
 
+
+    @Test
+    fun albumRecoveryAcceptsExactTitleAndPrimaryArtistWithNewBrowseId() {
+        val seed = AlbumHit(
+            title = "SACRO",
+            artist = "Serena Brancale, Levante, DELIA",
+            year = "2026",
+            thumbnailUrl = "https://example.test/sacro.jpg",
+            query = "SACRO Serena Brancale Levante DELIA",
+            browseId = "MPRE_OLD"
+        )
+        val candidate = seed.copy(
+            title = "Sacro",
+            artist = "Serena Brancale",
+            browseId = "MPRE_NEW"
+        )
+
+        val selected = selectAlbumRecoveryCandidate(
+            album = seed,
+            candidates = listOf(candidate),
+            excludedBrowseIds = setOf(seed.browseId)
+        )
+
+        assertEquals("MPRE_NEW", selected?.browseId)
+    }
+
+    @Test
+    fun albumRecoveryRejectsDifferentTitle() {
+        val seed = AlbumHit(
+            title = "SACRO",
+            artist = "Serena Brancale, Levante, DELIA",
+            year = "2026",
+            thumbnailUrl = "",
+            query = "SACRO Serena Brancale",
+            browseId = "MPRE_OLD"
+        )
+        val candidate = seed.copy(
+            title = "Anema e core",
+            artist = "Serena Brancale",
+            browseId = "MPRE_OTHER"
+        )
+
+        val selected = selectAlbumRecoveryCandidate(
+            album = seed,
+            candidates = listOf(candidate),
+            excludedBrowseIds = setOf(seed.browseId)
+        )
+
+        assertEquals(null, selected)
+    }
+
+    @Test
+    fun albumRecoveryRejectsAlreadyAttemptedBrowseId() {
+        val seed = AlbumHit(
+            title = "SACRO",
+            artist = "Serena Brancale",
+            year = "2026",
+            thumbnailUrl = "",
+            query = "SACRO Serena Brancale",
+            browseId = "MPRE_OLD"
+        )
+        val candidate = seed.copy(browseId = "MPRE_OLD")
+
+        val selected = selectAlbumRecoveryCandidate(
+            album = seed,
+            candidates = listOf(candidate),
+            excludedBrowseIds = setOf(seed.browseId)
+        )
+
+        assertEquals(null, selected)
+    }
 }


### PR DESCRIPTION
## Summary
- recover album detail once when a valid-looking browse ID returns no tracks, accepting only exact-title + strong artist matches
- show a compact localized tracks-unavailable state instead of the contradictory album-unavailable panel
- turn the primary album CTA into Retry when track loading fails, hide the unusable Offline action, and keep Artist/Share available
- bring album detail touch targets to 48dp
- add regression coverage for recovery candidate selection

## Validation
- `./gradlew --no-daemon :app:testDebugUnitTest --tests 'com.luc4n3x.levyra.data.YoutubeMusicRepositoryTest'`
- `./gradlew --no-daemon :app:compileDebugKotlin`
- `git diff --check`

## Risk
- recovery is bounded to one extra attempt only after an empty tracklist
- alternate results require an exact normalized album title plus strong artist identity
- no playback architecture, Media3, downloads, versions, dependencies, or release configuration changed