### PR TITLE
fix(download): prevent first-attempt download failures and playback stalls

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -417,11 +417,16 @@ class PlaybackResolver private constructor(private val context: Context) {
         return hit.track
     }
 
-    fun invalidate(track: Track, isVideoMode: Boolean = false) {
-        remove(cacheKey(track, isVideoMode))
+    fun invalidate(track: Track, isVideoMode: Boolean = false, offlineExport: Boolean = false) {
+        remove(cacheKey(track, isVideoMode, selectedAudioQuality, offlineExport))
     }
 
-    fun reportPlaybackFailure(track: Track, isVideoMode: Boolean, reason: String) {
+    fun reportPlaybackFailure(
+        track: Track,
+        isVideoMode: Boolean,
+        reason: String,
+        isOfflineExport: Boolean = false
+    ) {
         if (isLocalPlaybackTrack(track)) {
             resilienceEngine.recordPlayerFailure(track.id, isVideoMode, reason)
             return
@@ -434,18 +439,20 @@ class PlaybackResolver private constructor(private val context: Context) {
         Timber.w(
             "playback failure source=%s mode=%s reason=%s stream=%s",
             track.source,
-            if (isVideoMode) "video" else "audio",
+            if (isVideoMode) "video" else if (isOfflineExport) "offline" else "audio",
             reason.take(120),
             playbackStreamDiagnostics(track.streamUrl)
         )
-        invalidate(track, isVideoMode)
+        invalidate(track, isVideoMode, isOfflineExport)
         resilienceEngine.recordPlayerFailure(track.id, isVideoMode, reason)
         val now = System.currentTimeMillis()
         val lower = reason.lowercase()
         val recovery = resilienceEngine.recoveryPlan(reason)
-        listOf(track.streamUrl, track.videoStreamUrl)
-            .filter { it.isNotBlank() }
-            .forEach { failedPlaybackUrls[it] = now + recovery.quarantineMs }
+        if (!isOfflineExport) {
+            listOf(track.streamUrl, track.videoStreamUrl)
+                .filter { it.isNotBlank() }
+                .forEach { failedPlaybackUrls[it] = now + recovery.quarantineMs }
+        }
         if (recovery.rotateClient) {
             profileFromSource(track.source)?.let { profile ->
                 recordClientFailure(profile, null, PlaybackBlockedException(reason))
@@ -454,7 +461,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         if (recovery.refreshSecurity) {
             YoutubeLocalDecoder.notifyStreamRejected(track.source)
         }
-        if (recovery.rotateCodec) {
+        if (recovery.rotateCodec && !isOfflineExport) {
             videoSelector.reportPlaybackFailure(track.videoStreamUrl.ifBlank { track.streamUrl }, lower)
         }
         val sourceMatchQuarantineMs = when {
@@ -464,7 +471,13 @@ class PlaybackResolver private constructor(private val context: Context) {
         }
         sourceMatchScope.launch {
             runCatchingPreservingCancellation {
-                sourceMatchStore.recordFailure(track, isVideoMode, selectedAudioQuality, sourceMatchQuarantineMs)
+                sourceMatchStore.recordFailure(
+                    track = track,
+                    videoMode = isVideoMode,
+                    audioQuality = selectedAudioQuality,
+                    quarantineMs = sourceMatchQuarantineMs,
+                    preferMp4Audio = isOfflineExport
+                )
             }.onFailure { error ->
                 Timber.w(error, "persistent source match failure update failed")
             }
@@ -612,7 +625,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                     audioQuality = audioQuality,
                     errors = mutableListOf(),
                     allowNetworkRefresh = false
-                )?.also { store(offlineTrack, it, isVideoMode, audioQuality) }
+                )?.also { store(offlineTrack, it, isVideoMode, audioQuality, preferMp4Audio) }
             }
             restored?.let { return@coroutineScope it }
             throw PlaybackBlockedException("Connessione Internet non disponibile")
@@ -657,7 +670,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         val errors = Collections.synchronizedList(mutableListOf<String>())
 
         restorePersistentSource(track, isVideoMode, preferMp4Audio, audioQuality, errors)?.let { restored ->
-            store(track, restored, isVideoMode, audioQuality)
+            store(track, restored, isVideoMode, audioQuality, preferMp4Audio)
             return@withContext restored
         }
 
@@ -713,14 +726,14 @@ class PlaybackResolver private constructor(private val context: Context) {
 
         val resolved = resolveAudioFast(track, errors, preferMp4Audio, audioQuality)
         if (resolved != null) {
-            store(track, resolved, isVideoMode, audioQuality)
+            store(track, resolved, isVideoMode, audioQuality, preferMp4Audio)
             persistResolvedSource(track, resolved, isVideoMode, audioQuality, 96, preferMp4Audio)
             return@withContext resolved
         }
 
         val alternate = resolveAudioWithSearchFallback(track, errors, preferMp4Audio, audioQuality)
         if (alternate != null) {
-            store(track, alternate, isVideoMode, audioQuality)
+            store(track, alternate, isVideoMode, audioQuality, preferMp4Audio)
             persistResolvedSource(track, alternate, isVideoMode, audioQuality, 84, preferMp4Audio)
             return@withContext alternate
         }
@@ -1531,7 +1544,8 @@ class PlaybackResolver private constructor(private val context: Context) {
                     streamUrl = streamUrl,
                     playbackManifest = manifest
                 )
-                val audioCache = key.contains("_audio_", ignoreCase = true)
+                val audioCache = key.contains("_audio_", ignoreCase = true) ||
+                    key.contains("_offline_", ignoreCase = true)
                 if (track != null && streamUrl.isNotBlank() && now < expiresAt && streamStillFresh(streamUrl) && (!audioCache || isPlayableAudioUrl(streamUrl))) {
                     streamCache[key] = CachedStream(track, expiresAt)
                 } else {
@@ -1547,11 +1561,12 @@ class PlaybackResolver private constructor(private val context: Context) {
         requestedTrack: Track,
         resolvedTrack: Track,
         isVideoMode: Boolean = false,
-        audioQuality: String = selectedAudioQuality
+        audioQuality: String = selectedAudioQuality,
+        offlineExport: Boolean = false
     ) {
         if (resolvedTrack.streamUrl.isBlank() || !streamStillFresh(resolvedTrack.streamUrl)) return
         if (!isVideoMode && !isPlayableAudioUrl(resolvedTrack.streamUrl)) return
-        val key = cacheKey(requestedTrack, isVideoMode, audioQuality)
+        val key = cacheKey(requestedTrack, isVideoMode, audioQuality, offlineExport)
         val expiresAt = resolvedTrack.playbackManifest?.expiresAtMs
             ?.takeIf { it > System.currentTimeMillis() }
             ?.let { minOf(it, expiresAtFor(resolvedTrack.streamUrl)) }
@@ -1691,11 +1706,17 @@ class PlaybackResolver private constructor(private val context: Context) {
     private fun cacheKey(
         track: Track,
         isVideoMode: Boolean = false,
-        audioQuality: String = selectedAudioQuality
+        audioQuality: String = selectedAudioQuality,
+        offlineExport: Boolean = false
     ): String {
         val base = PlaybackSourceIdentity.canonicalKey(track)
         val quality = normalizeAudioQuality(audioQuality).lowercase()
-        return if (isVideoMode) "${base}_video_$quality" else "${base}_audio_$quality"
+        val mode = when {
+            isVideoMode -> "video"
+            offlineExport -> "offline"
+            else -> "audio"
+        }
+        return "${base}_${mode}_$quality"
     }
 
     private suspend fun resolveWithInnerTube(

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -418,14 +418,16 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     fun invalidate(track: Track, isVideoMode: Boolean = false, offlineExport: Boolean = false) {
-        remove(cacheKey(track, isVideoMode, selectedAudioQuality, offlineExport))
+        if (offlineExport) return
+        remove(cacheKey(track, isVideoMode))
     }
 
     fun reportPlaybackFailure(
         track: Track,
         isVideoMode: Boolean,
         reason: String,
-        isOfflineExport: Boolean = false
+        isOfflineExport: Boolean = false,
+        audioQuality: String? = null
     ) {
         if (isLocalPlaybackTrack(track)) {
             resilienceEngine.recordPlayerFailure(track.id, isVideoMode, reason)
@@ -448,11 +450,9 @@ class PlaybackResolver private constructor(private val context: Context) {
         val now = System.currentTimeMillis()
         val lower = reason.lowercase()
         val recovery = resilienceEngine.recoveryPlan(reason)
-        if (!isOfflineExport) {
-            listOf(track.streamUrl, track.videoStreamUrl)
-                .filter { it.isNotBlank() }
-                .forEach { failedPlaybackUrls[it] = now + recovery.quarantineMs }
-        }
+        listOf(track.streamUrl, track.videoStreamUrl)
+            .filter { it.isNotBlank() }
+            .forEach { failedPlaybackUrls[it] = now + recovery.quarantineMs }
         if (recovery.rotateClient) {
             profileFromSource(track.source)?.let { profile ->
                 recordClientFailure(profile, null, PlaybackBlockedException(reason))
@@ -474,7 +474,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 sourceMatchStore.recordFailure(
                     track = track,
                     videoMode = isVideoMode,
-                    audioQuality = selectedAudioQuality,
+                    audioQuality = audioQuality?.let(::normalizeAudioQuality) ?: selectedAudioQuality,
                     quarantineMs = sourceMatchQuarantineMs,
                     preferMp4Audio = isOfflineExport
                 )
@@ -1544,8 +1544,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                     streamUrl = streamUrl,
                     playbackManifest = manifest
                 )
-                val audioCache = key.contains("_audio_", ignoreCase = true) ||
-                    key.contains("_offline_", ignoreCase = true)
+                val audioCache = key.contains("_audio_", ignoreCase = true)
                 if (track != null && streamUrl.isNotBlank() && now < expiresAt && streamStillFresh(streamUrl) && (!audioCache || isPlayableAudioUrl(streamUrl))) {
                     streamCache[key] = CachedStream(track, expiresAt)
                 } else {
@@ -1562,11 +1561,12 @@ class PlaybackResolver private constructor(private val context: Context) {
         resolvedTrack: Track,
         isVideoMode: Boolean = false,
         audioQuality: String = selectedAudioQuality,
-        offlineExport: Boolean = false
+        preferMp4Audio: Boolean = false
     ) {
+        if (preferMp4Audio) return
         if (resolvedTrack.streamUrl.isBlank() || !streamStillFresh(resolvedTrack.streamUrl)) return
         if (!isVideoMode && !isPlayableAudioUrl(resolvedTrack.streamUrl)) return
-        val key = cacheKey(requestedTrack, isVideoMode, audioQuality, offlineExport)
+        val key = cacheKey(requestedTrack, isVideoMode, audioQuality)
         val expiresAt = resolvedTrack.playbackManifest?.expiresAtMs
             ?.takeIf { it > System.currentTimeMillis() }
             ?.let { minOf(it, expiresAtFor(resolvedTrack.streamUrl)) }
@@ -1706,17 +1706,11 @@ class PlaybackResolver private constructor(private val context: Context) {
     private fun cacheKey(
         track: Track,
         isVideoMode: Boolean = false,
-        audioQuality: String = selectedAudioQuality,
-        offlineExport: Boolean = false
+        audioQuality: String = selectedAudioQuality
     ): String {
         val base = PlaybackSourceIdentity.canonicalKey(track)
         val quality = normalizeAudioQuality(audioQuality).lowercase()
-        val mode = when {
-            isVideoMode -> "video"
-            offlineExport -> "offline"
-            else -> "audio"
-        }
-        return "${base}_${mode}_$quality"
+        return if (isVideoMode) "${base}_video_$quality" else "${base}_audio_$quality"
     }
 
     private suspend fun resolveWithInnerTube(

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlaybackCacheKey.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlaybackCacheKey.kt
@@ -16,6 +16,13 @@ object LevyraPlaybackCacheKey {
         return "levyra:$id:stream-v2:${variant(track.streamUrl)}"
     }
 
+    fun offlineStream(track: Track): String {
+        val id = PlaybackSourceIdentity.sourceVideoId(track)
+            .ifBlank { stableId(track) }
+            .replace(':', '_')
+        return "levyra:$id:offline-v1:${variant(track.streamUrl)}"
+    }
+
     fun video(track: Track): String {
         val id = PlaybackSourceIdentity.sourceVideoId(track)
             .ifBlank { stableId(track) }

--- a/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineAudioExporter.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineAudioExporter.kt
@@ -384,8 +384,10 @@ class OfflineAudioExporter(
                     resolver.reportPlaybackFailure(
                         track = playable,
                         isVideoMode = false,
-                        reason = firstError.message.orEmpty().ifBlank { "offline export source rejected" }
+                        reason = firstError.message.orEmpty().ifBlank { "offline export source rejected" },
+                        isOfflineExport = true
                     )
+                    releaseOfflineCacheSeed(playable)
                 }
                 reportProgress(7)
                 playable = resolver.resolveForOffline(track.copy(streamUrl = ""), settings.resolverAudioQuality)
@@ -418,6 +420,7 @@ class OfflineAudioExporter(
                 reportProgress(98)
                 val fileName = buildFileName(metadataTrack, embeddedFile.container.extension)
                 persistDownload(track, metadataTrack, fileName, exported.uri, embeddedFile.container, embeddedFile.fileMetadataEmbedded)
+                releaseOfflineCacheSeed(playable)
                 Timber.i("Offline export completed: %s", fileName)
                 reportProgress(100)
                 OfflineExportResult(
@@ -668,6 +671,17 @@ class OfflineAudioExporter(
         return File(workspace, "resume-$safeKey.${container.extension}.part")
     }
 
+    private fun offlineSeedCacheKeys(track: Track): List<String> {
+        val offlineKey = LevyraPlaybackCacheKey.offlineStream(track)
+        val playbackKey = LevyraPlaybackCacheKey.stream(track)
+        return if (offlineKey == playbackKey) listOf(offlineKey) else listOf(offlineKey, playbackKey)
+    }
+
+    private fun releaseOfflineCacheSeed(track: Track) {
+        runCatching { LevyraMediaCache.get(context).removeResource(LevyraPlaybackCacheKey.offlineStream(track)) }
+            .onFailure { Timber.d(it, "Offline cache seed release skipped") }
+    }
+
     private suspend fun prepareCachedPlaybackSeed(
         track: Track,
         workspace: File,
@@ -677,8 +691,8 @@ class OfflineAudioExporter(
     ): CachedAudioSeed? {
         if (track.id.isBlank() || expectedLength <= 0L) return null
         val cache = LevyraMediaCache.get(context)
-        val cacheKey = LevyraPlaybackCacheKey.stream(track)
-        val spans = cache.getCachedSpans(cacheKey)
+        val spans = offlineSeedCacheKeys(track)
+            .flatMap { key -> cache.getCachedSpans(key) }
             .filter { it.isCached && it.length > 0L && it.position < expectedLength && it.position + it.length > 0L }
             .sortedBy { it.position }
         if (spans.isEmpty()) return null

--- a/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineAudioExporter.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineAudioExporter.kt
@@ -385,7 +385,8 @@ class OfflineAudioExporter(
                         track = playable,
                         isVideoMode = false,
                         reason = firstError.message.orEmpty().ifBlank { "offline export source rejected" },
-                        isOfflineExport = true
+                        isOfflineExport = true,
+                        audioQuality = settings.resolverAudioQuality
                     )
                     releaseOfflineCacheSeed(playable)
                 }
@@ -671,11 +672,10 @@ class OfflineAudioExporter(
         return File(workspace, "resume-$safeKey.${container.extension}.part")
     }
 
-    private fun offlineSeedCacheKeys(track: Track): List<String> {
-        val offlineKey = LevyraPlaybackCacheKey.offlineStream(track)
-        val playbackKey = LevyraPlaybackCacheKey.stream(track)
-        return if (offlineKey == playbackKey) listOf(offlineKey) else listOf(offlineKey, playbackKey)
-    }
+    private fun offlineSeedCacheKeys(track: Track): List<String> = listOf(
+        LevyraPlaybackCacheKey.offlineStream(track),
+        LevyraPlaybackCacheKey.stream(track)
+    )
 
     private fun releaseOfflineCacheSeed(track: Track) {
         runCatching { LevyraMediaCache.get(context).removeResource(LevyraPlaybackCacheKey.offlineStream(track)) }

--- a/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineExportPipeline.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineExportPipeline.kt
@@ -16,6 +16,7 @@ import com.luc4n3x.levyra.player.LevyraPlaybackCacheKey
 import com.luc4n3x.levyra.player.LevyraYoutubeDataSource
 import com.luc4n3x.levyra.player.PlaybackNetworkStack
 import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CancellationException
@@ -25,6 +26,8 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -38,6 +41,30 @@ internal fun offlineContinuousDownloadProgress(bytesCached: Long, contentLength:
     return (12 + ratio * 68.0).toInt().coerceIn(12, 80)
 }
 
+internal object OfflineCacheWriteLocks {
+    private class Entry {
+        val mutex = Mutex()
+        var users = 0
+    }
+
+    private val entries = ConcurrentHashMap<String, Entry>()
+
+    internal fun activeKeyCount(): Int = entries.size
+
+    suspend fun <T> withKey(key: String, block: suspend () -> T): T {
+        val entry = entries.compute(key) { _, existing ->
+            (existing ?: Entry()).also { it.users += 1 }
+        }!!
+        try {
+            return entry.mutex.withLock { block() }
+        } finally {
+            entries.compute(key) { _, existing ->
+                existing?.apply { users -= 1 }?.takeIf { it.users > 0 }
+            }
+        }
+    }
+}
+
 @UnstableApi
 internal class OfflineStreamPrefetcher(context: Context) {
     private val appContext = context.applicationContext
@@ -48,6 +75,7 @@ internal class OfflineStreamPrefetcher(context: Context) {
     ) = coroutineScope {
         val url = track.streamUrl.trim()
         if (url.isBlank()) throw IOException("Stream audio non disponibile")
+        val cacheKey = LevyraPlaybackCacheKey.offlineStream(track)
 
         val requestLength = AtomicLong(-1L)
         val cachedBytes = AtomicLong(0L)
@@ -69,41 +97,43 @@ internal class OfflineStreamPrefetcher(context: Context) {
 
         try {
             withContext(Dispatchers.IO) {
-                val cache = LevyraMediaCache.get(appContext)
-                val upstream = LevyraYoutubeDataSource.Factory(
-                    PlaybackNetworkStack.playbackFactory(appContext)
-                        .setDefaultRequestProperties(
-                            mapOf(
-                                "Accept" to "*/*",
-                                "Accept-Encoding" to "identity"
+                OfflineCacheWriteLocks.withKey(cacheKey) {
+                    val cache = LevyraMediaCache.get(appContext)
+                    val upstream = LevyraYoutubeDataSource.Factory(
+                        PlaybackNetworkStack.playbackFactory(appContext)
+                            .setDefaultRequestProperties(
+                                mapOf(
+                                    "Accept" to "*/*",
+                                    "Accept-Encoding" to "identity"
+                                )
                             )
-                        )
-                )
-                val sink = CacheDataSink.Factory()
-                    .setCache(cache)
-                    .setFragmentSize(CACHE_FRAGMENT_BYTES)
-                val source = CacheDataSource.Factory()
-                    .setCache(cache)
-                    .setUpstreamDataSourceFactory(upstream)
-                    .setCacheWriteDataSinkFactory(sink)
-                    .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
-                    .createDataSource()
-                val dataSpec = DataSpec.Builder()
-                    .setUri(Uri.parse(url))
-                    .setKey(LevyraPlaybackCacheKey.offlineStream(track))
-                    .setPosition(0L)
-                    .build()
-                val listener = CacheWriter.ProgressListener { length, bytes, _ ->
-                    if (length > 0L) requestLength.set(length)
-                    cachedBytes.set(bytes.coerceAtLeast(0L))
-                }
+                    )
+                    val sink = CacheDataSink.Factory()
+                        .setCache(cache)
+                        .setFragmentSize(CACHE_FRAGMENT_BYTES)
+                    val source = CacheDataSource.Factory()
+                        .setCache(cache)
+                        .setUpstreamDataSourceFactory(upstream)
+                        .setCacheWriteDataSinkFactory(sink)
+                        .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
+                        .createDataSource()
+                    val dataSpec = DataSpec.Builder()
+                        .setUri(Uri.parse(url))
+                        .setKey(cacheKey)
+                        .setPosition(0L)
+                        .build()
+                    val listener = CacheWriter.ProgressListener { length, bytes, _ ->
+                        if (length > 0L) requestLength.set(length)
+                        cachedBytes.set(bytes.coerceAtLeast(0L))
+                    }
 
-                CacheWriter(
-                    source,
-                    dataSpec,
-                    ByteArray(CACHE_BUFFER_BYTES),
-                    listener
-                ).cache()
+                    CacheWriter(
+                        source,
+                        dataSpec,
+                        ByteArray(CACHE_BUFFER_BYTES),
+                        listener
+                    ).cache()
+                }
             }
             finished.set(true)
             progress(80)

--- a/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineExportPipeline.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineExportPipeline.kt
@@ -90,7 +90,7 @@ internal class OfflineStreamPrefetcher(context: Context) {
                     .createDataSource()
                 val dataSpec = DataSpec.Builder()
                     .setUri(Uri.parse(url))
-                    .setKey(LevyraPlaybackCacheKey.stream(track))
+                    .setKey(LevyraPlaybackCacheKey.offlineStream(track))
                     .setPosition(0L)
                     .build()
                 val listener = CacheWriter.ProgressListener { length, bytes, _ ->
@@ -145,7 +145,8 @@ internal class OfflineExportPipeline(
                 resolver.reportPlaybackFailure(
                     track = resolved,
                     isVideoMode = false,
-                    reason = error.message.orEmpty().ifBlank { "continuous offline prefetch failed" }
+                    reason = error.message.orEmpty().ifBlank { "continuous offline prefetch failed" },
+                    isOfflineExport = true
                 )
                 resolved = resolve(track)
                 if (supportsContinuousPrefetch(resolved.streamUrl)) {

--- a/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineExportPipeline.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineExportPipeline.kt
@@ -146,7 +146,8 @@ internal class OfflineExportPipeline(
                     track = resolved,
                     isVideoMode = false,
                     reason = error.message.orEmpty().ifBlank { "continuous offline prefetch failed" },
-                    isOfflineExport = true
+                    isOfflineExport = true,
+                    audioQuality = settings.resolverAudioQuality
                 )
                 resolved = resolve(track)
                 if (supportsContinuousPrefetch(resolved.streamUrl)) {

--- a/app/src/test/java/com/luc4n3x/levyra/player/LevyraPlaybackCacheKeyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/LevyraPlaybackCacheKeyTest.kt
@@ -59,6 +59,37 @@ class LevyraPlaybackCacheKeyTest {
         )
     }
 
+    @Test
+    fun offlineExportNeverSharesTheLiveStreamCacheKey() {
+        val muxedFallback = track("https://rr.example/videoplayback?itag=18&mime=video%2Fmp4&ratebypass=yes")
+        val audioMp4 = track("https://rr.example/videoplayback?itag=140&mime=audio%2Fmp4&ratebypass=yes")
+
+        assertNotEquals(
+            LevyraPlaybackCacheKey.stream(muxedFallback),
+            LevyraPlaybackCacheKey.offlineStream(muxedFallback)
+        )
+        assertNotEquals(
+            LevyraPlaybackCacheKey.stream(audioMp4),
+            LevyraPlaybackCacheKey.offlineStream(audioMp4)
+        )
+    }
+
+    @Test
+    fun offlineExportKeyStaysStableAcrossSignedUrlRefreshAndSplitsPerItag() {
+        val first = track("https://rr1---sn.example/videoplayback?expire=100&itag=18&sig=one")
+        val second = track("https://rr2---sn.example/videoplayback?expire=200&itag=18&sig=two")
+        val otherItag = track("https://rr2---sn.example/videoplayback?expire=200&itag=140&sig=two")
+
+        assertEquals(
+            LevyraPlaybackCacheKey.offlineStream(first),
+            LevyraPlaybackCacheKey.offlineStream(second)
+        )
+        assertNotEquals(
+            LevyraPlaybackCacheKey.offlineStream(second),
+            LevyraPlaybackCacheKey.offlineStream(otherItag)
+        )
+    }
+
     private fun track(streamUrl: String): Track = Track(
         id = "video-id",
         title = "Title",

--- a/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineDownloadPlaybackIsolationTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineDownloadPlaybackIsolationTest.kt
@@ -4,6 +4,16 @@ import com.luc4n3x.levyra.domain.Track
 import com.luc4n3x.levyra.player.LevyraPlaybackCacheKey
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -75,6 +85,77 @@ class OfflineDownloadPlaybackIsolationTest {
     }
 
     @Test
+    fun identicalOfflinePrefetchesRunOneAtATimeInsteadOfRefetchingUpstream() = runBlocking {
+        val exported = track("https://rr.example/videoplayback?itag=140&mime=audio%2Fmp4&ratebypass=yes")
+        val offlineKey = LevyraPlaybackCacheKey.offlineStream(exported)
+        val inFlight = AtomicInteger(0)
+        val overlaps = AtomicInteger(0)
+        val transfers = AtomicInteger(0)
+
+        coroutineScope {
+            repeat(4) {
+                launch(Dispatchers.Default) {
+                    OfflineCacheWriteLocks.withKey(offlineKey) {
+                        if (inFlight.incrementAndGet() > 1) overlaps.incrementAndGet()
+                        transfers.incrementAndGet()
+                        delay(20L)
+                        inFlight.decrementAndGet()
+                    }
+                }
+            }
+        }
+
+        assertEquals(0, overlaps.get())
+        assertEquals(4, transfers.get())
+        assertEquals(0, OfflineCacheWriteLocks.activeKeyCount())
+    }
+
+    @Test
+    fun differentTracksAreNeverSerialisedAgainstEachOther() = runBlocking {
+        val first = LevyraPlaybackCacheKey.offlineStream(track("https://rr.example/videoplayback?itag=140"))
+        val second = LevyraPlaybackCacheKey.offlineStream(track("https://rr.example/videoplayback?itag=251"))
+        val bothInside = CompletableDeferred<Unit>()
+        val inside = AtomicInteger(0)
+
+        withTimeout(5_000L) {
+            coroutineScope {
+                listOf(first, second).forEach { key ->
+                    launch(Dispatchers.Default) {
+                        OfflineCacheWriteLocks.withKey(key) {
+                            if (inside.incrementAndGet() == 2) bothInside.complete(Unit)
+                            bothInside.await()
+                        }
+                    }
+                }
+            }
+        }
+
+        assertEquals(0, OfflineCacheWriteLocks.activeKeyCount())
+    }
+
+    @Test
+    fun aCancelledPrefetchReleasesTheKeyForTheNextExport() = runBlocking {
+        val key = LevyraPlaybackCacheKey.offlineStream(track("https://rr.example/videoplayback?itag=140"))
+        val holding = CompletableDeferred<Unit>()
+
+        val holder = launch(Dispatchers.Default) {
+            OfflineCacheWriteLocks.withKey(key) {
+                holding.complete(Unit)
+                awaitCancellation()
+            }
+        }
+        holding.await()
+        holder.cancelAndJoin()
+
+        val ran = withTimeout(5_000L) {
+            OfflineCacheWriteLocks.withKey(key) { true }
+        }
+
+        assertTrue(ran)
+        assertEquals(0, OfflineCacheWriteLocks.activeKeyCount())
+    }
+
+    @Test
     fun exportSeedsFromBothTheOfflineAndThePlaybackCacheNamespace() {
         val exporter = Files.readString(sourceFile("player/offline/OfflineAudioExporter.kt"))
 
@@ -88,8 +169,10 @@ class OfflineDownloadPlaybackIsolationTest {
     fun continuousPrefetchWritesIntoTheOfflineNamespace() {
         val pipeline = Files.readString(sourceFile("player/offline/OfflineExportPipeline.kt"))
 
-        assertTrue(pipeline.contains(".setKey(LevyraPlaybackCacheKey.offlineStream(track))"))
-        assertFalse(pipeline.contains(".setKey(LevyraPlaybackCacheKey.stream(track))"))
+        assertTrue(pipeline.contains("val cacheKey = LevyraPlaybackCacheKey.offlineStream(track)"))
+        assertTrue(pipeline.contains(".setKey(cacheKey)"))
+        assertTrue(pipeline.contains("OfflineCacheWriteLocks.withKey(cacheKey)"))
+        assertFalse(pipeline.contains("LevyraPlaybackCacheKey.stream(track)"))
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineDownloadPlaybackIsolationTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineDownloadPlaybackIsolationTest.kt
@@ -115,29 +115,46 @@ class OfflineDownloadPlaybackIsolationTest {
     }
 
     @Test
-    fun anOfflineFailureNeverQuarantinesTheStreamThePlayerIsUsing() {
+    fun everyExportFailureCarriesTheQualityItActuallyResolvedAt() {
+        val exporter = Files.readString(sourceFile("player/offline/OfflineAudioExporter.kt"))
+        val pipeline = Files.readString(sourceFile("player/offline/OfflineExportPipeline.kt"))
+
+        assertEquals(1, occurrences(exporter, "audioQuality = settings.resolverAudioQuality"))
+        assertEquals(1, occurrences(pipeline, "audioQuality = settings.resolverAudioQuality"))
+    }
+
+    @Test
+    fun anOfflineFailureTargetsTheOfflineSourceMatchAndSparesTheVideoSelector() {
         val resolver = Files.readString(sourceFile("data/PlaybackResolver.kt"))
 
-        val guard = resolver.indexOf("if (!isOfflineExport) {")
-        val quarantine = resolver.indexOf("failedPlaybackUrls[it] = now + recovery.quarantineMs")
-
-        assertTrue(guard > 0)
-        assertTrue(quarantine > guard)
-        assertEquals(1, occurrences(resolver, "failedPlaybackUrls[it] = now + recovery.quarantineMs"))
-        assertTrue(resolver.contains("if (recovery.rotateCodec && !isOfflineExport)"))
         assertTrue(resolver.contains("preferMp4Audio = isOfflineExport"))
+        assertTrue(resolver.contains("audioQuality = audioQuality?.let(::normalizeAudioQuality) ?: selectedAudioQuality"))
+        assertTrue(resolver.contains("if (recovery.rotateCodec && !isOfflineExport)"))
         assertTrue(resolver.contains("invalidate(track, isVideoMode, isOfflineExport)"))
     }
 
     @Test
-    fun offlineResolutionKeepsItsOwnResolverCacheEntry() {
+    fun aDeadOfflineUrlIsStillQuarantinedSoTheRetryCanRotate() {
         val resolver = Files.readString(sourceFile("data/PlaybackResolver.kt"))
 
-        assertTrue(resolver.contains("offlineExport -> \"offline\""))
+        assertEquals(1, occurrences(resolver, "failedPlaybackUrls[it] = now + recovery.quarantineMs"))
+        assertFalse(resolver.contains("if (!isOfflineExport) {"))
+    }
+
+    @Test
+    fun offlineResolutionNeverEntersThePlaybackStreamCache() {
+        val resolver = Files.readString(sourceFile("data/PlaybackResolver.kt"))
+        val storeSignature = resolver.indexOf("private fun store(")
+        val skip = resolver.indexOf("if (preferMp4Audio) return", storeSignature)
+        val storeKey = resolver.indexOf("val key = cacheKey(requestedTrack, isVideoMode, audioQuality)", storeSignature)
+
+        assertTrue(storeSignature > 0)
+        assertTrue(skip > storeSignature)
+        assertTrue(storeKey > skip)
         assertTrue(resolver.contains("store(track, resolved, isVideoMode, audioQuality, preferMp4Audio)"))
         assertTrue(resolver.contains("store(track, alternate, isVideoMode, audioQuality, preferMp4Audio)"))
         assertTrue(resolver.contains("store(track, restored, isVideoMode, audioQuality, preferMp4Audio)"))
-        assertTrue(resolver.contains("key.contains(\"_offline_\", ignoreCase = true)"))
+        assertTrue(resolver.contains("if (offlineExport) return"))
     }
 
     private fun occurrences(source: String, needle: String): Int =

--- a/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineDownloadPlaybackIsolationTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineDownloadPlaybackIsolationTest.kt
@@ -1,0 +1,172 @@
+package com.luc4n3x.levyra.player.offline
+
+import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.player.LevyraPlaybackCacheKey
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Media3 allows a single writer per cache key: SimpleCache.startReadWriteNonBlocking returns null
+ * when the requested range intersects a range another writer already locked, and CacheDataSource
+ * then bypasses the cache instead of blocking. A live player holds that lock for its whole open
+ * span, so an offline export sharing the key wrote nothing, never advanced its cached-bytes
+ * progress and refetched the entire track while competing with playback.
+ */
+class OfflineDownloadPlaybackIsolationTest {
+    private class SingleWriterCache {
+        private val lockedRanges = mutableMapOf<String, MutableList<LongRange>>()
+
+        fun tryLock(key: String, start: Long, endInclusive: Long): Boolean {
+            val ranges = lockedRanges.getOrPut(key) { mutableListOf() }
+            if (ranges.any { it.first <= endInclusive && start <= it.last }) return false
+            ranges += start..endInclusive
+            return true
+        }
+
+        fun release(key: String) {
+            lockedRanges.remove(key)
+        }
+    }
+
+    @Test
+    fun offlineExportWriterNeverCollidesWithThePlayerHoldingItsBufferWindow() {
+        val cache = SingleWriterCache()
+        val playing = track("https://rr.example/videoplayback?itag=18&mime=video%2Fmp4&ratebypass=yes")
+        val playerKey = LevyraPlaybackCacheKey.stream(playing)
+        val offlineKey = LevyraPlaybackCacheKey.offlineStream(playing)
+
+        assertTrue(cache.tryLock(playerKey, 0L, Long.MAX_VALUE))
+        assertFalse(cache.tryLock(playerKey, 0L, Long.MAX_VALUE))
+        assertTrue(cache.tryLock(offlineKey, 0L, Long.MAX_VALUE))
+    }
+
+    @Test
+    fun playbackKeepsItsWriterThroughEveryBufferHorizonWhileADownloadRuns() {
+        val cache = SingleWriterCache()
+        val playing = track("https://rr.example/videoplayback?itag=140&mime=audio%2Fmp4&ratebypass=yes")
+        val playerKey = LevyraPlaybackCacheKey.stream(playing)
+        val offlineKey = LevyraPlaybackCacheKey.offlineStream(playing)
+
+        assertTrue(cache.tryLock(offlineKey, 0L, Long.MAX_VALUE))
+
+        // Low-RAM 12 s, aggressive-OEM 20 s and default 24 s max buffers from AdaptivePlaybackPolicy,
+        // plus the 30 s and 60 s horizons the stall was reported around.
+        listOf(12_000L, 20_000L, 24_000L, 30_000L, 60_000L).forEach { horizonMs ->
+            cache.release(playerKey)
+            assertTrue(
+                "playback loader must keep writing past ${horizonMs}ms while a download runs",
+                cache.tryLock(playerKey, 0L, horizonMs)
+            )
+        }
+    }
+
+    @Test
+    fun twoConcurrentExportsOfTheSameTrackStillCoalesceOnOneWriter() {
+        val cache = SingleWriterCache()
+        val exported = track("https://rr.example/videoplayback?itag=140&mime=audio%2Fmp4&ratebypass=yes")
+        val offlineKey = LevyraPlaybackCacheKey.offlineStream(exported)
+
+        assertTrue(cache.tryLock(offlineKey, 0L, Long.MAX_VALUE))
+        assertFalse(cache.tryLock(offlineKey, 0L, Long.MAX_VALUE))
+    }
+
+    @Test
+    fun exportSeedsFromBothTheOfflineAndThePlaybackCacheNamespace() {
+        val exporter = Files.readString(sourceFile("player/offline/OfflineAudioExporter.kt"))
+
+        assertTrue(exporter.contains("private fun offlineSeedCacheKeys"))
+        assertTrue(exporter.contains("LevyraPlaybackCacheKey.offlineStream(track)"))
+        assertTrue(exporter.contains("LevyraPlaybackCacheKey.stream(track)"))
+        assertTrue(exporter.contains("offlineSeedCacheKeys(track)"))
+    }
+
+    @Test
+    fun continuousPrefetchWritesIntoTheOfflineNamespace() {
+        val pipeline = Files.readString(sourceFile("player/offline/OfflineExportPipeline.kt"))
+
+        assertTrue(pipeline.contains(".setKey(LevyraPlaybackCacheKey.offlineStream(track))"))
+        assertFalse(pipeline.contains(".setKey(LevyraPlaybackCacheKey.stream(track))"))
+    }
+
+    @Test
+    fun exportReleasesItsOwnCacheNamespaceInsteadOfLeakingIt() {
+        val exporter = Files.readString(sourceFile("player/offline/OfflineAudioExporter.kt"))
+        val persist = exporter.indexOf("persistDownload(track, metadataTrack, fileName")
+        val release = exporter.indexOf("releaseOfflineCacheSeed(playable)", persist)
+
+        assertTrue(persist > 0)
+        assertTrue(release > persist)
+        assertTrue(exporter.contains("removeResource(LevyraPlaybackCacheKey.offlineStream(track))"))
+    }
+
+    @Test
+    fun everyExportFailureIsReportedAsAnOfflineFailure() {
+        val exporter = Files.readString(sourceFile("player/offline/OfflineAudioExporter.kt"))
+        val pipeline = Files.readString(sourceFile("player/offline/OfflineExportPipeline.kt"))
+
+        assertEquals(1, occurrences(exporter, "resolver.reportPlaybackFailure"))
+        assertEquals(1, occurrences(pipeline, "resolver.reportPlaybackFailure"))
+        assertEquals(1, occurrences(exporter, "isOfflineExport = true"))
+        assertEquals(1, occurrences(pipeline, "isOfflineExport = true"))
+    }
+
+    @Test
+    fun anOfflineFailureNeverQuarantinesTheStreamThePlayerIsUsing() {
+        val resolver = Files.readString(sourceFile("data/PlaybackResolver.kt"))
+
+        val guard = resolver.indexOf("if (!isOfflineExport) {")
+        val quarantine = resolver.indexOf("failedPlaybackUrls[it] = now + recovery.quarantineMs")
+
+        assertTrue(guard > 0)
+        assertTrue(quarantine > guard)
+        assertEquals(1, occurrences(resolver, "failedPlaybackUrls[it] = now + recovery.quarantineMs"))
+        assertTrue(resolver.contains("if (recovery.rotateCodec && !isOfflineExport)"))
+        assertTrue(resolver.contains("preferMp4Audio = isOfflineExport"))
+        assertTrue(resolver.contains("invalidate(track, isVideoMode, isOfflineExport)"))
+    }
+
+    @Test
+    fun offlineResolutionKeepsItsOwnResolverCacheEntry() {
+        val resolver = Files.readString(sourceFile("data/PlaybackResolver.kt"))
+
+        assertTrue(resolver.contains("offlineExport -> \"offline\""))
+        assertTrue(resolver.contains("store(track, resolved, isVideoMode, audioQuality, preferMp4Audio)"))
+        assertTrue(resolver.contains("store(track, alternate, isVideoMode, audioQuality, preferMp4Audio)"))
+        assertTrue(resolver.contains("store(track, restored, isVideoMode, audioQuality, preferMp4Audio)"))
+        assertTrue(resolver.contains("key.contains(\"_offline_\", ignoreCase = true)"))
+    }
+
+    private fun occurrences(source: String, needle: String): Int =
+        source.split(needle).size - 1
+
+    private fun sourceFile(relativePath: String): Path {
+        return sequenceOf(
+            Path.of("app/src/main/java/com/luc4n3x/levyra/$relativePath"),
+            Path.of("src/main/java/com/luc4n3x/levyra/$relativePath")
+        ).firstOrNull(Files::exists) ?: error("Source file not found: $relativePath")
+    }
+
+    private fun track(streamUrl: String): Track = Track(
+        id = "video-id",
+        title = "Title",
+        artist = "Artist",
+        album = "Album",
+        durationMs = 180_000L,
+        streamUrl = streamUrl,
+        videoUrl = "https://www.youtube.com/watch?v=video-id",
+        thumbnailUrl = "",
+        largeThumbnailUrl = "",
+        source = "test",
+        moodTags = emptySet(),
+        energy = 0,
+        vocal = 0,
+        replayScore = 0,
+        cacheScore = 0,
+        accentStart = 0,
+        accentEnd = 0
+    )
+}

--- a/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineExportPipelineTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineExportPipelineTest.kt
@@ -51,7 +51,7 @@ class OfflineExportPipelineTest {
         assertTrue(source.contains("CacheDataSource.Factory()"))
         assertTrue(source.contains("LevyraYoutubeDataSource.Factory"))
         assertTrue(source.contains("PlaybackNetworkStack.playbackFactory"))
-        assertTrue(source.contains("LevyraPlaybackCacheKey.stream(track)"))
+        assertTrue(source.contains("LevyraPlaybackCacheKey.offlineStream(track)"))
         assertFalse(source.contains("downloadAudioRanges("))
     }
 


### PR DESCRIPTION
## Summary

Downloading a track that is currently playing could fail on the first attempt while playback stalled shortly after the buffer horizon (~20 s on Xiaomi/Redmi/Poco/Honor/Huawei/Samsung, ~24 s elsewhere), recovered on its own, and then succeeded on a second attempt. It only happened for tracks whose playback audio and offline export resolve to the same stream, because the offline export shared both the Media3 cache key and the resolver cache key with the live player.

Media3 allows a single writer per cache key. `SimpleCache.startReadWriteNonBlocking` returns `null` when the requested range intersects a range another writer already locked, and `CacheDataSource` (no `FLAG_BLOCK_ON_CACHE` anywhere in Levyra) then silently bypasses the cache instead of blocking. A playing `ProgressiveMediaPeriod` holds that lock for its whole open span, so the export wrote nothing, its cached-bytes progress never moved past 12%, and it refetched the entire track while competing with playback. When the export then failed, `reportPlaybackFailure` invalidated the *player's* resolver entry, quarantined the *player's* stream URL and quarantined the *playback* source match, which is what stalled the current track until those quarantines expired.

This change gives the offline export its own cache namespace and its own resolver cache entry, and stops a download-side failure from being reported as a playback failure. The first download attempt now works, and playback is no longer disturbed by it.

## What changed

- `LevyraPlaybackCacheKey.offlineStream(track)` introduces an `offline-v1` Media3 namespace; the continuous prefetcher in `OfflineExportPipeline` writes there instead of the live `stream-v2` key, so the export and the player never contend for the same writer lock.
- `OfflineAudioExporter.prepareCachedPlaybackSeed` seeds from both namespaces, keeping the existing "reuse bytes the player already cached" optimisation while the export writes to its own key.
- `OfflineAudioExporter` releases its `offline-v1` resource after a successful export and after a rejected source, so downloads no longer occupy the shared media cache once the file is on disk.
- `OfflineCacheWriteLocks` gives the continuous prefetch refcounted keyed-mutex ownership of the cache key for the whole `CacheWriter` transaction. `CacheDataSource` never sets `FLAG_BLOCK_ON_CACHE`, so without it a second export of the same track bypassed the locked key and refetched every byte from upstream. Keys are independent, so exports of different tracks are never serialised.
- `PlaybackResolver.store` now skips offline resolutions entirely. `resolveInternal` already bypasses the stream cache whenever `preferMp4Audio` is set, so an offline result was never read back — storing it only ever handed the player the export's mp4 URL. `invalidate` is a no-op for offline callers for the same reason. The cache key itself is unchanged.
- `PlaybackResolver.reportPlaybackFailure` gained `isOfflineExport` and `audioQuality`. An offline failure now records the source match under the offline key (`preferMp4Audio = true` instead of the previous implicit `false`) and at the quality the export actually resolved at (`settings.resolverAudioQuality`, not the player's), and no longer rotates the native-video codec selector. The stream URL quarantine is deliberately kept for offline failures — see Reviewer notes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactor or maintenance
- [ ] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** Downloads / Player / Streaming

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [x] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

Run locally:

| Check | Result |
|---|---|
| `:app:compileDebugKotlin` | passed |
| `:app:testDebugUnitTest` (full suite) | passed, 886 tests, 0 failures |
| `:app:lintDebug` | passed |
| `python scripts/ai_quality_gate.py --profile fast` | passed |
| `python scripts/ai_quality_gate.py --profile full` | agent config, AI efficiency, claude-mem, F-Droid contract, script tests, Android regex compatibility and the full unit suite passed; the release stages are blocked |
| `:app:lintRelease -PlevyraFdroidBuild=true` | blocked: `Cannot find a Java installation ... matching {languageVersion=21}` |
| `:app:assembleRelease -PlevyraFdroidBuild=true` | blocked by the same missing JDK 21 toolchain |
| `git diff --check` | clean |

The two release stages fail before executing any Levyra code because this machine only has JDK 17 and toolchain download repositories are not configured; the same block is already recorded in `docs/project/TASKS.md`. They are not passes, and CI must confirm them.

New coverage in `OfflineDownloadPlaybackIsolationTest` models Media3's single-writer-per-key rule and asserts: the export writer never collides with a player holding its buffer window; playback keeps its writer past the 12 s, 20 s, 24 s, 30 s and 60 s horizons while a download runs; two concurrent exports of the same track still coalesce onto one writer; the export seeds from both namespaces and releases its own; every export failure is reported with `isOfflineExport = true` and with the quality it resolved at; a dead offline URL is still quarantined so the retry can rotate; the offline failure targets the offline source match and spares the video selector; and an offline resolution never enters the playback stream cache. Three behavioural coroutine tests cover the new keyed lock: identical prefetches never overlap, different tracks never serialise, and a cancelled prefetch releases its key. `LevyraPlaybackCacheKeyTest` adds the offline-key isolation and stability cases.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Physical device | Play a track, then download the same track from the first attempt | Not performed |
| Physical device | Playback continues past 20 s / 30 s / 60 s while that download runs | Not performed |
| Physical device | Download a track that is not playing, batch download, pause/resume, precache and prefetch | Not performed |

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** No schema or migration change, and no resolver cache-key change. `offline-v1` is a new Media3 namespace, so existing `stream-v2` and `video-v5` entries are untouched. Resolver entries an older build persisted for an offline resolution under the shared `_audio_` key stay readable and expire normally through their existing `expiresAt`.
- **Known limitations:** If an export fails for a reason other than a rejected source and the retry resolves a different itag, the previous `offline-v1` entry is left to the existing LRU evictor instead of being released eagerly, as are the bytes of a download abandoned by cancellation or storage failure. Two exports of the same track started under different task keys now serialise on the same cache key, so the second one waits and reuses the cached bytes; if the first has already released the seed by then, the second falls back to a normal download. `PlaybackResilienceEngine.recordPlayerFailure` still receives offline failures; it only appends a diagnostic trace event and drives no playback decision.
- **Rollback plan:** Revert this PR

## Reviewer notes

- The stream URL quarantine is intentionally still applied to offline failures. It is the only *synchronous* guard the immediate retry has: `sourceMatchStore.recordFailure` runs on a detached `sourceMatchScope`, and `sourceMatchQuarantineMs` is computed as `0L` for 403/410/expired/signature. Without the URL quarantine, `restorePersistentSource` → `manifestUrlsUsable` would hand the same dead URL straight back to the retry and turn a recoverable failure into a deterministic double failure. Only the three side effects that are genuinely playback-specific are gated.
- `recordClientFailure` and `YoutubeLocalDecoder.notifyStreamRejected` also stay shared for offline failures: a 403/410 seen by the exporter is a genuine upstream-health signal, and those paths repair shared state rather than invalidate a working URL.
- No retry loop is possible: `downloadAudio` keeps its bounded three-attempt sequence and `OfflineExportWorker` still retries at most once.
- `offlineSeedCacheKeys` unions the two namespaces safely because both keys derive `variant()` from the *same* export URL, so the itag — and therefore the encoding and `clen` — is identical in both; `mergeAudioRanges` already collapses the overlapping ranges they can produce.
- `OfflineExportPipelineTest.pipelineUsesMedia3CacheWriterAndYoutubeAwareDataSource` asserted the old shared-key contract and was updated to the offline key.

## Release note

Downloading a song you are listening to now works on the first try and no longer interrupts playback.

## Related issues

- N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
