### PR TITLE
Fix Search artist artwork, duplicate albums, and video thumbnails

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -7564,16 +7564,21 @@ private fun HomeMusicVideoShelf(
 private val HomeVideoIdPattern = Regex("[A-Za-z0-9_-]{11}")
 
 private fun homeMusicVideoPreviewTrack(track: Track): Track {
-    val videoId = track.counterpartVideoId
+    val videoId = PlaybackSourceIdentity.sourceVideoId(track)
         .trim()
         .takeIf(HomeVideoIdPattern::matches)
-        ?: PlaybackSourceIdentity.sourceVideoId(track)
+        ?: track.counterpartVideoId
             .trim()
             .takeIf(HomeVideoIdPattern::matches)
         ?: return track
+    val stableVideoThumbnail = "https://i.ytimg.com/vi/$videoId/hqdefault.jpg"
+    val fallbackThumbnail = track.thumbnailUrl
+        .trim()
+        .ifBlank { track.largeThumbnailUrl.trim() }
+        .ifBlank { "https://i.ytimg.com/vi/$videoId/mqdefault.jpg" }
     return track.copy(
-        thumbnailUrl = "https://i.ytimg.com/vi/$videoId/mqdefault.jpg",
-        largeThumbnailUrl = "https://i.ytimg.com/vi/$videoId/maxresdefault.jpg"
+        thumbnailUrl = fallbackThumbnail,
+        largeThumbnailUrl = stableVideoThumbnail
     )
 }
 
@@ -8799,6 +8804,10 @@ private fun SearchScreen(viewModel: SearchViewModel, state: LevyraUiState) {
     val keyboardController = LocalSoftwareKeyboardController.current
     var addTarget by remember { mutableStateOf<Track?>(null) }
 
+    LaunchedEffect(state.languageCode) {
+        viewModel.refreshArtistSuggestions()
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -8852,10 +8861,17 @@ private fun SearchScreen(viewModel: SearchViewModel, state: LevyraUiState) {
 
                 item {
                     val fallbackSuggestions = LevyraContentLocales.artistSuggestions(state.languageCode)
-                    SuggestionsList(
+                    SearchArtistSuggestions(
                         title = LevyraContentLocales.artistSuggestionsTitle(state.languageCode),
-                        suggestions = fallbackSuggestions,
-                        onSuggestionClick = { query ->
+                        artists = state.homeArtists,
+                        fallbackNames = fallbackSuggestions,
+                        loading = state.homeArtistsLoading,
+                        onArtistClick = { hit ->
+                            focusManager.clearFocus()
+                            keyboardController?.hide()
+                            viewModel.openArtistFromHit(hit)
+                        },
+                        onFallbackClick = { query ->
                             focusManager.clearFocus()
                             keyboardController?.hide()
                             viewModel.setQuery(query)

--- a/app/src/main/java/com/luc4n3x/levyra/ui/SearchArtistSuggestions.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/SearchArtistSuggestions.kt
@@ -1,0 +1,272 @@
+package com.luc4n3x.levyra.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowForward
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import com.luc4n3x.levyra.domain.ArtistHit
+
+@Composable
+internal fun SearchArtistSuggestions(
+    title: String,
+    artists: List<ArtistHit>,
+    fallbackNames: List<String>,
+    loading: Boolean,
+    onArtistClick: (ArtistHit) -> Unit,
+    onFallbackClick: (String) -> Unit,
+) {
+    val visibleArtists = artists
+        .asSequence()
+        .filter { it.name.isNotBlank() && it.thumbnailUrl.isNotBlank() }
+        .distinctBy { artist -> artist.browseId.ifBlank { artist.name.trim().lowercase() } }
+        .take(7)
+        .toList()
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text(
+            text = title,
+            color = MaterialTheme.colorScheme.onBackground,
+            fontSize = 27.sp,
+            lineHeight = 31.sp,
+            fontWeight = FontWeight.Black,
+        )
+
+        when {
+            visibleArtists.isNotEmpty() -> {
+                visibleArtists.forEach { artist ->
+                    SearchArtistSuggestionRow(
+                        artist = artist,
+                        onClick = { onArtistClick(artist) },
+                    )
+                }
+            }
+
+            loading -> {
+                repeat(5) {
+                    SearchArtistSuggestionSkeleton()
+                }
+            }
+
+            else -> {
+                fallbackNames.take(7).forEach { name ->
+                    SearchArtistFallbackRow(
+                        name = name,
+                        onClick = { onFallbackClick(name) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SearchArtistSuggestionRow(
+    artist: ArtistHit,
+    onClick: () -> Unit,
+) {
+    val shape = RoundedCornerShape(18.dp)
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.42f),
+        border = BorderStroke(
+            width = 1.dp,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.07f),
+        ),
+        shape = shape,
+        shadowElevation = 1.dp,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            AsyncImage(
+                model = artist.thumbnailUrl,
+                contentDescription = artist.name,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(54.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surface)
+                    .border(
+                        width = 1.dp,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+                        shape = CircleShape,
+                    ),
+            )
+
+            Spacer(modifier = Modifier.width(14.dp))
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                Text(
+                    text = artist.name,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontSize = 17.sp,
+                    fontWeight = FontWeight.ExtraBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (artist.subscribers.isNotBlank()) {
+                    Text(
+                        text = artist.subscribers,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+
+            Box(
+                modifier = Modifier
+                    .size(36.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.055f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.ArrowForward,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.72f),
+                    modifier = Modifier.size(19.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SearchArtistFallbackRow(
+    name: String,
+    onClick: () -> Unit,
+) {
+    val shape = RoundedCornerShape(18.dp)
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.34f),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f)),
+        shape = shape,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(54.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.11f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Person,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp),
+                )
+            }
+            Spacer(modifier = Modifier.width(14.dp))
+            Text(
+                text = name,
+                modifier = Modifier.weight(1f),
+                color = MaterialTheme.colorScheme.onSurface,
+                fontSize = 17.sp,
+                fontWeight = FontWeight.ExtraBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Icon(
+                imageVector = Icons.Rounded.ArrowForward,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(19.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SearchArtistSuggestionSkeleton() {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.26f),
+        shape = RoundedCornerShape(18.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(54.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f)),
+            )
+            Spacer(modifier = Modifier.width(14.dp))
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(7.dp),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(0.46f)
+                        .height(15.dp)
+                        .clip(RoundedCornerShape(99.dp))
+                        .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f)),
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(0.28f)
+                        .height(10.dp)
+                        .clip(RoundedCornerShape(99.dp))
+                        .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.05f)),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -171,6 +171,7 @@ class SearchViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::sea
     fun playFrom(list: List<Track>, track: Track, loopOnCompletion: Boolean = false) = root.playFrom(list, track, loopOnCompletion)
     fun playNext(track: Track) = root.playNext(track)
     fun removeRecentSearch(track: Track) = root.removeRecentSearch(track)
+    fun refreshArtistSuggestions() = root.refreshHomeArtists()
     fun searchNow() = root.searchNow()
     fun searchNow(query: String) = root.searchNow(query)
     fun setQuery(query: String) = root.setQuery(query)
@@ -823,6 +824,8 @@ private data class SearchProjection(
     val downloadingTrackIds: Set<String>,
     val downloads: List<DownloadedTrack>,
     val favoriteIds: Set<String>,
+    val homeArtists: List<ArtistHit>,
+    val homeArtistsLoading: Boolean,
     val isPlaying: Boolean,
     val isResolving: Boolean,
     val isSearching: Boolean,
@@ -844,6 +847,8 @@ private fun searchProjection(state: LevyraUiState): SearchProjection = SearchPro
     downloadingTrackIds = state.downloadingTrackIds,
     downloads = state.downloads,
     favoriteIds = state.favoriteIds,
+    homeArtists = state.homeArtists,
+    homeArtistsLoading = state.homeArtistsLoading,
     isPlaying = state.isPlaying,
     isResolving = state.isResolving,
     isSearching = state.isSearching,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -4183,6 +4183,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         }
     }
 
+    private fun searchAlbumDeduplicationKey(album: AlbumHit): String =
+        "${albumRecommendationTextKey(album.title)}|${albumRecommendationTextKey(album.artist)}"
+
     private suspend fun searchAlbumsForArtistQuery(
         query: String,
         raw: SearchResults,
@@ -4214,7 +4217,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                     releaseType = release.releaseType
                 )
             }
-            .distinctBy(::albumRecommendationDeduplicationKey)
+            .distinctBy(::searchAlbumDeduplicationKey)
             .take(10)
             .toList()
         if (officialAlbums.isNotEmpty()) return officialAlbums
@@ -4226,7 +4229,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             .toSet()
         return raw.albums
             .filterNot { album -> albumRecommendationTextKey(album.title) in songTitles }
-            .distinctBy(::albumRecommendationDeduplicationKey)
+            .distinctBy(::searchAlbumDeduplicationKey)
             .take(10)
     }
 
@@ -4583,7 +4586,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             val searchData = current.searchData.copy(
                 topTrack = current.searchData.topTrack?.let(::withArtwork),
                 songs = current.searchData.songs.map(::withArtwork),
-                albums = current.searchData.albums.map(::withAlbumMetadata)
+                albums = current.searchData.albums
+                    .map(::withAlbumMetadata)
+                    .distinctBy(::searchAlbumDeduplicationKey)
             )
             val albumDetail = current.albumDetail?.let { detail ->
                 detail.copy(


### PR DESCRIPTION
## Summary
- replace the idle text-only artist suggestions with artwork-backed artist cards using Levyra's existing curated artist source
- refresh and observe artist artwork while Search is visible, with loading and fallback states
- deduplicate Search albums by normalized visible title + artist, including after metadata enrichment
- make Home video cards use the authoritative playback video ID first and a reliable YouTube thumbnail fallback chain

## Fixes
- Search now presents artists with circular artwork and clearer tappable cards instead of generic suggestion rows
- artist release variants that resolve to the same visible album no longer render as repeated cards (for example repeated `After Hours` results for The Weeknd)
- Home video cards no longer depend on `maxresdefault`, which is not available for every video; they preserve existing artwork and fall back through `hqdefault`/`mqdefault` using the resolved video ID

## Scope
- Search UI/state and Home video preview artwork only
- no playback, extractor, release, or unrelated navigation behavior changes

## Verification
- final branch reduced to one scoped commit
- `git diff --check` passed while applying the video thumbnail patch
- PR CI is rerunning against the updated head
