### PR TITLE
fix(extractor): skip adaptive YouTube audio streams capped at ~1 MiB

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -2018,7 +2018,11 @@ class PlaybackResolver private constructor(private val context: Context) {
         val audio = selectAudioStream(completeAudioStreams, preferMp4Audio, audioQuality)
         val muxedAudioSource = if (audio == null && !preferMp4Audio) {
             info.videoStreams.firstOrNull {
-                it.isUrl && YoutubeStreamCapability.servesCompleteStream(it.content)
+                it.isUrl &&
+                    it.content.isNotBlank() &&
+                    YoutubeStreamCapability.servesCompleteStream(it.content) &&
+                    !isPlaybackUrlBlocked(it.content) &&
+                    streamStillFresh(it.content)
             }
         } else {
             null
@@ -2051,7 +2055,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 .map { audioDescriptor(it, it.content == url) }
                 .toList()
 
-            muxedAudioSource != null -> listOf(innerTubeAudioDescriptor(null, url))
+            muxedAudioSource != null -> listOf(videoDescriptor(extractorVideoCandidate(muxedAudioSource), true))
             else -> listOf(hlsDescriptor(url))
         }
         val manifest = buildManifest(
@@ -2097,7 +2101,10 @@ class PlaybackResolver private constructor(private val context: Context) {
         ).withYoutubeEngagement(info.likeCount, info.viewCount)
         cacheYoutubeEngagement(sourceVideoId, info.likeCount, info.viewCount)
         val durationMs = if (info.duration > 0L) info.duration * 1000L else track.durationMs
-        val selectedAudio = selectAudioStream(info.audioStreams, preferMp4Audio = false, audioQuality = audioQuality)
+        val completeAudioStreams = info.audioStreams.filter {
+            it.isUrl && YoutubeStreamCapability.servesCompleteStream(it.content)
+        }
+        val selectedAudio = selectAudioStream(completeAudioStreams, preferMp4Audio = false, audioQuality = audioQuality)
         val bestAudio = selectedAudio?.content.orEmpty()
         val muxedCandidates = info.videoStreams
             .filter { it.isUrl && it.content.isNotBlank() && streamStillFresh(it.content) }
@@ -2115,9 +2122,13 @@ class PlaybackResolver private constructor(private val context: Context) {
             val selectedAudioUrl = if (selection.candidate.muxed) selection.candidate.url else bestAudio
             val selectedVideoUrl = if (selection.candidate.muxed) "" else selection.candidate.url
             val descriptors = buildList {
-                info.audioStreams
+                completeAudioStreams
                     .asSequence()
-                    .filter { it.isUrl && it.content.isNotBlank() && streamStillFresh(it.content) }
+                    .filter {
+                        it.content.isNotBlank() &&
+                            !isPlaybackUrlBlocked(it.content) &&
+                            streamStillFresh(it.content)
+                    }
                     .mapTo(this) { audioDescriptor(it, it.content == selectedAudioUrl) }
                 muxedCandidates.mapTo(this) { videoDescriptor(it, it.url == selection.candidate.url) }
                 videoOnlyCandidates.mapTo(this) { videoDescriptor(it, it.url == selection.candidate.url) }

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -2012,13 +2012,23 @@ class PlaybackResolver private constructor(private val context: Context) {
         val sourceVideoUrl = "https://www.youtube.com/watch?v=$sourceVideoId"
         val info = StreamInfo.getInfo(ServiceList.YouTube, sourceVideoUrl)
         currentCoroutineContext().ensureActive()
-        val audio = selectAudioStream(info.audioStreams, preferMp4Audio, audioQuality)
-        val hlsUrl = if (audio == null && !preferMp4Audio) {
+        val completeAudioStreams = info.audioStreams.filter {
+            it.isUrl && YoutubeStreamCapability.servesCompleteStream(it.content)
+        }
+        val audio = selectAudioStream(completeAudioStreams, preferMp4Audio, audioQuality)
+        val muxedAudioSource = if (audio == null && !preferMp4Audio) {
+            info.videoStreams.firstOrNull {
+                it.isUrl && YoutubeStreamCapability.servesCompleteStream(it.content)
+            }
+        } else {
+            null
+        }
+        val hlsUrl = if (audio == null && muxedAudioSource == null && !preferMp4Audio) {
             info.hlsUrl.takeIf { isVerifiedHlsManifest(it) }
         } else {
             null
         }
-        val url = audio?.content ?: hlsUrl
+        val url = audio?.content ?: muxedAudioSource?.content ?: hlsUrl
             ?: throw IllegalStateException("LevyraExtractor non ha restituito stream audio diretti o HLS per ${track.title}")
         val bestThumb = info.thumbnails.maxByOrNull { image ->
             image.width.coerceAtLeast(0) * image.height.coerceAtLeast(0)
@@ -2029,15 +2039,20 @@ class PlaybackResolver private constructor(private val context: Context) {
             donor = track.copy(thumbnailUrl = bestThumb, largeThumbnailUrl = bestThumb)
         )
         val durationMs = if (info.duration > 0L) info.duration * 1000L else track.durationMs
-        val provider = if (audio != null) LEVYRA_EXTRACTOR_PROVIDER else LEVYRA_EXTRACTOR_HLS_PROVIDER
-        val descriptors = if (audio != null) {
-            info.audioStreams
+        val provider = if (audio != null || muxedAudioSource != null) {
+            LEVYRA_EXTRACTOR_PROVIDER
+        } else {
+            LEVYRA_EXTRACTOR_HLS_PROVIDER
+        }
+        val descriptors = when {
+            audio != null -> completeAudioStreams
                 .asSequence()
-                .filter { it.isUrl && it.content.isNotBlank() && streamStillFresh(it.content) }
+                .filter { it.content.isNotBlank() && streamStillFresh(it.content) }
                 .map { audioDescriptor(it, it.content == url) }
                 .toList()
-        } else {
-            listOf(hlsDescriptor(url))
+
+            muxedAudioSource != null -> listOf(innerTubeAudioDescriptor(null, url))
+            else -> listOf(hlsDescriptor(url))
         }
         val manifest = buildManifest(
             sourceVideoId = sourceVideoId,
@@ -2051,10 +2066,10 @@ class PlaybackResolver private constructor(private val context: Context) {
             streamUrl = url,
             videoStreamUrl = "",
             durationMs = durationMs,
-            source = if (audio != null) {
-                "LevyraExtractor${label.takeIf { it.isNotBlank() }?.let { " · $it" }.orEmpty()}"
-            } else {
-                LEVYRA_EXTRACTOR_HLS_PROVIDER
+            source = when {
+                audio != null -> "LevyraExtractor${label.takeIf { it.isNotBlank() }?.let { " · $it" }.orEmpty()}"
+                muxedAudioSource != null -> LEVYRA_EXTRACTOR_PROVIDER
+                else -> LEVYRA_EXTRACTOR_HLS_PROVIDER
             },
             playbackManifest = manifest
         ).withYoutubeEngagement(info.likeCount, info.viewCount).also {

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeStreamCapability.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeStreamCapability.kt
@@ -11,11 +11,24 @@ internal object YoutubeStreamCapability {
 
     private fun isGoogleVideoMedia(lowerUrl: String): Boolean {
         if (!lowerUrl.startsWith("https://")) return false
-        val host = lowerUrl.substringAfter("https://").substringBefore('/').substringBefore(':')
-        if (!host.endsWith("googlevideo.com")) return false
-        val path = lowerUrl.substringAfter(host).substringBefore('?')
-        if (path.endsWith(".m3u8") || path.endsWith(".mpd")) return false
+        val authority = lowerUrl.substringAfter("https://").substringBefore('/')
+        val host = authority.substringBefore(':')
+        if (host != "googlevideo.com" && !host.endsWith(".googlevideo.com")) return false
+        if (isManifestUrl(lowerUrl)) return false
+        val path = lowerUrl.substringAfter("https://$authority").substringBefore('?').substringBefore('#')
         return path.contains("videoplayback")
+    }
+
+    private fun isManifestUrl(lowerUrl: String): Boolean {
+        val clean = lowerUrl.substringBefore('#')
+        val path = clean.substringBefore('?')
+        return path.endsWith(".m3u8") ||
+            path.endsWith(".mpd") ||
+            path.contains("/hls_playlist") ||
+            path.contains("/manifest/hls") ||
+            clean.contains("mime=application%2fx-mpegurl") ||
+            clean.contains("mime=application/vnd.apple.mpegurl") ||
+            clean.contains("type=application%2fx-mpegurl")
     }
 
     private fun queryParameter(url: String, name: String): String? {

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeStreamCapability.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeStreamCapability.kt
@@ -1,0 +1,28 @@
+package com.luc4n3x.levyra.data
+
+internal object YoutubeStreamCapability {
+    fun servesCompleteStream(url: String): Boolean {
+        if (url.isBlank()) return false
+        val lower = url.lowercase()
+        if (!isGoogleVideoMedia(lower)) return true
+        if (queryParameter(lower, "ratebypass") == "yes") return true
+        return !queryParameter(lower, "pot").isNullOrBlank()
+    }
+
+    private fun isGoogleVideoMedia(lowerUrl: String): Boolean {
+        if (!lowerUrl.startsWith("https://")) return false
+        val host = lowerUrl.substringAfter("https://").substringBefore('/').substringBefore(':')
+        if (!host.endsWith("googlevideo.com")) return false
+        val path = lowerUrl.substringAfter(host).substringBefore('?')
+        if (path.endsWith(".m3u8") || path.endsWith(".mpd")) return false
+        return path.contains("videoplayback")
+    }
+
+    private fun queryParameter(url: String, name: String): String? {
+        val query = url.substringAfter('?', "").takeIf { it.isNotEmpty() } ?: return null
+        return query.split('&')
+            .firstOrNull { it.startsWith("$name=") }
+            ?.substringAfter('=')
+            ?.takeIf { it.isNotEmpty() }
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeStreamCapabilityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeStreamCapabilityTest.kt
@@ -1,0 +1,47 @@
+package com.luc4n3x.levyra.data
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class YoutubeStreamCapabilityTest {
+    private val adaptiveAudioWithoutToken =
+        "https://rr3---sn-example.googlevideo.com/videoplayback?expire=1786904043&itag=251&" +
+            "source=youtube&requiressl=yes&mime=audio%2Fwebm&gir=yes&clen=3168361&c=ANDROID_VR&lsig=abc"
+
+    private val progressiveMuxed =
+        "https://rr3---sn-example.googlevideo.com/videoplayback?expire=1786904043&itag=18&" +
+            "source=youtube&requiressl=yes&mime=video%2Fmp4&ratebypass=yes&clen=15857332&c=ANDROID_VR&lsig=abc"
+
+    private val adaptiveAudioWithToken = "$adaptiveAudioWithoutToken&pot=token-value"
+
+    @Test
+    fun `adaptive stream without ratebypass or proof of origin cannot serve a full track`() {
+        assertFalse(YoutubeStreamCapability.servesCompleteStream(adaptiveAudioWithoutToken))
+    }
+
+    @Test
+    fun `progressive ratebypass stream serves a full track`() {
+        assertTrue(YoutubeStreamCapability.servesCompleteStream(progressiveMuxed))
+    }
+
+    @Test
+    fun `adaptive stream with a proof of origin token serves a full track`() {
+        assertTrue(YoutubeStreamCapability.servesCompleteStream(adaptiveAudioWithToken))
+    }
+
+    @Test
+    fun `non googlevideo and manifest urls stay eligible`() {
+        assertTrue(YoutubeStreamCapability.servesCompleteStream("https://example.com/audio.m4a"))
+        assertTrue(
+            YoutubeStreamCapability.servesCompleteStream(
+                "https://rr3---sn-example.googlevideo.com/videoplayback/hls_playlist/index.m3u8?itag=251"
+            )
+        )
+    }
+
+    @Test
+    fun `a blank url is never eligible`() {
+        assertFalse(YoutubeStreamCapability.servesCompleteStream(""))
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeStreamCapabilityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeStreamCapabilityTest.kt
@@ -41,6 +41,29 @@ class YoutubeStreamCapabilityTest {
     }
 
     @Test
+    fun `googlevideo lookalike host is not treated as googlevideo`() {
+        assertTrue(
+            YoutubeStreamCapability.servesCompleteStream(
+                "https://notgooglevideo.com/videoplayback?itag=251&mime=audio%2Fwebm"
+            )
+        )
+    }
+
+    @Test
+    fun `extensionless and mime signaled hls urls stay eligible`() {
+        assertTrue(
+            YoutubeStreamCapability.servesCompleteStream(
+                "https://rr3---sn-example.googlevideo.com/videoplayback/hls_playlist?itag=251"
+            )
+        )
+        assertTrue(
+            YoutubeStreamCapability.servesCompleteStream(
+                "https://rr3---sn-example.googlevideo.com/videoplayback?itag=251&mime=application%2Fx-mpegURL"
+            )
+        )
+    }
+
+    @Test
     fun `a blank url is never eligible`() {
         assertFalse(YoutubeStreamCapability.servesCompleteStream(""))
     }


### PR DESCRIPTION
## Problem

Some YouTube songs started and then stopped roughly 20-57 seconds in, with the UI
message "YouTube ha rifiutato il link del brano". The same content played
perfectly in video mode. Most other songs were unaffected.

## Reproduction

Reproduced on a physical device (SM-S936B, Android 16, SDK 36) with `adb`:

```
E ExoPlayerImplInternal: Playback error
E ExoPlayerImplInternal:   Caused by: HttpDataSource$InvalidResponseCodeException: Response code: 403
```

Temporary sanitized diagnostics in the Media3 data source identified the exact
stream:

```
c=ANDROID_VR itag=251 mime=audio/webm n=false pot=false expire=... -> 403
c=ANDROID_VR itag=18  mime=video/mp4                              -> 200
```

## Root cause

The winning resolution path is `restorePersistentSource` ->
`refreshExactPersistentSource` -> `resolveWithLevyraExtractor`. The adaptive
audio URL it returns carries neither `ratebypass=yes` nor a proof-of-origin
token (`pot`). googlevideo serves roughly the first mebibyte of such a URL and
then rejects every continuation request with 403, so the track always died once
the initial buffer was consumed.

Measured on-device against the failing URL at offset 393216, at the same moment,
same User-Agent:

| request | result |
| --- | --- |
| `Range: bytes=393216-` | 403 |
| `Range: bytes=393216-394239` | 206 |
| `Range: bytes=393216-<clen-1>` | 403 |
| a bounded range once ~1 MiB had been served | 403 |

A freshly minted URL answers 206 for the same ranges, so the URL and its
signature are valid: the cap is on how much a token-less adaptive stream may
serve, not on the request shape. `itag=18` carries `ratebypass=yes` and is not
capped, which is why video mode never failed.

## Working vs failing

- failing: adaptive audio (`itag` 251/140) without `ratebypass` and without `pot`.
- working: progressive muxed (`itag` 18, `ratebypass=yes`), and any adaptive
  stream that does carry a `pot` token.

Songs whose selected stream is progressive, or short enough to fit in the first
mebibyte, were never affected — hence the partial symptom.

## Fix

`YoutubeStreamCapability.servesCompleteStream(url)` states the rule: a
googlevideo media URL can serve a whole track only when it carries
`ratebypass=yes` or a proof-of-origin token. `resolveWithLevyraExtractor` now
selects only audio streams that satisfy it and, when none does, reuses the
progressive muxed stream already returned in the same response as the audio
source. Non-googlevideo and manifest URLs are untouched.

No hardcoded video id, artist or URL. No new client, no extra fallback layer, no
retry or timeout changes, no Media3 change.

## Regression tests

`app/src/test/java/com/luc4n3x/levyra/data/YoutubeStreamCapabilityTest.kt` pins
the observed contract: a token-less adaptive URL is rejected, `ratebypass=yes`
and `pot` URLs are accepted, non-googlevideo and manifest URLs stay eligible.

## Device validation

- "Da Dio" - Bresh in song mode: plays past the previous 57 s wall, zero 403 in logcat.
- Video mode for the same track: unchanged.
- Next track and a previously working song: unchanged.

## Automated validation

```
./gradlew --no-daemon :app:testDebugUnitTest      # BUILD SUCCESSFUL
./gradlew --no-daemon :app:assembleDebug          # BUILD SUCCESSFUL
python scripts/ai_quality_gate.py --profile fast  # AI quality gate passed
git diff --check                                  # clean
```

## Risk

The selection only removes candidates that provably cannot serve a complete
track, and the muxed fallback is the stream video mode already plays, so tracks
that work today keep the same stream. The muxed fallback costs extra bandwidth
because it carries a video track; it is used only when no adaptive audio stream
qualifies. If YouTube later serves `pot`-bearing adaptive audio on this path,
those streams qualify again automatically and the fallback stops being used.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback stream selection by prioritizing complete audio streams.
  * Added fallback support for complete combined video streams and verified HLS streams when suitable audio is unavailable.
  * Prevented incomplete or invalid stream URLs from being selected for playback.
  * Preserved MP4-preferred offline playback behavior without using streaming fallbacks.

* **Tests**
  * Added coverage for stream URL validation across adaptive, progressive, HLS, and invalid URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->