### PR TITLE
feat(playback): harden YouTube resilience and self-healing

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicy.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicy.kt
@@ -48,7 +48,10 @@ internal data class PlaybackCompatibilityPolicy(
     val audioStrategies: List<PlaybackAudioStrategy>,
     val videoStrategies: List<PlaybackVideoStrategy>,
     val androidReelClientVersion: String,
-    val clientOverrides: Map<String, PlaybackClientOverride>
+    val clientOverrides: Map<String, PlaybackClientOverride>,
+    val expiresAt: Long,
+    val minSupportedAppVersion: Int,
+    val maxSupportedAppVersion: Int
 ) {
     companion object {
         const val SCHEMA = 1
@@ -70,7 +73,10 @@ internal data class PlaybackCompatibilityPolicy(
                 PlaybackVideoStrategy.REEL
             ),
             androidReelClientVersion = DEFAULT_ANDROID_REEL_CLIENT_VERSION,
-            clientOverrides = emptyMap()
+            clientOverrides = emptyMap(),
+            expiresAt = 0L,
+            minSupportedAppVersion = 0,
+            maxSupportedAppVersion = 0
         )
     }
 
@@ -91,12 +97,17 @@ internal data class PlaybackCompatibilityPolicy(
             .put("videoStrategy", JSONArray(videoStrategies.map { it.name }))
             .put("androidReelClientVersion", androidReelClientVersion)
             .put("clients", clients)
+            .put("expiresAt", expiresAt)
+            .put("minSupportedAppVersion", minSupportedAppVersion)
+            .put("maxSupportedAppVersion", maxSupportedAppVersion)
             .toString()
     }
 }
 
 internal object PlaybackCompatibilityPolicyParser {
     private val clientVersionPattern = Regex("^[A-Za-z0-9._-]{1,32}$")
+    private const val MIN_PLAUSIBLE_EXPIRES_AT_MS = 946_684_800_000L
+    private const val MAX_PLAUSIBLE_EXPIRES_AT_MS = 4_102_444_800_000L
     private val knownClients = setOf(
         "VISIONOS",
         "ANDROID_VR",
@@ -118,12 +129,12 @@ internal object PlaybackCompatibilityPolicyParser {
             require(revision > 0L)
 
             val audioStrategies = if (root.has("audioStrategy")) {
-                parseEnumArray<PlaybackAudioStrategy>(root.getJSONArray("audioStrategy"))
+                parseEnumArray(root.getJSONArray("audioStrategy"), base.audioStrategies)
             } else {
                 base.audioStrategies
             }
             val videoStrategies = if (root.has("videoStrategy")) {
-                parseEnumArray<PlaybackVideoStrategy>(root.getJSONArray("videoStrategy"))
+                parseEnumArray(root.getJSONArray("videoStrategy"), base.videoStrategies)
             } else {
                 base.videoStrategies
             }
@@ -145,27 +156,55 @@ internal object PlaybackCompatibilityPolicyParser {
             }
             require(knownClients.any { clientOverrides[it]?.enabled != false })
 
+            val expiresAt = if (root.has("expiresAt")) {
+                requiredLong(root, "expiresAt").also {
+                    require(it == 0L || it in MIN_PLAUSIBLE_EXPIRES_AT_MS..MAX_PLAUSIBLE_EXPIRES_AT_MS)
+                }
+            } else {
+                base.expiresAt
+            }
+
+            val minSupportedAppVersion = if (root.has("minSupportedAppVersion")) {
+                requiredInt(root, "minSupportedAppVersion").also { require(it >= 0) }
+            } else {
+                base.minSupportedAppVersion
+            }
+            val maxSupportedAppVersion = if (root.has("maxSupportedAppVersion")) {
+                requiredInt(root, "maxSupportedAppVersion").also { require(it >= 0) }
+            } else {
+                base.maxSupportedAppVersion
+            }
+            require(
+                minSupportedAppVersion == 0 ||
+                    maxSupportedAppVersion == 0 ||
+                    minSupportedAppVersion <= maxSupportedAppVersion
+            )
+
             PlaybackCompatibilityPolicy(
                 schema = schema,
                 revision = revision,
                 audioStrategies = audioStrategies,
                 videoStrategies = videoStrategies,
                 androidReelClientVersion = reelVersion,
-                clientOverrides = clientOverrides
+                clientOverrides = clientOverrides,
+                expiresAt = expiresAt,
+                minSupportedAppVersion = minSupportedAppVersion,
+                maxSupportedAppVersion = maxSupportedAppVersion
             )
         }.getOrNull()
     }
 
-    private inline fun <reified T : Enum<T>> parseEnumArray(array: JSONArray): List<T> {
+    private inline fun <reified T : Enum<T>> parseEnumArray(array: JSONArray, fallback: List<T>): List<T> {
         require(array.length() in 1..16)
         val values = ArrayList<T>(array.length())
         repeat(array.length()) { index ->
             val raw = array.get(index)
             require(raw is String)
-            values += enumValueOf<T>(raw)
+            val parsedValue = runCatching { enumValueOf<T>(raw) }.getOrNull()
+            if (parsedValue != null) values += parsedValue
         }
         require(values.distinct().size == values.size)
-        return values
+        return values.ifEmpty { fallback }
     }
 
     private fun parseClientOverrides(clients: JSONObject): Map<String, PlaybackClientOverride> {
@@ -204,6 +243,12 @@ internal object PlaybackCompatibilityPolicyParser {
         return raw
     }
 
+    private fun requiredInt(value: JSONObject, key: String): Int {
+        val longValue = requiredLong(value, key)
+        require(longValue in Int.MIN_VALUE..Int.MAX_VALUE)
+        return longValue.toInt()
+    }
+
     private fun optionalBoolean(value: JSONObject, key: String): Boolean? {
         if (!value.has(key) || value.isNull(key)) return null
         val raw = value.get(key)
@@ -228,9 +273,21 @@ internal object PlaybackCompatibilityPolicyParser {
     }
 }
 
+internal fun PlaybackCompatibilityPolicy.isExpired(nowMs: Long = System.currentTimeMillis()): Boolean {
+    return expiresAt != 0L && expiresAt <= nowMs
+}
+
+internal fun isAppVersionSupported(policy: PlaybackCompatibilityPolicy, appVersionCode: Int): Boolean {
+    if (appVersionCode == 0) return true
+    val belowMin = policy.minSupportedAppVersion != 0 && appVersionCode < policy.minSupportedAppVersion
+    val aboveMax = policy.maxSupportedAppVersion != 0 && appVersionCode > policy.maxSupportedAppVersion
+    return !belowMin && !aboveMax
+}
+
 internal class PlaybackCompatibilityPolicyStore(
     context: Context,
-    httpClient: OkHttpClient
+    httpClient: OkHttpClient,
+    private val appVersionCode: Int = 0
 ) {
     private val preferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     private val mutex = Mutex()
@@ -250,10 +307,13 @@ internal class PlaybackCompatibilityPolicyStore(
     @Volatile
     private var checkedAtMs: Long = preferences.getLong(KEY_CHECKED_AT_MS, 0L)
 
-    fun current(): PlaybackCompatibilityPolicy = currentPolicy.get()
+    fun current(): PlaybackCompatibilityPolicy {
+        val policy = currentPolicy.get()
+        return if (policy.isExpired()) bundledPolicy else policy
+    }
 
     fun needsRefresh(nowMs: Long = System.currentTimeMillis()): Boolean {
-        val stale = checkedAtMs <= 0L || nowMs - checkedAtMs >= REFRESH_TTL_MS
+        val stale = currentPolicy.get().isExpired(nowMs) || checkedAtMs <= 0L || nowMs - checkedAtMs >= REFRESH_TTL_MS
         if (!stale) return false
         val lastAttempt = lastAttemptAtMs.get()
         return lastAttempt <= 0L || nowMs - lastAttempt >= FAILED_FETCH_BACKOFF_MS
@@ -319,6 +379,21 @@ internal class PlaybackCompatibilityPolicyStore(
                 Timber.w("Playback compatibility policy payload rejected reason=%s", reason)
                 return false
             }
+            if (candidate.isExpired()) {
+                markCheckedWithoutEtagChange()
+                Timber.w("Playback compatibility policy expired revision=%d", candidate.revision)
+                return false
+            }
+            if (!isAppVersionSupported(candidate, appVersionCode)) {
+                markCheckedWithoutEtagChange()
+                Timber.w(
+                    "Playback compatibility policy app version %d outside supported range [%d,%d]",
+                    appVersionCode,
+                    candidate.minSupportedAppVersion,
+                    candidate.maxSupportedAppVersion
+                )
+                return false
+            }
             if (candidate.revision < before.revision) {
                 markCheckedWithoutEtagChange()
                 Timber.w(
@@ -351,6 +426,8 @@ internal class PlaybackCompatibilityPolicyStore(
         val raw = preferences.getString(KEY_POLICY_JSON, "").orEmpty()
         if (raw.isBlank()) return bundledPolicy
         val cached = PlaybackCompatibilityPolicyParser.parse(raw, bundledPolicy) ?: return bundledPolicy
+        if (cached.isExpired()) return bundledPolicy
+        if (!isAppVersionSupported(cached, appVersionCode)) return bundledPolicy
         return cached.takeIf { it.revision >= bundledPolicy.revision } ?: bundledPolicy
     }
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResilienceEngine.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResilienceEngine.kt
@@ -13,11 +13,17 @@ internal enum class PlaybackFailureKind {
     Forbidden,
     Gone,
     RateLimited,
+    NotFound,
+    RangeNotSatisfiable,
+    ServerError,
+    LoginRequired,
+    ContentRestricted,
     ExpiredUrl,
     Signature,
     Decoder,
     Network,
     Timeout,
+    Truncated,
     Unknown
 }
 
@@ -40,26 +46,41 @@ internal data class PlaybackTraceEvent(
 )
 
 private val playbackHttpStatusPattern = Regex(
-    """\b(?:http(?:\s+status)?|status(?:\s+code)?)\s*[:=]?\s*(403|410|429)\b""",
+    """\b(?:http(?:\s+status)?|status(?:\s+code)?|response\s+code)\s*[:=]?\s*(403|404|410|416|429|500|502|503|504)\b""",
     RegexOption.IGNORE_CASE
 )
+
+private val serverErrorHttpStatuses = setOf(500, 502, 503, 504)
 
 internal fun classifyPlaybackFailureReason(raw: String): PlaybackFailureKind {
     val value = raw.lowercase(Locale.ROOT)
     val httpStatus = playbackHttpStatusPattern.find(raw)?.groupValues?.getOrNull(1)?.toIntOrNull()
     return when {
-        httpStatus == 403 ||
-            value.contains("forbidden") ||
+        value.contains("login_required") ||
             value.contains("confirm you're not a bot") ||
             value.contains("confirm you’re not a bot") ||
             value.contains("confirm you are not a bot") ||
             value.contains("sign in to confirm") ||
-            value.contains("accedi per confermare") -> PlaybackFailureKind.Forbidden
+            value.contains("accedi per confermare") -> PlaybackFailureKind.LoginRequired
+        value.contains("age restrict") ||
+            value.contains("age-restrict") -> PlaybackFailureKind.ContentRestricted
+        httpStatus == 403 || value.contains("forbidden") -> PlaybackFailureKind.Forbidden
         httpStatus == 410 || value.contains("gone") -> PlaybackFailureKind.Gone
         httpStatus == 429 || value.contains("rate limit") -> PlaybackFailureKind.RateLimited
+        httpStatus == 404 || value.contains("not found") -> PlaybackFailureKind.NotFound
+        httpStatus == 416 || value.contains("range not satisfiable") -> PlaybackFailureKind.RangeNotSatisfiable
+        httpStatus in serverErrorHttpStatuses ||
+            value.contains("server error") ||
+            value.contains("service unavailable") ||
+            value.contains("bad gateway") ||
+            value.contains("gateway timeout") -> PlaybackFailureKind.ServerError
         value.contains("expired") || value.contains("scadut") || value.contains("stream non valido") -> PlaybackFailureKind.ExpiredUrl
         value.contains("signature") || value.contains("n-transform") || value.contains("potoken") || value.contains("po token") -> PlaybackFailureKind.Signature
         value.contains("decoder") || value.contains("codec") || value.contains("format") -> PlaybackFailureKind.Decoder
+        value.contains("truncated") ||
+            value.contains("unexpected end of stream") ||
+            value.contains("connection reset") ||
+            value.contains("premature end") -> PlaybackFailureKind.Truncated
         value.contains("timeout") || value.contains("timed out") || value.contains("lento") -> PlaybackFailureKind.Timeout
         value.contains("network") || value.contains("socket") || value.contains("dns") || value.contains("connection") || value.contains("host") -> PlaybackFailureKind.Network
         else -> PlaybackFailureKind.Unknown
@@ -144,7 +165,13 @@ internal class PlaybackResilienceEngine(context: Context) {
         return when (classifyPlaybackFailureReason(reason)) {
             PlaybackFailureKind.Forbidden,
             PlaybackFailureKind.Gone,
-            PlaybackFailureKind.RateLimited -> PlaybackRecoveryPlan(true, true, false, true, 10L * 60L * 1000L)
+            PlaybackFailureKind.RateLimited,
+            PlaybackFailureKind.LoginRequired -> PlaybackRecoveryPlan(true, true, false, true, 10L * 60L * 1000L)
+            PlaybackFailureKind.ContentRestricted -> PlaybackRecoveryPlan(true, false, false, false, 0L)
+            PlaybackFailureKind.NotFound,
+            PlaybackFailureKind.RangeNotSatisfiable -> PlaybackRecoveryPlan(true, false, false, false, 60_000L)
+            PlaybackFailureKind.ServerError,
+            PlaybackFailureKind.Truncated -> PlaybackRecoveryPlan(true, false, false, false, 30_000L)
             PlaybackFailureKind.ExpiredUrl -> PlaybackRecoveryPlan(true, true, false, false, 2L * 60L * 1000L)
             PlaybackFailureKind.Signature -> PlaybackRecoveryPlan(true, true, false, true, 10L * 60L * 1000L)
             PlaybackFailureKind.Decoder -> PlaybackRecoveryPlan(true, false, true, false, 30L * 60L * 1000L)

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -243,6 +243,9 @@ class PlaybackResolver private constructor(private val context: Context) {
         private const val YOUTUBE_VIDEO_ID_PATTERN = "[A-Za-z0-9_-]{11}"
         private const val LEVYRA_EXTRACTOR_PROVIDER = "LevyraExtractor"
         private const val LEVYRA_EXTRACTOR_HLS_PROVIDER = "LevyraExtractor HLS"
+        private const val AUDIO_HEALTH_MODE = "audio"
+        private const val VIDEO_HEALTH_MODE = "video"
+        private const val MAX_STRATEGY_ORIGINS = 256
         private val youtubeVideoIdRegex = Regex(YOUTUBE_VIDEO_ID_PATTERN)
         private val youtubeVideoUrlRegex = Regex("(?:v=|/shorts/|/embed/|/live/|youtu\\.be/)($YOUTUBE_VIDEO_ID_PATTERN)")
         private val youtubeSearchResultVideoIdRegex = Regex("""\\?["]videoId\\?["]\s*:\s*\\?["]($YOUTUBE_VIDEO_ID_PATTERN)\\?["]""")
@@ -272,8 +275,14 @@ class PlaybackResolver private constructor(private val context: Context) {
     private val youtubeHttpClient = LevyraHttpClientFactory.youtubePlayer()
     private val jsonMediaType = "application/json; charset=utf-8".toMediaType()
     private val playbackSecurity = YoutubePlaybackSecurity.getInstance(context)
-    private val playbackPolicyStore = PlaybackCompatibilityPolicyStore(context, youtubeHttpClient)
+    private val playbackPolicyStore = PlaybackCompatibilityPolicyStore(
+        context,
+        youtubeHttpClient,
+        BuildConfig.VERSION_CODE
+    )
     private val resilienceEngine = PlaybackResilienceEngine(context)
+    private val strategyHealth = PlaybackStrategyHealthStore(context)
+    private val strategyOriginByUrl = ConcurrentHashMap<String, PlaybackStrategyOrigin>()
     private val sourceMatchStore = PlaybackSourceMatchStore(LevyraDatabase.get(context).playbackSourceMatchDao())
     private val sourceMatchScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val fallbackTtlMs = 90L * 60L * 1000L
@@ -338,6 +347,7 @@ class PlaybackResolver private constructor(private val context: Context) {
 
     private suspend fun clearResolvedStreamCaches() {
         streamCache.clear()
+        strategyOriginByUrl.clear()
         prefs.edit().clear().apply()
         sourceMatchStore.clearOnline()
     }
@@ -471,6 +481,15 @@ class PlaybackResolver private constructor(private val context: Context) {
         )
         invalidate(track, isVideoMode, isOfflineExport)
         resilienceEngine.recordPlayerFailure(track.id, isVideoMode, reason)
+        if (!isOfflineExport) {
+            strategyOriginFor(track, isVideoMode)?.let { origin ->
+                strategyHealth.recordRuntimeFailure(
+                    mode = origin.mode,
+                    strategy = origin.strategy,
+                    kind = classifyPlaybackFailureReason(reason)
+                )
+            }
+        }
         val now = System.currentTimeMillis()
         val lower = reason.lowercase()
         val recovery = resilienceEngine.recoveryPlan(reason)
@@ -521,6 +540,25 @@ class PlaybackResolver private constructor(private val context: Context) {
         }
     }
 
+    private fun rememberStrategyOrigin(track: Track, mode: String, strategy: String) {
+        if (strategyOriginByUrl.size >= MAX_STRATEGY_ORIGINS) strategyOriginByUrl.clear()
+        val origin = PlaybackStrategyOrigin(mode, strategy)
+        listOf(track.streamUrl, track.videoStreamUrl)
+            .filter { it.isNotBlank() }
+            .forEach { strategyOriginByUrl[strategyOriginKey(mode, it)] = origin }
+    }
+
+    private fun strategyOriginFor(track: Track, isVideoMode: Boolean): PlaybackStrategyOrigin? {
+        val expectedMode = if (isVideoMode) VIDEO_HEALTH_MODE else AUDIO_HEALTH_MODE
+        return listOf(track.videoStreamUrl, track.streamUrl)
+            .asSequence()
+            .filter { it.isNotBlank() }
+            .mapNotNull { strategyOriginByUrl[strategyOriginKey(expectedMode, it)] }
+            .firstOrNull()
+    }
+
+    private fun strategyOriginKey(mode: String, url: String): String = "$mode\u0000$url"
+
     fun playbackDiagnostics(): String {
         val health = clientHealth.mapValues { (_, value) ->
             JSONObject()
@@ -531,7 +569,11 @@ class PlaybackResolver private constructor(private val context: Context) {
                 .put("blockedUntilMs", value.blockedUntilMs)
                 .put("score", value.score)
         }
-        return resilienceEngine.diagnostics(health)
+        val diagnostics = JSONObject(resilienceEngine.diagnostics(health))
+        val strategyHealthJson = JSONObject()
+        strategyHealth.snapshot().forEach { (key, value) -> strategyHealthJson.put(key, value) }
+        diagnostics.put("strategyHealth", strategyHealthJson)
+        return diagnostics.toString(2)
     }
 
     private fun isLocalPlaybackTrack(track: Track): Boolean =
@@ -788,8 +830,10 @@ class PlaybackResolver private constructor(private val context: Context) {
         errors: MutableList<String>
     ): Track? {
         val policy = playbackPolicyStore.current()
-        for (strategy in policy.audioStrategies) {
+        for (strategy in strategyHealth.order(AUDIO_HEALTH_MODE, policy.audioStrategies)) {
             currentCoroutineContext().ensureActive()
+            val startedAt = System.currentTimeMillis()
+            val errorsBefore = errors.size
             val resolved = when (strategy) {
                 PlaybackAudioStrategy.REEL_MUXED -> runCatchingPreservingCancellation {
                     resolveVideoWithAndroidReel(track)
@@ -825,7 +869,10 @@ class PlaybackResolver private constructor(private val context: Context) {
                     audioQuality = audioQuality
                 )
             }
+            val elapsedMs = System.currentTimeMillis() - startedAt
             if (resolved != null) {
+                strategyHealth.recordSuccess(AUDIO_HEALTH_MODE, strategy.name, elapsedMs)
+                rememberStrategyOrigin(resolved, AUDIO_HEALTH_MODE, strategy.name)
                 store(track, resolved, false, audioQuality, false)
                 val confidence = when (strategy) {
                     PlaybackAudioStrategy.REEL_MUXED,
@@ -839,6 +886,15 @@ class PlaybackResolver private constructor(private val context: Context) {
                 }
                 return resolved
             }
+            val failureReason = synchronized(errors) { errors.toList() }
+        .drop(errorsBefore)
+        .lastOrNull()
+            strategyHealth.recordFailure(
+                AUDIO_HEALTH_MODE,
+                strategy.name,
+                elapsedMs,
+                failureReason?.let(::classifyPlaybackFailureReason) ?: PlaybackFailureKind.Unknown
+            )
         }
         return null
     }
@@ -849,8 +905,10 @@ class PlaybackResolver private constructor(private val context: Context) {
         errors: MutableList<String>
     ): Track? {
         val policy = playbackPolicyStore.current()
-        for (strategy in policy.videoStrategies) {
+        for (strategy in strategyHealth.order(VIDEO_HEALTH_MODE, policy.videoStrategies)) {
             currentCoroutineContext().ensureActive()
+            val startedAt = System.currentTimeMillis()
+            val errorsBefore = errors.size
             val resolved = when (strategy) {
                 PlaybackVideoStrategy.PERSISTED -> restorePersistentSource(
                     track = track,
@@ -867,7 +925,10 @@ class PlaybackResolver private constructor(private val context: Context) {
                     errors += "Android Reel: ${error.playbackDiagnostic()}"
                 }.getOrNull()
             }
+            val elapsedMs = System.currentTimeMillis() - startedAt
             if (resolved != null) {
+                strategyHealth.recordSuccess(VIDEO_HEALTH_MODE, strategy.name, elapsedMs)
+                rememberStrategyOrigin(resolved, VIDEO_HEALTH_MODE, strategy.name)
                 store(track, resolved, true, audioQuality)
                 val confidence = when (strategy) {
                     PlaybackVideoStrategy.PERSISTED -> null
@@ -886,6 +947,15 @@ class PlaybackResolver private constructor(private val context: Context) {
                 }
                 return resolved
             }
+            val failureReason = synchronized(errors) { errors.toList() }
+        .drop(errorsBefore)
+        .lastOrNull()
+            strategyHealth.recordFailure(
+                VIDEO_HEALTH_MODE,
+                strategy.name,
+                elapsedMs,
+                failureReason?.let(::classifyPlaybackFailureReason) ?: PlaybackFailureKind.Unknown
+            )
         }
         return null
     }
@@ -3144,6 +3214,11 @@ private data class DirectStream(
     val manifest: ResolvedPlaybackManifest,
     val loudnessDb: Float? = null,
     val perceptualLoudnessDb: Float? = null
+)
+
+private data class PlaybackStrategyOrigin(
+    val mode: String,
+    val strategy: String
 )
 
 private data class CachedStream(

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackStrategyHealth.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackStrategyHealth.kt
@@ -1,0 +1,294 @@
+package com.luc4n3x.levyra.data
+
+import android.content.Context
+import org.json.JSONObject
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal enum class PlaybackStrategyCircuit { CLOSED, HALF_OPEN, OPEN }
+
+internal data class PlaybackStrategyStats(
+    val successes: Int = 0,
+    val failures: Int = 0,
+    val consecutiveFailures: Int = 0,
+    val averageLatencyMs: Long = Long.MAX_VALUE,
+    val quarantineUntilMs: Long = 0L,
+    val lastFailureKind: PlaybackFailureKind? = null,
+    val lastFailureAtMs: Long = 0L,
+    val updatedAtMs: Long = 0L
+) {
+    val score: Double
+        get() {
+            val total = successes + failures
+            if (total <= 0) return NEUTRAL_SCORE
+            val successRate = successes.toDouble() / total.toDouble()
+            val latencyPenalty = if (averageLatencyMs == Long.MAX_VALUE) {
+                0.0
+            } else {
+                (averageLatencyMs.toDouble() / MAX_LATENCY_FOR_SCORE_MS.toDouble())
+                    .coerceIn(0.0, 1.0) * LATENCY_PENALTY_WEIGHT
+            }
+            val consecutivePenalty =
+                consecutiveFailures.coerceIn(0, MAX_CONSECUTIVE_FOR_SCORE).toDouble() * CONSECUTIVE_PENALTY_WEIGHT
+            return (successRate * SUCCESS_WEIGHT - latencyPenalty - consecutivePenalty).coerceIn(0.0, 100.0)
+        }
+
+    fun circuitAt(nowMs: Long): PlaybackStrategyCircuit = when {
+        quarantineUntilMs <= 0L -> PlaybackStrategyCircuit.CLOSED
+        nowMs < quarantineUntilMs -> PlaybackStrategyCircuit.OPEN
+        else -> PlaybackStrategyCircuit.HALF_OPEN
+    }
+
+    private companion object {
+        const val NEUTRAL_SCORE = 50.0
+        const val SUCCESS_WEIGHT = 100.0
+        const val LATENCY_PENALTY_WEIGHT = 20.0
+        const val MAX_LATENCY_FOR_SCORE_MS = 8_000L
+        const val CONSECUTIVE_PENALTY_WEIGHT = 8.0
+        const val MAX_CONSECUTIVE_FOR_SCORE = 5
+    }
+}
+
+private const val SCORE_GAP_THRESHOLD = 25.0
+private const val HARD_FAILURE_STREAK_THRESHOLD = 3
+private const val BASE_QUARANTINE_MS = 5L * 60L * 1_000L
+private const val MAX_QUARANTINE_MS = 30L * 60L * 1_000L
+
+private val hardPlaybackFailureKinds = setOf(
+    PlaybackFailureKind.Forbidden,
+    PlaybackFailureKind.Gone,
+    PlaybackFailureKind.RateLimited,
+    PlaybackFailureKind.LoginRequired,
+    PlaybackFailureKind.Signature
+)
+
+private data class RankedPlaybackStrategy<T>(
+    val index: Int,
+    val strategy: T,
+    val circuit: PlaybackStrategyCircuit,
+    val score: Double
+)
+
+internal fun <T : Enum<T>> orderPlaybackStrategiesByHealth(
+    strategies: List<T>,
+    statsFor: (String) -> PlaybackStrategyStats?,
+    nowMs: Long
+): List<T> {
+    if (strategies.size <= 1) return strategies
+    val hasHealthData = strategies.any { statsFor(it.name) != null }
+    if (!hasHealthData) return strategies
+
+    val ranked = strategies.mapIndexed { index, strategy ->
+        val stats = statsFor(strategy.name) ?: PlaybackStrategyStats()
+        RankedPlaybackStrategy(index, strategy, stats.circuitAt(nowMs), stats.score)
+    }
+
+    val comparator = Comparator<RankedPlaybackStrategy<T>> { a, b ->
+        val circuitCompare = a.circuit.ordinal.compareTo(b.circuit.ordinal)
+        if (circuitCompare != 0) return@Comparator circuitCompare
+        val healthierGap = a.score - b.score
+        when {
+            healthierGap >= SCORE_GAP_THRESHOLD -> -1
+            -healthierGap >= SCORE_GAP_THRESHOLD -> 1
+            else -> a.index.compareTo(b.index)
+        }
+    }
+
+    return ranked.sortedWith(comparator).map { it.strategy }
+}
+
+internal fun playbackStrategyStatsAfterSuccess(
+    current: PlaybackStrategyStats?,
+    nowMs: Long,
+    latencyMs: Long
+): PlaybackStrategyStats {
+    val base = current ?: PlaybackStrategyStats()
+    val open = base.circuitAt(nowMs) == PlaybackStrategyCircuit.OPEN
+    return base.copy(
+        successes = base.successes + 1,
+        consecutiveFailures = if (open) base.consecutiveFailures else 0,
+        averageLatencyMs = blendPlaybackLatency(base.averageLatencyMs, latencyMs),
+        quarantineUntilMs = if (open) base.quarantineUntilMs else 0L,
+        updatedAtMs = nowMs
+    )
+}
+
+internal fun playbackStrategyStatsAfterFailure(
+    current: PlaybackStrategyStats?,
+    nowMs: Long,
+    latencyMs: Long?,
+    kind: PlaybackFailureKind
+): PlaybackStrategyStats {
+    val base = current ?: PlaybackStrategyStats()
+    val consecutiveFailures = base.consecutiveFailures + 1
+    val blendedLatency = if (latencyMs != null) {
+        blendPlaybackLatency(base.averageLatencyMs, latencyMs)
+    } else {
+        base.averageLatencyMs
+    }
+    val quarantineUntilMs = if (
+        consecutiveFailures >= HARD_FAILURE_STREAK_THRESHOLD && kind in hardPlaybackFailureKinds
+    ) {
+        nowMs + playbackQuarantineCooldownMs(consecutiveFailures)
+    } else {
+        base.quarantineUntilMs
+    }
+    return base.copy(
+        failures = base.failures + 1,
+        consecutiveFailures = consecutiveFailures,
+        averageLatencyMs = blendedLatency,
+        quarantineUntilMs = quarantineUntilMs,
+        lastFailureKind = kind,
+        lastFailureAtMs = nowMs,
+        updatedAtMs = nowMs
+    )
+}
+
+internal fun playbackStrategyStatsAfterRuntimeFailure(
+    current: PlaybackStrategyStats?,
+    nowMs: Long,
+    kind: PlaybackFailureKind
+): PlaybackStrategyStats {
+    val updated = playbackStrategyStatsAfterFailure(current, nowMs, latencyMs = null, kind = kind)
+    if (kind !in hardPlaybackFailureKinds) return updated
+    val forcedStreak = maxOf(updated.consecutiveFailures, HARD_FAILURE_STREAK_THRESHOLD)
+    return updated.copy(
+        consecutiveFailures = forcedStreak,
+        quarantineUntilMs = maxOf(
+            updated.quarantineUntilMs,
+            nowMs + playbackQuarantineCooldownMs(forcedStreak)
+        )
+    )
+}
+
+private fun playbackQuarantineCooldownMs(consecutiveFailures: Int): Long {
+    val overflow = (consecutiveFailures - HARD_FAILURE_STREAK_THRESHOLD).coerceIn(0, 6)
+    val cooldown = BASE_QUARANTINE_MS * (1L shl overflow)
+    return cooldown.coerceAtMost(MAX_QUARANTINE_MS)
+}
+
+private fun blendPlaybackLatency(previousMs: Long, sampleMs: Long): Long {
+    val boundedSample = sampleMs.coerceAtLeast(1L)
+    if (previousMs == Long.MAX_VALUE) return boundedSample
+    return ((previousMs * 3) + boundedSample) / 4
+}
+
+internal fun parsePlaybackStrategyHealthSnapshot(raw: String?): Map<String, PlaybackStrategyStats> {
+    if (raw.isNullOrBlank()) return emptyMap()
+    return runCatching {
+        val root = JSONObject(raw)
+        val result = LinkedHashMap<String, PlaybackStrategyStats>()
+        val keys = root.keys()
+        while (keys.hasNext()) {
+            val key = keys.next()
+            val entry = root.optJSONObject(key) ?: continue
+            result[key] = PlaybackStrategyStats(
+                successes = entry.optInt("successes", 0),
+                failures = entry.optInt("failures", 0),
+                consecutiveFailures = entry.optInt("consecutiveFailures", 0),
+                averageLatencyMs = entry.optLong("averageLatencyMs", Long.MAX_VALUE),
+                quarantineUntilMs = entry.optLong("quarantineUntilMs", 0L),
+                lastFailureKind = entry.optString("lastFailureKind", "").let { name ->
+                    if (name.isBlank()) null else runCatching { PlaybackFailureKind.valueOf(name) }.getOrNull()
+                },
+                lastFailureAtMs = entry.optLong("lastFailureAtMs", 0L),
+                updatedAtMs = entry.optLong("updatedAtMs", 0L)
+            )
+        }
+        result as Map<String, PlaybackStrategyStats>
+    }.getOrDefault(emptyMap())
+}
+
+internal fun playbackStrategyStatsToJson(stats: PlaybackStrategyStats): JSONObject = JSONObject()
+    .put("successes", stats.successes)
+    .put("failures", stats.failures)
+    .put("consecutiveFailures", stats.consecutiveFailures)
+    .put("averageLatencyMs", stats.averageLatencyMs)
+    .put("quarantineUntilMs", stats.quarantineUntilMs)
+    .put("lastFailureKind", stats.lastFailureKind?.name.orEmpty())
+    .put("lastFailureAtMs", stats.lastFailureAtMs)
+    .put("updatedAtMs", stats.updatedAtMs)
+
+internal class PlaybackStrategyHealthStore(context: Context) {
+    private val prefs = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val stats = ConcurrentHashMap<String, PlaybackStrategyStats>()
+    private val persistenceScheduled = AtomicBoolean(false)
+    private val persistenceExecutor = Executors.newSingleThreadScheduledExecutor { runnable ->
+        Thread(runnable, "levyra-playback-strategy-health").apply { isDaemon = true }
+    }
+
+    init {
+        stats.putAll(parsePlaybackStrategyHealthSnapshot(prefs.getString(KEY_HEALTH, null)))
+    }
+
+    fun <T : Enum<T>> order(mode: String, strategies: List<T>, nowMs: Long = System.currentTimeMillis()): List<T> {
+        return orderPlaybackStrategiesByHealth(
+            strategies = strategies,
+            statsFor = { strategyName -> stats[keyFor(mode, strategyName)] },
+            nowMs = nowMs
+        )
+    }
+
+    fun recordSuccess(mode: String, strategy: String, latencyMs: Long) {
+        val key = keyFor(mode, strategy)
+        stats[key] = playbackStrategyStatsAfterSuccess(stats[key], System.currentTimeMillis(), latencyMs)
+        trimToCapacity()
+        schedulePersist()
+    }
+
+    fun recordFailure(mode: String, strategy: String, latencyMs: Long?, kind: PlaybackFailureKind) {
+        val key = keyFor(mode, strategy)
+        stats[key] = playbackStrategyStatsAfterFailure(stats[key], System.currentTimeMillis(), latencyMs, kind)
+        trimToCapacity()
+        schedulePersist()
+    }
+
+    fun recordRuntimeFailure(mode: String, strategy: String, kind: PlaybackFailureKind) {
+        val key = keyFor(mode, strategy)
+        stats[key] = playbackStrategyStatsAfterRuntimeFailure(stats[key], System.currentTimeMillis(), kind)
+        trimToCapacity()
+        schedulePersist()
+    }
+
+    fun snapshot(): Map<String, JSONObject> {
+        return stats.mapValues { (_, value) -> playbackStrategyStatsToJson(value) }
+    }
+
+    private fun trimToCapacity() {
+        val overflow = stats.size - MAX_ENTRIES
+        if (overflow <= 0) return
+        stats.entries
+            .sortedBy { it.value.updatedAtMs }
+            .take(overflow)
+            .forEach { stats.remove(it.key) }
+    }
+
+    private fun schedulePersist() {
+        if (!persistenceScheduled.compareAndSet(false, true)) return
+        persistenceExecutor.schedule(
+            {
+                persistenceScheduled.set(false)
+                persistSnapshot()
+            },
+            PERSIST_DEBOUNCE_MS,
+            TimeUnit.MILLISECONDS
+        )
+    }
+
+    private fun persistSnapshot() {
+        val root = JSONObject()
+        stats.forEach { (key, value) -> root.put(key, playbackStrategyStatsToJson(value)) }
+        prefs.edit().putString(KEY_HEALTH, root.toString()).apply()
+    }
+
+    private fun keyFor(mode: String, strategy: String): String = "$mode::$strategy"
+
+    private companion object {
+        const val PREFS_NAME = "levyra_playback_strategy_health"
+        const val KEY_HEALTH = "health"
+        const val MAX_ENTRIES = 32
+        const val PERSIST_DEBOUNCE_MS = 1_500L
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
@@ -217,6 +217,7 @@ private class YoutubeLocalDecoderEngine(
             val decoded = try {
                 decodeAttempt(playerId, missingSignatures, missingNs, forceRefresh = false)
             } catch (firstError: Throwable) {
+                if (firstError is CancellationException) throw firstError
                 if (firstError is YoutubeRendererBackoffException) throw firstError
                 Timber.w(firstError, "Local decoder first attempt failed for player %s", playerId)
                 invalidateRuntime()
@@ -225,6 +226,7 @@ private class YoutubeLocalDecoderEngine(
                 try {
                     decodeAttempt(playerId, missingSignatures, missingNs, forceRefresh = true)
                 } catch (secondError: Throwable) {
+                    if (secondError is CancellationException) throw secondError
                     if (secondError is YoutubeRendererBackoffException) throw secondError
                     secondError.addSuppressed(firstError)
                     throw ParsingException("Local decode failed for player $playerId", secondError)
@@ -282,19 +284,22 @@ private class YoutubeLocalDecoderEngine(
         ) {
             playerSource.rejectAnalyzedConfig(rejectedHash)
         }
-        when (configStore.refreshAfterStreamRejection()) {
-            YoutubeStreamRefreshResult.CHANGED -> {
-                decodeCache.clear()
-                decodeCacheEpoch = configStore.epoch
-                runtimeMutex.withLock {
-                    if (lastSuccessfulDecodeAtMs.get() == feedbackAt) invalidateRuntimeLocked()
-                }
-            }
-            YoutubeStreamRefreshResult.UNCHANGED -> runtimeMutex.withLock {
+        val refreshResult = configStore.refreshAfterStreamRejection()
+        if (refreshResult == YoutubeStreamRefreshResult.CHANGED) {
+            decodeCache.clear()
+            decodeCacheEpoch = configStore.epoch
+        }
+        val action = YoutubeStreamRejectionActionPolicy.decide(
+            refreshResult,
+            generationMatches = lastSuccessfulDecodeAtMs.get() == feedbackAt
+        )
+        if (action.invalidateRuntime) {
+            runtimeMutex.withLock {
                 if (lastSuccessfulDecodeAtMs.get() == feedbackAt) invalidateRuntimeLocked()
             }
-            YoutubeStreamRefreshResult.SKIPPED,
-            YoutubeStreamRefreshResult.NETWORK_FAILURE -> Unit
+        }
+        if (action.invalidatePlayerSource && lastSuccessfulDecodeAtMs.get() == feedbackAt) {
+            playerSource.invalidate()
         }
     }
 
@@ -1202,6 +1207,19 @@ internal object YoutubeLocalDecoderFeedbackPolicy {
         val normalized = source.lowercase()
         val relevantSource = normalized.contains("web") || normalized.contains("levyraextractor")
         return relevantSource && YoutubePlayerConfigStore.withinWindow(now, lastDecodeAtMs, FEEDBACK_WINDOW_MS)
+    }
+}
+
+internal data class YoutubeStreamRejectionAction(
+    val invalidateRuntime: Boolean,
+    val invalidatePlayerSource: Boolean
+)
+
+internal object YoutubeStreamRejectionActionPolicy {
+    fun decide(result: YoutubeStreamRefreshResult, generationMatches: Boolean): YoutubeStreamRejectionAction {
+        val actionable = generationMatches &&
+            (result == YoutubeStreamRefreshResult.CHANGED || result == YoutubeStreamRefreshResult.UNCHANGED)
+        return YoutubeStreamRejectionAction(invalidateRuntime = actionable, invalidatePlayerSource = actionable)
     }
 }
 

--- a/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineAudioExporter.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/offline/OfflineAudioExporter.kt
@@ -12,6 +12,7 @@ import androidx.annotation.RequiresApi
 import androidx.media3.datasource.cache.CacheSpan
 import com.luc4n3x.levyra.data.LyricsMatcher
 import com.luc4n3x.levyra.data.PlaybackResolver
+import com.luc4n3x.levyra.data.PlaybackSourceIdentity
 import com.luc4n3x.levyra.data.YoutubeStreamCapability
 import com.luc4n3x.levyra.data.local.DownloadEntity
 import com.luc4n3x.levyra.data.local.LevyraDatabase
@@ -229,6 +230,53 @@ internal fun audioContentTypeFromUrl(url: String): String {
         .orEmpty()
 }
 
+internal fun audioItagFromUrl(url: String): String {
+    return url.toHttpUrlOrNull()
+        ?.queryParameter("itag")
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+        ?: Regex("(?:[?&])itag=(\\d+)").find(url)?.groupValues?.getOrNull(1)
+        ?: ""
+}
+
+internal data class OfflineStreamIdentity(
+    val videoId: String,
+    val itag: String,
+    val contentLength: Long,
+    val mimeType: String
+)
+
+internal fun offlineStreamIdentity(url: String, videoId: String): OfflineStreamIdentity {
+    return OfflineStreamIdentity(
+        videoId = videoId.trim(),
+        itag = audioItagFromUrl(url),
+        contentLength = audioContentLengthFromUrl(url),
+        mimeType = audioContentTypeFromUrl(url)
+    )
+}
+
+internal fun serializeOfflineStreamIdentity(identity: OfflineStreamIdentity): String {
+    return listOf(identity.videoId, identity.itag, identity.contentLength.toString(), identity.mimeType)
+        .joinToString("\n")
+}
+
+internal fun parseOfflineStreamIdentity(raw: String): OfflineStreamIdentity? {
+    val parts = raw.split("\n")
+    if (parts.size < 4) return null
+    val contentLength = parts[2].toLongOrNull() ?: return null
+    return OfflineStreamIdentity(videoId = parts[0], itag = parts[1], contentLength = contentLength, mimeType = parts[3])
+}
+
+internal fun resumableBytesForStreamIdentity(
+    existingBytes: Long,
+    storedIdentity: OfflineStreamIdentity?,
+    currentIdentity: OfflineStreamIdentity
+): Long {
+    if (existingBytes <= 0L) return 0L
+    if (storedIdentity == null) return 0L
+    return if (storedIdentity == currentIdentity) existingBytes else 0L
+}
+
 internal fun isMp4AudioExportUrl(url: String): Boolean {
     val clean = url.trim().lowercase(Locale.US)
     val path = clean.substringBefore('?').substringBefore('#')
@@ -277,7 +325,7 @@ internal fun isUnsupportedOfflineAudioSource(error: Throwable): Boolean {
 
 internal fun isRejectedOfflinePlaybackSource(error: Throwable): Boolean {
     val rejectedStatus = Regex(
-        """\b(?:HTTP|Response code)\s*:?\s*(403|410|429)\b""",
+        """\b(?:HTTP|Response code)\s*:?\s*(403|404|410|416|429)\b""",
         RegexOption.IGNORE_CASE
     )
     var current: Throwable? = error
@@ -476,6 +524,7 @@ class OfflineAudioExporter(
                 )
             } finally {
                 runCatching { downloaded.file.delete() }
+                runCatching { resumeIdentitySidecar(downloaded.file).delete() }
                 if (audioFile != downloaded.file) runCatching { audioFile.delete() }
                 embeddedFile?.file
                     ?.takeIf { it != downloaded.file && it != audioFile }
@@ -520,7 +569,16 @@ class OfflineAudioExporter(
             offlineSourceDiagnostics(sourceUrl)
         )
         val partial = resumablePartialFile(workspace, container)
-        val existingBytes = partial.takeIf { settings.resumable && it.exists() }?.length()?.coerceAtLeast(0L) ?: 0L
+        val identityFile = resumeIdentitySidecar(partial)
+        val currentIdentity = offlineStreamIdentity(sourceUrl, PlaybackSourceIdentity.sourceVideoId(track))
+        val storedBytes = partial.takeIf { settings.resumable && it.exists() }?.length()?.coerceAtLeast(0L) ?: 0L
+        val existingBytes = if (storedBytes > 0L) {
+            val resumeBytes = resumableBytesForStreamIdentity(storedBytes, readResumeIdentity(identityFile), currentIdentity)
+            if (resumeBytes == 0L) discardPartial(partial, identityFile)
+            resumeBytes
+        } else {
+            0L
+        }
         ensureStorageAvailable(workspace, expectedLength, existingBytes, requiresAudioExtraction)
         if (expectedLength > 0L && existingBytes == expectedLength) {
             reportProgress(82)
@@ -622,7 +680,8 @@ class OfflineAudioExporter(
             }
             val append = rangeStart > 0L
             val baseBytes = if (append) rangeStart else 0L
-            if (!append && partial.exists()) runCatching { partial.delete() }
+            if (!append) discardPartial(partial, identityFile)
+            writeResumeIdentity(identityFile, currentIdentity)
             val contentRangeTotal = contentRange.substringAfterLast('/').toLongOrNull() ?: -1L
             val targetLength = when {
                 contentRangeTotal > 0L -> contentRangeTotal
@@ -660,7 +719,7 @@ class OfflineAudioExporter(
                 DownloadedAudio(partial, container, requiresAudioExtraction)
             } catch (error: IOException) {
                 currentCoroutineContext().ensureActive()
-                if (!settings.resumable) runCatching { partial.delete() }
+                if (!settings.resumable) discardPartial(partial, identityFile)
                 throw error
             }
         }
@@ -717,6 +776,24 @@ class OfflineAudioExporter(
     private fun resumablePartialFile(workspace: File, container: AudioContainer): File {
         val safeKey = offlineDownloadTaskFileKey(taskKey.ifBlank { "${System.nanoTime()}" })
         return File(workspace, "resume-$safeKey.${container.extension}.part")
+    }
+
+    private fun resumeIdentitySidecar(partial: File): File {
+        return File(partial.parentFile, "${partial.name}.id")
+    }
+
+    private fun readResumeIdentity(identityFile: File): OfflineStreamIdentity? {
+        if (!identityFile.isFile) return null
+        return runCatching { parseOfflineStreamIdentity(identityFile.readText(Charsets.UTF_8)) }.getOrNull()
+    }
+
+    private fun writeResumeIdentity(identityFile: File, identity: OfflineStreamIdentity) {
+        runCatching { identityFile.writeText(serializeOfflineStreamIdentity(identity), Charsets.UTF_8) }
+    }
+
+    private fun discardPartial(partial: File, identityFile: File) {
+        runCatching { partial.delete() }
+        runCatching { identityFile.delete() }
     }
 
     private fun offlineSeedCacheKeys(track: Track): List<String> = listOf(
@@ -881,6 +958,7 @@ class OfflineAudioExporter(
                 limiter = limiter
             )
             if (failures.isEmpty()) return
+            firstRejectedRangeFailure(failures)?.let { throw it }
             lastFailures = failures
             if (batch < PARALLEL_BATCH_RETRY_COUNT - 1) {
                 pending = failures.flatMap { failure ->
@@ -930,17 +1008,9 @@ class OfflineAudioExporter(
         lastProgress: AtomicInteger,
         targetLength: Long
     ) {
-        var lastError: IOException? = null
-        repeat(RANGE_RETRY_COUNT) { attempt ->
-            try {
-                downloadAudioRangeAttempt(url, range, outputFile, downloadedBytes, lastProgress, targetLength)
-                return
-            } catch (error: IOException) {
-                lastError = error
-                if (attempt < RANGE_RETRY_COUNT - 1) delay(RANGE_RETRY_DELAY_MS * (attempt + 1L))
-            }
+        retryRangeDownload(RANGE_RETRY_COUNT, RANGE_RETRY_DELAY_MS, { millis -> delay(millis) }) {
+            downloadAudioRangeAttempt(url, range, outputFile, downloadedBytes, lastProgress, targetLength)
         }
-        throw lastError ?: IOException("Range audio non riuscito")
     }
 
     private suspend fun downloadAudioRangeAttempt(
@@ -1463,7 +1533,9 @@ class OfflineAudioExporter(
     private fun cleanupWorkspace(workspace: File) {
         val now = System.currentTimeMillis()
         workspace.listFiles()?.forEach { file ->
-            val retention = if (file.name.startsWith("resume-") && file.name.endsWith(".part")) {
+            val isResumeArtifact = file.name.startsWith("resume-") &&
+                (file.name.endsWith(".part") || file.name.endsWith(".part.id"))
+            val retention = if (isResumeArtifact) {
                 TimeUnit.DAYS.toMillis(7)
             } else {
                 TimeUnit.HOURS.toMillis(2)
@@ -1477,7 +1549,7 @@ class OfflineAudioExporter(
             val workspace = File(context.applicationContext.cacheDir, "levyra_offline_export")
             val prefix = "resume-${offlineDownloadTaskFileKey(taskKey)}."
             workspace.listFiles()?.forEach { file ->
-                if (file.name.startsWith(prefix) && file.name.endsWith(".part")) {
+                if (file.name.startsWith(prefix) && (file.name.endsWith(".part") || file.name.endsWith(".part.id"))) {
                     runCatching { file.delete() }
                 }
             }
@@ -1528,10 +1600,34 @@ private data class CachedAudioSeed(
     val missingRanges: List<AudioDownloadRange>
 )
 
-private data class RangeDownloadFailure(
+internal data class RangeDownloadFailure(
     val range: AudioDownloadRange,
     val error: IOException
 )
+
+internal fun firstRejectedRangeFailure(failures: List<RangeDownloadFailure>): IOException? {
+    return failures.firstOrNull { isUnsupportedOfflineAudioSource(it.error) || isRejectedOfflinePlaybackSource(it.error) }?.error
+}
+
+internal suspend fun retryRangeDownload(
+    retryCount: Int,
+    retryDelayMs: Long,
+    sleep: suspend (Long) -> Unit,
+    attempt: suspend () -> Unit
+) {
+    var lastError: IOException? = null
+    repeat(retryCount) { attemptIndex ->
+        try {
+            attempt()
+            return
+        } catch (error: IOException) {
+            lastError = error
+            if (isUnsupportedOfflineAudioSource(error) || isRejectedOfflinePlaybackSource(error)) throw error
+            if (attemptIndex < retryCount - 1) sleep(retryDelayMs * (attemptIndex + 1L))
+        }
+    }
+    throw lastError ?: IOException("Range audio non riuscito")
+}
 
 private data class PreparedAudioFile(
     val file: File,

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicyTest.kt
@@ -133,7 +133,8 @@ class PlaybackCompatibilityPolicyTest {
     }
 
     @Test
-    fun unsupportedStrategyRejectsWholeCandidate() {
+    fun unsupportedStrategyIsIgnoredInsteadOfRejectingTheWholeCandidate() {
+        val base = PlaybackCompatibilityPolicy.bundled()
         val parsed = PlaybackCompatibilityPolicyParser.parse(
             """
             {
@@ -142,10 +143,12 @@ class PlaybackCompatibilityPolicyTest {
               "audioStrategy": ["REMOTE_SCRIPT"]
             }
             """.trimIndent(),
-            PlaybackCompatibilityPolicy.bundled()
+            base
         )
 
-        assertNull(parsed)
+        assertNotNull(parsed)
+        assertFalse(parsed!!.audioStrategies.isEmpty())
+        assertEquals(base.audioStrategies, parsed.audioStrategies)
     }
 
     @Test
@@ -240,5 +243,68 @@ class PlaybackCompatibilityPolicyTest {
 
         assertEquals(parsed, roundTrip)
         assertFalse(roundTrip!!.audioStrategies.isEmpty())
+    }
+
+    @Test
+    fun unknownRemoteStrategyIsSkippedButKnownOnesAreAccepted() {
+        val parsed = PlaybackCompatibilityPolicyParser.parse(
+            """
+            {
+              "schema": 1,
+              "revision": 2026081802,
+              "audioStrategy": ["REEL_MUXED", "REMOTE_SCRIPT", "DIRECT"]
+            }
+            """.trimIndent(),
+            PlaybackCompatibilityPolicy.bundled()
+        )
+
+        assertNotNull(parsed)
+        assertEquals(
+            listOf(PlaybackAudioStrategy.REEL_MUXED, PlaybackAudioStrategy.DIRECT),
+            parsed!!.audioStrategies
+        )
+    }
+
+    @Test
+    fun allUnknownStrategiesFallBackToBaseListInsteadOfEmpty() {
+        val base = PlaybackCompatibilityPolicy.bundled()
+        val parsed = PlaybackCompatibilityPolicyParser.parse(
+            """
+            {
+              "schema": 1,
+              "revision": 2026081802,
+              "audioStrategy": ["REMOTE_SCRIPT", "ANOTHER_UNKNOWN"]
+            }
+            """.trimIndent(),
+            base
+        )
+
+        assertNotNull(parsed)
+        assertFalse(parsed!!.audioStrategies.isEmpty())
+        assertEquals(base.audioStrategies, parsed.audioStrategies)
+    }
+
+    @Test
+    fun expiredPolicyIsTreatedAsExpired() {
+        val expired = PlaybackCompatibilityPolicy.bundled().copy(expiresAt = 1_700_000_000_000L)
+        val notExpired = PlaybackCompatibilityPolicy.bundled().copy(expiresAt = 4_000_000_000_000L)
+        val neverExpires = PlaybackCompatibilityPolicy.bundled().copy(expiresAt = 0L)
+
+        assertTrue(expired.isExpired(nowMs = 1_800_000_000_000L))
+        assertFalse(notExpired.isExpired(nowMs = 1_800_000_000_000L))
+        assertFalse(neverExpires.isExpired(nowMs = 1_800_000_000_000L))
+    }
+
+    @Test
+    fun appVersionOutsideSupportedRangeIsRejected() {
+        val policy = PlaybackCompatibilityPolicy.bundled().copy(
+            minSupportedAppVersion = 10,
+            maxSupportedAppVersion = 20
+        )
+
+        assertFalse(isAppVersionSupported(policy, appVersionCode = 5))
+        assertFalse(isAppVersionSupported(policy, appVersionCode = 25))
+        assertTrue(isAppVersionSupported(policy, appVersionCode = 15))
+        assertTrue(isAppVersionSupported(policy, appVersionCode = 0))
     }
 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackFailureClassificationTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackFailureClassificationTest.kt
@@ -5,20 +5,35 @@ import org.junit.Test
 
 class PlaybackFailureClassificationTest {
     @Test
-    fun antiBotAndSignInChallengesTriggerForbiddenRecovery() {
+    fun antiBotAndSignInChallengesTriggerLoginRequiredRecovery() {
         val messages = listOf(
             "Sign in to confirm you're not a bot",
             "Sign in to confirm you’re not a bot",
             "Please confirm you are not a bot",
-            "Accedi per confermare di essere umano"
+            "Accedi per confermare di essere umano",
+            "LOGIN_REQUIRED"
         )
 
         messages.forEach { message ->
             assertEquals(
-                PlaybackFailureKind.Forbidden,
+                PlaybackFailureKind.LoginRequired,
                 classifyPlaybackFailureReason(message)
             )
         }
+    }
+
+    @Test
+    fun ageRestrictionIsTrackSpecificRatherThanGlobalLoginFailure() {
+        assertEquals(
+            PlaybackFailureKind.ContentRestricted,
+            classifyPlaybackFailureReason("This video is age restricted")
+        )
+    }
+
+    @Test
+    fun responseCodeWordingIsClassifiedLikeHttpStatus() {
+        assertEquals(PlaybackFailureKind.Forbidden, classifyPlaybackFailureReason("Response code: 403"))
+        assertEquals(PlaybackFailureKind.RateLimited, classifyPlaybackFailureReason("Response code: 429"))
     }
 
     @Test
@@ -43,5 +58,48 @@ class PlaybackFailureClassificationTest {
         assertEquals(PlaybackFailureKind.Gone, classifyPlaybackFailureReason("HTTP 410"))
         assertEquals(PlaybackFailureKind.RateLimited, classifyPlaybackFailureReason("HTTP 429"))
         assertEquals(PlaybackFailureKind.Signature, classifyPlaybackFailureReason("PO Token rejected"))
+    }
+
+    @Test
+    fun notFoundStatusIsClassified() {
+        assertEquals(PlaybackFailureKind.NotFound, classifyPlaybackFailureReason("HTTP 404"))
+        assertEquals(PlaybackFailureKind.NotFound, classifyPlaybackFailureReason("status code: 404"))
+        assertEquals(PlaybackFailureKind.NotFound, classifyPlaybackFailureReason("Resource not found"))
+    }
+
+    @Test
+    fun rangeNotSatisfiableStatusIsClassified() {
+        assertEquals(PlaybackFailureKind.RangeNotSatisfiable, classifyPlaybackFailureReason("HTTP 416"))
+        assertEquals(
+            PlaybackFailureKind.RangeNotSatisfiable,
+            classifyPlaybackFailureReason("Range not satisfiable")
+        )
+    }
+
+    @Test
+    fun serverErrorStatusesAreClassified() {
+        assertEquals(PlaybackFailureKind.ServerError, classifyPlaybackFailureReason("HTTP 500"))
+        assertEquals(PlaybackFailureKind.ServerError, classifyPlaybackFailureReason("HTTP 502"))
+        assertEquals(PlaybackFailureKind.ServerError, classifyPlaybackFailureReason("HTTP 503"))
+        assertEquals(PlaybackFailureKind.ServerError, classifyPlaybackFailureReason("HTTP 504"))
+        assertEquals(PlaybackFailureKind.ServerError, classifyPlaybackFailureReason("Bad gateway"))
+        assertEquals(PlaybackFailureKind.ServerError, classifyPlaybackFailureReason("Service unavailable"))
+    }
+
+    @Test
+    fun truncatedResponsesAreClassified() {
+        assertEquals(PlaybackFailureKind.Truncated, classifyPlaybackFailureReason("Truncated response body"))
+        assertEquals(
+            PlaybackFailureKind.Truncated,
+            classifyPlaybackFailureReason("Unexpected end of stream")
+        )
+        assertEquals(PlaybackFailureKind.Truncated, classifyPlaybackFailureReason("Connection reset by peer"))
+        assertEquals(PlaybackFailureKind.Truncated, classifyPlaybackFailureReason("Premature end of content-length"))
+    }
+
+    @Test
+    fun genericConnectionFailuresStillClassifyAsNetwork() {
+        assertEquals(PlaybackFailureKind.Network, classifyPlaybackFailureReason("Connection refused"))
+        assertEquals(PlaybackFailureKind.Network, classifyPlaybackFailureReason("Unknown host"))
     }
 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackStrategyHealthTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackStrategyHealthTest.kt
@@ -1,0 +1,259 @@
+package com.luc4n3x.levyra.data
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private enum class SampleStrategy { InnerTube, WebEmbedded, Android, IosClient }
+
+class PlaybackStrategyHealthTest {
+
+    @Test
+    fun orderIsAlwaysAPermutationOfInput() {
+        val strategies = SampleStrategy.values().toList()
+        val now = 1_000_000L
+
+        val scenarios = listOf(
+            emptyMap<String, PlaybackStrategyStats>(),
+            mapOf(SampleStrategy.WebEmbedded.name to openStatsAt(now, kind = PlaybackFailureKind.Forbidden)),
+            strategies.associate { it.name to openStatsAt(now, kind = PlaybackFailureKind.Gone) }
+        )
+
+        scenarios.forEach { statsMap ->
+            val result = orderPlaybackStrategiesByHealth(
+                strategies = strategies,
+                statsFor = { statsMap[it] },
+                nowMs = now
+            )
+            assertEquals(strategies.size, result.size)
+            assertEquals(strategies.sortedBy { it.ordinal }, result.sortedBy { it.ordinal })
+        }
+    }
+
+    @Test
+    fun emptyHealthReturnsInputUnchanged() {
+        val strategies = SampleStrategy.values().toList()
+        val result = orderPlaybackStrategiesByHealth(
+            strategies = strategies,
+            statsFor = { null },
+            nowMs = 1_000L
+        )
+        assertSame(strategies, result)
+    }
+
+    @Test
+    fun threeConsecutiveForbiddenFailuresMovesStrategyToBack() {
+        val now = 5_000_000L
+        val failing = statsAfterConsecutiveFailures(
+            count = 3,
+            kind = PlaybackFailureKind.Forbidden,
+            startAtMs = now - 3_000L
+        )
+        assertEquals(PlaybackStrategyCircuit.OPEN, failing.circuitAt(now))
+
+        val strategies = listOf(SampleStrategy.WebEmbedded, SampleStrategy.InnerTube, SampleStrategy.Android)
+        val statsMap = mapOf(SampleStrategy.WebEmbedded.name to failing)
+
+        val result = orderPlaybackStrategiesByHealth(
+            strategies = strategies,
+            statsFor = { statsMap[it] },
+            nowMs = now
+        )
+
+        assertEquals(strategies.toSet(), result.toSet())
+        assertEquals(SampleStrategy.WebEmbedded, result.last())
+    }
+
+    @Test
+    fun afterQuarantineExpiryStrategyIsHalfOpenAndCanaryAllowed() {
+        val openedAt = 10_000_000L
+        val opened = statsAfterConsecutiveFailures(
+            count = 3,
+            kind = PlaybackFailureKind.RateLimited,
+            startAtMs = openedAt - 3_000L
+        )
+        val stillQuarantined = opened.quarantineUntilMs - 1L
+        assertEquals(PlaybackStrategyCircuit.OPEN, opened.circuitAt(stillQuarantined))
+
+        val afterExpiry = opened.quarantineUntilMs + 1L
+        assertEquals(PlaybackStrategyCircuit.HALF_OPEN, opened.circuitAt(afterExpiry))
+
+        val strategies = listOf(SampleStrategy.InnerTube, SampleStrategy.WebEmbedded, SampleStrategy.Android)
+        val stillOpenOther = statsAfterConsecutiveFailures(
+            count = 3,
+            kind = PlaybackFailureKind.Forbidden,
+            startAtMs = afterExpiry - 3_000L
+        )
+        val statsMap = mapOf(
+            SampleStrategy.WebEmbedded.name to opened,
+            SampleStrategy.Android.name to stillOpenOther
+        )
+
+        val result = orderPlaybackStrategiesByHealth(
+            strategies = strategies,
+            statsFor = { statsMap[it] },
+            nowMs = afterExpiry
+        )
+
+        assertEquals(strategies.toSet(), result.toSet())
+        assertTrue("half-open canary must not be dropped", result.contains(SampleStrategy.WebEmbedded))
+        assertTrue(result.indexOf(SampleStrategy.WebEmbedded) < result.indexOf(SampleStrategy.Android))
+    }
+
+    @Test
+    fun hardRuntimeFailureOpensCircuitImmediately() {
+        val now = 15_000_000L
+        val updated = playbackStrategyStatsAfterRuntimeFailure(
+            current = null,
+            nowMs = now,
+            kind = PlaybackFailureKind.Forbidden
+        )
+
+        assertEquals(PlaybackStrategyCircuit.OPEN, updated.circuitAt(now))
+        assertTrue(updated.quarantineUntilMs > now)
+    }
+
+    @Test
+    fun transientRuntimeFailureDoesNotOpenCircuitImmediately() {
+        val now = 16_000_000L
+        val updated = playbackStrategyStatsAfterRuntimeFailure(
+            current = null,
+            nowMs = now,
+            kind = PlaybackFailureKind.ServerError
+        )
+
+        assertEquals(PlaybackStrategyCircuit.CLOSED, updated.circuitAt(now))
+    }
+
+    @Test
+    fun resolutionSuccessCannotCloseAnOpenCircuitBeforeCooldown() {
+        val now = 18_000_000L
+        val opened = playbackStrategyStatsAfterRuntimeFailure(
+            current = null,
+            nowMs = now,
+            kind = PlaybackFailureKind.Forbidden
+        )
+        val stillOpenAt = now + 1_000L
+
+        val resolvedAgain = playbackStrategyStatsAfterSuccess(opened, stillOpenAt, latencyMs = 120L)
+
+        assertEquals(PlaybackStrategyCircuit.OPEN, resolvedAgain.circuitAt(stillOpenAt))
+        assertEquals(opened.quarantineUntilMs, resolvedAgain.quarantineUntilMs)
+    }
+
+    @Test
+    fun successOnHalfOpenStrategyReturnsToClosed() {
+        val openedAt = 20_000_000L
+        val opened = statsAfterConsecutiveFailures(
+            count = 4,
+            kind = PlaybackFailureKind.Signature,
+            startAtMs = openedAt - 4_000L
+        )
+        val afterExpiry = opened.quarantineUntilMs + 1L
+        assertEquals(PlaybackStrategyCircuit.HALF_OPEN, opened.circuitAt(afterExpiry))
+
+        val recovered = playbackStrategyStatsAfterSuccess(opened, afterExpiry, latencyMs = 250L)
+
+        assertEquals(PlaybackStrategyCircuit.CLOSED, recovered.circuitAt(afterExpiry))
+        assertEquals(0, recovered.consecutiveFailures)
+        assertEquals(0L, recovered.quarantineUntilMs)
+    }
+
+    @Test
+    fun marginallyWorseScoringStrategyDoesNotLeapfrogPolicyOrder() {
+        val now = 1_000L
+        val policyFirstLowerScore = PlaybackStrategyStats(successes = 8, failures = 2)
+        val policySecondHigherScore = PlaybackStrategyStats(successes = 9, failures = 1)
+        assertTrue(policySecondHigherScore.score - policyFirstLowerScore.score < 25.0)
+
+        val strategies = listOf(SampleStrategy.WebEmbedded, SampleStrategy.InnerTube)
+        val statsMap = mapOf(
+            SampleStrategy.WebEmbedded.name to policyFirstLowerScore,
+            SampleStrategy.InnerTube.name to policySecondHigherScore
+        )
+
+        val result = orderPlaybackStrategiesByHealth(
+            strategies = strategies,
+            statsFor = { statsMap[it] },
+            nowMs = now
+        )
+
+        assertEquals(strategies, result)
+    }
+
+    @Test
+    fun materialScoreGapDoesReorderWithinSameCircuit() {
+        val now = 1_000L
+        val policyFirstMuchWorse = PlaybackStrategyStats(successes = 5, failures = 5)
+        val policySecondMuchBetter = PlaybackStrategyStats(successes = 9, failures = 1)
+        assertTrue(policySecondMuchBetter.score - policyFirstMuchWorse.score >= 25.0)
+
+        val strategies = listOf(SampleStrategy.WebEmbedded, SampleStrategy.InnerTube)
+        val statsMap = mapOf(
+            SampleStrategy.WebEmbedded.name to policyFirstMuchWorse,
+            SampleStrategy.InnerTube.name to policySecondMuchBetter
+        )
+
+        val result = orderPlaybackStrategiesByHealth(
+            strategies = strategies,
+            statsFor = { statsMap[it] },
+            nowMs = now
+        )
+
+        assertEquals(listOf(SampleStrategy.InnerTube, SampleStrategy.WebEmbedded), result)
+    }
+
+    @Test
+    fun corruptPersistedJsonDegradesToEmptyHealth() {
+        assertEquals(emptyMap<String, PlaybackStrategyStats>(), parsePlaybackStrategyHealthSnapshot("{not valid json"))
+        assertEquals(emptyMap<String, PlaybackStrategyStats>(), parsePlaybackStrategyHealthSnapshot("[1,2,3]"))
+        assertEquals(emptyMap<String, PlaybackStrategyStats>(), parsePlaybackStrategyHealthSnapshot(""))
+        assertEquals(emptyMap<String, PlaybackStrategyStats>(), parsePlaybackStrategyHealthSnapshot(null))
+    }
+
+    @Test
+    fun validPersistedJsonRoundTrips() {
+        val stats = statsAfterConsecutiveFailures(
+            count = 3,
+            kind = PlaybackFailureKind.LoginRequired,
+            startAtMs = 1_000L
+        )
+        val json = playbackStrategyStatsToJson(stats)
+        val root = JSONObject().put("audio::WebEmbedded", json)
+        val restored = parsePlaybackStrategyHealthSnapshot(root.toString())
+
+        val restoredStats = restored["audio::WebEmbedded"]
+        assertNotNull(restoredStats)
+        assertEquals(stats.consecutiveFailures, restoredStats!!.consecutiveFailures)
+        assertEquals(stats.quarantineUntilMs, restoredStats.quarantineUntilMs)
+        assertEquals(PlaybackFailureKind.LoginRequired, restoredStats.lastFailureKind)
+    }
+
+    @Test
+    fun unparseableFailureKindDegradesToNull() {
+        val entry = JSONObject().put("lastFailureKind", "NotARealKind")
+        val root = JSONObject().put("audio::Android", entry)
+        val restored = parsePlaybackStrategyHealthSnapshot(root.toString())
+        assertNull(restored["audio::Android"]!!.lastFailureKind)
+    }
+
+    private fun openStatsAt(nowMs: Long, kind: PlaybackFailureKind): PlaybackStrategyStats {
+        return statsAfterConsecutiveFailures(count = 3, kind = kind, startAtMs = nowMs - 3_000L)
+    }
+
+    private fun statsAfterConsecutiveFailures(
+        count: Int,
+        kind: PlaybackFailureKind,
+        startAtMs: Long
+    ): PlaybackStrategyStats {
+        var stats: PlaybackStrategyStats? = null
+        repeat(count) { attempt ->
+            stats = playbackStrategyStatsAfterFailure(stats, startAtMs + attempt, latencyMs = null, kind = kind)
+        }
+        return stats!!
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeLocalDecoderTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeLocalDecoderTest.kt
@@ -463,6 +463,50 @@ class YoutubeLocalDecoderTest {
         )
     }
 
+    @Test
+    fun streamRejectionSkippedOrNetworkFailureNeverInvalidatesPlayerSource() {
+        val skipped = YoutubeStreamRejectionActionPolicy.decide(
+            YoutubeStreamRefreshResult.SKIPPED,
+            generationMatches = true
+        )
+        val networkFailure = YoutubeStreamRejectionActionPolicy.decide(
+            YoutubeStreamRefreshResult.NETWORK_FAILURE,
+            generationMatches = true
+        )
+
+        assertFalse(skipped.invalidatePlayerSource)
+        assertFalse(skipped.invalidateRuntime)
+        assertFalse(networkFailure.invalidatePlayerSource)
+        assertFalse(networkFailure.invalidateRuntime)
+    }
+
+    @Test
+    fun streamRejectionChangedOrUnchangedInvalidatesPlayerSourceWhenGenerationMatches() {
+        val changed = YoutubeStreamRejectionActionPolicy.decide(
+            YoutubeStreamRefreshResult.CHANGED,
+            generationMatches = true
+        )
+        val unchanged = YoutubeStreamRejectionActionPolicy.decide(
+            YoutubeStreamRefreshResult.UNCHANGED,
+            generationMatches = true
+        )
+
+        assertTrue(changed.invalidatePlayerSource)
+        assertTrue(changed.invalidateRuntime)
+        assertTrue(unchanged.invalidatePlayerSource)
+        assertTrue(unchanged.invalidateRuntime)
+    }
+
+    @Test
+    fun streamRejectionWithStaleGenerationInvalidatesNothing() {
+        YoutubeStreamRefreshResult.entries.forEach { result ->
+            val action = YoutubeStreamRejectionActionPolicy.decide(result, generationMatches = false)
+
+            assertFalse(result.name, action.invalidatePlayerSource)
+            assertFalse(result.name, action.invalidateRuntime)
+        }
+    }
+
     private fun parityResource(name: String): String {
         val resource = requireNotNull(javaClass.classLoader?.getResource("config-parity/$name"))
         return resource.readText()

--- a/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineAudioExporterTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineAudioExporterTest.kt
@@ -7,6 +7,7 @@ import java.nio.file.Path
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 class OfflineAudioExporterTest {
@@ -228,5 +229,185 @@ class OfflineAudioExporterTest {
     fun taskKeysProduceStableSafePartialFileNames() {
         assertEquals("track_id_with_spaces", offlineDownloadTaskFileKey(" track id with spaces "))
         assertEquals("unknown", offlineDownloadTaskFileKey(""))
+    }
+
+    @Test
+    fun differingItagProducesADifferentStreamIdentity() {
+        val a = offlineStreamIdentity(
+            "https://rr1---sn.googlevideo.com/videoplayback?itag=140&clen=1000&mime=audio%2Fmp4&expire=1",
+            "abcdefghijk"
+        )
+        val b = offlineStreamIdentity(
+            "https://rr1---sn.googlevideo.com/videoplayback?itag=251&clen=1000&mime=audio%2Fmp4&expire=1",
+            "abcdefghijk"
+        )
+
+        assertFalse(a == b)
+    }
+
+    @Test
+    fun differingContentLengthProducesADifferentStreamIdentity() {
+        val a = offlineStreamIdentity(
+            "https://rr1---sn.googlevideo.com/videoplayback?itag=140&clen=1000&mime=audio%2Fmp4&expire=1",
+            "abcdefghijk"
+        )
+        val b = offlineStreamIdentity(
+            "https://rr1---sn.googlevideo.com/videoplayback?itag=140&clen=2000&mime=audio%2Fmp4&expire=1",
+            "abcdefghijk"
+        )
+
+        assertFalse(a == b)
+    }
+
+    @Test
+    fun aResignedUrlWithTheSameItagClenAndMimeProducesTheSameStreamIdentity() {
+        val original = offlineStreamIdentity(
+            "https://rr1---sn.googlevideo.com/videoplayback?itag=140&clen=1000&mime=audio%2Fmp4&expire=1000&sig=aaa",
+            "abcdefghijk"
+        )
+        val refreshed = offlineStreamIdentity(
+            "https://rr1---sn.googlevideo.com/videoplayback?itag=140&clen=1000&mime=audio%2Fmp4&expire=9999&sig=zzz",
+            "abcdefghijk"
+        )
+
+        assertEquals(original, refreshed)
+    }
+
+    @Test
+    fun mismatchedStreamIdentityDiscardsAndRestartsFromZero() {
+        val stored = offlineStreamIdentity(
+            "https://rr1---sn.googlevideo.com/videoplayback?itag=140&clen=1000&mime=audio%2Fmp4",
+            "abcdefghijk"
+        )
+        val current = offlineStreamIdentity(
+            "https://rr1---sn.googlevideo.com/videoplayback?itag=251&clen=1000&mime=audio%2Fwebm",
+            "abcdefghijk"
+        )
+
+        assertEquals(0L, resumableBytesForStreamIdentity(existingBytes = 4096L, storedIdentity = stored, currentIdentity = current))
+    }
+
+    @Test
+    fun matchingStreamIdentityResumesAtTheExistingByteCount() {
+        val stored = offlineStreamIdentity(
+            "https://rr1---sn.googlevideo.com/videoplayback?itag=140&clen=1000&mime=audio%2Fmp4&expire=1",
+            "abcdefghijk"
+        )
+        val current = offlineStreamIdentity(
+            "https://rr1---sn.googlevideo.com/videoplayback?itag=140&clen=1000&mime=audio%2Fmp4&expire=2",
+            "abcdefghijk"
+        )
+
+        assertEquals(4096L, resumableBytesForStreamIdentity(existingBytes = 4096L, storedIdentity = stored, currentIdentity = current))
+    }
+
+    @Test
+    fun unknownMissingSidecarIdentityIsTreatedAsUnsafeAndDiscarded() {
+        val current = offlineStreamIdentity(
+            "https://rr1---sn.googlevideo.com/videoplayback?itag=140&clen=1000&mime=audio%2Fmp4",
+            "abcdefghijk"
+        )
+
+        assertEquals(
+            0L,
+            resumableBytesForStreamIdentity(existingBytes = 4096L, storedIdentity = null, currentIdentity = current)
+        )
+    }
+
+    @Test
+    fun streamIdentitySurvivesSerializeAndParseRoundTrip() {
+        val identity = offlineStreamIdentity(
+            "https://rr1---sn.googlevideo.com/videoplayback?itag=140&clen=1000&mime=audio%2Fmp4",
+            "abcdefghijk"
+        )
+
+        assertEquals(identity, parseOfflineStreamIdentity(serializeOfflineStreamIdentity(identity)))
+    }
+
+    @Test
+    fun rejectionErrorsAbortRangeRetryAfterTheFirstAttempt() = runBlocking {
+        var attempts = 0
+
+        val error = runCatching {
+            retryRangeDownload(
+                retryCount = 3,
+                retryDelayMs = 10L,
+                sleep = { fail("rejection must not trigger a retry sleep") }
+            ) {
+                attempts++
+                throw IOException("Range audio non supportato: HTTP 403")
+            }
+        }.exceptionOrNull()
+
+        assertEquals(1, attempts)
+        assertTrue(error is IOException)
+        assertTrue(isRejectedOfflinePlaybackSource(error as IOException))
+    }
+
+    @Test
+    fun staleRangeStatusesAbortRetryImmediately() = runBlocking {
+        listOf(404, 416).forEach { status ->
+            var attempts = 0
+            val error = runCatching {
+                retryRangeDownload(
+                    retryCount = 3,
+                    retryDelayMs = 10L,
+                    sleep = { fail("stale source must not trigger retry sleep") }
+                ) {
+                    attempts++
+                    throw IOException("Range audio non supportato: HTTP $status")
+                }
+            }.exceptionOrNull()
+
+            assertEquals(1, attempts)
+            assertTrue(error is IOException)
+            assertTrue(isRejectedOfflinePlaybackSource(error as IOException))
+        }
+    }
+
+    @Test
+    fun transientRangeErrorsConsumeAllConfiguredRetries() = runBlocking {
+        var attempts = 0
+        var sleeps = 0
+
+        val error = runCatching {
+            retryRangeDownload(
+                retryCount = 3,
+                retryDelayMs = 10L,
+                sleep = { sleeps++ }
+            ) {
+                attempts++
+                throw IOException("timeout while reading stream")
+            }
+        }.exceptionOrNull()
+
+        assertEquals(3, attempts)
+        assertEquals(2, sleeps)
+        assertTrue(error is IOException)
+    }
+
+    @Test
+    fun aRejectedRangeFailureIsDetectedAmongOtherFailures() {
+        val range = AudioDownloadRange(0L, 1023L)
+        val failures = listOf(
+            RangeDownloadFailure(range, IOException("timeout while reading stream")),
+            RangeDownloadFailure(range, IOException("Range audio non supportato: HTTP 429"))
+        )
+
+        val rejected = firstRejectedRangeFailure(failures)
+
+        assertTrue(rejected != null)
+        assertTrue(isRejectedOfflinePlaybackSource(rejected as IOException))
+    }
+
+    @Test
+    fun onlyTransientRangeFailuresDoNotShortCircuitTheBatch() {
+        val range = AudioDownloadRange(0L, 1023L)
+        val failures = listOf(
+            RangeDownloadFailure(range, IOException("timeout while reading stream")),
+            RangeDownloadFailure(range, IOException("connection reset"))
+        )
+
+        assertEquals(null, firstRejectedRangeFailure(failures))
     }
 }

--- a/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineDownloadPlaybackIsolationTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineDownloadPlaybackIsolationTest.kt
@@ -220,8 +220,14 @@ class OfflineDownloadPlaybackIsolationTest {
     fun aDeadOfflineUrlIsStillQuarantinedSoTheRetryCanRotate() {
         val resolver = Files.readString(sourceFile("data/PlaybackResolver.kt"))
 
-        assertEquals(1, occurrences(resolver, "failedPlaybackUrls[it] = now + recovery.quarantineMs"))
-        assertFalse(resolver.contains("if (!isOfflineExport) {"))
+        val recoveryStart = resolver.indexOf("val recovery = resilienceEngine.recoveryPlan(reason)")
+        val rotateClient = resolver.indexOf("if (recovery.rotateClient)", recoveryStart)
+        val quarantineBlock = resolver.substring(recoveryStart, rotateClient)
+
+        assertTrue(recoveryStart > 0)
+        assertTrue(rotateClient > recoveryStart)
+        assertEquals(1, occurrences(quarantineBlock, "failedPlaybackUrls[it] = now + recovery.quarantineMs"))
+        assertFalse(quarantineBlock.contains("if (!isOfflineExport)"))
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineDownloadReliabilityContractTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineDownloadReliabilityContractTest.kt
@@ -179,7 +179,9 @@ class OfflineDownloadReliabilityContractTest {
 
         assertTrue(source.contains("if (written != range.length)"))
         assertTrue(source.contains("if (downloadedBytes.get() != targetLength || temp.length() != targetLength)"))
-        assertTrue(source.contains("repeat(RANGE_RETRY_COUNT)"))
+        assertTrue(source.contains("retryRangeDownload(RANGE_RETRY_COUNT, RANGE_RETRY_DELAY_MS"))
+        assertTrue(source.contains("repeat(retryCount)"))
+        assertTrue(source.contains("if (isUnsupportedOfflineAudioSource(error) || isRejectedOfflinePlaybackSource(error)) throw error"))
         assertTrue(source.contains("repeat(PARALLEL_BATCH_RETRY_COUNT)"))
         assertTrue(source.contains("Parallel offline download failed, falling back to serial"))
         assertTrue(source.contains("if (targetLength > 0L && total != targetLength)"))

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -263,20 +263,20 @@ files/diagnostics/artwork-startup-metrics.json
 ## 6. Playback resolver
  
 ### 6.1 Resolution entry
- 
-`PlaybackResolver` receives a `Track` and resolves a playable stream.
- 
+
+`PlaybackResolver` receives a `Track` and resolves a playable stream. Song and native-video requests use the server-driven compatibility policy as the allowlisted strategy order; local strategy health may reorder only strategies already allowed by that policy.
+
 ```text
 resolve(track)
-├── validate cached stream URL
+├── validate local/persistent state where the selected strategy allows it
 ├── join existing in-flight Deferred
-└── create immediate race
-    ├── LevyraExtractor
-    └── InnerTube resolver
+├── read the last-known-good compatibility policy
+├── apply local strategy-health ordering
+└── resolve through the first healthy policy strategy
 ```
- 
-The first valid result wins. Losing work is cancelled when safe.
- 
+
+Individual strategies may still hedge LevyraExtractor and InnerTube work internally. The first valid result wins and losing work is cancelled when safe.
+
 ### 6.2 In-flight deduplication
  
 Concurrent requests for the same media key share one `Deferred`.
@@ -308,20 +308,30 @@ Start     immediate
  
 It remains first even when dynamic client-health ranking is active.
  
-### 6.4 Client health
- 
+### 6.4 Client and strategy health
+
 The resolver tracks per-client:
- 
+
 - successes;
 - consecutive failures;
 - average latency;
 - temporary blocks;
 - last update time.
- 
-Dynamic health can delay unhealthy fallback clients, but it does not demote Android VR.
- 
-### 6.5 Protected URL processing
- 
+
+It also keeps local, privacy-preserving health for the higher-level audio and video strategies. Server policy remains the authority for which strategies are allowed; local health can only reorder that allowlist. Repeated resolution failures open a temporary circuit, while a hard runtime rejection such as `403`, `410`, `429`, `LOGIN_REQUIRED`, or a signature/PO-Token failure can quarantine the strategy immediately. Open strategies remain last-resort fallbacks and become half-open after cooldown.
+
+The URL that reached Media3 is associated in memory with the strategy that produced it, so a later player-side rejection is charged to the correct strategy instead of being mistaken for a successful resolve.
+
+Dynamic client health can delay unhealthy fallback clients, but it does not demote Android VR inside the standard InnerTube client path.
+
+### 6.5 Server-driven compatibility policy
+
+`PlaybackCompatibilityPolicyStore` fetches the bounded JSON policy from the Levyra repository with short timeouts, ETag support, no redirects, monotonic revisions, and a bundled last-resort policy. Unknown future strategy names are ignored rather than executed. The policy may constrain audio/video strategy order, known client overrides, Android Reel client version, expiry, and supported Android version-code range; it cannot provide executable code or arbitrary endpoints.
+
+Expired, malformed, downgraded, or app-incompatible policies do not replace the last usable built-in behavior. Rejected playback can force a policy refresh without putting the fetch on the direct tap-to-play critical path.
+
+### 6.6 Protected URL processing
+
 Selected formats may contain `signatureCipher`, `s`, or `n`.
  
 Processing order:
@@ -626,21 +636,26 @@ Workers use retry policies for eligible network failures and reject incomplete m
 ### Offline source eligibility
 
 A googlevideo `videoplayback` URL without `ratebypass` and without a
-proof-of-origin token serves roughly the first mebibyte and then answers `403`
-for every continuation request. `YoutubeStreamCapability.servesCompleteStream`
-identifies those sources. Playback skips them, the export path refuses to select
-or replay them, and the sequential cache prefetch is limited to sources that can
-stream to the end. Every remaining download runs through bounded parallel range
-requests.
+proof-of-origin token can serve only an initial portion before later requests are
+rejected. `YoutubeStreamCapability.servesCompleteStream` identifies sources that
+can serve the complete object. The effective offline pipeline accepts only
+complete Android Reel-derived sources and rejects legacy MP4 resolver results
+before prefetch or file transfer begins.
 
-When no audio-only MP4 source qualifies, the export reuses the progressive muxed
-MP4 the player already streams and reduces it to its audio track with
-`androidx.media3:media3-transformer` (`OfflineAudioTrackExtractor`). The
-extraction runs on device, keeps the AAC audio, and produces the same `.m4a`
-output the tagger and MediaStore steps expect.
- 
+Reel/PO-Token downloads use a serial resumable transfer instead of aggressive
+parallel fan-out. If a URL is rejected, the exporter stops retrying that exact
+URL, reports it to playback recovery, resolves a fresh source, and resumes only
+when the stored partial-file identity still matches the source video ID, itag,
+content length, and MIME type. A mismatched or identity-less partial is discarded
+instead of being appended to a different representation.
+
+When the selected Reel source is a progressive muxed MP4, the export reduces it
+to its audio track with `androidx.media3:media3-transformer`
+(`OfflineAudioTrackExtractor`). The extraction runs on device, keeps the AAC
+audio, and produces the same `.m4a` output the tagger and MediaStore steps expect.
+
 ---
- 
+
 ## 15. Local persistence
  
 Room stores structured application state including:

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -31,6 +31,8 @@ docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md
                                   ChatGPT Project instructions source
 docs/ai/OPENCLAW.md               OpenClaw workspace and delegation
 docs/ai/WORKFLOW.md               clarification-to-release lifecycle
+docs/ai/YOUTUBE_PLAYBACK_RECOVERY_RUNBOOK.md
+                                  YouTube playback/download recovery operations
 ```
 
 Planning files remain distinct:

--- a/docs/ai/YOUTUBE_PLAYBACK_RECOVERY_RUNBOOK.md
+++ b/docs/ai/YOUTUBE_PLAYBACK_RECOVERY_RUNBOOK.md
@@ -1,0 +1,139 @@
+# YouTube Playback Recovery Runbook
+
+Use this when Levyra suddenly loses song playback, native video playback, or offline downloads after a YouTube-side change.
+
+## First checks
+
+1. Reproduce with at least one known public track and one native video.
+2. Check whether the failure is limited to Wi-Fi, mobile data, or both.
+3. Capture the sanitized playback diagnostic and the HTTP/player error. Useful classes are `PlaybackResolver`, `PlaybackResilienceEngine`, `YoutubeLocalDecoder`, `YoutubePlaybackSecurity`, and `OfflineAudioExporter`.
+4. Do not start by changing several clients at once. Identify the failing strategy or client, then make the smallest policy/config change that restores service.
+
+The common failure families are:
+
+- `403`, `410`, `429`, `LOGIN_REQUIRED`, or “confirm you're not a bot”: treat as a rejected/risk-controlled stream and refresh the playback policy/security state.
+- `signature`, `n-transform`, `PoToken`, or player-JS failures: inspect `player_configs.json`, the local decoder, and the current player configuration before changing client order.
+- `404` or `416`: treat the current URL/range as stale and re-resolve it instead of repeatedly retrying the same URL.
+- `5xx`, connection reset, or truncated body: first distinguish a transient network/server failure from a consistently broken strategy.
+
+## Songs
+
+The default working path is controlled by `config/playback_policy.json` under `audioStrategy`.
+
+Current strategy names compiled into the app are:
+
+- `REEL_MUXED`
+- `REEL_AUDIO`
+- `PERSISTED`
+- `DIRECT`
+- `SEARCH`
+
+The remote policy can reorder or omit only strategies that the installed APK already knows. Unknown future strategy names are ignored; the server cannot inject executable code.
+
+If one strategy consistently fails while another works, move the healthy strategy earlier or remove the broken strategy from the remote list, then increment `revision`.
+
+For song mode, a muxed Reel source is still presented as audio-only: the player must not expose a video stream or change the music UI.
+
+## Native video
+
+Video order is controlled by `videoStrategy`.
+
+Compiled strategy names are:
+
+- `PERSISTED`
+- `STANDARD`
+- `REEL`
+
+If standard video extraction starts failing but Reel still works, move `REEL` ahead of `STANDARD` and increment the policy revision. Do not change song strategy order just because video is affected.
+
+## Downloads
+
+Offline export intentionally accepts only complete Android Reel-derived sources. Do not re-enable the old anonymous MP4 fallback merely to make resolution succeed: an apparently valid URL that cannot serve the whole file can stall part-way through the download.
+
+On a rejected download source:
+
+1. abort retries against that exact rejected URL;
+2. report the failure to the resolver/security recovery path;
+3. obtain a fresh source;
+4. resume only if the new source identity matches the existing partial file;
+5. otherwise discard the partial file and restart safely.
+
+Resume identity includes the source video ID, itag, content length, and MIME type. A newly signed URL for the same representation may resume; a different representation must not be appended to the old `.part` file.
+
+## Remote playback policy
+
+File:
+
+`config/playback_policy.json`
+
+The app fetches it from the Levyra repository and keeps a last-known-good policy. The built-in policy remains the final fallback when the remote file is unavailable, invalid, expired, rolled back, or outside the supported app-version range.
+
+Relevant fields:
+
+- `schema`: policy schema understood by the APK.
+- `revision`: monotonically increasing policy revision. Increment this for every behavior change.
+- `audioStrategy`: ordered song strategies.
+- `videoStrategy`: ordered native-video strategies.
+- `androidReelClientVersion`: allowlisted client version string used by Android Reel requests.
+- `clients`: allowlisted per-client enable/priority/tier/PoToken/version overrides.
+- `expiresAt`: optional absolute epoch milliseconds; `0` means no expiry.
+- `minSupportedAppVersion`: optional minimum Android version code; `0` means no lower bound.
+- `maxSupportedAppVersion`: optional maximum Android version code; `0` means no upper bound.
+
+Never place credentials, cookies, arbitrary endpoints, arbitrary headers, JavaScript, Kotlin, shell code, DEX, or executable payloads in this file.
+
+### Safe policy update procedure
+
+1. Start from the current `main` policy.
+2. Change only the strategy/client setting proven to be broken.
+3. Increment `revision`.
+4. Keep at least one viable playback path enabled.
+5. Commit the policy change to `main` only after JSON/schema review.
+6. Re-test song, native video, and a download on a real device.
+7. If the change makes things worse, publish a new higher revision restoring the previous known-good values. Do not lower the revision.
+
+## Player configuration / local decoder
+
+If a rejection points to signature, `n-transform`, STS, or player JavaScript:
+
+1. inspect the current Zemer/player config state;
+2. on a decode failure, invalidate the stale decoder runtime, force the config refresh, invalidate the player source, then retry with a forced player refresh;
+3. on a stream rejection, refresh the config first, clear decode cache only when the config changed, and apply runtime/player-source invalidation only while the rejection still matches the same successful decoder generation;
+4. preserve cancellation and do not replace TLS validation or use `trustAll` workarounds.
+
+A stream rejection that arrives after a newer successful decoder generation must not invalidate that newer generation.
+
+## Strategy health and circuit breaker
+
+The server policy defines what is allowed and its preferred order. Local strategy health may reorder only those allowed strategies.
+
+Local health tracks success/failure history, latency, consecutive failures, and temporary quarantine. Repeated resolution failures can open a circuit. A hard runtime rejection such as `403`, `410`, `429`, `LOGIN_REQUIRED`, or a signature/PoToken failure can quarantine the strategy immediately so the next resolve prefers a healthy path.
+
+An open strategy remains available as a last-resort fallback, but a mere URL-resolution success cannot close its circuit before the cooldown. After cooldown it becomes half-open; a successful canary resolution can return it to normal service.
+
+All health data stays local. Do not add user telemetry for this mechanism.
+
+## When a server-side change is enough
+
+A new APK is normally not required when the installed app already contains a healthy strategy/client and the repair only needs:
+
+- strategy reordering or disabling;
+- an allowlisted client-version change;
+- PoToken requirement/priority changes already supported by the policy;
+- a refreshed player/cipher configuration already understood by the installed decoder.
+
+## When a new APK is required
+
+Ship code only when YouTube introduces behavior the installed app cannot express, such as a new protocol, new attestation mechanism, new request/response format, or a required strategy that is not already compiled into the APK.
+
+Do not use remote configuration as remote code execution to avoid shipping an APK.
+
+## Validation before merge/release
+
+At minimum run the repository quality gate, extractor tests, Android unit tests, lint, release compile, and the F-Droid compile path. Then test on a real device:
+
+- several songs start on the first attempt;
+- native video still starts and renders;
+- a download reaches 100%;
+- a failed/rejected download can recover without corrupting the partial file;
+- offline/local playback remains unaffected.


### PR DESCRIPTION
## Summary

Completes and hardens the unfinished YouTube resilience work, preserving the currently working Android Reel playback/download baseline while making recovery more adaptive and safer.

## What changes

- Adds local per-strategy health and circuit-breaker state on top of the existing server-driven playback policy.
- Attributes hard runtime playback rejections back to the strategy that produced the failing URL, so 403/410/429/login/signature failures can quarantine the bad route immediately.
- Keeps server hard-disable authoritative while allowing local health to demote temporarily unhealthy strategies.
- Hardens remote policy parsing with expiry/app-version fencing and forward-compatible unknown strategy handling.
- Expands structured failure classification and targeted recovery for HTTP rejection, login/bot enforcement, signature/n-transform/player failures, 5xx and truncated responses.
- Makes YouTube player/decoder rejection refresh generation-safe and cancellation-safe.
- Strengthens offline resume with media identity checks before reusing a partial file and rotates rejected download URLs immediately instead of blindly retrying them.
- Adds focused unit/contract coverage and an operational YouTube recovery runbook.

## Safety

- Normal working Reel-first song/video behavior is preserved.
- Offline remains Reel-only as established by the current main branch.
- `config/playback_policy.json` is intentionally unchanged: this PR improves the engine without changing the live remote strategy for installed users.
- No OAuth/account requirement, cookies, telemetry, TLS bypass, arbitrary remote code, new remote endpoints or secrets.
- No version bump, release, tag or merge.

## Validation

Local review/validation completed on the focused diff:

- `git diff --check` ✅
- `python3 scripts/ai_quality_gate.py --profile fast --base-ref HEAD` ✅ (73 repository script tests)
- `python3 scripts/check_android_regex_compatibility.py` ✅
- Full Gradle execution could not run in the local sandbox because the Gradle wrapper could not reach `services.gradle.org` (`UnknownHostException`); GitHub CI is therefore the compile/full-test authority for this PR.

## Review notes

The original unfinished implementation was reviewed and corrected before publishing. In particular: video failures now feed strategy health, `Response code: 403` is classified correctly, age/content restrictions do not globally poison a client strategy, player-source invalidation is generation-safe, and download resume validates source identity before continuing a partial file.

Rollback is a single PR revert; the live server policy remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved playback reliability by learning which streaming methods perform best and temporarily avoiding failing methods.
  * Added safer handling for expired or app-incompatible playback settings.
  * Expanded recovery for sign-in requirements, content restrictions, unavailable videos, server errors, and interrupted streams.
  * Improved offline download resuming by validating partial files before reuse.

* **Bug Fixes**
  * Prevented stale or mismatched download data from being reused.
  * Improved stream refresh behavior after playback or download failures.
  * Preserved cancellation handling during retries.

* **Documentation**
  * Added guidance for diagnosing and recovering playback and download issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->