### PR TITLE
feat(playback): add server-driven compatibility policy

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicy.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicy.kt
@@ -1,0 +1,411 @@
+package com.luc4n3x.levyra.data
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.json.JSONArray
+import org.json.JSONObject
+import timber.log.Timber
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+internal enum class PlaybackAudioStrategy {
+    REEL_MUXED,
+    REEL_AUDIO,
+    PERSISTED,
+    DIRECT,
+    SEARCH
+}
+
+internal enum class PlaybackVideoStrategy {
+    PERSISTED,
+    STANDARD,
+    REEL
+}
+
+internal data class PlaybackClientOverride(
+    val enabled: Boolean? = null,
+    val priority: Int? = null,
+    val requiresPoToken: Boolean? = null,
+    val clientVersion: String? = null
+)
+
+internal data class PlaybackCompatibilityPolicy(
+    val schema: Int,
+    val revision: Long,
+    val audioStrategies: List<PlaybackAudioStrategy>,
+    val videoStrategies: List<PlaybackVideoStrategy>,
+    val androidReelClientVersion: String,
+    val clientOverrides: Map<String, PlaybackClientOverride>
+) {
+    companion object {
+        const val SCHEMA = 1
+        const val BUNDLED_REVISION = 2026081801L
+        const val DEFAULT_ANDROID_REEL_CLIENT_VERSION = "21.03.36"
+
+        fun bundled(): PlaybackCompatibilityPolicy = PlaybackCompatibilityPolicy(
+            schema = SCHEMA,
+            revision = BUNDLED_REVISION,
+            audioStrategies = listOf(
+                PlaybackAudioStrategy.REEL_MUXED,
+                PlaybackAudioStrategy.PERSISTED,
+                PlaybackAudioStrategy.DIRECT,
+                PlaybackAudioStrategy.SEARCH
+            ),
+            videoStrategies = listOf(
+                PlaybackVideoStrategy.PERSISTED,
+                PlaybackVideoStrategy.STANDARD,
+                PlaybackVideoStrategy.REEL
+            ),
+            androidReelClientVersion = DEFAULT_ANDROID_REEL_CLIENT_VERSION,
+            clientOverrides = emptyMap()
+        )
+    }
+
+    fun toJson(): String {
+        val clients = JSONObject()
+        clientOverrides.toSortedMap().forEach { (name, override) ->
+            val value = JSONObject()
+            override.enabled?.let { value.put("enabled", it) }
+            override.priority?.let { value.put("priority", it) }
+            override.requiresPoToken?.let { value.put("requiresPoToken", it) }
+            override.clientVersion?.let { value.put("clientVersion", it) }
+            clients.put(name, value)
+        }
+        return JSONObject()
+            .put("schema", schema)
+            .put("revision", revision)
+            .put("audioStrategy", JSONArray(audioStrategies.map { it.name }))
+            .put("videoStrategy", JSONArray(videoStrategies.map { it.name }))
+            .put("androidReelClientVersion", androidReelClientVersion)
+            .put("clients", clients)
+            .toString()
+    }
+}
+
+internal object PlaybackCompatibilityPolicyParser {
+    private val clientVersionPattern = Regex("^[A-Za-z0-9._-]{1,32}$")
+    private val knownClients = setOf(
+        "VISIONOS",
+        "ANDROID_VR",
+        "ANDROID_MUSIC",
+        "ANDROID",
+        "IOS",
+        "WEB_REMIX",
+        "WEB",
+        "WEB_EMBEDDED_PLAYER"
+    )
+
+    fun parse(raw: String, base: PlaybackCompatibilityPolicy): PlaybackCompatibilityPolicy? {
+        return runCatching {
+            val root = JSONObject(raw)
+            val schemaValue = requiredLong(root, "schema")
+            require(schemaValue == PlaybackCompatibilityPolicy.SCHEMA.toLong())
+            val schema = schemaValue.toInt()
+            val revision = requiredLong(root, "revision")
+            require(revision > 0L)
+
+            val audioStrategies = if (root.has("audioStrategy")) {
+                parseEnumArray<PlaybackAudioStrategy>(root.getJSONArray("audioStrategy"))
+            } else {
+                base.audioStrategies
+            }
+            val videoStrategies = if (root.has("videoStrategy")) {
+                parseEnumArray<PlaybackVideoStrategy>(root.getJSONArray("videoStrategy"))
+            } else {
+                base.videoStrategies
+            }
+            require(audioStrategies.isNotEmpty())
+            require(videoStrategies.isNotEmpty())
+
+            val reelVersion = if (root.has("androidReelClientVersion")) {
+                requiredString(root, "androidReelClientVersion").also {
+                    require(clientVersionPattern.matches(it))
+                }
+            } else {
+                base.androidReelClientVersion
+            }
+
+            val clientOverrides = if (root.has("clients")) {
+                parseClientOverrides(root.getJSONObject("clients"))
+            } else {
+                base.clientOverrides
+            }
+            require(knownClients.any { clientOverrides[it]?.enabled != false })
+
+            PlaybackCompatibilityPolicy(
+                schema = schema,
+                revision = revision,
+                audioStrategies = audioStrategies,
+                videoStrategies = videoStrategies,
+                androidReelClientVersion = reelVersion,
+                clientOverrides = clientOverrides
+            )
+        }.getOrNull()
+    }
+
+    private inline fun <reified T : Enum<T>> parseEnumArray(array: JSONArray): List<T> {
+        require(array.length() in 1..16)
+        val values = ArrayList<T>(array.length())
+        repeat(array.length()) { index ->
+            val raw = array.get(index)
+            require(raw is String)
+            values += enumValueOf<T>(raw)
+        }
+        require(values.distinct().size == values.size)
+        return values
+    }
+
+    private fun parseClientOverrides(clients: JSONObject): Map<String, PlaybackClientOverride> {
+        val output = LinkedHashMap<String, PlaybackClientOverride>()
+        val names = clients.keys()
+        while (names.hasNext()) {
+            val name = names.next()
+            if (name !in knownClients) continue
+            val value = clients.get(name)
+            require(value is JSONObject)
+            val enabled = optionalBoolean(value, "enabled")
+            val priority = optionalInt(value, "priority")?.also { require(it in 0..20) }
+            val requiresPoToken = optionalBoolean(value, "requiresPoToken")
+            val clientVersion = optionalString(value, "clientVersion")?.also {
+                require(clientVersionPattern.matches(it))
+            }
+            output[name] = PlaybackClientOverride(
+                enabled = enabled,
+                priority = priority,
+                requiresPoToken = requiresPoToken,
+                clientVersion = clientVersion
+            )
+        }
+        return output
+    }
+
+    private fun requiredLong(value: JSONObject, key: String): Long {
+        val raw = value.get(key)
+        require(raw is Byte || raw is Short || raw is Int || raw is Long)
+        return (raw as Number).toLong()
+    }
+
+    private fun requiredString(value: JSONObject, key: String): String {
+        val raw = value.get(key)
+        require(raw is String && raw.isNotBlank())
+        return raw
+    }
+
+    private fun optionalBoolean(value: JSONObject, key: String): Boolean? {
+        if (!value.has(key) || value.isNull(key)) return null
+        val raw = value.get(key)
+        require(raw is Boolean)
+        return raw
+    }
+
+    private fun optionalInt(value: JSONObject, key: String): Int? {
+        if (!value.has(key) || value.isNull(key)) return null
+        val raw = value.get(key)
+        require(raw is Byte || raw is Short || raw is Int || raw is Long)
+        val longValue = (raw as Number).toLong()
+        require(longValue in Int.MIN_VALUE..Int.MAX_VALUE)
+        return longValue.toInt()
+    }
+
+    private fun optionalString(value: JSONObject, key: String): String? {
+        if (!value.has(key) || value.isNull(key)) return null
+        val raw = value.get(key)
+        require(raw is String && raw.isNotBlank())
+        return raw
+    }
+}
+
+internal class PlaybackCompatibilityPolicyStore(
+    context: Context,
+    httpClient: OkHttpClient
+) {
+    private val preferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val mutex = Mutex()
+    private val lastAttemptAtMs = AtomicLong(0L)
+    private val rejectionRefreshAtMs = AtomicLong(0L)
+    private val bundledPolicy = PlaybackCompatibilityPolicy.bundled()
+    private val currentPolicy = AtomicReference(loadCachedPolicy())
+    private val client = httpClient.newBuilder()
+        .followRedirects(false)
+        .followSslRedirects(false)
+        .connectTimeout(900, TimeUnit.MILLISECONDS)
+        .readTimeout(1_400, TimeUnit.MILLISECONDS)
+        .writeTimeout(700, TimeUnit.MILLISECONDS)
+        .callTimeout(1_800, TimeUnit.MILLISECONDS)
+        .build()
+
+    @Volatile
+    private var checkedAtMs: Long = preferences.getLong(KEY_CHECKED_AT_MS, 0L)
+
+    fun current(): PlaybackCompatibilityPolicy = currentPolicy.get()
+
+    fun needsRefresh(nowMs: Long = System.currentTimeMillis()): Boolean {
+        val stale = checkedAtMs <= 0L || nowMs - checkedAtMs >= REFRESH_TTL_MS
+        if (!stale) return false
+        val lastAttempt = lastAttemptAtMs.get()
+        return lastAttempt <= 0L || nowMs - lastAttempt >= FAILED_FETCH_BACKOFF_MS
+    }
+
+    suspend fun refresh(force: Boolean, reason: String): Boolean {
+        if (!force && !needsRefresh()) return false
+        return mutex.withLock {
+            if (!force && !needsRefresh()) return@withLock false
+            refreshLocked(reason)
+        }
+    }
+
+    suspend fun refreshAfterRejection(): Boolean {
+        val now = System.currentTimeMillis()
+        while (true) {
+            val previous = rejectionRefreshAtMs.get()
+            if (previous > 0L && now - previous < REJECTION_REFRESH_COOLDOWN_MS) return false
+            if (rejectionRefreshAtMs.compareAndSet(previous, now)) break
+        }
+        return refresh(force = true, reason = "stream-rejected")
+    }
+
+    private suspend fun refreshLocked(reason: String): Boolean {
+        lastAttemptAtMs.set(System.currentTimeMillis())
+        val etag = preferences.getString(KEY_ETAG, "").orEmpty()
+        val request = Request.Builder()
+            .url(REMOTE_POLICY_URL)
+            .get()
+            .header("Accept", "application/json")
+            .header("User-Agent", USER_AGENT)
+            .apply { etag.takeIf { it.isNotBlank() }?.let { header("If-None-Match", it) } }
+            .build()
+
+        val response = try {
+            withContext(Dispatchers.IO) { await(request) }
+        } catch (error: IOException) {
+            Timber.w(error, "Playback compatibility policy fetch failed reason=%s", reason)
+            return false
+        }
+
+        response.use { value ->
+            if (value.code == 304) {
+                markChecked(value.header("ETag").orEmpty().ifBlank { etag })
+                return false
+            }
+            if (!value.isSuccessful) {
+                markCheckedWithoutEtagChange()
+                Timber.w("Playback compatibility policy HTTP %d reason=%s", value.code, reason)
+                return false
+            }
+            val raw = try {
+                readBoundedYoutubeJsonBody(value.body, MAX_POLICY_BYTES)
+            } catch (error: IOException) {
+                markCheckedWithoutEtagChange()
+                Timber.w(error, "Playback compatibility policy response rejected")
+                return false
+            }
+            val before = currentPolicy.get()
+            val candidate = PlaybackCompatibilityPolicyParser.parse(raw, before)
+            if (candidate == null) {
+                markCheckedWithoutEtagChange()
+                Timber.w("Playback compatibility policy payload rejected reason=%s", reason)
+                return false
+            }
+            if (candidate.revision < before.revision) {
+                markCheckedWithoutEtagChange()
+                Timber.w(
+                    "Playback compatibility policy downgrade ignored current=%d remote=%d",
+                    before.revision,
+                    candidate.revision
+                )
+                return false
+            }
+            if (candidate.revision == before.revision && candidate != before) {
+                markCheckedWithoutEtagChange()
+                Timber.w("Playback compatibility policy changed without revision bump: %d", candidate.revision)
+                return false
+            }
+
+            val changed = candidate != before
+            if (changed) currentPolicy.set(candidate)
+            persistPolicy(candidate, value.header("ETag").orEmpty().ifBlank { etag })
+            Timber.i(
+                "Playback compatibility policy active revision=%d changed=%s reason=%s",
+                candidate.revision,
+                changed,
+                reason
+            )
+            return changed
+        }
+    }
+
+    private fun loadCachedPolicy(): PlaybackCompatibilityPolicy {
+        val raw = preferences.getString(KEY_POLICY_JSON, "").orEmpty()
+        if (raw.isBlank()) return bundledPolicy
+        val cached = PlaybackCompatibilityPolicyParser.parse(raw, bundledPolicy) ?: return bundledPolicy
+        return cached.takeIf { it.revision >= bundledPolicy.revision } ?: bundledPolicy
+    }
+
+    private fun persistPolicy(policy: PlaybackCompatibilityPolicy, etag: String) {
+        val now = System.currentTimeMillis()
+        checkedAtMs = now
+        preferences.edit()
+            .putString(KEY_POLICY_JSON, policy.toJson())
+            .putString(KEY_ETAG, etag)
+            .putLong(KEY_CHECKED_AT_MS, now)
+            .apply()
+    }
+
+    private fun markChecked(etag: String) {
+        val now = System.currentTimeMillis()
+        checkedAtMs = now
+        preferences.edit()
+            .putString(KEY_ETAG, etag)
+            .putLong(KEY_CHECKED_AT_MS, now)
+            .apply()
+    }
+
+    private fun markCheckedWithoutEtagChange() {
+        val now = System.currentTimeMillis()
+        checkedAtMs = now
+        preferences.edit()
+            .putLong(KEY_CHECKED_AT_MS, now)
+            .apply()
+    }
+
+    private suspend fun await(request: Request): Response = suspendCancellableCoroutine { continuation ->
+        val call = client.newCall(request)
+        continuation.invokeOnCancellation { call.cancel() }
+        call.enqueue(object : Callback {
+            override fun onFailure(call: Call, error: IOException) {
+                if (continuation.isActive) continuation.resumeWithException(error)
+            }
+
+            override fun onResponse(call: Call, response: Response) {
+                continuation.resume(response) { _, value, _ -> value.close() }
+            }
+        })
+    }
+
+    companion object {
+        private const val PREFS_NAME = "levyra_playback_compatibility_policy"
+        private const val KEY_POLICY_JSON = "policy_json"
+        private const val KEY_ETAG = "etag"
+        private const val KEY_CHECKED_AT_MS = "checked_at_ms"
+        private const val REFRESH_TTL_MS = 5L * 60L * 1000L
+        private const val FAILED_FETCH_BACKOFF_MS = 30_000L
+        private const val REJECTION_REFRESH_COOLDOWN_MS = 30_000L
+        private const val MAX_POLICY_BYTES = 64L * 1024L
+        private const val USER_AGENT = "Levyra playback-policy/1"
+        private const val REMOTE_POLICY_URL =
+            "https://raw.githubusercontent.com/LUC4N3X/Levyra-deepsound/main/config/playback_policy.json"
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResilienceEngine.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResilienceEngine.kt
@@ -39,6 +39,33 @@ internal data class PlaybackTraceEvent(
     val detail: String
 )
 
+private val playbackHttpStatusPattern = Regex(
+    """\b(?:http(?:\s+status)?|status(?:\s+code)?)\s*[:=]?\s*(403|410|429)\b""",
+    RegexOption.IGNORE_CASE
+)
+
+internal fun classifyPlaybackFailureReason(raw: String): PlaybackFailureKind {
+    val value = raw.lowercase(Locale.ROOT)
+    val httpStatus = playbackHttpStatusPattern.find(raw)?.groupValues?.getOrNull(1)?.toIntOrNull()
+    return when {
+        httpStatus == 403 ||
+            value.contains("forbidden") ||
+            value.contains("confirm you're not a bot") ||
+            value.contains("confirm you’re not a bot") ||
+            value.contains("confirm you are not a bot") ||
+            value.contains("sign in to confirm") ||
+            value.contains("accedi per confermare") -> PlaybackFailureKind.Forbidden
+        httpStatus == 410 || value.contains("gone") -> PlaybackFailureKind.Gone
+        httpStatus == 429 || value.contains("rate limit") -> PlaybackFailureKind.RateLimited
+        value.contains("expired") || value.contains("scadut") || value.contains("stream non valido") -> PlaybackFailureKind.ExpiredUrl
+        value.contains("signature") || value.contains("n-transform") || value.contains("potoken") || value.contains("po token") -> PlaybackFailureKind.Signature
+        value.contains("decoder") || value.contains("codec") || value.contains("format") -> PlaybackFailureKind.Decoder
+        value.contains("timeout") || value.contains("timed out") || value.contains("lento") -> PlaybackFailureKind.Timeout
+        value.contains("network") || value.contains("socket") || value.contains("dns") || value.contains("connection") || value.contains("host") -> PlaybackFailureKind.Network
+        else -> PlaybackFailureKind.Unknown
+    }
+}
+
 internal class PlaybackResilienceEngine(context: Context) {
     private val prefs = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     private val events = ArrayDeque<PlaybackTraceEvent>(MAX_EVENTS)
@@ -91,7 +118,7 @@ internal class PlaybackResilienceEngine(context: Context) {
                 profile = profile,
                 mode = mode,
                 latencyMs = latencyMs?.coerceAtLeast(1L) ?: 0L,
-                outcome = classify(detail).name,
+                outcome = classifyPlaybackFailureReason(detail).name,
                 detail = sanitize(detail)
             ),
             persist = true
@@ -106,7 +133,7 @@ internal class PlaybackResilienceEngine(context: Context) {
                 profile = "active",
                 mode = if (videoMode) "video" else "audio",
                 latencyMs = 0L,
-                outcome = classify(reason).name,
+                outcome = classifyPlaybackFailureReason(reason).name,
                 detail = "${trackId.take(20)} ${sanitize(reason)}".trim()
             ),
             persist = true
@@ -114,7 +141,7 @@ internal class PlaybackResilienceEngine(context: Context) {
     }
 
     fun recoveryPlan(reason: String): PlaybackRecoveryPlan {
-        return when (classify(reason)) {
+        return when (classifyPlaybackFailureReason(reason)) {
             PlaybackFailureKind.Forbidden,
             PlaybackFailureKind.Gone,
             PlaybackFailureKind.RateLimited -> PlaybackRecoveryPlan(true, true, false, true, 10L * 60L * 1000L)
@@ -141,21 +168,6 @@ internal class PlaybackResilienceEngine(context: Context) {
         }
         root.put("trace", trace)
         return root.toString(2)
-    }
-
-    private fun classify(raw: String): PlaybackFailureKind {
-        val value = raw.lowercase(Locale.ROOT)
-        return when {
-            value.contains("403") || value.contains("forbidden") -> PlaybackFailureKind.Forbidden
-            value.contains("410") || value.contains("gone") -> PlaybackFailureKind.Gone
-            value.contains("429") || value.contains("rate limit") -> PlaybackFailureKind.RateLimited
-            value.contains("expired") || value.contains("scadut") || value.contains("stream non valido") -> PlaybackFailureKind.ExpiredUrl
-            value.contains("signature") || value.contains("n-transform") || value.contains("potoken") || value.contains("po token") -> PlaybackFailureKind.Signature
-            value.contains("decoder") || value.contains("codec") || value.contains("format") -> PlaybackFailureKind.Decoder
-            value.contains("timeout") || value.contains("timed out") || value.contains("lento") -> PlaybackFailureKind.Timeout
-            value.contains("network") || value.contains("socket") || value.contains("dns") || value.contains("connection") || value.contains("host") -> PlaybackFailureKind.Network
-            else -> PlaybackFailureKind.Unknown
-        }
     }
 
     private fun sanitize(value: String): String {

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -110,7 +110,6 @@ internal fun preserveEditorialArtwork(presented: Track, resolved: Track): Track 
 }
 
 private const val YOUTUBE_NONCE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
-private const val ANDROID_REEL_CLIENT_VERSION = "21.03.36"
 private const val MAX_YOUTUBE_JSON_RESPONSE_BYTES = 8L * 1024L * 1024L
 private val youtubeNonceRandom = SecureRandom()
 
@@ -124,9 +123,12 @@ internal fun visionOsUserAgent(countryCode: String): String {
     return "com.google.visionos.youtube/1.02(RealityDevice14,1; U; CPU visionOS 25_6_0 like Mac OS X; $country)"
 }
 
-internal fun androidReelUserAgent(countryCode: String): String {
+internal fun androidReelUserAgent(
+    countryCode: String,
+    clientVersion: String = PlaybackCompatibilityPolicy.DEFAULT_ANDROID_REEL_CLIENT_VERSION
+): String {
     val country = normalizedYoutubeCountryCode(countryCode)
-    return "com.google.android.youtube/$ANDROID_REEL_CLIENT_VERSION (Linux; U; Android 15; $country) gzip"
+    return "com.google.android.youtube/$clientVersion (Linux; U; Android 15; $country) gzip"
 }
 
 internal fun applyVisionOsClientIdentity(client: JSONObject): JSONObject {
@@ -142,11 +144,12 @@ internal fun applyVisionOsClientIdentity(client: JSONObject): JSONObject {
 internal fun buildAndroidReelContext(
     hl: String,
     gl: String,
-    visitorData: String
+    visitorData: String,
+    clientVersion: String = PlaybackCompatibilityPolicy.DEFAULT_ANDROID_REEL_CLIENT_VERSION
 ): JSONObject {
     val client = JSONObject()
         .put("clientName", "ANDROID")
-        .put("clientVersion", ANDROID_REEL_CLIENT_VERSION)
+        .put("clientVersion", clientVersion)
         .put("clientScreen", "WATCH")
         .put("platform", "MOBILE")
         .put("osName", "Android")
@@ -172,10 +175,11 @@ internal fun buildAndroidReelRequestBody(
     cpn: String,
     hl: String,
     gl: String,
-    visitorData: String
+    visitorData: String,
+    clientVersion: String = PlaybackCompatibilityPolicy.DEFAULT_ANDROID_REEL_CLIENT_VERSION
 ): JSONObject {
     return JSONObject()
-        .put("context", buildAndroidReelContext(hl, gl, visitorData))
+        .put("context", buildAndroidReelContext(hl, gl, visitorData, clientVersion))
         .put(
             "playerRequest",
             JSONObject()
@@ -268,6 +272,7 @@ class PlaybackResolver private constructor(private val context: Context) {
     private val youtubeHttpClient = LevyraHttpClientFactory.youtubePlayer()
     private val jsonMediaType = "application/json; charset=utf-8".toMediaType()
     private val playbackSecurity = YoutubePlaybackSecurity.getInstance(context)
+    private val playbackPolicyStore = PlaybackCompatibilityPolicyStore(context, youtubeHttpClient)
     private val resilienceEngine = PlaybackResilienceEngine(context)
     private val sourceMatchStore = PlaybackSourceMatchStore(LevyraDatabase.get(context).playbackSourceMatchDao())
     private val sourceMatchScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -312,10 +317,29 @@ class PlaybackResolver private constructor(private val context: Context) {
     init {
         restoreCache()
         restoreClientHealth()
+        refreshPlaybackPolicyInBackground(force = true, reason = "startup")
     }
 
     fun setAudioQuality(value: String) {
         selectedAudioQuality = normalizeAudioQuality(value)
+    }
+
+    private fun refreshPlaybackPolicyInBackground(force: Boolean, reason: String) {
+        if (!force && !playbackPolicyStore.needsRefresh()) return
+        resolveScope.launch {
+            val changed = runCatchingPreservingCancellation {
+                playbackPolicyStore.refresh(force = force, reason = reason)
+            }.onFailure { error ->
+                Timber.w(error, "Playback compatibility policy refresh failed reason=%s", reason)
+            }.getOrDefault(false)
+            if (changed) clearResolvedStreamCaches()
+        }
+    }
+
+    private suspend fun clearResolvedStreamCaches() {
+        streamCache.clear()
+        prefs.edit().clear().apply()
+        sourceMatchStore.clearOnline()
     }
 
     private fun normalizeAudioQuality(value: String): String {
@@ -339,7 +363,7 @@ class PlaybackResolver private constructor(private val context: Context) {
             val request = Request.Builder()
                 .url(url)
                 .head()
-                .header("User-Agent", profiles.first().userAgent)
+                .header("User-Agent", effectiveProfiles().firstOrNull()?.userAgent ?: profiles.first().userAgent)
                 .build()
             youtubeHttpClient.newCall(request).enqueue(object : Callback {
                 override fun onFailure(call: Call, e: IOException) {
@@ -461,6 +485,12 @@ class PlaybackResolver private constructor(private val context: Context) {
         if (recovery.refreshSecurity) {
             YoutubeLocalDecoder.notifyStreamRejected(track.source)
             resolveScope.launch {
+                val policyChanged = runCatchingPreservingCancellation {
+                    playbackPolicyStore.refreshAfterRejection()
+                }.onFailure { error ->
+                    Timber.w(error, "Playback compatibility policy rejection refresh failed")
+                }.getOrDefault(false)
+                if (policyChanged) clearResolvedStreamCaches()
                 runCatchingPreservingCancellation {
                     playbackSecurity.rotateIfNeeded(PlaybackBlockedException(reason))
                 }.onFailure { error ->
@@ -597,6 +627,9 @@ class PlaybackResolver private constructor(private val context: Context) {
         audioQuality: String,
         reuseProvidedStream: Boolean
     ): Track = coroutineScope {
+        if (requestKind == "playback") {
+            refreshPlaybackPolicyInBackground(force = false, reason = "resolve")
+        }
         if (isLocalPlaybackTrack(track)) {
             if (!isLocalPlaybackUri(track.streamUrl)) {
                 throw PlaybackBlockedException("File offline non disponibile per ${track.title}")
@@ -677,67 +710,37 @@ class PlaybackResolver private constructor(private val context: Context) {
         val errors = Collections.synchronizedList(mutableListOf<String>())
 
         if (!preferMp4Audio && !isVideoMode) {
-            val reelAudio = runCatchingPreservingCancellation {
-                resolveVideoWithAndroidReel(track)
-            }.onFailure { error ->
-                errors += "Android Reel audio: ${error.playbackDiagnostic()}"
-            }.getOrNull()
-            if (reelAudio != null) {
-                store(track, reelAudio, isVideoMode, audioQuality, preferMp4Audio)
-                persistResolvedSource(track, reelAudio, isVideoMode, audioQuality, 96, preferMp4Audio)
-                return@withContext reelAudio
-            }
+            val resolved = resolveAudioByCompatibilityPolicy(track, audioQuality, errors)
+            if (resolved != null) return@withContext resolved
+
+            val reason = errors.firstOrNull { it.startsWith("LevyraExtractor:") }
+                ?: errors.firstOrNull {
+                    it.contains("age", true) ||
+                        it.contains("anonymous", true) ||
+                        it.contains("login", true) ||
+                        it.contains("accedi", true)
+                }
+                ?: errors.firstOrNull()
+                ?: "Stream non disponibile"
+            Timber.w(
+                "audio resolve failed offlineExport=false policyRevision=%d errors=%s",
+                playbackPolicyStore.current().revision,
+                errors.joinToString(" | ").take(900)
+            )
+            throw PlaybackBlockedException(reason)
         }
 
-        restorePersistentSource(track, isVideoMode, preferMp4Audio, audioQuality, errors)?.let { restored ->
-            store(track, restored, isVideoMode, audioQuality, preferMp4Audio)
-            return@withContext restored
+        if (preferMp4Audio) {
+            restorePersistentSource(track, isVideoMode, preferMp4Audio, audioQuality, errors)?.let { restored ->
+                store(track, restored, isVideoMode, audioQuality, preferMp4Audio)
+                return@withContext restored
+            }
         }
 
         if (isVideoMode) {
-            val resolved = coroutineScope {
-                val winner = CompletableDeferred<Track?>()
-                val extractorJob = launch {
-                    delay(LevyraResolverLatency.extractorHedgeDelayMs(isVideoMode = true, preferMp4Audio = false))
-                    if (winner.isCompleted) return@launch
-                    val result = runCatchingPreservingCancellation { resolveVideoWithLevyraExtractor(track, audioQuality) }
-                    result.onSuccess { winner.complete(it) }
-                        .onFailure { error ->
-                            errors += "LevyraExtractor video: ${error.playbackDiagnostic()}"
-                        }
-                }
-                val innerTubeJob = launch {
-                    delay(LevyraResolverLatency.innerTubeFallbackDelayMs(isVideoMode = true, preferMp4Audio = false))
-                    if (winner.isCompleted) return@launch
-                    val stream = runCatchingPreservingCancellation { hedgedInnerTube(track, errors, true, audioQuality) }.getOrNull()
-                    if (stream != null) {
-                        winner.complete(track.withDirectStream(stream))
-                    }
-                }
-                launch {
-                    extractorJob.join()
-                    innerTubeJob.join()
-                    winner.complete(null)
-                }
-                val result = winner.await()
-                coroutineContext.cancelChildren()
-                result
-            }
-            if (resolved != null) {
-                store(track, resolved, isVideoMode, audioQuality)
-                persistResolvedSource(track, resolved, isVideoMode, audioQuality, 92, preferMp4Audio)
-                return@withContext resolved
-            }
-            val reelFallback = runCatchingPreservingCancellation {
-                resolveVideoWithAndroidReel(track)
-            }.onFailure { error ->
-                errors += "Android Reel: ${error.playbackDiagnostic()}"
-            }.getOrNull()
-            if (reelFallback != null) {
-                store(track, reelFallback, isVideoMode, audioQuality)
-                persistResolvedSource(track, reelFallback, isVideoMode, audioQuality, 78, preferMp4Audio)
-                return@withContext reelFallback
-            }
+            val resolved = resolveVideoByCompatibilityPolicy(track, audioQuality, errors)
+            if (resolved != null) return@withContext resolved
+
             val reason = errors.firstOrNull { it.contains("age", true) || it.contains("login", true) }
                 ?: errors.firstOrNull()
                 ?: "Video non disponibile"
@@ -770,6 +773,149 @@ class PlaybackResolver private constructor(private val context: Context) {
         throw PlaybackBlockedException(reason)
     }
 
+    private suspend fun resolveAudioByCompatibilityPolicy(
+        track: Track,
+        audioQuality: String,
+        errors: MutableList<String>
+    ): Track? {
+        val policy = playbackPolicyStore.current()
+        for (strategy in policy.audioStrategies) {
+            currentCoroutineContext().ensureActive()
+            val resolved = when (strategy) {
+                PlaybackAudioStrategy.REEL_MUXED -> runCatchingPreservingCancellation {
+                    resolveVideoWithAndroidReel(track)
+                }.onFailure { error ->
+                    errors += "Android Reel muxed: ${error.playbackDiagnostic()}"
+                }.getOrNull()
+
+                PlaybackAudioStrategy.REEL_AUDIO -> runCatchingPreservingCancellation {
+                    resolveAudioWithAndroidReel(track, audioQuality)
+                }.onFailure { error ->
+                    errors += "Android Reel audio: ${error.playbackDiagnostic()}"
+                }.getOrNull()
+
+                PlaybackAudioStrategy.PERSISTED -> restorePersistentSource(
+                    track = track,
+                    isVideoMode = false,
+                    preferMp4Audio = false,
+                    audioQuality = audioQuality,
+                    errors = errors
+                )
+
+                PlaybackAudioStrategy.DIRECT -> resolveAudioFast(
+                    track = track,
+                    errors = errors,
+                    preferMp4Audio = false,
+                    audioQuality = audioQuality
+                )
+
+                PlaybackAudioStrategy.SEARCH -> resolveAudioWithSearchFallback(
+                    track = track,
+                    errors = errors,
+                    preferMp4Audio = false,
+                    audioQuality = audioQuality
+                )
+            }
+            if (resolved != null) {
+                store(track, resolved, false, audioQuality, false)
+                val confidence = when (strategy) {
+                    PlaybackAudioStrategy.REEL_MUXED,
+                    PlaybackAudioStrategy.REEL_AUDIO -> 96
+                    PlaybackAudioStrategy.DIRECT -> 90
+                    PlaybackAudioStrategy.SEARCH -> 84
+                    PlaybackAudioStrategy.PERSISTED -> null
+                }
+                confidence?.let {
+                    persistResolvedSource(track, resolved, false, audioQuality, it, false)
+                }
+                return resolved
+            }
+        }
+        return null
+    }
+
+    private suspend fun resolveVideoByCompatibilityPolicy(
+        track: Track,
+        audioQuality: String,
+        errors: MutableList<String>
+    ): Track? {
+        val policy = playbackPolicyStore.current()
+        for (strategy in policy.videoStrategies) {
+            currentCoroutineContext().ensureActive()
+            val resolved = when (strategy) {
+                PlaybackVideoStrategy.PERSISTED -> restorePersistentSource(
+                    track = track,
+                    isVideoMode = true,
+                    preferMp4Audio = false,
+                    audioQuality = audioQuality,
+                    errors = errors
+                )
+
+                PlaybackVideoStrategy.STANDARD -> resolveStandardVideo(track, audioQuality, errors)
+                PlaybackVideoStrategy.REEL -> runCatchingPreservingCancellation {
+                    resolveVideoWithAndroidReel(track)
+                }.onFailure { error ->
+                    errors += "Android Reel: ${error.playbackDiagnostic()}"
+                }.getOrNull()
+            }
+            if (resolved != null) {
+                store(track, resolved, true, audioQuality)
+                val confidence = when (strategy) {
+                    PlaybackVideoStrategy.PERSISTED -> null
+                    PlaybackVideoStrategy.STANDARD -> 92
+                    PlaybackVideoStrategy.REEL -> 78
+                }
+                confidence?.let {
+                    persistResolvedSource(
+                        original = track,
+                        resolved = resolved,
+                        isVideoMode = true,
+                        audioQuality = audioQuality,
+                        confidence = it,
+                        preferMp4Audio = false
+                    )
+                }
+                return resolved
+            }
+        }
+        return null
+    }
+
+    private suspend fun resolveStandardVideo(
+        track: Track,
+        audioQuality: String,
+        errors: MutableList<String>
+    ): Track? = coroutineScope {
+        val winner = CompletableDeferred<Track?>()
+        val extractorJob = launch {
+            delay(LevyraResolverLatency.extractorHedgeDelayMs(isVideoMode = true, preferMp4Audio = false))
+            if (winner.isCompleted) return@launch
+            val result = runCatchingPreservingCancellation {
+                resolveVideoWithLevyraExtractor(track, audioQuality)
+            }
+            result.onSuccess { winner.complete(it) }
+                .onFailure { error ->
+                    errors += "LevyraExtractor video: ${error.playbackDiagnostic()}"
+                }
+        }
+        val innerTubeJob = launch {
+            delay(LevyraResolverLatency.innerTubeFallbackDelayMs(isVideoMode = true, preferMp4Audio = false))
+            if (winner.isCompleted) return@launch
+            val stream = runCatchingPreservingCancellation {
+                hedgedInnerTube(track, errors, true, audioQuality)
+            }.getOrNull()
+            if (stream != null) winner.complete(track.withDirectStream(stream))
+        }
+        launch {
+            extractorJob.join()
+            innerTubeJob.join()
+            winner.complete(null)
+        }
+        val result = winner.await()
+        coroutineContext.cancelChildren()
+        result
+    }
+
     private suspend fun resolveAudioWithAndroidReel(
         track: Track,
         audioQuality: String
@@ -778,10 +924,11 @@ class PlaybackResolver private constructor(private val context: Context) {
             .takeIf(youtubeVideoIdRegex::matches)
             ?: throw YoutubePlayerRequestException(null, "Identità video YouTube assente o non valida")
         val locale = LevyraContentLocales.forLanguage(userPreferences.languageCode())
-        val userAgent = androidReelUserAgent(locale.gl)
+        val reelClientVersion = playbackPolicyStore.current().androidReelClientVersion
+        val userAgent = androidReelUserAgent(locale.gl, reelClientVersion)
         val cachedVisitorData = playbackSecurity.cachedSession().visitorData
         val visitorData = runCatchingPreservingCancellation {
-            fetchAndroidReelVisitorData(locale.hl, locale.gl, userAgent)
+            fetchAndroidReelVisitorData(locale.hl, locale.gl, userAgent, reelClientVersion)
         }.getOrNull().orEmpty().ifBlank { cachedVisitorData }
         currentCoroutineContext().ensureActive()
 
@@ -792,7 +939,8 @@ class PlaybackResolver private constructor(private val context: Context) {
             cpn = cpn,
             hl = locale.hl,
             gl = locale.gl,
-            visitorData = visitorData
+            visitorData = visitorData,
+            clientVersion = reelClientVersion
         ).toString()
         val endpoint = "https://youtubei.googleapis.com/youtubei/v1/reel/reel_item_watch" +
             "?prettyPrint=false&t=$tParameter&id=$sourceVideoId&\$fields=playerResponse"
@@ -967,10 +1115,11 @@ class PlaybackResolver private constructor(private val context: Context) {
             .takeIf(youtubeVideoIdRegex::matches)
             ?: throw YoutubePlayerRequestException(null, "Identità video YouTube assente o non valida")
         val locale = LevyraContentLocales.forLanguage(userPreferences.languageCode())
-        val userAgent = androidReelUserAgent(locale.gl)
+        val reelClientVersion = playbackPolicyStore.current().androidReelClientVersion
+        val userAgent = androidReelUserAgent(locale.gl, reelClientVersion)
         val cachedVisitorData = playbackSecurity.cachedSession().visitorData
         val visitorData = runCatchingPreservingCancellation {
-            fetchAndroidReelVisitorData(locale.hl, locale.gl, userAgent)
+            fetchAndroidReelVisitorData(locale.hl, locale.gl, userAgent, reelClientVersion)
         }.getOrNull().orEmpty().ifBlank { cachedVisitorData }
         currentCoroutineContext().ensureActive()
 
@@ -981,7 +1130,8 @@ class PlaybackResolver private constructor(private val context: Context) {
             cpn = cpn,
             hl = locale.hl,
             gl = locale.gl,
-            visitorData = visitorData
+            visitorData = visitorData,
+            clientVersion = reelClientVersion
         ).toString()
         val endpoint = "https://youtubei.googleapis.com/youtubei/v1/reel/reel_item_watch" +
             "?prettyPrint=false&t=$tParameter&id=$sourceVideoId&\$fields=playerResponse"
@@ -1076,10 +1226,11 @@ class PlaybackResolver private constructor(private val context: Context) {
     private fun fetchAndroidReelVisitorData(
         hl: String,
         gl: String,
-        userAgent: String
+        userAgent: String,
+        clientVersion: String
     ): String {
         val body = JSONObject()
-            .put("context", buildAndroidReelContext(hl, gl, ""))
+            .put("context", buildAndroidReelContext(hl, gl, "", clientVersion))
             .toString()
         val request = Request.Builder()
             .url("https://youtubei.googleapis.com/youtubei/v1/visitor_id?prettyPrint=false")
@@ -1627,17 +1778,42 @@ class PlaybackResolver private constructor(private val context: Context) {
         result
     }
 
+    private fun effectiveProfiles(): List<ClientProfile> {
+        val overrides = playbackPolicyStore.current().clientOverrides
+        val effective = profiles.mapNotNull { base ->
+            val override = overrides[base.clientName]
+            if (override?.enabled == false) return@mapNotNull null
+            val version = override?.clientVersion ?: base.clientVersion
+            base.copy(
+                clientVersion = version,
+                userAgent = if (version == base.clientVersion) {
+                    base.userAgent
+                } else {
+                    base.userAgent.replace(base.clientVersion, version)
+                },
+                tier = override?.priority ?: base.tier,
+                requiresPoToken = override?.requiresPoToken ?: base.requiresPoToken
+            )
+        }
+        return effective.ifEmpty { profiles }
+    }
+
     private fun profileFromSource(source: String): ClientProfile? {
         val normalized = source.lowercase()
-        return profiles.firstOrNull { profile ->
+        return effectiveProfiles().firstOrNull { profile ->
+            normalized.contains(profile.label.lowercase()) || normalized.contains(profile.clientName.lowercase())
+        } ?: profiles.firstOrNull { profile ->
             normalized.contains(profile.label.lowercase()) || normalized.contains(profile.clientName.lowercase())
         }
     }
 
     private fun orderedProfiles(): List<ClientProfile> {
         val now = System.currentTimeMillis()
-        val available = profiles.filter { profile -> (clientHealth[profile.clientName]?.blockedUntilMs ?: 0L) <= now }
-        val candidates = if (available.isNotEmpty()) available else profiles
+        val configured = effectiveProfiles()
+        val available = configured.filter { profile ->
+            (clientHealth[profile.clientName]?.blockedUntilMs ?: 0L) <= now
+        }
+        val candidates = if (available.isNotEmpty()) available else configured
         val sorted = candidates.sortedWith(
             compareByDescending<ClientProfile> { it.requiresPoToken }
                 .thenByDescending { profile -> clientHealth[profile.clientName]?.score ?: 50.0 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSourceMatchStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSourceMatchStore.kt
@@ -96,4 +96,8 @@ internal class PlaybackSourceMatchStore(
     ) {
         dao.delete(PlaybackSourceIdentity.matchKey(track, videoMode, audioQuality, preferMp4Audio))
     }
+
+    suspend fun clearOnline() {
+        dao.deleteOnlineMatches()
+    }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/local/PlaybackSourceMatchEntity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/local/PlaybackSourceMatchEntity.kt
@@ -54,6 +54,9 @@ interface PlaybackSourceMatchDao {
     @Query("DELETE FROM playback_source_matches WHERE matchKey = :matchKey")
     suspend fun delete(matchKey: String)
 
+    @Query("DELETE FROM playback_source_matches WHERE mode IN ('audio', 'video')")
+    suspend fun deleteOnlineMatches(): Int
+
     @Query("DELETE FROM playback_source_matches WHERE updatedAt < :olderThan AND successCount = 0")
     suspend fun deleteUnusedOlderThan(olderThan: Long): Int
 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicyTest.kt
@@ -1,0 +1,244 @@
+package com.luc4n3x.levyra.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaybackCompatibilityPolicyTest {
+    @Test
+    fun bundledPolicyMatchesCurrentWorkingPlaybackOrder() {
+        val policy = PlaybackCompatibilityPolicy.bundled()
+
+        assertEquals(
+            listOf(
+                PlaybackAudioStrategy.REEL_MUXED,
+                PlaybackAudioStrategy.PERSISTED,
+                PlaybackAudioStrategy.DIRECT,
+                PlaybackAudioStrategy.SEARCH
+            ),
+            policy.audioStrategies
+        )
+        assertEquals(
+            listOf(
+                PlaybackVideoStrategy.PERSISTED,
+                PlaybackVideoStrategy.STANDARD,
+                PlaybackVideoStrategy.REEL
+            ),
+            policy.videoStrategies
+        )
+        assertEquals("21.03.36", policy.androidReelClientVersion)
+        assertTrue(policy.clientOverrides.isEmpty())
+    }
+
+    @Test
+    fun partialPolicyCanSwitchPlaybackWithoutReplacingUnrelatedDefaults() {
+        val base = PlaybackCompatibilityPolicy.bundled()
+        val parsed = PlaybackCompatibilityPolicyParser.parse(
+            """
+            {
+              "schema": 1,
+              "revision": 2026081802,
+              "audioStrategy": ["REEL_AUDIO", "REEL_MUXED", "DIRECT"],
+              "clients": {
+                "ANDROID_VR": {
+                  "enabled": false
+                },
+                "ANDROID_MUSIC": {
+                  "priority": 0,
+                  "requiresPoToken": true,
+                  "clientVersion": "8.11.00"
+                }
+              }
+            }
+            """.trimIndent(),
+            base
+        )
+
+        assertNotNull(parsed)
+        parsed!!
+        assertEquals(
+            listOf(
+                PlaybackAudioStrategy.REEL_AUDIO,
+                PlaybackAudioStrategy.REEL_MUXED,
+                PlaybackAudioStrategy.DIRECT
+            ),
+            parsed.audioStrategies
+        )
+        assertEquals(base.videoStrategies, parsed.videoStrategies)
+        assertEquals(base.androidReelClientVersion, parsed.androidReelClientVersion)
+        assertEquals(false, parsed.clientOverrides.getValue("ANDROID_VR").enabled)
+        assertEquals(0, parsed.clientOverrides.getValue("ANDROID_MUSIC").priority)
+        assertEquals(true, parsed.clientOverrides.getValue("ANDROID_MUSIC").requiresPoToken)
+        assertEquals("8.11.00", parsed.clientOverrides.getValue("ANDROID_MUSIC").clientVersion)
+    }
+
+    @Test
+    fun policyCanMoveReelAheadOfStandardVideoPath() {
+        val parsed = PlaybackCompatibilityPolicyParser.parse(
+            """
+            {
+              "schema": 1,
+              "revision": 2026081802,
+              "videoStrategy": ["REEL", "STANDARD"]
+            }
+            """.trimIndent(),
+            PlaybackCompatibilityPolicy.bundled()
+        )
+
+        assertEquals(
+            listOf(PlaybackVideoStrategy.REEL, PlaybackVideoStrategy.STANDARD),
+            parsed?.videoStrategies
+        )
+    }
+
+    @Test
+    fun policyCanUpdateAndroidReelClientVersion() {
+        val parsed = PlaybackCompatibilityPolicyParser.parse(
+            """
+            {
+              "schema": 1,
+              "revision": 2026081802,
+              "androidReelClientVersion": "21.04.00"
+            }
+            """.trimIndent(),
+            PlaybackCompatibilityPolicy.bundled()
+        )
+
+        assertEquals("21.04.00", parsed?.androidReelClientVersion)
+    }
+
+    @Test
+    fun unknownFutureClientOverrideIsIgnoredSafely() {
+        val parsed = PlaybackCompatibilityPolicyParser.parse(
+            """
+            {
+              "schema": 1,
+              "revision": 2026081802,
+              "clients": {
+                "FUTURE_CLIENT": {
+                  "enabled": false,
+                  "priority": 0
+                }
+              }
+            }
+            """.trimIndent(),
+            PlaybackCompatibilityPolicy.bundled()
+        )
+
+        assertNotNull(parsed)
+        assertTrue(parsed!!.clientOverrides.isEmpty())
+    }
+
+    @Test
+    fun unsupportedStrategyRejectsWholeCandidate() {
+        val parsed = PlaybackCompatibilityPolicyParser.parse(
+            """
+            {
+              "schema": 1,
+              "revision": 2026081802,
+              "audioStrategy": ["REMOTE_SCRIPT"]
+            }
+            """.trimIndent(),
+            PlaybackCompatibilityPolicy.bundled()
+        )
+
+        assertNull(parsed)
+    }
+
+    @Test
+    fun unsupportedSchemaRejectsWholeCandidate() {
+        val parsed = PlaybackCompatibilityPolicyParser.parse(
+            """
+            {
+              "schema": 99,
+              "revision": 2026081802
+            }
+            """.trimIndent(),
+            PlaybackCompatibilityPolicy.bundled()
+        )
+
+        assertNull(parsed)
+    }
+
+    @Test
+    fun fractionalSchemaValueIsRejected() {
+        val parsed = PlaybackCompatibilityPolicyParser.parse(
+            """{"schema":1.5,"revision":2026081802}""",
+            PlaybackCompatibilityPolicy.bundled()
+        )
+
+        assertNull(parsed)
+    }
+
+    @Test
+    fun invalidClientVersionRejectsWholeCandidate() {
+        val parsed = PlaybackCompatibilityPolicyParser.parse(
+            """
+            {
+              "schema": 1,
+              "revision": 2026081802,
+              "clients": {
+                "ANDROID_VR": {
+                  "clientVersion": "1.65.10 injected header"
+                }
+              }
+            }
+            """.trimIndent(),
+            PlaybackCompatibilityPolicy.bundled()
+        )
+
+        assertNull(parsed)
+    }
+
+    @Test
+    fun disablingEveryKnownClientIsRejected() {
+        val clients = listOf(
+            "VISIONOS",
+            "ANDROID_VR",
+            "ANDROID_MUSIC",
+            "ANDROID",
+            "IOS",
+            "WEB_REMIX",
+            "WEB",
+            "WEB_EMBEDDED_PLAYER"
+        ).joinToString(",") { "\"$it\":{\"enabled\":false}" }
+        val parsed = PlaybackCompatibilityPolicyParser.parse(
+            """{"schema":1,"revision":2026081802,"clients":{$clients}}""",
+            PlaybackCompatibilityPolicy.bundled()
+        )
+
+        assertNull(parsed)
+    }
+
+    @Test
+    fun canonicalCacheRoundTripPreservesPolicy() {
+        val base = PlaybackCompatibilityPolicy.bundled()
+        val parsed = PlaybackCompatibilityPolicyParser.parse(
+            """
+            {
+              "schema": 1,
+              "revision": 2026081802,
+              "audioStrategy": ["DIRECT", "REEL_MUXED"],
+              "videoStrategy": ["REEL"],
+              "androidReelClientVersion": "21.04.00",
+              "clients": {
+                "ANDROID_VR": {
+                  "enabled": true,
+                  "priority": 2,
+                  "requiresPoToken": true
+                }
+              }
+            }
+            """.trimIndent(),
+            base
+        )!!
+
+        val roundTrip = PlaybackCompatibilityPolicyParser.parse(parsed.toJson(), base)
+
+        assertEquals(parsed, roundTrip)
+        assertFalse(roundTrip!!.audioStrategies.isEmpty())
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackFailureClassificationTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackFailureClassificationTest.kt
@@ -1,0 +1,47 @@
+package com.luc4n3x.levyra.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PlaybackFailureClassificationTest {
+    @Test
+    fun antiBotAndSignInChallengesTriggerForbiddenRecovery() {
+        val messages = listOf(
+            "Sign in to confirm you're not a bot",
+            "Sign in to confirm you’re not a bot",
+            "Please confirm you are not a bot",
+            "Accedi per confermare di essere umano"
+        )
+
+        messages.forEach { message ->
+            assertEquals(
+                PlaybackFailureKind.Forbidden,
+                classifyPlaybackFailureReason(message)
+            )
+        }
+    }
+
+    @Test
+    fun unrelatedNumbersDoNotMasqueradeAsHttpStatuses() {
+        assertEquals(
+            PlaybackFailureKind.Unknown,
+            classifyPlaybackFailureReason("playback position 403 seconds")
+        )
+        assertEquals(
+            PlaybackFailureKind.Unknown,
+            classifyPlaybackFailureReason("track token abc410xyz")
+        )
+        assertEquals(
+            PlaybackFailureKind.Unknown,
+            classifyPlaybackFailureReason("buffer contains 429 samples")
+        )
+    }
+
+    @Test
+    fun existingHttpRecoveryClassificationIsPreserved() {
+        assertEquals(PlaybackFailureKind.Forbidden, classifyPlaybackFailureReason("HTTP 403"))
+        assertEquals(PlaybackFailureKind.Gone, classifyPlaybackFailureReason("HTTP 410"))
+        assertEquals(PlaybackFailureKind.RateLimited, classifyPlaybackFailureReason("HTTP 429"))
+        assertEquals(PlaybackFailureKind.Signature, classifyPlaybackFailureReason("PO Token rejected"))
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeExtractorFallbackContractTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeExtractorFallbackContractTest.kt
@@ -66,6 +66,27 @@ class YoutubeExtractorFallbackContractTest {
     }
 
     @Test
+    fun androidReelRequestAcceptsServerProvidedClientVersion() {
+        val body = buildAndroidReelRequestBody(
+            videoId = "abcdefghijk",
+            cpn = "ABCDEFGHIJKLMNOP",
+            hl = "it",
+            gl = "it",
+            visitorData = "visitor-123",
+            clientVersion = "21.04.00"
+        )
+
+        assertEquals(
+            "21.04.00",
+            body.getJSONObject("context").getJSONObject("client").getString("clientVersion")
+        )
+        assertEquals(
+            "com.google.android.youtube/21.04.00 (Linux; U; Android 15; IT) gzip",
+            androidReelUserAgent("it", "21.04.00")
+        )
+    }
+
+    @Test
     fun androidReelFormatsAreReadOnlyFromNestedPlayerResponse() {
         val expected = JSONArray().put(JSONObject().put("itag", 18))
         val response = JSONObject()

--- a/config/playback_policy.json
+++ b/config/playback_policy.json
@@ -1,0 +1,17 @@
+{
+  "schema": 1,
+  "revision": 2026081801,
+  "audioStrategy": [
+    "REEL_MUXED",
+    "PERSISTED",
+    "DIRECT",
+    "SEARCH"
+  ],
+  "videoStrategy": [
+    "PERSISTED",
+    "STANDARD",
+    "REEL"
+  ],
+  "androidReelClientVersion": "21.03.36",
+  "clients": {}
+}


### PR DESCRIPTION
## Summary
Adds a server-driven YouTube playback compatibility policy so common upstream breakages can be mitigated by editing a small JSON on `main`, without requiring users to install another APK.

The bundled defaults exactly preserve the currently working post-#413 playback behavior. If the remote policy is unavailable, invalid, stale, or downgraded, Levyra keeps the bundled/last-known-good policy.

## Remote controls
`config/playback_policy.json` can change only precompiled, allowlisted behavior:

- audio resolver order: `REEL_MUXED`, `REEL_AUDIO`, `PERSISTED`, `DIRECT`, `SEARCH`;
- video resolver order: `PERSISTED`, `STANDARD`, `REEL`;
- Android Reel client version;
- known InnerTube clients: enable/disable, tier/priority hint, PoToken requirement, client version.

It cannot provide executable code, arbitrary endpoints, headers, tokens, cookies, credentials, or new client implementations.

## Runtime behavior
- fetches the policy asynchronously at startup and when stale, never blocking the first tap;
- uses a 5-minute normal refresh TTL and ETag validation;
- forces a refresh after 403/410/429/signature/PoToken and anti-bot/sign-in challenges;
- keeps a 30-second rejection/fetch backoff to avoid retry storms;
- persists a canonical last-known-good policy in app-private storage;
- rejects unsupported schema, invalid strategies, invalid client versions, all-clients-disabled policies, revision downgrades, and same-revision behavior changes;
- updates the ETag only for an accepted representation (or a confirming 304), so rejected payloads cannot become sticky;
- when a newer policy becomes active, invalidates in-memory and persisted online stream/source caches while preserving offline `audio-mp4` source matches;
- keeps offline/download resolution outside the remote policy.

## Safety
- fixed HTTPS source: `raw.githubusercontent.com/LUC4N3X/Levyra-deepsound/main/config/playback_policy.json`;
- redirects disabled for the policy fetch;
- response capped at 64 KiB;
- cancellation closes an in-flight HTTP response if it wins the resume race;
- no new dependency, permission, telemetry, account, cookie, or secret;
- no UI/player/queue/DSP changes;
- no release/version/F-Droid metadata changes.

## Emergency usage
1. Edit `config/playback_policy.json` on `main`.
2. Increase `revision`.
3. Change only the required strategy/client switch.
4. Users pick it up on startup / stale refresh; a playback rejection forces an immediate refresh.

Example: if the current Reel route breaks, change audio order to `DIRECT`, `REEL_MUXED`, `SEARCH`; if Android VR breaks, add an `ANDROID_VR` override with `enabled: false`. A rollback is done by restoring the old fields with a **higher** revision.

## Inspiration
SimpMusic's core uses a small GitHub-Raw remote JSON with persistent cached values. Levyra adapts that pattern specifically for playback with stricter schema validation, fixed trust boundaries, ETag/last-known-good handling, bounded retries, and rejection-triggered recovery.

## Validation
- focused parser/config/recovery tests added;
- existing Android Reel contract tests extended for server-provided client versions;
- CodeRabbit findings for response cancellation, ETag integrity, status classification, persisted cache invalidation, and VisionOS client identity were addressed;
- complete repository CI is validating the final single-commit head;
- no merge/release performed.