### PR TITLE
Automate Codex tooling bootstrap

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -120,6 +120,7 @@ boundaries.
 | `levyra-project-manager` | Specification, roadmap, active phase, acceptance criteria, and handoff |
 | `levyra-openclaw-orchestrator` | OpenClaw delegation, coding-runtime coordination, review, and evidence |
 | `levyra-context-efficiency` | RTK routing, focused context selection, measured savings, and raw-output fallback |
+| `levyra-codex-bootstrap` | Codex SessionStart tooling bootstrap, jCodeMunch/RTK/Matt skill setup, and fail-open validation |
 | `levyra-real-engineering` | Matt Pocock-style clarify/spec/tickets/implement/review routing for non-trivial work |
 | `levyra-player` | Android playback, queue, Media3, MediaSession, notification, and audio/video modes |
 | `levyra-extractor` | InnerTube, extraction, stream resolution, fallback, retry, and cache |

--- a/.agents/skills/levyra-codex-bootstrap/SKILL.md
+++ b/.agents/skills/levyra-codex-bootstrap/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: levyra-codex-bootstrap
+description: Use when Codex tooling, jCodeMunch, RTK, Matt Pocock skills, automatic setup, context efficiency, or Codex MCP/bootstrap behavior for Levyra is being inspected, repaired, or changed. Do not load for ordinary coding tasks unless the bootstrap itself is relevant.
+---
+
+# Levyra Codex bootstrap
+
+The repository owner explicitly authorizes Levyra's checked-in Codex bootstrap to install and run only the pinned/allowlisted tooling defined by the repository:
+
+- the existing pinned `rtk-ai/rtk` revision;
+- jCodeMunch `1.108.279` from the exact release wheel and SHA-256 declared in `scripts/codex_jcodemunch.py`;
+- the focused Matt Pocock Codex skill allowlist already declared by Levyra;
+- the existing claude-mem integration only under its separate on-demand policy.
+
+The automatic bootstrap must remain idempotent and fail-open. A missing package manager, unavailable network, failed install, failed MCP handshake, or stale index must never disable Codex's native repository tools or block normal coding. Do not add read/search blocking rules. Prefer jCodeMunch for targeted exploration, then expand to native reads/search whenever control flow, lifecycle, concurrency, state, tests, generated behavior, or correctness requires broader evidence.
+
+Do not add Token Optimizer or another always-on compression proxy without a separate owner decision. Token savings never override correctness, validation, security evidence, or repository architecture.
+
+Relevant files:
+
+- `.codex/config.toml`
+- `.codex/hooks.json`
+- `scripts/codex_jcodemunch.py`
+- `scripts/ensure-codex-tooling.ps1`
+- `scripts/ensure-codex-tooling.sh`
+- `docs/ai/CODEX_AUTO_BOOTSTRAP.md`

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,11 @@
+#:schema https://developers.openai.com/codex/config-schema.json
+
+# Project-scoped, optional MCP. The launcher pins and verifies jCodeMunch before
+# handing stdio to the server. If the bootstrap fails, Codex remains usable with
+# its native repository tools because this server is intentionally not required.
+[mcp_servers.jcodemunch]
+command = "python"
+args = ["scripts/codex_jcodemunch.py", "serve"]
+required = false
+startup_timeout_sec = 180
+tool_timeout_sec = 120

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Levyra project lifecycle hooks for automatic owner-authorized tooling bootstrap.",
+  "description": "Levyra project lifecycle hooks for automatic owner-authorized Codex tooling bootstrap.",
   "hooks": {
     "SessionStart": [
       {
@@ -7,10 +7,10 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -lc '\"$(git rev-parse --show-toplevel)/scripts/ensure-rtk.sh\" --quiet >/dev/null 2>&1 || true'",
-            "commandWindows": "powershell -NoProfile -Command \"$root=(git rev-parse --show-toplevel); & (Join-Path $root 'scripts/ensure-rtk.ps1') -Quiet *> $null; exit 0\"",
+            "command": "bash -lc '\"$(git rev-parse --show-toplevel)/scripts/ensure-codex-tooling.sh\" --quiet >/dev/null 2>&1 || true; printf \"%s\\n\" \"Levyra Codex bootstrap is automatic. Prefer jCodeMunch for non-trivial code discovery, but use native reads/search whenever broader context is needed for correctness. Token savings never override correctness.\"'",
+            "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -Command \"$root=(git rev-parse --show-toplevel); & (Join-Path $root 'scripts/ensure-codex-tooling.ps1') -Quiet *> $null; Write-Output 'Levyra Codex bootstrap is automatic. Prefer jCodeMunch for non-trivial code discovery, but use native reads/search whenever broader context is needed for correctness. Token savings never override correctness.'; exit 0\"",
             "timeout": 600,
-            "statusMessage": "Preparing Levyra RTK"
+            "statusMessage": "Preparing Levyra Codex tooling"
           }
         ]
       }

