### PR TITLE
Automate Claude Code jCodeMunch bootstrap

### DIFF
--- a/.claude/hooks/jcodemunch-start.sh
+++ b/.claude/hooks/jcodemunch-start.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -u
+
+project_dir="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+runtime="$project_dir/scripts/codex_jcodemunch.py"
+status="jCodeMunch: unavailable; continue with Claude native Read/Grep/Glob/Bash tools."
+
+python_cmd=""
+for candidate in python3 python py; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    python_cmd="$candidate"
+    break
+  fi
+done
+
+if [[ -n "$python_cmd" && -f "$runtime" ]]; then
+  if "$python_cmd" "$runtime" index --quiet >/dev/null 2>&1; then
+    status="jCodeMunch: pinned runtime ready and Levyra index refreshed. Prefer symbol-level discovery first; expand to native reads/search whenever correctness needs broader context."
+  else
+    status="jCodeMunch: automatic install/index failed. Continue with Claude native Read/Grep/Glob/Bash tools; token savings never override correctness."
+  fi
+elif [[ -z "$python_cmd" ]]; then
+  status="jCodeMunch: Python unavailable. Continue with Claude native tools; do not block coding."
+else
+  status="jCodeMunch: repository runtime missing. Continue with Claude native tools and report the tooling mismatch once."
+fi
+
+if [[ -n "$python_cmd" ]]; then
+  "$python_cmd" - "$status" <<'PY' 2>/dev/null || true
+import json
+import sys
+
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": sys.argv[1],
+    }
+}))
+PY
+fi
+
+exit 0

--- a/.claude/hooks/jcodemunch-start.sh
+++ b/.claude/hooks/jcodemunch-start.sh
@@ -3,7 +3,7 @@ set -u
 
 project_dir="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 runtime="$project_dir/scripts/codex_jcodemunch.py"
-status="jCodeMunch: unavailable; continue with Claude native Read/Grep/Glob/Bash tools."
+status="jCodeMunch: unavailable; continue with Claude native Read/Grep/Glob/Bash tools. Token savings never override correctness."
 
 python_cmd=""
 for candidate in python3 python py; do
@@ -15,14 +15,14 @@ done
 
 if [[ -n "$python_cmd" && -f "$runtime" ]]; then
   if "$python_cmd" "$runtime" index --quiet >/dev/null 2>&1; then
-    status="jCodeMunch: pinned runtime ready and Levyra index refreshed. Prefer symbol-level discovery first; expand to native reads/search whenever correctness needs broader context."
+    status="jCodeMunch: pinned runtime ready and Levyra index refreshed. Prefer symbol-level discovery first; expand to native reads/search whenever correctness needs broader context. Token savings never override correctness."
   else
-    status="jCodeMunch: automatic install/index failed. Continue with Claude native Read/Grep/Glob/Bash tools; token savings never override correctness."
+    status="jCodeMunch: automatic install/index failed. Continue with Claude native Read/Grep/Glob/Bash tools. Token savings never override correctness."
   fi
 elif [[ -z "$python_cmd" ]]; then
-  status="jCodeMunch: Python unavailable. Continue with Claude native tools; do not block coding."
+  status="jCodeMunch: Python unavailable. Continue with Claude native tools; do not block coding. Token savings never override correctness."
 else
-  status="jCodeMunch: repository runtime missing. Continue with Claude native tools and report the tooling mismatch once."
+  status="jCodeMunch: repository runtime missing. Continue with Claude native tools and report the tooling mismatch once. Token savings never override correctness."
 fi
 
 if [[ -n "$python_cmd" ]]; then

--- a/.claude/rules/context-efficiency.md
+++ b/.claude/rules/context-efficiency.md
@@ -11,6 +11,13 @@ repository reading or noisy commands:
 - keep security, Perfetto, R8, signing, exact failures, and decisive diagnostics
   raw when compression could change the conclusion.
 
+For non-trivial repository exploration, prefer the project-scoped jCodeMunch MCP
+for symbol-level discovery before broad reads. Treat it as a navigator, not a
+restriction: Claude native Read/Grep/Glob/Bash tools remain available and must be
+used whenever control flow, lifecycle, state, concurrency, generated behavior,
+tests, or correctness require broader evidence. Token savings never override
+correctness.
+
 For non-trivial repository exploration, builds, tests, lint, logs, broad
 searches, dependencies, Git/GitHub, CI, CodeRabbit, adb, setup, or other
 high-volume work, invoke `levyra-context-efficiency` and follow

--- a/.claude/rules/context-efficiency.md
+++ b/.claude/rules/context-efficiency.md
@@ -15,8 +15,9 @@ For non-trivial repository exploration, prefer the project-scoped jCodeMunch MCP
 for symbol-level discovery before broad reads. Treat it as a navigator, not a
 restriction: Claude native Read/Grep/Glob/Bash tools remain available and must be
 used whenever control flow, lifecycle, state, concurrency, generated behavior,
-tests, or correctness require broader evidence. Token savings never override
-correctness.
+tests, or correctness require broader evidence.
+
+Token savings never override correctness.
 
 For non-trivial repository exploration, builds, tests, lint, logs, broad
 searches, dependencies, Git/GitHub, CI, CodeRabbit, adb, setup, or other

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,7 +39,8 @@
       "Bash(git status*)",
       "Bash(git branch --show-current)",
       "Bash(git branch --list*)",
-      "Bash(python3 scripts/check_android_regex_compatibility.py)"
+      "Bash(python3 scripts/check_android_regex_compatibility.py)",
+      "mcp__jcodemunch"
     ],
     "deny": [
       "Read(./local.properties)",
@@ -64,6 +65,12 @@
             "command": "\"${CLAUDE_PROJECT_DIR}/.claude/hooks/session-start.sh\"",
             "timeout": 600,
             "statusMessage": "Preparing Levyra tooling"
+          },
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}/.claude/hooks/jcodemunch-start.sh\"",
+            "timeout": 600,
+            "statusMessage": "Preparing Levyra jCodeMunch"
           }
         ]
       }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "jcodemunch": {
+      "command": "bash",
+      "args": [
+        "-lc",
+        "exec \"$(git rev-parse --show-toplevel)/scripts/claude-jcodemunch-mcp.sh\""
+      ]
+    }
+  }
+}

--- a/docs/ai/CLAUDE_AUTO_BOOTSTRAP.md
+++ b/docs/ai/CLAUDE_AUTO_BOOTSTRAP.md
@@ -1,0 +1,52 @@
+# Claude Code automatic tooling bootstrap
+
+Levyra keeps Claude Code project tooling automatic and fail-open. The existing
+Claude `SessionStart` environment probe and prompt-routing hooks stay in place;
+this layer adds the project-scoped jCodeMunch MCP without replacing Claude's
+native repository tools.
+
+## Automatic behavior
+
+On `startup` and `resume`:
+
+1. the existing Levyra environment hook checks RTK and the local toolchain;
+2. `.claude/hooks/jcodemunch-start.sh` ensures the pinned jCodeMunch runtime via
+   the shared `scripts/codex_jcodemunch.py` launcher and refreshes the Levyra
+   index;
+3. `.mcp.json` exposes that same pinned runtime to Claude as the project-scoped
+   `jcodemunch` MCP server;
+4. `.claude/settings.json` allows `mcp__jcodemunch`, so individual jCodeMunch
+   tool calls do not require repeated permission prompts.
+
+Claude should prefer jCodeMunch for targeted symbol-level discovery, then use
+native Read/Grep/Glob/Bash whenever broader context is necessary for control
+flow, lifecycle, concurrency, state, generated behavior, tests, or correctness.
+Token savings never override correctness.
+
+## First project approval
+
+Claude Code requires approval before using a project-scoped MCP server from
+`.mcp.json`. Levyra does not bypass that security decision. After the project
+server is approved, normal jCodeMunch tool calls are covered by the checked-in
+`mcp__jcodemunch` project permission.
+
+If the MCP install, index, or server launch fails, Claude continues with its
+native repository tools. Failure must not block coding or be treated as
+permission to weaken sandboxing or validation.
+
+## Existing Claude plugins
+
+Levyra continues to use the existing project plugin configuration in
+`.claude/settings.json`, including the Kotlin, Chris Banes, Karpathy, and Matt
+Pocock skill integrations. This change does not add another compression plugin
+or duplicate their responsibilities.
+
+## Validation
+
+```bash
+python3 scripts/validate_claude_bootstrap.py
+python3 -m unittest scripts.tests.test_claude_bootstrap
+```
+
+The repository AI quality gate also discovers the new unit test through its
+normal `scripts/tests/test_*.py` suite.

