### PR TITLE
fix(playback): validate direct audio candidates before fallback

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -2122,9 +2122,12 @@ class PlaybackResolver private constructor(private val context: Context) {
         return true
     }
 
-    private suspend fun verifyDirectAudioUrlFast(url: String): Boolean {
+    private suspend fun verifyDirectAudioUrlFast(
+        url: String,
+        trustAttestedGoogleVideo: Boolean = true
+    ): Boolean {
         if (url.isBlank() || !streamStillFresh(url) || !isDirectAudioUrl(url)) return false
-        if (isTrustedGoogleVideoUrl(url) && url.containsQueryParameter("pot")) return true
+        if (trustAttestedGoogleVideo && isTrustedGoogleVideoUrl(url) && url.containsQueryParameter("pot")) return true
         val request = Request.Builder()
             .url(url)
             .get()
@@ -2328,7 +2331,10 @@ class PlaybackResolver private constructor(private val context: Context) {
                     streamingPoToken = poTokens?.streamingToken,
                     transformThrottling = profile.clientName.startsWith("WEB")
                 )
-                if (url.isBlank() || isPlaybackUrlBlocked(url)) continue
+                if (url.isBlank() || isPlaybackUrlBlocked(url) || !streamStillFresh(url)) continue
+                if (!isVideoMode && !preferMp4Audio &&
+                    !verifyDirectAudioUrlFast(url, trustAttestedGoogleVideo = false)
+                ) continue
                 bestAudioUrl = url
                 bestAudioLabel = label
                 bestAudioFormat = format

--- a/app/src/test/java/com/luc4n3x/levyra/data/DirectAudioFallbackContractTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/DirectAudioFallbackContractTest.kt
@@ -1,0 +1,47 @@
+package com.luc4n3x.levyra.data
+
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DirectAudioFallbackContractTest {
+    @Test
+    fun directAudioValidatesRankedCandidatesBeforeAcceptingOne() {
+        val resolver = Files.readString(sourceFile("data/PlaybackResolver.kt"))
+        val function = resolver.indexOf("private suspend fun resolveWithInnerTubeOnce")
+        val candidates = resolver.indexOf("val audioCandidates = buildList", function)
+        val loop = resolver.indexOf("for ((format, _, label) in audioCandidates)", candidates)
+        val strictProbe = resolver.indexOf(
+            "!verifyDirectAudioUrlFast(url, trustAttestedGoogleVideo = false)",
+            loop
+        )
+        val assignment = resolver.indexOf("bestAudioUrl = url", loop)
+
+        assertTrue(function >= 0)
+        assertTrue(candidates > function)
+        assertTrue(loop > candidates)
+        assertTrue(strictProbe > loop)
+        assertTrue(assignment > strictProbe)
+    }
+
+    @Test
+    fun strictCandidateProbeIsLimitedToNormalAudioFallback() {
+        val resolver = Files.readString(sourceFile("data/PlaybackResolver.kt"))
+
+        assertTrue(
+            resolver.contains(
+                "if (!isVideoMode && !preferMp4Audio &&\n" +
+                    "                    !verifyDirectAudioUrlFast(url, trustAttestedGoogleVideo = false)"
+            )
+        )
+        assertTrue(resolver.contains("trustAttestedGoogleVideo: Boolean = true"))
+    }
+
+    private fun sourceFile(relativePath: String): Path {
+        return sequenceOf(
+            Path.of("app/src/main/java/com/luc4n3x/levyra/$relativePath"),
+            Path.of("src/main/java/com/luc4n3x/levyra/$relativePath")
+        ).firstOrNull(Files::exists) ?: error("Source file not found: $relativePath")
+    }
+}


### PR DESCRIPTION
## Summary

Strengthens Levyra's existing `DIRECT` YouTube audio fallback without adding a second resolver or changing the current Reel-first playback policy.

The useful idea taken from OuterTune's former YouTube Music path is simple: **validate a candidate stream before treating the client as successful**. Levyra already had the client ladder, signature/n-transform handling, PoToken flow, format scoring and final stream probe; this PR tightens the point where an InnerTube audio candidate is chosen.

## What changes

- keeps `adaptiveFormats` audio candidates ranked by Levyra's existing quality scorer;
- for normal `DIRECT` audio playback, performs the existing bounded range probe on each ranked candidate before accepting it;
- if the highest-ranked format is rejected, stale or unusable, tries the next audio format from the **same player response** before rotating to another InnerTube client;
- preserves the existing final validation and client/strategy health accounting;
- adds a focused contract test that pins candidate validation before assignment and scopes the strict probe to normal audio fallback only.

## Intentionally unchanged

- Reel remains the normal working first route according to the current compatibility policy;
- no changes to `config/playback_policy.json` or live strategy order;
- no changes to video resolution;
- no changes to offline/download resolution;
- no client version changes;
- no new endpoint, dependency, WebView, account, cookie, telemetry, TLS bypass or token logging;
- Levyra's existing `YoutubePlaybackSecurity`, PoToken, signature and n-transform implementation remains authoritative.

## Why

Previously `DIRECT` selected the first ranked audio format that produced a URL, then the caller probed that one URL. If that format was dead, the entire client attempt was rejected even when another adaptive audio format in the same response could work. This change exhausts the useful candidates within that response first, giving `DIRECT` a more independent and resilient fallback path if Reel is ever unavailable.

## Validation

- focused contract assertions passed locally;
- `git diff --check` passed on the intended source/test diff;
- final branch diff is limited to `PlaybackResolver.kt` plus one focused test;
- GitHub CI is the compile/full-test authority.

No version bump, release, tag or merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audio playback URL verification for online audio.
  - Rejects blank, blocked, outdated, or unverified direct audio links.
  - Ensures trusted video URLs bypass additional verification only when explicitly enabled.

- **Tests**
  - Added coverage to verify strict validation and selection of fallback audio URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->