### PR TITLE
docs: refine README header with brand headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="docs/assets/levyra-github-banner.webp" alt="Levyra — Advanced Music Application" width="100%" />
 
-### Hear every layer. No limits.
+# Hear every layer. No limits.
 
 **A native music player, stream extractor, and private offline vault for Android & Windows.**
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="docs/assets/levyra-github-banner.webp" alt="Levyra — Advanced Music Application" width="100%" />
 
-# Levyra
+### Hear every layer. No limits.
 
 **A native music player, stream extractor, and private offline vault for Android & Windows.**
 


### PR DESCRIPTION
## Summary
- Replaces the redundant \# Levyra\ title immediately below the hero banner with the official brand headline \### Hear every layer. No limits.\
- Eliminates duplicate brand name repetition, improving overall flow and visual balance with the newly integrated hero banner.

## Validation
- Fast AI quality gate passed cleanly.
- Verified README markdown presentation on GitHub.