--- a/scripts/claude-jcodemunch-mcp.sh
+++ b/scripts/claude-jcodemunch-mcp.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNTIME="$ROOT/scripts/codex_jcodemunch.py"
+
+if [[ ! -f "$RUNTIME" ]]; then
+  printf 'Levyra jCodeMunch launcher: missing %s\n' "$RUNTIME" >&2
+  exit 1
+fi
+
+for candidate in python3 python py; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    exec "$candidate" "$RUNTIME" serve
+  fi
+done
+
+printf 'Levyra jCodeMunch launcher: Python is unavailable.\n' >&2
+exit 1

--- a/scripts/tests/test_claude_bootstrap.py
+++ b/scripts/tests/test_claude_bootstrap.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.validate_claude_bootstrap import main as validate_claude_bootstrap
+
+
+class ClaudeBootstrapTest(unittest.TestCase):
+    def test_claude_bootstrap_contract_is_valid(self) -> None:
+        self.assertEqual(0, validate_claude_bootstrap())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_claude_bootstrap.py
+++ b/scripts/validate_claude_bootstrap.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Validate Levyra's automatic Claude Code jCodeMunch bootstrap contract."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_json(relative_path: str, errors: list[str]) -> dict:
+    path = ROOT / relative_path
+    if not path.is_file():
+        errors.append(f"missing required Claude bootstrap file: {relative_path}")
+        return {}
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        errors.append(f"{relative_path} is invalid JSON: {exc}")
+        return {}
+    if not isinstance(document, dict):
+        errors.append(f"{relative_path} must contain a JSON object")
+        return {}
+    return document
+
+
+def require_terms(relative_path: str, terms: tuple[str, ...], errors: list[str]) -> None:
+    path = ROOT / relative_path
+    if not path.is_file():
+        errors.append(f"missing required Claude bootstrap file: {relative_path}")
+        return
+    text = path.read_text(encoding="utf-8")
+    for term in terms:
+        if term not in text:
+            errors.append(f"{relative_path}: missing Claude bootstrap contract {term!r}")
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    mcp = read_json(".mcp.json", errors)
+    servers = mcp.get("mcpServers") if isinstance(mcp, dict) else None
+    server = servers.get("jcodemunch") if isinstance(servers, dict) else None
+    if not isinstance(server, dict):
+        errors.append(".mcp.json must define project-scoped jcodemunch")
+    else:
+        if server.get("command") != "bash":
+            errors.append(".mcp.json jcodemunch must launch through bash")
+        args = server.get("args")
+        if not isinstance(args, list) or not any(
+            "scripts/claude-jcodemunch-mcp.sh" in str(item) for item in args
+        ):
+            errors.append(".mcp.json jcodemunch must use the checked-in Claude launcher")
+
+    settings = read_json(".claude/settings.json", errors)
+    permissions = settings.get("permissions") if isinstance(settings, dict) else None
+    allowed = permissions.get("allow") if isinstance(permissions, dict) else None
+    if not isinstance(allowed, list) or "mcp__jcodemunch" not in allowed:
+        errors.append(".claude/settings.json must allow the project jcodemunch MCP server")
+
+    hooks = settings.get("hooks") if isinstance(settings, dict) else None
+    groups = hooks.get("SessionStart") if isinstance(hooks, dict) else None
+    matching_group = None
+    if isinstance(groups, list):
+        matching_group = next(
+            (
+                group
+                for group in groups
+                if isinstance(group, dict) and group.get("matcher") == "startup|resume"
+            ),
+            None,
+        )
+    if matching_group is None:
+        errors.append(".claude/settings.json must run SessionStart on startup and resume")
+    else:
+        handlers = matching_group.get("hooks")
+        commands = [
+            handler
+            for handler in handlers or []
+            if isinstance(handler, dict) and handler.get("type") == "command"
+        ]
+        command_text = "\n".join(str(handler.get("command", "")) for handler in commands)
+        for required_hook in ("session-start.sh", "jcodemunch-start.sh"):
+            if required_hook not in command_text:
+                errors.append(
+                    f"Claude SessionStart is missing automatic hook {required_hook!r}"
+                )
+        jcodemunch_handler = next(
+            (
+                handler
+                for handler in commands
+                if "jcodemunch-start.sh" in str(handler.get("command", ""))
+            ),
+            None,
+        )
+        if jcodemunch_handler is not None and jcodemunch_handler.get("timeout") != 600:
+            errors.append("Claude jCodeMunch SessionStart timeout must be 600 seconds")
+
+    require_terms(
+        "scripts/claude-jcodemunch-mcp.sh",
+        ("codex_jcodemunch.py", "serve", "python3", "python", "py"),
+        errors,
+    )
+    require_terms(
+        ".claude/hooks/jcodemunch-start.sh",
+        (
+            "codex_jcodemunch.py",
+            "index --quiet",
+            "Read/Grep/Glob/Bash",
+            "Token savings never override correctness",
+            "exit 0",
+        ),
+        errors,
+    )
+    require_terms(
+        ".claude/rules/context-efficiency.md",
+        (
+            "jCodeMunch",
+            "Claude native Read/Grep/Glob/Bash",
+            "Token savings never override correctness",
+        ),
+        errors,
+    )
+
+    for relative_path in (
+        ".mcp.json",
+        ".claude/settings.json",
+        ".claude/hooks/jcodemunch-start.sh",
+        "scripts/claude-jcodemunch-mcp.sh",
+    ):
+        path = ROOT / relative_path
+        if path.is_file() and "dangerously-skip-permissions" in path.read_text(
+            encoding="utf-8"
+        ):
+            errors.append(f"{relative_path}: must not bypass Claude permission safety")
+
+    if errors:
+        print("Claude bootstrap validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(
+        "Claude bootstrap validation passed: project jCodeMunch MCP, automatic "
+        "startup/resume indexing, server-level tool permission, native-tool fallback, "
+        "and correctness-first context policy verified."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add project-scoped jCodeMunch MCP for Claude Code through `.mcp.json`
- automatically ensure/install the already-pinned Levyra jCodeMunch runtime and refresh its index on Claude `startup` and `resume`
- allow `mcp__jcodemunch` at project level so individual symbol-search calls do not prompt repeatedly
- preserve the existing Claude environment probe, prompt routing, RTK bootstrap, and enabled plugin configuration
- add a dedicated Claude bootstrap validator, CI-discovered unit test, and documentation

## Quality-first behavior

This intentionally optimizes discovery without reducing Claude's coding capability:

- jCodeMunch is a first-pass navigator, not a replacement for native tools
- Claude Read/Grep/Glob/Bash remain available and are required whenever broader context is necessary
- install/index failure is fail-open and must not block coding
- no read/search blocking rules are added
- no always-on compression proxy or Token Optimizer is added
- token savings never override correctness, lifecycle/state/concurrency understanding, tests, diagnostics, or security evidence

## Automatic behavior

After Claude Code's one-time security approval for the project-scoped `.mcp.json` server, normal sessions require no manual jCodeMunch setup. On `startup` and `resume`, Levyra refreshes the pinned jCodeMunch runtime/index automatically. The checked-in `mcp__jcodemunch` permission avoids repeated per-tool prompts.

The one-time project MCP approval is intentionally not bypassed.

## Scope

Exactly 8 Claude/AI-tooling files are changed. No Android application, Gradle product code, release version, or Codex bootstrap behavior is modified.

## Validation

- `.claude/settings.json` remains valid JSON and preserves existing plugins/permissions plus the jCodeMunch server permission
- `.mcp.json` uses the project-scoped Claude MCP format
- new shell launch/startup scripts are covered by Levyra's AI quality gate Bash syntax checks
- `scripts/validate_claude_bootstrap.py` validates MCP wiring, startup/resume hooks, fallback policy, permission safety, and correctness-first routing
- `scripts/tests/test_claude_bootstrap.py` is automatically included by the existing `test_*.py` quality-gate suite

GitHub Actions is authoritative for the complete repository checks.