### PR TITLE
Redesign the Android library experience

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
@@ -58,15 +58,16 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.luc4n3x.levyra.domain.DownloadedTrack
 import com.luc4n3x.levyra.domain.Playlist
 import com.luc4n3x.levyra.domain.Track
 import com.luc4n3x.levyra.domain.visibleDownloadBatches
 import com.luc4n3x.levyra.ui.i18n.LocalLevyraStrings
 import com.luc4n3x.levyra.ui.i18n.formatLibraryBytes
 import com.luc4n3x.levyra.ui.theme.LevyraCyan
+import com.luc4n3x.levyra.ui.theme.LevyraGlass
 import com.luc4n3x.levyra.ui.theme.LevyraInk
 import com.luc4n3x.levyra.ui.theme.LevyraMuted
-import com.luc4n3x.levyra.ui.theme.LevyraPanel
 import com.luc4n3x.levyra.ui.theme.LevyraText
 import com.luc4n3x.levyra.viewmodel.LevyraUiState
 import com.luc4n3x.levyra.viewmodel.LevyraViewModel
@@ -110,6 +111,7 @@ internal fun LevyraLibraryScreen(
     var sortExpanded by remember { mutableStateOf(false) }
     var addToPlaylistTracks by remember { mutableStateOf<List<Track>>(emptyList()) }
     var confirmDelete by remember { mutableStateOf(false) }
+    var pendingDownloadDelete by remember { mutableStateOf<DownloadedTrack?>(null) }
     var showCreatePlaylist by remember { mutableStateOf(false) }
     var showImportPlaylist by remember { mutableStateOf(false) }
     var showImportPlaylistCard by rememberSaveable { mutableStateOf(true) }
@@ -190,16 +192,20 @@ internal fun LevyraLibraryScreen(
                 top = 12.dp,
                 bottom = if (state.currentTrack != null || selectionActive) 230.dp else 116.dp
             ),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(14.dp)
         ) {
             item(key = "library-title") {
                 LibraryHero(
                     title = strings.libraryTitle,
-                    subtitle = listOf(
-                        strings.formatTrackCount(catalog.tracks.size),
-                        "${state.playlists.size} ${strings.playlists}",
-                        strings.formatDownloadedTrackCount(state.downloads.size)
-                    ).joinToString(" · ")
+                    subtitle = when (category) {
+                        LibraryCategory.Overview, LibraryCategory.Songs ->
+                            strings.formatTrackCount(catalog.tracks.size)
+                        LibraryCategory.Playlists -> "${state.playlists.size} ${strings.playlistsPlain}"
+                        LibraryCategory.Albums -> "${catalog.albums.size} ${strings.albumsPlain}"
+                        LibraryCategory.Artists -> "${catalog.artists.size} ${strings.artists}"
+                        LibraryCategory.Offline ->
+                            strings.formatDownloadedTrackCount(state.downloads.size)
+                    }
                 )
             }
 
@@ -207,20 +213,20 @@ internal fun LevyraLibraryScreen(
                 OutlinedTextField(
                     value = query,
                     onValueChange = { query = it },
-                    modifier = Modifier.fillMaxWidth().height(54.dp),
+                    modifier = Modifier.fillMaxWidth().height(50.dp),
                     singleLine = true,
-                    shape = RoundedCornerShape(18.dp),
-                    textStyle = MaterialTheme.typography.bodyLarge.copy(
+                    shape = RoundedCornerShape(16.dp),
+                    textStyle = MaterialTheme.typography.bodyMedium.copy(
                         color = LevyraText,
-                        fontWeight = FontWeight.SemiBold
+                        fontWeight = FontWeight.Medium
                     ),
                     colors = OutlinedTextFieldDefaults.colors(
                         focusedTextColor = LevyraText,
                         unfocusedTextColor = LevyraText,
-                        focusedContainerColor = LevyraPanel.copy(alpha = 0.72f),
-                        unfocusedContainerColor = LevyraPanel.copy(alpha = 0.55f),
-                        focusedBorderColor = LevyraCyan.copy(alpha = 0.56f),
-                        unfocusedBorderColor = Color.White.copy(alpha = 0.10f),
+                        focusedContainerColor = LevyraGlass,
+                        unfocusedContainerColor = LevyraGlass,
+                        focusedBorderColor = LevyraCyan.copy(alpha = 0.45f),
+                        unfocusedBorderColor = Color.Transparent,
                         cursorColor = LevyraCyan,
                         focusedLeadingIconColor = LevyraCyan,
                         unfocusedLeadingIconColor = LevyraMuted,
@@ -229,12 +235,12 @@ internal fun LevyraLibraryScreen(
                     ),
                     placeholder = { Text(strings.searchPlaceholder, color = LevyraMuted, fontSize = 14.sp) },
                     leadingIcon = {
-                        Icon(Icons.Rounded.Search, contentDescription = null, modifier = Modifier.size(22.dp))
+                        Icon(Icons.Rounded.Search, contentDescription = null, modifier = Modifier.size(20.dp))
                     },
                     trailingIcon = {
                         if (query.isNotBlank()) {
                             IconButton(onClick = { query = "" }) {
-                                Icon(Icons.Rounded.Close, contentDescription = strings.clear)
+                                Icon(Icons.Rounded.Close, contentDescription = strings.clear, modifier = Modifier.size(20.dp))
                             }
                         }
                     }
@@ -353,14 +359,6 @@ internal fun LevyraLibraryScreen(
                 }
 
                 LibraryCategory.Playlists -> {
-                    item(key = "playlist-heading") {
-                        LibrarySectionTitle(
-                            title = strings.playlists,
-                            detail = "${visiblePlaylists.size} ${strings.playlists}",
-                            action = strings.newItem,
-                            onAction = { showCreatePlaylist = true }
-                        )
-                    }
                     item(key = "playlist-import-action") {
                         if (showImportPlaylistCard) {
                             LibraryImportPlaylistCard(
@@ -372,7 +370,17 @@ internal fun LevyraLibraryScreen(
                         }
                     }
                     if (visiblePlaylists.isEmpty()) {
-                        item { LibraryEmpty(Icons.AutoMirrored.Rounded.QueueMusic, strings.createFirstPlaylistSubtitle) }
+                        item {
+                            if (query.isBlank()) {
+                                LibraryEmpty(
+                                    Icons.AutoMirrored.Rounded.QueueMusic,
+                                    strings.createFirstPlaylist,
+                                    strings.createFirstPlaylistSubtitle
+                                )
+                            } else {
+                                LibraryEmpty(Icons.Rounded.Search, strings.emptySearchPrompt)
+                            }
+                        }
                     } else if (layout == LibraryLayout.List) {
                         items(visiblePlaylists, key = { "playlist-${it.id}" }) { playlist ->
                             val key = "playlist:${playlist.id}"
@@ -409,11 +417,14 @@ internal fun LevyraLibraryScreen(
                 }
 
                 LibraryCategory.Albums -> {
-                    item(key = "album-heading") {
-                        LibrarySectionTitle(strings.albumsPlain, strings.savedTracks)
-                    }
                     if (visibleAlbums.isEmpty()) {
-                        item { LibraryEmpty(Icons.Rounded.Album, strings.albumUnavailable) }
+                        item {
+                            LibraryEmpty(
+                                Icons.Rounded.Album,
+                                if (query.isBlank()) strings.albumUnavailable else strings.emptySearchPrompt,
+                                if (query.isBlank()) strings.savedTracks else null
+                            )
+                        }
                     } else if (layout == LibraryLayout.Grid) {
                         items(
                             items = visibleAlbums.chunked(2),
@@ -450,11 +461,14 @@ internal fun LevyraLibraryScreen(
                 }
 
                 LibraryCategory.Artists -> {
-                    item(key = "artist-heading") {
-                        LibrarySectionTitle(strings.artists, strings.followedArtistsSubtitle)
-                    }
                     if (visibleArtists.isEmpty()) {
-                        item { LibraryEmpty(Icons.Rounded.Person, strings.artistProfileUnavailable) }
+                        item {
+                            LibraryEmpty(
+                                Icons.Rounded.Person,
+                                if (query.isBlank()) strings.artistProfileUnavailable else strings.emptySearchPrompt,
+                                if (query.isBlank()) strings.followedArtistsSubtitle else null
+                            )
+                        }
                     } else if (layout == LibraryLayout.Grid) {
                         items(
                             items = visibleArtists.chunked(2),
@@ -491,11 +505,14 @@ internal fun LevyraLibraryScreen(
                 }
 
                 LibraryCategory.Songs -> {
-                    item(key = "songs-heading") {
-                        LibrarySectionTitle(strings.songsPlain, strings.savedTracks)
-                    }
                     if (visibleTracks.isEmpty()) {
-                        item { LibraryEmpty(Icons.Rounded.MusicNote, strings.emptySearchPrompt) }
+                        item {
+                            LibraryEmpty(
+                                if (query.isBlank()) Icons.Rounded.MusicNote else Icons.Rounded.Search,
+                                if (query.isBlank()) strings.savedTracks else strings.emptySearchPrompt,
+                                if (query.isBlank()) strings.tapHeartToAdd else null
+                            )
+                        }
                     } else {
                         items(visibleTracks, key = { "song-${libraryTrackKey(it)}" }) { track ->
                             val key = libraryTrackKey(track)
@@ -514,7 +531,10 @@ internal fun LevyraLibraryScreen(
                                 },
                                 onLongClick = { selectedKeys = selectedKeys.toggle(key) },
                                 onFavorite = { viewModel.toggleFavorite(track) },
-                                onDownload = { viewModel.exportTrack(track) }
+                                onDownload = { viewModel.exportTrack(track) },
+                                onQueue = { viewModel.addToQueue(track) },
+                                onAddToPlaylist = { addToPlaylistTracks = listOf(track) },
+                                modifier = Modifier.animateItem()
                             )
                         }
                     }
@@ -522,9 +542,8 @@ internal fun LevyraLibraryScreen(
 
                 LibraryCategory.Offline -> {
                     item(key = "offline-storage") {
-                        LibraryStorageCard(
+                        LibraryOfflineSummary(
                             bytes = state.downloadStorageBytes,
-                            count = state.downloads.size,
                             activeCount = state.downloadQueue.count {
                                 it.state in setOf("QUEUED", "RUNNING", "RETRYING", "PAUSED")
                             },
@@ -532,33 +551,40 @@ internal fun LevyraLibraryScreen(
                         )
                     }
                     val activeBatches = visibleDownloadBatches(state.downloadBatches)
-                    if (activeBatches.isNotEmpty()) {
-                        items(activeBatches, key = { "batch-${it.key}" }) { batch ->
-                            LibraryBatchDownloadRow(
-                                batch = batch,
-                                onRetry = { viewModel.retryBatchDownload(batch.key) },
-                                onCancel = { viewModel.cancelBatchDownload(batch.key) }
-                            )
-                        }
-                    }
-                    if (state.downloadQueue.isNotEmpty()) {
+                    val hasTransfers = activeBatches.isNotEmpty() || state.downloadQueue.isNotEmpty()
+                    if (hasTransfers) {
                         item(key = "offline-queue-title") {
                             LibrarySectionTitle(strings.downloadsInProgress, strings.downloadInProgress)
                         }
-                        items(state.downloadQueue, key = { "task-${it.taskKey}" }) { task ->
-                            LibraryDownloadTaskRow(
-                                task = task,
-                                onPause = { viewModel.pauseDownload(task.taskKey) },
-                                onResume = { viewModel.resumeDownload(task.taskKey) },
-                                onCancel = { viewModel.cancelDownload(task.taskKey) }
-                            )
+                    }
+                    items(activeBatches, key = { "batch-${it.key}" }) { batch ->
+                        LibraryBatchDownloadRow(
+                            batch = batch,
+                            onRetry = { viewModel.retryBatchDownload(batch.key) },
+                            onCancel = { viewModel.cancelBatchDownload(batch.key) }
+                        )
+                    }
+                    items(state.downloadQueue, key = { "task-${it.taskKey}" }) { task ->
+                        LibraryDownloadTaskRow(
+                            task = task,
+                            onPause = { viewModel.pauseDownload(task.taskKey) },
+                            onResume = { viewModel.resumeDownload(task.taskKey) },
+                            onCancel = { viewModel.cancelDownload(task.taskKey) }
+                        )
+                    }
+                    if (hasTransfers && visibleOffline.isNotEmpty()) {
+                        item(key = "offline-saved-title") {
+                            LibrarySectionTitle(strings.downloaded, "")
                         }
                     }
-                    item(key = "offline-heading") {
-                        LibrarySectionTitle(strings.offlineDownloadsPlain, strings.downloadsFolder)
-                    }
                     if (visibleOffline.isEmpty()) {
-                        item { LibraryEmpty(Icons.Rounded.OfflinePin, strings.noOfflineDownloads) }
+                        item {
+                            LibraryEmpty(
+                                if (query.isBlank()) Icons.Rounded.OfflinePin else Icons.Rounded.Search,
+                                if (query.isBlank()) strings.noOfflineDownloads else strings.emptySearchPrompt,
+                                if (query.isBlank()) strings.downloadTrackHint else null
+                            )
+                        }
                     } else {
                         items(visibleOffline, key = { "offline-${it.key}" }) { item ->
                             val track = item.track
@@ -572,7 +598,7 @@ internal fun LevyraLibraryScreen(
                                 isFavorite = track.id in state.favoriteIds,
                                 isDownloaded = true,
                                 downloadProgress = null,
-                                secondaryDetail = listOf(
+                                metadata = listOf(
                                     item.download.mimeType.substringAfter('/').uppercase(Locale.ROOT),
                                     strings.formatLibraryBytes(item.download.sizeBytes)
                                 ).filter(String::isNotBlank).joinToString(" · "),
@@ -582,7 +608,11 @@ internal fun LevyraLibraryScreen(
                                 },
                                 onLongClick = { selectedKeys = selectedKeys.toggle(key) },
                                 onFavorite = { viewModel.toggleFavorite(track) },
-                                onDownload = {}
+                                onDownload = {},
+                                onQueue = { viewModel.addToQueue(track) },
+                                onAddToPlaylist = { addToPlaylistTracks = listOf(track) },
+                                onDeleteDownload = { pendingDownloadDelete = item.download },
+                                modifier = Modifier.animateItem()
                             )
                         }
                     }
@@ -691,6 +721,24 @@ internal fun LevyraLibraryScreen(
                 viewModel.createPlaylistWithTracks(name, addToPlaylistTracks)
                 addToPlaylistTracks = emptyList()
                 selectedKeys = emptySet()
+            }
+        )
+    }
+
+    pendingDownloadDelete?.let { download ->
+        AlertDialog(
+            onDismissRequest = { pendingDownloadDelete = null },
+            title = { Text(strings.deleteDownload) },
+            text = { Text(download.title) },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.deleteDownload(download)
+                    selectedKeys = selectedKeys - "download:${download.id}"
+                    pendingDownloadDelete = null
+                }) { Text(strings.delete) }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDownloadDelete = null }) { Text(strings.cancel) }
             }
         )
     }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
@@ -213,7 +213,7 @@ internal fun LevyraLibraryScreen(
                 OutlinedTextField(
                     value = query,
                     onValueChange = { query = it },
-                    modifier = Modifier.fillMaxWidth().height(50.dp),
+                    modifier = Modifier.fillMaxWidth().height(56.dp),
                     singleLine = true,
                     shape = RoundedCornerShape(16.dp),
                     textStyle = MaterialTheme.typography.bodyMedium.copy(
@@ -546,8 +546,7 @@ internal fun LevyraLibraryScreen(
                             bytes = state.downloadStorageBytes,
                             activeCount = state.downloadQueue.count {
                                 it.state in setOf("QUEUED", "RUNNING", "RETRYING", "PAUSED")
-                            },
-                            onOpenFolder = onOpenDownloads
+                            }
                         )
                     }
                     val activeBatches = visibleDownloadBatches(state.downloadBatches)

--- a/app/src/main/java/com/luc4n3x/levyra/ui/library/LibraryActions.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/library/LibraryActions.kt
@@ -416,7 +416,7 @@ internal fun AddTracksToPlaylistDialog(
                                 modifier = Modifier.fillMaxWidth().combinedClickable(onClick = { onAdd(playlist.id) })
                             ) {
                                 Row(modifier = Modifier.padding(10.dp), verticalAlignment = Alignment.CenterVertically) {
-                                    Icon(Icons.AutoMirrored.Rounded.QueueMusic, contentDescription = null)
+                                    Icon(Icons.AutoMirrored.Rounded.QueueMusic, contentDescription = null, tint = LevyraMuted)
                                     Spacer(Modifier.width(10.dp))
                                     Text(
                                         playlist.name,

--- a/app/src/main/java/com/luc4n3x/levyra/ui/library/LibraryActions.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/library/LibraryActions.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -35,7 +34,6 @@ import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.Edit
-import androidx.compose.material.icons.rounded.FolderOpen
 import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
@@ -92,8 +90,7 @@ import com.luc4n3x.levyra.viewmodel.LevyraUiState
 @Composable
 internal fun LibraryOfflineSummary(
     bytes: Long,
-    activeCount: Int,
-    onOpenFolder: () -> Unit
+    activeCount: Int
 ) {
     val strings = LocalLevyraStrings.current
     Surface(
@@ -103,7 +100,7 @@ internal fun LibraryOfflineSummary(
         modifier = Modifier.fillMaxWidth()
     ) {
         Row(
-            modifier = Modifier.padding(start = 14.dp, end = 6.dp, top = 8.dp, bottom = 8.dp),
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
@@ -129,27 +126,6 @@ internal fun LibraryOfflineSummary(
                     ).filter(String::isNotBlank).joinToString(" · "),
                     color = LevyraMuted,
                     fontSize = 11.sp,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
-            TextButton(
-                onClick = onOpenFolder,
-                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp),
-                modifier = Modifier.widthIn(max = 150.dp)
-            ) {
-                Icon(
-                    Icons.Rounded.FolderOpen,
-                    contentDescription = null,
-                    tint = LevyraCyan,
-                    modifier = Modifier.size(16.dp)
-                )
-                Spacer(Modifier.width(6.dp))
-                Text(
-                    strings.downloadsFolder,
-                    color = LevyraCyan,
-                    fontSize = 12.sp,
-                    fontWeight = FontWeight.Bold,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
@@ -440,7 +416,7 @@ internal fun AddTracksToPlaylistDialog(
                                 modifier = Modifier.fillMaxWidth().combinedClickable(onClick = { onAdd(playlist.id) })
                             ) {
                                 Row(modifier = Modifier.padding(10.dp), verticalAlignment = Alignment.CenterVertically) {
-                                    Icon(Icons.AutoMirrored.Rounded.QueueMusic, contentDescription = null, tint = LevyraMuted)
+                                    Icon(Icons.AutoMirrored.Rounded.QueueMusic, contentDescription = null)
                                     Spacer(Modifier.width(10.dp))
                                     Text(
                                         playlist.name,

--- a/app/src/main/java/com/luc4n3x/levyra/ui/library/LibraryActions.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/library/LibraryActions.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -34,6 +35,7 @@ import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.Edit
+import androidx.compose.material.icons.rounded.FolderOpen
 import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
@@ -61,6 +63,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -76,6 +79,8 @@ import com.luc4n3x.levyra.ui.i18n.LocalLevyraStrings
 import com.luc4n3x.levyra.ui.i18n.formatLibraryBytes
 import com.luc4n3x.levyra.ui.i18n.formatLibraryDuration
 import com.luc4n3x.levyra.ui.theme.LevyraCyan
+import com.luc4n3x.levyra.ui.theme.LevyraGlass
+import com.luc4n3x.levyra.ui.theme.LevyraGlassBorder
 import com.luc4n3x.levyra.ui.theme.LevyraMuted
 import com.luc4n3x.levyra.ui.theme.LevyraPanel
 import com.luc4n3x.levyra.ui.theme.LevyraPanelSoft
@@ -85,56 +90,70 @@ import com.luc4n3x.levyra.ui.theme.LevyraViolet
 import com.luc4n3x.levyra.viewmodel.LevyraUiState
 
 @Composable
-internal fun LibraryStorageCard(
+internal fun LibraryOfflineSummary(
     bytes: Long,
-    count: Int,
     activeCount: Int,
     onOpenFolder: () -> Unit
 ) {
     val strings = LocalLevyraStrings.current
     Surface(
-        color = LevyraPanel.copy(alpha = 0.92f),
-        shape = RoundedCornerShape(26.dp),
-        border = BorderStroke(1.dp, LevyraCyan.copy(alpha = 0.18f)),
+        color = LevyraGlass,
+        shape = RoundedCornerShape(20.dp),
+        border = BorderStroke(1.dp, LevyraGlassBorder),
         modifier = Modifier.fillMaxWidth()
     ) {
-        Column(modifier = Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Surface(color = LevyraCyan.copy(alpha = 0.15f), shape = CircleShape) {
-                    Icon(
-                        Icons.Rounded.Storage,
-                        contentDescription = null,
-                        tint = LevyraCyan,
-                        modifier = Modifier.padding(10.dp).size(24.dp)
-                    )
-                }
-                Spacer(Modifier.width(12.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        strings.offlineDownloadsPlain,
-                        color = LevyraText,
-                        fontSize = 17.sp,
-                        fontWeight = FontWeight.Black
-                    )
-                    Text(
-                        listOf(
-                            strings.formatLibraryBytes(bytes),
-                            strings.formatDownloadedTrackCount(count),
-                            activeCount.takeIf { it > 0 }?.let { "$it ${strings.activeIndicator}" }.orEmpty()
-                        ).filter(String::isNotBlank).joinToString(" · "),
-                        color = LevyraMuted,
-                        fontSize = 12.sp
-                    )
-                }
-                TextButton(onClick = onOpenFolder) {
-                    Text(strings.downloadsFolder, color = LevyraCyan, fontWeight = FontWeight.Bold)
-                }
-            }
-            Text(
-                strings.downloadTrackHint,
-                color = LevyraMuted,
-                fontSize = 11.sp
+        Row(
+            modifier = Modifier.padding(start = 14.dp, end = 6.dp, top = 8.dp, bottom = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                Icons.Rounded.Storage,
+                contentDescription = null,
+                tint = LevyraCyan,
+                modifier = Modifier.size(20.dp)
             )
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
+                Text(
+                    strings.offlineDownloadsPlain,
+                    color = LevyraText,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    listOf(
+                        strings.formatLibraryBytes(bytes),
+                        activeCount.takeIf { it > 0 }?.let { "$it ${strings.activeIndicator}" }.orEmpty()
+                    ).filter(String::isNotBlank).joinToString(" · "),
+                    color = LevyraMuted,
+                    fontSize = 11.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            TextButton(
+                onClick = onOpenFolder,
+                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp),
+                modifier = Modifier.widthIn(max = 150.dp)
+            ) {
+                Icon(
+                    Icons.Rounded.FolderOpen,
+                    contentDescription = null,
+                    tint = LevyraCyan,
+                    modifier = Modifier.size(16.dp)
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    strings.downloadsFolder,
+                    color = LevyraCyan,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
         }
     }
 }
@@ -343,14 +362,40 @@ private fun LibrarySelectionAction(
 }
 
 @Composable
-internal fun LibraryEmpty(icon: androidx.compose.ui.graphics.vector.ImageVector, title: String) {
+internal fun LibraryEmpty(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    detail: String? = null
+) {
     Column(
-        modifier = Modifier.fillMaxWidth().padding(vertical = 42.dp),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 36.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(10.dp)
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        Icon(icon, contentDescription = null, tint = LevyraMuted, modifier = Modifier.size(42.dp))
-        Text(title, color = LevyraMuted, fontSize = 14.sp, fontWeight = FontWeight.Bold)
+        Surface(color = LevyraGlass, shape = CircleShape) {
+            Icon(
+                icon,
+                contentDescription = null,
+                tint = LevyraMuted,
+                modifier = Modifier.padding(16.dp).size(26.dp)
+            )
+        }
+        Text(
+            title,
+            color = LevyraText,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center
+        )
+        if (!detail.isNullOrBlank()) {
+            Text(
+                detail,
+                color = LevyraMuted,
+                fontSize = 12.sp,
+                lineHeight = 17.sp,
+                textAlign = TextAlign.Center
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/luc4n3x/levyra/ui/library/LibraryOverviewComponents.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/library/LibraryOverviewComponents.kt
@@ -1,9 +1,12 @@
 package com.luc4n3x.levyra.ui.library
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -23,6 +26,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -44,7 +48,6 @@ import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Replay
 import androidx.compose.material.icons.rounded.Schedule
 import androidx.compose.material.icons.rounded.Shuffle
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -53,6 +56,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -60,6 +64,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -71,6 +78,7 @@ import com.luc4n3x.levyra.domain.Track
 import com.luc4n3x.levyra.ui.i18n.LocalLevyraStrings
 import com.luc4n3x.levyra.ui.i18n.formatLibraryDuration
 import com.luc4n3x.levyra.ui.theme.LevyraCyan
+import com.luc4n3x.levyra.ui.theme.LevyraGlass
 import com.luc4n3x.levyra.ui.theme.LevyraMuted
 import com.luc4n3x.levyra.ui.theme.LevyraPanel
 import com.luc4n3x.levyra.ui.theme.LevyraPink
@@ -81,73 +89,68 @@ import com.luc4n3x.levyra.viewmodel.LibraryViewModel
 import java.time.format.TextStyle as DayTextStyle
 import java.util.Locale
 
+internal val LibraryPillShape = RoundedCornerShape(999.dp)
+
 @Composable
 internal fun LibraryHero(title: String, subtitle: String) {
-    Row(
+    Column(
         modifier = Modifier.fillMaxWidth().padding(top = 2.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
+        verticalArrangement = Arrangement.spacedBy(2.dp)
     ) {
-        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            Text(
-                text = title,
-                color = LevyraText,
-                fontSize = 32.sp,
-                lineHeight = 35.sp,
-                fontWeight = FontWeight.Black,
-                letterSpacing = (-0.8).sp
-            )
+        Text(
+            text = title,
+            color = LevyraText,
+            fontSize = 28.sp,
+            lineHeight = 32.sp,
+            fontWeight = FontWeight.Black,
+            letterSpacing = (-0.6).sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.semantics { heading() }
+        )
+        if (subtitle.isNotBlank()) {
             Text(
                 text = subtitle,
                 color = LevyraMuted,
                 fontSize = 12.sp,
                 lineHeight = 16.sp,
-                fontWeight = FontWeight.SemiBold,
+                fontWeight = FontWeight.Medium,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
-            )
-        }
-        Spacer(Modifier.width(14.dp))
-        Surface(
-            color = LevyraPanel.copy(alpha = 0.82f),
-            shape = CircleShape,
-            border = BorderStroke(1.dp, LevyraCyan.copy(alpha = 0.22f))
-        ) {
-            Icon(
-                imageVector = Icons.Rounded.LibraryMusic,
-                contentDescription = null,
-                tint = LevyraCyan,
-                modifier = Modifier.padding(12.dp).size(24.dp)
             )
         }
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun LibraryCategoryChip(label: String, selected: Boolean, onClick: () -> Unit) {
+    val container by animateColorAsState(
+        targetValue = if (selected) LevyraCyan.copy(alpha = 0.16f) else LevyraGlass,
+        animationSpec = tween(durationMillis = 160),
+        label = "libraryChipContainer"
+    )
+    val content by animateColorAsState(
+        targetValue = if (selected) LevyraCyan else LevyraMuted,
+        animationSpec = tween(durationMillis = 160),
+        label = "libraryChipContent"
+    )
     Surface(
-        color = if (selected) LevyraViolet.copy(alpha = 0.28f) else LevyraPanel.copy(alpha = 0.50f),
-        shape = RoundedCornerShape(999.dp),
-        border = BorderStroke(
-            1.dp,
-            if (selected) LevyraViolet.copy(alpha = 0.58f) else Color.White.copy(alpha = 0.09f)
-        ),
-        modifier = Modifier.height(38.dp).combinedClickable(onClick = onClick)
+        color = container,
+        shape = LibraryPillShape,
+        modifier = Modifier
+            .height(40.dp)
+            .clip(LibraryPillShape)
+            .selectable(selected = selected, role = Role.Tab, onClick = onClick)
     ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 13.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(7.dp)
+        Box(
+            modifier = Modifier.fillMaxHeight().padding(horizontal = 16.dp),
+            contentAlignment = Alignment.Center
         ) {
-            if (selected) {
-                Icon(Icons.Rounded.Check, contentDescription = null, tint = LevyraText, modifier = Modifier.size(15.dp))
-            }
             Text(
                 text = label,
-                color = if (selected) LevyraText else LevyraMuted,
+                color = content,
                 fontSize = 13.sp,
-                fontWeight = if (selected) FontWeight.Black else FontWeight.Bold,
+                fontWeight = if (selected) FontWeight.Black else FontWeight.SemiBold,
                 maxLines = 1
             )
         }
@@ -172,19 +175,34 @@ internal fun LibraryToolbar(
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Box {
-            TextButton(
-                onClick = { onSortExpanded(true) },
-                colors = ButtonDefaults.textButtonColors(contentColor = LevyraText),
-                contentPadding = PaddingValues(horizontal = 4.dp, vertical = 2.dp)
+            Surface(
+                color = LevyraGlass,
+                shape = LibraryPillShape,
+                modifier = Modifier
+                    .height(38.dp)
+                    .clip(LibraryPillShape)
+                    .clickable(onClick = { onSortExpanded(true) })
             ) {
-                Icon(
-                    Icons.AutoMirrored.Rounded.Sort,
-                    contentDescription = null,
-                    tint = LevyraCyan,
-                    modifier = Modifier.size(18.dp)
-                )
-                Spacer(Modifier.width(7.dp))
-                Text(sort.libraryLabel(strings), fontSize = 13.sp, fontWeight = FontWeight.Black)
+                Row(
+                    modifier = Modifier.fillMaxHeight().padding(horizontal = 14.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(7.dp)
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Rounded.Sort,
+                        contentDescription = null,
+                        tint = LevyraCyan,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Text(
+                        text = sort.libraryLabel(strings),
+                        color = LevyraText,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
             }
             DropdownMenu(expanded = sortExpanded, onDismissRequest = { onSortExpanded(false) }) {
                 LibrarySort.entries.forEach { option ->
@@ -202,21 +220,21 @@ internal fun LibraryToolbar(
             }
         }
         Row(verticalAlignment = Alignment.CenterVertically) {
-            TextButton(
-                onClick = onSelectAll,
-                colors = ButtonDefaults.textButtonColors(contentColor = LevyraText),
-                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 2.dp)
-            ) {
-                Icon(Icons.Rounded.DoneAll, contentDescription = null, tint = LevyraCyan, modifier = Modifier.size(18.dp))
-                Spacer(Modifier.width(6.dp))
-                Text(strings.all, fontSize = 13.sp, fontWeight = FontWeight.Black)
+            IconButton(onClick = onSelectAll) {
+                Icon(
+                    Icons.Rounded.DoneAll,
+                    contentDescription = strings.all,
+                    tint = LevyraMuted,
+                    modifier = Modifier.size(20.dp)
+                )
             }
             if (category != LibraryCategory.Offline && category != LibraryCategory.Songs) {
                 IconButton(onClick = onLayout) {
                     Icon(
                         if (layout == LibraryLayout.List) Icons.Rounded.GridView else Icons.AutoMirrored.Rounded.ViewList,
-                        contentDescription = null,
-                        tint = LevyraMuted
+                        contentDescription = strings.options,
+                        tint = LevyraMuted,
+                        modifier = Modifier.size(20.dp)
                     )
                 }
             }
@@ -233,16 +251,34 @@ internal fun LibrarySectionTitle(
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.Bottom,
+        verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(title, color = LevyraText, fontSize = 20.sp, fontWeight = FontWeight.Black)
-            Text(detail, color = LevyraMuted, fontSize = 11.sp, fontWeight = FontWeight.SemiBold)
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
+            Text(
+                text = title,
+                color = LevyraText,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Black,
+                letterSpacing = (-0.3).sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.semantics { heading() }
+            )
+            if (detail.isNotBlank()) {
+                Text(
+                    text = detail,
+                    color = LevyraMuted,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
         }
         if (action != null && onAction != null) {
             TextButton(onClick = onAction) {
-                Text(action, color = LevyraCyan, fontWeight = FontWeight.Bold)
+                Text(action, color = LevyraCyan, fontSize = 13.sp, fontWeight = FontWeight.Bold, maxLines = 1)
             }
         }
     }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/library/LibraryRows.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/library/LibraryRows.kt
@@ -19,23 +19,32 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
 import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
-import androidx.compose.material.icons.rounded.Album
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.Favorite
 import androidx.compose.material.icons.rounded.FavoriteBorder
+import androidx.compose.material.icons.rounded.GraphicEq
 import androidx.compose.material.icons.rounded.LibraryMusic
+import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.OfflinePin
-import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.RadioButtonUnchecked
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -58,7 +67,10 @@ import com.luc4n3x.levyra.ui.theme.LevyraMuted
 import com.luc4n3x.levyra.ui.theme.LevyraPanelSoft
 import com.luc4n3x.levyra.ui.theme.LevyraPink
 import com.luc4n3x.levyra.ui.theme.LevyraText
-import com.luc4n3x.levyra.ui.theme.LevyraViolet
+
+internal val LibraryRowShape = RoundedCornerShape(16.dp)
+internal val LibraryArtworkShape = RoundedCornerShape(12.dp)
+internal val LibraryCardShape = RoundedCornerShape(18.dp)
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -71,58 +83,81 @@ internal fun LibraryTrackRow(
     isFavorite: Boolean,
     isDownloaded: Boolean,
     downloadProgress: Int?,
-    secondaryDetail: String? = null,
+    metadata: String? = null,
     onClick: () -> Unit,
     onLongClick: () -> Unit,
     onFavorite: () -> Unit,
-    onDownload: () -> Unit
+    onDownload: () -> Unit,
+    onQueue: (() -> Unit)? = null,
+    onAddToPlaylist: (() -> Unit)? = null,
+    onDeleteDownload: (() -> Unit)? = null,
+    modifier: Modifier = Modifier
 ) {
     val strings = LocalLevyraStrings.current
+    var menuExpanded by remember { mutableStateOf(false) }
     Surface(
         color = when {
             selected -> LevyraCyan.copy(alpha = 0.14f)
-            isCurrent -> LevyraViolet.copy(alpha = 0.11f)
+            isCurrent -> LevyraCyan.copy(alpha = 0.08f)
             else -> Color.Transparent
         },
-        shape = RoundedCornerShape(19.dp),
+        shape = LibraryRowShape,
         border = if (selected) BorderStroke(1.dp, LevyraCyan.copy(alpha = 0.55f)) else null,
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
+            .clip(LibraryRowShape)
             .combinedClickable(onClick = onClick, onLongClick = onLongClick)
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 7.dp),
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            LibraryArtwork(
-                url = track.largeThumbnailUrl.ifBlank { track.thumbnailUrl },
-                title = track.title,
-                modifier = Modifier.size(56.dp),
-                shape = RoundedCornerShape(15.dp),
-                selected = selected
-            )
+            Box(contentAlignment = Alignment.Center) {
+                LibraryArtwork(
+                    url = track.largeThumbnailUrl.ifBlank { track.thumbnailUrl },
+                    title = track.title,
+                    modifier = Modifier.size(52.dp),
+                    shape = LibraryArtworkShape,
+                    selected = selected
+                )
+                if (isPlaying) {
+                    Box(
+                        modifier = Modifier
+                            .matchParentSize()
+                            .clip(LibraryArtworkShape)
+                            .background(Color.Black.copy(alpha = 0.45f)),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            Icons.Rounded.GraphicEq,
+                            contentDescription = strings.playing,
+                            tint = LevyraCyan,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                }
+            }
             Spacer(Modifier.width(12.dp))
-            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
                 Text(
                     track.title,
                     color = if (isCurrent) LevyraCyan else LevyraText,
-                    fontSize = 14.sp,
+                    fontSize = 15.sp,
                     fontWeight = FontWeight.Bold,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
                 Text(
-                    secondaryDetail?.takeIf(String::isNotBlank)
-                        ?: listOf(track.artist, track.album).filter(String::isNotBlank).joinToString(" · "),
+                    libraryTrackSubtitle(track, metadata),
                     color = LevyraMuted,
-                    fontSize = 11.sp,
+                    fontSize = 12.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
                 if (downloadProgress != null) {
                     LinearProgressIndicator(
                         progress = { downloadProgress.coerceIn(0, 100) / 100f },
-                        modifier = Modifier.fillMaxWidth().height(3.dp),
+                        modifier = Modifier.fillMaxWidth().padding(top = 3.dp).height(3.dp),
                         color = LevyraCyan,
                         trackColor = LevyraPanelSoft
                     )
@@ -132,36 +167,97 @@ internal fun LibraryTrackRow(
                 Icon(
                     if (selected) Icons.Rounded.CheckCircle else Icons.Rounded.RadioButtonUnchecked,
                     contentDescription = null,
-                    tint = if (selected) LevyraCyan else LevyraMuted.copy(alpha = 0.35f)
+                    tint = if (selected) LevyraCyan else LevyraMuted.copy(alpha = 0.35f),
+                    modifier = Modifier.padding(horizontal = 8.dp)
                 )
             } else {
                 if (isDownloaded) {
-                    Icon(Icons.Rounded.OfflinePin, contentDescription = null, tint = LevyraCyan, modifier = Modifier.size(17.dp))
+                    Icon(
+                        Icons.Rounded.OfflinePin,
+                        contentDescription = strings.downloaded,
+                        tint = LevyraCyan,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(Modifier.width(4.dp))
                 }
                 IconButton(onClick = onFavorite) {
                     Icon(
                         if (isFavorite) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
                         contentDescription = if (isFavorite) strings.removeFromFavorites else strings.addToFavorites,
                         tint = if (isFavorite) LevyraPink else LevyraMuted,
-                        modifier = Modifier.size(20.dp)
+                        modifier = Modifier.size(19.dp)
                     )
                 }
-                if (!isDownloaded && downloadProgress == null) {
-                    IconButton(onClick = onDownload) {
+                Box {
+                    IconButton(onClick = { menuExpanded = true }) {
                         Icon(
-                            Icons.Rounded.Download,
-                            contentDescription = strings.download,
+                            Icons.Rounded.MoreVert,
+                            contentDescription = strings.songOptions,
                             tint = LevyraMuted,
-                            modifier = Modifier.size(21.dp)
+                            modifier = Modifier.size(20.dp)
                         )
                     }
-                }
-                if (isPlaying) {
-                    Icon(Icons.Rounded.PlayArrow, contentDescription = null, tint = LevyraCyan, modifier = Modifier.size(20.dp))
+                    DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
+                        DropdownMenuItem(
+                            text = { Text(strings.play) },
+                            leadingIcon = { Icon(Icons.Rounded.PlayArrow, contentDescription = null) },
+                            onClick = {
+                                menuExpanded = false
+                                onClick()
+                            }
+                        )
+                        if (onQueue != null) {
+                            DropdownMenuItem(
+                                text = { Text(strings.addToQueue) },
+                                leadingIcon = { Icon(Icons.AutoMirrored.Rounded.QueueMusic, contentDescription = null) },
+                                onClick = {
+                                    menuExpanded = false
+                                    onQueue()
+                                }
+                            )
+                        }
+                        if (onAddToPlaylist != null) {
+                            DropdownMenuItem(
+                                text = { Text(strings.addToPlaylist) },
+                                leadingIcon = { Icon(Icons.AutoMirrored.Rounded.PlaylistAdd, contentDescription = null) },
+                                onClick = {
+                                    menuExpanded = false
+                                    onAddToPlaylist()
+                                }
+                            )
+                        }
+                        if (onDeleteDownload != null) {
+                            DropdownMenuItem(
+                                text = { Text(strings.deleteDownload, color = LevyraPink) },
+                                leadingIcon = {
+                                    Icon(Icons.Rounded.Delete, contentDescription = null, tint = LevyraPink)
+                                },
+                                onClick = {
+                                    menuExpanded = false
+                                    onDeleteDownload()
+                                }
+                            )
+                        } else if (!isDownloaded && downloadProgress == null) {
+                            DropdownMenuItem(
+                                text = { Text(strings.download) },
+                                leadingIcon = { Icon(Icons.Rounded.Download, contentDescription = null) },
+                                onClick = {
+                                    menuExpanded = false
+                                    onDownload()
+                                }
+                            )
+                        }
+                    }
                 }
             }
         }
     }
+}
+
+private fun libraryTrackSubtitle(track: Track, metadata: String?): String {
+    val identity = listOf(track.artist, track.album).filter(String::isNotBlank).joinToString(" · ")
+    val extra = metadata?.trim().orEmpty()
+    return listOf(identity, extra).filter(String::isNotBlank).joinToString(" · ")
 }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -177,19 +273,22 @@ internal fun LibraryPlaylistRow(
     val strings = LocalLevyraStrings.current
     Surface(
         color = if (selected) LevyraCyan.copy(alpha = 0.14f) else Color.Transparent,
-        shape = RoundedCornerShape(20.dp),
+        shape = LibraryRowShape,
         border = if (selected) BorderStroke(1.dp, LevyraCyan.copy(alpha = 0.55f)) else null,
-        modifier = Modifier.fillMaxWidth().combinedClickable(onClick = onClick, onLongClick = onLongClick)
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(LibraryRowShape)
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick)
     ) {
         Row(modifier = Modifier.padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
-            LibraryArtwork(playlist.coverUrl, playlist.name, Modifier.size(66.dp), RoundedCornerShape(18.dp), selected)
-            Spacer(Modifier.width(13.dp))
+            LibraryArtwork(playlist.coverUrl, playlist.name, Modifier.size(56.dp), LibraryArtworkShape, selected)
+            Spacer(Modifier.width(12.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     playlist.name,
                     color = LevyraText,
                     fontSize = 15.sp,
-                    fontWeight = FontWeight.Black,
+                    fontWeight = FontWeight.Bold,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
@@ -231,19 +330,22 @@ internal fun LibraryAlbumRow(
     val strings = LocalLevyraStrings.current
     Surface(
         color = if (selected) LevyraCyan.copy(alpha = 0.14f) else Color.Transparent,
-        shape = RoundedCornerShape(20.dp),
+        shape = LibraryRowShape,
         border = if (selected) BorderStroke(1.dp, LevyraCyan.copy(alpha = 0.55f)) else null,
-        modifier = Modifier.fillMaxWidth().combinedClickable(onClick = onClick, onLongClick = onLongClick)
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(LibraryRowShape)
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick)
     ) {
         Row(modifier = Modifier.padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
-            LibraryArtwork(album.artworkUrl, album.title, Modifier.size(66.dp), RoundedCornerShape(18.dp), selected)
-            Spacer(Modifier.width(13.dp))
+            LibraryArtwork(album.artworkUrl, album.title, Modifier.size(56.dp), LibraryArtworkShape, selected)
+            Spacer(Modifier.width(12.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     album.title,
                     color = LevyraText,
                     fontSize = 15.sp,
-                    fontWeight = FontWeight.Black,
+                    fontWeight = FontWeight.Bold,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
@@ -285,19 +387,22 @@ internal fun LibraryArtistRow(
     val strings = LocalLevyraStrings.current
     Surface(
         color = if (selected) LevyraCyan.copy(alpha = 0.14f) else Color.Transparent,
-        shape = RoundedCornerShape(20.dp),
+        shape = LibraryRowShape,
         border = if (selected) BorderStroke(1.dp, LevyraCyan.copy(alpha = 0.55f)) else null,
-        modifier = Modifier.fillMaxWidth().combinedClickable(onClick = onClick, onLongClick = onLongClick)
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(LibraryRowShape)
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick)
     ) {
         Row(modifier = Modifier.padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
-            LibraryArtistAvatar(artist = artist, size = 64.dp, selected = selected)
-            Spacer(Modifier.width(13.dp))
+            LibraryArtistAvatar(artist = artist, size = 56.dp, selected = selected)
+            Spacer(Modifier.width(12.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     artist.name,
                     color = LevyraText,
                     fontSize = 15.sp,
-                    fontWeight = FontWeight.Black,
+                    fontWeight = FontWeight.Bold,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
@@ -362,7 +467,7 @@ private fun LibraryPlaylistGridCard(
                 playlist.coverUrl,
                 playlist.name,
                 Modifier.fillMaxWidth().height(164.dp),
-                RoundedCornerShape(22.dp),
+                LibraryCardShape,
                 selected
             )
             if (selectionActive) {
@@ -447,7 +552,7 @@ private fun LibraryAlbumGridCard(
                 album.artworkUrl,
                 album.title,
                 Modifier.fillMaxWidth().height(164.dp),
-                RoundedCornerShape(22.dp),
+                LibraryCardShape,
                 selected
             )
             if (selectionActive) {


### PR DESCRIPTION
## Summary

Redesigns the Android Library to make it cleaner, easier to scan, and less crowded while keeping the core playback, selection, playlist and download-management flows intact. The latest follow-up also fixes the clipped Library search field and removes the Downloads folder shortcut from the Offline section, since downloaded tracks can already be managed directly from the Library.

## What changed

- Simplified the Library header, category chips, sort/select controls and search field so the screen feels lighter and more consistent.
- Restored the search field to a safe Material height so placeholder and typed text are no longer vertically clipped.
- Reworked the Offline section into a compact storage/transfer summary and removed the Downloads folder button.
- Kept downloaded tracks manageable directly from their row/menu: playback, queue, playlist, favorite and delete-download actions remain available.
- Cleaned up song and downloaded-track rows and added direct single-download deletion with confirmation.
- Improved empty states for saved content vs search results, plus accessibility semantics and responsive text handling.
- Reused Levyra theme tokens instead of one-off surface colors and kept the existing selection, navigation, playback and download flows intact.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor or maintenance
- [x] UI or UX change
- [x] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** Library / UI / Downloads

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [ ] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

Checks already run for this PR:

- `:app:compileDebugKotlin` — passed
- `:app:testDebugUnitTest` — passed
- `:app:lintRelease -PlevyraFdroidBuild=true` — passed with the local JDK 21 path supplied
- `scripts/ai_quality_gate.py --profile full` — passed all completed checks; `assembleRelease` was not re-run after fixing the local toolchain path

The latest follow-up commits restarted GitHub CI. CodeRabbit and Dependency Review are green; PR Check and the APK workflows are still running/pending at the time of this update.

Localization was checked against Levyra's localization contract: the Library continues to use existing localized keys only, including `searchPlaceholder`, `offlineDownloadsPlain`, `activeIndicator`, download actions and delete confirmation. Levyra's bundle validation requires the same key set across all 26 supported language bundles, so no new untranslated or hardcoded Library copy was introduced.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Android device | Library browsing, search field, download deletion and TalkBack | Pending after latest follow-up |

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** None
- **Known limitations:** Device-level verification of the latest visual adjustment is still pending
- **Rollback plan:** Revert this PR

## Reviewer notes

- The latest follow-up is limited to two Android Library UI files.
- Search field height changed from 50dp to 56dp to avoid clipping Material text content.
- The Downloads folder shortcut was intentionally removed; storage usage and active transfer count remain visible.
- Per-track download management remains in the existing overflow/selection flows, including delete download.
- A final diff check was done against the previous PR head to make sure no unrelated UI changes remained.

## Release note

Redesigned the Android Library with a cleaner layout, readable search field, clearer offline management and easier access to track actions.

## Related issues

N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR