### PR TITLE
Streamline Antigravity workspace bridge and fix validator doc drift

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -240,12 +240,14 @@ there; every other unapproved executable or plugin remains opt-in.
 python3 scripts/validate_agent_config.py
 python3 scripts/validate_ai_efficiency.py
 python3 scripts/validate_matt_skills.py
+python3 scripts/validate_claude_mem.py
 ```
 
 The validators check shared discovery, skill inventory, RTK TOML, setup
 behavior, real-engineering integration, cross-runtime
 design/performance/R8/Intent-security/general-security routing, dependency
-review, plugin scope, and absence of unapproved local-model profiles.
+review, plugin scope, claude-mem integration, and absence of unapproved
+local-model profiles.
 
 ## Maintenance rules
 

--- a/.agents/rules/levyra-workspace.md
+++ b/.agents/rules/levyra-workspace.md
@@ -2,177 +2,65 @@
 
 @../../AGENTS.md
 
-## Automatic local tooling
+This is a thin Antigravity-specific bridge. The imported root `AGENTS.md` is
+authoritative for the instruction hierarchy, the complete "Native skill
+routing" table, the work method, the quality gate, and publication
+boundaries — do not restate that content here. Apply
+`../../docs/ai/AI_ENGINEERING_GUARDRAILS.md` before production-code
+implementation or broad review.
 
-For shell-capable work in this repository, ensure the owner-authorized pinned
-RTK build before the first noisy command without asking the owner to run setup:
+## Antigravity-specific automation
+
+Ensure the owner-authorized pinned RTK build before the first noisy
+shell-capable command, without asking the owner to run setup:
 
 - Windows PowerShell: `./scripts/ensure-rtk.ps1 -Quiet`;
 - Bash/WSL/Linux/macOS: `./scripts/ensure-rtk.sh --quiet`.
 
-The scripts are idempotent: they only install `rtk-ai/rtk` when `rtk --version`
-and `rtk gain` do not prove the expected tool is ready. If Cargo is unavailable
-or installation fails, continue with raw commands and report the limitation
-once. Never weaken sandboxing or approval controls to make RTK install.
+These scripts are idempotent: they only install `rtk-ai/rtk` when
+`rtk --version` and `rtk gain` do not already prove the tool is ready. If Cargo
+is unavailable or installation fails, continue with raw commands and report the
+limitation once. Never weaken sandboxing or approval controls to make RTK
+install.
 
-When prior-session context is materially useful and claude-mem tools are absent,
-Codex and Antigravity are owner-authorized to run the pinned dedicated
-claude-mem setup once automatically, then retry the focused memory lookup. If
-setup or health checks fail, continue without memory. See
-`../../docs/ai/CLAUDE_MEM.md`.
+When prior-session context is materially useful and claude-mem tools are
+absent, run the pinned dedicated claude-mem setup once automatically, then
+retry the focused lookup. If setup or health checks fail, continue without
+memory. See `../../docs/ai/CLAUDE_MEM.md`.
 
-Treat the repository-root `AGENTS.md` as Levyra's authoritative operating
-contract. Before investigating, editing, reviewing, or running commands:
+## Skills discovered here
 
-1. apply the nearest path-specific `AGENTS.md` files for every file in scope;
-2. read only relevant approved planning material under `docs/project/`;
-3. discover and load every matching `levyra-*` skill under `.agents/skills/`;
-4. read `../../docs/ai/AI_ENGINEERING_GUARDRAILS.md` before production-code
-   implementation or broad review and apply its architecture-first, reuse-first,
-   explicit-assumptions, simpler-alternatives, goal-verification,
-   complexity-budget, scope-checkpoint, surgical-edit, and diff-quality rules;
-5. automatically load `levyra-real-engineering` for non-trivial features,
-   architectural changes, unclear defects, or multi-step work where requirements
-   and implementation should be separated; use only the stages needed and skip
-   the full workflow for tiny, already-unambiguous changes;
-6. automatically load `levyra-context-efficiency` for builds, tests, lint,
-   logs, broad searches, dependencies, Git/GitHub, CI, CodeRabbit, setup, or any
-   command expected to produce large repetitive output;
-7. automatically load `levyra-security-review` for vulnerability scans,
-   attacker-controlled input, trust-boundary changes, authentication, secrets,
-   permissions, privacy, dependency risk, update integrity, or security-related
-   pull requests;
-8. automatically load `levyra-android-intent-security` together with
-   `levyra-security-review` for Android Intent/deep-link/PendingIntent handling,
-   exported activities/services/receivers/providers, nested Intent forwarding,
-   `onNewIntent`, URI grants, FileProvider/ContentProvider, mutable PendingIntents,
-   caller/signature verification, or Android component-boundary audits;
-9. automatically load `levyra-design-taste` together with the matching UI skill
-   for visual redesigns, UI polish, hierarchy, spacing, typography, color, shape,
-   motion, screenshot/reference work, or requests to make Levyra more premium,
-   modern, distinctive, cohesive, or less AI-generated;
-10. automatically load `levyra-android-performance` for Android jank, latency,
-    startup, Perfetto/System Trace, CPU/thread-state, graphics, Binder/IPC,
-    blocking, memory, I/O, power, or measured runtime-performance investigations,
-    together with the affected domain skill;
-11. automatically load `levyra-r8-proguard` for R8/Proguard, minification,
-    resource shrinking, keep/consumer rules, release-only shrinker failures,
-    reflection/serialization/JNI shrinker issues, mapping output, missing classes,
-    or APK-size optimization;
-12. when RTK is available, use it selectively for noisy supported commands,
-    verify exit status and success/failure markers, and rerun the exact command
-    raw whenever compact output hides required evidence;
-13. keep exploit evidence, security validation, hashes, signatures, secret scans,
-    signing, Perfetto evidence needed for timing/dependency conclusions, and exact
-    reproduction output raw;
-14. inspect current code, tests, architecture, build files, dependencies, and
-    workflows before relying on memory or previous agent output;
-15. for security work, follow threat model, identification, safe validation,
-    minimal remediation, human review, and revalidation;
-16. identify the current architecture owner and expected production files before
-    editing, then make the smallest coherent change and preserve unrelated
-    behavior;
-17. if the implementation crosses an AI guardrail scope checkpoint, re-evaluate
-    and split the work instead of expanding autonomously unless the owner
-    explicitly approves the larger scope;
-18. run focused validation first, then
-    `python3 scripts/ai_quality_gate.py --profile fast` before commit and
-    `python3 scripts/ai_quality_gate.py --profile full` before push or PR;
-19. inspect final diff statistics and the complete diff for unnecessary code
-    growth, duplicate ownership, speculative abstractions, generated churn, and
-    unrelated edits;
-20. treat every blocked or skipped required gate check as not passed;
-21. keep implementation, validation, review, publication, merge, and release as
-    separate states.
+Antigravity reads skills from `.agents/skills/<skill-name>/SKILL.md`; open the
+repository root as the workspace so discovery is complete, and keep this rule
+**Always On** when an activation control is available.
 
-## Automatic task-to-skill routing
+Select every matching skill from the task itself using root `AGENTS.md`'s
+"Native skill routing" table, including `levyra-real-engineering`,
+`levyra-compose`, `levyra-design-taste`, `levyra-android-performance`,
+`levyra-r8-proguard`, `levyra-android-intent-security`, `levyra-ci-workflows`,
+`levyra-context-efficiency`, `levyra-pr-review`, and `levyra-release-check`.
+Never require the owner to name a skill. Follow the referenced
+`.agents/skills/*/SKILL.md` procedure directly; do not reconstruct it from
+memory. The canonical `levyra-real-engineering` and `levyra-design-taste`
+adapters remain authoritative over any upstream package.
 
-Codex, Antigravity, OpenCode, OpenClaw, and any other compatible runtime using
-this workspace must select matching skills from the task itself. Never require
-the owner to name a skill, type a slash command, or remind the agent to use one.
-Load multiple skills when several rows apply.
+For security-sensitive work, load `levyra-security-review` (paired with
+`levyra-android-intent-security` for Android component-boundary work) and
+follow the shared cycle: threat model, identification, safe validation, minimal
+remediation, human review, revalidation. RTK reduces command output; it is not
+validation authority — rerun the exact command raw whenever compact output
+hides required evidence. Keep exploit evidence, hashes, signatures, secret
+scans, and signing evidence raw.
 
-For non-trivial implementation, follow `Plan -> Execute -> Verify`: form the
-smallest evidence-based plan, implement one coherent slice, and validate its
-success criterion before expanding. Do not insert a plan-approval pause unless
-the owner explicitly reserved one.
+## Validation and publication
 
-Match the requested action mode. `inspect`, `review`, `diagnose`, and `report`
-authorize investigation and reporting, not implementation. `fix`, `update`,
-`address`, and `implement` authorize the requested code change and its
-validation. Commit, push, PR, merge, release, deployment, and other publication
-remain separate owner-controlled actions.
-
-Treat user-provided screenshots and direct runtime observations as acceptance
-evidence. Reconcile visible failures even if automated checks are green.
-
-- bugs, regressions, test/build failures, races, crashes, or unexpected behavior
-  that need investigation -> `levyra-real-engineering` plus the affected domain
-  skill; use its hypothesis-driven debugging lane before speculative fixes;
-- Compose UI/state/accessibility work -> `levyra-compose`; if the task is jank,
-  scrolling, frame misses, Layout Inspector, Perfetto/System Trace, scheduling,
-  Binder/IPC, graphics, blocking, memory, I/O, power, or another measured Android
-  runtime-performance problem, also load `levyra-android-performance`;
-- Android Intent, deep-link, PendingIntent, exported component, receiver,
-  service, provider, URI-grant, FileProvider, `onNewIntent`, nested Intent, or
-  caller-verification work -> `levyra-android-intent-security` plus
-  `levyra-security-review` and the affected Android domain skill;
-- visual redesign, polish, hierarchy, spacing, typography, color, shape, motion,
-  screenshot/reference recreation, "più bella", "premium", "modern", "clean",
-  "cinematic", "cohesive", or anti-AI-slop UI work -> `levyra-design-taste`
-  plus `levyra-compose` on Android or `levyra-desktop` on Desktop;
-- R8, Proguard, minification, resource shrinking, keep rules, consumer rules,
-  release-only shrinker crashes, mapping/missing classes, reflection or JNI
-  shrinker issues, or APK-size work -> `levyra-r8-proguard`; also load
-  `levyra-ci-workflows` for build-tooling changes and `levyra-release-check` for
-  release/minified runtime validation;
-- GitHub Actions, CI, F-Droid, Gradle, AGP, Kotlin, KSP, configuration/build
-  cache, build speed, artifacts, or workflow automation ->
-  `levyra-ci-workflows`; also load `levyra-context-efficiency` when command
-  output is expected to be noisy;
-- emulator/device smoke tests, `adb` runtime verification, pre-merge evidence,
-  signing, APK/package checks, or release validation -> `levyra-release-check`;
-- branch, commit, diff, or pull-request review -> `levyra-pr-review` plus any
-  matching domain/security skill.
-
-These automatic routes activate the repository-local workflows that incorporate
-curated practices from the reviewed external skill sources. External packages
-are not required at runtime for these Levyra-native behaviors.
-
-For real-engineering work, follow
-`../../.agents/skills/levyra-real-engineering/SKILL.md`. When the upstream Matt
-Pocock package is available, load the exact stage skill selected by that adapter
-instead of reconstructing it from memory. The adapter remains authoritative for
-Levyra scope, architecture, validation, and publication boundaries.
-
-For visual product work, follow
-`../../.agents/skills/levyra-design-taste/SKILL.md` together with the applicable
-platform skill. The design-taste skill is a Levyra-native adaptation of reviewed
-anti-template design practices; it does not vendor or require the upstream web
-skill at runtime.
-
-For Android runtime-performance work, follow
-`../../.agents/skills/levyra-android-performance/SKILL.md`, validate Perfetto
-schemas/queries instead of guessing them, and keep measured trace evidence
-separate from hypotheses. For shrinker work, follow
-`../../.agents/skills/levyra-r8-proguard/SKILL.md`; do not fix release-only
-failures with blanket keep rules or by disabling minification/resource shrinking.
-For Android component-boundary security, follow
-`../../.agents/skills/levyra-android-intent-security/SKILL.md` together with
-`levyra-security-review`; do not treat generic exposure patterns as confirmed
-vulnerabilities without a reachable attacker-controlled path.
-
-RTK reduces command output; it is not validation authority and its savings are
-not equal to total model-billing savings. Security-engine findings and generated
-patches are proposals that require evidence, complete diff review, CI, and
-explicit owner-controlled publication.
+Run focused validation first, then
+`python3 scripts/ai_quality_gate.py --profile fast` before commit and
+`python3 scripts/ai_quality_gate.py --profile full` before push or PR. Treat
+every blocked or skipped required check as not passed, and keep
+implementation, validation, review, publication, merge, and release as
+separate states.
 
 Never commit, push, open or merge a pull request, tag, publish, release, change
-versions, or modify repository settings without explicit owner authorization for
-the exact action and scope.
-
-This lightweight bridge gives Codex, Antigravity, OpenCode, OpenClaw, and other
-compatible workspaces one source of truth while discovering Levyra's real-
-engineering, context-efficiency, design-taste, Android-performance, R8/Proguard,
-Android Intent security, AI engineering guardrails, and general security-review
-workflows automatically.
+versions, or modify repository settings without explicit owner authorization
+for the exact action and scope.

--- a/docs/ai/ANTIGRAVITY.md
+++ b/docs/ai/ANTIGRAVITY.md
@@ -115,11 +115,12 @@ Rerun the exact command raw whenever compact output is insufficient.
 python3 scripts/validate_agent_config.py
 python3 scripts/validate_ai_efficiency.py
 python3 scripts/validate_matt_skills.py
+python3 scripts/validate_claude_mem.py
 ```
 
 The validators check the workspace bridge, skill frontmatter/inventory, RTK
-configuration, real-engineering routing, automatic security routing, and shared
-documentation.
+configuration, real-engineering routing, automatic security routing,
+claude-mem integration, and shared documentation.
 
 ## Rule activation
 
@@ -151,7 +152,7 @@ If skills do not appear:
 3. confirm each skill has YAML frontmatter with a non-empty `description`;
 4. keep `.agents/rules/levyra-workspace.md` active;
 5. start a new conversation;
-6. run all three validators and fix every reported error.
+6. run all four validators and fix every reported error.
 
 Do not copy skills into `.gemini/skills/`. `.agents/skills/` is the canonical
 location shared by supported runtimes.


### PR DESCRIPTION
## Summary

Audited the repository's cross-runtime AI agent configuration (`AGENTS.md`,
`.claude/`, `.agents/`, `docs/ai/`, hooks, skills, plugins, validators) end to
end. The infrastructure is already well designed: instruction hierarchy is
explicit, Claude's skill routing is enforced by a cheap fail-open
`UserPromptSubmit` hook plus path-scoped `.claude/rules/*.md`, and the
`.claude/skills/` vs `.agents/skills/` split is intentional (Claude gets short
pointers into its own auto-loading rules; other runtimes get one
self-contained procedure). Those were left untouched.

One real duplication surfaced: `.agents/rules/levyra-workspace.md`, the
always-on Antigravity workspace rule, already imports the root contract via
`@../../AGENTS.md` (and `docs/ai/ANTIGRAVITY.md` confirms Antigravity reads
`AGENTS.md` directly too), yet it also restated that file's entire native
skill routing table and a 21-step guardrail checklist in its own prose. That
duplicated content loads on every Antigravity session for no added coverage,
and directly contradicts `.agents/README.md`'s own maintenance rule that
runtime-specific files must stay "thin routing bridges only."

## Why

- Same skill-routing/guardrail information was fully expressed twice
  (`AGENTS.md` and `.agents/rules/levyra-workspace.md`), with the second copy
  always loaded and contributing nothing the import doesn't already cover.
- The validator guidance had a small documentation drift: `.agents/README.md`
  and `docs/ai/ANTIGRAVITY.md` did not both list all four validator scripts,
  including `validate_claude_mem.py`.

## Changes

- `.agents/rules/levyra-workspace.md`: replaced the duplicated routing table
  and 21-step checklist with a short pointer to `AGENTS.md`'s "Native skill
  routing" table, keeping only what's genuinely Antigravity-specific (RTK /
  claude-mem bootstrap automation, skill-discovery path, security-cycle
  reminder, publication boundary). Every literal term the agent-config
  validators require of this file is preserved.
- `.agents/README.md`: added the missing `validate_claude_mem.py` line to the
  Validation section so the doc matches `AGENTS.md` and the actual `scripts/`
  contents.
- `docs/ai/ANTIGRAVITY.md`: synchronized first-run/troubleshooting guidance with
  the same four-validator set and documented claude-mem validation coverage.

No application code, versions, hooks, `.claude/` routing, or skill content
were touched.

## Context/token efficiency

`.agents/rules/levyra-workspace.md` (always-on for every Antigravity session):

```
Before -> After
178 lines -> 66 lines  (-63%)
~7.0 KB   -> ~2.9 KB   (-59%)
```

## Skills

No skills added, removed, or renamed. Skill inventory and routing tables are
unchanged; only the duplicated restatement of that routing table in the
Antigravity bridge file was removed.

## Validation

The initial audit commit passed:

```
python3 scripts/validate_agent_config.py     -> passed
python3 scripts/validate_ai_efficiency.py    -> passed
python3 scripts/validate_claude_mem.py       -> passed
python3 scripts/ai_quality_gate.py --profile fast  -> passed
python3 scripts/ai_quality_gate.py --profile full  -> passed
```

The final documentation-only sync triggers the repository CI again; current
GitHub checks are the source of truth for the final head commit.

`scripts/validate_matt_skills.py` fails on `main` before this branch too (two
unrelated pre-existing findings in `.agents/skills/levyra-real-engineering/SKILL.md`
and `docs/agents/issue-tracker.md`); it is not part of the `ai_quality_gate.py`
command set and this PR does not touch either file. Left out of scope per the
task's no-unrelated-fixes instruction; flagging for separate follow-up.