--- a/docs/ai/CODEX_AUTO_BOOTSTRAP.md
+++ b/docs/ai/CODEX_AUTO_BOOTSTRAP.md
@@ -1,0 +1,53 @@
+# Codex automatic tooling bootstrap
+
+Levyra treats Codex setup as repository infrastructure rather than a manual checklist. Once the project-local `.codex` layer is trusted, a Codex `SessionStart` hook checks the owner-authorized tooling automatically on `startup` and `resume`.
+
+## What is automatic
+
+- RTK is verified through the existing pinned Levyra bootstrap and installed only when missing.
+- jCodeMunch `1.108.279` is installed into a versioned user cache from the exact GitHub release wheel pinned by SHA-256, then the Levyra index is refreshed.
+- The focused Matt Pocock Codex skills are installed only when one or more expected global skills are missing.
+- Repository-native `levyra-*` skills need no installation; Codex discovers them directly from `.agents/skills`.
+- claude-mem keeps its existing automatic-on-need policy and is not forced into every session.
+
+## jCodeMunch MCP
+
+`.codex/config.toml` registers jCodeMunch as a project-scoped optional MCP server. `scripts/codex_jcodemunch.py` verifies the pinned version before starting the server and keeps bootstrap chatter off MCP stdout so the JSON-RPC handshake is not contaminated.
+
+The MCP is deliberately `required = false`. If Python, networking, installation, indexing, or the MCP handshake fails, Codex continues with its native repository tools. jCodeMunch is a first-pass navigator, not a replacement for full-file reads or native search when broader context is necessary.
+
+## First trust
+
+Codex requires review/trust for non-managed project hooks. That trust decision is intentionally not bypassed. After the project hook is trusted, normal sessions require no manual setup command. Changing the hook may cause Codex to request trust again.
+
+## Repair and verification
+
+Windows:
+
+```powershell
+.\scripts\ensure-codex-tooling.ps1
+```
+
+Bash/WSL/Linux/macOS:
+
+```bash
+./scripts/ensure-codex-tooling.sh
+```
+
+Dry-run without installs:
+
+```powershell
+.\scripts\ensure-codex-tooling.ps1 -DryRun
+```
+
+```bash
+./scripts/ensure-codex-tooling.sh --dry-run
+```
+
+A bootstrap failure is diagnostic, not permission to weaken sandboxing, bypass hook trust, disable validation, or block normal coding.
+
+Repository contract check:
+
+```bash
+python3 scripts/validate_codex_bootstrap.py
+```

