### PR TITLE
Redesign Now Playing, Canvas presentation and mini player

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -473,6 +473,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         if (isLocalPlaybackTrack(track)) return track.takeIf { isLocalPlaybackUri(it.streamUrl) }
         if (track.streamUrl.isNotBlank()) {
             if (!isVideoMode && !isPlayableAudioUrl(track.streamUrl)) return null
+            if (isVideoMode && !track.hasVideoPlaybackPayload()) return null
             if (streamStillFresh(track.streamUrl)) {
                 store(track, track, isVideoMode)
                 return track
@@ -679,12 +680,15 @@ class PlaybackResolver private constructor(private val context: Context) {
         if (stored.entity.blockedUntil > now) return null
         val manifest = stored.manifest
         if (manifest != null && manifest.isFresh(now) && manifestUrlsUsable(manifest, isVideoMode, preferMp4Audio)) {
-            recordSourceMatchSuccess(track, isVideoMode, audioQuality, preferMp4Audio)
-            return track.applyManifest(
+            val restored = track.applyManifest(
                 manifest = manifest,
                 sourceVideoUrl = stored.entity.sourceVideoUrl,
                 source = stored.entity.provider.ifBlank { "Persistent source match" }
             )
+            if (!isVideoMode || restored.hasVideoPlaybackPayload()) {
+                recordSourceMatchSuccess(track, isVideoMode, audioQuality, preferMp4Audio)
+                return restored
+            }
         }
         if (!allowNetworkRefresh) return null
         val sourceVideoId = stored.entity.sourceVideoId
@@ -2289,11 +2293,6 @@ private fun Throwable.playbackDiagnostic(): String {
 
 class PlaybackBlockedException(message: String) : IllegalStateException(message)
 
-/**
- * Clients that still receive classic progressive `videoplayback` URLs. Other clients are being
- * moved to server-driven adaptive delivery, whose URLs serve the first range and then reject
- * continuations, so playback stops as soon as the initial buffer is consumed.
- */
 private val PROGRESSIVE_STREAM_CLIENTS = setOf("VISIONOS", "ANDROID_VR")
 
 private data class ClientProfile(

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -147,13 +147,14 @@ class PlaybackResolver private constructor(private val context: Context) {
     private var lastNetworkWarmAt = 0L
 
     private val profiles = listOf(
-        ClientProfile("ANDROID_VR", "1.65.10", "Android VR", "com.google.android.apps.youtube.vr.oculus/1.65.10 (Linux; U; Android 12L; Quest 3 Build/SQ3A.220605.009.A1) gzip", true, 0L, 0, false),
-        ClientProfile("ANDROID_MUSIC", "8.10.52", "Android Music", "Mozilla/5.0 (Linux; Android 15; Pixel 8 Pro) AppleWebKit/537.36 (KHTML, like Gecko) com.google.android.apps.youtube.music/8.10.52", true, 0L, 1, false),
-        ClientProfile("ANDROID", "19.44.38", "Android", "com.google.android.youtube/19.44.38 (Linux; U; Android 15)", true, 0L, 2, false),
-        ClientProfile("IOS", "20.10.4", "iOS", "com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3 like Mac OS X; it_IT)", false, 0L, 3, false),
-        ClientProfile("WEB_REMIX", "1.20260423.01.00", "YouTube Music Web", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36", false, 0L, 4, true),
-        ClientProfile("WEB", "2.20260630.01.00", "YouTube Web", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36", false, 0L, 5, true),
-        ClientProfile("WEB_EMBEDDED_PLAYER", "1.20260423.01.00", "Embedded Player", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36", false, 0L, 6, false)
+        ClientProfile("VISIONOS", "1.02", "Apple Vision Pro", "com.google.visionos.youtube/1.02(RealityDevice14,1; U; CPU visionOS 25_6_0 like Mac OS X)", false, 0L, 0, false),
+        ClientProfile("ANDROID_VR", "1.65.10", "Android VR", "com.google.android.apps.youtube.vr.oculus/1.65.10 (Linux; U; Android 12L; Quest 3 Build/SQ3A.220605.009.A1) gzip", true, 0L, 1, false),
+        ClientProfile("ANDROID_MUSIC", "8.10.52", "Android Music", "Mozilla/5.0 (Linux; Android 15; Pixel 8 Pro) AppleWebKit/537.36 (KHTML, like Gecko) com.google.android.apps.youtube.music/8.10.52", true, 0L, 2, false),
+        ClientProfile("ANDROID", "19.44.38", "Android", "com.google.android.youtube/19.44.38 (Linux; U; Android 15)", true, 0L, 3, false),
+        ClientProfile("IOS", "20.10.4", "iOS", "com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3 like Mac OS X; it_IT)", false, 0L, 4, false),
+        ClientProfile("WEB_REMIX", "1.20260423.01.00", "YouTube Music Web", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36", false, 0L, 5, true),
+        ClientProfile("WEB", "2.20260630.01.00", "YouTube Web", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36", false, 0L, 6, true),
+        ClientProfile("WEB_EMBEDDED_PLAYER", "1.20260423.01.00", "Embedded Player", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36", false, 0L, 7, false)
     )
 
     init {
@@ -1070,7 +1071,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 .thenBy { profile -> clientHealth[profile.clientName]?.averageLatencyMs ?: Long.MAX_VALUE }
                 .thenBy { it.tier }
         )
-        val vr = sorted.firstOrNull { it.clientName == "ANDROID_VR" } ?: return sorted
+        val vr = sorted.firstOrNull { it.clientName in PROGRESSIVE_STREAM_CLIENTS } ?: return sorted
         val best = sorted.firstOrNull() ?: return sorted
         val vrHealth = clientHealth[vr.clientName]
         val bestScore = clientHealth[best.clientName]?.score ?: 50.0
@@ -2044,6 +2045,13 @@ class PlaybackResolver private constructor(private val context: Context) {
                     .put("deviceModel", "Quest 3")
             }
         }
+        if (profile.clientName == "VISIONOS") {
+            client.put("deviceMake", "Apple")
+                .put("deviceModel", "RealityDevice14,1")
+                .put("osName", "visionOS")
+                .put("osVersion", "25.6.0.23O471")
+                .put("platform", "TV")
+        }
         if (profile.clientName == "IOS") {
             client.put("deviceMake", "Apple")
                 .put("deviceModel", "iPhone16,2")
@@ -2167,7 +2175,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         transformThrottling: Boolean
     ): String {
         val transformed = if (transformThrottling && containsQueryParameter("n")) {
-            decodeThrottlingParameter(videoId, this)
+            decodeThrottlingParameter(videoId, this) ?: return ""
         } else {
             this
         }
@@ -2186,14 +2194,28 @@ class PlaybackResolver private constructor(private val context: Context) {
             .getOrElse { "" }
     }
 
-    private fun decodeThrottlingParameter(videoId: String, url: String): String {
-        return runCatching { YoutubeJavaScriptPlayerManager.getUrlWithThrottlingParameterDeobfuscated(videoId, url) }
+    private fun decodeThrottlingParameter(videoId: String, url: String): String? {
+        val deobfuscated = runCatching {
+            YoutubeJavaScriptPlayerManager.getUrlWithThrottlingParameterDeobfuscated(videoId, url)
+        }
             .recoverCatching {
                 YoutubeJavaScriptPlayerManager.clearThrottlingParametersCache()
                 YoutubeJavaScriptPlayerManager.getUrlWithThrottlingParameterDeobfuscated(videoId, url)
             }
-            .getOrElse { url }
+            .onFailure { error ->
+                Timber.w(error, "Throttling parameter deobfuscation failed for %s", videoId)
+            }
+            .getOrNull()
+            ?: return null
+        if (throttlingParameterOf(deobfuscated) == throttlingParameterOf(url)) {
+            Timber.w("Throttling parameter unchanged for %s, treating stream as throttled", videoId)
+            return null
+        }
+        return deobfuscated
     }
+
+    private fun throttlingParameterOf(url: String): String =
+        url.substringAfter("&n=", "").ifBlank { url.substringAfter("?n=", "") }.substringBefore('&')
 
     private fun JSONObject.finiteFloat(key: String): Float? {
         if (!has(key) || isNull(key)) return null
@@ -2267,6 +2289,13 @@ private fun Throwable.playbackDiagnostic(): String {
 
 class PlaybackBlockedException(message: String) : IllegalStateException(message)
 
+/**
+ * Clients that still receive classic progressive `videoplayback` URLs. Other clients are being
+ * moved to server-driven adaptive delivery, whose URLs serve the first range and then reject
+ * continuations, so playback stops as soon as the initial buffer is consumed.
+ */
+private val PROGRESSIVE_STREAM_CLIENTS = setOf("VISIONOS", "ANDROID_VR")
+
 private data class ClientProfile(
     val clientName: String,
     val clientVersion: String,
@@ -2282,6 +2311,7 @@ private data class ClientProfile(
             "ANDROID" -> "3"
             "ANDROID_MUSIC" -> "21"
             "ANDROID_VR" -> "28"
+            "VISIONOS" -> "101"
             "IOS" -> "5"
             "WEB_REMIX" -> "67"
             "WEB" -> "1"

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -14,6 +14,7 @@ import com.luc4n3x.levyra.domain.PlaybackStreamKind
 import com.luc4n3x.levyra.domain.ResolvedPlaybackManifest
 import com.luc4n3x.levyra.domain.LevyraPersonalOrbit
 import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.domain.hasVideoPlaybackPayload
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -243,6 +244,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         if (track.streamUrl.isNotBlank()) {
             if (isPlaybackUrlBlocked(track.streamUrl) || track.videoStreamUrl.isNotBlank() && isPlaybackUrlBlocked(track.videoStreamUrl)) return null
             if (!isVideoMode && !isPlayableAudioUrl(track.streamUrl)) return null
+            if (isVideoMode && !track.hasVideoPlaybackPayload()) return null
             return if (streamStillFresh(track.streamUrl)) track else null
         }
         val key = cacheKey(track, isVideoMode, audioQuality)
@@ -252,6 +254,10 @@ class PlaybackResolver private constructor(private val context: Context) {
             return null
         }
         if (!isVideoMode && !isPlayableAudioUrl(hit.track.streamUrl)) {
+            remove(key)
+            return null
+        }
+        if (isVideoMode && !hit.track.hasVideoPlaybackPayload()) {
             remove(key)
             return null
         }
@@ -423,7 +429,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 !isPlaybackUrlBlocked(it) &&
                 (track.videoStreamUrl.isBlank() || !isPlaybackUrlBlocked(track.videoStreamUrl)) &&
                 streamStillFresh(it) &&
-                (isVideoMode || isPlayableAudioUrl(it)) &&
+                (if (isVideoMode) track.hasVideoPlaybackPayload() else isPlayableAudioUrl(it)) &&
                 (!preferMp4Audio || track.playbackManifest?.supportsMp4AudioExport() == true || isMp4AudioUrl(it))
         }?.let { return@coroutineScope track }
         if (!preferMp4Audio) {

--- a/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeClientIdentityInterceptor.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeClientIdentityInterceptor.kt
@@ -21,6 +21,7 @@ internal object YoutubeClientIdentityInterceptor : Interceptor {
     private const val CLIENT_IOS = "5"
     private const val CLIENT_ANDROID_MUSIC = "21"
     private const val CLIENT_ANDROID_VR = "28"
+    private const val CLIENT_VISIONOS = "101"
     private const val CLIENT_WEB_EMBEDDED = "56"
     private const val CLIENT_WEB_REMIX = "67"
 
@@ -28,7 +29,8 @@ internal object YoutubeClientIdentityInterceptor : Interceptor {
         CLIENT_ANDROID,
         CLIENT_IOS,
         CLIENT_ANDROID_MUSIC,
-        CLIENT_ANDROID_VR
+        CLIENT_ANDROID_VR,
+        CLIENT_VISIONOS
     )
 
     override fun intercept(chain: Interceptor.Chain): Response {

--- a/app/src/main/java/com/luc4n3x/levyra/feature/motion/AppleMotionArtworkProvider.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/motion/AppleMotionArtworkProvider.kt
@@ -337,11 +337,11 @@ internal fun selectAppleEditorialVideo(editorialVideo: JSONObject?): AppleEditor
     var best: AppleEditorialVideo? = null
     var bestRank = Int.MIN_VALUE
     var bestArea = -1L
-    keys.forEachIndexed { keyIndex, key ->
-        val asset = root.optJSONObject(key) ?: return@forEachIndexed
+    keys.take(APPLE_EDITORIAL_MAX_ASSETS).forEach { key ->
+        val asset = root.optJSONObject(key) ?: return@forEach
         val url = APPLE_EDITORIAL_URL_FIELDS.firstNotNullOfOrNull { field ->
             asset.optString(field).trim().takeIf { it.startsWith("https://") }
-        } ?: return@forEachIndexed
+        } ?: return@forEach
         val frame = asset.optJSONObject("previewFrame")
         val width = frame?.optInt("width")?.takeIf { it > 0 }
         val height = frame?.optInt("height")?.takeIf { it > 0 }
@@ -360,7 +360,6 @@ internal fun selectAppleEditorialVideo(editorialVideo: JSONObject?): AppleEditor
             bestRank = orientationRank
             bestArea = area
         }
-        if (keyIndex >= APPLE_EDITORIAL_MAX_ASSETS) return best
     }
     return best
 }

--- a/app/src/main/java/com/luc4n3x/levyra/feature/motion/AppleMotionArtworkProvider.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/motion/AppleMotionArtworkProvider.kt
@@ -101,11 +101,11 @@ class AppleMotionArtworkProvider(context: Context) : MotionArtworkProvider {
 
         val output = ArrayList<MotionArtworkCandidate>(ranked.size)
         for (result in ranked) {
-            val directUrl = extractEditorialVideoUrl(result.attributes.optJSONObject("editorialVideo"))
+            val directVideo = extractEditorialVideoUrl(result.attributes.optJSONObject("editorialVideo"))
             val albumId = resolveAlbumId(result.item, result.attributes, type)
-            val resolved = if (!directUrl.isNullOrBlank()) {
+            val resolved = if (directVideo != null) {
                 AppleMotionResult(
-                    url = directUrl,
+                    video = directVideo,
                     albumName = result.album,
                     albumArtist = result.artist,
                     upc = result.attributes.optString("upc"),
@@ -132,10 +132,10 @@ class AppleMotionArtworkProvider(context: Context) : MotionArtworkProvider {
                     trackId = result.item.optString("id"),
                     albumId = albumId.orEmpty()
                 ),
-                url = resolved.url,
+                url = resolved.video.url,
                 mimeType = "application/x-mpegURL",
-                width = 1280,
-                height = 1280,
+                width = resolved.video.width,
+                height = resolved.video.height,
                 expiresAtMs = System.currentTimeMillis() + MOTION_ARTWORK_POSITIVE_TTL_MS
             )
         }
@@ -154,9 +154,9 @@ class AppleMotionArtworkProvider(context: Context) : MotionArtworkProvider {
         val attributes = root.optJSONArray("data")?.optJSONObject(0)?.optJSONObject("attributes") ?: return null
         val albumName = attributes.optString("name").trim()
         if (isUnsafeResult(albumName, albumName)) return null
-        val motionUrl = extractEditorialVideoUrl(attributes.optJSONObject("editorialVideo")) ?: return null
+        val motionVideo = extractEditorialVideoUrl(attributes.optJSONObject("editorialVideo")) ?: return null
         return AppleMotionResult(
-            url = motionUrl,
+            video = motionVideo,
             albumName = albumName,
             albumArtist = attributes.optString("artistName").trim(),
             upc = attributes.optString("upc").trim(),
@@ -252,16 +252,8 @@ class AppleMotionArtworkProvider(context: Context) : MotionArtworkProvider {
             .takeIf { value -> value.isNotBlank() && value.all { it.isDigit() } }
     }
 
-    private fun extractEditorialVideoUrl(editorialVideo: JSONObject?): String? {
-        val keys = listOf("motionDetailSquare", "motionDetailRaw", "motionDetailTall", "motionDetailStatic")
-        for (key in keys) {
-            val asset = editorialVideo?.optJSONObject(key) ?: continue
-            val url = listOf("video", "videoUrl", "hlsUrl", "url")
-                .firstNotNullOfOrNull { field -> asset.optString(field).takeIf { it.startsWith("https://") } }
-            if (url != null) return url
-        }
-        return null
-    }
+    private fun extractEditorialVideoUrl(editorialVideo: JSONObject?): AppleEditorialVideo? =
+        selectAppleEditorialVideo(editorialVideo)
 
     private fun jwtExpiration(token: String): Long? = runCatching {
         val payload = token.split('.').getOrNull(1) ?: return@runCatching null
@@ -297,7 +289,7 @@ class AppleMotionArtworkProvider(context: Context) : MotionArtworkProvider {
     )
 
     private data class AppleMotionResult(
-        val url: String,
+        val video: AppleEditorialVideo,
         val albumName: String,
         val albumArtist: String,
         val upc: String,
@@ -318,3 +310,59 @@ class AppleMotionArtworkProvider(context: Context) : MotionArtworkProvider {
 private class MotionProviderException(message: String, cause: Throwable? = null) : IOException(message, cause)
 
 private fun JSONArray.optJSONObject(index: Int): JSONObject? = if (index in 0 until length()) opt(index) as? JSONObject else null
+
+internal data class AppleEditorialVideo(
+    val url: String,
+    val width: Int?,
+    val height: Int?
+)
+
+private val APPLE_EDITORIAL_URL_FIELDS = listOf("video", "videoUrl", "hlsUrl", "url")
+
+private val APPLE_EDITORIAL_KEY_ORDER = listOf(
+    "motionDetailTall",
+    "motionTallVideo3x4",
+    "motionDetailSquare",
+    "motionSquareVideo1x1",
+    "motionDetailRaw",
+    "motionDetailStatic"
+)
+
+internal fun selectAppleEditorialVideo(editorialVideo: JSONObject?): AppleEditorialVideo? {
+    val root = editorialVideo ?: return null
+    val keys = buildList {
+        APPLE_EDITORIAL_KEY_ORDER.forEach { if (root.has(it)) add(it) }
+        root.keys().forEach { key -> if (key !in APPLE_EDITORIAL_KEY_ORDER) add(key) }
+    }
+    var best: AppleEditorialVideo? = null
+    var bestRank = Int.MIN_VALUE
+    var bestArea = -1L
+    keys.forEachIndexed { keyIndex, key ->
+        val asset = root.optJSONObject(key) ?: return@forEachIndexed
+        val url = APPLE_EDITORIAL_URL_FIELDS.firstNotNullOfOrNull { field ->
+            asset.optString(field).trim().takeIf { it.startsWith("https://") }
+        } ?: return@forEachIndexed
+        val frame = asset.optJSONObject("previewFrame")
+        val width = frame?.optInt("width")?.takeIf { it > 0 }
+        val height = frame?.optInt("height")?.takeIf { it > 0 }
+        val orientationRank = when {
+            width == null || height == null -> 1
+            height > width -> 3
+            height == width -> 2
+            else -> 0
+        }
+        val area = if (width != null && height != null) width.toLong() * height.toLong() else 0L
+        val better = orientationRank > bestRank ||
+            (orientationRank == bestRank && area > bestArea) ||
+            (orientationRank == bestRank && area == bestArea && best == null)
+        if (better) {
+            best = AppleEditorialVideo(url = url, width = width, height = height)
+            bestRank = orientationRank
+            bestArea = area
+        }
+        if (keyIndex >= APPLE_EDITORIAL_MAX_ASSETS) return best
+    }
+    return best
+}
+
+private const val APPLE_EDITORIAL_MAX_ASSETS = 12

--- a/app/src/main/java/com/luc4n3x/levyra/feature/motion/CanonicalTrackMatcher.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/motion/CanonicalTrackMatcher.kt
@@ -80,11 +80,16 @@ object CanonicalTrackMatcher {
                 }
             }
         } else {
-            if (reference.album.isBlank() || albumSimilarity < 0.82) return MotionArtworkMatch(false, 0)
-            score += when {
-                albumSimilarity >= 1.0 -> 30
-                albumSimilarity >= 0.9 -> 25
-                else -> 20
+            if (hasUsableAlbum(reference)) {
+                if (albumSimilarity < 0.82) return MotionArtworkMatch(false, 0)
+                score += when {
+                    albumSimilarity >= 1.0 -> 30
+                    albumSimilarity >= 0.9 -> 25
+                    else -> 20
+                }
+            } else {
+                if (!releaseMatchesTrackTitle(reference.title, source.album)) return MotionArtworkMatch(false, 0)
+                score += 30
             }
             if (reference.upc.isNotBlank() && source.upc.isNotBlank()) {
                 if (reference.upc != source.upc) return MotionArtworkMatch(false, 0)
@@ -143,10 +148,49 @@ object CanonicalTrackMatcher {
         candidate: MotionTrackIdentity,
         scope: MotionArtworkScope
     ): Boolean {
-        val target = normalizeMotionText(if (scope == MotionArtworkScope.ALBUM) reference.album else reference.title)
-        val result = normalizeMotionText(if (scope == MotionArtworkScope.ALBUM) candidate.album else candidate.title)
+        val albumScope = scope == MotionArtworkScope.ALBUM
+        val referenceText = if (albumScope && hasUsableAlbum(reference)) reference.album else reference.title
+        val target = normalizeMotionText(referenceText)
+        val result = normalizeMotionText(if (albumScope) candidate.album else candidate.title)
         return editionTerms.none { term -> motionTextContainsTerm(result, term) != motionTextContainsTerm(target, term) }
     }
+
+    private fun hasUsableAlbum(reference: MotionTrackIdentity): Boolean {
+        val normalized = normalizeMotionText(reference.album)
+        if (normalized.isBlank()) return false
+        return normalized !in genericAlbumNames
+    }
+
+    private fun releaseMatchesTrackTitle(trackTitle: String, candidateAlbum: String): Boolean {
+        val title = releaseCoreName(trackTitle)
+        val album = releaseCoreName(candidateAlbum)
+        return title.isNotBlank() && title == album
+    }
+
+    private fun releaseCoreName(value: String): String {
+        var normalized = normalizeMotionText(value)
+        for (suffix in releaseSuffixes) {
+            if (normalized.endsWith(" $suffix")) {
+                normalized = normalized.removeSuffix(" $suffix").trim()
+                break
+            }
+        }
+        return normalized
+    }
+
+    private val genericAlbumNames = setOf(
+        "youtube",
+        "youtube music",
+        "youtube music video",
+        "youtube music charts",
+        "youtube shorts",
+        "apple music charts",
+        "unknown album",
+        "single",
+        "ep"
+    )
+
+    private val releaseSuffixes = listOf("single", "ep")
 
     private const val MINIMUM_STRUCTURAL_SCORE = 70
 }

--- a/app/src/main/java/com/luc4n3x/levyra/feature/motion/MotionArtworkEngine.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/motion/MotionArtworkEngine.kt
@@ -132,24 +132,28 @@ class MotionArtworkEngine(context: Context) {
             )
         }
 
-        val ranked = candidates.mapNotNull { candidate ->
-            val match = CanonicalTrackMatcher.match(identity, candidate)
-            Timber.d(
-                "motion candidate %s scope=%s score=%d accepted=%b minimum=%d album=%s",
-                candidate.provider,
-                candidate.scope,
-                match.score,
-                match.accepted,
-                config.minimumConfidence,
-                candidate.identity.album
-            )
-            if (!match.accepted || match.score < config.minimumConfidence) null
-            else MotionArtworkRankedCandidate(
-                candidate,
-                match.score,
-                providerRanks[candidate.provider] ?: Int.MAX_VALUE
-            )
-        }.sortedWith(
+        val ranked = candidates
+            .map { candidate -> candidate to CanonicalTrackMatcher.match(identity, candidate) }
+            .onEach { (candidate, match) ->
+                Timber.d(
+                    "motion candidate %s scope=%s score=%d accepted=%b minimum=%d album=%s",
+                    candidate.provider,
+                    candidate.scope,
+                    match.score,
+                    match.accepted,
+                    config.minimumConfidence,
+                    candidate.identity.album
+                )
+            }
+            .mapNotNull { (candidate, match) ->
+                if (!match.accepted || match.score < config.minimumConfidence) null
+                else MotionArtworkRankedCandidate(
+                    candidate,
+                    match.score,
+                    providerRanks[candidate.provider] ?: Int.MAX_VALUE
+                )
+            }
+            .sortedWith(
             compareBy<MotionArtworkRankedCandidate> { it.providerRank }
                 .thenByDescending { it.confidence }
         )

--- a/app/src/main/java/com/luc4n3x/levyra/feature/motion/MotionArtworkEngine.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/motion/MotionArtworkEngine.kt
@@ -115,8 +115,34 @@ class MotionArtworkEngine(context: Context) {
             }
         }
 
+        outcomes.forEachIndexed { index, outcome ->
+            val provider = providers.getOrNull(index)?.id ?: "unknown"
+            val summary = when (outcome) {
+                is MotionArtworkProviderResult.Found -> "found=${outcome.candidates.size}"
+                MotionArtworkProviderResult.NoMatch -> "noMatch"
+                is MotionArtworkProviderResult.Failed -> "failed"
+            }
+            Timber.d(
+                "motion provider %s -> %s for %s / %s (album=%s)",
+                provider,
+                summary,
+                identity.title,
+                identity.artists.joinToString(),
+                identity.album
+            )
+        }
+
         val ranked = candidates.mapNotNull { candidate ->
             val match = CanonicalTrackMatcher.match(identity, candidate)
+            Timber.d(
+                "motion candidate %s scope=%s score=%d accepted=%b minimum=%d album=%s",
+                candidate.provider,
+                candidate.scope,
+                match.score,
+                match.accepted,
+                config.minimumConfidence,
+                candidate.identity.album
+            )
             if (!match.accepted || match.score < config.minimumConfidence) null
             else MotionArtworkRankedCandidate(
                 candidate,

--- a/app/src/main/java/com/luc4n3x/levyra/feature/motion/MotionArtworkRuntime.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/motion/MotionArtworkRuntime.kt
@@ -36,4 +36,4 @@ object MotionArtworkRuntime {
     )
 }
 
-internal const val MOTION_ARTWORK_CACHE_SCHEMA_EPOCH = 1L
+internal const val MOTION_ARTWORK_CACHE_SCHEMA_EPOCH = 2L

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -1240,8 +1240,7 @@ class PlaybackService : MediaLibraryService() {
     private data class ServiceRecoveryPlan(
         val localPlayback: Boolean,
         val delaysMs: LongArray,
-        val positionMs: Long,
-        val trackId: String?
+        val positionMs: Long
     )
 
     private fun scheduleServiceRecovery(error: PlaybackException) {
@@ -1258,19 +1257,8 @@ class PlaybackService : MediaLibraryService() {
         return ServiceRecoveryPlan(
             localPlayback = localPlayback,
             delaysMs = if (localPlayback) LOCAL_RECOVERY_DELAYS_MS else ONLINE_RECOVERY_DELAYS_MS,
-            positionMs = mediaSession?.player?.currentPosition?.coerceAtLeast(0L) ?: 0L,
-            trackId = currentRecoveryTrackId()
+            positionMs = mediaSession?.player?.currentPosition?.coerceAtLeast(0L) ?: 0L
         )
-    }
-
-    private fun currentRecoveryTrackId(): String? =
-        queueEngine.state.value.currentTrack?.id?.takeIf { it.isNotBlank() }
-            ?: mediaSession?.player?.currentMediaItem?.mediaId?.takeIf { it.isNotBlank() }
-
-    private fun recoveryTargetChanged(plan: ServiceRecoveryPlan): Boolean {
-        val expected = plan.trackId ?: return false
-        val current = currentRecoveryTrackId() ?: return false
-        return current != expected
     }
 
     private suspend fun runServiceRecovery(error: PlaybackException, plan: ServiceRecoveryPlan) {
@@ -1344,17 +1332,6 @@ class PlaybackService : MediaLibraryService() {
         val attempt = serviceRecoveryAttempts++
         acquirePlaybackWakeLock()
         delay(plan.delaysMs[attempt])
-        if (recoveryTargetChanged(plan)) {
-            serviceRecoveryAttempts = 0
-            serviceRecoveryExhausted = false
-            releasePlaybackWakeLock()
-            Timber.i("Background playback recovery abandoned: track changed")
-            return true
-        }
-        if (finishHealthyServiceRecovery()) {
-            releasePlaybackWakeLock()
-            return true
-        }
         val restored = restoreCurrentPlayback(
             positionMs = plan.positionMs,
             preferFreshResolution = !plan.localPlayback && hasInternetCapableNetwork()

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -1240,7 +1240,8 @@ class PlaybackService : MediaLibraryService() {
     private data class ServiceRecoveryPlan(
         val localPlayback: Boolean,
         val delaysMs: LongArray,
-        val positionMs: Long
+        val positionMs: Long,
+        val trackId: String?
     )
 
     private fun scheduleServiceRecovery(error: PlaybackException) {
@@ -1257,8 +1258,19 @@ class PlaybackService : MediaLibraryService() {
         return ServiceRecoveryPlan(
             localPlayback = localPlayback,
             delaysMs = if (localPlayback) LOCAL_RECOVERY_DELAYS_MS else ONLINE_RECOVERY_DELAYS_MS,
-            positionMs = mediaSession?.player?.currentPosition?.coerceAtLeast(0L) ?: 0L
+            positionMs = mediaSession?.player?.currentPosition?.coerceAtLeast(0L) ?: 0L,
+            trackId = currentRecoveryTrackId()
         )
+    }
+
+    private fun currentRecoveryTrackId(): String? =
+        queueEngine.state.value.currentTrack?.id?.takeIf { it.isNotBlank() }
+            ?: mediaSession?.player?.currentMediaItem?.mediaId?.takeIf { it.isNotBlank() }
+
+    private fun recoveryTargetChanged(plan: ServiceRecoveryPlan): Boolean {
+        val expected = plan.trackId ?: return false
+        val current = currentRecoveryTrackId() ?: return false
+        return current != expected
     }
 
     private suspend fun runServiceRecovery(error: PlaybackException, plan: ServiceRecoveryPlan) {
@@ -1332,6 +1344,17 @@ class PlaybackService : MediaLibraryService() {
         val attempt = serviceRecoveryAttempts++
         acquirePlaybackWakeLock()
         delay(plan.delaysMs[attempt])
+        if (recoveryTargetChanged(plan)) {
+            serviceRecoveryAttempts = 0
+            serviceRecoveryExhausted = false
+            releasePlaybackWakeLock()
+            Timber.i("Background playback recovery abandoned: track changed")
+            return true
+        }
+        if (finishHealthyServiceRecovery()) {
+            releasePlaybackWakeLock()
+            return true
+        }
         val restored = restoreCurrentPlayback(
             positionMs = plan.positionMs,
             preferFreshResolution = !plan.localPlayback && hasInternetCapableNetwork()

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -11102,13 +11102,13 @@ private fun PlayerCanvasFusionScrim(
             drawRect(
                 Brush.verticalGradient(
                     colorStops = arrayOf(
-                        0.00f to baseColor.copy(alpha = 0.62f),
-                        0.13f to baseColor.copy(alpha = 0.14f),
-                        0.32f to Color.Transparent,
-                        0.50f to baseColor.copy(alpha = 0.26f),
-                        0.62f to baseColor.copy(alpha = 0.70f),
-                        0.74f to baseColor.copy(alpha = 0.93f),
-                        0.84f to baseColor,
+                        0.00f to baseColor.copy(alpha = 0.55f),
+                        0.12f to baseColor.copy(alpha = 0.18f),
+                        0.24f to Color.Transparent,
+                        0.48f to Color.Transparent,
+                        0.62f to baseColor.copy(alpha = 0.38f),
+                        0.76f to baseColor.copy(alpha = 0.78f),
+                        0.88f to baseColor.copy(alpha = 0.94f),
                         1.00f to baseColor
                     )
                 )
@@ -11135,8 +11135,10 @@ private fun PlayerModeSwitch(
         modifier = Modifier
             .selectableGroup()
             .playerGlass(
-                shape = LevyraPlayerDesign.ShapePill,
-                fill = LevyraPlayerDesign.GlassFillSunken
+                shape = CircleShape,
+                fill = Color.Black.copy(alpha = 0.35f),
+                borderTop = Color.White.copy(alpha = 0.14f),
+                borderBottom = Color.White.copy(alpha = 0.08f)
             )
             .padding(3.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -11174,7 +11176,7 @@ private fun PlayerModeSwitchTab(
         snap()
     }
     val background by animateColorAsState(
-        targetValue = if (selected) Color.White.copy(alpha = 0.20f) else Color.Transparent,
+        targetValue = if (selected) Color.White.copy(alpha = 0.22f) else Color.Transparent,
         animationSpec = tabSpec,
         label = "player-mode-tab-background"
     )
@@ -11192,21 +11194,21 @@ private fun PlayerModeSwitchTab(
             .then(
                 if (selected) {
                     Modifier
-                        .shadow(4.dp, LevyraPlayerDesign.ShapePill, clip = false)
-                        .background(background, LevyraPlayerDesign.ShapePill)
-                        .border(BorderStroke(1.dp, Color.White.copy(alpha = 0.24f)), LevyraPlayerDesign.ShapePill)
+                        .shadow(3.dp, CircleShape, clip = false)
+                        .background(background, CircleShape)
+                        .border(BorderStroke(1.dp, Color.White.copy(alpha = 0.28f)), CircleShape)
                 } else {
-                    Modifier.background(background, LevyraPlayerDesign.ShapePill)
+                    Modifier.background(background, CircleShape)
                 }
             )
             .pressable(enabled = !selected, onClick = onClick)
-            .padding(horizontal = 15.dp, vertical = 6.5.dp)
+            .padding(horizontal = 16.dp, vertical = 6.dp)
     ) {
         Text(
             text = label,
             color = contentColor,
             fontSize = 12.sp,
-            fontWeight = FontWeight.Bold,
+            fontWeight = FontWeight.SemiBold,
             letterSpacing = 0.2.sp,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
@@ -11224,96 +11226,53 @@ private fun LevyraControlPulseHandle(
     onToggle: () -> Unit
 ) {
     val strings = LocalLevyraStrings.current
-    val width = if (compact) 88.dp else 94.dp
-    val height = if (compact) 28.dp else 30.dp
-    val lineWidth = if (compact) 18.dp else 20.dp
-    val iconBoxSize = if (compact) 22.dp else 24.dp
-    val iconSize = if (compact) 17.dp else 18.dp
+    val width = if (compact) 82.dp else 88.dp
+    val height = if (compact) 26.dp else 28.dp
     val rotation by animateFloatAsState(
         targetValue = if (expanded) 180f else 0f,
-        animationSpec = tween(durationMillis = 180, easing = FastOutSlowInEasing),
+        animationSpec = tween(durationMillis = 200, easing = FastOutSlowInEasing),
         label = "player-shelf-chevron"
     )
-
-    val leftAccent = Color(0xFF4A7DFF).playerMix(activeColor, 0.4f)
-    val rightAccent = Color(0xFFFF4B8B).playerMix(secondaryColor, 0.4f)
 
     Box(
         modifier = Modifier.fillMaxWidth(),
         contentAlignment = Alignment.Center
     ) {
         Surface(
-            color = Color(0xFF140D22).copy(alpha = 0.85f),
+            color = Color.Black.copy(alpha = 0.30f),
             border = BorderStroke(
                 1.dp,
-                Color.White.copy(alpha = if (expanded) 0.22f else 0.12f)
+                Color.White.copy(alpha = if (expanded) 0.20f else 0.10f)
             ),
-            shape = RoundedCornerShape(500.dp),
+            shape = CircleShape,
             modifier = Modifier
                 .width(width)
                 .height(height)
                 .shadow(
-                    elevation = 6.dp,
-                    shape = RoundedCornerShape(500.dp),
-                    ambientColor = activeColor.copy(alpha = 0.25f),
-                    spotColor = Color.Black.copy(alpha = 0.50f)
+                    elevation = 4.dp,
+                    shape = CircleShape,
+                    ambientColor = Color.Black.copy(alpha = 0.25f),
+                    spotColor = Color.Black.copy(alpha = 0.45f)
                 )
-                .pressable(pressedScale = 0.96f, onClick = onToggle)
+                .pressable(pressedScale = 0.94f, onClick = onToggle)
         ) {
             Box(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center
             ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.Center
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .width(lineWidth)
-                            .height(2.5.dp)
-                            .background(leftAccent.copy(alpha = 0.85f), CircleShape)
-                    )
-                    Spacer(modifier = Modifier.width(6.dp))
-                    Box(
-                        modifier = Modifier
-                            .size(iconBoxSize)
-                            .graphicsLayer { rotationZ = rotation }
-                            .background(
-                                brush = Brush.linearGradient(
-                                    listOf(
-                                        Color(0xFF6B73FF),
-                                        Color(0xFFC355E6)
-                                    )
-                                ),
-                                shape = RoundedCornerShape(7.dp)
-                            )
-                            .border(
-                                BorderStroke(1.dp, Color.White.copy(alpha = 0.25f)),
-                                RoundedCornerShape(7.dp)
-                            ),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(
-                            imageVector = Icons.Rounded.KeyboardArrowDown,
-                            contentDescription = strings.options,
-                            tint = Color.White,
-                            modifier = Modifier.size(iconSize)
-                        )
-                    }
-                    Spacer(modifier = Modifier.width(6.dp))
-                    Box(
-                        modifier = Modifier
-                            .width(lineWidth)
-                            .height(2.5.dp)
-                            .background(rightAccent.copy(alpha = 0.85f), CircleShape)
-                    )
-                }
+                Icon(
+                    imageVector = Icons.Rounded.KeyboardArrowDown,
+                    contentDescription = strings.options,
+                    tint = Color.White.copy(alpha = if (expanded) 1f else 0.80f),
+                    modifier = Modifier
+                        .size(18.dp)
+                        .graphicsLayer { rotationZ = rotation }
+                )
                 if (hasActiveState && !expanded) {
                     Box(
                         modifier = Modifier
                             .align(Alignment.CenterEnd)
-                            .padding(end = 6.dp)
+                            .padding(end = 8.dp)
                             .size(5.dp)
                             .background(activeColor.playerMix(Color.White, 0.4f), CircleShape)
                     )
@@ -11476,34 +11435,34 @@ private fun PlayerYoutubeEngagementRow(
         ) {
             // Likes & Dislikes Capsule
             Surface(
-                color = Color.Black.copy(alpha = 0.32f),
+                color = Color.White.copy(alpha = 0.08f),
                 border = BorderStroke(1.dp, Color.White.copy(alpha = 0.12f)),
                 shape = CircleShape
             ) {
                 Row(
-                    modifier = Modifier.height(32.dp),
+                    modifier = Modifier.height(28.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Row(
                         modifier = Modifier.padding(
-                            start = 12.dp,
-                            end = 10.dp
+                            start = 10.dp,
+                            end = 8.dp
                         ),
                         verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(6.dp)
+                        horizontalArrangement = Arrangement.spacedBy(5.dp)
                     ) {
                         Icon(
                             imageVector = Icons.Rounded.ThumbUp,
                             contentDescription = null,
                             tint = Color.White.copy(alpha = if (hasLikes) 0.92f else 0.50f),
-                            modifier = Modifier.size(15.dp)
+                            modifier = Modifier.size(13.dp)
                         )
                         if (hasLikes) {
                             Text(
                                 text = compactYoutubeCount(track.youtubeLikeCount),
                                 color = Color.White.copy(alpha = 0.92f),
-                                fontSize = 12.sp,
-                                fontWeight = FontWeight.Bold,
+                                fontSize = 11.5.sp,
+                                fontWeight = FontWeight.SemiBold,
                                 maxLines = 1
                             )
                         }
@@ -11511,16 +11470,16 @@ private fun PlayerYoutubeEngagementRow(
                     Box(
                         modifier = Modifier
                             .width(1.dp)
-                            .height(16.dp)
-                            .background(Color.White.copy(alpha = 0.14f))
+                            .height(14.dp)
+                            .background(Color.White.copy(alpha = 0.12f))
                     )
                     Row(
                         modifier = Modifier.padding(
-                            start = 10.dp,
-                            end = 12.dp
+                            start = 8.dp,
+                            end = 10.dp
                         ),
                         verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(6.dp)
+                        horizontalArrangement = Arrangement.spacedBy(5.dp)
                     ) {
                         Icon(
                             imageVector = Icons.Rounded.ThumbDown,
@@ -11530,19 +11489,19 @@ private fun PlayerYoutubeEngagementRow(
                             } else {
                                 Color.White.copy(alpha = 0.50f)
                             },
-                            modifier = Modifier.size(15.dp)
+                            modifier = Modifier.size(13.dp)
                         )
                         when {
                             engagement.dislikeEstimateLoading -> CircularProgressIndicator(
-                                modifier = Modifier.size(11.dp),
-                                strokeWidth = 1.6.dp,
+                                modifier = Modifier.size(10.dp),
+                                strokeWidth = 1.4.dp,
                                 color = Color.White.copy(alpha = 0.72f)
                             )
                             hasDislikeEstimate -> Text(
                                 text = "~${compactYoutubeCount(engagement.estimatedDislikeCount)}",
-                                color = Color.White.copy(alpha = 0.88f),
-                                fontSize = 12.sp,
-                                fontWeight = FontWeight.Bold,
+                                color = Color.White.copy(alpha = 0.85f),
+                                fontSize = 11.5.sp,
+                                fontWeight = FontWeight.SemiBold,
                                 maxLines = 1
                             )
                         }
@@ -11552,7 +11511,7 @@ private fun PlayerYoutubeEngagementRow(
 
             // Comments Capsule
             Surface(
-                color = Color.Black.copy(alpha = 0.32f),
+                color = Color.White.copy(alpha = 0.08f),
                 border = BorderStroke(
                     1.dp,
                     if (comments.visible) Color.White.copy(alpha = 0.26f) else Color.White.copy(alpha = 0.12f)
@@ -11561,36 +11520,36 @@ private fun PlayerYoutubeEngagementRow(
             ) {
                 Box(
                     modifier = Modifier
-                        .height(32.dp)
+                        .height(28.dp)
                         .pressable(enabled = canOpenComments, onClick = onComments)
-                        .padding(horizontal = 12.dp),
+                        .padding(horizontal = 10.dp),
                     contentAlignment = Alignment.Center
                 ) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(6.dp)
+                        horizontalArrangement = Arrangement.spacedBy(5.dp)
                     ) {
                         Icon(
                             imageVector = Icons.Rounded.ChatBubbleOutline,
                             contentDescription = null,
                             tint = if (canOpenComments) {
-                                Color.White.copy(alpha = 0.72f)
+                                Color.White.copy(alpha = 0.75f)
                             } else {
                                 Color.White.copy(alpha = 0.45f)
                             },
-                            modifier = Modifier.size(15.dp)
+                            modifier = Modifier.size(13.dp)
                         )
                         when {
                             comments.loading && !comments.loaded -> CircularProgressIndicator(
-                                modifier = Modifier.size(11.dp),
-                                strokeWidth = 1.6.dp,
+                                modifier = Modifier.size(10.dp),
+                                strokeWidth = 1.4.dp,
                                 color = Color.White.copy(alpha = 0.72f)
                             )
                             commentBadge.isNotBlank() -> Text(
                                 text = commentBadge,
                                 color = Color.White.copy(alpha = 0.90f),
-                                fontSize = 12.sp,
-                                fontWeight = FontWeight.Bold,
+                                fontSize = 11.5.sp,
+                                fontWeight = FontWeight.SemiBold,
                                 maxLines = 1
                             )
                         }
@@ -12068,7 +12027,7 @@ private fun PlayerScreen(
                     icon = Icons.Rounded.KeyboardArrowDown,
                     contentDescription = strings.collapsePlayer,
                     size = headerButtonSize,
-                    iconSize = if (compactPlayer) 25.dp else 26.dp,
+                    iconSize = if (compactPlayer) 22.dp else 24.dp,
                     onClick = collapseActions.collapse
                 )
                 Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
@@ -12084,8 +12043,10 @@ private fun PlayerScreen(
                         Box(
                             modifier = Modifier
                                 .playerGlass(
-                                    shape = LevyraPlayerDesign.ShapePill,
-                                    fill = LevyraPlayerDesign.GlassFillSunken
+                                    shape = CircleShape,
+                                    fill = Color.Black.copy(alpha = 0.35f),
+                                    borderTop = Color.White.copy(alpha = 0.14f),
+                                    borderBottom = Color.White.copy(alpha = 0.08f)
                                 )
                                 .padding(horizontal = 14.dp, vertical = 7.dp)
                         ) {
@@ -12093,7 +12054,7 @@ private fun PlayerScreen(
                                 text = strings.formatPlayingFrom(track?.source ?: "LEVYRA"),
                                 color = LevyraPlayerDesign.TextSecondary,
                                 fontSize = 10.sp,
-                                fontWeight = FontWeight.Black,
+                                fontWeight = FontWeight.Bold,
                                 letterSpacing = 1.1.sp,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis
@@ -12106,7 +12067,7 @@ private fun PlayerScreen(
                         icon = Icons.Rounded.PictureInPictureAlt,
                         contentDescription = strings.pictureInPicture,
                         size = headerButtonSize,
-                        iconSize = 20.dp,
+                        iconSize = 19.dp,
                         borderTop = primary.copy(alpha = 0.48f),
                         borderBottom = primary.copy(alpha = 0.14f),
                         onClick = { LevyraPipBridge.enter() }
@@ -12116,7 +12077,7 @@ private fun PlayerScreen(
                     icon = Icons.Rounded.MoreVert,
                     contentDescription = strings.options,
                     size = headerButtonSize,
-                    iconSize = if (compactPlayer) 21.dp else 22.dp,
+                    iconSize = if (compactPlayer) 20.dp else 21.dp,
                     onClick = { viewModel.openAudioQualityPanel() }
                 )
             }
@@ -12276,11 +12237,11 @@ private fun PlayerScreen(
 
         val metaBlock: @Composable (Track) -> Unit = { activeTrack ->
             val isFavorite = activeTrack.id in state.favoriteIds
-            val favoriteFill = if (isFavorite) Color(0xFFFF2D55).copy(alpha = 0.22f) else Color.White.copy(alpha = 0.06f)
-            val favoriteTint = if (isFavorite) Color(0xFFFF2D55) else Color.White.copy(alpha = 0.85f)
-            val favoriteBorder = if (isFavorite) Color(0xFFFF2D55).copy(alpha = 0.65f) else Color.White.copy(alpha = 0.22f)
+            val favoriteFill = if (isFavorite) Color(0xFFFF2D55).copy(alpha = 0.18f) else Color.White.copy(alpha = 0.06f)
+            val favoriteTint = if (isFavorite) Color(0xFFFF2D55) else Color.White.copy(alpha = 0.70f)
+            val favoriteBorder = if (isFavorite) Color(0xFFFF2D55).copy(alpha = 0.50f) else Color.White.copy(alpha = 0.12f)
             val favoriteScale by animateFloatAsState(
-                targetValue = if (isFavorite) 1.08f else 1f,
+                targetValue = if (isFavorite) 1.12f else 1f,
                 animationSpec = if (state.animationsEnabled) {
                     LevyraPlayerDesign.expressiveSpring()
                 } else {
@@ -12288,7 +12249,7 @@ private fun PlayerScreen(
                 },
                 label = "player-favorite-scale"
             )
-            val heartButtonSize = if (compactPlayer) LevyraPlayerDesign.HeaderButtonCompact else LevyraPlayerDesign.HeaderButton
+            val heartButtonSize = if (compactPlayer) 38.dp else 40.dp
 
             Column(
                 modifier = Modifier
@@ -12358,7 +12319,7 @@ private fun PlayerScreen(
                         icon = if (isFavorite) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
                         contentDescription = strings.favoritesPlain,
                         size = heartButtonSize,
-                        iconSize = if (compactPlayer) 24.dp else 26.dp,
+                        iconSize = if (compactPlayer) 22.dp else 24.dp,
                         tint = favoriteTint,
                         fill = favoriteFill,
                         borderTop = favoriteBorder,
@@ -12376,7 +12337,11 @@ private fun PlayerScreen(
                         icon = Icons.AutoMirrored.Rounded.PlaylistAdd,
                         contentDescription = strings.addToPlaylist,
                         size = heartButtonSize,
-                        iconSize = if (compactPlayer) 23.dp else 25.dp,
+                        iconSize = if (compactPlayer) 22.dp else 24.dp,
+                        tint = Color.White.copy(alpha = 0.75f),
+                        fill = Color.White.copy(alpha = 0.06f),
+                        borderTop = Color.White.copy(alpha = 0.12f),
+                        borderBottom = Color.White.copy(alpha = 0.06f),
                         onClick = { playlistTarget = activeTrack }
                     )
                 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -11102,13 +11102,13 @@ private fun PlayerCanvasFusionScrim(
             drawRect(
                 Brush.verticalGradient(
                     colorStops = arrayOf(
-                        0.00f to baseColor.copy(alpha = 0.55f),
-                        0.12f to baseColor.copy(alpha = 0.18f),
-                        0.24f to Color.Transparent,
-                        0.48f to Color.Transparent,
-                        0.62f to baseColor.copy(alpha = 0.38f),
-                        0.76f to baseColor.copy(alpha = 0.78f),
-                        0.88f to baseColor.copy(alpha = 0.94f),
+                        0.00f to baseColor.copy(alpha = 0.72f),
+                        0.09f to baseColor.copy(alpha = 0.30f),
+                        0.19f to Color.Transparent,
+                        0.50f to Color.Transparent,
+                        0.57f to baseColor.copy(alpha = 0.55f),
+                        0.63f to baseColor.copy(alpha = 0.92f),
+                        0.68f to baseColor,
                         1.00f to baseColor
                     )
                 )
@@ -12258,7 +12258,7 @@ private fun PlayerScreen(
             ) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.Top
                 ) {
                     Column(modifier = Modifier.weight(1f)) {
                         AnimatedContent(

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -10912,114 +10912,64 @@ private fun PlaylistDetailOverlay(viewModel: LevyraViewModel, state: LevyraUiSta
 
 @Composable
 private fun PlayerImmersiveBackdrop(
-    primaryTarget: Color,
-    secondaryTarget: Color,
+    ambience: PlayerAmbience,
     isPlaying: Boolean,
     modifier: Modifier = Modifier
 ) {
-    val primary by animateColorAsState(
-        targetValue = primaryTarget,
-        animationSpec = tween(750, easing = LinearOutSlowInEasing),
-        label = "player-backdrop-primary"
+    val tint = animateColorAsState(
+        targetValue = ambience.tint,
+        animationSpec = tween(700, easing = LinearOutSlowInEasing),
+        label = "player-backdrop-tint"
     )
-    val secondary by animateColorAsState(
-        targetValue = secondaryTarget,
-        animationSpec = tween(750, easing = LinearOutSlowInEasing),
-        label = "player-backdrop-secondary"
+    val elevated = animateColorAsState(
+        targetValue = ambience.elevated,
+        animationSpec = tween(700, easing = LinearOutSlowInEasing),
+        label = "player-backdrop-elevated"
     )
-    val intensity by animateFloatAsState(
-        targetValue = if (isPlaying) 1f else 0.85f,
+    val base = animateColorAsState(
+        targetValue = ambience.base,
+        animationSpec = tween(700, easing = LinearOutSlowInEasing),
+        label = "player-backdrop-base"
+    )
+    val glow = animateFloatAsState(
+        targetValue = if (isPlaying) 1f else 0.74f,
         animationSpec = tween(600, easing = FastOutSlowInEasing),
-        label = "player-backdrop-intensity"
+        label = "player-backdrop-glow"
     )
-    val primarySurface = remember(primary) {
-        primary.playerAdjustBackgroundFor(Color.White, PlayerStrongContrast).color
-    }
-    val secondarySurface = remember(secondary) {
-        secondary.playerAdjustBackgroundFor(Color.White, PlayerStrongContrast).color
-    }
-    val mixedAccent = remember(primarySurface, secondarySurface) {
-        primarySurface.playerMix(secondarySurface, 0.40f)
-    }
 
     Box(
-        modifier = modifier
-            .background(
+        modifier = modifier.drawBehind {
+            if (size.minDimension <= 0f) return@drawBehind
+            val elevatedColor = elevated.value
+            val baseColor = base.value
+            drawRect(
                 Brush.verticalGradient(
                     colorStops = arrayOf(
-                        0.00f to mixedAccent.playerMix(Color(0xFF2C1445), 0.35f),
-                        0.32f to primarySurface.playerMix(Color(0xFF13091E), 0.55f),
-                        0.64f to Color(0xFF0C0614),
-                        1.00f to Color(0xFF050308)
+                        0.00f to elevatedColor,
+                        0.38f to elevatedColor.playerAmbienceMix(baseColor, 0.58f),
+                        0.72f to baseColor.playerAmbienceMix(elevatedColor, 0.16f),
+                        1.00f to baseColor
                     )
                 )
             )
-            .drawBehind {
-                if (size.minDimension <= 0f) return@drawBehind
-                val topCenter = androidx.compose.ui.geometry.Offset(size.width * 0.30f, size.height * 0.16f)
-                val centerOrb = androidx.compose.ui.geometry.Offset(size.width * 0.75f, size.height * 0.30f)
-                val auraCenter = androidx.compose.ui.geometry.Offset(size.width * 0.50f, size.height * 0.24f)
-
-                // Wide soft central glow behind artwork
-                drawCircle(
-                    brush = Brush.radialGradient(
-                        colors = listOf(
-                            primarySurface.playerMix(Color(0xFF8A50E6), 0.35f).copy(alpha = 0.45f * intensity),
-                            primarySurface.copy(alpha = 0.22f * intensity),
-                            Color.Transparent
-                        ),
-                        center = auraCenter,
-                        radius = size.width * 0.90f
+            val glowAmount = glow.value
+            val center = androidx.compose.ui.geometry.Offset(size.width * 0.5f, size.height * 0.21f)
+            val radius = size.width * 1.02f
+            drawCircle(
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        tint.value.copy(alpha = 0.30f * glowAmount),
+                        tint.value.copy(alpha = 0.09f * glowAmount),
+                        Color.Transparent
                     ),
-                    radius = size.width * 0.90f,
-                    center = auraCenter
-                )
-
-                // Secondary atmospheric top orb
-                drawCircle(
-                    brush = Brush.radialGradient(
-                        colors = listOf(
-                            secondarySurface.playerMix(Color(0xFFC04FE6), 0.30f).copy(alpha = 0.38f * intensity),
-                            secondarySurface.copy(alpha = 0.15f * intensity),
-                            Color.Transparent
-                        ),
-                        center = centerOrb,
-                        radius = size.width * 0.75f
-                    ),
-                    radius = size.width * 0.75f,
-                    center = centerOrb
-                )
-
-                // Top highlight bloom
-                drawCircle(
-                    brush = Brush.radialGradient(
-                        colors = listOf(
-                            primarySurface.copy(alpha = 0.28f * intensity),
-                            Color.Transparent
-                        ),
-                        center = topCenter,
-                        radius = size.width * 0.65f
-                    ),
-                    radius = size.width * 0.65f,
-                    center = topCenter
-                )
-            }
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(
-                    Brush.verticalGradient(
-                        listOf(
-                            Color.Transparent,
-                            Color.Black.copy(alpha = 0.08f),
-                            Color.Black.copy(alpha = 0.45f),
-                            Color.Black.copy(alpha = 0.86f)
-                        )
-                    )
-                )
-        )
-    }
+                    center = center,
+                    radius = radius
+                ),
+                radius = radius,
+                center = center
+            )
+        }
+    )
 }
 
 @Composable
@@ -11033,71 +10983,34 @@ private fun PlayerArtworkCanvas(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
-    val haloScale by animateFloatAsState(
-        targetValue = if (isPlaying) 1.035f else 1.0f,
-        animationSpec = tween(400, easing = FastOutSlowInEasing),
-        label = "player-artwork-halo-scale"
-    )
-    val haloAlpha by animateFloatAsState(
-        targetValue = if (isPlaying) 0.65f else 0.45f,
-        animationSpec = tween(400, easing = FastOutSlowInEasing),
-        label = "player-artwork-halo-alpha"
-    )
-    val artworkShadow by animateFloatAsState(
-        targetValue = if (isPlaying) 28f else 18f,
-        animationSpec = tween(400, easing = FastOutSlowInEasing),
+    val artworkShadow by animateDpAsState(
+        targetValue = if (isPlaying) 26.dp else 14.dp,
+        animationSpec = tween(420, easing = FastOutSlowInEasing),
         label = "player-artwork-shadow"
     )
     val primary = Color(track.accentStart)
-    val secondary = Color(track.accentEnd)
     val artworkShape = RoundedCornerShape(cornerRadius)
 
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
-        // Luminous Ambient Halo
         Box(
             modifier = Modifier
-                .fillMaxSize(0.96f)
-                .graphicsLayer {
-                    scaleX = haloScale
-                    scaleY = haloScale
-                    alpha = haloAlpha
-                }
-                .background(
-                    Brush.radialGradient(
-                        listOf(
-                            primary.playerMix(Color.White, 0.15f).copy(alpha = 0.35f),
-                            secondary.copy(alpha = 0.20f),
-                            primary.playerMix(Color.Black, 0.50f).copy(alpha = 0.08f),
-                            Color.Transparent
-                        )
-                    ),
-                    RoundedCornerShape(cornerRadius + 20.dp)
-                )
-        )
-        // 3D Elevated Cover Surface
-        Box(
-            modifier = Modifier
-                .fillMaxSize(0.92f)
+                .fillMaxSize()
                 .shadow(
-                    elevation = artworkShadow.dp,
+                    elevation = artworkShadow,
                     shape = artworkShape,
                     clip = false,
-                    ambientColor = primary.copy(alpha = 0.50f),
-                    spotColor = Color.Black.copy(alpha = 0.85f)
+                    ambientColor = primary.copy(alpha = 0.42f),
+                    spotColor = Color.Black.copy(alpha = 0.80f)
                 )
                 .clip(artworkShape)
-                .background(Color.Black.copy(alpha = 0.20f), artworkShape)
-                .border(
-                    width = 1.dp,
-                    color = Color.White.copy(alpha = 0.18f),
-                    shape = artworkShape
-                )
+                .background(Color.Black.copy(alpha = 0.24f), artworkShape)
         ) {
             MotionArtworkLayer(
                 artwork = motionArtwork,
                 enabled = animationsEnabled,
                 isPlaying = isPlaying,
                 cornerRadius = cornerRadius,
+                presentation = MotionArtworkPresentation.Card,
                 modifier = Modifier.fillMaxSize()
             ) {
                 if (artworkUrl.isNotBlank()) {
@@ -11116,19 +11029,13 @@ private fun PlayerArtworkCanvas(
                     InstantArtworkPlaceholder(track = track, modifier = Modifier.fillMaxSize())
                 }
             }
-            // Delicate top-down lighting sheen
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(
-                        Brush.verticalGradient(
-                            listOf(
-                                Color.White.copy(alpha = 0.09f),
-                                Color.Transparent,
-                                Color.Transparent,
-                                Color.Black.copy(alpha = 0.14f)
-                            )
-                        )
+                    .border(
+                        width = LevyraPlayerDesign.Hairline,
+                        color = Color.White.copy(alpha = 0.12f),
+                        shape = artworkShape
                     )
             )
         }
@@ -11140,47 +11047,20 @@ private fun PlayerImmersiveMotionCanvas(
     track: Track,
     artworkUrl: String,
     motionArtwork: com.luc4n3x.levyra.feature.motion.MotionArtwork?,
+    ambience: PlayerAmbience,
     animationsEnabled: Boolean,
     isPlaying: Boolean,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
-    val animateFallback = motionArtwork == null && animationsEnabled && isPlaying
-    val fallbackScale: Float
-    val fallbackDrift: Float
-    if (animateFallback) {
-        val fallbackMotion = rememberInfiniteTransition(label = "player-artwork-fallback")
-        fallbackScale = fallbackMotion.animateFloat(
-            initialValue = 1.08f,
-            targetValue = 1.16f,
-            animationSpec = infiniteRepeatable(
-                animation = tween(14_000, easing = LevyraPlayerDesign.Standard),
-                repeatMode = RepeatMode.Reverse
-            ),
-            label = "player-artwork-fallback-scale"
-        ).value
-        fallbackDrift = fallbackMotion.animateFloat(
-            initialValue = -10f,
-            targetValue = 10f,
-            animationSpec = infiniteRepeatable(
-                animation = tween(18_000, easing = LevyraPlayerDesign.Standard),
-                repeatMode = RepeatMode.Reverse
-            ),
-            label = "player-artwork-fallback-drift"
-        ).value
-    } else {
-        fallbackScale = 1.08f
-        fallbackDrift = 0f
-    }
     Box(modifier = modifier) {
         MotionArtworkLayer(
             artwork = motionArtwork,
             enabled = animationsEnabled,
             isPlaying = isPlaying,
             cornerRadius = 0.dp,
-            modifier = Modifier
-                .fillMaxSize()
-                .graphicsLayer { alpha = 0.9f }
+            presentation = MotionArtworkPresentation.Immersive,
+            modifier = Modifier.fillMaxSize()
         ) {
             if (artworkUrl.isNotBlank()) {
                 AsyncImage(
@@ -11192,36 +11072,48 @@ private fun PlayerImmersiveMotionCanvas(
                         .build(),
                     contentDescription = null,
                     contentScale = ContentScale.Crop,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .graphicsLayer {
-                            if (animateFallback) {
-                                scaleX = fallbackScale
-                                scaleY = fallbackScale
-                                translationX = fallbackDrift
-                            }
-                        }
+                    modifier = Modifier.fillMaxSize()
                 )
             } else {
                 InstantArtworkPlaceholder(track = track, modifier = Modifier.fillMaxSize())
             }
         }
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(
-                    Brush.verticalGradient(
-                        colorStops = arrayOf(
-                            0f to Color.Black.copy(alpha = 0.24f),
-                            0.38f to Color.Black.copy(alpha = 0.12f),
-                            0.58f to Color.Black.copy(alpha = 0.46f),
-                            0.74f to Color.Black.copy(alpha = 0.84f),
-                            1f to Color.Black.copy(alpha = 0.99f)
-                        )
-                    )
-                )
+        PlayerCanvasFusionScrim(
+            ambience = ambience,
+            modifier = Modifier.fillMaxSize()
         )
     }
+}
+
+@Composable
+private fun PlayerCanvasFusionScrim(
+    ambience: PlayerAmbience,
+    modifier: Modifier = Modifier
+) {
+    val base = animateColorAsState(
+        targetValue = ambience.base,
+        animationSpec = tween(700, easing = LinearOutSlowInEasing),
+        label = "player-canvas-fusion-base"
+    )
+    Box(
+        modifier = modifier.drawBehind {
+            if (size.minDimension <= 0f) return@drawBehind
+            val baseColor = base.value
+            drawRect(
+                Brush.verticalGradient(
+                    colorStops = arrayOf(
+                        0.00f to baseColor.copy(alpha = 0.62f),
+                        0.13f to baseColor.copy(alpha = 0.14f),
+                        0.34f to Color.Transparent,
+                        0.55f to baseColor.copy(alpha = 0.20f),
+                        0.70f to baseColor.copy(alpha = 0.60f),
+                        0.84f to baseColor.copy(alpha = 0.90f),
+                        1.00f to baseColor
+                    )
+                )
+            )
+        }
+    )
 }
 
 @Composable
@@ -12017,6 +11909,9 @@ private fun PlayerScreen(
         primaryTarget = primaryTarget,
         secondaryTarget = secondaryTarget
     )
+    val ambience = remember(primaryTarget, secondaryTarget) {
+        playerAmbienceOf(primaryTarget, secondaryTarget)
+    }
     val playerControlLabels = remember(strings) {
         PlayerControlLabels(
             shuffle = strings.shuffle,
@@ -12099,6 +11994,8 @@ private fun PlayerScreen(
             levyraFoldAwareGutterDp(layoutMode, compactPlayer).dp
         }
         val playerItemSpacing = if (compactPlayer) LevyraPlayerDesign.SpaceSm else LevyraPlayerDesign.SpaceMd
+        val playerMetaSpacing = if (compactPlayer) LevyraPlayerDesign.SpaceMd else LevyraPlayerDesign.SpaceLg
+        val playerControlSpacing = if (compactPlayer) LevyraPlayerDesign.SpaceXs else LevyraPlayerDesign.SpaceSm
         val paneCount = if (playerPane == LevyraPlayerPane.SideBySide) 2f else 1f
         val artworkSize = minOf(
             ((maxWidth - playerHorizontalPadding * 2f) / paneCount).coerceAtLeast(180.dp),
@@ -12110,7 +12007,8 @@ private fun PlayerScreen(
             state.animationsEnabled &&
             playerPane == LevyraPlayerPane.Stacked &&
             !state.isVideoMode &&
-            track != null
+            track != null &&
+            state.motionArtwork != null
         val immersiveMotionArtwork = state.motionArtwork.takeIf { immersiveArtworkEnabled }
         val immersiveMotionAlpha by animateFloatAsState(
             targetValue = if (immersiveArtworkEnabled) 1f else 0f,
@@ -12119,16 +12017,16 @@ private fun PlayerScreen(
         )
 
         PlayerImmersiveBackdrop(
-            primaryTarget = primaryTarget,
-            secondaryTarget = secondaryTarget,
+            ambience = ambience,
             isPlaying = state.isPlaying,
             modifier = Modifier.fillMaxSize()
         )
-        if (track != null && immersiveArtworkEnabled) {
+        if (track != null && (immersiveArtworkEnabled || immersiveMotionAlpha > 0.01f)) {
             PlayerImmersiveMotionCanvas(
                 track = track,
                 artworkUrl = artworkUrl,
                 motionArtwork = immersiveMotionArtwork,
+                ambience = ambience,
                 animationsEnabled = state.animationsEnabled,
                 isPlaying = state.isPlaying,
                 modifier = Modifier
@@ -12382,12 +12280,12 @@ private fun PlayerScreen(
                 },
                 label = "player-favorite-scale"
             )
-            val heartButtonSize = if (compactPlayer) 44.dp else 48.dp
+            val heartButtonSize = if (compactPlayer) LevyraPlayerDesign.HeaderButtonCompact else LevyraPlayerDesign.HeaderButton
 
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = LevyraPlayerDesign.SpaceXs)
+                    .padding(horizontal = LevyraPlayerDesign.SpaceXxs)
             ) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -12409,24 +12307,23 @@ private fun PlayerScreen(
                         ) { titleTrack ->
                             Text(
                                 text = titleTrack.title,
-                                color = Color.White,
-                                fontSize = if (compactPlayer) 23.sp else 26.sp,
-                                lineHeight = if (compactPlayer) 25.sp else 29.sp,
+                                color = LevyraPlayerDesign.TextPrimary,
+                                fontSize = if (compactPlayer) 22.sp else 25.sp,
+                                lineHeight = if (compactPlayer) 26.sp else 29.sp,
                                 fontWeight = FontWeight.Bold,
-                                letterSpacing = (-0.3).sp,
+                                letterSpacing = (-0.4).sp,
                                 maxLines = if (state.animationsEnabled) 1 else 2,
                                 overflow = TextOverflow.Ellipsis,
                                 modifier = if (state.animationsEnabled) {
                                     Modifier.basicMarquee(
                                         iterations = Int.MAX_VALUE,
-                                        repeatDelayMillis = 2_600
+                                        repeatDelayMillis = 3_200
                                     )
                                 } else {
                                     Modifier
                                 }
                             )
                         }
-                        Spacer(modifier = Modifier.height(2.dp))
                         Row(
                             modifier = Modifier
                                 .heightIn(min = LevyraPlayerDesign.MinimumTouchTarget)
@@ -12439,9 +12336,10 @@ private fun PlayerScreen(
                         ) {
                             Text(
                                 text = activeTrack.artist,
-                                color = Color.White.copy(alpha = 0.70f),
+                                color = LevyraPlayerDesign.TextSecondary,
                                 fontSize = if (compactPlayer) 14.sp else 15.sp,
                                 fontWeight = FontWeight.Medium,
+                                letterSpacing = (-0.1).sp,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis
                             )
@@ -12490,7 +12388,6 @@ private fun PlayerScreen(
                 durationMs = state.durationMs,
                 activeColor = Color.White.copy(alpha = 0.94f),
                 secondaryColor = Color.White.copy(alpha = 0.62f),
-                isPlaying = state.isPlaying,
                 animationsEnabled = state.animationsEnabled,
                 compact = compactPlayer,
                 onSeek = viewModel::seekTo
@@ -12513,7 +12410,10 @@ private fun PlayerScreen(
                 onToggle = viewModel::togglePlay,
                 onNext = viewModel::next,
                 onRepeat = viewModel::toggleRepeat,
-                modifier = Modifier.padding(vertical = if (compactPlayer) 2.dp else LevyraPlayerDesign.SpaceXs)
+                modifier = Modifier.padding(
+                    horizontal = if (compactPlayer) 0.dp else LevyraPlayerDesign.SpaceXs,
+                    vertical = if (compactPlayer) LevyraPlayerDesign.SpaceXxs else LevyraPlayerDesign.SpaceXs
+                )
             )
         }
 
@@ -12635,12 +12535,11 @@ private fun PlayerScreen(
                     ) {
                         mediaBlock(track)
                     }
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalArrangement = Arrangement.spacedBy(playerItemSpacing)
-                    ) {
+                    Column(modifier = Modifier.fillMaxWidth()) {
                         metaBlock(track)
+                        Spacer(modifier = Modifier.height(playerMetaSpacing))
                         timelineBlock()
+                        Spacer(modifier = Modifier.height(playerControlSpacing))
                         transportBlock()
                         pulseBlock()
                         if (advancedControlsExpanded) {
@@ -13502,7 +13401,6 @@ private fun PlayerTimeline(
     durationMs: Long,
     activeColor: Color,
     secondaryColor: Color,
-    isPlaying: Boolean,
     animationsEnabled: Boolean,
     compact: Boolean,
     onSeek: (Float) -> Unit
@@ -13519,31 +13417,29 @@ private fun PlayerTimeline(
             },
             activeColor = activeColor,
             trailingColor = secondaryColor,
-            inactiveColor = Color.White.copy(alpha = 0.16f),
-            isPlaying = isPlaying,
+            inactiveColor = LevyraPlayerDesign.TrackInactive,
             animated = animationsEnabled
         )
-        Spacer(modifier = Modifier.height(2.dp))
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 4.dp),
+                .padding(horizontal = LevyraPlayerDesign.SpaceXxs),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
                 text = formatSeekbarMillis(positionMs),
-                color = Color.White.copy(alpha = 0.82f),
-                fontSize = if (compact) 11.5.sp else 12.sp,
-                fontWeight = FontWeight.SemiBold,
-                letterSpacing = 0.2.sp
+                color = LevyraPlayerDesign.TextSecondary,
+                fontSize = if (compact) 11.sp else 11.5.sp,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 0.3.sp
             )
             Text(
                 text = if (durationMs > 0L) formatSeekbarMillis(durationMs) else formatDuration(durationMs),
-                color = Color.White.copy(alpha = 0.65f),
-                fontSize = if (compact) 11.5.sp else 12.sp,
+                color = LevyraPlayerDesign.TextTertiary,
+                fontSize = if (compact) 11.sp else 11.5.sp,
                 fontWeight = FontWeight.Medium,
-                letterSpacing = 0.2.sp
+                letterSpacing = 0.3.sp
             )
         }
     }
@@ -17283,7 +17179,7 @@ private fun PlayerArtworkMorphLayer(
     expansion: () -> Float
 ) {
     val density = LocalDensity.current
-    val startCornerPx = with(density) { LevyraPlayerDesign.CornerSm.toPx() }
+    val startCornerPx = with(density) { LevyraPlayerDesign.CornerXs.toPx() }
     val endCornerPx = with(density) { LevyraPlayerDesign.CornerLg.toPx() }
     Box(
         modifier = Modifier
@@ -17370,6 +17266,9 @@ private fun settleMiniPlayerVerticalDrag(
     if (!event.peeked && result == PlayerVerticalResult.Collapse) playbackActions.close()
 }
 
+private val MiniPlayerTrackColor = Color.White.copy(alpha = 0.09f)
+private val MiniPlayerBufferedColor = Color.White.copy(alpha = 0.16f)
+
 @Composable
 private fun MiniPlayer(
     model: MiniPlayerModel,
@@ -17388,29 +17287,26 @@ private fun MiniPlayer(
     val miniRightToLeft = LocalLayoutDirection.current == LayoutDirection.Rtl
     val accentStart = Color(track.accentStart)
     val accentEnd = Color(track.accentEnd)
-    val accentCenter = accentStart.playerMix(accentEnd, 0.48f)
-    val rawMiniStart = accentStart.playerMix(Color.Black, 0.34f)
-    val rawMiniEnd = accentEnd.playerMix(Color.Black, 0.48f)
-    val miniGradient = remember(accentStart, accentEnd) {
-        PlayerContrastGradient(
-            start = rawMiniStart.playerAdjustBackgroundFor(Color.White, PlayerStrongContrast).color,
-            end = rawMiniEnd.playerAdjustBackgroundFor(Color.White, PlayerStrongContrast).color,
-            content = Color.White
-        )
+    val ambience = remember(accentStart, accentEnd) {
+        playerAmbienceOf(accentStart, accentEnd)
     }
-    val miniBackgrounds = remember(miniGradient) {
-        listOf(miniGradient.start, Color(0xFF111114), Color(0xFF09090C), miniGradient.end)
+    val miniSurfaceLeading = remember(ambience) {
+        ambience.elevated.playerAmbienceMix(ambience.tint, 0.20f)
     }
-    val miniPrimaryContent = miniGradient.content
-    val miniSecondaryContent = remember(miniGradient) {
-        miniPrimaryContent.playerMutedContentColor(miniBackgrounds)
+    val miniSurfaceTrailing = remember(ambience) {
+        ambience.elevated.playerAmbienceMix(ambience.base, 0.35f)
     }
-    val animatedProgress by animateFloatAsState(
+    val miniProgressColor = remember(ambience) {
+        ambience.tint.playerAmbienceMix(Color.White, 0.55f)
+    }
+    val miniPrimaryContent = LevyraPlayerDesign.TextPrimary
+    val miniSecondaryContent = LevyraPlayerDesign.TextSecondary
+    val animatedProgress = animateFloatAsState(
         targetValue = progress.coerceIn(0f, 1f),
         animationSpec = tween(420, easing = LinearOutSlowInEasing),
         label = "mini-progress"
     )
-    val animatedBuffered by animateFloatAsState(
+    val animatedBuffered = animateFloatAsState(
         targetValue = bufferedProgress.coerceIn(0f, 1f),
         animationSpec = tween(520, easing = LinearOutSlowInEasing),
         label = "mini-buffered"
@@ -17422,21 +17318,21 @@ private fun MiniPlayer(
         label = "mini-swipe-offset"
     )
     val containerShape = RoundedCornerShape(
-        topStart = LevyraPlayerDesign.CornerLg,
-        topEnd = LevyraPlayerDesign.CornerLg
+        topStart = LevyraPlayerDesign.CornerMd,
+        topEnd = LevyraPlayerDesign.CornerMd
     )
     Surface(
         color = Color.Transparent,
         shape = containerShape,
-        border = BorderStroke(1.dp, accentCenter.copy(alpha = 0.24f)),
+        border = BorderStroke(LevyraPlayerDesign.Hairline, Color.White.copy(alpha = 0.09f)),
         modifier = Modifier
             .fillMaxWidth()
             .shadow(
-                elevation = 18.dp,
+                elevation = 20.dp,
                 shape = containerShape,
                 clip = false,
-                ambientColor = accentStart.copy(alpha = 0.16f),
-                spotColor = Color.Black.copy(alpha = 0.82f)
+                ambientColor = Color.Black.copy(alpha = 0.40f),
+                spotColor = Color.Black.copy(alpha = 0.75f)
             )
             .playerAxisDragGestures(
                 key = track.id,
@@ -17454,31 +17350,24 @@ private fun MiniPlayer(
     ) {
         Column(
             modifier = Modifier.background(
-                Brush.linearGradient(
-                    listOf(
-                        miniGradient.start,
-                        Color(0xFF111114),
-                        Color(0xFF09090C),
-                        miniGradient.end
-                    )
-                )
+                Brush.horizontalGradient(listOf(miniSurfaceLeading, miniSurfaceTrailing))
             )
         ) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(66.dp)
-                    .padding(start = 12.dp, end = 10.dp),
+                    .height(64.dp)
+                    .padding(start = LevyraPlayerDesign.SpaceMd, end = LevyraPlayerDesign.SpaceSm),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(10.dp)
+                horizontalArrangement = Arrangement.spacedBy(LevyraPlayerDesign.SpaceMd)
             ) {
                 Box(
                     modifier = Modifier
                         .playerMorphAnchor(morphAnchors, PlayerMorphSlot.Mini)
                         .size(46.dp)
                         .graphicsLayer { translationX = settledSwipeOffset * 0.4f }
-                        .shadow(8.dp, LevyraPlayerDesign.ShapeSm, clip = false)
-                        .clip(LevyraPlayerDesign.ShapeSm)
+                        .shadow(10.dp, LevyraPlayerDesign.ShapeXs, clip = false)
+                        .clip(LevyraPlayerDesign.ShapeXs)
                         .pressable(onClick = playbackActions.open)
                 ) {
                     CoverImage(track, Modifier.fillMaxSize())
@@ -17486,8 +17375,8 @@ private fun MiniPlayer(
                         modifier = Modifier
                             .matchParentSize()
                             .border(
-                                BorderStroke(LevyraPlayerDesign.Hairline, Color.White.copy(alpha = 0.16f)),
-                                LevyraPlayerDesign.ShapeSm
+                                BorderStroke(LevyraPlayerDesign.Hairline, Color.White.copy(alpha = 0.12f)),
+                                LevyraPlayerDesign.ShapeXs
                             )
                     )
                 }
@@ -17516,37 +17405,29 @@ private fun MiniPlayer(
                         label = "mini-track"
                     ) { animatedTrack ->
                         Column {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(6.dp)
-                            ) {
-                                if (isPlaying) {
-                                    ActiveTrackEqualizer(
-                                        color = accentCenter.playerMix(Color.White, 0.35f),
-                                        isPlaying = true,
-                                        width = 13.dp,
-                                        height = 10.dp
-                                    )
-                                }
-                                Text(
-                                    text = animatedTrack.title,
-                                    color = miniPrimaryContent,
-                                    fontSize = 14.5.sp,
-                                    fontWeight = FontWeight.Bold,
-                                    letterSpacing = (-0.1).sp,
-                                    maxLines = 1,
-                                    modifier = Modifier.basicMarquee(
+                            Text(
+                                text = animatedTrack.title,
+                                color = miniPrimaryContent,
+                                fontSize = 14.5.sp,
+                                fontWeight = FontWeight.SemiBold,
+                                letterSpacing = (-0.2).sp,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = if (animated) {
+                                    Modifier.basicMarquee(
                                         iterations = Int.MAX_VALUE,
-                                        repeatDelayMillis = 2400
+                                        repeatDelayMillis = 3_200
                                     )
-                                )
-                            }
-                            Spacer(modifier = Modifier.height(2.dp))
+                                } else {
+                                    Modifier
+                                }
+                            )
+                            Spacer(modifier = Modifier.height(1.dp))
                             Text(
                                 text = animatedTrack.artist,
                                 color = miniSecondaryContent,
                                 fontSize = 12.sp,
-                                fontWeight = FontWeight.Medium,
+                                fontWeight = FontWeight.Normal,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis
                             )
@@ -17567,21 +17448,21 @@ private fun MiniPlayer(
                     PlayerRoundIconButton(
                         icon = Icons.Rounded.SkipNext,
                         contentDescription = strings.next,
-                        size = 36.dp,
-                        iconSize = 20.dp,
+                        size = 40.dp,
+                        iconSize = 22.dp,
                         tint = miniPrimaryContent,
-                        background = miniPrimaryContent.copy(alpha = 0.08f),
-                        borderColor = miniPrimaryContent.copy(alpha = 0.16f),
+                        background = Color.Transparent,
+                        borderColor = Color.Transparent,
                         onClick = playbackActions.next
                     )
                     PlayerRoundIconButton(
                         icon = Icons.Rounded.Close,
                         contentDescription = strings.closePlayer,
-                        size = 34.dp,
+                        size = 40.dp,
                         iconSize = 18.dp,
-                        tint = miniSecondaryContent,
-                        background = miniPrimaryContent.copy(alpha = 0.06f),
-                        borderColor = miniPrimaryContent.copy(alpha = 0.13f),
+                        tint = LevyraPlayerDesign.TextTertiary,
+                        background = Color.Transparent,
+                        borderColor = Color.Transparent,
                         onClick = playbackActions.close
                     )
                 }
@@ -17589,34 +17470,25 @@ private fun MiniPlayer(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 14.dp)
-                    .height(2.5.dp)
-                    .clip(RoundedCornerShape(99.dp))
-                    .background(miniPrimaryContent.copy(alpha = 0.12f))
-            ) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth(animatedBuffered)
-                        .fillMaxHeight()
-                        .clip(RoundedCornerShape(99.dp))
-                        .background(miniPrimaryContent.copy(alpha = 0.22f))
-                )
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth(animatedProgress)
-                        .fillMaxHeight()
-                        .clip(RoundedCornerShape(99.dp))
-                        .background(
-                            Brush.horizontalGradient(
-                                listOf(
-                                    accentStart.playerMix(Color.White, 0.16f),
-                                    accentEnd.playerMix(Color.White, 0.10f)
-                                )
+                    .height(2.dp)
+                    .drawBehind {
+                        drawRect(MiniPlayerTrackColor)
+                        drawRect(
+                            color = MiniPlayerBufferedColor,
+                            size = androidx.compose.ui.geometry.Size(
+                                size.width * animatedBuffered.value,
+                                size.height
                             )
                         )
-                )
-            }
-            Spacer(modifier = Modifier.height(5.dp))
+                        drawRect(
+                            color = miniProgressColor,
+                            size = androidx.compose.ui.geometry.Size(
+                                size.width * animatedProgress.value,
+                                size.height
+                            )
+                        )
+                    }
+            )
         }
     }
 }
@@ -17631,9 +17503,9 @@ private fun MiniPlayerToggleButton(
     modifier: Modifier = Modifier
 ) {
     val playBg = buttonColor.copy(alpha = 1f)
-    val playTint = remember(playBg) { Color.White.playerContentColor(listOf(playBg)) }
+    val playTint = LevyraPlayerDesign.PrimaryContent
     val corner by animateDpAsState(
-        targetValue = if (isPlaying) 14.dp else 20.dp,
+        targetValue = if (isPlaying) 12.dp else 19.dp,
         animationSpec = if (animated) LevyraPlayerDesign.expressiveSpring() else snap(),
         label = "mini-play-corner"
     )
@@ -17648,7 +17520,7 @@ private fun MiniPlayerToggleButton(
     ) {
         Box(
             modifier = Modifier
-                .size(40.dp)
+                .size(38.dp)
                 .background(playBg, RoundedCornerShape(corner)),
             contentAlignment = Alignment.Center
         ) {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -11104,10 +11104,11 @@ private fun PlayerCanvasFusionScrim(
                     colorStops = arrayOf(
                         0.00f to baseColor.copy(alpha = 0.62f),
                         0.13f to baseColor.copy(alpha = 0.14f),
-                        0.34f to Color.Transparent,
-                        0.55f to baseColor.copy(alpha = 0.20f),
-                        0.70f to baseColor.copy(alpha = 0.60f),
-                        0.84f to baseColor.copy(alpha = 0.90f),
+                        0.32f to Color.Transparent,
+                        0.50f to baseColor.copy(alpha = 0.26f),
+                        0.62f to baseColor.copy(alpha = 0.70f),
+                        0.74f to baseColor.copy(alpha = 0.93f),
+                        0.84f to baseColor,
                         1.00f to baseColor
                     )
                 )
@@ -12021,26 +12022,33 @@ private fun PlayerScreen(
             isPlaying = state.isPlaying,
             modifier = Modifier.fillMaxSize()
         )
-        if (track != null && (immersiveArtworkEnabled || immersiveMotionAlpha > 0.01f)) {
-            PlayerImmersiveMotionCanvas(
-                track = track,
-                artworkUrl = artworkUrl,
-                motionArtwork = immersiveMotionArtwork,
-                ambience = ambience,
-                animationsEnabled = state.animationsEnabled,
-                isPlaying = state.isPlaying,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .graphicsLayer {
-                        alpha = if (morphActive) 0f else {
-                            immersiveMotionAlpha * playerSwipeContentAlpha(
-                                settledSwipeOffset,
-                                size.width
-                            )
+        AnimatedVisibility(
+            visible = track != null && immersiveArtworkEnabled,
+            enter = if (state.animationsEnabled) fadeIn(tween(520, easing = LinearOutSlowInEasing)) else EnterTransition.None,
+            exit = if (state.animationsEnabled) fadeOut(tween(320, easing = LinearOutSlowInEasing)) else ExitTransition.None,
+            modifier = Modifier.fillMaxSize()
+        ) {
+            val canvasTrack = track ?: state.currentTrack
+            if (canvasTrack != null) {
+                PlayerImmersiveMotionCanvas(
+                    track = canvasTrack,
+                    artworkUrl = artworkUrl,
+                    motionArtwork = immersiveMotionArtwork,
+                    ambience = ambience,
+                    animationsEnabled = state.animationsEnabled,
+                    isPlaying = state.isPlaying,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .graphicsLayer {
+                            alpha = if (morphActive) {
+                                0f
+                            } else {
+                                playerSwipeContentAlpha(settledSwipeOffset, size.width)
+                            }
+                            translationX = settledSwipeOffset * 0.32f
                         }
-                        translationX = settledSwipeOffset * 0.32f
-                    }
-            )
+                )
+            }
         }
 
         val headerBlock: @Composable () -> Unit = {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -10916,24 +10916,25 @@ private fun PlayerImmersiveBackdrop(
     isPlaying: Boolean,
     modifier: Modifier = Modifier
 ) {
+    val animationsEnabled = LocalAnimationsEnabled.current
     val tint = animateColorAsState(
         targetValue = ambience.tint,
-        animationSpec = tween(700, easing = LinearOutSlowInEasing),
+        animationSpec = if (animationsEnabled) tween(700, easing = LinearOutSlowInEasing) else snap(),
         label = "player-backdrop-tint"
     )
     val elevated = animateColorAsState(
         targetValue = ambience.elevated,
-        animationSpec = tween(700, easing = LinearOutSlowInEasing),
+        animationSpec = if (animationsEnabled) tween(700, easing = LinearOutSlowInEasing) else snap(),
         label = "player-backdrop-elevated"
     )
     val base = animateColorAsState(
         targetValue = ambience.base,
-        animationSpec = tween(700, easing = LinearOutSlowInEasing),
+        animationSpec = if (animationsEnabled) tween(700, easing = LinearOutSlowInEasing) else snap(),
         label = "player-backdrop-base"
     )
     val glow = animateFloatAsState(
         targetValue = if (isPlaying) 1f else 0.74f,
-        animationSpec = tween(600, easing = FastOutSlowInEasing),
+        animationSpec = if (animationsEnabled) tween(600, easing = FastOutSlowInEasing) else snap(),
         label = "player-backdrop-glow"
     )
 
@@ -10985,7 +10986,7 @@ private fun PlayerArtworkCanvas(
     val context = LocalContext.current
     val artworkShadow by animateDpAsState(
         targetValue = if (isPlaying) 26.dp else 14.dp,
-        animationSpec = tween(420, easing = FastOutSlowInEasing),
+        animationSpec = if (animationsEnabled) tween(420, easing = FastOutSlowInEasing) else snap(),
         label = "player-artwork-shadow"
     )
     val primary = Color(track.accentStart)
@@ -11090,14 +11091,15 @@ private fun PlayerCanvasFusionScrim(
     ambience: PlayerAmbience,
     modifier: Modifier = Modifier
 ) {
+    val animationsEnabled = LocalAnimationsEnabled.current
     val base = animateColorAsState(
         targetValue = ambience.base,
-        animationSpec = tween(700, easing = LinearOutSlowInEasing),
+        animationSpec = if (animationsEnabled) tween(700, easing = LinearOutSlowInEasing) else snap(),
         label = "player-canvas-fusion-base"
     )
     val control = animateColorAsState(
         targetValue = ambience.control,
-        animationSpec = tween(700, easing = LinearOutSlowInEasing),
+        animationSpec = if (animationsEnabled) tween(700, easing = LinearOutSlowInEasing) else snap(),
         label = "player-canvas-fusion-control"
     )
     Box(
@@ -11233,11 +11235,12 @@ private fun LevyraControlPulseHandle(
     onToggle: () -> Unit
 ) {
     val strings = LocalLevyraStrings.current
+    val animationsEnabled = LocalAnimationsEnabled.current
     val width = if (compact) 82.dp else 88.dp
     val height = if (compact) 26.dp else 28.dp
     val rotation by animateFloatAsState(
         targetValue = if (expanded) 180f else 0f,
-        animationSpec = tween(durationMillis = 200, easing = FastOutSlowInEasing),
+        animationSpec = if (animationsEnabled) tween(durationMillis = 200, easing = FastOutSlowInEasing) else snap(),
         label = "player-shelf-chevron"
     )
 
@@ -11416,6 +11419,7 @@ private fun PlayerQuickAction(
                 minWidth = LevyraPlayerDesign.MinimumTouchTarget,
                 minHeight = LevyraPlayerDesign.MinimumTouchTarget
             )
+            .semantics { this.contentDescription = contentDescription }
             .pressable(enabled = enabled, pressedScale = 0.92f, onClick = onClick),
         contentAlignment = Alignment.Center
     ) {
@@ -11435,7 +11439,7 @@ private fun PlayerQuickAction(
             } else {
                 Icon(
                     imageVector = icon,
-                    contentDescription = contentDescription,
+                    contentDescription = null,
                     tint = tint,
                     modifier = Modifier.size(if (compact) 19.dp else 20.dp)
                 )
@@ -17414,12 +17418,12 @@ private fun MiniPlayer(
     val miniSecondaryContent = LevyraPlayerDesign.TextSecondary
     val animatedProgress = animateFloatAsState(
         targetValue = progress.coerceIn(0f, 1f),
-        animationSpec = tween(420, easing = LinearOutSlowInEasing),
+        animationSpec = if (animated) tween(420, easing = LinearOutSlowInEasing) else snap(),
         label = "mini-progress"
     )
     val animatedBuffered = animateFloatAsState(
         targetValue = bufferedProgress.coerceIn(0f, 1f),
-        animationSpec = tween(520, easing = LinearOutSlowInEasing),
+        animationSpec = if (animated) tween(520, easing = LinearOutSlowInEasing) else snap(),
         label = "mini-buffered"
     )
     var swipeOffsetPx by remember(track.id) { mutableStateOf(0f) }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -11290,6 +11290,161 @@ private fun LevyraControlPulseHandle(
 }
 
 @Composable
+private fun PlayerQuickActionsBar(
+    track: Track,
+    state: LevyraUiState,
+    primary: Color,
+    secondary: Color,
+    compact: Boolean,
+    viewModel: PlayerViewModel
+) {
+    val strings = LocalLevyraStrings.current
+    var optionsExpanded by remember(track.id) { mutableStateOf(false) }
+    val isDownloaded = track.id in state.downloadedTrackIds
+    val optionsActive = state.playbackSpeed != 1f ||
+        state.sleepTimerMinutes > 0 ||
+        state.audioNormalization
+    val activePrimary = primary.playerMix(Color.White, 0.48f)
+    val activeSecondary = secondary.playerMix(Color.White, 0.44f)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(LevyraPlayerDesign.MinimumTouchTarget),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceEvenly
+    ) {
+        PlayerQuickAction(
+            icon = Icons.AutoMirrored.Rounded.QueueMusic,
+            contentDescription = strings.queue,
+            tint = Color.White.copy(alpha = 0.76f),
+            active = false,
+            compact = compact,
+            modifier = Modifier.weight(1f),
+            onClick = viewModel::openQueue
+        )
+        PlayerQuickAction(
+            icon = Icons.AutoMirrored.Rounded.Subject,
+            contentDescription = strings.lyrics,
+            tint = if (state.lyrics.isNotEmpty()) activePrimary else Color.White.copy(alpha = 0.72f),
+            active = state.lyrics.isNotEmpty(),
+            compact = compact,
+            modifier = Modifier.weight(1f),
+            onClick = viewModel::openLyrics
+        )
+        PlayerQuickAction(
+            icon = if (isDownloaded) Icons.Rounded.DownloadDone else Icons.Rounded.Download,
+            contentDescription = when {
+                state.isOfflineExporting -> strings.downloadInProgress
+                isDownloaded -> strings.downloaded
+                else -> strings.download
+            },
+            tint = if (state.isOfflineExporting || isDownloaded) activeSecondary else Color.White.copy(alpha = 0.72f),
+            active = state.isOfflineExporting || isDownloaded,
+            busy = state.isOfflineExporting,
+            enabled = !state.isOfflineExporting,
+            compact = compact,
+            modifier = Modifier.weight(1f),
+            onClick = viewModel::exportCurrentTrack
+        )
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.Center
+        ) {
+            PlayerQuickAction(
+                icon = Icons.Rounded.Equalizer,
+                contentDescription = strings.options,
+                tint = if (optionsActive) activePrimary else Color.White.copy(alpha = 0.72f),
+                active = optionsActive || optionsExpanded,
+                compact = compact,
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { optionsExpanded = !optionsExpanded }
+            )
+            DropdownMenu(
+                expanded = optionsExpanded,
+                onDismissRequest = { optionsExpanded = false },
+                modifier = Modifier
+                    .width(if (compact) 276.dp else 296.dp)
+                    .background(Color(0xFF15161A), LevyraPlayerDesign.ShapeMd)
+            ) {
+                Box(modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)) {
+                    PlayerOptionsRow(
+                        speed = state.playbackSpeed,
+                        sleepMinutes = state.sleepTimerMinutes,
+                        audioNormalization = state.audioNormalization,
+                        activeColor = primary,
+                        secondaryColor = secondary,
+                        compact = true,
+                        onSpeed = viewModel::cycleSpeed,
+                        onSleep = viewModel::cycleSleepTimer,
+                        onNormalization = viewModel::toggleAudioNormalization
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlayerQuickAction(
+    icon: ImageVector,
+    contentDescription: String,
+    tint: Color,
+    active: Boolean,
+    compact: Boolean,
+    modifier: Modifier = Modifier,
+    busy: Boolean = false,
+    enabled: Boolean = true,
+    onClick: () -> Unit
+) {
+    val animationsEnabled = LocalAnimationsEnabled.current
+    val fill by animateColorAsState(
+        targetValue = if (active) tint.copy(alpha = 0.15f) else Color.White.copy(alpha = 0.035f),
+        animationSpec = if (animationsEnabled) LevyraPlayerDesign.standardTween(170) else snap(),
+        label = "player-quick-fill"
+    )
+    val border by animateColorAsState(
+        targetValue = if (active) tint.copy(alpha = 0.28f) else Color.White.copy(alpha = 0.065f),
+        animationSpec = if (animationsEnabled) LevyraPlayerDesign.standardTween(170) else snap(),
+        label = "player-quick-border"
+    )
+    val shape = LevyraPlayerDesign.ShapeSm
+
+    Box(
+        modifier = modifier
+            .sizeIn(
+                minWidth = LevyraPlayerDesign.MinimumTouchTarget,
+                minHeight = LevyraPlayerDesign.MinimumTouchTarget
+            )
+            .pressable(enabled = enabled, pressedScale = 0.92f, onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Box(
+            modifier = Modifier
+                .size(if (compact) 38.dp else 40.dp)
+                .background(fill, shape)
+                .border(LevyraPlayerDesign.Hairline, border, shape),
+            contentAlignment = Alignment.Center
+        ) {
+            if (busy) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(if (compact) 17.dp else 18.dp),
+                    strokeWidth = 2.dp,
+                    color = tint
+                )
+            } else {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = contentDescription,
+                    tint = tint,
+                    modifier = Modifier.size(if (compact) 19.dp else 20.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
 private fun PlayerUtilityDock(
     activeColor: Color,
     secondaryColor: Color,
@@ -11952,17 +12107,14 @@ private fun PlayerScreen(
             resolvePlayerPane(maxWidth.value, maxHeight.value)
         }
         val compactPlayer = layoutMode == LevyraLayoutMode.Compact && (maxWidth < 380.dp || maxHeight < 700.dp)
-        var advancedControlsExpanded by remember(track?.id) {
-            mutableStateOf(false)
-        }
         val playerHorizontalPadding = if (state.isVideoMode) {
             LevyraPlayerDesign.SpaceSm
         } else {
             levyraFoldAwareGutterDp(layoutMode, compactPlayer).dp
         }
         val playerItemSpacing = if (compactPlayer) LevyraPlayerDesign.SpaceSm else LevyraPlayerDesign.SpaceMd
-        val playerMetaSpacing = if (compactPlayer) LevyraPlayerDesign.SpaceMd else LevyraPlayerDesign.SpaceLg
-        val playerControlSpacing = if (compactPlayer) LevyraPlayerDesign.SpaceXs else LevyraPlayerDesign.SpaceSm
+        val playerMetaSpacing = if (compactPlayer) LevyraPlayerDesign.SpaceSm else LevyraPlayerDesign.SpaceMd
+        val playerControlSpacing = if (compactPlayer) LevyraPlayerDesign.SpaceXxs else LevyraPlayerDesign.SpaceXs
         val paneCount = if (playerPane == LevyraPlayerPane.SideBySide) 2f else 1f
         val artworkSize = minOf(
             ((maxWidth - playerHorizontalPadding * 2f) / paneCount).coerceAtLeast(180.dp),
@@ -12396,30 +12548,14 @@ private fun PlayerScreen(
             )
         }
 
-        val pulseBlock: @Composable () -> Unit = {
-            LevyraControlPulseHandle(
-                expanded = advancedControlsExpanded,
-                compact = compactPlayer,
-                activeColor = primary,
-                secondaryColor = secondary,
-                hasActiveState = state.playbackSpeed != 1f || state.sleepTimerMinutes > 0 || state.isOfflineExporting,
-                onToggle = { advancedControlsExpanded = !advancedControlsExpanded }
-            )
-        }
-
-        val advancedBlock: @Composable (Track) -> Unit = { activeTrack ->
-            PlayerAdvancedControlsPanel(
-                expanded = advancedControlsExpanded,
+        val quickActionsBlock: @Composable (Track) -> Unit = { activeTrack ->
+            PlayerQuickActionsBar(
                 track = activeTrack,
                 state = state,
                 primary = primary,
                 secondary = secondary,
-                primaryContent = primaryContent,
-                secondaryContent = secondaryContent,
                 compact = compactPlayer,
-                strings = strings,
-                viewModel = viewModel,
-                onAddToPlaylist = { playlistTarget = activeTrack }
+                viewModel = viewModel
             )
         }
 
@@ -12459,14 +12595,13 @@ private fun PlayerScreen(
                         metaBlock(track)
                         timelineBlock()
                         transportBlock()
-                        pulseBlock()
-                        advancedBlock(track)
+                        quickActionsBlock(track)
                         PlayerError(state.playerError)
                     }
                 }
             }
         } else {
-            val isPortraitScrollable = advancedControlsExpanded || maxHeight < 540.dp
+            val isPortraitScrollable = maxHeight < 540.dp
             Column(
                 modifier = Modifier
                     .fillMaxSize()
@@ -12520,10 +12655,7 @@ private fun PlayerScreen(
                         timelineBlock()
                         Spacer(modifier = Modifier.height(playerControlSpacing))
                         transportBlock()
-                        pulseBlock()
-                        if (advancedControlsExpanded) {
-                            advancedBlock(track)
-                        }
+                        quickActionsBlock(track)
                         PlayerError(state.playerError)
                     }
                 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -11095,10 +11095,16 @@ private fun PlayerCanvasFusionScrim(
         animationSpec = tween(700, easing = LinearOutSlowInEasing),
         label = "player-canvas-fusion-base"
     )
+    val control = animateColorAsState(
+        targetValue = ambience.control,
+        animationSpec = tween(700, easing = LinearOutSlowInEasing),
+        label = "player-canvas-fusion-control"
+    )
     Box(
         modifier = modifier.drawBehind {
             if (size.minDimension <= 0f) return@drawBehind
             val baseColor = base.value
+            val controlColor = control.value
             drawRect(
                 Brush.verticalGradient(
                     colorStops = arrayOf(
@@ -11106,9 +11112,10 @@ private fun PlayerCanvasFusionScrim(
                         0.09f to baseColor.copy(alpha = 0.30f),
                         0.19f to Color.Transparent,
                         0.50f to Color.Transparent,
-                        0.57f to baseColor.copy(alpha = 0.55f),
-                        0.63f to baseColor.copy(alpha = 0.92f),
-                        0.68f to baseColor,
+                        0.57f to controlColor.copy(alpha = 0.55f),
+                        0.63f to controlColor.copy(alpha = 0.92f),
+                        0.68f to controlColor,
+                        0.86f to controlColor.playerAmbienceMix(baseColor, 0.55f),
                         1.00f to baseColor
                     )
                 )
@@ -11967,8 +11974,7 @@ private fun PlayerScreen(
             state.animationsEnabled &&
             playerPane == LevyraPlayerPane.Stacked &&
             !state.isVideoMode &&
-            track != null &&
-            state.motionArtwork != null
+            track != null
         val immersiveMotionArtwork = state.motionArtwork.takeIf { immersiveArtworkEnabled }
         val immersiveMotionAlpha by animateFloatAsState(
             targetValue = if (immersiveArtworkEnabled) 1f else 0f,

--- a/app/src/main/java/com/luc4n3x/levyra/ui/MotionArtworkLayer.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/MotionArtworkLayer.kt
@@ -71,13 +71,13 @@ internal fun MotionArtworkLayer(
 ) {
     val lifecycleActive = rememberMotionArtworkLifecycleActive()
     val environment = rememberMotionArtworkEnvironment(enabled && lifecycleActive)
-    var videoUnavailable by remember(artwork?.identityKey, artwork?.url, artwork?.mimeType) {
+    var videoUnavailable by remember(artwork?.identityKey, artwork?.url, artwork?.mimeType, presentation) {
         mutableStateOf(false)
     }
-    var videoReady by remember(artwork?.identityKey, artwork?.url, artwork?.mimeType) {
+    var videoReady by remember(artwork?.identityKey, artwork?.url, artwork?.mimeType, presentation) {
         mutableStateOf(false)
     }
-    var videoRetryCount by remember(artwork?.identityKey, artwork?.url, artwork?.mimeType) {
+    var videoRetryCount by remember(artwork?.identityKey, artwork?.url, artwork?.mimeType, presentation) {
         mutableStateOf(0)
     }
     val videoArtwork = artwork?.takeIf {
@@ -358,11 +358,11 @@ private fun MotionArtworkVideo(
     val context = LocalContext.current
     val currentOnFirstFrame by rememberUpdatedState(onFirstFrame)
     val currentOnUnavailable by rememberUpdatedState(onUnavailable)
-    var firstFrameRendered by remember(artwork.identityKey, artwork.url, artwork.mimeType) {
+    var firstFrameRendered by remember(artwork.identityKey, artwork.url, artwork.mimeType, presentation) {
         mutableStateOf(false)
     }
-    var failed by remember(artwork.identityKey, artwork.url, artwork.mimeType) { mutableStateOf(false) }
-    var videoSize by remember(artwork.identityKey, artwork.url, artwork.mimeType) {
+    var failed by remember(artwork.identityKey, artwork.url, artwork.mimeType, presentation) { mutableStateOf(false) }
+    var videoSize by remember(artwork.identityKey, artwork.url, artwork.mimeType, presentation) {
         mutableStateOf(VideoSize.UNKNOWN)
     }
     var surfaceSize by remember { mutableStateOf(IntSize.Zero) }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/MotionArtworkLayer.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/MotionArtworkLayer.kt
@@ -45,6 +45,7 @@ import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
+import androidx.media3.common.VideoSize
 import androidx.media3.exoplayer.ExoPlayer
 import com.luc4n3x.levyra.feature.motion.MotionArtwork
 import com.luc4n3x.levyra.feature.motion.MotionArtworkNetworkPolicy
@@ -53,6 +54,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
+internal enum class MotionArtworkPresentation {
+    Card,
+    Immersive
+}
+
 @Composable
 internal fun MotionArtworkLayer(
     artwork: MotionArtwork?,
@@ -60,6 +66,7 @@ internal fun MotionArtworkLayer(
     isPlaying: Boolean,
     cornerRadius: Dp,
     modifier: Modifier = Modifier,
+    presentation: MotionArtworkPresentation = MotionArtworkPresentation.Card,
     staticArtwork: @Composable () -> Unit
 ) {
     val lifecycleActive = rememberMotionArtworkLifecycleActive()
@@ -116,11 +123,22 @@ internal fun MotionArtworkLayer(
         environment.localAllowed &&
         isPlaying &&
         !videoReady
+    val videoCoversStaticArtwork = presentation == MotionArtworkPresentation.Card
+    val staticBedAlpha by animateFloatAsState(
+        targetValue = if (videoReady && videoCoversStaticArtwork) 0f else 1f,
+        animationSpec = tween(
+            durationMillis = STATIC_ARTWORK_BED_FADE_MS,
+            delayMillis = if (videoReady) VIDEO_FADE_IN_MS else 0,
+            easing = FastOutSlowInEasing
+        ),
+        label = "motion-artwork-bed-alpha"
+    )
 
     Box(modifier = modifier) {
         MotionArtworkStaticFallback(
             animated = animateStatic,
             cornerRadius = cornerRadius,
+            alpha = { staticBedAlpha },
             modifier = Modifier.fillMaxSize(),
             content = staticArtwork
         )
@@ -129,6 +147,7 @@ internal fun MotionArtworkLayer(
                 artwork = videoArtwork,
                 isPlaying = isPlaying,
                 cornerRadius = cornerRadius,
+                presentation = presentation,
                 onFirstFrame = {
                     videoReady = true
                     videoRetryCount = 0
@@ -225,6 +244,7 @@ private fun rememberMotionArtworkEnvironment(observe: Boolean): MotionArtworkEnv
 private fun MotionArtworkStaticFallback(
     animated: Boolean,
     cornerRadius: Dp,
+    alpha: () -> Float,
     modifier: Modifier,
     content: @Composable () -> Unit
 ) {
@@ -233,7 +253,6 @@ private fun MotionArtworkStaticFallback(
     val zoomPhase = remember { Animatable(0f) }
     val horizontalDrift = remember { Animatable(0f) }
     val verticalDrift = remember { Animatable(0f) }
-    val tiltPhase = remember { Animatable(0f) }
     val motionAmount by animateFloatAsState(
         targetValue = if (animated) 1f else 0f,
         animationSpec = tween(
@@ -260,12 +279,6 @@ private fun MotionArtworkStaticFallback(
                 }
                 launch {
                     verticalDrift.animateTo(
-                        0f,
-                        tween(STATIC_ARTWORK_MOTION_EXIT_MS, easing = FastOutSlowInEasing)
-                    )
-                }
-                launch {
-                    tiltPhase.animateTo(
                         0f,
                         tween(STATIC_ARTWORK_MOTION_EXIT_MS, easing = FastOutSlowInEasing)
                     )
@@ -310,18 +323,6 @@ private fun MotionArtworkStaticFallback(
                     )
                 }
             }
-            launch {
-                while (isActive) {
-                    tiltPhase.animateTo(
-                        1f,
-                        tween(STATIC_ARTWORK_TILT_DURATION_MS, easing = FastOutSlowInEasing)
-                    )
-                    tiltPhase.animateTo(
-                        -1f,
-                        tween(STATIC_ARTWORK_TILT_DURATION_MS, easing = FastOutSlowInEasing)
-                    )
-                }
-            }
         }
     }
 
@@ -331,17 +332,13 @@ private fun MotionArtworkStaticFallback(
                 .fillMaxSize()
                 .onSizeChanged { artworkSize = it }
                 .graphicsLayer {
+                    this.alpha = alpha()
                     val amount = motionAmount
-                    val scale = 1f + amount * (0.058f + zoomPhase.value * 0.026f)
+                    val scale = 1f + amount * (0.042f + zoomPhase.value * 0.022f)
                     scaleX = scale
                     scaleY = scale
-                    translationX = artworkSize.width * 0.021f * horizontalDrift.value * amount
-                    translationY = artworkSize.height * 0.016f * verticalDrift.value * amount
-                    rotationZ = 0.18f * tiltPhase.value * amount
-                    rotationX = 3.5f * verticalDrift.value * amount
-                    rotationY = 4.2f * horizontalDrift.value * amount
-                    val maxDim = maxOf(artworkSize.width, artworkSize.height).toFloat()
-                    cameraDistance = (maxDim * 4f).coerceAtLeast(12f * density)
+                    translationX = artworkSize.width * 0.016f * horizontalDrift.value * amount
+                    translationY = artworkSize.height * 0.012f * verticalDrift.value * amount
                 }
         ) {
             content()
@@ -354,6 +351,7 @@ private fun MotionArtworkVideo(
     artwork: MotionArtwork,
     isPlaying: Boolean,
     cornerRadius: Dp,
+    presentation: MotionArtworkPresentation,
     onFirstFrame: () -> Unit,
     onUnavailable: () -> Unit,
     modifier: Modifier
@@ -365,22 +363,38 @@ private fun MotionArtworkVideo(
         mutableStateOf(false)
     }
     var failed by remember(artwork.identityKey, artwork.url, artwork.mimeType) { mutableStateOf(false) }
-    val player = remember(artwork.identityKey, artwork.url, artwork.mimeType) {
+    var videoSize by remember(artwork.identityKey, artwork.url, artwork.mimeType) {
+        mutableStateOf(VideoSize.UNKNOWN)
+    }
+    var surfaceSize by remember { mutableStateOf(IntSize.Zero) }
+    val maxZoom = when (presentation) {
+        MotionArtworkPresentation.Card -> MotionArtworkCardMaxZoom
+        MotionArtworkPresentation.Immersive -> MotionArtworkImmersiveMaxZoom
+    }
+    val player = remember(artwork.identityKey, artwork.url, artwork.mimeType, presentation) {
+        val decodeLimit = when (presentation) {
+            MotionArtworkPresentation.Card -> CARD_MAX_VIDEO_DIMENSION
+            MotionArtworkPresentation.Immersive -> IMMERSIVE_MAX_VIDEO_DIMENSION
+        }
+        val bitrateLimit = when (presentation) {
+            MotionArtworkPresentation.Card -> CARD_MAX_VIDEO_BITRATE
+            MotionArtworkPresentation.Immersive -> IMMERSIVE_MAX_VIDEO_BITRATE
+        }
         ExoPlayer.Builder(context).build().apply {
             repeatMode = Player.REPEAT_MODE_ONE
             volume = 0f
-            videoScalingMode = C.VIDEO_SCALING_MODE_SCALE_TO_FIT_WITH_CROPPING
             trackSelectionParameters = trackSelectionParameters.buildUpon()
                 .setTrackTypeDisabled(C.TRACK_TYPE_AUDIO, true)
-                .setMaxVideoSize(1280, 1280)
-                .setMaxVideoBitrate(4_000_000)
+                .setViewportSize(decodeLimit, decodeLimit, false)
+                .setMaxVideoSize(decodeLimit, decodeLimit)
+                .setMaxVideoBitrate(bitrateLimit)
                 .build()
         }
     }
     val textureView = remember(player) { TextureView(context) }
     val videoAlpha by animateFloatAsState(
         targetValue = if (firstFrameRendered && !failed) 1f else 0f,
-        animationSpec = tween(durationMillis = 700, easing = FastOutSlowInEasing),
+        animationSpec = tween(durationMillis = VIDEO_FADE_IN_MS, easing = FastOutSlowInEasing),
         label = "motion-artwork-alpha"
     )
 
@@ -389,6 +403,10 @@ private fun MotionArtworkVideo(
             override fun onRenderedFirstFrame() {
                 firstFrameRendered = true
                 currentOnFirstFrame()
+            }
+
+            override fun onVideoSizeChanged(size: VideoSize) {
+                videoSize = size
             }
 
             override fun onPlayerError(error: PlaybackException) {
@@ -432,7 +450,20 @@ private fun MotionArtworkVideo(
         factory = { textureView },
         modifier = modifier
             .clip(RoundedCornerShape(cornerRadius))
-            .graphicsLayer { alpha = videoAlpha }
+            .onSizeChanged { surfaceSize = it }
+            .graphicsLayer {
+                alpha = videoAlpha
+                val fit = motionArtworkFit(
+                    videoWidth = videoSize.width,
+                    videoHeight = videoSize.height,
+                    pixelWidthHeightRatio = videoSize.pixelWidthHeightRatio,
+                    containerWidth = surfaceSize.width,
+                    containerHeight = surfaceSize.height,
+                    maxZoom = maxZoom
+                )
+                scaleX = fit.scaleX
+                scaleY = fit.scaleY
+            }
     )
 }
 
@@ -441,12 +472,17 @@ private data class MotionArtworkEnvironment(
     val localAllowed: Boolean
 )
 
-private const val STATIC_ARTWORK_ZOOM_DURATION_MS = 9_000
-private const val STATIC_ARTWORK_HORIZONTAL_DURATION_MS = 11_500
-private const val STATIC_ARTWORK_VERTICAL_DURATION_MS = 13_500
-private const val STATIC_ARTWORK_TILT_DURATION_MS = 17_000
+private const val STATIC_ARTWORK_ZOOM_DURATION_MS = 11_000
+private const val STATIC_ARTWORK_HORIZONTAL_DURATION_MS = 14_000
+private const val STATIC_ARTWORK_VERTICAL_DURATION_MS = 17_000
 private const val STATIC_ARTWORK_MOTION_ENTER_MS = 360
 private const val STATIC_ARTWORK_MOTION_EXIT_MS = 220
+private const val STATIC_ARTWORK_BED_FADE_MS = 420
+private const val VIDEO_FADE_IN_MS = 620
 private const val VIDEO_FIRST_FRAME_TIMEOUT_MS = 9_000L
 private const val VIDEO_RETRY_DELAY_MS = 4_000L
 private const val MAX_VIDEO_RETRIES = 1
+private const val CARD_MAX_VIDEO_DIMENSION = 1_280
+private const val IMMERSIVE_MAX_VIDEO_DIMENSION = 1_920
+private const val CARD_MAX_VIDEO_BITRATE = 4_000_000
+private const val IMMERSIVE_MAX_VIDEO_BITRATE = 8_000_000

--- a/app/src/main/java/com/luc4n3x/levyra/ui/MotionArtworkLayer.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/MotionArtworkLayer.kt
@@ -123,9 +123,8 @@ internal fun MotionArtworkLayer(
         environment.localAllowed &&
         isPlaying &&
         !videoReady
-    val videoCoversStaticArtwork = presentation == MotionArtworkPresentation.Card
     val staticBedAlpha by animateFloatAsState(
-        targetValue = if (videoReady && videoCoversStaticArtwork) 0f else 1f,
+        targetValue = if (videoReady) 0f else 1f,
         animationSpec = tween(
             durationMillis = STATIC_ARTWORK_BED_FADE_MS,
             delayMillis = if (videoReady) VIDEO_FADE_IN_MS else 0,

--- a/app/src/main/java/com/luc4n3x/levyra/ui/MotionArtworkScaling.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/MotionArtworkScaling.kt
@@ -1,0 +1,42 @@
+package com.luc4n3x.levyra.ui
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+internal data class MotionArtworkFit(val scaleX: Float, val scaleY: Float)
+
+internal val MotionArtworkFitIdentity = MotionArtworkFit(1f, 1f)
+
+internal const val MotionArtworkCardMaxZoom = 2.6f
+internal const val MotionArtworkImmersiveMaxZoom = 1.32f
+
+internal fun motionArtworkFit(
+    videoWidth: Int,
+    videoHeight: Int,
+    pixelWidthHeightRatio: Float,
+    containerWidth: Int,
+    containerHeight: Int,
+    maxZoom: Float
+): MotionArtworkFit {
+    if (videoWidth <= 0 || videoHeight <= 0) return MotionArtworkFitIdentity
+    if (containerWidth <= 0 || containerHeight <= 0) return MotionArtworkFitIdentity
+    val pixelRatio = if (pixelWidthHeightRatio > 0f && pixelWidthHeightRatio.isFinite()) {
+        pixelWidthHeightRatio
+    } else {
+        1f
+    }
+    val videoAspect = videoWidth.toFloat() * pixelRatio / videoHeight.toFloat()
+    val containerAspect = containerWidth.toFloat() / containerHeight.toFloat()
+    if (!videoAspect.isFinite() || videoAspect <= 0f) return MotionArtworkFitIdentity
+    if (!containerAspect.isFinite() || containerAspect <= 0f) return MotionArtworkFitIdentity
+
+    val aspectRatioDelta = videoAspect / containerAspect
+    val containScaleX = if (aspectRatioDelta >= 1f) 1f else aspectRatioDelta
+    val containScaleY = if (aspectRatioDelta >= 1f) 1f / aspectRatioDelta else 1f
+    val coverZoom = maxOf(aspectRatioDelta, 1f / aspectRatioDelta)
+    val zoom = coverZoom.coerceAtMost(maxZoom.coerceAtLeast(1f))
+    return MotionArtworkFit(
+        scaleX = containScaleX * zoom,
+        scaleY = containScaleY * zoom
+    )
+}

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerAmbience.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerAmbience.kt
@@ -7,19 +7,22 @@ import androidx.compose.ui.graphics.Color
 internal data class PlayerAmbience(
     val tint: Color,
     val elevated: Color,
+    val control: Color,
     val base: Color
 )
 
 private const val AmbienceTintLevel = 0.30f
 private const val AmbienceElevatedLevel = 0.085f
-private const val AmbienceBaseLevel = 0.022f
+private const val AmbienceControlLevel = 0.090f
+private const val AmbienceBaseLevel = 0.042f
 
 internal fun playerAmbienceOf(primary: Color, secondary: Color): PlayerAmbience {
     val blended = primary.playerAmbienceMix(secondary, 0.5f)
     return PlayerAmbience(
         tint = blended.playerAmbienceDesaturate(0.28f).playerAmbienceTone(AmbienceTintLevel),
         elevated = blended.playerAmbienceDesaturate(0.42f).playerAmbienceTone(AmbienceElevatedLevel),
-        base = blended.playerAmbienceDesaturate(0.66f).playerAmbienceTone(AmbienceBaseLevel)
+        control = blended.playerAmbienceDesaturate(0.20f).playerAmbienceTone(AmbienceControlLevel),
+        base = blended.playerAmbienceDesaturate(0.34f).playerAmbienceTone(AmbienceBaseLevel)
     )
 }
 

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerAmbience.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerAmbience.kt
@@ -1,0 +1,59 @@
+package com.luc4n3x.levyra.ui
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+
+@Immutable
+internal data class PlayerAmbience(
+    val tint: Color,
+    val elevated: Color,
+    val base: Color
+)
+
+private const val AmbienceTintLevel = 0.30f
+private const val AmbienceElevatedLevel = 0.085f
+private const val AmbienceBaseLevel = 0.022f
+
+internal fun playerAmbienceOf(primary: Color, secondary: Color): PlayerAmbience {
+    val blended = primary.playerAmbienceMix(secondary, 0.5f)
+    return PlayerAmbience(
+        tint = blended.playerAmbienceDesaturate(0.28f).playerAmbienceTone(AmbienceTintLevel),
+        elevated = blended.playerAmbienceDesaturate(0.42f).playerAmbienceTone(AmbienceElevatedLevel),
+        base = blended.playerAmbienceDesaturate(0.66f).playerAmbienceTone(AmbienceBaseLevel)
+    )
+}
+
+internal fun Color.playerAmbienceMix(other: Color, amount: Float): Color {
+    val fraction = amount.coerceIn(0f, 1f)
+    return Color(
+        red = red + (other.red - red) * fraction,
+        green = green + (other.green - green) * fraction,
+        blue = blue + (other.blue - blue) * fraction,
+        alpha = 1f
+    )
+}
+
+private fun Color.playerAmbienceDesaturate(amount: Float): Color {
+    val fraction = amount.coerceIn(0f, 1f)
+    val grey = playerAmbienceLevel()
+    return Color(
+        red = red + (grey - red) * fraction,
+        green = green + (grey - green) * fraction,
+        blue = blue + (grey - blue) * fraction,
+        alpha = 1f
+    )
+}
+
+private fun Color.playerAmbienceTone(target: Float): Color {
+    val level = playerAmbienceLevel()
+    if (level <= 0.004f) return Color(target, target, target, 1f)
+    val factor = target / level
+    return Color(
+        red = (red * factor).coerceIn(0f, 1f),
+        green = (green * factor).coerceIn(0f, 1f),
+        blue = (blue * factor).coerceIn(0f, 1f),
+        alpha = 1f
+    )
+}
+
+private fun Color.playerAmbienceLevel(): Float = 0.299f * red + 0.587f * green + 0.114f * blue

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerColorContrast.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerColorContrast.kt
@@ -145,26 +145,3 @@ internal fun playerContrastGradient(
         else -> PlayerContrastGradient(Color.Black, Color.Black, Color.White)
     }
 }
-
-internal fun Color.playerMutedContentColor(
-    backgrounds: List<Color>,
-    minimumContrast: Float = PlayerMinimumContrast
-): Color {
-    val source = copy(alpha = 1f)
-    if (backgrounds.any { playerContrastRatio(source, it) < minimumContrast }) return source
-    val averageBackground = backgrounds.fold(Color.Transparent) { accumulator, color ->
-        if (accumulator == Color.Transparent) color.copy(alpha = 1f) else accumulator.playerMix(color.copy(alpha = 1f), 0.5f)
-    }
-    var low = 0f
-    var high = 1f
-    repeat(24) {
-        val middle = (low + high) / 2f
-        val candidate = source.playerMix(averageBackground, middle).copy(alpha = 1f)
-        if (backgrounds.all { playerContrastRatio(candidate, it) >= minimumContrast }) {
-            low = middle
-        } else {
-            high = middle
-        }
-    }
-    return source.playerMix(averageBackground, low).copy(alpha = 1f)
-}

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
@@ -251,12 +251,12 @@ private fun PlayerSkipButton(
             minWidth = LevyraPlayerDesign.MinimumTouchTarget,
             minHeight = LevyraPlayerDesign.MinimumTouchTarget
         ),
-        pressedScale = 0.88f,
+        pressedScale = 0.86f,
         contentDescription = contentDescription
     ) {
         PlayerIcon(
             icon = icon,
-            tint = LevyraPlayerDesign.TextPrimary,
+            tint = Color.White,
             modifier = Modifier.size(iconSize)
         )
     }
@@ -273,7 +273,7 @@ private fun PlayerModeToggleButton(
     onClick: () -> Unit
 ) {
     val activeTint = remember(accentTarget) {
-        Color.White.playerMix(accentTarget, 0.22f)
+        Color(0xFF1DB954).playerMix(accentTarget, 0.35f)
     }
     val tint by animateColorAsState(
         targetValue = if (active) activeTint else LevyraPlayerDesign.IconIdle,
@@ -294,7 +294,7 @@ private fun PlayerModeToggleButton(
                 minHeight = LevyraPlayerDesign.MinimumTouchTarget
             )
             .semantics { toggleableState = ToggleableState(active) },
-        pressedScale = 0.88f,
+        pressedScale = 0.86f,
         contentDescription = contentDescription
     ) {
         Box(
@@ -325,18 +325,17 @@ private fun playerPrimaryIconTransition(): ContentTransform =
             scaleOut(targetScale = 0.82f, animationSpec = LevyraPlayerDesign.standardTween(100)))
 
 private fun Modifier.playerPrimarySurface(
-    shape: Shape,
-    gradientColors: List<Color>
+    shape: Shape
 ): Modifier = this
     .shadow(
-        elevation = 12.dp,
+        elevation = 10.dp,
         shape = shape,
         clip = false,
-        ambientColor = Color.Black.copy(alpha = 0.30f),
-        spotColor = Color.Black.copy(alpha = 0.55f)
+        ambientColor = Color.Black.copy(alpha = 0.35f),
+        spotColor = Color.Black.copy(alpha = 0.60f)
     )
     .background(
-        Brush.verticalGradient(gradientColors),
+        Color.White,
         shape
     )
 
@@ -374,26 +373,17 @@ private fun PlayerPrimaryButton(
     onClick: () -> Unit
 ) {
     val contentColor = LevyraPlayerDesign.PrimaryContent
-    val corner by animateDpAsState(
-        targetValue = if (isPlaying) LevyraPlayerDesign.PrimaryCornerPlaying else size / 2f,
-        animationSpec = if (animated) LevyraPlayerDesign.expressiveSpring() else snap(),
-        label = "player-primary-corner"
-    )
-    val gradientColors = remember {
-        listOf(Color.White, Color(0xFFEDEDF1))
-    }
 
     SpringIconButton(
         onClick = onClick,
-        pressedScale = 0.93f,
+        pressedScale = 0.90f,
         contentDescription = if (isPlaying) pauseLabel else playLabel
     ) {
         Box(
             modifier = Modifier
                 .size(size)
                 .playerPrimarySurface(
-                    shape = RoundedCornerShape(corner),
-                    gradientColors = gradientColors
+                    shape = CircleShape
                 ),
             contentAlignment = Alignment.Center
         ) {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
@@ -5,7 +5,7 @@ import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.snap
 import androidx.compose.animation.fadeIn
@@ -19,7 +19,6 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -38,7 +37,6 @@ import androidx.compose.material.icons.rounded.SkipNext
 import androidx.compose.material.icons.rounded.SkipPrevious
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
@@ -53,12 +51,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.toggleableState
 import androidx.compose.ui.state.ToggleableState
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.luc4n3x.levyra.ui.PlayerMinimumContrast
-import com.luc4n3x.levyra.ui.playerContrastGradient
 import com.luc4n3x.levyra.ui.playerMix
 import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
 
@@ -193,14 +187,9 @@ fun PlayerTransportControls(
     onRepeat: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val utilitySize = if (compact) LevyraPlayerDesign.UtilityButtonCompact else LevyraPlayerDesign.UtilityButton
-    val transportSize = if (compact) LevyraPlayerDesign.TransportButtonCompact else LevyraPlayerDesign.TransportButton
-    val primaryWidth = if (compact) LevyraPlayerDesign.PrimaryWidthCompact else LevyraPlayerDesign.PrimaryWidth
-    val primaryHeight = if (compact) LevyraPlayerDesign.PrimaryHeightCompact else LevyraPlayerDesign.PrimaryHeight
-
-    val transportShape = RoundedCornerShape(
-        if (compact) LevyraPlayerDesign.TransportSquircleCornerCompact else LevyraPlayerDesign.TransportSquircleCorner
-    )
+    val skipIconSize = if (compact) LevyraPlayerDesign.SkipGlyphCompact else LevyraPlayerDesign.SkipGlyph
+    val modeIconSize = if (compact) LevyraPlayerDesign.ModeGlyphCompact else LevyraPlayerDesign.ModeGlyph
+    val primarySize = if (compact) LevyraPlayerDesign.PrimarySizeCompact else LevyraPlayerDesign.PrimarySize
 
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -211,55 +200,64 @@ fun PlayerTransportControls(
             icon = Icons.Rounded.Shuffle,
             contentDescription = labels.shuffle,
             active = shuffleOn,
-            accent = accents.primary,
             accentTarget = accents.primaryTarget,
-            size = utilitySize,
-            iconSize = if (compact) 20.dp else 21.dp,
+            iconSize = modeIconSize,
             animated = animated,
             onClick = onShuffle
         )
-        PlayerGlassIconButton(
+        PlayerSkipButton(
             icon = Icons.Rounded.SkipPrevious,
             contentDescription = labels.previous,
-            size = transportSize,
-            iconSize = if (compact) 24.dp else 26.dp,
-            fill = Color.White.copy(alpha = 0.08f),
-            borderTop = Color.White.copy(alpha = 0.16f),
-            borderBottom = Color.White.copy(alpha = 0.06f),
-            shape = transportShape,
+            iconSize = skipIconSize,
             onClick = onPrevious
         )
         PlayerPrimaryButton(
             isPlaying = isPlaying,
             isResolving = isResolving,
-            width = primaryWidth,
-            height = primaryHeight,
+            size = primarySize,
             animated = animated,
             playLabel = labels.play,
             pauseLabel = labels.pause,
             onClick = onToggle
         )
-        PlayerGlassIconButton(
+        PlayerSkipButton(
             icon = Icons.Rounded.SkipNext,
             contentDescription = labels.next,
-            size = transportSize,
-            iconSize = if (compact) 24.dp else 26.dp,
-            fill = Color.White.copy(alpha = 0.08f),
-            borderTop = Color.White.copy(alpha = 0.16f),
-            borderBottom = Color.White.copy(alpha = 0.06f),
-            shape = transportShape,
+            iconSize = skipIconSize,
             onClick = onNext
         )
         PlayerModeToggleButton(
             icon = if (repeatOne) Icons.Rounded.RepeatOne else Icons.Rounded.Repeat,
             contentDescription = labels.repeat,
             active = repeatOn,
-            accent = accents.secondary,
             accentTarget = accents.secondaryTarget,
-            size = utilitySize,
-            iconSize = if (compact) 20.dp else 21.dp,
+            iconSize = modeIconSize,
             animated = animated,
             onClick = onRepeat
+        )
+    }
+}
+
+@Composable
+private fun PlayerSkipButton(
+    icon: ImageVector,
+    contentDescription: String,
+    iconSize: Dp,
+    onClick: () -> Unit
+) {
+    SpringIconButton(
+        onClick = onClick,
+        modifier = Modifier.sizeIn(
+            minWidth = LevyraPlayerDesign.MinimumTouchTarget,
+            minHeight = LevyraPlayerDesign.MinimumTouchTarget
+        ),
+        pressedScale = 0.88f,
+        contentDescription = contentDescription
+    ) {
+        PlayerIcon(
+            icon = icon,
+            tint = LevyraPlayerDesign.TextPrimary,
+            modifier = Modifier.size(iconSize)
         )
     }
 }
@@ -269,35 +267,23 @@ private fun PlayerModeToggleButton(
     icon: ImageVector,
     contentDescription: String,
     active: Boolean,
-    accent: Color,
     accentTarget: Color,
-    size: Dp,
     iconSize: Dp,
     animated: Boolean,
     onClick: () -> Unit
 ) {
-    val fill by animateColorAsState(
-        targetValue = if (active) {
-            Color.White.playerMix(accent, 0.18f).copy(alpha = 0.16f)
-        } else {
-            Color.Transparent
-        },
-        animationSpec = if (animated) LevyraPlayerDesign.standardTween() else snap(),
-        label = "player-toggle-fill"
-    )
     val activeTint = remember(accentTarget) {
-        Color.White.playerMix(accentTarget, 0.08f)
+        Color.White.playerMix(accentTarget, 0.22f)
     }
-    val tint = if (active) activeTint else LevyraPlayerDesign.IconIdle
-    val borderAlpha by animateFloatAsState(
-        targetValue = if (active) 0.38f else 0f,
+    val tint by animateColorAsState(
+        targetValue = if (active) activeTint else LevyraPlayerDesign.IconIdle,
         animationSpec = if (animated) LevyraPlayerDesign.standardTween() else snap(),
-        label = "player-toggle-border"
+        label = "player-toggle-tint"
     )
-    val scale by animateFloatAsState(
-        targetValue = if (active) 1.04f else 1.0f,
-        animationSpec = if (animated) LevyraPlayerDesign.expressiveSpring() else snap(),
-        label = "player-toggle-scale"
+    val indicatorAlpha by animateFloatAsState(
+        targetValue = if (active) 1f else 0f,
+        animationSpec = if (animated) LevyraPlayerDesign.standardTween() else snap(),
+        label = "player-toggle-indicator"
     )
 
     SpringIconButton(
@@ -307,25 +293,12 @@ private fun PlayerModeToggleButton(
                 minWidth = LevyraPlayerDesign.MinimumTouchTarget,
                 minHeight = LevyraPlayerDesign.MinimumTouchTarget
             )
-            .graphicsLayer {
-                scaleX = scale
-                scaleY = scale
-            }
             .semantics { toggleableState = ToggleableState(active) },
-        pressedScale = 0.92f,
+        pressedScale = 0.88f,
         contentDescription = contentDescription
     ) {
         Box(
-            modifier = Modifier
-                .size(size)
-                .background(fill, CircleShape)
-                .border(
-                    BorderStroke(
-                        LevyraPlayerDesign.Hairline,
-                        accent.playerMix(Color.White, 0.20f).copy(alpha = borderAlpha)
-                    ),
-                    CircleShape
-                ),
+            modifier = Modifier.size(LevyraPlayerDesign.ModeSlot),
             contentAlignment = Alignment.Center
         ) {
             PlayerIcon(
@@ -333,15 +306,14 @@ private fun PlayerModeToggleButton(
                 tint = tint,
                 modifier = Modifier.size(iconSize)
             )
-            if (active) {
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(bottom = 4.dp)
-                        .size(3.dp)
-                        .background(accentTarget.playerMix(Color.White, 0.4f), CircleShape)
-                )
-            }
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = LevyraPlayerDesign.SpaceXxs)
+                    .size(LevyraPlayerDesign.ModeIndicator)
+                    .graphicsLayer { alpha = indicatorAlpha }
+                    .background(activeTint, CircleShape)
+            )
         }
     }
 }
@@ -354,25 +326,17 @@ private fun playerPrimaryIconTransition(): ContentTransform =
 
 private fun Modifier.playerPrimarySurface(
     shape: Shape,
-    gradientColors: List<Color>,
-    ambientColor: Color
+    gradientColors: List<Color>
 ): Modifier = this
     .shadow(
-        elevation = 10.dp,
+        elevation = 12.dp,
         shape = shape,
         clip = false,
-        ambientColor = ambientColor.copy(alpha = 0.38f),
-        spotColor = Color.Black.copy(alpha = 0.52f)
+        ambientColor = Color.Black.copy(alpha = 0.30f),
+        spotColor = Color.Black.copy(alpha = 0.55f)
     )
     .background(
-        Brush.linearGradient(gradientColors),
-        shape
-    )
-    .border(
-        BorderStroke(
-            1.dp,
-            Color.White.copy(alpha = 0.24f)
-        ),
+        Brush.verticalGradient(gradientColors),
         shape
     )
 
@@ -403,22 +367,20 @@ private fun PlayerPrimaryIcon(isPlaying: Boolean, iconSize: Dp, tint: Color, ani
 private fun PlayerPrimaryButton(
     isPlaying: Boolean,
     isResolving: Boolean,
-    width: Dp,
-    height: Dp,
+    size: Dp,
     animated: Boolean,
     playLabel: String,
     pauseLabel: String,
     onClick: () -> Unit
 ) {
-    val contentColor = Color(0xFF171717)
-    val shape = RoundedCornerShape(LevyraPlayerDesign.PrimaryCorner)
-
+    val contentColor = LevyraPlayerDesign.PrimaryContent
+    val corner by animateDpAsState(
+        targetValue = if (isPlaying) LevyraPlayerDesign.PrimaryCornerPlaying else size / 2f,
+        animationSpec = if (animated) LevyraPlayerDesign.expressiveSpring() else snap(),
+        label = "player-primary-corner"
+    )
     val gradientColors = remember {
-        listOf(
-            Color.White.copy(alpha = 0.98f),
-            Color(0xFFF2F2F4),
-            Color(0xFFE4E4E8)
-        )
+        listOf(Color.White, Color(0xFFEDEDF1))
     }
 
     SpringIconButton(
@@ -428,24 +390,23 @@ private fun PlayerPrimaryButton(
     ) {
         Box(
             modifier = Modifier
-                .size(width = width, height = height)
+                .size(size)
                 .playerPrimarySurface(
-                    shape = shape,
-                    gradientColors = gradientColors,
-                    ambientColor = gradientColors[1]
+                    shape = RoundedCornerShape(corner),
+                    gradientColors = gradientColors
                 ),
             contentAlignment = Alignment.Center
         ) {
             if (isResolving) {
                 CircularProgressIndicator(
-                    modifier = Modifier.size(24.dp),
-                    strokeWidth = 2.8.dp,
+                    modifier = Modifier.size(LevyraPlayerDesign.PrimaryGlyph * 0.8f),
+                    strokeWidth = 2.6.dp,
                     color = contentColor
                 )
             } else {
                 PlayerPrimaryIcon(
                     isPlaying = isPlaying,
-                    iconSize = 30.dp,
+                    iconSize = LevyraPlayerDesign.PrimaryGlyph,
                     tint = contentColor,
                     animated = animated
                 )

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
@@ -245,20 +245,33 @@ private fun PlayerSkipButton(
     iconSize: Dp,
     onClick: () -> Unit
 ) {
+    val shape = LevyraPlayerDesign.ShapeSm
     SpringIconButton(
         onClick = onClick,
         modifier = Modifier.sizeIn(
             minWidth = LevyraPlayerDesign.MinimumTouchTarget,
             minHeight = LevyraPlayerDesign.MinimumTouchTarget
         ),
-        pressedScale = 0.86f,
+        pressedScale = 0.88f,
         contentDescription = contentDescription
     ) {
-        PlayerIcon(
-            icon = icon,
-            tint = Color.White,
-            modifier = Modifier.size(iconSize)
-        )
+        Box(
+            modifier = Modifier
+                .size(42.dp)
+                .background(Color.White.copy(alpha = 0.055f), shape)
+                .border(
+                    LevyraPlayerDesign.Hairline,
+                    Color.White.copy(alpha = 0.09f),
+                    shape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            PlayerIcon(
+                icon = icon,
+                tint = Color.White.copy(alpha = 0.94f),
+                modifier = Modifier.size(iconSize)
+            )
+        }
     }
 }
 
@@ -285,6 +298,16 @@ private fun PlayerModeToggleButton(
         animationSpec = if (animated) LevyraPlayerDesign.standardTween() else snap(),
         label = "player-toggle-indicator"
     )
+    val surfaceColor by animateColorAsState(
+        targetValue = if (active) activeTint.copy(alpha = 0.15f) else Color.White.copy(alpha = 0.035f),
+        animationSpec = if (animated) LevyraPlayerDesign.standardTween(180) else snap(),
+        label = "player-toggle-surface"
+    )
+    val surfaceBorder by animateColorAsState(
+        targetValue = if (active) activeTint.copy(alpha = 0.26f) else Color.White.copy(alpha = 0.06f),
+        animationSpec = if (animated) LevyraPlayerDesign.standardTween(180) else snap(),
+        label = "player-toggle-border"
+    )
 
     SpringIconButton(
         onClick = onClick,
@@ -298,7 +321,14 @@ private fun PlayerModeToggleButton(
         contentDescription = contentDescription
     ) {
         Box(
-            modifier = Modifier.size(LevyraPlayerDesign.ModeSlot),
+            modifier = Modifier
+                .size(LevyraPlayerDesign.ModeSlot)
+                .background(surfaceColor, LevyraPlayerDesign.ShapeSm)
+                .border(
+                    LevyraPlayerDesign.Hairline,
+                    surfaceBorder,
+                    LevyraPlayerDesign.ShapeSm
+                ),
             contentAlignment = Alignment.Center
         ) {
             PlayerIcon(
@@ -373,6 +403,11 @@ private fun PlayerPrimaryButton(
     onClick: () -> Unit
 ) {
     val contentColor = LevyraPlayerDesign.PrimaryContent
+    val corner by animateDpAsState(
+        targetValue = if (isPlaying) LevyraPlayerDesign.CornerMd else size * 0.5f,
+        animationSpec = if (animated) LevyraPlayerDesign.expressiveSpring() else snap(),
+        label = "player-primary-corner"
+    )
 
     SpringIconButton(
         onClick = onClick,
@@ -383,7 +418,7 @@ private fun PlayerPrimaryButton(
             modifier = Modifier
                 .size(size)
                 .playerPrimarySurface(
-                    shape = CircleShape
+                    shape = RoundedCornerShape(corner)
                 ),
             contentAlignment = Alignment.Center
         ) {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PremiumSeekbar.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PremiumSeekbar.kt
@@ -96,21 +96,21 @@ fun PremiumSeekbar(
     val scrubMillis by remember(durationMs) {
         derivedStateOf { seekbarSeekMillis(dragProgressFraction, durationMs) }
     }
+
     val wavePath = remember(widthPx, density) {
         Path().apply {
             if (widthPx <= 0f) return@apply
             val centerY = with(density) { LevyraPlayerDesign.MinimumTouchTarget.toPx() / 2f }
-            val amplitude = with(density) { 1.dp.toPx() }
-            val wavelength = with(density) { 30.dp.toPx() }
-            moveTo(0f, centerY)
-            var waveStart = 0f
-            while (waveStart < widthPx) {
-                val waveEnd = (waveStart + wavelength).coerceAtMost(widthPx)
-                val waveWidth = waveEnd - waveStart
+            val amplitude = with(density) { 2.6.dp.toPx() }
+            val wavelength = with(density) { 20.dp.toPx() }
+            var waveStart = -wavelength
+            moveTo(waveStart, centerY)
+            while (waveStart < widthPx + wavelength) {
+                val waveEnd = waveStart + wavelength
                 cubicTo(
-                    waveStart + waveWidth * 0.25f,
+                    waveStart + wavelength * 0.22f,
                     centerY - amplitude,
-                    waveStart + waveWidth * 0.75f,
+                    waveStart + wavelength * 0.78f,
                     centerY + amplitude,
                     waveEnd,
                     centerY

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PremiumSeekbar.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PremiumSeekbar.kt
@@ -101,21 +101,45 @@ fun PremiumSeekbar(
         Path().apply {
             if (widthPx <= 0f) return@apply
             val centerY = with(density) { LevyraPlayerDesign.MinimumTouchTarget.toPx() / 2f }
-            val amplitude = with(density) { 2.6.dp.toPx() }
-            val wavelength = with(density) { 20.dp.toPx() }
+            val amplitude = with(density) { 2.4.dp.toPx() }
+            val wavelength = with(density) { 38.dp.toPx() }
+            val quarterWave = wavelength / 4f
             var waveStart = -wavelength
             moveTo(waveStart, centerY)
             while (waveStart < widthPx + wavelength) {
-                val waveEnd = waveStart + wavelength
                 cubicTo(
-                    waveStart + wavelength * 0.22f,
+                    waveStart + quarterWave * 0.45f,
+                    centerY,
+                    waveStart + quarterWave * 0.55f,
                     centerY - amplitude,
-                    waveStart + wavelength * 0.78f,
-                    centerY + amplitude,
-                    waveEnd,
+                    waveStart + quarterWave,
+                    centerY - amplitude
+                )
+                cubicTo(
+                    waveStart + quarterWave * 1.45f,
+                    centerY - amplitude,
+                    waveStart + quarterWave * 1.55f,
+                    centerY,
+                    waveStart + quarterWave * 2f,
                     centerY
                 )
-                waveStart = waveEnd
+                cubicTo(
+                    waveStart + quarterWave * 2.45f,
+                    centerY,
+                    waveStart + quarterWave * 2.55f,
+                    centerY + amplitude,
+                    waveStart + quarterWave * 3f,
+                    centerY + amplitude
+                )
+                cubicTo(
+                    waveStart + quarterWave * 3.45f,
+                    centerY + amplitude,
+                    waveStart + quarterWave * 3.55f,
+                    centerY,
+                    waveStart + wavelength,
+                    centerY
+                )
+                waveStart += wavelength
             }
         }
     }
@@ -239,17 +263,29 @@ fun PremiumSeekbar(
             }
 
             if (handleX > trackStart) {
+                val activeSpan = handleX - trackStart
                 clipRect(
                     left = trackStart,
                     top = 0f,
                     right = handleX,
                     bottom = size.height
                 ) {
-                    drawPath(
-                        path = wavePath,
-                        color = activeColor,
-                        style = Stroke(width = trackHeight, cap = StrokeCap.Round)
-                    )
+                    if (scrub > 0.001f) {
+                        drawRoundRect(
+                            color = activeColor.copy(alpha = activeColor.alpha * scrub),
+                            topLeft = Offset(trackStart, trackTop),
+                            size = Size(activeSpan, trackHeight),
+                            cornerRadius = radius
+                        )
+                    }
+                    val waveAlpha = (1f - scrub).coerceIn(0f, 1f)
+                    if (waveAlpha > 0.001f) {
+                        drawPath(
+                            path = wavePath,
+                            color = activeColor.copy(alpha = activeColor.alpha * waveAlpha),
+                            style = Stroke(width = trackHeight, cap = StrokeCap.Round)
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PremiumSeekbar.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PremiumSeekbar.kt
@@ -182,11 +182,8 @@ fun PremiumSeekbar(
 
             val trackHeight = LevyraPlayerDesign.TrackHeight.toPx() +
                 (LevyraPlayerDesign.TrackHeightActive - LevyraPlayerDesign.TrackHeight).toPx() * scrub
-            val handleWidth = LevyraPlayerDesign.HandleWidth.toPx() +
-                (LevyraPlayerDesign.HandleWidthActive - LevyraPlayerDesign.HandleWidth).toPx() * scrub
-            val handleHeight = LevyraPlayerDesign.HandleHeight.toPx() +
-                (LevyraPlayerDesign.HandleHeightActive - LevyraPlayerDesign.HandleHeight).toPx() * scrub
-            val gap = trackHeight * 1.05f
+            val thumbRadius = LevyraPlayerDesign.ThumbRadius.toPx() +
+                (LevyraPlayerDesign.ThumbRadiusActive - LevyraPlayerDesign.ThumbRadius).toPx() * scrub
             val capInset = trackHeight / 2f
             val trackStart = capInset
             val trackEnd = (totalWidth - capInset).coerceAtLeast(trackStart)
@@ -194,30 +191,30 @@ fun PremiumSeekbar(
             val radius = CornerRadius(trackHeight / 2f, trackHeight / 2f)
             val trackTop = centerY - trackHeight / 2f
 
-            val handleX = trackStart + seekbarHandleCenterX(effectiveProgress, trackSpan, handleWidth)
-            val activeEnd = (handleX - handleWidth / 2f - gap).coerceIn(trackStart, trackEnd)
-            val inactiveStart = (handleX + handleWidth / 2f + gap).coerceIn(trackStart, trackEnd)
+            val handleX = trackStart + seekbarHandleCenterX(effectiveProgress, trackSpan, thumbRadius * 2f)
 
-            if (inactiveStart < trackEnd) {
-                drawRoundRect(
-                    color = inactiveColor,
-                    topLeft = Offset(inactiveStart, trackTop),
-                    size = Size(trackEnd - inactiveStart, trackHeight),
-                    cornerRadius = radius
-                )
-            }
+            // 1. Inactive continuous background track
+            drawRoundRect(
+                color = inactiveColor,
+                topLeft = Offset(trackStart, trackTop),
+                size = Size(trackSpan, trackHeight),
+                cornerRadius = radius
+            )
 
+            // 2. Buffered progress span
             val bufferedEnd = (trackStart + bufferedProgress * trackSpan).coerceIn(trackStart, trackEnd)
-            if (bufferedEnd > inactiveStart) {
+            val bufferedSpan = bufferedEnd - trackStart
+            if (bufferedSpan > 0f) {
                 drawRoundRect(
                     color = LevyraPlayerDesign.TrackBuffered,
-                    topLeft = Offset(inactiveStart, trackTop),
-                    size = Size(bufferedEnd - inactiveStart, trackHeight),
+                    topLeft = Offset(trackStart, trackTop),
+                    size = Size(bufferedSpan, trackHeight),
                     cornerRadius = radius
                 )
             }
 
-            val activeSpan = activeEnd - trackStart
+            // 3. Active continuous progress track
+            val activeSpan = handleX - trackStart
             if (activeSpan > 0f) {
                 drawRoundRect(
                     color = activeColor,
@@ -227,22 +224,26 @@ fun PremiumSeekbar(
                 )
             }
 
+            // 4. Thumb glow when scrubbing
             if (scrub > 0.01f) {
-                val glowWidth = handleWidth * 3.4f
-                val glowHeight = handleHeight * 1.36f
-                drawRoundRect(
+                val glowRadius = thumbRadius * 1.8f
+                drawCircle(
                     color = trailingColor.copy(alpha = 0.22f * scrub),
-                    topLeft = Offset(handleX - glowWidth / 2f, centerY - glowHeight / 2f),
-                    size = Size(glowWidth, glowHeight),
-                    cornerRadius = CornerRadius(glowWidth / 2f, glowWidth / 2f)
+                    radius = glowRadius,
+                    center = Offset(handleX, centerY)
                 )
             }
 
-            drawRoundRect(
+            // 5. Thumb circle with soft shadow
+            drawCircle(
+                color = Color.Black.copy(alpha = 0.20f),
+                radius = thumbRadius + 1f,
+                center = Offset(handleX, centerY + 1f)
+            )
+            drawCircle(
                 color = thumbColor,
-                topLeft = Offset(handleX - handleWidth / 2f, centerY - handleHeight / 2f),
-                size = Size(handleWidth, handleHeight),
-                cornerRadius = CornerRadius(handleWidth / 2f, handleWidth / 2f)
+                radius = thumbRadius,
+                center = Offset(handleX, centerY)
             )
         }
     }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PremiumSeekbar.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PremiumSeekbar.kt
@@ -29,6 +29,10 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
@@ -91,6 +95,29 @@ fun PremiumSeekbar(
 
     val scrubMillis by remember(durationMs) {
         derivedStateOf { seekbarSeekMillis(dragProgressFraction, durationMs) }
+    }
+    val wavePath = remember(widthPx, density) {
+        Path().apply {
+            if (widthPx <= 0f) return@apply
+            val centerY = with(density) { LevyraPlayerDesign.MinimumTouchTarget.toPx() / 2f }
+            val amplitude = with(density) { 1.dp.toPx() }
+            val wavelength = with(density) { 30.dp.toPx() }
+            moveTo(0f, centerY)
+            var waveStart = 0f
+            while (waveStart < widthPx) {
+                val waveEnd = (waveStart + wavelength).coerceAtMost(widthPx)
+                val waveWidth = waveEnd - waveStart
+                cubicTo(
+                    waveStart + waveWidth * 0.25f,
+                    centerY - amplitude,
+                    waveStart + waveWidth * 0.75f,
+                    centerY + amplitude,
+                    waveEnd,
+                    centerY
+                )
+                waveStart = waveEnd
+            }
+        }
     }
 
     Box(
@@ -193,7 +220,6 @@ fun PremiumSeekbar(
 
             val handleX = trackStart + seekbarHandleCenterX(effectiveProgress, trackSpan, thumbRadius * 2f)
 
-            // 1. Inactive continuous background track
             drawRoundRect(
                 color = inactiveColor,
                 topLeft = Offset(trackStart, trackTop),
@@ -201,7 +227,6 @@ fun PremiumSeekbar(
                 cornerRadius = radius
             )
 
-            // 2. Buffered progress span
             val bufferedEnd = (trackStart + bufferedProgress * trackSpan).coerceIn(trackStart, trackEnd)
             val bufferedSpan = bufferedEnd - trackStart
             if (bufferedSpan > 0f) {
@@ -213,18 +238,21 @@ fun PremiumSeekbar(
                 )
             }
 
-            // 3. Active continuous progress track
-            val activeSpan = handleX - trackStart
-            if (activeSpan > 0f) {
-                drawRoundRect(
-                    color = activeColor,
-                    topLeft = Offset(trackStart, trackTop),
-                    size = Size(activeSpan, trackHeight),
-                    cornerRadius = radius
-                )
+            if (handleX > trackStart) {
+                clipRect(
+                    left = trackStart,
+                    top = 0f,
+                    right = handleX,
+                    bottom = size.height
+                ) {
+                    drawPath(
+                        path = wavePath,
+                        color = activeColor,
+                        style = Stroke(width = trackHeight, cap = StrokeCap.Round)
+                    )
+                }
             }
 
-            // 4. Thumb glow when scrubbing
             if (scrub > 0.01f) {
                 val glowRadius = thumbRadius * 1.8f
                 drawCircle(
@@ -234,7 +262,6 @@ fun PremiumSeekbar(
                 )
             }
 
-            // 5. Thumb circle with soft shadow
             drawCircle(
                 color = Color.Black.copy(alpha = 0.20f),
                 radius = thumbRadius + 1f,

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PremiumSeekbar.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PremiumSeekbar.kt
@@ -2,11 +2,7 @@ package com.luc4n3x.levyra.ui.components
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationSpec
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.snap
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -33,10 +29,6 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.StrokeJoin
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
@@ -55,7 +47,6 @@ import com.luc4n3x.levyra.ui.theme.LevyraCyan
 import com.luc4n3x.levyra.ui.theme.LevyraMuted
 import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
 import java.util.Locale
-import kotlin.math.PI
 import kotlin.math.roundToInt
 
 @Composable
@@ -69,7 +60,6 @@ fun PremiumSeekbar(
     trailingColor: Color = activeColor,
     inactiveColor: Color = LevyraMuted.copy(alpha = 0.35f),
     thumbColor: Color = Color.White,
-    isPlaying: Boolean = false,
     animated: Boolean = true,
     contentDescription: String? = null
 ) {
@@ -89,44 +79,13 @@ fun PremiumSeekbar(
         seekbarProgressFraction(bufferedPositionMs, durationMs).coerceAtLeast(effectiveProgress)
     }
 
-    val trackScale = remember { Animatable(1f) }
-    val handleScale = remember { Animatable(0f) }
-    val waveAmplitude = remember { Animatable(0f) }
-
+    val scrubAmount = remember { Animatable(0f) }
     val scrubSpec: AnimationSpec<Float> =
         if (animated) LevyraPlayerDesign.expressiveSpring() else snap()
     LaunchedEffect(isDragging, animated) {
-        trackScale.animateTo(
-            targetValue = if (isDragging) 1.55f else 1f,
-            animationSpec = scrubSpec
-        )
-    }
-    LaunchedEffect(isDragging, animated) {
-        handleScale.animateTo(
+        scrubAmount.animateTo(
             targetValue = if (isDragging) 1f else 0f,
             animationSpec = scrubSpec
-        )
-    }
-
-    val waveActive = animated && isPlaying && !isDragging && durationMs > 0L
-    LaunchedEffect(waveActive, animated) {
-        waveAmplitude.animateTo(
-            targetValue = if (waveActive) 1f else 0f,
-            animationSpec = if (animated) LevyraPlayerDesign.smoothSpring() else snap()
-        )
-    }
-
-    val wavePath = remember { Path() }
-    val wavePhase = remember { Animatable(0f) }
-    LaunchedEffect(waveActive) {
-        if (!waveActive) return@LaunchedEffect
-        wavePhase.snapTo(0f)
-        wavePhase.animateTo(
-            targetValue = -2f * PI.toFloat(),
-            animationSpec = infiniteRepeatable(
-                animation = tween(LevyraPlayerDesign.WaveCycleMillis, easing = LinearEasing),
-                repeatMode = RepeatMode.Restart
-            )
         )
     }
 
@@ -219,18 +178,21 @@ fun PremiumSeekbar(
             val totalWidth = size.width
             if (totalWidth <= 0f) return@Canvas
             val centerY = size.height / 2f
+            val scrub = scrubAmount.value
 
-            val baseTrackHeight = LevyraPlayerDesign.TrackHeight.toPx()
-            val trackHeight = baseTrackHeight * trackScale.value
+            val trackHeight = LevyraPlayerDesign.TrackHeight.toPx() +
+                (LevyraPlayerDesign.TrackHeightActive - LevyraPlayerDesign.TrackHeight).toPx() * scrub
             val handleWidth = LevyraPlayerDesign.HandleWidth.toPx() +
-                (LevyraPlayerDesign.HandleWidthActive - LevyraPlayerDesign.HandleWidth).toPx() * handleScale.value
+                (LevyraPlayerDesign.HandleWidthActive - LevyraPlayerDesign.HandleWidth).toPx() * scrub
             val handleHeight = LevyraPlayerDesign.HandleHeight.toPx() +
-                (LevyraPlayerDesign.HandleHeightActive - LevyraPlayerDesign.HandleHeight).toPx() * handleScale.value
-            val gap = trackHeight * 1.1f
+                (LevyraPlayerDesign.HandleHeightActive - LevyraPlayerDesign.HandleHeight).toPx() * scrub
+            val gap = trackHeight * 1.05f
             val capInset = trackHeight / 2f
             val trackStart = capInset
             val trackEnd = (totalWidth - capInset).coerceAtLeast(trackStart)
             val trackSpan = trackEnd - trackStart
+            val radius = CornerRadius(trackHeight / 2f, trackHeight / 2f)
+            val trackTop = centerY - trackHeight / 2f
 
             val handleX = trackStart + seekbarHandleCenterX(effectiveProgress, trackSpan, handleWidth)
             val activeEnd = (handleX - handleWidth / 2f - gap).coerceIn(trackStart, trackEnd)
@@ -239,66 +201,40 @@ fun PremiumSeekbar(
             if (inactiveStart < trackEnd) {
                 drawRoundRect(
                     color = inactiveColor,
-                    topLeft = Offset(inactiveStart, centerY - trackHeight / 2f),
+                    topLeft = Offset(inactiveStart, trackTop),
                     size = Size(trackEnd - inactiveStart, trackHeight),
-                    cornerRadius = CornerRadius(trackHeight / 2f, trackHeight / 2f)
+                    cornerRadius = radius
                 )
             }
 
             val bufferedEnd = (trackStart + bufferedProgress * trackSpan).coerceIn(trackStart, trackEnd)
             if (bufferedEnd > inactiveStart) {
                 drawRoundRect(
-                    color = thumbColor.copy(alpha = 0.22f),
-                    topLeft = Offset(inactiveStart, centerY - trackHeight / 2f),
+                    color = LevyraPlayerDesign.TrackBuffered,
+                    topLeft = Offset(inactiveStart, trackTop),
                     size = Size(bufferedEnd - inactiveStart, trackHeight),
-                    cornerRadius = CornerRadius(trackHeight / 2f, trackHeight / 2f)
+                    cornerRadius = radius
                 )
             }
 
             val activeSpan = activeEnd - trackStart
             if (activeSpan > 0f) {
-                val amplitudePx = LevyraPlayerDesign.WaveAmplitude.toPx() * waveAmplitude.value
-                if (amplitudePx > 0.4f) {
-                    val wavelength = LevyraPlayerDesign.WavePeriodDp.dp.toPx()
-                    val taper = wavelength * 0.75f
-                    val samples = seekbarWaveSampleCount(activeSpan)
-                    val step = activeSpan / samples
-                    wavePath.rewind()
-                    var offsetX = 0f
-                    var index = 0
-                    while (index <= samples) {
-                        val local = seekbarWaveTaper(offsetX, activeSpan, taper)
-                        val y = centerY + seekbarWaveOffset(offsetX, amplitudePx * local, wavelength, wavePhase.value)
-                        val pointX = trackStart + offsetX
-                        if (index == 0) wavePath.moveTo(pointX, y) else wavePath.lineTo(pointX, y)
-                        offsetX += step
-                        index += 1
-                    }
-                    drawPath(
-                        path = wavePath,
-                        color = activeColor,
-                        style = Stroke(
-                            width = trackHeight,
-                            cap = StrokeCap.Round,
-                            join = StrokeJoin.Round
-                        )
-                    )
-                } else {
-                    drawRoundRect(
-                        color = activeColor,
-                        topLeft = Offset(trackStart, centerY - trackHeight / 2f),
-                        size = Size(activeSpan, trackHeight),
-                        cornerRadius = CornerRadius(trackHeight / 2f, trackHeight / 2f)
-                    )
-                }
+                drawRoundRect(
+                    color = activeColor,
+                    topLeft = Offset(trackStart, trackTop),
+                    size = Size(activeSpan, trackHeight),
+                    cornerRadius = radius
+                )
             }
 
-            if (handleScale.value > 0.01f) {
+            if (scrub > 0.01f) {
+                val glowWidth = handleWidth * 3.4f
+                val glowHeight = handleHeight * 1.36f
                 drawRoundRect(
-                    color = trailingColor.copy(alpha = 0.30f * handleScale.value),
-                    topLeft = Offset(handleX - handleWidth * 1.6f, centerY - handleHeight * 0.65f),
-                    size = Size(handleWidth * 3.2f, handleHeight * 1.30f),
-                    cornerRadius = CornerRadius(handleWidth * 1.6f, handleWidth * 1.6f)
+                    color = trailingColor.copy(alpha = 0.22f * scrub),
+                    topLeft = Offset(handleX - glowWidth / 2f, centerY - glowHeight / 2f),
+                    size = Size(glowWidth, glowHeight),
+                    cornerRadius = CornerRadius(glowWidth / 2f, glowWidth / 2f)
                 )
             }
 

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/SeekbarGeometry.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/SeekbarGeometry.kt
@@ -1,11 +1,5 @@
 package com.luc4n3x.levyra.ui.components
 
-import kotlin.math.PI
-import kotlin.math.ceil
-import kotlin.math.sin
-
-internal const val SeekbarWaveSampleStepPx = 3f
-
 internal fun seekbarFractionAt(x: Float, widthPx: Float): Float {
     if (widthPx <= 0f) return 0f
     return (x / widthPx).coerceIn(0f, 1f)
@@ -27,28 +21,6 @@ internal fun seekbarTooltipOffsetX(fraction: Float, widthPx: Float, tooltipWidth
     if (tooltipWidthPx >= widthPx) return 0f
     val centered = fraction.coerceIn(0f, 1f) * widthPx - tooltipWidthPx / 2f
     return centered.coerceIn(0f, widthPx - tooltipWidthPx)
-}
-
-internal fun seekbarWaveSampleCount(widthPx: Float): Int {
-    if (widthPx <= 0f) return 0
-    return ceil(widthPx / SeekbarWaveSampleStepPx).toInt().coerceIn(1, 900)
-}
-
-internal fun seekbarWaveTaper(x: Float, activeWidthPx: Float, taperPx: Float): Float {
-    if (activeWidthPx <= 0f || taperPx <= 0f) return 0f
-    val fromStart = (x / taperPx).coerceIn(0f, 1f)
-    val fromEnd = ((activeWidthPx - x) / taperPx).coerceIn(0f, 1f)
-    return minOf(fromStart, fromEnd)
-}
-
-internal fun seekbarWaveOffset(
-    x: Float,
-    amplitudePx: Float,
-    wavelengthPx: Float,
-    phase: Float
-): Float {
-    if (amplitudePx <= 0f || wavelengthPx <= 0f) return 0f
-    return amplitudePx * sin((2f * PI.toFloat() * x / wavelengthPx) + phase)
 }
 
 internal fun seekbarSeekMillis(fraction: Float, durationMs: Long): Long {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
@@ -763,6 +763,18 @@ class LevyraStrings private constructor(
             } else {
                 "Slow connection: try again in a few seconds"
             }
+            raw.contains("429", ignoreCase = true) -> if (code == "it") {
+                "Troppe richieste a YouTube: attendi qualche secondo"
+            } else {
+                "Too many requests to YouTube: wait a few seconds"
+            }
+            raw.contains("403", ignoreCase = true) ||
+                raw.contains("410", ignoreCase = true) ||
+                raw.contains("Source error", ignoreCase = true) -> if (code == "it") {
+                    "YouTube ha rifiutato il link del brano: sto riprovando con una nuova sorgente"
+                } else {
+                    "YouTube rejected this track link: retrying with a fresh source"
+                }
             raw.contains("Primary directory Music not allowed", ignoreCase = true) ||
                 raw.contains("content://media/external_primary/file", ignoreCase = true) -> if (code == "it") {
                     "Questo dispositivo non ha consentito il salvataggio in Music/Levyra"

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
@@ -743,11 +743,11 @@ class LevyraStrings private constructor(
         }
     }
 
-    fun localizeUserError(rawMessage: String?): String {
+    fun localizeUserError(rawMessage: String?, youtubePlayback: Boolean = false): String {
         val raw = rawMessage?.trim().orEmpty()
         return when {
-            raw.contains("Timed out waiting", ignoreCase = true) ||
-                raw.contains("sto aspettando lo stream", ignoreCase = true) -> if (code == "it") {
+            youtubePlayback && (raw.contains("Timed out waiting", ignoreCase = true) ||
+                raw.contains("sto aspettando lo stream", ignoreCase = true)) -> if (code == "it") {
                     "YouTube è lento: riprova tra qualche secondo"
                 } else {
                     "YouTube is slow: try again in a few seconds"
@@ -763,17 +763,17 @@ class LevyraStrings private constructor(
             } else {
                 "Slow connection: try again in a few seconds"
             }
-            raw.contains("429", ignoreCase = true) -> if (code == "it") {
+            youtubePlayback && raw.contains("429", ignoreCase = true) -> if (code == "it") {
                 "Troppe richieste a YouTube: attendi qualche secondo"
             } else {
                 "Too many requests to YouTube: wait a few seconds"
             }
-            raw.contains("403", ignoreCase = true) ||
+            youtubePlayback && (raw.contains("403", ignoreCase = true) ||
                 raw.contains("410", ignoreCase = true) ||
-                raw.contains("Source error", ignoreCase = true) -> if (code == "it") {
-                    "YouTube ha rifiutato il link del brano: sto riprovando con una nuova sorgente"
+                raw.contains("Source error", ignoreCase = true)) -> if (code == "it") {
+                    "YouTube ha rifiutato il link del brano: riprova"
                 } else {
-                    "YouTube rejected this track link: retrying with a fresh source"
+                    "YouTube rejected this track link: try again"
                 }
             raw.contains("Primary directory Music not allowed", ignoreCase = true) ||
                 raw.contains("content://media/external_primary/file", ignoreCase = true) -> if (code == "it") {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/theme/PlayerDesign.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/theme/PlayerDesign.kt
@@ -39,27 +39,29 @@ object LevyraPlayerDesign {
     val GutterCompact: Dp = 16.dp
     val Gutter: Dp = 22.dp
 
-    val HeaderButton: Dp = 42.dp
-    val HeaderButtonCompact: Dp = 38.dp
-    val ModeSlot: Dp = 40.dp
-    val ModeGlyph: Dp = 20.dp
-    val ModeGlyphCompact: Dp = 19.dp
-    val ModeIndicator: Dp = 3.dp
+    val HeaderButton: Dp = 40.dp
+    val HeaderButtonCompact: Dp = 36.dp
+    val ModeSlot: Dp = 42.dp
+    val ModeGlyph: Dp = 22.dp
+    val ModeGlyphCompact: Dp = 20.dp
+    val ModeIndicator: Dp = 4.dp
     val SkipGlyph: Dp = 34.dp
     val SkipGlyphCompact: Dp = 30.dp
-    val PrimarySize: Dp = 68.dp
-    val PrimarySizeCompact: Dp = 60.dp
+    val PrimarySize: Dp = 66.dp
+    val PrimarySizeCompact: Dp = 58.dp
     val PrimaryGlyph: Dp = 30.dp
     val PrimaryCornerPlaying: Dp = 22.dp
     val MinimumTouchTarget: Dp = 48.dp
 
     val Hairline: Dp = 1.dp
     val TrackHeight: Dp = 4.dp
-    val TrackHeightActive: Dp = 6.5.dp
-    val HandleWidth: Dp = 5.dp
-    val HandleWidthActive: Dp = 7.dp
-    val HandleHeight: Dp = 18.dp
-    val HandleHeightActive: Dp = 26.dp
+    val TrackHeightActive: Dp = 6.dp
+    val ThumbRadius: Dp = 6.dp
+    val ThumbRadiusActive: Dp = 8.5.dp
+    val HandleWidth: Dp = 12.dp
+    val HandleWidthActive: Dp = 17.dp
+    val HandleHeight: Dp = 12.dp
+    val HandleHeightActive: Dp = 17.dp
 
     val Emphasized: Easing = CubicBezierEasing(0.2f, 0f, 0f, 1f)
     val Standard: Easing = CubicBezierEasing(0.3f, 0f, 0.1f, 1f)
@@ -87,17 +89,17 @@ object LevyraPlayerDesign {
     fun <T> standardTween(durationMillis: Int = 220): TweenSpec<T> =
         tween(durationMillis = durationMillis, easing = Standard)
 
-    val GlassFill: Color = Color.White.copy(alpha = 0.055f)
-    val GlassFillStrong: Color = Color.White.copy(alpha = 0.10f)
-    val GlassFillSunken: Color = Color.Black.copy(alpha = 0.28f)
+    val GlassFill: Color = Color.White.copy(alpha = 0.08f)
+    val GlassFillStrong: Color = Color.White.copy(alpha = 0.14f)
+    val GlassFillSunken: Color = Color.Black.copy(alpha = 0.32f)
     val GlassBorderTop: Color = Color.White.copy(alpha = 0.14f)
-    val GlassBorderBottom: Color = Color.White.copy(alpha = 0.05f)
+    val GlassBorderBottom: Color = Color.White.copy(alpha = 0.06f)
 
     val TextPrimary: Color = Color.White
-    val TextSecondary: Color = Color.White.copy(alpha = 0.76f)
-    val TextTertiary: Color = Color.White.copy(alpha = 0.52f)
-    val IconIdle: Color = Color.White.copy(alpha = 0.58f)
-    val PrimaryContent: Color = Color(0xFF141416)
+    val TextSecondary: Color = Color.White.copy(alpha = 0.70f)
+    val TextTertiary: Color = Color.White.copy(alpha = 0.48f)
+    val IconIdle: Color = Color.White.copy(alpha = 0.55f)
+    val PrimaryContent: Color = Color(0xFF121214)
     val TrackInactive: Color = Color.White.copy(alpha = 0.18f)
-    val TrackBuffered: Color = Color.White.copy(alpha = 0.30f)
+    val TrackBuffered: Color = Color.White.copy(alpha = 0.32f)
 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/theme/PlayerDesign.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/theme/PlayerDesign.kt
@@ -41,26 +41,24 @@ object LevyraPlayerDesign {
 
     val HeaderButton: Dp = 42.dp
     val HeaderButtonCompact: Dp = 38.dp
-    val UtilityButton: Dp = 44.dp
-    val UtilityButtonCompact: Dp = 40.dp
-    val TransportButton: Dp = 54.dp
-    val TransportButtonCompact: Dp = 48.dp
-    val TransportSquircleCorner: Dp = 18.dp
-    val TransportSquircleCornerCompact: Dp = 16.dp
-    val PrimaryWidth: Dp = 76.dp
-    val PrimaryWidthCompact: Dp = 70.dp
-    val PrimaryHeight: Dp = 64.dp
-    val PrimaryHeightCompact: Dp = 58.dp
-    val PrimaryCorner: Dp = 24.dp
+    val ModeSlot: Dp = 40.dp
+    val ModeGlyph: Dp = 20.dp
+    val ModeGlyphCompact: Dp = 19.dp
+    val ModeIndicator: Dp = 3.dp
+    val SkipGlyph: Dp = 34.dp
+    val SkipGlyphCompact: Dp = 30.dp
+    val PrimarySize: Dp = 68.dp
+    val PrimarySizeCompact: Dp = 60.dp
+    val PrimaryGlyph: Dp = 30.dp
+    val PrimaryCornerPlaying: Dp = 22.dp
     val MinimumTouchTarget: Dp = 48.dp
 
     val Hairline: Dp = 1.dp
-    val TrackHeight: Dp = 4.5.dp
-    val TrackHeightActive: Dp = 7.5.dp
-    val WaveAmplitude: Dp = 3.5.dp
-    val HandleWidth: Dp = 6.dp
-    val HandleWidthActive: Dp = 8.dp
-    val HandleHeight: Dp = 20.dp
+    val TrackHeight: Dp = 4.dp
+    val TrackHeightActive: Dp = 6.5.dp
+    val HandleWidth: Dp = 5.dp
+    val HandleWidthActive: Dp = 7.dp
+    val HandleHeight: Dp = 18.dp
     val HandleHeightActive: Dp = 26.dp
 
     val Emphasized: Easing = CubicBezierEasing(0.2f, 0f, 0f, 1f)
@@ -89,18 +87,17 @@ object LevyraPlayerDesign {
     fun <T> standardTween(durationMillis: Int = 220): TweenSpec<T> =
         tween(durationMillis = durationMillis, easing = Standard)
 
-    const val WavePeriodDp: Float = 26f
-    const val WaveCycleMillis: Int = 1_600
-
     val GlassFill: Color = Color.White.copy(alpha = 0.055f)
     val GlassFillStrong: Color = Color.White.copy(alpha = 0.10f)
     val GlassFillSunken: Color = Color.Black.copy(alpha = 0.28f)
     val GlassBorderTop: Color = Color.White.copy(alpha = 0.14f)
     val GlassBorderBottom: Color = Color.White.copy(alpha = 0.05f)
-    val GlassSpecular: Color = Color.White.copy(alpha = 0.025f)
 
     val TextPrimary: Color = Color.White
     val TextSecondary: Color = Color.White.copy(alpha = 0.76f)
-    val TextTertiary: Color = Color.White.copy(alpha = 0.50f)
-    val IconIdle: Color = Color.White.copy(alpha = 0.65f)
+    val TextTertiary: Color = Color.White.copy(alpha = 0.52f)
+    val IconIdle: Color = Color.White.copy(alpha = 0.58f)
+    val PrimaryContent: Color = Color(0xFF141416)
+    val TrackInactive: Color = Color.White.copy(alpha = 0.18f)
+    val TrackBuffered: Color = Color.White.copy(alpha = 0.30f)
 }

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -394,6 +394,19 @@ internal fun videoPlaybackCandidateScore(target: Track, candidate: Track): Int {
 internal fun Track.forModeResolution(): Track =
     copy(streamUrl = "", videoStreamUrl = "", playbackManifest = null)
 
+/**
+ * Song mode resolves from [Track.audioVideoId] and falls back to the video URL when it is blank,
+ * so a video-mode replacement must carry the original song identity or returning to song mode
+ * would resolve the official video as if it were the song.
+ */
+internal fun Track.withPreservedAudioIdentity(source: Track): Track {
+    if (audioVideoId.isNotBlank()) return this
+    val audioId = source.audioVideoId.trim().ifBlank {
+        youtubePlayableTrack(source)?.audioVideoId?.trim().orEmpty()
+    }
+    return if (audioId.isBlank()) this else copy(audioVideoId = audioId)
+}
+
 internal fun videoCandidateId(candidate: Track): String =
     youtubeVideoId(candidate.videoUrl).ifBlank { candidate.id.trim() }
 
@@ -1781,7 +1794,11 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         _state.update { it.copy(pendingVideoMode = targetMode, isResolving = true, playerError = null) }
         modeSwitchJob = viewModelScope.launch {
             try {
-                val selectedSource = if (targetMode) preferredVideoPlaybackTrack(track) else youtubePlayableTrack(track)
+                val selectedSource = if (targetMode) {
+                    preferredVideoPlaybackTrack(track)?.withPreservedAudioIdentity(track)
+                } else {
+                    youtubePlayableTrack(track)
+                }
                 val baseTrack = selectedSource?.forModeResolution()
                     ?: throw IllegalStateException("Nessuna sorgente YouTube riproducibile per ${track.title}")
                 val resolved = withContext(Dispatchers.IO) {
@@ -1840,8 +1857,6 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         errorMessage: String
     ) {
         if (isLocalPlaybackTrack(failedTrack)) return
-        val currentTrackId = _state.value.currentTrack?.id
-        if (currentTrackId != null && currentTrackId != failedTrack.id) return
         val transitionId = ++streamTransitionId
         modeSwitchJob?.cancel()
         streamRecoveryJob?.cancel()

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -994,7 +994,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             _state.value.currentTrack
                 ?.takeUnless(::isLocalPlaybackTrack)
                 ?.let { resolver.invalidate(it, _state.value.isVideoMode) }
-            _state.update { it.copy(playerError = cleanUserError(errorMsg), isPlaying = false, isResolving = false) }
+            _state.update { it.copy(playerError = cleanPlaybackError(errorMsg), isPlaying = false, isResolving = false) }
         }
         applyFollowedArtists(followedArtistsStore.load())
         startTicker()
@@ -1842,7 +1842,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                         pendingVideoMode = null,
                         isResolving = false,
                         isPlaying = player.isPlaying || snapshot.isPlaying,
-                        playerError = cleanUserError(error)
+                        playerError = cleanPlaybackError(error)
                     )
                 }
             }
@@ -1900,7 +1900,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             } catch (error: Throwable) {
                 if (error is CancellationException) throw error
                 if (transitionId != streamTransitionId) return@launch
-                val message = cleanUserError(error)
+                val message = cleanPlaybackError(error)
                 player.failRecovery(message)
                 _state.update { it.copy(isResolving = false, isPlaying = false, playerError = message) }
             }
@@ -3884,6 +3884,19 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
 
+    private fun cleanPlaybackError(error: Throwable): String {
+        if (error is TimeoutCancellationException) {
+            return LevyraStrings.forCode(_state.value.languageCode)
+                .localizeUserError("timeout", youtubePlayback = true)
+        }
+        return cleanPlaybackError(error.message)
+    }
+
+    private fun cleanPlaybackError(message: String?): String {
+        return LevyraStrings.forCode(_state.value.languageCode)
+            .localizeUserError(message, youtubePlayback = true)
+    }
+
     private fun cleanUserError(error: Throwable): String {
         if (error is TimeoutCancellationException) {
             return LevyraStrings.forCode(_state.value.languageCode).localizeUserError("timeout")
@@ -4909,7 +4922,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 bufferedPositionMs = 0L,
                 durationMs = track.durationMs,
                 currentTrack = track.copy(streamUrl = ""),
-                playerError = if (retryWhenOnline) null else cleanUserError(error)
+                playerError = if (retryWhenOnline) null else cleanPlaybackError(error)
             )
         }
         if (retryWhenOnline) scheduleOfflineAutoAdvanceRetry(track, requestId)
@@ -6641,7 +6654,6 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                             bufferedPositionMs = buffered.coerceAtLeast(position),
                             durationMs = duration,
                             isPlaying = player.isPlaying,
-                            playerError = if (player.isPlaying) null else it.playerError,
                             activeLyric = active
                         )
                     }

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -1840,6 +1840,8 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         errorMessage: String
     ) {
         if (isLocalPlaybackTrack(failedTrack)) return
+        val currentTrackId = _state.value.currentTrack?.id
+        if (currentTrackId != null && currentTrackId != failedTrack.id) return
         val transitionId = ++streamTransitionId
         modeSwitchJob?.cancel()
         streamRecoveryJob?.cancel()

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -6624,6 +6624,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                             bufferedPositionMs = buffered.coerceAtLeast(position),
                             durationMs = duration,
                             isPlaying = player.isPlaying,
+                            playerError = if (player.isPlaying) null else it.playerError,
                             activeLyric = active
                         )
                     }

--- a/app/src/test/java/com/luc4n3x/levyra/feature/motion/AppleEditorialVideoSelectionTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/feature/motion/AppleEditorialVideoSelectionTest.kt
@@ -1,0 +1,84 @@
+package com.luc4n3x.levyra.feature.motion
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AppleEditorialVideoSelectionTest {
+
+    @Test
+    fun `missing editorial video yields nothing`() {
+        assertNull(selectAppleEditorialVideo(null))
+        assertNull(selectAppleEditorialVideo(JSONObject("{}")))
+    }
+
+    @Test
+    fun `assets without an https url are rejected`() {
+        val selected = selectAppleEditorialVideo(
+            JSONObject(
+                """
+                {"motionDetailSquare": {"video": "http://example.invalid/insecure.m3u8"},
+                 "motionDetailTall": {"previewFrame": {"width": 1080, "height": 1920}}}
+                """.trimIndent()
+            )
+        )
+        assertNull(selected)
+    }
+
+    @Test
+    fun `tall asset wins over a larger square asset`() {
+        val selected = selectAppleEditorialVideo(
+            JSONObject(
+                """
+                {"motionDetailSquare": {"video": "https://example.invalid/square.m3u8",
+                                        "previewFrame": {"width": 2048, "height": 2048}},
+                 "motionDetailTall": {"video": "https://example.invalid/tall.m3u8",
+                                      "previewFrame": {"width": 1080, "height": 1920}}}
+                """.trimIndent()
+            )
+        )
+        assertEquals("https://example.invalid/tall.m3u8", selected?.url)
+        assertEquals(1080, selected?.width)
+        assertEquals(1920, selected?.height)
+    }
+
+    @Test
+    fun `the highest resolution asset wins within the same orientation`() {
+        val selected = selectAppleEditorialVideo(
+            JSONObject(
+                """
+                {"motionDetailTall": {"video": "https://example.invalid/small.m3u8",
+                                      "previewFrame": {"width": 540, "height": 960}},
+                 "motionTallVideo3x4": {"hlsUrl": "https://example.invalid/large.m3u8",
+                                        "previewFrame": {"width": 1080, "height": 1440}}}
+                """.trimIndent()
+            )
+        )
+        assertEquals("https://example.invalid/large.m3u8", selected?.url)
+    }
+
+    @Test
+    fun `an asset without dimensions is still usable as a fallback`() {
+        val selected = selectAppleEditorialVideo(
+            JSONObject("""{"motionDetailRaw": {"url": "https://example.invalid/raw.m3u8"}}""")
+        )
+        assertEquals("https://example.invalid/raw.m3u8", selected?.url)
+        assertNull(selected?.width)
+        assertNull(selected?.height)
+    }
+
+    @Test
+    fun `a wide asset loses against an undimensioned one`() {
+        val selected = selectAppleEditorialVideo(
+            JSONObject(
+                """
+                {"motionDetailStatic": {"video": "https://example.invalid/wide.m3u8",
+                                        "previewFrame": {"width": 1920, "height": 1080}},
+                 "motionDetailRaw": {"video": "https://example.invalid/raw.m3u8"}}
+                """.trimIndent()
+            )
+        )
+        assertEquals("https://example.invalid/raw.m3u8", selected?.url)
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/feature/motion/CanonicalTrackMatcherTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/feature/motion/CanonicalTrackMatcherTest.kt
@@ -192,6 +192,59 @@ class CanonicalTrackMatcherTest {
         assertNotEquals(MotionArtworkIdentityKey.create(first), MotionArtworkIdentityKey.create(different))
     }
 
+    @Test
+    fun singleWithoutAlbumMetadataStillAcceptsAlbumMotion() {
+        val reference = identity(title = "SWAG MUSIC", artist = "Artie 5ive", album = "")
+        val candidate = albumCandidate(title = "SWAG MUSIC", artist = "Artie 5ive", album = "SWAG MUSIC")
+
+        val match = CanonicalTrackMatcher.match(reference, candidate)
+
+        assertTrue(match.accepted)
+        assertTrue(match.score >= 84)
+    }
+
+    @Test
+    fun singleWithPlaceholderAlbumStillAcceptsAlbumMotion() {
+        val candidate = albumCandidate(title = "SWAG MUSIC", artist = "Artie 5ive", album = "SWAG MUSIC - Single")
+        listOf("YouTube Music", "YouTube Music Video", "YouTube Music Charts", "YouTube").forEach { placeholder ->
+            val reference = identity(title = "SWAG MUSIC", artist = "Artie 5ive", album = placeholder)
+
+            val match = CanonicalTrackMatcher.match(reference, candidate)
+
+            assertTrue("rejected for placeholder $placeholder", match.accepted)
+        }
+    }
+
+    @Test
+    fun singleWithoutAlbumMetadataRejectsAnUnrelatedRelease() {
+        val reference = identity(title = "SWAG MUSIC", artist = "Artie 5ive", album = "")
+        val candidate = albumCandidate(title = "SWAG MUSIC", artist = "Artie 5ive", album = "Greatest Hits")
+
+        val match = CanonicalTrackMatcher.match(reference, candidate)
+
+        assertFalse(match.accepted)
+    }
+
+    @Test
+    fun singleWithoutAlbumMetadataRejectsAnEditionMismatch() {
+        val reference = identity(title = "SWAG MUSIC", artist = "Artie 5ive", album = "")
+        val candidate = albumCandidate(title = "SWAG MUSIC", artist = "Artie 5ive", album = "SWAG MUSIC (Remix)")
+
+        val match = CanonicalTrackMatcher.match(reference, candidate)
+
+        assertFalse(match.accepted)
+    }
+
+    @Test
+    fun realAlbumMetadataStillRequiresTheAlbumToMatch() {
+        val reference = identity(title = "Cenere", artist = "Lazza", album = "Sirio")
+        val candidate = albumCandidate(title = "Cenere", artist = "Lazza", album = "Cenere")
+
+        val match = CanonicalTrackMatcher.match(reference, candidate)
+
+        assertFalse(match.accepted)
+    }
+
     private fun albumCandidate(
         title: String,
         artist: String,

--- a/app/src/test/java/com/luc4n3x/levyra/ui/MotionArtworkScalingTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/MotionArtworkScalingTest.kt
@@ -1,0 +1,74 @@
+package com.luc4n3x.levyra.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MotionArtworkScalingTest {
+
+    @Test
+    fun `unknown video size keeps the surface untouched`() {
+        assertEquals(
+            MotionArtworkFitIdentity,
+            motionArtworkFit(0, 0, 1f, 1080, 2400, MotionArtworkImmersiveMaxZoom)
+        )
+        assertEquals(
+            MotionArtworkFitIdentity,
+            motionArtworkFit(1080, 1920, 1f, 0, 0, MotionArtworkImmersiveMaxZoom)
+        )
+    }
+
+    @Test
+    fun `matching aspect ratio needs no correction`() {
+        val fit = motionArtworkFit(1080, 1920, 1f, 540, 960, MotionArtworkImmersiveMaxZoom)
+        assertEquals(1f, fit.scaleX, 0.0001f)
+        assertEquals(1f, fit.scaleY, 0.0001f)
+    }
+
+    @Test
+    fun `nine by sixteen canvas covers a taller screen without distortion`() {
+        val fit = motionArtworkFit(1080, 1920, 1f, 1080, 2340, MotionArtworkImmersiveMaxZoom)
+        val videoAspect = 1080f / 1920f
+        val containerAspect = 1080f / 2340f
+        assertEquals(videoAspect / containerAspect, fit.scaleX / fit.scaleY, 0.0001f)
+        assertEquals(1f, fit.scaleY, 0.0001f)
+        assertTrue(fit.scaleX > 1f)
+    }
+
+    @Test
+    fun `square canvas on a tall screen stops at the crop budget instead of filling`() {
+        val fit = motionArtworkFit(1080, 1080, 1f, 1080, 2340, MotionArtworkImmersiveMaxZoom)
+        val containerAspect = 1080f / 2340f
+        assertEquals(1f / containerAspect, fit.scaleX / fit.scaleY, 0.0001f)
+        assertEquals(MotionArtworkImmersiveMaxZoom, fit.scaleX, 0.0001f)
+        assertEquals(MotionArtworkImmersiveMaxZoom * containerAspect, fit.scaleY, 0.0001f)
+        assertTrue(fit.scaleY < 1f)
+    }
+
+    @Test
+    fun `card presentation still covers a nine by sixteen canvas`() {
+        val fit = motionArtworkFit(720, 1280, 1f, 900, 900, MotionArtworkCardMaxZoom)
+        assertEquals(1f, fit.scaleX, 0.0001f)
+        assertEquals(1280f / 720f, fit.scaleY, 0.0001f)
+    }
+
+    @Test
+    fun `non square pixels are folded into the video aspect ratio`() {
+        val fit = motionArtworkFit(960, 1080, 2f, 1080, 1080, MotionArtworkCardMaxZoom)
+        assertEquals(2f * 960f / 1080f, fit.scaleX / fit.scaleY, 0.0001f)
+    }
+
+    @Test
+    fun `invalid pixel ratio falls back to square pixels`() {
+        val fit = motionArtworkFit(1080, 1920, 0f, 1080, 1920, MotionArtworkCardMaxZoom)
+        assertEquals(1f, fit.scaleX, 0.0001f)
+        assertEquals(1f, fit.scaleY, 0.0001f)
+    }
+
+    @Test
+    fun `max zoom below one never shrinks past the contain fit`() {
+        val fit = motionArtworkFit(1080, 1080, 1f, 1080, 2340, 0.2f)
+        assertEquals(1f, fit.scaleX, 0.0001f)
+        assertEquals(1080f / 2340f, fit.scaleY, 0.0001f)
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/ui/PlayerAmbienceTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/PlayerAmbienceTest.kt
@@ -1,0 +1,67 @@
+package com.luc4n3x.levyra.ui
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlayerAmbienceTest {
+
+    private fun level(color: Color): Float =
+        0.299f * color.red + 0.587f * color.green + 0.114f * color.blue
+
+    @Test
+    fun `ambience darkens from tint to base`() {
+        val ambience = playerAmbienceOf(Color(0xFF3A7BD5), Color(0xFF00D2FF))
+        assertTrue(level(ambience.tint) > level(ambience.elevated))
+        assertTrue(level(ambience.elevated) > level(ambience.base))
+        assertTrue(level(ambience.base) > 0f)
+    }
+
+    @Test
+    fun `base stays dark enough for white content`() {
+        listOf(
+            Color.White to Color.White,
+            Color(0xFFFFEB3B) to Color(0xFFFF5722),
+            Color(0xFF101010) to Color(0xFF050505)
+        ).forEach { (primary, secondary) ->
+            val base = playerAmbienceOf(primary, secondary).base
+            assertTrue("base too bright for $primary", level(base) < 0.05f)
+        }
+    }
+
+    @Test
+    fun `saturated artwork keeps a trace of its hue`() {
+        val ambience = playerAmbienceOf(Color(0xFF1DB954), Color(0xFF1DB954))
+        assertTrue(ambience.tint.green > ambience.tint.red)
+        assertTrue(ambience.tint.green > ambience.tint.blue)
+        assertTrue(ambience.base.green >= ambience.base.red)
+    }
+
+    @Test
+    fun `pure black artwork degrades to a neutral surface`() {
+        val ambience = playerAmbienceOf(Color.Black, Color.Black)
+        assertEquals(ambience.base.red, ambience.base.green, 0.0001f)
+        assertEquals(ambience.base.green, ambience.base.blue, 0.0001f)
+        assertTrue(level(ambience.base) > 0f)
+    }
+
+    @Test
+    fun `every ambience channel stays opaque and in range`() {
+        val ambience = playerAmbienceOf(Color(0xFFFF00FF), Color(0xFF00FF00))
+        listOf(ambience.tint, ambience.elevated, ambience.base).forEach { color ->
+            assertEquals(1f, color.alpha, 0.0001f)
+            listOf(color.red, color.green, color.blue).forEach {
+                assertTrue(it in 0f..1f)
+            }
+        }
+    }
+
+    @Test
+    fun `mix interpolates between both accents`() {
+        val mixed = Color.Black.playerAmbienceMix(Color.White, 0.5f)
+        assertEquals(0.5f, mixed.red, 0.005f)
+        assertEquals(0f, Color.Black.playerAmbienceMix(Color.White, -1f).red, 0.0001f)
+        assertEquals(1f, Color.Black.playerAmbienceMix(Color.White, 4f).red, 0.0001f)
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/ui/components/SeekbarGeometryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/components/SeekbarGeometryTest.kt
@@ -61,37 +61,6 @@ class SeekbarGeometryTest {
     }
 
     @Test
-    fun `wave sample count stays bounded`() {
-        assertEquals(0, seekbarWaveSampleCount(0f))
-        assertEquals(1, seekbarWaveSampleCount(1f))
-        assertTrue(seekbarWaveSampleCount(100_000f) <= 900)
-    }
-
-    @Test
-    fun `wave amplitude tapers to zero at both edges`() {
-        val activeWidth = 200f
-        val taper = 20f
-        assertEquals(0f, seekbarWaveTaper(0f, activeWidth, taper), 0.0001f)
-        assertEquals(0f, seekbarWaveTaper(activeWidth, activeWidth, taper), 0.0001f)
-        assertEquals(1f, seekbarWaveTaper(100f, activeWidth, taper), 0.0001f)
-    }
-
-    @Test
-    fun `wave offset is flat without amplitude or wavelength`() {
-        assertEquals(0f, seekbarWaveOffset(10f, 0f, 30f, 0f), 0f)
-        assertEquals(0f, seekbarWaveOffset(10f, 4f, 0f, 0f), 0f)
-    }
-
-    @Test
-    fun `wave offset follows the sine of the travelled distance`() {
-        val wavelength = 40f
-        val amplitude = 3f
-        assertEquals(0f, seekbarWaveOffset(0f, amplitude, wavelength, 0f), 0.0001f)
-        assertEquals(amplitude, seekbarWaveOffset(wavelength / 4f, amplitude, wavelength, 0f), 0.0001f)
-        assertEquals(-amplitude, seekbarWaveOffset(3f * wavelength / 4f, amplitude, wavelength, 0f), 0.0001f)
-    }
-
-    @Test
     fun `seek millis is clamped to the track duration`() {
         assertEquals(0L, seekbarSeekMillis(0.5f, 0L))
         assertEquals(30_000L, seekbarSeekMillis(0.5f, 60_000L))

--- a/app/src/test/java/com/luc4n3x/levyra/ui/i18n/LevyraStringsTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/i18n/LevyraStringsTest.kt
@@ -313,4 +313,22 @@ class LevyraStringsTest {
             }
         }
     }
+
+
+    @Test
+    fun youtubePlaybackErrorsRequirePlaybackContext() {
+        val english = LevyraStrings.forCode("en")
+        val italian = LevyraStrings.forCode("it")
+
+        assertEquals(english.operationFailed, english.localizeUserError("HTTP 403"))
+        assertEquals(italian.operationFailed, italian.localizeUserError("HTTP 429"))
+        assertEquals(
+            "YouTube rejected this track link: try again",
+            english.localizeUserError("HTTP 403", youtubePlayback = true)
+        )
+        assertEquals(
+            "Troppe richieste a YouTube: attendi qualche secondo",
+            italian.localizeUserError("HTTP 429", youtubePlayback = true)
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Refines Levyra's fullscreen Now Playing and Canvas presentation while hardening the playback-resolution edge cases found during physical-device testing. The player keeps an artwork-first, no-scroll portrait composition with always-visible secondary actions, modern transport controls and a Samsung/One UI-inspired squiggly seekbar. Motion artwork preserves its source aspect ratio, and the resolver now rejects unusable video/cache candidates instead of allowing them to block a fresh resolution path.

## What changed

- Preserved motion-artwork aspect ratios with presentation-aware Card and Immersive fitting, bounded zoom and real decoded video dimensions.
- Reworked the fullscreen player around a calmer ambience, tighter portrait spacing and a cleaner mini-player/full-player visual language.
- Replaced the expandable secondary-controls chevron in the active player with an always-visible quick-action row for queue, lyrics, download and playback options.
- Kept speed, sleep timer and normalization in a compact options surface without making the standard portrait player scrollable.
- Modernized transport controls and active states while preserving the existing callbacks and accessibility semantics.
- Refined `PremiumSeekbar` into a soft squiggly played-progress treatment inspired by the system media control: the curve is cached, the unplayed portion remains straight, and scrubbing crossfades the squiggle into a precise flat track.
- Rejected failed/no-op YouTube `n` transformations instead of returning throttled URLs to Media3.
- Added VisionOS as an additional classic progressive-stream fallback without adopting PipePipeExtractor's later SABR/Media3-incompatible rewrite.
- Preserved the canonical audio identity across Video → Song round trips.
- Validated video payloads at prefetch and persistent-cache ingress so audio-only video-mode candidates fall through instead of becoming unusable cached results.
- Reset motion-video readiness/failure state when switching Card ↔ Immersive presentation so a recreated player cannot inherit stale first-frame state.
- Scoped YouTube-specific error copy to playback errors only; backup, shared-media and offline-export errors keep generic handling.
- Stopped the playback ticker from erasing a failed mode-switch error merely because the previous source is still playing.
- Honored the user animation setting across ambience, Canvas fusion, artwork shadow, shelf and mini-player progress transitions.
- Preserved the quick-action accessibility label while its icon is replaced by a busy progress indicator.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Performance improvement
- [x] Refactor or maintenance
- [x] UI or UX change
- [x] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** Player / Streaming / UI / Localization

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease` — final GitHub `PR Check` is running on head `838e8afa`; build-input validation, AI Quality Gate, runtime compatibility scan and extractor tests have passed, with the remaining lint/test/release stages still running at the time of this update.
- [ ] Desktop: `cd desktop && ./gradlew check assemble` — N/A; no Desktop code is changed.
- [x] Focused Android compilation and `:app:testDebugUnitTest` passed for `LevyraStringsTest`, `AppleEditorialVideoSelectionTest`, `MotionArtworkScalingTest` and `VideoPlaybackContractTest` on the staged review-fix tree.
- [x] `git diff --check` passed for the staged review fixes.
- [x] Dependency Review passed on the final head.
- [x] APK Size Report passed on the final head.
- [x] Editorial Catalog passed on the final head.
- [x] CodeRabbit status is green; all 9 inline findings were individually verified, answered and resolved. The final touch-target finding required no code change because Levyra's `pressable` delegates to Compose `clickable`/`combinedClickable`, which already expands undersized clickable hit targets at the input layer without changing measured layout size.
- [x] The CodeRabbit fix commit is isolated to seven reviewed app/test files and does not modify `PremiumSeekbar.kt` or introduce temporary workflow/script files.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Samsung SM-S936B, Android 16 / SDK 36 | Previously failing songs after the resolution-path fix | Passed — songs start and continue normally |
| Samsung SM-S936B, Android 16 / SDK 36 | Video playback after the resolution-path fix | Passed for tested videos except the isolated `Da Dio` / Bresh case below |
| Samsung SM-S936B, Android 16 / SDK 36 | Final fullscreen controls and current squiggly seekbar | Not yet re-tested on device |

## Risk and compatibility

- **Risk level:** Medium
- **Compatibility or migration notes:** No database migration, new dependency, Android permission or playback-service ownership change. Media3 remains the playback stack.
- **Known limitations:** One isolated official-video case, **Da Dio — Bresh**, was observed returning `YouTube ha rifiutato il link` while other tested videos play. It is intentionally left for a separate extractor-focused change rather than adding another hypothesis to this player PR. The final visual polish still needs a physical-device pass for the intended S25+ no-scroll composition and seekbar appearance.
- **Rollback plan:** Revert this PR. No user-data or schema cleanup is required.

## Reviewer notes

- `PlaybackResolver.kt` / `YoutubeClientIdentityInterceptor.kt`: review fail-closed throttling handling, progressive client ordering and video-payload validation. Audio playback ownership is unchanged.
- `MotionArtworkLayer.kt` / `MotionArtworkScaling.kt`: review aspect-ratio preservation and presentation-keyed first-frame state.
- `LevyraApp.kt`: the active fullscreen composition uses permanent compact quick actions rather than an expandable advanced panel; animation-disabled paths now snap instead of tweening.
- `PremiumSeekbar.kt`: the squiggle geometry is cached and clipped to played progress; there is no per-tick path reconstruction or perpetual waveform animation.
- The newer PipePipeExtractor SABR rewrite is intentionally not imported because Levyra remains Media3-based.

## Release note

Now Playing is cleaner and more compact, Canvas keeps its proper proportions, the progress bar has a softer system-inspired squiggle, and playback resolution falls back more safely when a cached or throttled source is unusable.

## Related issues

- Related to #380
- Related to #382

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, localization and accessibility were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR — the final PR Check and signed APK build are still running; no current failure is being hidden
