### PR TITLE
Multi-entity search results and album/playlist batch downloads

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/SearchEntityIdentity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/SearchEntityIdentity.kt
@@ -48,6 +48,12 @@ internal fun searchPlaylistMetadataKey(playlist: PlaylistHit): String {
     return "playlist:$title|$author"
 }
 
+internal fun nextSearchContinuation(requested: String, returned: String): String {
+    val cleanReturned = returned.trim()
+    if (cleanReturned.isBlank()) return ""
+    return if (cleanReturned == requested.trim()) "" else cleanReturned
+}
+
 internal fun isMusicVideoResult(videoType: String): Boolean {
     val normalized = videoType.trim().uppercase(Locale.ROOT)
     if (normalized.isBlank()) return false

--- a/app/src/main/java/com/luc4n3x/levyra/data/SearchEntityIdentity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/SearchEntityIdentity.kt
@@ -1,0 +1,155 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.domain.AlbumHit
+import com.luc4n3x.levyra.domain.ArtistHit
+import com.luc4n3x.levyra.domain.PlaylistHit
+import com.luc4n3x.levyra.domain.ReleaseType
+import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.domain.artistIdentityKey
+import com.luc4n3x.levyra.domain.primaryArtistSegment
+import java.util.Locale
+
+internal fun searchSongIdentityKey(track: Track): String =
+    track.id.trim().lowercase(Locale.ROOT)
+
+internal fun searchAlbumCanonicalKey(album: AlbumHit): String {
+    val browseId = album.browseId.trim().lowercase(Locale.ROOT)
+    if (browseId.isNotBlank()) return "browse:$browseId"
+    val playlistId = album.audioPlaylistId.trim().lowercase(Locale.ROOT)
+    if (playlistId.isNotBlank()) return "playlist:$playlistId"
+    val upc = album.upc.filter(Char::isLetterOrDigit).lowercase(Locale.ROOT)
+    if (upc.isNotBlank()) return "upc:$upc"
+    return ""
+}
+
+internal fun searchAlbumMetadataKey(album: AlbumHit): String = homeAlbumDeduplicationKey(album)
+
+internal fun searchArtistCanonicalKey(artist: ArtistHit): String {
+    val browseId = artist.browseId.trim().lowercase(Locale.ROOT)
+    return if (browseId.isBlank()) "" else "browse:$browseId"
+}
+
+internal fun searchArtistMetadataKey(artist: ArtistHit): String {
+    val primary = artistIdentityKey(primaryArtistSegment(artist.name))
+    return if (primary.isBlank()) "" else "artist:$primary"
+}
+
+internal fun searchPlaylistCanonicalKey(playlist: PlaylistHit): String {
+    val playlistId = playlist.playlistId.trim().lowercase(Locale.ROOT)
+    if (playlistId.isNotBlank()) return "playlist:$playlistId"
+    val browseId = playlist.browseId.trim().lowercase(Locale.ROOT)
+    return if (browseId.isBlank()) "" else "browse:$browseId"
+}
+
+internal fun searchPlaylistMetadataKey(playlist: PlaylistHit): String {
+    val title = albumRecommendationTextKey(playlist.title)
+    if (title.isBlank()) return ""
+    val author = albumRecommendationTextKey(primaryArtistSegment(playlist.author))
+    return "playlist:$title|$author"
+}
+
+internal fun isMusicVideoResult(videoType: String): Boolean {
+    val normalized = videoType.trim().uppercase(Locale.ROOT)
+    if (normalized.isBlank()) return false
+    return normalized != MUSIC_VIDEO_TYPE_AUDIO
+}
+
+internal fun mergeSearchSongs(existing: List<Track>, incoming: List<Track>): List<Track> =
+    mergeSearchEntities(existing, incoming, ::searchSongIdentityKey, { "" }, ::richerSong)
+
+internal fun mergeSearchAlbums(existing: List<AlbumHit>, incoming: List<AlbumHit>): List<AlbumHit> =
+    mergeSearchEntities(existing, incoming, ::searchAlbumCanonicalKey, ::searchAlbumMetadataKey, ::richerAlbum)
+
+internal fun mergeSearchArtists(existing: List<ArtistHit>, incoming: List<ArtistHit>): List<ArtistHit> =
+    mergeSearchEntities(existing, incoming, ::searchArtistCanonicalKey, ::searchArtistMetadataKey, ::richerArtist)
+
+internal fun mergeSearchPlaylists(existing: List<PlaylistHit>, incoming: List<PlaylistHit>): List<PlaylistHit> =
+    mergeSearchEntities(existing, incoming, ::searchPlaylistCanonicalKey, ::searchPlaylistMetadataKey, ::richerPlaylist)
+
+internal fun deduplicateSearchSongs(songs: List<Track>): List<Track> = mergeSearchSongs(emptyList(), songs)
+
+internal fun deduplicateSearchAlbums(albums: List<AlbumHit>): List<AlbumHit> = mergeSearchAlbums(emptyList(), albums)
+
+internal fun deduplicateSearchArtists(artists: List<ArtistHit>): List<ArtistHit> =
+    mergeSearchArtists(emptyList(), artists)
+
+internal fun deduplicateSearchPlaylists(playlists: List<PlaylistHit>): List<PlaylistHit> =
+    mergeSearchPlaylists(emptyList(), playlists)
+
+private fun <T> mergeSearchEntities(
+    existing: List<T>,
+    incoming: List<T>,
+    canonicalKey: (T) -> String,
+    metadataKey: (T) -> String,
+    richer: (T, T) -> T
+): List<T> {
+    if (existing.isEmpty() && incoming.size < 2) return incoming
+    val ordered = mutableListOf<T>()
+    val slotByKey = HashMap<String, Int>()
+    (existing.asSequence() + incoming.asSequence()).forEach { candidate ->
+        val keys = entityKeys(candidate, canonicalKey, metadataKey)
+        val slot = keys.firstNotNullOfOrNull(slotByKey::get)
+        if (slot == null) {
+            val index = ordered.size
+            ordered.add(candidate)
+            keys.forEach { key -> slotByKey[key] = index }
+        } else {
+            ordered[slot] = richer(ordered[slot], candidate)
+            keys.forEach { key -> slotByKey.putIfAbsent(key, slot) }
+        }
+    }
+    return ordered.toList()
+}
+
+private fun <T> entityKeys(
+    entity: T,
+    canonicalKey: (T) -> String,
+    metadataKey: (T) -> String
+): List<String> {
+    val canonical = canonicalKey(entity)
+    val metadata = metadataKey(entity)
+    return buildList {
+        if (canonical.isNotBlank()) add("id$canonical")
+        if (metadata.isNotBlank()) add("meta$metadata")
+    }
+}
+
+private fun richerSong(current: Track, candidate: Track): Track = current.copy(
+    thumbnailUrl = current.thumbnailUrl.ifBlank { candidate.thumbnailUrl },
+    largeThumbnailUrl = current.largeThumbnailUrl.ifBlank { candidate.largeThumbnailUrl },
+    album = current.album.ifBlank { candidate.album },
+    albumBrowseId = current.albumBrowseId.ifBlank { candidate.albumBrowseId },
+    artistBrowseIds = current.artistBrowseIds.ifEmpty { candidate.artistBrowseIds },
+    durationMs = if (current.durationMs > 0L) current.durationMs else candidate.durationMs,
+    videoType = current.videoType.ifBlank { candidate.videoType }
+)
+
+private fun richerAlbum(current: AlbumHit, candidate: AlbumHit): AlbumHit = current.copy(
+    browseId = current.browseId.ifBlank { candidate.browseId },
+    artistBrowseId = current.artistBrowseId.ifBlank { candidate.artistBrowseId },
+    audioPlaylistId = current.audioPlaylistId.ifBlank { candidate.audioPlaylistId },
+    thumbnailUrl = current.thumbnailUrl.ifBlank { candidate.thumbnailUrl },
+    year = current.year.ifBlank { candidate.year },
+    releaseDate = current.releaseDate.ifBlank { candidate.releaseDate },
+    upc = current.upc.ifBlank { candidate.upc },
+    canonicalUrl = current.canonicalUrl.ifBlank { candidate.canonicalUrl },
+    explicit = current.explicit || candidate.explicit,
+    releaseType = if (current.releaseType == ReleaseType.Unknown) candidate.releaseType else current.releaseType
+)
+
+private fun richerArtist(current: ArtistHit, candidate: ArtistHit): ArtistHit = current.copy(
+    browseId = current.browseId.ifBlank { candidate.browseId },
+    thumbnailUrl = current.thumbnailUrl.ifBlank { candidate.thumbnailUrl },
+    subscribers = current.subscribers.ifBlank { candidate.subscribers },
+    officialArtwork = current.officialArtwork || candidate.officialArtwork
+)
+
+private fun richerPlaylist(current: PlaylistHit, candidate: PlaylistHit): PlaylistHit = current.copy(
+    playlistId = current.playlistId.ifBlank { candidate.playlistId },
+    browseId = current.browseId.ifBlank { candidate.browseId },
+    thumbnailUrl = current.thumbnailUrl.ifBlank { candidate.thumbnailUrl },
+    author = current.author.ifBlank { candidate.author },
+    trackCountLabel = current.trackCountLabel.ifBlank { candidate.trackCountLabel }
+)
+
+private const val MUSIC_VIDEO_TYPE_AUDIO = "MUSIC_VIDEO_TYPE_ATV"

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
@@ -700,14 +700,16 @@ class YoutubeMusicRepository(private val context: Context? = null) {
         val playlistId = extractSearchPlaylistId(renderer)
         val browseId = extractSearchPlaylistBrowseId(renderer)
         if (playlistId.isBlank() && browseId.isBlank()) return null
-        val author = tokens.drop(1).firstOrNull(::isAlbumArtistToken).orEmpty()
+        val author = tokens.firstOrNull(::isAlbumArtistToken).orEmpty()
         return PlaylistHit(
             title = title.cleanLabel(),
             author = author.cleanLabel(),
             thumbnailUrl = upgradeThumbnail(findBestThumbnail(renderer)),
             playlistId = playlistId,
             browseId = browseId,
-            trackCountLabel = tokens.drop(1).firstOrNull { token -> token.any(Char::isDigit) }.orEmpty()
+            trackCountLabel = tokens
+                .firstOrNull { token -> token != author && token.any(Char::isDigit) }
+                .orEmpty()
         )
     }
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
@@ -12,11 +12,14 @@ import com.luc4n3x.levyra.domain.HomeSection
 import com.luc4n3x.levyra.domain.LevyraContentLocales
 import com.luc4n3x.levyra.domain.LevyraLanguageCatalog
 import com.luc4n3x.levyra.domain.LevyraLocalizedDiscovery
+import com.luc4n3x.levyra.domain.PlaylistHit
+import com.luc4n3x.levyra.domain.SearchPage
 import com.luc4n3x.levyra.domain.SearchResults
 import com.luc4n3x.levyra.domain.ReleaseType
 import com.luc4n3x.levyra.domain.releaseTypeFromProviderLabel
 import com.luc4n3x.levyra.domain.Track
 import com.luc4n3x.levyra.domain.artistIdentityKey
+import com.luc4n3x.levyra.domain.isArtistShelfNameEligible
 import com.luc4n3x.levyra.domain.primaryArtistSegment
 import com.luc4n3x.levyra.domain.parseCompactViewCount
 import kotlinx.coroutines.CancellationException
@@ -251,6 +254,30 @@ private const val ALBUM_RESULTS_PER_SEED = 8
 private const val ALBUM_RESULTS_PER_FALLBACK_QUERY = 8
 private const val ALBUM_RESULT_RANK_PENALTY = 18
 internal const val YOUTUBE_MUSIC_VIDEO_SEARCH_PARAMS = "EgWKAQIQAWoMEA4QChADEAQQCRAF"
+internal const val YOUTUBE_MUSIC_SONG_SEARCH_PARAMS = "EgWKAQIIAWoMEA4QChADEAQQCRAF"
+internal const val YOUTUBE_MUSIC_ALBUM_SEARCH_PARAMS = "EgWKAQIYAWoMEA4QChADEAQQCRAF"
+internal const val YOUTUBE_MUSIC_ARTIST_SEARCH_PARAMS = "EgWKAQIgAWoMEA4QChADEAQQCRAF"
+internal const val YOUTUBE_MUSIC_PLAYLIST_SEARCH_PARAMS = "EgWKAQIoAWoMEA4QChADEAQQCRAF"
+
+internal enum class SearchEntityKind {
+    Track,
+    Album,
+    Artist,
+    Playlist
+}
+
+private const val MUSIC_PAGE_TYPE_ALBUM = "MUSIC_PAGE_TYPE_ALBUM"
+private const val MUSIC_PAGE_TYPE_ARTIST = "MUSIC_PAGE_TYPE_ARTIST"
+private const val MUSIC_PAGE_TYPE_PLAYLIST = "MUSIC_PAGE_TYPE_PLAYLIST"
+private const val SEARCH_OVERVIEW_SONG_LIMIT = 20
+private const val SEARCH_OVERVIEW_VIDEO_LIMIT = 10
+private const val SEARCH_OVERVIEW_ARTIST_LIMIT = 8
+private const val SEARCH_OVERVIEW_ALBUM_LIMIT = 10
+private const val SEARCH_OVERVIEW_PLAYLIST_LIMIT = 10
+private val SUBSCRIBER_TOKEN_HINTS = listOf(
+    "subscriber", "iscritt", "scritt", "abonn", "suscriptor", "inscrito", "abonnee",
+    "subskry", "abonat", "συνδρομ", "подпис", "订阅", "訂閱", "チャンネル登録", "구독", "सदस्य", "ผู้ติดตาม", "מנוי", "مشترك"
+)
 private const val YOUTUBE_MUSIC_NEW_RELEASE_FALLBACK_LIMIT = 4
 private const val YOUTUBE_MUSIC_ARTIST_CONTAINS_MIN_LENGTH = 4
 
@@ -450,77 +477,290 @@ class YoutubeMusicRepository(private val context: Context? = null) {
         val cleanQuery = query.trim()
         if (cleanQuery.length < 2) return@withContext SearchResults()
         val root = runCatching { searchInnerTubeRaw(cleanQuery, languageCode) }.getOrNull() ?: return@withContext fallbackResults(cleanQuery, languageCode)
-        val renderers = mutableListOf<JSONObject>()
-        collectObjectsByKey(root, "musicResponsiveListItemRenderer", renderers)
-        val songs = LinkedHashMap<String, Track>()
-        val artists = LinkedHashMap<String, ArtistHit>()
-        val albums = LinkedHashMap<String, AlbumHit>()
-        renderers.forEach { renderer ->
-            val lines = extractFlexLines(renderer)
-            val title = lines.firstOrNull()?.takeIf { it.isNotBlank() } ?: return@forEach
-            val subtitleTokens = lines.drop(1).flatMap { it.split(" • ", " · ") }.map { it.trim() }
-            val kind = subtitleTokens.firstOrNull()?.lowercase().orEmpty()
-            val thumb = findBestThumbnail(renderer)
-            when {
-                kind.startsWith("artist") || kind.startsWith("artista") || kind.startsWith("artiste") || kind.startsWith("künstler") || kind.startsWith("kunstler") || kind.startsWith("artiest") || kind.startsWith("artysta") -> {
-                    val artistReference = extractYoutubeMusicArtistReference(renderer, title)
-                    val resolvedName = artistReference?.name?.ifBlank { title }.orEmpty().ifBlank { title }
-                    val artistKey = resolvedName.lowercase()
-                    if (!artists.containsKey(artistKey)) {
-                        val subs = subtitleTokens.firstOrNull { it.contains("scritt", ignoreCase = true) || it.contains("subscriber", ignoreCase = true) || it.contains("iscritt", ignoreCase = true) }.orEmpty()
-                        val seed = stableSeed(resolvedName)
-                        artists[artistKey] = ArtistHit(
-                            name = resolvedName,
-                            subscribers = subs,
-                            thumbnailUrl = upgradeThumbnail(thumb),
-                            accentStart = palette(seed).first,
-                            accentEnd = palette(seed).second,
-                            browseId = artistReference?.browseId.orEmpty()
-                        )
-                    }
-                }
-                levyraReleaseType(kind) == ReleaseType.Album && isPlausibleYoutubeMusicAlbumTitle(title) -> {
-                    val albumArtist = subtitleTokens.getOrNull(1).orEmpty()
-                    val artistReference = extractYoutubeMusicArtistReference(renderer, albumArtist)
-                    val resolvedArtist = artistReference?.name?.ifBlank { albumArtist }.orEmpty().ifBlank { albumArtist }
-                    val year = subtitleTokens.firstNotNullOfOrNull { Regex("\\b(19|20)\\d{2}\\b").find(it)?.value }.orEmpty()
-                    val key = "${title.lowercase()}|${resolvedArtist.lowercase()}"
-                    if (!albums.containsKey(key)) {
-                        albums[key] = AlbumHit(
-                            title = title,
-                            artist = resolvedArtist.ifBlank { "Album" },
-                            year = year,
-                            thumbnailUrl = upgradeThumbnail(thumb),
-                            query = "$title $resolvedArtist",
-                            browseId = extractAlbumBrowseId(renderer),
-                            artistBrowseId = artistReference?.browseId.orEmpty(),
-                            releaseType = ReleaseType.Album
-                        )
-                    }
-                }
-                else -> {
-                    val track = parseMusicRenderer(renderer, cleanQuery) ?: return@forEach
-                    if (!songs.containsKey(track.id)) songs[track.id] = track
-                }
-            }
+        val overview = parseSearchOverview(root, cleanQuery)
+        val withLegacyFallback = if (overview.songs.isEmpty() && overview.videos.isEmpty()) {
+            overview.copy(songs = parseLegacyVideoRenderers(root, cleanQuery))
+        } else {
+            overview
         }
-        if (songs.isEmpty()) {
-            val videoRenderers = mutableListOf<JSONObject>()
-            collectObjectsByKey(root, "videoRenderer", videoRenderers)
-            videoRenderers.forEach { renderer ->
-                val track = parseVideoRenderer(renderer, cleanQuery) ?: return@forEach
-                if (!songs.containsKey(track.id)) songs[track.id] = track
-            }
+        val results = withLegacyFallback.let { parsed ->
+            parsed.copy(
+                topTrack = parsed.songs.firstOrNull() ?: parsed.videos.firstOrNull(),
+                songs = parsed.songs.take(SEARCH_OVERVIEW_SONG_LIMIT),
+                videos = parsed.videos.take(SEARCH_OVERVIEW_VIDEO_LIMIT),
+                artists = parsed.artists.take(SEARCH_OVERVIEW_ARTIST_LIMIT),
+                albums = parsed.albums.take(SEARCH_OVERVIEW_ALBUM_LIMIT),
+                playlists = parsed.playlists.take(SEARCH_OVERVIEW_PLAYLIST_LIMIT)
+            )
         }
-        songs.values.forEach { memory[it.id] = it }
-        val songList = songs.values.toList()
-        val results = SearchResults(
-            topTrack = songList.firstOrNull(),
-            songs = songList.take(20),
-            artists = artists.values.take(8).toList(),
-            albums = albums.values.take(10).toList()
-        )
+        rememberSearchTracks(results.songs)
+        rememberSearchTracks(results.videos)
         if (results.isEmpty) fallbackResults(cleanQuery, languageCode) else results
+    }
+
+    suspend fun searchSongsPage(
+        query: String,
+        languageCode: String = LevyraLanguageCatalog.deviceDefault(),
+        continuation: String = ""
+    ): SearchPage<Track> = searchTrackPage(query, languageCode, YOUTUBE_MUSIC_SONG_SEARCH_PARAMS, continuation)
+
+    suspend fun searchVideosPage(
+        query: String,
+        languageCode: String = LevyraLanguageCatalog.deviceDefault(),
+        continuation: String = ""
+    ): SearchPage<Track> = searchTrackPage(query, languageCode, YOUTUBE_MUSIC_VIDEO_SEARCH_PARAMS, continuation)
+
+    suspend fun searchAlbumsPage(
+        query: String,
+        languageCode: String = LevyraLanguageCatalog.deviceDefault(),
+        continuation: String = ""
+    ): SearchPage<AlbumHit> = withContext(Dispatchers.IO) {
+        val root = searchSectionRoot(query, languageCode, YOUTUBE_MUSIC_ALBUM_SEARCH_PARAMS, continuation)
+            ?: return@withContext SearchPage()
+        SearchPage(parseSearchOverview(root, query.trim()).albums, findSearchContinuation(root))
+    }
+
+    suspend fun searchArtistsPage(
+        query: String,
+        languageCode: String = LevyraLanguageCatalog.deviceDefault(),
+        continuation: String = ""
+    ): SearchPage<ArtistHit> = withContext(Dispatchers.IO) {
+        val root = searchSectionRoot(query, languageCode, YOUTUBE_MUSIC_ARTIST_SEARCH_PARAMS, continuation)
+            ?: return@withContext SearchPage()
+        SearchPage(parseSearchOverview(root, query.trim()).artists, findSearchContinuation(root))
+    }
+
+    suspend fun searchPlaylistsPage(
+        query: String,
+        languageCode: String = LevyraLanguageCatalog.deviceDefault(),
+        continuation: String = ""
+    ): SearchPage<PlaylistHit> = withContext(Dispatchers.IO) {
+        val root = searchSectionRoot(query, languageCode, YOUTUBE_MUSIC_PLAYLIST_SEARCH_PARAMS, continuation)
+            ?: return@withContext SearchPage()
+        SearchPage(parseSearchOverview(root, query.trim()).playlists, findSearchContinuation(root))
+    }
+
+    private suspend fun searchTrackPage(
+        query: String,
+        languageCode: String,
+        params: String,
+        continuation: String
+    ): SearchPage<Track> = withContext(Dispatchers.IO) {
+        val cleanQuery = query.trim()
+        val root = searchSectionRoot(cleanQuery, languageCode, params, continuation) ?: return@withContext SearchPage()
+        val parsed = parseSearchOverview(root, cleanQuery)
+        val tracks = mergeSearchSongs(parsed.songs, parsed.videos).ifEmpty {
+            parseLegacyVideoRenderers(root, cleanQuery)
+        }
+        rememberSearchTracks(tracks)
+        SearchPage(tracks, findSearchContinuation(root))
+    }
+
+    private fun searchSectionRoot(
+        query: String,
+        languageCode: String,
+        params: String,
+        continuation: String
+    ): JSONObject? {
+        val cleanQuery = query.trim()
+        if (cleanQuery.length < 2) return null
+        return runCatching {
+            searchInnerTubeRaw(cleanQuery, languageCode, params, continuation.trim())
+        }.getOrNull()
+    }
+
+    private fun rememberSearchTracks(tracks: List<Track>) {
+        tracks.forEach { track -> memory[track.id] = track }
+    }
+
+    internal fun parseSearchOverview(root: JSONObject, query: String): SearchResults {
+        val songs = mutableListOf<Track>()
+        val videos = mutableListOf<Track>()
+        val artists = mutableListOf<ArtistHit>()
+        val albums = mutableListOf<AlbumHit>()
+        val playlists = mutableListOf<PlaylistHit>()
+        val listItems = mutableListOf<JSONObject>()
+        collectObjectsByKey(root, "musicResponsiveListItemRenderer", listItems)
+        listItems.forEach { renderer ->
+            when (searchEntityKind(renderer)) {
+                SearchEntityKind.Artist -> parseSearchArtistHit(renderer)?.let(artists::add)
+                SearchEntityKind.Album -> parseSearchAlbumHit(renderer)?.let(albums::add)
+                SearchEntityKind.Playlist -> parseSearchPlaylistHit(renderer)?.let(playlists::add)
+                SearchEntityKind.Track -> {
+                    val track = parseMusicRenderer(renderer, query) ?: return@forEach
+                    if (isMusicVideoResult(track.videoType)) videos.add(track) else songs.add(track)
+                }
+            }
+        }
+        val cards = mutableListOf<JSONObject>()
+        collectObjectsByKey(root, "musicTwoRowItemRenderer", cards)
+        cards.forEach { card ->
+            when (searchEntityKind(card)) {
+                SearchEntityKind.Artist -> parseSearchArtistHit(card)?.let(artists::add)
+                SearchEntityKind.Album -> parseTwoRowAlbumHit(card)?.let(albums::add)
+                SearchEntityKind.Playlist -> parseSearchPlaylistHit(card)?.let(playlists::add)
+                SearchEntityKind.Track -> Unit
+            }
+        }
+        return SearchResults(
+            songs = deduplicateSearchSongs(songs),
+            videos = deduplicateSearchSongs(videos),
+            artists = deduplicateSearchArtists(artists),
+            albums = deduplicateSearchAlbums(albums),
+            playlists = deduplicateSearchPlaylists(playlists)
+        )
+    }
+
+    private fun parseLegacyVideoRenderers(root: JSONObject, query: String): List<Track> {
+        val videoRenderers = mutableListOf<JSONObject>()
+        collectObjectsByKey(root, "videoRenderer", videoRenderers)
+        return deduplicateSearchSongs(videoRenderers.mapNotNull { parseVideoRenderer(it, query) })
+    }
+
+    internal fun searchEntityKind(renderer: JSONObject): SearchEntityKind {
+        if (extractPrimaryMusicVideoId(renderer).isNotBlank()) return SearchEntityKind.Track
+        val browseEndpoints = mutableListOf<JSONObject>()
+        collectObjectsByKey(renderer, "browseEndpoint", browseEndpoints)
+        var artist = false
+        var album = false
+        var playlist = false
+        browseEndpoints.forEach { endpoint ->
+            val browseId = endpoint.optString("browseId").orEmpty()
+            val pageType = endpoint.optJSONObject("browseEndpointContextSupportedConfigs")
+                ?.optJSONObject("browseEndpointContextMusicConfig")
+                ?.optString("pageType")
+                .orEmpty()
+                .uppercase(Locale.ROOT)
+            when {
+                pageType == MUSIC_PAGE_TYPE_ALBUM || browseId.startsWith("MPRE", ignoreCase = true) -> album = true
+                pageType == MUSIC_PAGE_TYPE_PLAYLIST || browseId.startsWith("VL", ignoreCase = true) -> playlist = true
+                pageType == MUSIC_PAGE_TYPE_ARTIST || browseId.startsWith("UC") -> artist = true
+            }
+        }
+        if (album) return SearchEntityKind.Album
+        if (playlist) return SearchEntityKind.Playlist
+        if (hasPlaylistOnlyWatchEndpoint(renderer)) return SearchEntityKind.Playlist
+        if (artist) return SearchEntityKind.Artist
+        return SearchEntityKind.Track
+    }
+
+    private fun hasPlaylistOnlyWatchEndpoint(renderer: JSONObject): Boolean {
+        val watchEndpoints = mutableListOf<JSONObject>()
+        collectObjectsByKey(renderer, "watchEndpoint", watchEndpoints)
+        if (watchEndpoints.isEmpty()) return false
+        return watchEndpoints.any { endpoint ->
+            endpoint.optString("playlistId").isNotBlank() && endpoint.optString("videoId").isBlank()
+        }
+    }
+
+    private fun parseSearchArtistHit(renderer: JSONObject): ArtistHit? {
+        val title = searchEntityTitle(renderer).ifBlank { return null }
+        val artistReference = extractYoutubeMusicArtistReference(renderer, title)
+        val resolvedName = artistReference?.name.orEmpty().ifBlank { title }.cleanLabel()
+        if (!isArtistShelfNameEligible(resolvedName)) return null
+        val seed = stableSeed(resolvedName)
+        val accents = palette(seed)
+        return ArtistHit(
+            name = resolvedName,
+            subscribers = searchEntitySubtitleTokens(renderer).firstOrNull(::isSubscriberToken).orEmpty(),
+            thumbnailUrl = upgradeThumbnail(findBestThumbnail(renderer)),
+            accentStart = accents.first,
+            accentEnd = accents.second,
+            browseId = artistReference?.browseId.orEmpty()
+        )
+    }
+
+    private fun parseSearchAlbumHit(renderer: JSONObject): AlbumHit? {
+        val title = searchEntityTitle(renderer).ifBlank { return null }
+        if (!isPlausibleYoutubeMusicAlbumTitle(title)) return null
+        val tokens = searchEntitySubtitleTokens(renderer)
+        val releaseType = levyraReleaseType(tokens.firstOrNull().orEmpty())
+        val albumArtist = tokens.drop(1).firstOrNull(::isAlbumArtistToken)
+            ?: tokens.firstOrNull(::isAlbumArtistToken)
+            .orEmpty()
+        val artistReference = extractYoutubeMusicArtistReference(renderer, albumArtist)
+        val resolvedArtist = artistReference?.name.orEmpty().ifBlank { albumArtist }.cleanLabel()
+        val year = tokens.firstNotNullOfOrNull { Regex("""\b(19|20)\d{2}\b""").find(it)?.value }.orEmpty()
+        return AlbumHit(
+            title = title.cleanLabel(),
+            artist = resolvedArtist.ifBlank { "Album" },
+            year = year,
+            thumbnailUrl = upgradeThumbnail(findBestThumbnail(renderer)),
+            query = listOf(title, resolvedArtist).filter(String::isNotBlank).joinToString(" "),
+            browseId = extractAlbumBrowseId(renderer),
+            artistBrowseId = artistReference?.browseId.orEmpty(),
+            audioPlaylistId = extractSearchPlaylistId(renderer),
+            releaseType = releaseType
+        )
+    }
+
+    private fun parseSearchPlaylistHit(renderer: JSONObject): PlaylistHit? {
+        val title = searchEntityTitle(renderer).ifBlank { return null }
+        val tokens = searchEntitySubtitleTokens(renderer)
+        val playlistId = extractSearchPlaylistId(renderer)
+        val browseId = extractSearchPlaylistBrowseId(renderer)
+        if (playlistId.isBlank() && browseId.isBlank()) return null
+        val author = tokens.drop(1).firstOrNull(::isAlbumArtistToken).orEmpty()
+        return PlaylistHit(
+            title = title.cleanLabel(),
+            author = author.cleanLabel(),
+            thumbnailUrl = upgradeThumbnail(findBestThumbnail(renderer)),
+            playlistId = playlistId,
+            browseId = browseId,
+            trackCountLabel = tokens.drop(1).firstOrNull { token -> token.any(Char::isDigit) }.orEmpty()
+        )
+    }
+
+    private fun searchEntityTitle(renderer: JSONObject): String {
+        extractFlexLines(renderer).firstOrNull()?.takeIf(String::isNotBlank)?.let { return it.trim() }
+        return renderer.optJSONObject("title")?.optJSONArray("runs")?.joinText().orEmpty().trim()
+    }
+
+    private fun searchEntitySubtitleTokens(renderer: JSONObject): List<String> {
+        val flexTokens = extractFlexLines(renderer).drop(1)
+        val subtitle = renderer.optJSONObject("subtitle")?.optJSONArray("runs")?.joinText().orEmpty()
+        return (flexTokens + subtitle)
+            .flatMap { line -> line.split(" • ", " · ", " - ") }
+            .map(String::trim)
+            .filter(String::isNotBlank)
+    }
+
+    private fun isSubscriberToken(token: String): Boolean =
+        token.any(Char::isDigit) && SUBSCRIBER_TOKEN_HINTS.any { hint -> token.contains(hint, ignoreCase = true) }
+
+    private fun extractSearchPlaylistId(renderer: JSONObject): String {
+        val watchEndpoints = mutableListOf<JSONObject>()
+        collectObjectsByKey(renderer, "watchEndpoint", watchEndpoints)
+        watchEndpoints.firstNotNullOfOrNull { endpoint ->
+            endpoint.optString("playlistId").takeIf(String::isNotBlank)
+        }?.let { return it }
+        val browseId = extractSearchPlaylistBrowseId(renderer)
+        return browseId.removePrefix("VL").takeIf { it.isNotBlank() && it != browseId }.orEmpty()
+    }
+
+    private fun extractSearchPlaylistBrowseId(renderer: JSONObject): String {
+        val endpoints = mutableListOf<JSONObject>()
+        collectObjectsByKey(renderer, "browseEndpoint", endpoints)
+        return endpoints.firstNotNullOfOrNull { endpoint ->
+            val browseId = endpoint.optString("browseId").orEmpty()
+            val pageType = endpoint.optJSONObject("browseEndpointContextSupportedConfigs")
+                ?.optJSONObject("browseEndpointContextMusicConfig")
+                ?.optString("pageType")
+                .orEmpty()
+                .uppercase(Locale.ROOT)
+            browseId.takeIf {
+                it.startsWith("VL", ignoreCase = true) || pageType == MUSIC_PAGE_TYPE_PLAYLIST
+            }
+        }.orEmpty()
+    }
+
+    private fun findSearchContinuation(root: JSONObject): String {
+        val legacy = mutableListOf<JSONObject>()
+        collectObjectsByKey(root, "nextContinuationData", legacy)
+        legacy.firstNotNullOfOrNull { it.optString("continuation").takeIf(String::isNotBlank) }?.let { return it }
+        val commands = mutableListOf<JSONObject>()
+        collectObjectsByKey(root, "continuationCommand", commands)
+        return commands.firstNotNullOfOrNull { it.optString("token").takeIf(String::isNotBlank) }.orEmpty()
     }
 
     private suspend fun fallbackResults(query: String, languageCode: String): SearchResults {
@@ -541,9 +781,10 @@ class YoutubeMusicRepository(private val context: Context? = null) {
     private fun searchInnerTubeRaw(
         query: String,
         languageCode: String,
-        params: String = ""
+        params: String = "",
+        continuation: String = ""
     ): JSONObject? {
-        return resilienceClient.search(query, languageCode, params)
+        return resilienceClient.search(query, languageCode, params, continuation)
     }
 
     suspend fun home(

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicResilienceClient.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicResilienceClient.kt
@@ -103,15 +103,22 @@ internal class YoutubeMusicResilienceClient(
         )
     )
 
-    fun search(query: String, languageCode: String, params: String = ""): JSONObject? {
+    fun search(
+        query: String,
+        languageCode: String,
+        params: String = "",
+        continuation: String = ""
+    ): JSONObject? {
         val clean = query.trim()
-        if (clean.length < 2 || apiKey.isBlank()) return null
+        val cleanContinuation = continuation.trim()
+        if (apiKey.isBlank()) return null
+        if (clean.length < 2 && cleanContinuation.isBlank()) return null
         return request(
             kind = YoutubeMusicRequestKind.SEARCH,
             languageCode = languageCode,
             browseId = "",
             params = params.trim(),
-            continuation = "",
+            continuation = cleanContinuation,
             query = clean
         )
     }
@@ -319,8 +326,9 @@ internal class YoutubeMusicResilienceClient(
         val root = JSONObject().put("context", JSONObject().put("client", client))
         when (kind) {
             YoutubeMusicRequestKind.SEARCH -> {
-                root.put("query", query)
+                if (query.isNotBlank()) root.put("query", query)
                 if (params.isNotBlank()) root.put("params", params)
+                if (continuation.isNotBlank()) root.put("continuation", continuation)
             }
             YoutubeMusicRequestKind.BROWSE -> {
                 if (browseId.isNotBlank()) root.put("browseId", browseId)

--- a/app/src/main/java/com/luc4n3x/levyra/data/local/LevyraDatabase.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/local/LevyraDatabase.kt
@@ -23,7 +23,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         PlaybackSourceMatchEntity::class,
         ArtistLoreEntity::class
     ],
-    version = 14,
+    version = 15,
     exportSchema = true
 )
 abstract class LevyraDatabase : RoomDatabase() {
@@ -456,6 +456,20 @@ abstract class LevyraDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_14_15 = object : Migration(14, 15) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE offline_download_tasks ADD COLUMN batchKey TEXT NOT NULL DEFAULT ''")
+                db.execSQL("ALTER TABLE offline_download_tasks ADD COLUMN batchTitle TEXT NOT NULL DEFAULT ''")
+                db.execSQL("ALTER TABLE offline_download_tasks ADD COLUMN batchKind TEXT NOT NULL DEFAULT ''")
+                db.execSQL("ALTER TABLE offline_download_tasks ADD COLUMN batchArtworkUrl TEXT NOT NULL DEFAULT ''")
+                db.execSQL("ALTER TABLE offline_download_tasks ADD COLUMN batchPosition INTEGER NOT NULL DEFAULT 0")
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS index_offline_download_tasks_batchKey " +
+                        "ON offline_download_tasks(batchKey)"
+                )
+            }
+        }
+
         fun get(context: Context): LevyraDatabase {
             return instance ?: synchronized(this) {
                 instance ?: Room.databaseBuilder(
@@ -477,7 +491,8 @@ abstract class LevyraDatabase : RoomDatabase() {
                         MIGRATION_10_11,
                         MIGRATION_11_12,
                         MIGRATION_12_13,
-                        MIGRATION_13_14
+                        MIGRATION_13_14,
+                        MIGRATION_14_15
                     )
                     .build()
                     .also { instance = it }

--- a/app/src/main/java/com/luc4n3x/levyra/data/local/OfflineDownloadTaskEntity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/local/OfflineDownloadTaskEntity.kt
@@ -1,6 +1,7 @@
 package com.luc4n3x.levyra.data.local
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import kotlinx.coroutines.flow.Flow
 import androidx.room.Dao
@@ -8,7 +9,10 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 
-@Entity(tableName = "offline_download_tasks")
+@Entity(
+    tableName = "offline_download_tasks",
+    indices = [Index(value = ["batchKey"])]
+)
 data class OfflineDownloadTaskEntity(
     @PrimaryKey val taskKey: String,
     val trackId: String,
@@ -20,6 +24,24 @@ data class OfflineDownloadTaskEntity(
     val workId: String,
     val error: String,
     val createdAt: Long,
+    val updatedAt: Long,
+    val batchKey: String = "",
+    val batchTitle: String = "",
+    val batchKind: String = "",
+    val batchArtworkUrl: String = "",
+    val batchPosition: Int = 0
+)
+
+data class OfflineDownloadBatchRow(
+    val batchKey: String,
+    val batchTitle: String,
+    val batchKind: String,
+    val batchArtworkUrl: String,
+    val total: Int,
+    val completed: Int,
+    val failed: Int,
+    val active: Int,
+    val progressSum: Int,
     val updatedAt: Long
 )
 
@@ -46,6 +68,45 @@ interface OfflineDownloadTasksDao {
     @Query("DELETE FROM offline_download_tasks WHERE taskKey = :taskKey")
     suspend fun delete(taskKey: String)
 
-    @Query("DELETE FROM offline_download_tasks WHERE state IN ('SUCCEEDED','CANCELLED') AND updatedAt < :before")
+    @Query(
+        """
+        SELECT batchKey,
+               MAX(batchTitle) AS batchTitle,
+               MAX(batchKind) AS batchKind,
+               MAX(batchArtworkUrl) AS batchArtworkUrl,
+               COUNT(*) AS total,
+               SUM(CASE WHEN state = 'SUCCEEDED' THEN 1 ELSE 0 END) AS completed,
+               SUM(CASE WHEN state = 'FAILED' THEN 1 ELSE 0 END) AS failed,
+               SUM(CASE WHEN state IN ('QUEUED','RUNNING','PAUSED','RETRYING') THEN 1 ELSE 0 END) AS active,
+               SUM(CASE WHEN state = 'SUCCEEDED' THEN 100 ELSE progress END) AS progressSum,
+               MAX(updatedAt) AS updatedAt
+        FROM offline_download_tasks
+        WHERE batchKey <> ''
+        GROUP BY batchKey
+        ORDER BY MIN(createdAt) ASC
+        """
+    )
+    fun observeBatches(): Flow<List<OfflineDownloadBatchRow>>
+
+    @Query("SELECT * FROM offline_download_tasks WHERE batchKey = :batchKey ORDER BY batchPosition ASC")
+    suspend fun batchTasks(batchKey: String): List<OfflineDownloadTaskEntity>
+
+    @Query("DELETE FROM offline_download_tasks WHERE batchKey = :batchKey")
+    suspend fun deleteBatch(batchKey: String)
+
+    @Query(
+        """
+        DELETE FROM offline_download_tasks
+        WHERE state IN ('SUCCEEDED','CANCELLED')
+          AND updatedAt < :before
+          AND (
+            batchKey = ''
+            OR batchKey NOT IN (
+              SELECT batchKey FROM offline_download_tasks
+              WHERE batchKey <> '' AND state IN ('QUEUED','RUNNING','PAUSED','RETRYING','FAILED')
+            )
+          )
+        """
+    )
     suspend fun prune(before: Long)
 }

--- a/app/src/main/java/com/luc4n3x/levyra/domain/BatchDownload.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/BatchDownload.kt
@@ -1,0 +1,73 @@
+package com.luc4n3x.levyra.domain
+
+import java.util.Locale
+
+enum class BatchDownloadKind {
+    Album,
+    Playlist
+}
+
+enum class BatchDownloadState {
+    Queued,
+    Downloading,
+    Completed,
+    Failed,
+    Cancelled
+}
+
+data class BatchDownload(
+    val key: String,
+    val kind: BatchDownloadKind,
+    val title: String,
+    val artworkUrl: String,
+    val total: Int,
+    val completed: Int,
+    val failed: Int,
+    val active: Int,
+    val progress: Int,
+    val state: BatchDownloadState
+) {
+    val isFinished: Boolean
+        get() = state == BatchDownloadState.Completed ||
+            state == BatchDownloadState.Failed ||
+            state == BatchDownloadState.Cancelled
+
+    val canRetry: Boolean
+        get() = failed > 0 && active == 0
+}
+
+fun batchDownloadKindOf(raw: String): BatchDownloadKind =
+    if (raw.equals(BatchDownloadKind.Playlist.name, ignoreCase = true)) {
+        BatchDownloadKind.Playlist
+    } else {
+        BatchDownloadKind.Album
+    }
+
+fun batchDownloadProgress(total: Int, progressSum: Int): Int {
+    if (total <= 0) return 0
+    return (progressSum.coerceAtLeast(0) / total).coerceIn(0, 100)
+}
+
+fun batchDownloadState(
+    total: Int,
+    completed: Int,
+    failed: Int,
+    active: Int,
+    progressSum: Int
+): BatchDownloadState {
+    if (total <= 0) return BatchDownloadState.Cancelled
+    if (active > 0) {
+        return if (progressSum > 0 || completed > 0) BatchDownloadState.Downloading else BatchDownloadState.Queued
+    }
+    if (completed >= total) return BatchDownloadState.Completed
+    if (failed > 0) return BatchDownloadState.Failed
+    return BatchDownloadState.Cancelled
+}
+
+fun batchDownloadKey(kind: BatchDownloadKind, canonicalId: String, fallbackTitle: String): String {
+    val identity = canonicalId.trim().lowercase(Locale.ROOT).ifBlank {
+        fallbackTitle.trim().lowercase(Locale.ROOT).replace(Regex("[^\\p{L}\\p{N}]+"), "-").trim('-')
+    }
+    if (identity.isBlank()) return ""
+    return "${kind.name.lowercase(Locale.ROOT)}:$identity"
+}

--- a/app/src/main/java/com/luc4n3x/levyra/domain/BatchDownload.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/BatchDownload.kt
@@ -64,6 +64,23 @@ fun batchDownloadState(
     return BatchDownloadState.Cancelled
 }
 
+fun visibleDownloadBatches(batches: List<BatchDownload>): List<BatchDownload> = batches.filterNot {
+    it.state == BatchDownloadState.Completed || it.state == BatchDownloadState.Cancelled
+}
+
+fun retainsExistingBatchMembership(
+    previousBatchKey: String,
+    previousState: String,
+    requestedBatchKey: String
+): Boolean {
+    if (previousBatchKey.isBlank()) return false
+    if (previousBatchKey == requestedBatchKey) return false
+    if (requestedBatchKey.isBlank()) return true
+    return previousState.uppercase(Locale.ROOT) in UNSETTLED_BATCH_CHILD_STATES
+}
+
+private val UNSETTLED_BATCH_CHILD_STATES = setOf("QUEUED", "RUNNING", "PAUSED", "RETRYING", "FAILED")
+
 fun batchDownloadKey(kind: BatchDownloadKind, canonicalId: String, fallbackTitle: String): String {
     val identity = canonicalId.trim().lowercase(Locale.ROOT).ifBlank {
         fallbackTitle.trim().lowercase(Locale.ROOT).replace(Regex("[^\\p{L}\\p{N}]+"), "-").trim('-')

--- a/app/src/main/java/com/luc4n3x/levyra/domain/Models.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/Models.kt
@@ -426,22 +426,46 @@ data class AlbumDetail(
     val durationMs: Long = tracks.sumOf { it.durationMs }
 )
 
+data class PlaylistHit(
+    val title: String,
+    val author: String,
+    val thumbnailUrl: String,
+    val playlistId: String = "",
+    val browseId: String = "",
+    val trackCountLabel: String = ""
+)
+
 data class SearchResults(
     val topTrack: Track? = null,
     val songs: List<Track> = emptyList(),
     val artists: List<ArtistHit> = emptyList(),
-    val albums: List<AlbumHit> = emptyList()
+    val albums: List<AlbumHit> = emptyList(),
+    val playlists: List<PlaylistHit> = emptyList(),
+    val videos: List<Track> = emptyList(),
+    val failedSections: Set<SearchFilter> = emptySet()
 ) {
     val isEmpty: Boolean
-        get() = topTrack == null && songs.isEmpty() && artists.isEmpty() && albums.isEmpty()
+        get() = topTrack == null &&
+            songs.isEmpty() &&
+            artists.isEmpty() &&
+            albums.isEmpty() &&
+            playlists.isEmpty() &&
+            videos.isEmpty()
 }
 
 enum class SearchFilter {
     All,
     Songs,
     Artists,
-    Albums
+    Albums,
+    Playlists,
+    Videos
 }
+
+data class SearchPage<T>(
+    val items: List<T> = emptyList(),
+    val continuation: String = ""
+)
 
 data class Playlist(
     val id: String,

--- a/app/src/main/java/com/luc4n3x/levyra/player/offline/work/OfflineExportWorker.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/offline/work/OfflineExportWorker.kt
@@ -41,6 +41,14 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import timber.log.Timber
 
+data class OfflineDownloadBatchRef(
+    val key: String,
+    val title: String,
+    val kind: String,
+    val artworkUrl: String,
+    val position: Int
+)
+
 private object OfflineDownloadConcurrencyGate {
     private val mutex = Mutex()
     private var active = 0
@@ -306,7 +314,12 @@ class OfflineExportWorker(
         private const val NOTIFICATION_ID_RANGE = 5000
         private const val COMPLETED_TASK_RETENTION_MS = 7L * 24L * 60L * 60L * 1000L
 
-        suspend fun enqueue(context: Context, trackId: String, trackPayload: String): UUID {
+        suspend fun enqueue(
+            context: Context,
+            trackId: String,
+            trackPayload: String,
+            batch: OfflineDownloadBatchRef? = null
+        ): UUID {
             val appContext = context.applicationContext
             val workManager = WorkManager.getInstance(appContext)
             val uniqueName = uniqueNameFor(trackId)
@@ -340,7 +353,12 @@ class OfflineExportWorker(
                     workId = request.id.toString(),
                     error = "",
                     createdAt = previous?.createdAt ?: now,
-                    updatedAt = now
+                    updatedAt = now,
+                    batchKey = batch?.key ?: previous?.batchKey.orEmpty(),
+                    batchTitle = batch?.title ?: previous?.batchTitle.orEmpty(),
+                    batchKind = batch?.kind ?: previous?.batchKind.orEmpty(),
+                    batchArtworkUrl = batch?.artworkUrl ?: previous?.batchArtworkUrl.orEmpty(),
+                    batchPosition = batch?.position ?: previous?.batchPosition ?: 0
                 )
             )
             workManager.enqueueUniqueWork(uniqueName, ExistingWorkPolicy.REPLACE, request)

--- a/app/src/main/java/com/luc4n3x/levyra/player/offline/work/OfflineExportWorker.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/offline/work/OfflineExportWorker.kt
@@ -313,6 +313,7 @@ class OfflineExportWorker(
         private const val NOTIFICATION_ID_BASE = 4200
         private const val NOTIFICATION_ID_RANGE = 5000
         private const val COMPLETED_TASK_RETENTION_MS = 7L * 24L * 60L * 60L * 1000L
+        private val UNSETTLED_TASK_STATES = setOf("QUEUED", "RUNNING", "PAUSED", "RETRYING", "FAILED")
 
         suspend fun enqueue(
             context: Context,
@@ -339,6 +340,11 @@ class OfflineExportWorker(
             val dao = LevyraDatabase.get(appContext).offlineDownloadTasksDao()
             val track = TrackPayloadCodec.decode(trackPayload)
             val previous = dao.byKey(trackId)
+            val retainedBatch = previous
+                ?.takeIf { it.batchKey.isNotBlank() && it.batchKey != batch?.key && it.state in UNSETTLED_TASK_STATES }
+                ?.let { OfflineDownloadBatchRef(it.batchKey, it.batchTitle, it.batchKind, it.batchArtworkUrl, it.batchPosition) }
+                ?: previous?.takeIf { batch == null && it.batchKey.isNotBlank() }
+                    ?.let { OfflineDownloadBatchRef(it.batchKey, it.batchTitle, it.batchKind, it.batchArtworkUrl, it.batchPosition) }
             val now = System.currentTimeMillis()
             dao.prune(now - COMPLETED_TASK_RETENTION_MS)
             dao.upsert(
@@ -354,11 +360,11 @@ class OfflineExportWorker(
                     error = "",
                     createdAt = previous?.createdAt ?: now,
                     updatedAt = now,
-                    batchKey = batch?.key ?: previous?.batchKey.orEmpty(),
-                    batchTitle = batch?.title ?: previous?.batchTitle.orEmpty(),
-                    batchKind = batch?.kind ?: previous?.batchKind.orEmpty(),
-                    batchArtworkUrl = batch?.artworkUrl ?: previous?.batchArtworkUrl.orEmpty(),
-                    batchPosition = batch?.position ?: previous?.batchPosition ?: 0
+                    batchKey = retainedBatch?.key ?: batch?.key.orEmpty(),
+                    batchTitle = retainedBatch?.title ?: batch?.title.orEmpty(),
+                    batchKind = retainedBatch?.kind ?: batch?.kind.orEmpty(),
+                    batchArtworkUrl = retainedBatch?.artworkUrl ?: batch?.artworkUrl.orEmpty(),
+                    batchPosition = retainedBatch?.position ?: batch?.position ?: 0
                 )
             )
             workManager.enqueueUniqueWork(uniqueName, ExistingWorkPolicy.REPLACE, request)

--- a/app/src/main/java/com/luc4n3x/levyra/player/offline/work/OfflineExportWorker.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/offline/work/OfflineExportWorker.kt
@@ -29,6 +29,7 @@ import com.luc4n3x.levyra.data.TrackPayloadCodec
 import com.luc4n3x.levyra.data.local.LevyraDatabase
 import com.luc4n3x.levyra.data.local.OfflineDownloadTaskEntity
 import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.domain.retainsExistingBatchMembership
 import com.luc4n3x.levyra.player.offline.OfflineAudioExporter
 import com.luc4n3x.levyra.player.offline.OfflineExportPipeline
 import com.luc4n3x.levyra.ui.i18n.LevyraStrings
@@ -313,7 +314,6 @@ class OfflineExportWorker(
         private const val NOTIFICATION_ID_BASE = 4200
         private const val NOTIFICATION_ID_RANGE = 5000
         private const val COMPLETED_TASK_RETENTION_MS = 7L * 24L * 60L * 60L * 1000L
-        private val UNSETTLED_TASK_STATES = setOf("QUEUED", "RUNNING", "PAUSED", "RETRYING", "FAILED")
 
         suspend fun enqueue(
             context: Context,
@@ -341,10 +341,14 @@ class OfflineExportWorker(
             val track = TrackPayloadCodec.decode(trackPayload)
             val previous = dao.byKey(trackId)
             val retainedBatch = previous
-                ?.takeIf { it.batchKey.isNotBlank() && it.batchKey != batch?.key && it.state in UNSETTLED_TASK_STATES }
+                ?.takeIf {
+                    retainsExistingBatchMembership(
+                        previousBatchKey = it.batchKey,
+                        previousState = it.state,
+                        requestedBatchKey = batch?.key.orEmpty()
+                    )
+                }
                 ?.let { OfflineDownloadBatchRef(it.batchKey, it.batchTitle, it.batchKind, it.batchArtworkUrl, it.batchPosition) }
-                ?: previous?.takeIf { batch == null && it.batchKey.isNotBlank() }
-                    ?.let { OfflineDownloadBatchRef(it.batchKey, it.batchTitle, it.batchKind, it.batchArtworkUrl, it.batchPosition) }
             val now = System.currentTimeMillis()
             dao.prune(now - COMPLETED_TASK_RETENTION_MS)
             dao.upsert(

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -17282,7 +17282,7 @@ private fun PlaylistHitRow(
                         modifier = Modifier.align(Alignment.BottomEnd)
                     ) {
                         Icon(
-                            Icons.Rounded.DownloadDone,
+                            Icons.Rounded.Download,
                             contentDescription = LocalLevyraStrings.current.downloadPlaylist,
                             tint = LevyraViolet,
                             modifier = Modifier.size(22.dp)
@@ -17324,7 +17324,7 @@ private fun SearchSectionFooter(
             contentAlignment = Alignment.Center
         ) {
             TextButton(onClick = onLoadMore) {
-                Text(strings.showAll, color = LevyraCyan, fontSize = 13.sp, fontWeight = FontWeight.Bold)
+                Text(strings.more, color = LevyraCyan, fontSize = 13.sp, fontWeight = FontWeight.Bold)
             }
         }
     }
@@ -17390,7 +17390,7 @@ private fun AlbumHitRow(
                             modifier = Modifier.align(Alignment.BottomEnd)
                         ) {
                             Icon(
-                                Icons.Rounded.DownloadDone,
+                                Icons.Rounded.Download,
                                 contentDescription = LocalLevyraStrings.current.download,
                                 tint = LevyraViolet,
                                 modifier = Modifier.size(22.dp)

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -333,6 +333,7 @@ import com.luc4n3x.levyra.domain.ArtistHit
 import com.luc4n3x.levyra.domain.ArtistRelease
 import com.luc4n3x.levyra.domain.DownloadedTrack
 import com.luc4n3x.levyra.domain.FollowedArtist
+import com.luc4n3x.levyra.domain.PlaylistHit
 import com.luc4n3x.levyra.domain.SearchFilter
 import com.luc4n3x.levyra.domain.SmartMusicProfile
 import com.luc4n3x.levyra.domain.LevyraContentLocales
@@ -8920,6 +8921,8 @@ private fun SearchScreen(viewModel: SearchViewModel, state: LevyraUiState) {
                                 selected = filter,
                                 hasArtists = data.artists.isNotEmpty(),
                                 hasAlbums = data.albums.isNotEmpty(),
+                                hasPlaylists = data.playlists.isNotEmpty(),
+                                hasVideos = data.videos.isNotEmpty(),
                                 onSelect = viewModel::setSearchFilter
                             )
                         }
@@ -8943,7 +8946,13 @@ private fun SearchScreen(viewModel: SearchViewModel, state: LevyraUiState) {
                             }
                         }
                         if ((filter == SearchFilter.All || filter == SearchFilter.Artists) && data.artists.isNotEmpty()) {
-                            item { SectionTitle(strings.artists) }
+                            item {
+                                SearchSectionHeader(
+                                    title = strings.artists,
+                                    showAll = filter == SearchFilter.All,
+                                    onShowAll = { viewModel.setSearchFilter(SearchFilter.Artists) }
+                                )
+                            }
                             item {
                                 ArtistHitRow(
                                     artists = data.artists,
@@ -8956,7 +8965,13 @@ private fun SearchScreen(viewModel: SearchViewModel, state: LevyraUiState) {
                             }
                         }
                         if ((filter == SearchFilter.All || filter == SearchFilter.Albums) && data.albums.isNotEmpty()) {
-                            item { SectionTitle(strings.albumsPlain) }
+                            item {
+                                SearchSectionHeader(
+                                    title = strings.albumsPlain,
+                                    showAll = filter == SearchFilter.All,
+                                    onShowAll = { viewModel.setSearchFilter(SearchFilter.Albums) }
+                                )
+                            }
                             item {
                                 AlbumHitRow(
                                     albums = data.albums,
@@ -8964,14 +8979,71 @@ private fun SearchScreen(viewModel: SearchViewModel, state: LevyraUiState) {
                                         focusManager.clearFocus()
                                         keyboardController?.hide()
                                         viewModel.openAlbum(album)
-                                    }
+                                    },
+                                    onDownload = { album -> viewModel.exportAlbumHit(album) }
+                                )
+                            }
+                        }
+                        if ((filter == SearchFilter.All || filter == SearchFilter.Playlists) && data.playlists.isNotEmpty()) {
+                            item {
+                                SearchSectionHeader(
+                                    title = strings.playlistsPlain,
+                                    showAll = filter == SearchFilter.All,
+                                    onShowAll = { viewModel.setSearchFilter(SearchFilter.Playlists) }
+                                )
+                            }
+                            item {
+                                PlaylistHitRow(
+                                    playlists = data.playlists,
+                                    onClick = { playlist ->
+                                        focusManager.clearFocus()
+                                        keyboardController?.hide()
+                                        viewModel.playPlaylistHit(playlist)
+                                    },
+                                    onDownload = { playlist -> viewModel.exportPlaylistHit(playlist) }
+                                )
+                            }
+                        }
+                        if ((filter == SearchFilter.All || filter == SearchFilter.Videos) && data.videos.isNotEmpty()) {
+                            item {
+                                SearchSectionHeader(
+                                    title = strings.video,
+                                    showAll = filter == SearchFilter.All,
+                                    onShowAll = { viewModel.setSearchFilter(SearchFilter.Videos) }
+                                )
+                            }
+                            items(data.videos, key = { "search-video-${it.id}" }) { track ->
+                                SearchTrackCard(
+                                    track = track,
+                                    isCurrent = track.id == state.currentTrack?.id,
+                                    isPlaying = state.isPlaying && track.id == state.currentTrack?.id,
+                                    isResolving = state.isResolving && track.id == state.currentTrack?.id,
+                                    isFavorite = track.id in state.favoriteIds,
+                                    isDownloading = track.id in state.downloadingTrackIds,
+                                    isDownloaded = track.id in state.downloadedTrackIds,
+                                    downloadProgress = state.downloadProgressByTrackId[track.id],
+                                    onClick = {
+                                        focusManager.clearFocus()
+                                        keyboardController?.hide()
+                                        viewModel.playFrom(data.videos, track)
+                                    },
+                                    onFavorite = { viewModel.toggleFavorite(track) },
+                                    onAddToPlaylist = { addTarget = track },
+                                    onDownload = { viewModel.exportTrack(track) },
+                                    onArtist = { viewModel.openArtist(track) }
                                 )
                             }
                         }
                         if (filter == SearchFilter.All || filter == SearchFilter.Songs) {
                             val songs = if (filter == SearchFilter.All) data.songs.drop(if (data.topTrack != null) 1 else 0) else data.songs
                             if (songs.isNotEmpty()) {
-                                item { SectionTitle(strings.songs) }
+                                item {
+                                    SearchSectionHeader(
+                                        title = strings.songs,
+                                        showAll = filter == SearchFilter.All,
+                                        onShowAll = { viewModel.setSearchFilter(SearchFilter.Songs) }
+                                    )
+                                }
                                 items(songs, key = { "search-song-${it.id}" }) { track ->
                                     SearchTrackCard(
                                         track = track,
@@ -8993,6 +9065,16 @@ private fun SearchScreen(viewModel: SearchViewModel, state: LevyraUiState) {
                                         onArtist = { viewModel.openArtist(track) }
                                     )
                                 }
+                            }
+                        }
+                        if (filter != SearchFilter.All) {
+                            item(key = "search-section-footer") {
+                                SearchSectionFooter(
+                                    loading = filter in state.searchSectionLoading,
+                                    failed = filter in data.failedSections,
+                                    canLoadMore = state.searchSectionContinuations[filter].orEmpty().isNotBlank(),
+                                    onLoadMore = { viewModel.loadMoreSearchSection(filter) }
+                                )
                             }
                         }
                     }
@@ -16938,6 +17020,8 @@ private fun SearchFilterChips(
     selected: SearchFilter,
     hasArtists: Boolean,
     hasAlbums: Boolean,
+    hasPlaylists: Boolean,
+    hasVideos: Boolean,
     onSelect: (SearchFilter) -> Unit
 ) {
     val strings = LocalLevyraStrings.current
@@ -16946,6 +17030,8 @@ private fun SearchFilterChips(
         add(SearchFilter.Songs to strings.songsPlain)
         if (hasArtists) add(SearchFilter.Artists to strings.artistsLabelPlural)
         if (hasAlbums) add(SearchFilter.Albums to strings.albumsPlain)
+        if (hasPlaylists) add(SearchFilter.Playlists to strings.playlistsPlain)
+        if (hasVideos) add(SearchFilter.Videos to strings.video)
     }
     Row(
         modifier = Modifier.horizontalScroll(rememberScrollState()),
@@ -17157,7 +17243,120 @@ private fun ArtistHitRow(
 }
 
 @Composable
-private fun AlbumHitRow(albums: List<AlbumHit>, onClick: (AlbumHit) -> Unit) {
+private fun PlaylistHitRow(
+    playlists: List<PlaylistHit>,
+    onClick: (PlaylistHit) -> Unit,
+    onDownload: (PlaylistHit) -> Unit
+) {
+    LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        itemsIndexed(
+            items = playlists,
+            key = { index, playlist ->
+                "playlist-hit-$index-${playlist.playlistId.ifBlank { playlist.title.trim().lowercase(Locale.ROOT) }}"
+            },
+            contentType = { _, _ -> "playlist-hit" }
+        ) { _, playlist ->
+            Column(
+                modifier = Modifier.width(150.dp).clickable { onClick(playlist) },
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(150.dp)
+                        .clip(RoundedCornerShape(14.dp))
+                        .background(LevyraPanelSoft),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (playlist.thumbnailUrl.isNotBlank()) {
+                        AsyncImage(
+                            model = ImageRequest.Builder(LocalContext.current).data(playlist.thumbnailUrl).crossfade(true).build(),
+                            contentDescription = playlist.title,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.matchParentSize()
+                        )
+                    } else {
+                        Icon(Icons.AutoMirrored.Rounded.PlaylistPlay, null, tint = LevyraMuted, modifier = Modifier.size(40.dp))
+                    }
+                    IconButton(
+                        onClick = { onDownload(playlist) },
+                        modifier = Modifier.align(Alignment.BottomEnd)
+                    ) {
+                        Icon(
+                            Icons.Rounded.DownloadDone,
+                            contentDescription = LocalLevyraStrings.current.downloadPlaylist,
+                            tint = LevyraViolet,
+                            modifier = Modifier.size(22.dp)
+                        )
+                    }
+                }
+                Text(playlist.title, color = LevyraText, fontSize = 13.sp, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text(
+                    listOf(playlist.author, playlist.trackCountLabel).filter { it.isNotBlank() }.joinToString(" · "),
+                    color = LevyraMuted,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SearchSectionFooter(
+    loading: Boolean,
+    failed: Boolean,
+    canLoadMore: Boolean,
+    onLoadMore: () -> Unit
+) {
+    val strings = LocalLevyraStrings.current
+    when {
+        loading -> Box(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator(modifier = Modifier.size(22.dp), strokeWidth = 2.dp, color = LevyraCyan)
+        }
+        failed -> GlassMessage(strings.searchFailed, LevyraOrange)
+        canLoadMore -> Box(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            TextButton(onClick = onLoadMore) {
+                Text(strings.showAll, color = LevyraCyan, fontSize = 13.sp, fontWeight = FontWeight.Bold)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SearchSectionHeader(title: String, showAll: Boolean, onShowAll: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Box(modifier = Modifier.weight(1f, fill = false)) { SectionTitle(title) }
+        if (showAll) {
+            TextButton(onClick = onShowAll) {
+                Text(
+                    LocalLevyraStrings.current.showAll,
+                    color = LevyraCyan,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlbumHitRow(
+    albums: List<AlbumHit>,
+    onClick: (AlbumHit) -> Unit,
+    onDownload: ((AlbumHit) -> Unit)? = null
+) {
     LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
         itemsIndexed(
             items = albums,
@@ -17184,6 +17383,19 @@ private fun AlbumHitRow(albums: List<AlbumHit>, onClick: (AlbumHit) -> Unit) {
                         )
                     } else {
                         Icon(Icons.Rounded.Album, null, tint = LevyraMuted, modifier = Modifier.size(40.dp))
+                    }
+                    onDownload?.let { download ->
+                        IconButton(
+                            onClick = { download(album) },
+                            modifier = Modifier.align(Alignment.BottomEnd)
+                        ) {
+                            Icon(
+                                Icons.Rounded.DownloadDone,
+                                contentDescription = LocalLevyraStrings.current.download,
+                                tint = LevyraViolet,
+                                modifier = Modifier.size(22.dp)
+                            )
+                        }
                     }
                 }
                 Text(album.title, color = LevyraText, fontSize = 13.sp, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)

--- a/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.luc4n3x.levyra.domain.BatchDownloadState
 import com.luc4n3x.levyra.domain.Playlist
 import com.luc4n3x.levyra.domain.Track
 import com.luc4n3x.levyra.ui.i18n.LocalLevyraStrings
@@ -530,8 +531,11 @@ internal fun LevyraLibraryScreen(
                             onOpenFolder = onOpenDownloads
                         )
                     }
-                    if (state.downloadBatches.isNotEmpty()) {
-                        items(state.downloadBatches, key = { "batch-${it.key}" }) { batch ->
+                    val activeBatches = state.downloadBatches.filterNot {
+                        it.state == BatchDownloadState.Completed || it.state == BatchDownloadState.Cancelled
+                    }
+                    if (activeBatches.isNotEmpty()) {
+                        items(activeBatches, key = { "batch-${it.key}" }) { batch ->
                             LibraryBatchDownloadRow(
                                 batch = batch,
                                 onRetry = { viewModel.retryBatchDownload(batch.key) },

--- a/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
@@ -530,6 +530,15 @@ internal fun LevyraLibraryScreen(
                             onOpenFolder = onOpenDownloads
                         )
                     }
+                    if (state.downloadBatches.isNotEmpty()) {
+                        items(state.downloadBatches, key = { "batch-${it.key}" }) { batch ->
+                            LibraryBatchDownloadRow(
+                                batch = batch,
+                                onRetry = { viewModel.retryBatchDownload(batch.key) },
+                                onCancel = { viewModel.cancelBatchDownload(batch.key) }
+                            )
+                        }
+                    }
                     if (state.downloadQueue.isNotEmpty()) {
                         item(key = "offline-queue-title") {
                             LibrarySectionTitle(strings.downloadsInProgress, strings.downloadInProgress)

--- a/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
@@ -58,9 +58,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.luc4n3x.levyra.domain.BatchDownloadState
 import com.luc4n3x.levyra.domain.Playlist
 import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.domain.visibleDownloadBatches
 import com.luc4n3x.levyra.ui.i18n.LocalLevyraStrings
 import com.luc4n3x.levyra.ui.i18n.formatLibraryBytes
 import com.luc4n3x.levyra.ui.theme.LevyraCyan
@@ -531,9 +531,7 @@ internal fun LevyraLibraryScreen(
                             onOpenFolder = onOpenDownloads
                         )
                     }
-                    val activeBatches = state.downloadBatches.filterNot {
-                        it.state == BatchDownloadState.Completed || it.state == BatchDownloadState.Cancelled
-                    }
+                    val activeBatches = visibleDownloadBatches(state.downloadBatches)
                     if (activeBatches.isNotEmpty()) {
                         items(activeBatches, key = { "batch-${it.key}" }) { batch ->
                             LibraryBatchDownloadRow(

--- a/app/src/main/java/com/luc4n3x/levyra/ui/library/LibraryActions.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/library/LibraryActions.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
 import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
+import androidx.compose.material.icons.rounded.Album
 import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.automirrored.rounded.Sort
 import androidx.compose.material.icons.rounded.ArrowDownward
@@ -64,6 +65,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.luc4n3x.levyra.domain.AlbumHit
+import com.luc4n3x.levyra.domain.BatchDownload
+import com.luc4n3x.levyra.domain.BatchDownloadKind
+import com.luc4n3x.levyra.domain.BatchDownloadState
 import com.luc4n3x.levyra.domain.OfflineDownloadTask
 import com.luc4n3x.levyra.domain.Playlist
 import com.luc4n3x.levyra.domain.Track
@@ -77,6 +81,7 @@ import com.luc4n3x.levyra.ui.theme.LevyraPanel
 import com.luc4n3x.levyra.ui.theme.LevyraPanelSoft
 import com.luc4n3x.levyra.ui.theme.LevyraPink
 import com.luc4n3x.levyra.ui.theme.LevyraText
+import com.luc4n3x.levyra.ui.theme.LevyraViolet
 import com.luc4n3x.levyra.viewmodel.LevyraUiState
 
 @Composable
@@ -193,6 +198,66 @@ internal fun LibraryDownloadTaskRow(
                 else "${strings.localizeDownloadState(task.state)} · ${task.progress.coerceIn(0, 100)}%",
                 color = if (failed) MaterialTheme.colorScheme.error else LevyraMuted,
                 fontSize = 10.sp
+            )
+        }
+    }
+}
+
+@Composable
+internal fun LibraryBatchDownloadRow(
+    batch: BatchDownload,
+    onRetry: () -> Unit,
+    onCancel: () -> Unit
+) {
+    val strings = LocalLevyraStrings.current
+    val failed = batch.state == BatchDownloadState.Failed
+    Surface(
+        color = LevyraPanel.copy(alpha = 0.84f),
+        shape = RoundedCornerShape(20.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    if (batch.kind == BatchDownloadKind.Playlist) Icons.AutoMirrored.Rounded.PlaylistPlay else Icons.Rounded.Album,
+                    contentDescription = null,
+                    tint = LevyraViolet,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(10.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        batch.title,
+                        color = LevyraText,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        "${batch.completed} / ${batch.total}",
+                        color = LevyraMuted,
+                        fontSize = 11.sp,
+                        maxLines = 1
+                    )
+                }
+                if (batch.canRetry) {
+                    IconButton(onClick = onRetry) {
+                        Icon(Icons.Rounded.Refresh, contentDescription = strings.resumeDownload, tint = LevyraCyan)
+                    }
+                }
+                IconButton(onClick = onCancel) {
+                    Icon(Icons.Rounded.Cancel, contentDescription = strings.cancelDownload, tint = LevyraMuted)
+                }
+            }
+            LinearProgressIndicator(
+                progress = { batch.progress.coerceIn(0, 100) / 100f },
+                modifier = Modifier.fillMaxWidth().height(4.dp),
+                color = if (failed) MaterialTheme.colorScheme.error else LevyraViolet,
+                trackColor = LevyraPanelSoft
             )
         }
     }

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -9,6 +9,7 @@ import com.luc4n3x.levyra.data.HomeEditorialEngine
 import com.luc4n3x.levyra.data.LevyraStartupCatalog
 import com.luc4n3x.levyra.data.deduplicateHomeAlbums
 import com.luc4n3x.levyra.domain.AlbumHit
+import com.luc4n3x.levyra.domain.PlaylistHit
 import com.luc4n3x.levyra.domain.ArtistHit
 import com.luc4n3x.levyra.domain.ChartRegion
 import com.luc4n3x.levyra.domain.DownloadedTrack
@@ -176,6 +177,10 @@ class SearchViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::sea
     fun searchNow(query: String) = root.searchNow(query)
     fun setQuery(query: String) = root.setQuery(query)
     fun setSearchFilter(filter: SearchFilter) = root.setSearchFilter(filter)
+    fun loadMoreSearchSection(filter: SearchFilter) = root.loadMoreSearchSection(filter)
+    fun playPlaylistHit(playlist: PlaylistHit) = root.playPlaylistHit(playlist)
+    fun exportPlaylistHit(playlist: PlaylistHit) = root.exportPlaylistHit(playlist)
+    fun exportAlbumHit(album: AlbumHit) = root.exportAlbumHit(album)
     fun toggleFavorite(track: Track) = root.toggleFavorite(track)
 }
 
@@ -201,6 +206,8 @@ class LibraryViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::li
     fun addToQueue(track: Track) = root.addToQueue(track)
     fun addTracksToQueue(tracks: List<Track>) = root.addTracksToQueue(tracks)
     fun cancelDownload(taskKey: String) = root.cancelDownload(taskKey)
+    fun retryBatchDownload(batchKey: String) = root.retryBatchDownload(batchKey)
+    fun cancelBatchDownload(batchKey: String) = root.cancelBatchDownload(batchKey)
     fun closePlaylist() = root.closePlaylist()
     fun createPlaylist(name: String, firstTrack: Track? = null) = root.createPlaylist(name, firstTrack)
     fun createPlaylistWithTracks(name: String, tracks: List<Track>) = root.createPlaylistWithTracks(name, tracks)

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -9,6 +9,7 @@ import com.luc4n3x.levyra.data.HomeEditorialEngine
 import com.luc4n3x.levyra.data.LevyraStartupCatalog
 import com.luc4n3x.levyra.data.deduplicateHomeAlbums
 import com.luc4n3x.levyra.domain.AlbumHit
+import com.luc4n3x.levyra.domain.BatchDownload
 import com.luc4n3x.levyra.domain.PlaylistHit
 import com.luc4n3x.levyra.domain.ArtistHit
 import com.luc4n3x.levyra.domain.ChartRegion
@@ -824,7 +825,7 @@ private fun homeProjection(state: LevyraUiState): HomeProjection = HomeProjectio
     interfaceSettings = state.interfaceSettings
 )
 
-private data class SearchProjection(
+internal data class SearchProjection(
     val currentTrack: Track?,
     val downloadProgressByTrackId: Map<String, Int>,
     val downloadedTrackIds: Set<String>,
@@ -844,10 +845,12 @@ private data class SearchProjection(
     val searchError: String?,
     val searchFilter: SearchFilter,
     val searchResults: List<Track>,
+    val searchSectionContinuations: Map<SearchFilter, String>,
+    val searchSectionLoading: Set<SearchFilter>,
     val searchSuggestions: List<String>
 )
 
-private fun searchProjection(state: LevyraUiState): SearchProjection = SearchProjection(
+internal fun searchProjection(state: LevyraUiState): SearchProjection = SearchProjection(
     currentTrack = state.currentTrack,
     downloadProgressByTrackId = state.downloadProgressByTrackId,
     downloadedTrackIds = state.downloadedTrackIds,
@@ -867,6 +870,8 @@ private fun searchProjection(state: LevyraUiState): SearchProjection = SearchPro
     searchError = state.searchError,
     searchFilter = state.searchFilter,
     searchResults = state.searchResults,
+    searchSectionContinuations = state.searchSectionContinuations,
+    searchSectionLoading = state.searchSectionLoading,
     searchSuggestions = state.searchSuggestions
 )
 
@@ -914,12 +919,13 @@ internal fun exploreProjection(state: LevyraUiState): ExploreProjection = Explor
     playlists = state.playlists
 )
 
-private data class LibraryProjection(
+internal data class LibraryProjection(
     val currentTrack: Track?,
     val downloadProgressByTrackId: Map<String, Int>,
     val downloadedTrackIds: Set<String>,
     val downloadingTrackIds: Set<String>,
     val downloadQueue: List<OfflineDownloadTask>,
+    val downloadBatches: List<BatchDownload>,
     val downloadStorageBytes: Long,
     val downloads: List<DownloadedTrack>,
     val favoriteIds: Set<String>,
@@ -933,12 +939,13 @@ private data class LibraryProjection(
     val recentListens: List<Track>
 )
 
-private fun libraryProjection(state: LevyraUiState): LibraryProjection = LibraryProjection(
+internal fun libraryProjection(state: LevyraUiState): LibraryProjection = LibraryProjection(
     currentTrack = state.currentTrack,
     downloadProgressByTrackId = state.downloadProgressByTrackId,
     downloadedTrackIds = state.downloadedTrackIds,
     downloadingTrackIds = state.downloadingTrackIds,
     downloadQueue = state.downloadQueue,
+    downloadBatches = state.downloadBatches,
     downloadStorageBytes = state.downloadStorageBytes,
     downloads = state.downloads,
     favoriteIds = state.favoriteIds,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
@@ -17,6 +17,7 @@ import com.luc4n3x.levyra.domain.LevyraDownloadSettings
 import com.luc4n3x.levyra.domain.LevyraInterfaceSettings
 import com.luc4n3x.levyra.domain.LevyraBackupSettings
 import com.luc4n3x.levyra.domain.LevyraIntelligenceSummary
+import com.luc4n3x.levyra.domain.BatchDownload
 import com.luc4n3x.levyra.domain.OfflineDownloadTask
 import com.luc4n3x.levyra.domain.ListeningPulse
 import com.luc4n3x.levyra.domain.LyricLine
@@ -156,6 +157,7 @@ data class LevyraUiState(
     val downloadTitleByTrackId: Map<String, String> = emptyMap(),
     val offlineQueueSize: Int = 0,
     val downloadQueue: List<OfflineDownloadTask> = emptyList(),
+    val downloadBatches: List<BatchDownload> = emptyList(),
     val showArtist: Boolean = false,
     val artistLoading: Boolean = false,
     val artistError: String? = null,
@@ -163,6 +165,8 @@ data class LevyraUiState(
     val artistListStateKey: String = "",
     val searchData: SearchResults = SearchResults(),
     val searchFilter: SearchFilter = SearchFilter.All,
+    val searchSectionContinuations: Map<SearchFilter, String> = emptyMap(),
+    val searchSectionLoading: Set<SearchFilter> = emptySet(),
     val themePreset: String = LevyraThemes.COSMIC,
     val interfaceSettings: LevyraInterfaceSettings = LevyraInterfaceSettings(),
     val downloadSettings: LevyraDownloadSettings = LevyraDownloadSettings(),

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -60,7 +60,20 @@ import com.luc4n3x.levyra.domain.ArtistRelease
 import com.luc4n3x.levyra.domain.AlbumHit
 import com.luc4n3x.levyra.domain.AlbumRecommendationSeed
 import com.luc4n3x.levyra.domain.AlbumDetail
+import com.luc4n3x.levyra.data.mergeSearchAlbums
+import com.luc4n3x.levyra.data.mergeSearchArtists
+import com.luc4n3x.levyra.data.mergeSearchPlaylists
+import com.luc4n3x.levyra.data.mergeSearchSongs
+import com.luc4n3x.levyra.data.runCatchingPreservingCancellation
 import com.luc4n3x.levyra.domain.ArtistHit
+import com.luc4n3x.levyra.domain.BatchDownload
+import com.luc4n3x.levyra.domain.BatchDownloadKind
+import com.luc4n3x.levyra.domain.PlaylistHit
+import com.luc4n3x.levyra.domain.batchDownloadKey
+import com.luc4n3x.levyra.domain.batchDownloadKindOf
+import com.luc4n3x.levyra.domain.batchDownloadProgress
+import com.luc4n3x.levyra.domain.batchDownloadState
+import com.luc4n3x.levyra.player.offline.work.OfflineDownloadBatchRef
 import com.luc4n3x.levyra.domain.artistIdentityKey
 import com.luc4n3x.levyra.domain.isArtistShelfNameEligible
 import com.luc4n3x.levyra.domain.primaryArtistSegment
@@ -158,12 +171,25 @@ import java.io.File
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
 private const val ARTIST_PROFILE_UNAVAILABLE_ERROR = "artist_profile_unavailable"
 private const val ARTIST_INITIAL_BIOGRAPHY_WAIT_MS = 4_500L
 private const val EXPLORE_SHORTS_FEED_LIMIT = 24
+
+private const val REMOTE_PLAYLIST_TRACK_LIMIT = 150
+private val ACTIVE_DOWNLOAD_STATES = setOf("QUEUED", "RUNNING", "PAUSED", "RETRYING")
+
+private data class SearchSectionPage(
+    val songs: List<Track> = emptyList(),
+    val videos: List<Track> = emptyList(),
+    val albums: List<AlbumHit> = emptyList(),
+    val artists: List<ArtistHit> = emptyList(),
+    val playlists: List<PlaylistHit> = emptyList(),
+    val continuation: String = ""
+)
 
 private data class HomeArtistCandidate(
     val name: String,
@@ -529,6 +555,8 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         )
     )
     private var searchJob: Job? = null
+    private val searchGeneration = AtomicInteger(0)
+    private val searchSectionJobs = mutableMapOf<SearchFilter, Job>()
     private var playlistImportJob: Job? = null
     private var sharedMediaJob: Job? = null
     private var playJob: Job? = null
@@ -1000,6 +1028,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         startTicker()
         observeDownloads()
         observeDownloadTasks()
+        observeDownloadBatches()
         loadPlaylists()
         viewModelScope.launch(Dispatchers.Default) { consumeOfficialMetadataQueue() }
         refreshListeningPulse(force = true)
@@ -1008,6 +1037,28 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         LevyraWidgetBridge.onNext = { next() }
         LevyraWidgetBridge.onPrevious = { previous() }
         updateWidget()
+    }
+
+    private fun observeDownloadBatches() {
+        viewModelScope.launch {
+            offlineDownloadTasksDao.observeBatches().collectLatest { rows ->
+                val batches = rows.map { row ->
+                    BatchDownload(
+                        key = row.batchKey,
+                        kind = batchDownloadKindOf(row.batchKind),
+                        title = row.batchTitle,
+                        artworkUrl = row.batchArtworkUrl,
+                        total = row.total,
+                        completed = row.completed,
+                        failed = row.failed,
+                        active = row.active,
+                        progress = batchDownloadProgress(row.total, row.progressSum),
+                        state = batchDownloadState(row.total, row.completed, row.failed, row.active, row.progressSum)
+                    )
+                }
+                _state.update { it.copy(downloadBatches = batches) }
+            }
+        }
     }
 
     private fun observeDownloadTasks() {
@@ -3670,13 +3721,177 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     fun exportCurrentAlbum() {
         val detail = _state.value.albumDetail ?: return
-        exportTracksSequential(detail.tracks, "Album offline")
+        startBatchDownload(
+            kind = BatchDownloadKind.Album,
+            canonicalId = detail.album.browseId.ifBlank { detail.album.audioPlaylistId },
+            title = detail.album.title,
+            artworkUrl = detail.album.thumbnailUrl,
+            tracks = detail.tracks
+        )
+    }
+
+    fun exportAlbumHit(album: AlbumHit) {
+        viewModelScope.launch {
+            val detail = runCatchingPreservingCancellation {
+                providerRouter.albumDetail(album, _state.value.languageCode)
+            }.onFailure { Timber.w(it, "album batch download lookup failed") }.getOrNull()
+            val tracks = detail?.tracks.orEmpty()
+            if (tracks.isEmpty()) {
+                _state.update { it.copy(offlineExportMessage = albumBatchUnavailableMessage()) }
+                return@launch
+            }
+            startBatchDownload(
+                kind = BatchDownloadKind.Album,
+                canonicalId = album.browseId.ifBlank { album.audioPlaylistId },
+                title = album.title,
+                artworkUrl = album.thumbnailUrl,
+                tracks = tracks
+            )
+        }
     }
 
     fun exportOpenPlaylist() {
         val playlist = _state.value.openPlaylist ?: return
-        exportTracksSequential(playlist.tracks, "Playlist offline")
+        startBatchDownload(
+            kind = BatchDownloadKind.Playlist,
+            canonicalId = playlist.id,
+            title = playlist.name,
+            artworkUrl = playlist.coverUrl,
+            tracks = playlist.tracks
+        )
     }
+
+    fun exportPlaylistHit(playlist: PlaylistHit) {
+        val playlistId = playlist.playlistId.ifBlank { return }
+        viewModelScope.launch {
+            val detail = runCatchingPreservingCancellation {
+                providerRouter.playlist(playlistId, _state.value.languageCode, REMOTE_PLAYLIST_TRACK_LIMIT)
+            }.onFailure { Timber.w(it, "playlist batch download lookup failed") }.getOrNull()
+            val tracks = detail?.tracks.orEmpty()
+            if (tracks.isEmpty()) {
+                _state.update { it.copy(offlineExportMessage = playlistBatchUnavailableMessage()) }
+                return@launch
+            }
+            startBatchDownload(
+                kind = BatchDownloadKind.Playlist,
+                canonicalId = playlistId,
+                title = playlist.title.ifBlank { detail?.title.orEmpty() },
+                artworkUrl = playlist.thumbnailUrl.ifBlank { detail?.thumbnailUrl.orEmpty() },
+                tracks = tracks
+            )
+        }
+    }
+
+    fun playPlaylistHit(playlist: PlaylistHit) {
+        val playlistId = playlist.playlistId.ifBlank { return }
+        viewModelScope.launch {
+            val detail = runCatchingPreservingCancellation {
+                providerRouter.playlist(playlistId, _state.value.languageCode, REMOTE_PLAYLIST_TRACK_LIMIT)
+            }.onFailure { Timber.w(it, "playlist playback lookup failed") }.getOrNull()
+            val tracks = detail?.tracks.orEmpty()
+            if (tracks.isEmpty()) {
+                _state.update { it.copy(searchError = playlistBatchUnavailableMessage()) }
+                return@launch
+            }
+            _state.update { it.copy(tracks = mergeTracks(it.tracks, tracks)) }
+            playFrom(tracks, tracks.first())
+        }
+    }
+
+    fun retryBatchDownload(batchKey: String) {
+        if (batchKey.isBlank()) return
+        viewModelScope.launch {
+            val failed = withContext(Dispatchers.IO) {
+                offlineDownloadTasksDao.batchTasks(batchKey).filter { it.state == "FAILED" }
+            }
+            failed.forEach { task ->
+                OfflineExportWorker.enqueue(
+                    context = getApplication<Application>().applicationContext,
+                    trackId = task.taskKey,
+                    trackPayload = task.payload,
+                    batch = OfflineDownloadBatchRef(
+                        key = task.batchKey,
+                        title = task.batchTitle,
+                        kind = task.batchKind,
+                        artworkUrl = task.batchArtworkUrl,
+                        position = task.batchPosition
+                    )
+                )
+            }
+        }
+    }
+
+    fun cancelBatchDownload(batchKey: String) {
+        if (batchKey.isBlank()) return
+        viewModelScope.launch {
+            val appContext = getApplication<Application>().applicationContext
+            val tasks = withContext(Dispatchers.IO) { offlineDownloadTasksDao.batchTasks(batchKey) }
+            tasks.filter { it.state in ACTIVE_DOWNLOAD_STATES }.forEach { task ->
+                runCatchingPreservingCancellation { OfflineExportWorker.cancel(appContext, task.taskKey) }
+                    .onFailure { Timber.w(it, "batch child cancel failed") }
+            }
+            withContext(Dispatchers.IO) { offlineDownloadTasksDao.deleteBatch(batchKey) }
+        }
+    }
+
+    private fun startBatchDownload(
+        kind: BatchDownloadKind,
+        canonicalId: String,
+        title: String,
+        artworkUrl: String,
+        tracks: List<Track>
+    ) {
+        val batchKey = batchDownloadKey(kind, canonicalId, title)
+        if (batchKey.isBlank()) {
+            exportTracksSequential(tracks, title)
+            return
+        }
+        val currentState = _state.value
+        val pending = tracks
+            .filter { it.id.isNotBlank() || it.videoUrl.isNotBlank() || it.title.isNotBlank() }
+            .distinctBy { downloadKeyFor(it) }
+            .filterNot { track ->
+                currentState.downloadSettings.shouldSkipExistingDownload(
+                    trackId = track.id,
+                    downloadedTrackIds = currentState.downloadedTrackIds
+                )
+            }
+        val strings = LevyraStrings.forCode(currentState.languageCode)
+        if (pending.isEmpty()) {
+            _state.update { it.copy(offlineExportMessage = strings.alreadyOffline) }
+            return
+        }
+        viewModelScope.launch {
+            val appContext = getApplication<Application>().applicationContext
+            _state.update { it.copy(offlineExportMessage = strings.downloadsInProgress) }
+            pending.forEachIndexed { index, track ->
+                val downloadKey = downloadKeyFor(track)
+                val enqueued = runCatchingPreservingCancellation {
+                    withContext(Dispatchers.IO) {
+                        OfflineExportWorker.enqueue(
+                            context = appContext,
+                            trackId = downloadKey,
+                            trackPayload = TrackPayloadCodec.encode(track),
+                            batch = OfflineDownloadBatchRef(
+                                key = batchKey,
+                                title = title,
+                                kind = kind.name,
+                                artworkUrl = artworkUrl,
+                                position = index
+                            )
+                        )
+                    }
+                }.onFailure { error -> Timber.e(error, "batch download enqueue failed") }
+                if (enqueued.isSuccess) recordSmartDownload(track)
+            }
+        }
+    }
+
+    private fun albumBatchUnavailableMessage(): String =
+        LevyraStrings.forCode(_state.value.languageCode).albumTracksUnavailable
+
+    private fun playlistBatchUnavailableMessage(): String =
+        LevyraStrings.forCode(_state.value.languageCode).playlistEmpty
 
     fun exportTracks(tracks: List<Track>, label: String = "Selezione offline") {
         exportTracksSequential(tracks, label)
@@ -4120,37 +4335,27 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     private suspend fun runSearch(clean: String) {
         moveToTab(LevyraTab.Search, rememberCurrent = true)
-        _state.update { it.copy(isSearching = true, searchError = null, searchSuggestions = emptyList(), searchFilter = SearchFilter.All) }
+        searchGeneration.incrementAndGet()
+        _state.update {
+            it.copy(
+                isSearching = true,
+                searchError = null,
+                searchSuggestions = emptyList(),
+                searchFilter = SearchFilter.All,
+                searchSectionContinuations = emptyMap(),
+                searchSectionLoading = emptySet()
+            )
+        }
         val result = runCatching {
             coroutineScope {
                 val rawSearch = async {
                     providerRouter.searchEverything(clean, _state.value.languageCode)
                 }
                 val exactArtistSearch = async {
-                    runCatching { artistRepository.artistHitFor(clean) }.getOrNull()
+                    runCatchingPreservingCancellation { artistRepository.artistHitFor(clean) }.getOrNull()
                 }
                 val raw = rawSearch.await()
-                val exactArtist = exactArtistSearch.await()
-                val generalCandidates = raw.artists.filterNot { candidate ->
-                    exactArtist != null &&
-                        candidate.browseId.isNotBlank() &&
-                        candidate.browseId.equals(exactArtist.browseId, ignoreCase = true)
-                }
-                val verifiedGeneralArtists = artistRepository.officialArtistHits(generalCandidates)
-                val officialArtists = mergeReliableArtistSearchResults(
-                    query = clean,
-                    exactArtist = exactArtist,
-                    verifiedArtists = verifiedGeneralArtists
-                )
-                val artistResolvedResults = enrichSearchTracksWithExactArtist(
-                    query = clean,
-                    results = raw,
-                    reliableArtists = officialArtists
-                )
-                artistResolvedResults.copy(
-                    artists = officialArtists,
-                    albums = searchAlbumsForArtistQuery(clean, artistResolvedResults, officialArtists)
-                )
+                enrichSearchOverview(clean, raw, exactArtistSearch.await())
             }
         }
         result.onSuccess { data ->
@@ -4233,8 +4438,131 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             .take(10)
     }
 
+    private suspend fun enrichSearchOverview(
+        query: String,
+        raw: SearchResults,
+        exactArtist: ArtistHit?
+    ): SearchResults {
+        val generalCandidates = raw.artists.filterNot { candidate ->
+            exactArtist != null &&
+                candidate.browseId.isNotBlank() &&
+                candidate.browseId.equals(exactArtist.browseId, ignoreCase = true)
+        }
+        val officialArtists = runCatchingPreservingCancellation {
+            mergeReliableArtistSearchResults(
+                query = query,
+                exactArtist = exactArtist,
+                verifiedArtists = artistRepository.officialArtistHits(generalCandidates)
+            )
+        }.onFailure { Timber.w(it, "search artist verification failed") }.getOrNull()
+        val resolvedArtists = officialArtists ?: raw.artists
+        val artistResolvedResults = runCatchingPreservingCancellation {
+            enrichSearchTracksWithExactArtist(
+                query = query,
+                results = raw,
+                reliableArtists = resolvedArtists
+            )
+        }.onFailure { Timber.w(it, "search track artist enrichment failed") }.getOrDefault(raw)
+        val albums = runCatchingPreservingCancellation {
+            searchAlbumsForArtistQuery(query, artistResolvedResults, resolvedArtists)
+        }.onFailure { Timber.w(it, "search album refinement failed") }
+            .getOrDefault(artistResolvedResults.albums)
+        return artistResolvedResults.copy(
+            artists = resolvedArtists,
+            albums = albums,
+            failedSections = buildSet {
+                if (officialArtists == null && raw.artists.isEmpty()) add(SearchFilter.Artists)
+            }
+        )
+    }
+
     fun setSearchFilter(filter: SearchFilter) {
         _state.update { it.copy(searchFilter = filter) }
+        loadSearchSection(filter, initial = true)
+    }
+
+    fun loadMoreSearchSection(filter: SearchFilter) {
+        loadSearchSection(filter, initial = false)
+    }
+
+    private fun loadSearchSection(filter: SearchFilter, initial: Boolean) {
+        if (filter == SearchFilter.All) return
+        val snapshot = _state.value
+        val query = snapshot.query.trim()
+        if (query.length < 2) return
+        if (filter in snapshot.searchSectionLoading) return
+        if (searchSectionJobs[filter]?.isActive == true) return
+        val alreadyPaged = snapshot.searchSectionContinuations.containsKey(filter)
+        val continuation = snapshot.searchSectionContinuations[filter].orEmpty()
+        if (initial && alreadyPaged) return
+        if (!initial && (!alreadyPaged || continuation.isBlank())) return
+        val generation = searchGeneration.get()
+        _state.update { it.copy(searchSectionLoading = it.searchSectionLoading + filter) }
+        searchSectionJobs[filter] = viewModelScope.launch {
+            try {
+                val outcome = runCatching { fetchSearchSection(filter, query, continuation) }
+                if (generation != searchGeneration.get()) return@launch
+                outcome.onSuccess { page -> publishSearchSection(filter, page) }
+                    .onFailure { error ->
+                        if (error is CancellationException) throw error
+                        Timber.w(error, "search section load failed filter=%s", filter)
+                        _state.update { state ->
+                            state.copy(
+                                searchData = state.searchData.copy(
+                                    failedSections = state.searchData.failedSections + filter
+                                )
+                            )
+                        }
+                    }
+            } finally {
+                _state.update { it.copy(searchSectionLoading = it.searchSectionLoading - filter) }
+            }
+        }
+    }
+
+    private suspend fun fetchSearchSection(
+        filter: SearchFilter,
+        query: String,
+        continuation: String
+    ): SearchSectionPage {
+        val language = _state.value.languageCode
+        return when (filter) {
+            SearchFilter.Songs -> repository.searchSongsPage(query, language, continuation)
+                .let { page -> SearchSectionPage(songs = page.items, continuation = page.continuation) }
+            SearchFilter.Videos -> repository.searchVideosPage(query, language, continuation)
+                .let { page -> SearchSectionPage(videos = page.items, continuation = page.continuation) }
+            SearchFilter.Albums -> repository.searchAlbumsPage(query, language, continuation)
+                .let { page -> SearchSectionPage(albums = page.items, continuation = page.continuation) }
+            SearchFilter.Artists -> repository.searchArtistsPage(query, language, continuation)
+                .let { page -> SearchSectionPage(artists = page.items, continuation = page.continuation) }
+            SearchFilter.Playlists -> repository.searchPlaylistsPage(query, language, continuation)
+                .let { page -> SearchSectionPage(playlists = page.items, continuation = page.continuation) }
+            SearchFilter.All -> SearchSectionPage()
+        }
+    }
+
+    private fun publishSearchSection(filter: SearchFilter, page: SearchSectionPage) {
+        _state.update { state ->
+            val data = state.searchData
+            val merged = when (filter) {
+                SearchFilter.Songs -> data.copy(songs = mergeSearchSongs(data.songs, page.songs))
+                SearchFilter.Videos -> data.copy(videos = mergeSearchSongs(data.videos, page.videos))
+                SearchFilter.Albums -> data.copy(albums = mergeSearchAlbums(data.albums, page.albums))
+                SearchFilter.Artists -> data.copy(artists = mergeSearchArtists(data.artists, page.artists))
+                SearchFilter.Playlists -> data.copy(playlists = mergeSearchPlaylists(data.playlists, page.playlists))
+                SearchFilter.All -> data
+            }
+            state.copy(
+                searchData = merged.copy(failedSections = merged.failedSections - filter),
+                searchResults = if (filter == SearchFilter.Songs) merged.songs else state.searchResults,
+                tracks = if (filter == SearchFilter.Songs || filter == SearchFilter.Videos) {
+                    mergeTracks(state.tracks, page.songs + page.videos)
+                } else {
+                    state.tracks
+                },
+                searchSectionContinuations = state.searchSectionContinuations + (filter to page.continuation)
+            )
+        }
     }
 
     fun searchAlbum(album: AlbumHit) {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -3801,22 +3801,24 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     fun retryBatchDownload(batchKey: String) {
         if (batchKey.isBlank()) return
         viewModelScope.launch {
-            val failed = withContext(Dispatchers.IO) {
-                offlineDownloadTasksDao.batchTasks(batchKey).filter { it.state == "FAILED" }
-            }
-            failed.forEach { task ->
-                OfflineExportWorker.enqueue(
-                    context = getApplication<Application>().applicationContext,
-                    trackId = task.taskKey,
-                    trackPayload = task.payload,
-                    batch = OfflineDownloadBatchRef(
-                        key = task.batchKey,
-                        title = task.batchTitle,
-                        kind = task.batchKind,
-                        artworkUrl = task.batchArtworkUrl,
-                        position = task.batchPosition
-                    )
-                )
+            val appContext = getApplication<Application>().applicationContext
+            withContext(Dispatchers.IO) {
+                offlineDownloadTasksDao.batchTasks(batchKey)
+                    .filter { it.state == "FAILED" }
+                    .forEach { task ->
+                        OfflineExportWorker.enqueue(
+                            context = appContext,
+                            trackId = task.taskKey,
+                            trackPayload = task.payload,
+                            batch = OfflineDownloadBatchRef(
+                                key = task.batchKey,
+                                title = task.batchTitle,
+                                kind = task.batchKind,
+                                artworkUrl = task.batchArtworkUrl,
+                                position = task.batchPosition
+                            )
+                        )
+                    }
             }
         }
     }
@@ -3825,12 +3827,15 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         if (batchKey.isBlank()) return
         viewModelScope.launch {
             val appContext = getApplication<Application>().applicationContext
-            val tasks = withContext(Dispatchers.IO) { offlineDownloadTasksDao.batchTasks(batchKey) }
-            tasks.filter { it.state in ACTIVE_DOWNLOAD_STATES }.forEach { task ->
-                runCatchingPreservingCancellation { OfflineExportWorker.cancel(appContext, task.taskKey) }
-                    .onFailure { Timber.w(it, "batch child cancel failed") }
+            withContext(Dispatchers.IO) {
+                offlineDownloadTasksDao.batchTasks(batchKey)
+                    .filter { it.state in ACTIVE_DOWNLOAD_STATES }
+                    .forEach { task ->
+                        runCatchingPreservingCancellation { OfflineExportWorker.cancel(appContext, task.taskKey) }
+                            .onFailure { Timber.w(it, "batch child cancel failed") }
+                    }
+                offlineDownloadTasksDao.deleteBatch(batchKey)
             }
-            withContext(Dispatchers.IO) { offlineDownloadTasksDao.deleteBatch(batchKey) }
         }
     }
 
@@ -4502,7 +4507,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             try {
                 val outcome = runCatching { fetchSearchSection(filter, query, continuation) }
                 if (generation != searchGeneration.get()) return@launch
-                outcome.onSuccess { page -> publishSearchSection(filter, page) }
+                outcome.onSuccess { page -> publishSearchSection(filter, page, continuation) }
                     .onFailure { error ->
                         if (error is CancellationException) throw error
                         Timber.w(error, "search section load failed filter=%s", filter)
@@ -4541,7 +4546,12 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         }
     }
 
-    private fun publishSearchSection(filter: SearchFilter, page: SearchSectionPage) {
+    private fun publishSearchSection(
+        filter: SearchFilter,
+        page: SearchSectionPage,
+        requestedContinuation: String
+    ) {
+        val nextContinuation = page.continuation.takeUnless { it == requestedContinuation }.orEmpty()
         _state.update { state ->
             val data = state.searchData
             val merged = when (filter) {
@@ -4560,7 +4570,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 } else {
                     state.tracks
                 },
-                searchSectionContinuations = state.searchSectionContinuations + (filter to page.continuation)
+                searchSectionContinuations = state.searchSectionContinuations + (filter to nextContinuation)
             )
         }
     }

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -64,6 +64,7 @@ import com.luc4n3x.levyra.data.mergeSearchAlbums
 import com.luc4n3x.levyra.data.mergeSearchArtists
 import com.luc4n3x.levyra.data.mergeSearchPlaylists
 import com.luc4n3x.levyra.data.mergeSearchSongs
+import com.luc4n3x.levyra.data.nextSearchContinuation
 import com.luc4n3x.levyra.data.runCatchingPreservingCancellation
 import com.luc4n3x.levyra.domain.ArtistHit
 import com.luc4n3x.levyra.domain.BatchDownload
@@ -4551,7 +4552,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         page: SearchSectionPage,
         requestedContinuation: String
     ) {
-        val nextContinuation = page.continuation.takeUnless { it == requestedContinuation }.orEmpty()
+        val nextContinuation = nextSearchContinuation(requestedContinuation, page.continuation)
         _state.update { state ->
             val data = state.searchData
             val merged = when (filter) {

--- a/app/src/test/java/com/luc4n3x/levyra/data/SearchEntityIdentityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/SearchEntityIdentityTest.kt
@@ -1,0 +1,235 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.domain.AlbumHit
+import com.luc4n3x.levyra.domain.ArtistHit
+import com.luc4n3x.levyra.domain.PlaylistHit
+import com.luc4n3x.levyra.domain.ReleaseType
+import com.luc4n3x.levyra.domain.Track
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SearchEntityIdentityTest {
+
+    @Test
+    fun `same album from different endpoints collapses on canonical browse id`() {
+        val merged = deduplicateSearchAlbums(
+            listOf(
+                album(title = "Ghost Stories", artist = "Coldplay", browseId = "MPREb_ghost"),
+                album(title = "Ghost Stories Deluxe", artist = "Coldplay", browseId = "MPREb_ghost", thumbnailUrl = "https://img/2")
+            )
+        )
+
+        assertEquals(1, merged.size)
+        assertEquals("Ghost Stories", merged.single().title)
+    }
+
+    @Test
+    fun `same album with different browse ids still collapses on metadata`() {
+        val merged = deduplicateSearchAlbums(
+            listOf(
+                album(title = "Ghost Stories", artist = "Coldplay", browseId = "MPREb_one", thumbnailUrl = ""),
+                album(title = "Ghost Stories", artist = "Coldplay", browseId = "MPREb_two", thumbnailUrl = "https://img/2")
+            )
+        )
+
+        assertEquals(1, merged.size)
+        assertEquals("MPREb_one", merged.single().browseId)
+        assertEquals("https://img/2", merged.single().thumbnailUrl)
+    }
+
+    @Test
+    fun `distinct albums by the same artist are preserved`() {
+        val merged = deduplicateSearchAlbums(
+            listOf(
+                album(title = "Parachutes", artist = "Coldplay", browseId = "MPREb_par"),
+                album(title = "X and Y", artist = "Coldplay", browseId = "MPREb_xy")
+            )
+        )
+
+        assertEquals(2, merged.size)
+    }
+
+    @Test
+    fun `album merge fills missing canonical identifiers from the duplicate`() {
+        val merged = deduplicateSearchAlbums(
+            listOf(
+                album(title = "Viva la Vida", artist = "Coldplay", browseId = ""),
+                album(title = "Viva la Vida", artist = "Coldplay", browseId = "MPREb_viva", audioPlaylistId = "OLAK5uy_viva")
+            )
+        )
+
+        assertEquals(1, merged.size)
+        assertEquals("MPREb_viva", merged.single().browseId)
+        assertEquals("OLAK5uy_viva", merged.single().audioPlaylistId)
+    }
+
+    @Test
+    fun `artists collapse on canonical browse id despite different display names`() {
+        val merged = deduplicateSearchArtists(
+            listOf(
+                artist(name = "Coldplay", browseId = "UCchannel"),
+                artist(name = "COLDPLAY ", browseId = "UCchannel", thumbnailUrl = "https://img/artist")
+            )
+        )
+
+        assertEquals(1, merged.size)
+        assertEquals("https://img/artist", merged.single().thumbnailUrl)
+    }
+
+    @Test
+    fun `different artists with different browse ids are preserved`() {
+        val merged = deduplicateSearchArtists(
+            listOf(
+                artist(name = "Coldplay", browseId = "UCone"),
+                artist(name = "Radiohead", browseId = "UCtwo")
+            )
+        )
+
+        assertEquals(2, merged.size)
+    }
+
+    @Test
+    fun `playlists collapse on playlist id`() {
+        val merged = deduplicateSearchPlaylists(
+            listOf(
+                playlist(title = "Chill Hits", playlistId = "PL123"),
+                playlist(title = "Chill Hits Official", playlistId = "PL123", thumbnailUrl = "https://img/pl")
+            )
+        )
+
+        assertEquals(1, merged.size)
+        assertEquals("https://img/pl", merged.single().thumbnailUrl)
+    }
+
+    @Test
+    fun `songs collapse on video id and keep the richer record`() {
+        val merged = deduplicateSearchSongs(
+            listOf(
+                track(id = "abc", title = "Yellow", album = ""),
+                track(id = "abc", title = "Yellow", album = "Parachutes", durationMs = 267_000L)
+            )
+        )
+
+        assertEquals(1, merged.size)
+        assertEquals("Parachutes", merged.single().album)
+        assertEquals(267_000L, merged.single().durationMs)
+    }
+
+    @Test
+    fun `continuation merge appends new items without duplicating the first page`() {
+        val firstPage = listOf(track(id = "a"), track(id = "b"))
+        val secondPage = listOf(track(id = "b"), track(id = "c"))
+
+        val merged = mergeSearchSongs(firstPage, secondPage)
+
+        assertEquals(listOf("a", "b", "c"), merged.map { it.id })
+    }
+
+    @Test
+    fun `music video type classification separates songs from videos`() {
+        assertFalse(isMusicVideoResult("MUSIC_VIDEO_TYPE_ATV"))
+        assertFalse(isMusicVideoResult(""))
+        assertTrue(isMusicVideoResult("MUSIC_VIDEO_TYPE_OMV"))
+        assertTrue(isMusicVideoResult("MUSIC_VIDEO_TYPE_UGC"))
+    }
+
+    @Test
+    fun `albums without canonical ids stay separate when metadata differs`() {
+        val merged = deduplicateSearchAlbums(
+            listOf(
+                album(title = "Parachutes", artist = "Coldplay", browseId = ""),
+                album(title = "Kid A", artist = "Radiohead", browseId = "")
+            )
+        )
+
+        assertEquals(2, merged.size)
+    }
+
+    @Test
+    fun `indistinguishable malformed entries collapse instead of duplicating the shelf`() {
+        val merged = deduplicateSearchAlbums(
+            listOf(
+                album(title = "", artist = "", browseId = ""),
+                album(title = "", artist = "", browseId = "")
+            )
+        )
+
+        assertEquals(1, merged.size)
+    }
+
+    @Test
+    fun `empty input stays empty`() {
+        assertTrue(deduplicateSearchAlbums(emptyList()).isEmpty())
+        assertTrue(deduplicateSearchArtists(emptyList()).isEmpty())
+        assertTrue(deduplicateSearchPlaylists(emptyList()).isEmpty())
+        assertTrue(deduplicateSearchSongs(emptyList()).isEmpty())
+    }
+
+    private fun album(
+        title: String,
+        artist: String,
+        browseId: String,
+        audioPlaylistId: String = "",
+        thumbnailUrl: String = "https://img/1"
+    ) = AlbumHit(
+        title = title,
+        artist = artist,
+        year = "",
+        thumbnailUrl = thumbnailUrl,
+        query = "$title $artist",
+        browseId = browseId,
+        audioPlaylistId = audioPlaylistId,
+        releaseType = ReleaseType.Album
+    )
+
+    private fun artist(
+        name: String,
+        browseId: String,
+        thumbnailUrl: String = ""
+    ) = ArtistHit(
+        name = name,
+        subscribers = "",
+        thumbnailUrl = thumbnailUrl,
+        accentStart = 0,
+        accentEnd = 0,
+        browseId = browseId
+    )
+
+    private fun playlist(
+        title: String,
+        playlistId: String,
+        thumbnailUrl: String = ""
+    ) = PlaylistHit(
+        title = title,
+        author = "YouTube Music",
+        thumbnailUrl = thumbnailUrl,
+        playlistId = playlistId
+    )
+
+    private fun track(
+        id: String,
+        title: String = "Song",
+        album: String = "Album",
+        durationMs: Long = 0L
+    ) = Track(
+        id = id,
+        title = title,
+        artist = "Coldplay",
+        album = album,
+        durationMs = durationMs,
+        streamUrl = "",
+        videoUrl = "",
+        thumbnailUrl = "",
+        largeThumbnailUrl = "",
+        source = "YouTube Music",
+        moodTags = emptySet(),
+        energy = 0,
+        vocal = 0,
+        replayScore = 0,
+        cacheScore = 0,
+        accentStart = 0,
+        accentEnd = 0
+    )
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/SearchEntityIdentityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/SearchEntityIdentityTest.kt
@@ -160,6 +160,24 @@ class SearchEntityIdentityTest {
     }
 
     @Test
+    fun `an echoed continuation token ends pagination instead of refetching page one`() {
+        assertEquals("", nextSearchContinuation(requested = "TOKEN_A", returned = "TOKEN_A"))
+        assertEquals("", nextSearchContinuation(requested = "TOKEN_A", returned = " TOKEN_A "))
+        assertEquals("TOKEN_B", nextSearchContinuation(requested = "TOKEN_A", returned = "TOKEN_B"))
+    }
+
+    @Test
+    fun `a missing continuation token ends pagination`() {
+        assertEquals("", nextSearchContinuation(requested = "TOKEN_A", returned = ""))
+        assertEquals("", nextSearchContinuation(requested = "", returned = "   "))
+    }
+
+    @Test
+    fun `the first page accepts the token it did not request`() {
+        assertEquals("TOKEN_A", nextSearchContinuation(requested = "", returned = "TOKEN_A"))
+    }
+
+    @Test
     fun `empty input stays empty`() {
         assertTrue(deduplicateSearchAlbums(emptyList()).isEmpty())
         assertTrue(deduplicateSearchArtists(emptyList()).isEmpty())

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicSearchEntityKindTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicSearchEntityKindTest.kt
@@ -1,0 +1,160 @@
+package com.luc4n3x.levyra.data
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class YoutubeMusicSearchEntityKindTest {
+    private val repository = YoutubeMusicRepository()
+
+    @Test
+    fun `renderer with a video id is a track regardless of localized labels`() {
+        val renderer = JSONObject()
+            .put("playlistItemData", JSONObject().put("videoId", "2nd73lyvq4w"))
+            .put("flexColumns", JSONArray().put(line("Yellow")).put(line("アーティスト")))
+
+        assertEquals(SearchEntityKind.Track, repository.searchEntityKind(renderer))
+    }
+
+    @Test
+    fun `artist row is detected from the browse endpoint page type not the localized word`() {
+        val renderer = JSONObject().put(
+            "flexColumns",
+            JSONArray()
+                .put(line("Coldplay"))
+                .put(runLine(browseRun("아티스트", "UCchannel", "MUSIC_PAGE_TYPE_ARTIST")))
+        )
+
+        assertEquals(SearchEntityKind.Artist, repository.searchEntityKind(renderer))
+    }
+
+    @Test
+    fun `album row wins over the artist endpoint it also carries`() {
+        val renderer = JSONObject().put(
+            "flexColumns",
+            JSONArray()
+                .put(runLine(browseRun("Ghost Stories", "MPREb_ghost", "MUSIC_PAGE_TYPE_ALBUM")))
+                .put(runLine(browseRun("Coldplay", "UCchannel", "MUSIC_PAGE_TYPE_ARTIST")))
+        )
+
+        assertEquals(SearchEntityKind.Album, repository.searchEntityKind(renderer))
+    }
+
+    @Test
+    fun `playlist row wins over the author artist endpoint`() {
+        val renderer = JSONObject().put(
+            "flexColumns",
+            JSONArray()
+                .put(runLine(browseRun("Chill Hits", "VLPL123", "MUSIC_PAGE_TYPE_PLAYLIST")))
+                .put(runLine(browseRun("YouTube Music", "UCauthor", "MUSIC_PAGE_TYPE_ARTIST")))
+        )
+
+        assertEquals(SearchEntityKind.Playlist, repository.searchEntityKind(renderer))
+    }
+
+    @Test
+    fun `watch endpoint carrying only a playlist id is a playlist`() {
+        val renderer = JSONObject()
+            .put("flexColumns", JSONArray().put(line("Chill Hits")))
+            .put(
+                "navigationEndpoint",
+                JSONObject().put("watchEndpoint", JSONObject().put("playlistId", "PL123"))
+            )
+
+        assertEquals(SearchEntityKind.Playlist, repository.searchEntityKind(renderer))
+    }
+
+    @Test
+    fun `overview splits official music videos out of the songs section`() {
+        val root = JSONObject().put(
+            "contents",
+            JSONArray()
+                .put(JSONObject().put("musicResponsiveListItemRenderer", trackRenderer("aaa", "Song", "MUSIC_VIDEO_TYPE_ATV")))
+                .put(JSONObject().put("musicResponsiveListItemRenderer", trackRenderer("bbb", "Clip", "MUSIC_VIDEO_TYPE_OMV")))
+        )
+
+        val overview = repository.parseSearchOverview(root, "coldplay")
+
+        assertEquals(listOf("aaa"), overview.songs.map { it.id })
+        assertEquals(listOf("bbb"), overview.videos.map { it.id })
+    }
+
+    @Test
+    fun `overview collects playlists with their canonical playlist id`() {
+        val root = JSONObject().put(
+            "contents",
+            JSONArray().put(
+                JSONObject().put(
+                    "musicResponsiveListItemRenderer",
+                    JSONObject().put(
+                        "flexColumns",
+                        JSONArray()
+                            .put(runLine(browseRun("Chill Hits", "VLPL123", "MUSIC_PAGE_TYPE_PLAYLIST")))
+                            .put(line("YouTube Music"))
+                    )
+                )
+            )
+        )
+
+        val overview = repository.parseSearchOverview(root, "chill")
+
+        assertEquals(1, overview.playlists.size)
+        assertEquals("PL123", overview.playlists.single().playlistId)
+        assertEquals("Chill Hits", overview.playlists.single().title)
+    }
+
+    @Test
+    fun `overview is empty for an unparsable payload`() {
+        val overview = repository.parseSearchOverview(JSONObject().put("contents", JSONArray()), "query")
+
+        assertTrue(overview.isEmpty)
+    }
+
+    private fun trackRenderer(videoId: String, title: String, videoType: String): JSONObject = JSONObject()
+        .put("playlistItemData", JSONObject().put("videoId", videoId))
+        .put("flexColumns", JSONArray().put(line(title)).put(line("Coldplay")))
+        .put(
+            "navigationEndpoint",
+            JSONObject().put(
+                "watchEndpoint",
+                JSONObject()
+                    .put("videoId", videoId)
+                    .put(
+                        "watchEndpointMusicSupportedConfigs",
+                        JSONObject().put(
+                            "watchEndpointMusicConfig",
+                            JSONObject().put("musicVideoType", videoType)
+                        )
+                    )
+            )
+        )
+
+    private fun line(text: String): JSONObject = flexColumn(JSONArray().put(JSONObject().put("text", text)))
+
+    private fun runLine(run: JSONObject): JSONObject = flexColumn(JSONArray().put(run))
+
+    private fun browseRun(text: String, browseId: String, pageType: String): JSONObject = JSONObject()
+        .put("text", text)
+        .put(
+            "navigationEndpoint",
+            JSONObject().put(
+                "browseEndpoint",
+                JSONObject()
+                    .put("browseId", browseId)
+                    .put(
+                        "browseEndpointContextSupportedConfigs",
+                        JSONObject().put(
+                            "browseEndpointContextMusicConfig",
+                            JSONObject().put("pageType", pageType)
+                        )
+                    )
+            )
+        )
+
+    private fun flexColumn(runs: JSONArray): JSONObject = JSONObject().put(
+        "musicResponsiveListItemFlexColumnRenderer",
+        JSONObject().put("text", JSONObject().put("runs", runs))
+    )
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicSearchEntityKindTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicSearchEntityKindTest.kt
@@ -106,6 +106,29 @@ class YoutubeMusicSearchEntityKindTest {
     }
 
     @Test
+    fun `an author containing digits is not reused as the track count label`() {
+        val root = JSONObject().put(
+            "contents",
+            JSONArray().put(
+                JSONObject().put(
+                    "musicResponsiveListItemRenderer",
+                    JSONObject().put(
+                        "flexColumns",
+                        JSONArray()
+                            .put(runLine(browseRun("Punk Essentials", "VLPL999", "MUSIC_PAGE_TYPE_PLAYLIST")))
+                            .put(line("Blink 182"))
+                    )
+                )
+            )
+        )
+
+        val playlist = repository.parseSearchOverview(root, "punk").playlists.single()
+
+        assertEquals("Blink 182", playlist.author)
+        assertEquals("", playlist.trackCountLabel)
+    }
+
+    @Test
     fun `overview is empty for an unparsable payload`() {
         val overview = repository.parseSearchOverview(JSONObject().put("contents", JSONArray()), "query")
 

--- a/app/src/test/java/com/luc4n3x/levyra/domain/BatchDownloadTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/domain/BatchDownloadTest.kt
@@ -1,0 +1,100 @@
+package com.luc4n3x.levyra.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BatchDownloadTest {
+
+    @Test
+    fun `progress averages child progress across the batch`() {
+        assertEquals(50, batchDownloadProgress(total = 4, progressSum = 200))
+        assertEquals(0, batchDownloadProgress(total = 0, progressSum = 500))
+        assertEquals(100, batchDownloadProgress(total = 2, progressSum = 400))
+    }
+
+    @Test
+    fun `queued batch reports queued until a child makes progress`() {
+        assertEquals(
+            BatchDownloadState.Queued,
+            batchDownloadState(total = 14, completed = 0, failed = 0, active = 14, progressSum = 0)
+        )
+        assertEquals(
+            BatchDownloadState.Downloading,
+            batchDownloadState(total = 14, completed = 0, failed = 0, active = 14, progressSum = 40)
+        )
+        assertEquals(
+            BatchDownloadState.Downloading,
+            batchDownloadState(total = 14, completed = 8, failed = 0, active = 6, progressSum = 812)
+        )
+    }
+
+    @Test
+    fun `batch completes only when every child succeeded`() {
+        assertEquals(
+            BatchDownloadState.Completed,
+            batchDownloadState(total = 14, completed = 14, failed = 0, active = 0, progressSum = 1400)
+        )
+        assertEquals(
+            BatchDownloadState.Failed,
+            batchDownloadState(total = 14, completed = 12, failed = 2, active = 0, progressSum = 1200)
+        )
+        assertEquals(
+            BatchDownloadState.Cancelled,
+            batchDownloadState(total = 14, completed = 3, failed = 0, active = 0, progressSum = 300)
+        )
+    }
+
+    @Test
+    fun `empty batch is treated as cancelled`() {
+        assertEquals(
+            BatchDownloadState.Cancelled,
+            batchDownloadState(total = 0, completed = 0, failed = 0, active = 0, progressSum = 0)
+        )
+    }
+
+    @Test
+    fun `retry is offered only for settled batches with failures`() {
+        assertTrue(batch(total = 10, completed = 8, failed = 2, active = 0).canRetry)
+        assertFalse(batch(total = 10, completed = 8, failed = 2, active = 1).canRetry)
+        assertFalse(batch(total = 10, completed = 10, failed = 0, active = 0).canRetry)
+    }
+
+    @Test
+    fun `batch key prefers the canonical identifier`() {
+        assertEquals(
+            "album:mpreb_ghost",
+            batchDownloadKey(BatchDownloadKind.Album, canonicalId = "MPREb_ghost", fallbackTitle = "Ghost Stories")
+        )
+        assertEquals(
+            "playlist:chill-hits",
+            batchDownloadKey(BatchDownloadKind.Playlist, canonicalId = "", fallbackTitle = "Chill Hits")
+        )
+        assertEquals(
+            "",
+            batchDownloadKey(BatchDownloadKind.Album, canonicalId = "", fallbackTitle = "   ")
+        )
+    }
+
+    @Test
+    fun `unknown kind labels fall back to album`() {
+        assertEquals(BatchDownloadKind.Playlist, batchDownloadKindOf("Playlist"))
+        assertEquals(BatchDownloadKind.Playlist, batchDownloadKindOf("PLAYLIST"))
+        assertEquals(BatchDownloadKind.Album, batchDownloadKindOf(""))
+        assertEquals(BatchDownloadKind.Album, batchDownloadKindOf("something-else"))
+    }
+
+    private fun batch(total: Int, completed: Int, failed: Int, active: Int) = BatchDownload(
+        key = "album:test",
+        kind = BatchDownloadKind.Album,
+        title = "Test",
+        artworkUrl = "",
+        total = total,
+        completed = completed,
+        failed = failed,
+        active = active,
+        progress = batchDownloadProgress(total, completed * 100),
+        state = batchDownloadState(total, completed, failed, active, completed * 100)
+    )
+}

--- a/app/src/test/java/com/luc4n3x/levyra/domain/BatchDownloadTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/domain/BatchDownloadTest.kt
@@ -85,6 +85,97 @@ class BatchDownloadTest {
         assertEquals(BatchDownloadKind.Album, batchDownloadKindOf("something-else"))
     }
 
+    @Test
+    fun `settled batches leave the active list but failed ones stay for retry`() {
+        val batches = listOf(
+            batchWith(BatchDownloadState.Downloading, "a"),
+            batchWith(BatchDownloadState.Completed, "b"),
+            batchWith(BatchDownloadState.Failed, "c"),
+            batchWith(BatchDownloadState.Cancelled, "d"),
+            batchWith(BatchDownloadState.Queued, "e")
+        )
+
+        assertEquals(listOf("a", "c", "e"), visibleDownloadBatches(batches).map { it.key })
+    }
+
+    @Test
+    fun `a track already owned by an unsettled batch keeps its first membership`() {
+        assertTrue(
+            retainsExistingBatchMembership(
+                previousBatchKey = "album:first",
+                previousState = "RUNNING",
+                requestedBatchKey = "playlist:second"
+            )
+        )
+        assertTrue(
+            retainsExistingBatchMembership(
+                previousBatchKey = "album:first",
+                previousState = "FAILED",
+                requestedBatchKey = "playlist:second"
+            )
+        )
+    }
+
+    @Test
+    fun `a settled batch releases the track to a new batch`() {
+        assertFalse(
+            retainsExistingBatchMembership(
+                previousBatchKey = "album:first",
+                previousState = "SUCCEEDED",
+                requestedBatchKey = "playlist:second"
+            )
+        )
+        assertFalse(
+            retainsExistingBatchMembership(
+                previousBatchKey = "album:first",
+                previousState = "CANCELLED",
+                requestedBatchKey = "playlist:second"
+            )
+        )
+    }
+
+    @Test
+    fun `retrying the same batch is not treated as a competing membership`() {
+        assertFalse(
+            retainsExistingBatchMembership(
+                previousBatchKey = "album:first",
+                previousState = "FAILED",
+                requestedBatchKey = "album:first"
+            )
+        )
+    }
+
+    @Test
+    fun `a single track download does not clear an existing batch membership`() {
+        assertTrue(
+            retainsExistingBatchMembership(
+                previousBatchKey = "album:first",
+                previousState = "SUCCEEDED",
+                requestedBatchKey = ""
+            )
+        )
+        assertFalse(
+            retainsExistingBatchMembership(
+                previousBatchKey = "",
+                previousState = "QUEUED",
+                requestedBatchKey = ""
+            )
+        )
+    }
+
+    private fun batchWith(state: BatchDownloadState, key: String) = BatchDownload(
+        key = key,
+        kind = BatchDownloadKind.Album,
+        title = key,
+        artworkUrl = "",
+        total = 4,
+        completed = 1,
+        failed = 0,
+        active = 1,
+        progress = 25,
+        state = state
+    )
+
     private fun batch(total: Int, completed: Int, failed: Int, active: Int) = BatchDownload(
         key = "album:test",
         kind = BatchDownloadKind.Album,

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/ScreenProjectionCoverageTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/ScreenProjectionCoverageTest.kt
@@ -1,0 +1,77 @@
+package com.luc4n3x.levyra.viewmodel
+
+import com.luc4n3x.levyra.domain.BatchDownload
+import com.luc4n3x.levyra.domain.BatchDownloadKind
+import com.luc4n3x.levyra.domain.BatchDownloadState
+import com.luc4n3x.levyra.domain.PlaylistHit
+import com.luc4n3x.levyra.domain.SearchFilter
+import com.luc4n3x.levyra.domain.SearchResults
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class ScreenProjectionCoverageTest {
+    private val base = LevyraUiState()
+
+    @Test
+    fun `search projection reacts to section loading state`() {
+        assertNotEquals(
+            searchProjection(base),
+            searchProjection(base.copy(searchSectionLoading = setOf(SearchFilter.Albums)))
+        )
+    }
+
+    @Test
+    fun `search projection reacts to section continuations`() {
+        assertNotEquals(
+            searchProjection(base),
+            searchProjection(base.copy(searchSectionContinuations = mapOf(SearchFilter.Albums to "TOKEN")))
+        )
+    }
+
+    @Test
+    fun `search projection reacts to the new result categories`() {
+        val withPlaylists = base.copy(
+            searchData = SearchResults(
+                playlists = listOf(PlaylistHit(title = "Chill", author = "YT", thumbnailUrl = "", playlistId = "PL1"))
+            )
+        )
+
+        assertNotEquals(searchProjection(base), searchProjection(withPlaylists))
+    }
+
+    @Test
+    fun `search projection reacts to failed sections`() {
+        assertNotEquals(
+            searchProjection(base),
+            searchProjection(base.copy(searchData = SearchResults(failedSections = setOf(SearchFilter.Artists))))
+        )
+    }
+
+    @Test
+    fun `library projection reacts to batch downloads`() {
+        val withBatch = base.copy(downloadBatches = listOf(batch(completed = 1, progress = 25)))
+
+        assertNotEquals(libraryProjection(base), libraryProjection(withBatch))
+    }
+
+    @Test
+    fun `library projection reacts to batch progress advancing`() {
+        val early = base.copy(downloadBatches = listOf(batch(completed = 1, progress = 25)))
+        val later = base.copy(downloadBatches = listOf(batch(completed = 2, progress = 50)))
+
+        assertNotEquals(libraryProjection(early), libraryProjection(later))
+    }
+
+    private fun batch(completed: Int, progress: Int) = BatchDownload(
+        key = "album:test",
+        kind = BatchDownloadKind.Album,
+        title = "Test",
+        artworkUrl = "",
+        total = 4,
+        completed = completed,
+        failed = 0,
+        active = 4 - completed,
+        progress = progress,
+        state = BatchDownloadState.Downloading
+    )
+}


### PR DESCRIPTION
## Summary

Search classified result rows by a localized subtitle word, so artists were only
recognised in seven Latin-script languages and playlists and music videos had no
category at all. Albums and artists were deduplicated by normalized title/name,
which merged distinct releases while still letting the same release appear twice
when it arrived from two endpoints with different artwork.

Album and playlist downloads fanned out into independent per-track jobs with no
grouping, aggregate progress, or batch-level retry/cancel.

This PR fixes both, reusing the existing extractor, resilience client, Room
schema, and WorkManager download engine rather than adding parallel systems.

## Search and discovery

- Rows are classified from their InnerTube navigation endpoint instead of a
  localized label: a row carrying a video id is a track (split into songs and
  videos by `musicVideoType`), and the rest resolve to album, playlist, or
  artist from the browse endpoint page type. Album wins over the artist endpoint
  a release row also carries, and playlist wins over its author endpoint.
- `SearchResults` gains `playlists`, `videos`, and `failedSections`;
  `SearchFilter` gains `Playlists` and `Videos`. All fields are defaulted, so
  existing construction sites are unchanged.
- Deduplication merges on canonical id **or** normalized metadata, keeping the
  richer artwork and identifiers. Matching on either side is what fixes both
  directions of the duplicate problem: one release split across two `browseId`s
  collapses, and two genuinely different releases that normalize to the same
  title stay separate when their ids differ.
- Each category has its own filtered search request with continuation support.
  "Show all" loads a section on demand with independent loading and error state,
  so the first screen is not inflated with hundreds of rows. The same merge
  backs paging, so a continuation cannot re-add visible items, and a token
  echoed back unchanged is treated as end-of-results rather than refetching the
  first page forever.
- Artist verification, track enrichment, and album refinement no longer share a
  single `runCatching`; one failing no longer empties the other sections.
- `YoutubeMusicResilienceClient.search` accepts a continuation token. Its
  request key, in-flight deduplication, and TTL selection already accounted for
  continuations, so only the `SEARCH` payload branch needed the field.

## Downloads

- Album and playlist downloads are grouped by a batch key stored on the existing
  `offline_download_tasks` rows (`batchKey`, `batchTitle`, `batchKind`,
  `batchArtworkUrl`, `batchPosition`), so persistence, retry, resume, atomic
  finalisation, and the concurrency gate come from the current engine unchanged.
- Aggregate progress, state, retry, and cancel are derived from those rows, so a
  batch survives backgrounding and process death through the records WorkManager
  already persists. Pruning no longer deletes completed children of a batch that
  is still running, which would otherwise corrupt the completed count.
- A track already owned by a still-unsettled batch keeps that membership when a
  second collection requests it, so the first batch can still settle.
- Batch children skip the per-track `WorkInfo` polling loop and report through
  the Room flow the UI already collects, replacing one polling coroutine per
  track.
- Search album and playlist cards expose a download action; the library shows a
  batch row with `completed / total`, progress, retry (only when the batch has
  settled with failures), and cancel. Completed and cancelled batches are
  hidden; failed ones stay visible for retry.
- Database version 14 → 15 with an additive migration; no destructive migration
  and no user data dropped.

## Not included

Several items considered for this work already exist in Levyra and were left
alone rather than duplicated: expired stream URL recovery with position restore
and bounded attempts (`PlaybackService.runServiceRecovery` /
`PlaybackResilienceEngine`), next-track pre-resolution and Media3 cache warm-up
(`PlaybackWarmup` / `QueuePrecachePolicy`), configurable equal-power crossfade
(`AutoMixPlanner`), and Canvas/motion artwork with its bounded Room cache and
URL verification (`feature/motion`). BPM-driven automatic crossfade was
evaluated and deferred: it needs heavy analysis for a marginal gain and would
cost battery on the audio path.

A full batch-to-task membership model (a join table letting one track belong to
several batches at once) is also deferred; see the open review thread.

## Tests

`:app:testDebugUnitTest` — 870 tests, all passing. New coverage:

- `SearchEntityIdentityTest` — canonical-id and metadata merging in both
  directions, distinct releases preserved, richer-record merge, continuation
  paging without duplicates, echoed/blank continuation handling, song/video
  classification, empty and malformed input.
- `YoutubeMusicSearchEntityKindTest` — endpoint-based classification including
  non-Latin labels, album-over-artist and playlist-over-author precedence,
  playlist-only watch endpoints, the song/video split, and a digit-bearing
  author not being reused as the track count.
- `BatchDownloadTest` — progress aggregation, state transitions, retry
  eligibility, batch key derivation, batch visibility, and membership retention.
- `ScreenProjectionCoverageTest` — asserts the `distinctUntilChanged` projection
  gate actually publishes the new pagination and batch fields.

The review surfaced defects that lived in imperative code the tests could not
reach. Those decisions were extracted into pure functions
(`nextSearchContinuation`, `retainsExistingBatchMembership`,
`visibleDownloadBatches`) and covered, and each new test was mutation-checked:
reverting the function to its pre-fix form fails the corresponding cases.

## Validation

- `python3 scripts/ai_quality_gate.py --profile fast` — passed.
- `:app:testDebugUnitTest` — passed.
- `:app:lintDebug` — passed.
- `:app:lintRelease` and `:app:assembleRelease -PlevyraFdroidBuild=true` —
  **blocked locally, not run**. The F-Droid release profile builds
  `third_party/LevyraNexus` with a JDK 21 toolchain; only JDK 17 is installed on
  this machine, so the included build cannot produce the artifact and Gradle
  falls back to resolving `com.github.LUC4N3X:LevyraNexus:1.0.0` from JitPack,
  which this environment cannot reach. The failure is dependency resolution and
  is unrelated to this diff, which adds no dependencies. CI runs both.
- Device checks (playback, MediaSession, notification, Android Auto, the Room
  14 → 15 upgrade path on real data) have **not** been performed.