--- a/scripts/codex_jcodemunch.py
+++ b/scripts/codex_jcodemunch.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Bootstrap and launch Levyra's pinned jCodeMunch MCP runtime."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+JCODEMUNCH_VERSION = "1.108.279"
+JCODEMUNCH_WHEEL_SHA256 = "d192998a9abcd8afa1474f2a1637e260a9ab48fdd0080b6b690632b2af1e30f1"
+JCODEMUNCH_WHEEL_URL = (
+    "https://github.com/jgravelle/jcodemunch-mcp/releases/download/"
+    f"v{JCODEMUNCH_VERSION}/jcodemunch_mcp-{JCODEMUNCH_VERSION}-py3-none-any.whl"
+    f"#sha256={JCODEMUNCH_WHEEL_SHA256}"
+)
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def cache_root() -> Path:
+    if os.name == "nt":
+        base = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+    else:
+        base = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    return base / "Levyra" / "codex-tools" / "jcodemunch" / JCODEMUNCH_VERSION
+
+
+def venv_dir() -> Path:
+    return cache_root() / "venv"
+
+
+def venv_python() -> Path:
+    if os.name == "nt":
+        return venv_dir() / "Scripts" / "python.exe"
+    return venv_dir() / "bin" / "python"
+
+
+def jcodemunch_binary() -> Path:
+    if os.name == "nt":
+        return venv_dir() / "Scripts" / "jcodemunch-mcp.exe"
+    return venv_dir() / "bin" / "jcodemunch-mcp"
+
+
+def _run_quiet(command: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def installed_version() -> str | None:
+    binary = jcodemunch_binary()
+    if not binary.is_file():
+        return None
+    try:
+        result = _run_quiet([str(binary), "--version"])
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    output = f"{result.stdout}\n{result.stderr}"
+    return JCODEMUNCH_VERSION if JCODEMUNCH_VERSION in output else None
+
+
+def ensure_installed(*, quiet: bool) -> Path:
+    binary = jcodemunch_binary()
+    if installed_version() == JCODEMUNCH_VERSION:
+        return binary
+
+    target = venv_dir()
+    if target.exists():
+        shutil.rmtree(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    stream = subprocess.DEVNULL if quiet else sys.stderr
+    subprocess.run([sys.executable, "-m", "venv", str(target)], check=True, stdout=stream, stderr=stream)
+    subprocess.run(
+        [
+            str(venv_python()),
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            "--no-input",
+            JCODEMUNCH_WHEEL_URL,
+        ],
+        check=True,
+        stdout=stream,
+        stderr=stream,
+    )
+
+    if installed_version() != JCODEMUNCH_VERSION:
+        raise RuntimeError(f"jCodeMunch {JCODEMUNCH_VERSION} installed but verification failed")
+    return binary
+
+
+def index_repository(*, quiet: bool) -> None:
+    binary = ensure_installed(quiet=quiet)
+    stream = subprocess.DEVNULL if quiet else sys.stderr
+    subprocess.run(
+        [str(binary), "index", str(repo_root())],
+        check=True,
+        cwd=repo_root(),
+        stdout=stream,
+        stderr=stream,
+    )
+
+
+def serve() -> int:
+    try:
+        binary = ensure_installed(quiet=True)
+    except Exception as exc:  # fail closed for this optional MCP only; Codex itself stays usable.
+        print(f"Levyra jCodeMunch bootstrap failed: {exc}", file=sys.stderr)
+        return 1
+
+    os.execv(str(binary), [str(binary)])
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("ensure", "index", "serve"))
+    parser.add_argument("--quiet", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.action == "serve":
+            return serve()
+        if args.action == "ensure":
+            ensure_installed(quiet=args.quiet)
+        else:
+            index_repository(quiet=args.quiet)
+    except Exception as exc:
+        if not args.quiet:
+            print(f"Levyra jCodeMunch bootstrap failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ensure-codex-tooling.ps1
+++ b/scripts/ensure-codex-tooling.ps1
@@ -1,0 +1,132 @@
+[CmdletBinding()]
+param(
+    [switch] $DryRun,
+    [switch] $Quiet,
+    [switch] $SkipIndex
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+if (Get-Variable -Name PSNativeCommandUseErrorActionPreference -ErrorAction SilentlyContinue) {
+    $PSNativeCommandUseErrorActionPreference = $false
+}
+
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+$mattSkillSource = 'mattpocock/skills'
+$mattSkills = @(
+    'setup-matt-pocock-skills',
+    'grill-with-docs',
+    'wayfinder',
+    'to-spec',
+    'to-tickets',
+    'implement',
+    'tdd',
+    'diagnosing-bugs',
+    'code-review',
+    'domain-modeling'
+)
+$failures = New-Object System.Collections.Generic.List[string]
+
+function Test-Command {
+    param([Parameter(Mandatory)][string] $Name)
+    return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Write-Step {
+    param([Parameter(Mandatory)][string] $Message)
+    if (-not $Quiet) {
+        Write-Output $Message
+    }
+}
+
+function Invoke-FailOpen {
+    param(
+        [Parameter(Mandatory)][string] $Label,
+        [Parameter(Mandatory)][scriptblock] $Command
+    )
+    if ($DryRun) {
+        Write-Step "[dry-run] $Label"
+        return
+    }
+    try {
+        $global:LASTEXITCODE = 0
+        & $Command
+        if ($LASTEXITCODE -ne 0) {
+            throw "exit code $LASTEXITCODE"
+        }
+    }
+    catch {
+        $failures.Add("$Label`: $($_.Exception.Message)")
+    }
+}
+
+function Get-PythonCommand {
+    foreach ($candidate in @('python3', 'python', 'py')) {
+        if (Test-Command $candidate) {
+            return $candidate
+        }
+    }
+    return $null
+}
+
+$ensureRtk = Join-Path $PSScriptRoot 'ensure-rtk.ps1'
+if (Test-Path -LiteralPath $ensureRtk -PathType Leaf) {
+    Invoke-FailOpen 'Ensure pinned RTK' {
+        & $ensureRtk -Quiet
+    }
+}
+else {
+    $failures.Add('Ensure pinned RTK: scripts/ensure-rtk.ps1 is missing')
+}
+
+$pythonCommand = Get-PythonCommand
+$jCodeMunchRuntime = Join-Path $PSScriptRoot 'codex_jcodemunch.py'
+if (-not $pythonCommand) {
+    $failures.Add('Ensure jCodeMunch: Python is unavailable')
+}
+elseif (-not (Test-Path -LiteralPath $jCodeMunchRuntime -PathType Leaf)) {
+    $failures.Add('Ensure jCodeMunch: scripts/codex_jcodemunch.py is missing')
+}
+else {
+    Invoke-FailOpen 'Ensure pinned jCodeMunch' {
+        & $pythonCommand $jCodeMunchRuntime ensure --quiet
+    }
+    if (-not $SkipIndex) {
+        Invoke-FailOpen 'Refresh Levyra jCodeMunch index' {
+            & $pythonCommand $jCodeMunchRuntime index --quiet
+        }
+    }
+}
+
+$skillRoot = Join-Path $HOME '.agents\skills'
+$missingMattSkills = @(
+    $mattSkills | Where-Object {
+        -not (Test-Path -LiteralPath (Join-Path $skillRoot "$_\SKILL.md") -PathType Leaf)
+    }
+)
+if ($missingMattSkills.Count -gt 0) {
+    if (-not (Test-Command 'npx')) {
+        $failures.Add('Ensure Matt Pocock skills: npx is unavailable')
+    }
+    else {
+        Invoke-FailOpen 'Install missing Matt Pocock Codex skills' {
+            $skillArgs = @('skills@latest', 'add', $mattSkillSource, '-g', '-a', 'codex', '-y')
+            foreach ($skill in $mattSkills) {
+                $skillArgs += @('-s', $skill)
+            }
+            & npx @skillArgs *> $null
+        }
+    }
+}
+
+if ($failures.Count -gt 0) {
+    if (-not $Quiet) {
+        foreach ($failure in $failures) {
+            Write-Warning $failure
+        }
+    }
+    exit 1
+}
+
+Write-Step '[ok] Levyra Codex tooling is ready.'
+exit 0

--- a/scripts/ensure-codex-tooling.sh
+++ b/scripts/ensure-codex-tooling.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -u
+
+DRY_RUN=0
+QUIET=0
+SKIP_INDEX=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1 ;;
+    --quiet) QUIET=1 ;;
+    --skip-index) SKIP_INDEX=1 ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FAILURES=()
+MATT_SKILLS=(
+  setup-matt-pocock-skills grill-with-docs wayfinder to-spec to-tickets
+  implement tdd diagnosing-bugs code-review domain-modeling
+)
+
+log() {
+  if [[ "$QUIET" -eq 0 ]]; then printf '%s\n' "$1"; fi
+}
+
+fail_open() {
+  local label="$1"
+  shift
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    log "[dry-run] $label"
+    return 0
+  fi
+  if ! "$@" >/dev/null 2>&1; then
+    FAILURES+=("$label")
+    return 1
+  fi
+  return 0
+}
+
+if [[ -f "$ROOT/scripts/ensure-rtk.sh" ]]; then
+  fail_open "Ensure pinned RTK" "$ROOT/scripts/ensure-rtk.sh" --quiet || true
+else
+  FAILURES+=("Ensure pinned RTK: scripts/ensure-rtk.sh is missing")
+fi
+
+PYTHON=""
+for candidate in python3 python; do
+  if command -v "$candidate" >/dev/null 2>&1; then PYTHON="$candidate"; break; fi
+done
+
+if [[ -z "$PYTHON" ]]; then
+  FAILURES+=("Ensure jCodeMunch: Python is unavailable")
+else
+  fail_open "Ensure pinned jCodeMunch" "$PYTHON" "$ROOT/scripts/codex_jcodemunch.py" ensure --quiet || true
+  if [[ "$SKIP_INDEX" -eq 0 ]]; then
+    fail_open "Refresh Levyra jCodeMunch index" "$PYTHON" "$ROOT/scripts/codex_jcodemunch.py" index --quiet || true
+  fi
+fi
+
+SKILL_ROOT="$HOME/.agents/skills"
+MISSING=0
+for skill in "${MATT_SKILLS[@]}"; do
+  if [[ ! -f "$SKILL_ROOT/$skill/SKILL.md" ]]; then MISSING=1; break; fi
+done
+
+if [[ "$MISSING" -eq 1 ]]; then
+  if ! command -v npx >/dev/null 2>&1; then
+    FAILURES+=("Ensure Matt Pocock skills: npx is unavailable")
+  elif [[ "$DRY_RUN" -eq 1 ]]; then
+    log "[dry-run] Install missing Matt Pocock Codex skills"
+  else
+    ARGS=(skills@latest add mattpocock/skills -g -a codex -y)
+    for skill in "${MATT_SKILLS[@]}"; do ARGS+=(-s "$skill"); done
+    if ! npx "${ARGS[@]}" >/dev/null 2>&1; then
+      FAILURES+=("Install missing Matt Pocock Codex skills")
+    fi
+  fi
+fi
+
+if [[ ${#FAILURES[@]} -gt 0 ]]; then
+  if [[ "$QUIET" -eq 0 ]]; then
+    for failure in "${FAILURES[@]}"; do printf 'warning: %s\n' "$failure" >&2; done
+  fi
+  exit 1
+fi
+
+log '[ok] Levyra Codex tooling is ready.'

--- a/scripts/tests/test_codex_jcodemunch.py
+++ b/scripts/tests/test_codex_jcodemunch.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "scripts" / "codex_jcodemunch.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("codex_jcodemunch", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_jcodemunch_release_is_pinned_by_version_and_sha256():
+    module = load_module()
+    assert module.JCODEMUNCH_VERSION == "1.108.279"
+    assert len(module.JCODEMUNCH_WHEEL_SHA256) == 64
+    assert module.JCODEMUNCH_WHEEL_URL.endswith(
+        f"#sha256={module.JCODEMUNCH_WHEEL_SHA256}"
+    )
+
+
+def test_jcodemunch_cache_is_version_scoped():
+    module = load_module()
+    assert module.JCODEMUNCH_VERSION in str(module.cache_root())
+
+
+def test_repo_root_resolves_from_script_location():
+    module = load_module()
+    assert module.repo_root() == ROOT

--- a/scripts/validate_codex_bootstrap.py
+++ b/scripts/validate_codex_bootstrap.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Validate Levyra's deterministic Codex bootstrap contract."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - repository setup already requires modern Python.
+    tomllib = None  # type: ignore[assignment]
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_VERSION = "1.108.279"
+EXPECTED_WHEEL_SHA256 = "d192998a9abcd8afa1474f2a1637e260a9ab48fdd0080b6b690632b2af1e30f1"
+REQUIRED_FILES = (
+    ".codex/config.toml",
+    ".codex/hooks.json",
+    ".agents/skills/levyra-codex-bootstrap/SKILL.md",
+    "scripts/codex_jcodemunch.py",
+    "scripts/ensure-codex-tooling.ps1",
+    "scripts/ensure-codex-tooling.sh",
+    "docs/ai/CODEX_AUTO_BOOTSTRAP.md",
+)
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    for relative in REQUIRED_FILES:
+        if not (ROOT / relative).is_file():
+            errors.append(f"missing Codex bootstrap file: {relative}")
+
+    config_path = ROOT / ".codex/config.toml"
+    if config_path.is_file():
+        if tomllib is None:
+            errors.append("Python 3.11+ is required to parse .codex/config.toml")
+        else:
+            try:
+                config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+            except tomllib.TOMLDecodeError as exc:
+                errors.append(f".codex/config.toml is invalid TOML: {exc}")
+            else:
+                server = config.get("mcp_servers", {}).get("jcodemunch", {})
+                if server.get("required") is not False:
+                    errors.append("jCodeMunch MCP must remain optional/fail-open")
+                if server.get("command") != "python":
+                    errors.append("jCodeMunch MCP must launch through the checked-in Python bootstrap")
+                args = server.get("args")
+                if args != ["scripts/codex_jcodemunch.py", "serve"]:
+                    errors.append("jCodeMunch MCP launcher arguments changed unexpectedly")
+
+    hooks_path = ROOT / ".codex/hooks.json"
+    if hooks_path.is_file():
+        try:
+            hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            errors.append(f".codex/hooks.json is invalid JSON: {exc}")
+        else:
+            session = hooks.get("hooks", {}).get("SessionStart", [])
+            serialized = json.dumps(session)
+            for required in (
+                "ensure-codex-tooling.ps1",
+                "ensure-codex-tooling.sh",
+                "Token savings never override correctness",
+            ):
+                if required not in serialized:
+                    errors.append(f"SessionStart hook is missing: {required}")
+
+    runtime_path = ROOT / "scripts/codex_jcodemunch.py"
+    if runtime_path.is_file():
+        runtime = runtime_path.read_text(encoding="utf-8")
+        if f'JCODEMUNCH_VERSION = "{EXPECTED_VERSION}"' not in runtime:
+            errors.append("jCodeMunch version pin changed unexpectedly")
+        if f'JCODEMUNCH_WHEEL_SHA256 = "{EXPECTED_WHEEL_SHA256}"' not in runtime:
+            errors.append("jCodeMunch wheel SHA-256 pin changed unexpectedly")
+        if "#sha256=" not in runtime:
+            errors.append("jCodeMunch wheel URL is not hash-bound")
+        if "os.execv" not in runtime:
+            errors.append("MCP launcher must hand stdio directly to the verified server")
+
+    skill_path = ROOT / ".agents/skills/levyra-codex-bootstrap/SKILL.md"
+    if skill_path.is_file():
+        skill = skill_path.read_text(encoding="utf-8")
+        for required in (
+            "fail-open",
+            "Do not add read/search blocking rules",
+            "Token savings never override correctness",
+            "Do not add Token Optimizer",
+        ):
+            if required not in skill:
+                errors.append(f"Codex bootstrap skill is missing safety rule: {required}")
+
+    if errors:
+        print("Codex bootstrap validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(
+        "Codex bootstrap validation passed: project MCP, SessionStart automation, "
+        "pinned jCodeMunch, fail-open behavior, and quality-first policy verified."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_codex_hooks.py
+++ b/scripts/validate_codex_hooks.py
@@ -12,6 +12,17 @@ HOOKS_PATH = ROOT / ".codex" / "hooks.json"
 PIN = "b34be37caf3796b69a50952a28e60e32b5daad43"
 
 
+def require_terms(errors: list[str], relative_path: str, terms: tuple[str, ...]) -> None:
+    path = ROOT / relative_path
+    if not path.is_file():
+        errors.append(f"missing Codex bootstrap script: {relative_path}")
+        return
+    text = path.read_text(encoding="utf-8")
+    for term in terms:
+        if term not in text:
+            errors.append(f"{relative_path}: missing bootstrap contract {term!r}")
+
+
 def main() -> int:
     errors: list[str] = []
 
@@ -62,7 +73,7 @@ def main() -> int:
                             command_windows = command_handler.get("commandWindows", "")
                             for term in (
                                 "git rev-parse --show-toplevel",
-                                "scripts/ensure-rtk.sh",
+                                "scripts/ensure-codex-tooling.sh",
                                 "|| true",
                             ):
                                 if term not in command:
@@ -71,7 +82,7 @@ def main() -> int:
                                     )
                             for term in (
                                 "git rev-parse --show-toplevel",
-                                "scripts/ensure-rtk.ps1",
+                                "scripts/ensure-codex-tooling.ps1",
                                 "exit 0",
                             ):
                                 if term not in command_windows:
@@ -80,8 +91,19 @@ def main() -> int:
                                     )
                             if command_handler.get("timeout") != 600:
                                 errors.append(
-                                    "Codex RTK bootstrap hook timeout must be 600 seconds"
+                                    "Codex tooling bootstrap hook timeout must be 600 seconds"
                                 )
+
+    require_terms(
+        errors,
+        "scripts/ensure-codex-tooling.sh",
+        ("scripts/ensure-rtk.sh", "codex_jcodemunch.py", "mattpocock/skills"),
+    )
+    require_terms(
+        errors,
+        "scripts/ensure-codex-tooling.ps1",
+        ("ensure-rtk.ps1", "codex_jcodemunch.py", "mattpocock/skills"),
+    )
 
     for relative_path in ("scripts/ensure-rtk.sh", "scripts/ensure-rtk.ps1"):
         path = ROOT / relative_path
@@ -101,8 +123,8 @@ def main() -> int:
 
     print(
         "Codex hook validation passed: project SessionStart automatically "
-        "ensures the pinned RTK build on startup/resume with Unix/Windows "
-        "fail-open commands."
+        "runs the fail-open unified tooling bootstrap on startup/resume, and the "
+        "bootstrap still delegates to the pinned RTK contract."
     )
     return 0
 


### PR DESCRIPTION
## Summary

- make Levyra's Codex tooling bootstrap automatic on `SessionStart` (`startup` and `resume`)
- add project-scoped optional jCodeMunch MCP integration
- pin jCodeMunch `1.108.279` to the exact release wheel SHA-256
- automatically verify/install RTK, refresh the Levyra jCodeMunch index, and install the existing focused Matt Pocock Codex skill allowlist when missing
- add a focused Levyra bootstrap skill, documentation, validator, and unit tests
- align the existing Codex hook validator and native-skill inventory with the unified bootstrap

## Quality and safety

This is intentionally quality-first rather than aggressively token-minimizing:

- jCodeMunch is `required = false` and fail-open
- native Codex reads/search remain available and must be used whenever broader context is needed for correctness
- no Read/Grep blocking policy is added
- Token Optimizer is intentionally not installed
- claude-mem keeps its existing automatic-on-need policy instead of being injected into every session
- project/hook trust is not bypassed
- bootstrap/install failures do not grant permission to weaken sandboxing or validation
- the hook validator still verifies that the unified bootstrap delegates to Levyra's pinned RTK contract

## Automatic behavior

After the project-local Codex hook is trusted, opening or resuming Codex in the Levyra repository runs the checked-in bootstrap automatically. Normal work does not require a manual setup command. Codex may require trust again if the project hook itself changes.

## Validation

Local/structural validation completed for the bootstrap implementation:

- Python syntax compilation for the new bootstrap, validator, and tests: passed
- `.codex/hooks.json` JSON parse: passed
- `.codex/config.toml` TOML parse and optional MCP contract: passed
- `python scripts/validate_codex_bootstrap.py`: passed
- jCodeMunch bootstrap unit tests: passed
- `bash -n scripts/ensure-codex-tooling.sh`: passed

GitHub Actions after the follow-up CI fix:

- `AI Quality Gate` in PR Check run #3376: **passed**
- agent configuration validation: **passed**
- repository script tests / Codex hook contract: **passed**
- Bash syntax: **passed**
- PowerShell syntax: **passed**

The PR currently changes 11 intended Codex/AI-tooling files. Remaining Android/APK workflow steps continue independently after the fast AI quality gate.