### PR TITLE
fix(download): reject legacy MP4 fallback sources

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineExportPipeline.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineExportPipeline.kt
@@ -35,6 +35,19 @@ internal fun supportsContinuousPrefetch(streamUrl: String): Boolean {
     return isMp4AudioExportUrl(streamUrl) && YoutubeStreamCapability.servesCompleteStream(streamUrl)
 }
 
+internal fun isAllowedOfflineReelSource(
+    source: String,
+    manifestProvider: String,
+    streamUrl: String
+): Boolean {
+    val reelIdentity = source.contains("Android Reel", ignoreCase = true) ||
+        manifestProvider.contains("Android Reel", ignoreCase = true)
+    return reelIdentity &&
+        streamUrl.isNotBlank() &&
+        isSupportedOfflineSource("", streamUrl) &&
+        YoutubeStreamCapability.servesCompleteStream(streamUrl)
+}
+
 internal fun offlineContinuousDownloadProgress(bytesCached: Long, contentLength: Long): Int {
     if (contentLength <= 0L) return 12
     val ratio = bytesCached.coerceIn(0L, contentLength).toDouble() / contentLength.toDouble()
@@ -203,6 +216,15 @@ internal class OfflineExportPipeline(
             settings.resolverAudioQuality
         )
         if (resolved.streamUrl.isBlank()) throw IOException("Stream audio non disponibile")
+        if (
+            !isAllowedOfflineReelSource(
+                source = resolved.source,
+                manifestProvider = resolved.playbackManifest?.provider.orEmpty(),
+                streamUrl = resolved.streamUrl
+            )
+        ) {
+            throw IOException("Download non disponibile: nessuna sorgente Android Reel compatibile")
+        }
         return resolved
     }
 }

--- a/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineExportPipelineTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineExportPipelineTest.kt
@@ -44,6 +44,23 @@ class OfflineExportPipelineTest {
     }
 
     @Test
+    fun offlinePipelineAcceptsOnlyCompleteAndroidReelSources() {
+        val muxedReel = "https://rr3---sn-example.googlevideo.com/videoplayback?itag=18&" +
+            "mime=video%2Fmp4&ratebypass=yes&clen=15857332"
+        val attestedAudio = "https://rr3---sn-example.googlevideo.com/videoplayback?itag=140&" +
+            "mime=audio%2Fmp4&gir=yes&clen=3168361&pot=token-value"
+        val legacyMp4 = "https://rr3---sn-example.googlevideo.com/videoplayback?itag=140&" +
+            "mime=audio%2Fmp4&gir=yes&clen=3168361&ratebypass=yes&c=ANDROID_VR"
+        val incompleteReel = "https://rr3---sn-example.googlevideo.com/videoplayback?itag=140&" +
+            "mime=audio%2Fmp4&gir=yes&clen=3168361"
+
+        assertTrue(isAllowedOfflineReelSource("YouTube Android Reel", "", muxedReel))
+        assertTrue(isAllowedOfflineReelSource("", "YouTube Android Reel Audio", attestedAudio))
+        assertFalse(isAllowedOfflineReelSource("YouTube Android VR", "LevyraExtractor", legacyMp4))
+        assertFalse(isAllowedOfflineReelSource("YouTube Android Reel Audio", "", incompleteReel))
+    }
+
+    @Test
     fun pipelineUsesMedia3CacheWriterAndYoutubeAwareDataSource() {
         val source = Files.readString(sourceFile("player/offline/OfflineExportPipeline.kt"))
 


### PR DESCRIPTION
## Summary

Removes the legacy MP4 resolver path from the **effective offline download pipeline** without changing normal playback.

## What changes

- Offline export now accepts only complete Android Reel sources (`YouTube Android Reel` / `YouTube Android Reel Audio`).
- Legacy resolver results such as Android VR / LevyraExtractor MP4 sources are rejected before any download or prefetch starts.
- Reel sources must still pass the existing complete-stream and offline-container checks.
- If Reel is unavailable, the download fails clearly instead of starting from a legacy URL that can stall part-way through.
- Normal song/video playback and its fallback policy are unchanged.

## Why

The current YouTube enforcement made the legacy MP4 download route unreliable, while the Android Reel route is the path verified to work for playback/download recovery. Keeping legacy results eligible for offline export adds latency and can reintroduce partial-download stalls.

## Tests

Adds coverage proving that:
- complete Reel muxed and attested Reel audio sources are accepted;
- legacy Android VR/LevyraExtractor MP4 is rejected;
- incomplete Reel audio without a complete-stream signal is rejected.

No version bump, release, or unrelated changes.