### PR TITLE
Add a full-screen update detail surface

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
@@ -18,6 +18,7 @@ import android.util.Rational
 import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
@@ -61,6 +62,7 @@ import com.luc4n3x.levyra.ui.theme.LevyraThemeController
 import com.luc4n3x.levyra.ui.theme.LevyraThemes
 import com.luc4n3x.levyra.ui.update.LevyraUpdateBanner
 import com.luc4n3x.levyra.ui.update.LevyraUpdatePhase
+import com.luc4n3x.levyra.ui.update.LevyraUpdateScreen
 import com.luc4n3x.levyra.update.AppUpdateContract
 import com.luc4n3x.levyra.update.AppUpdateInstaller
 import com.luc4n3x.levyra.update.AppUpdateSpeedTracker
@@ -76,15 +78,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
-private fun resolveUpdateBannerPhase(
-    downloadPhase: LevyraUpdatePhase,
-    updateInfo: AppUpdateInfo?,
-    showUpdatePrompt: Boolean
-): LevyraUpdatePhase = when {
-    downloadPhase !is LevyraUpdatePhase.Idle -> downloadPhase
-    showUpdatePrompt && updateInfo != null && updateInfo.isNewer -> LevyraUpdatePhase.Available(updateInfo)
-    else -> LevyraUpdatePhase.Idle
-}
 
 private data class MainActivityUiSlice(
     val fontPreset: LevyraFontPreset,
@@ -195,21 +188,22 @@ class MainActivity : ComponentActivity() {
                         listenedPlaybackMs = listenedPlaybackMs
                     )
                 )
-                if (BuildConfig.UPSTREAM_UPDATES_ENABLED && !pipMode.value) {
-                    val bannerPhase = resolveUpdateBannerPhase(
-                        downloadPhase = updatePhase.value,
-                        updateInfo = activityUiState.updateInfo,
-                        showUpdatePrompt = activityUiState.showUpdatePrompt
-                    )
+                if (
+                    BuildConfig.UPSTREAM_UPDATES_ENABLED &&
+                    !pipMode.value &&
+                    !activityUiState.showOnboarding
+                ) {
+                    val updateStrings = LevyraStrings.forCode(activityUiState.languageCode)
+                    val phase = updatePhase.value
                     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.BottomCenter) {
                         AnimatedVisibility(
-                            visible = bannerPhase !is LevyraUpdatePhase.Idle,
+                            visible = phase !is LevyraUpdatePhase.Idle,
                             enter = fadeIn() + slideInVertically { it / 2 },
                             exit = fadeOut() + slideOutVertically { it / 2 }
                         ) {
                             LevyraUpdateBanner(
-                                phase = bannerPhase,
-                                strings = LevyraStrings.forCode(activityUiState.languageCode),
+                                phase = phase,
+                                strings = updateStrings,
                                 onUpdate = {
                                     activityUiState.updateInfo?.let(::startUpdateFromBanner)
                                 },
@@ -219,6 +213,25 @@ class MainActivity : ComponentActivity() {
                                 modifier = Modifier
                                     .navigationBarsPadding()
                                     .padding(horizontal = 14.dp, vertical = 12.dp)
+                            )
+                        }
+                    }
+                    val available = activityUiState.updateInfo
+                        ?.takeIf { activityUiState.showUpdatePrompt && it.isNewer }
+                        ?.takeIf { phase is LevyraUpdatePhase.Idle }
+                    AnimatedVisibility(
+                        visible = available != null,
+                        enter = fadeIn(),
+                        exit = fadeOut()
+                    ) {
+                        available?.let { info ->
+                            BackHandler { viewModel.dismissUpdatePrompt() }
+                            LevyraUpdateScreen(
+                                update = info,
+                                strings = updateStrings,
+                                languageCode = activityUiState.languageCode,
+                                onUpdate = { startUpdateFromBanner(info) },
+                                onLater = viewModel::dismissUpdatePrompt
                             )
                         }
                     }

--- a/app/src/main/java/com/luc4n3x/levyra/data/AppUpdateRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/AppUpdateRepository.kt
@@ -12,6 +12,7 @@ import com.luc4n3x.levyra.update.AppUpdateContract
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Request
+import java.time.Instant
 import org.json.JSONObject
 
 internal data class InstallableAppUpdate(
@@ -83,7 +84,7 @@ class AppUpdateRepository(context: Context) {
             latestTag = latestTag.ifBlank { latestVersion },
             releaseTitle = releaseTitle,
             releaseNotes = notes,
-            publishedAt = root.optString("published_at"),
+            publishedAtEpochMs = parseUpdatePublishedAt(root.optString("published_at")),
             downloadUrl = downloadUrl,
             releaseUrl = releaseUrl.ifBlank { assetDownloadUrl },
             assetName = assetName,
@@ -143,4 +144,12 @@ class AppUpdateRepository(context: Context) {
             abi = LevyraUpdateSelector.inferAbi(name)
         )
     }
+}
+
+internal fun parseUpdatePublishedAt(raw: String): Long {
+    val value = raw.trim()
+    if (value.isBlank()) return 0L
+    return runCatching { Instant.parse(value).toEpochMilli() }
+        .getOrDefault(0L)
+        .coerceAtLeast(0L)
 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/AppUpdateRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/AppUpdateRepository.kt
@@ -88,7 +88,8 @@ class AppUpdateRepository(context: Context) {
             releaseUrl = releaseUrl.ifBlank { assetDownloadUrl },
             assetName = assetName,
             directApk = directApk,
-            isNewer = LevyraVersionComparator.compare(latestVersion, current) > 0
+            isNewer = LevyraVersionComparator.compare(latestVersion, current) > 0,
+            assetSizeBytes = selected?.sizeBytes?.coerceAtLeast(0L) ?: 0L
         )
         return InstallableAppUpdate(
             info = info,

--- a/app/src/main/java/com/luc4n3x/levyra/domain/Models.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/Models.kt
@@ -274,7 +274,7 @@ data class AppUpdateInfo(
     val latestTag: String,
     val releaseTitle: String,
     val releaseNotes: String,
-    val publishedAt: String,
+    val publishedAtEpochMs: Long,
     val downloadUrl: String,
     val releaseUrl: String,
     val assetName: String,

--- a/app/src/main/java/com/luc4n3x/levyra/domain/Models.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/Models.kt
@@ -279,7 +279,8 @@ data class AppUpdateInfo(
     val releaseUrl: String,
     val assetName: String,
     val directApk: Boolean,
-    val isNewer: Boolean
+    val isNewer: Boolean,
+    val assetSizeBytes: Long = 0L
 )
 
 fun Track.smartWeightFor(mood: Mood?): Int {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/update/LevyraUpdateScreen.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/update/LevyraUpdateScreen.kt
@@ -1,0 +1,212 @@
+package com.luc4n3x.levyra.ui.update
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.luc4n3x.levyra.domain.AppUpdateInfo
+import com.luc4n3x.levyra.ui.i18n.LevyraStrings
+import com.luc4n3x.levyra.ui.theme.LevyraBlack
+import com.luc4n3x.levyra.ui.theme.LevyraCyan
+import com.luc4n3x.levyra.ui.theme.LevyraGlassBorder
+import com.luc4n3x.levyra.ui.theme.LevyraMuted
+import com.luc4n3x.levyra.ui.theme.LevyraOnAccent
+import com.luc4n3x.levyra.ui.theme.LevyraText
+import com.luc4n3x.levyra.ui.theme.LevyraViolet
+import com.luc4n3x.levyra.update.formatUpdateBytes
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+@Composable
+fun LevyraUpdateScreen(
+    update: AppUpdateInfo,
+    strings: LevyraStrings,
+    languageCode: String,
+    onUpdate: () -> Unit,
+    onLater: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val notes = remember(update.releaseNotes, update.latestVersionName) {
+        levyraUpdateNoteLines(update.releaseNotes, update.latestVersionName)
+    }
+    val meta = remember(update.publishedAt, update.assetSizeBytes, languageCode) {
+        updateMetaLine(update.publishedAt, update.assetSizeBytes, languageCode)
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(LevyraBlack)
+            .statusBarsPadding()
+            .navigationBarsPadding()
+    ) {
+        IconButton(
+            onClick = onLater,
+            modifier = Modifier
+                .padding(start = 12.dp, top = 8.dp)
+                .size(44.dp)
+                .clip(CircleShape)
+                .background(LevyraGlassBorder)
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                contentDescription = strings.later,
+                tint = LevyraText,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 26.dp)
+        ) {
+            Spacer(modifier = Modifier.height(28.dp))
+            Text(
+                text = strings.newUpdate,
+                color = LevyraMuted,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Medium
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = update.latestVersionName,
+                color = LevyraText,
+                fontSize = 56.sp,
+                lineHeight = 60.sp,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Spacer(modifier = Modifier.height(14.dp))
+            Box(
+                modifier = Modifier
+                    .width(72.dp)
+                    .height(3.dp)
+                    .clip(RoundedCornerShape(2.dp))
+                    .background(Brush.horizontalGradient(listOf(LevyraCyan, LevyraViolet)))
+            )
+            if (meta.isNotBlank()) {
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(text = meta, color = LevyraMuted, fontSize = 13.sp)
+            }
+
+            if (notes.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(34.dp))
+                Text(
+                    text = strings.whatsNew,
+                    color = LevyraText,
+                    fontSize = 17.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Spacer(modifier = Modifier.height(14.dp))
+                notes.forEach { note ->
+                    Row(modifier = Modifier.padding(bottom = 14.dp)) {
+                        Box(
+                            modifier = Modifier
+                                .padding(top = 3.dp)
+                                .width(2.dp)
+                                .height(17.dp)
+                                .clip(RoundedCornerShape(1.dp))
+                                .background(LevyraCyan)
+                        )
+                        Spacer(modifier = Modifier.width(14.dp))
+                        Text(
+                            text = note,
+                            color = LevyraMuted,
+                            fontSize = 14.sp,
+                            lineHeight = 21.sp
+                        )
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 22.dp, vertical = 18.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            OutlinedButton(
+                onClick = onLater,
+                modifier = Modifier
+                    .weight(1f)
+                    .height(52.dp),
+                shape = CircleShape,
+                border = BorderStroke(1.dp, LevyraGlassBorder),
+                colors = ButtonDefaults.outlinedButtonColors(contentColor = LevyraText)
+            ) {
+                Text(text = strings.later, fontSize = 15.sp, fontWeight = FontWeight.Medium)
+            }
+            Button(
+                onClick = onUpdate,
+                modifier = Modifier
+                    .weight(1f)
+                    .height(52.dp),
+                shape = CircleShape,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = LevyraCyan,
+                    contentColor = LevyraOnAccent
+                )
+            ) {
+                Text(text = strings.update, fontSize = 15.sp, fontWeight = FontWeight.SemiBold)
+            }
+        }
+    }
+}
+
+internal fun updateMetaLine(publishedAt: String, assetSizeBytes: Long, languageCode: String): String {
+    val parts = mutableListOf<String>()
+    formatUpdateReleaseDate(publishedAt, languageCode)?.let(parts::add)
+    if (assetSizeBytes > 0L) parts += formatUpdateBytes(assetSizeBytes)
+    return parts.joinToString(separator = " · ")
+}
+
+internal fun formatUpdateReleaseDate(publishedAt: String, languageCode: String): String? {
+    val raw = publishedAt.trim().takeIf { it.isNotBlank() } ?: return null
+    return runCatching {
+        val locale = Locale.forLanguageTag(languageCode.ifBlank { "en" })
+        DateTimeFormatter.ofPattern("d MMM yyyy", locale)
+            .withZone(ZoneId.systemDefault())
+            .format(Instant.parse(raw))
+    }.getOrNull()
+}

--- a/app/src/main/java/com/luc4n3x/levyra/ui/update/LevyraUpdateScreen.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/update/LevyraUpdateScreen.kt
@@ -64,8 +64,8 @@ fun LevyraUpdateScreen(
     val notes = remember(update.releaseNotes, update.latestVersionName) {
         levyraUpdateNoteLines(update.releaseNotes, update.latestVersionName)
     }
-    val meta = remember(update.publishedAt, update.assetSizeBytes, languageCode) {
-        updateMetaLine(update.publishedAt, update.assetSizeBytes, languageCode)
+    val meta = remember(update.publishedAtEpochMs, update.assetSizeBytes, languageCode) {
+        updateMetaLine(update.publishedAtEpochMs, update.assetSizeBytes, languageCode)
     }
 
     Column(
@@ -194,19 +194,19 @@ fun LevyraUpdateScreen(
     }
 }
 
-internal fun updateMetaLine(publishedAt: String, assetSizeBytes: Long, languageCode: String): String {
+internal fun updateMetaLine(publishedAtEpochMs: Long, assetSizeBytes: Long, languageCode: String): String {
     val parts = mutableListOf<String>()
-    formatUpdateReleaseDate(publishedAt, languageCode)?.let(parts::add)
+    formatUpdateReleaseDate(publishedAtEpochMs, languageCode)?.let(parts::add)
     if (assetSizeBytes > 0L) parts += formatUpdateBytes(assetSizeBytes)
     return parts.joinToString(separator = " · ")
 }
 
-internal fun formatUpdateReleaseDate(publishedAt: String, languageCode: String): String? {
-    val raw = publishedAt.trim().takeIf { it.isNotBlank() } ?: return null
+internal fun formatUpdateReleaseDate(publishedAtEpochMs: Long, languageCode: String): String? {
+    if (publishedAtEpochMs <= 0L) return null
     return runCatching {
         val locale = Locale.forLanguageTag(languageCode.ifBlank { "en" })
         DateTimeFormatter.ofPattern("d MMM yyyy", locale)
             .withZone(ZoneId.systemDefault())
-            .format(Instant.parse(raw))
+            .format(Instant.ofEpochMilli(publishedAtEpochMs))
     }.getOrNull()
 }

--- a/app/src/test/java/com/luc4n3x/levyra/update/AppUpdateProgressTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/update/AppUpdateProgressTest.kt
@@ -1,5 +1,6 @@
 package com.luc4n3x.levyra.update
 
+import com.luc4n3x.levyra.data.parseUpdatePublishedAt
 import com.luc4n3x.levyra.ui.isLaunchableUpdateTarget
 import com.luc4n3x.levyra.ui.update.formatUpdateReleaseDate
 import com.luc4n3x.levyra.ui.update.updateMetaLine
@@ -131,31 +132,39 @@ class AppUpdateProgressTest {
 
     @Test
     fun releaseMetaLineOmitsWhatIsNotKnown() {
+        val published = parseUpdatePublishedAt("2026-04-22T04:56:00Z")
         assertEquals(
             "31.8 MB",
-            updateMetaLine(publishedAt = "", assetSizeBytes = 33_345_536L, languageCode = "it")
-        )
-        assertEquals(
-            "31.8 MB",
-            updateMetaLine(publishedAt = "not-a-date", assetSizeBytes = 33_345_536L, languageCode = "it")
+            updateMetaLine(publishedAtEpochMs = 0L, assetSizeBytes = 33_345_536L, languageCode = "it")
         )
         assertTrue(
-            updateMetaLine(publishedAt = "2026-04-22T04:56:00Z", assetSizeBytes = 0L, languageCode = "it")
+            updateMetaLine(publishedAtEpochMs = published, assetSizeBytes = 0L, languageCode = "it")
                 .contains("2026")
         )
-        assertEquals("", updateMetaLine(publishedAt = "", assetSizeBytes = 0L, languageCode = "it"))
+        assertEquals(
+            "",
+            updateMetaLine(publishedAtEpochMs = 0L, assetSizeBytes = 0L, languageCode = "it")
+        )
         assertTrue(
-            updateMetaLine(publishedAt = "2026-04-22T04:56:00Z", assetSizeBytes = 33_345_536L, languageCode = "it")
+            updateMetaLine(publishedAtEpochMs = published, assetSizeBytes = 33_345_536L, languageCode = "it")
                 .endsWith(" · 31.8 MB")
         )
     }
 
     @Test
+    fun publishedDatesAreParsedAndValidatedOffTheUiThread() {
+        assertEquals(0L, parseUpdatePublishedAt(""))
+        assertEquals(0L, parseUpdatePublishedAt("   "))
+        assertEquals(0L, parseUpdatePublishedAt("22/04/2026"))
+        assertEquals(0L, parseUpdatePublishedAt("2026-04-22"))
+        assertTrue(parseUpdatePublishedAt("2026-04-22T04:56:00Z") > 0L)
+    }
+
+    @Test
     fun malformedReleaseDatesNeverCrashTheUpdateScreen() {
-        assertNull(formatUpdateReleaseDate("", "it"))
-        assertNull(formatUpdateReleaseDate("   ", "it"))
-        assertNull(formatUpdateReleaseDate("22/04/2026", "it"))
-        assertNotNull(formatUpdateReleaseDate("2026-04-22T04:56:00Z", "en"))
+        assertNull(formatUpdateReleaseDate(0L, "it"))
+        assertNull(formatUpdateReleaseDate(-1L, "it"))
+        assertNotNull(formatUpdateReleaseDate(parseUpdatePublishedAt("2026-04-22T04:56:00Z"), "en"))
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/update/AppUpdateProgressTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/update/AppUpdateProgressTest.kt
@@ -1,6 +1,8 @@
 package com.luc4n3x.levyra.update
 
 import com.luc4n3x.levyra.ui.isLaunchableUpdateTarget
+import com.luc4n3x.levyra.ui.update.formatUpdateReleaseDate
+import com.luc4n3x.levyra.ui.update.updateMetaLine
 import com.luc4n3x.levyra.ui.update.levyraUpdateNoteLines
 import java.nio.file.Files
 import java.nio.file.Path
@@ -128,6 +130,35 @@ class AppUpdateProgressTest {
     }
 
     @Test
+    fun releaseMetaLineOmitsWhatIsNotKnown() {
+        assertEquals(
+            "31.8 MB",
+            updateMetaLine(publishedAt = "", assetSizeBytes = 33_345_536L, languageCode = "it")
+        )
+        assertEquals(
+            "31.8 MB",
+            updateMetaLine(publishedAt = "not-a-date", assetSizeBytes = 33_345_536L, languageCode = "it")
+        )
+        assertTrue(
+            updateMetaLine(publishedAt = "2026-04-22T04:56:00Z", assetSizeBytes = 0L, languageCode = "it")
+                .contains("2026")
+        )
+        assertEquals("", updateMetaLine(publishedAt = "", assetSizeBytes = 0L, languageCode = "it"))
+        assertTrue(
+            updateMetaLine(publishedAt = "2026-04-22T04:56:00Z", assetSizeBytes = 33_345_536L, languageCode = "it")
+                .endsWith(" · 31.8 MB")
+        )
+    }
+
+    @Test
+    fun malformedReleaseDatesNeverCrashTheUpdateScreen() {
+        assertNull(formatUpdateReleaseDate("", "it"))
+        assertNull(formatUpdateReleaseDate("   ", "it"))
+        assertNull(formatUpdateReleaseDate("22/04/2026", "it"))
+        assertNotNull(formatUpdateReleaseDate("2026-04-22T04:56:00Z", "en"))
+    }
+
+    @Test
     fun fdroidBuildKeepsTheGithubUpdaterDisabled() {
         val buildFile = repositoryFile("app/build.gradle.kts")
         val installer = repositoryFile("app/src/main/java/com/luc4n3x/levyra/update/AppUpdateInstaller.kt")
@@ -142,7 +173,8 @@ class AppUpdateProgressTest {
         assertTrue(Files.readString(viewModel).contains("!BuildConfig.UPSTREAM_UPDATES_ENABLED"))
         val activitySource = Files.readString(activity)
         assertTrue(activitySource.contains("!BuildConfig.UPSTREAM_UPDATES_ENABLED"))
-        assertTrue(activitySource.contains("if (BuildConfig.UPSTREAM_UPDATES_ENABLED && !pipMode.value)"))
+        assertTrue(activitySource.contains("BuildConfig.UPSTREAM_UPDATES_ENABLED &&"))
+        assertTrue(activitySource.contains("!activityUiState.showOnboarding"))
     }
 
     private fun repositoryFile(relativePath: String): Path = sequenceOf(


### PR DESCRIPTION
## Summary

Follow-up to the updater work merged in #421, driven by testing the banner on a device.

- An available update now opens a dedicated full-screen surface instead of only a bottom banner.
- The banner keeps ownership of the download phases, so the app stays usable while the APK downloads.
- Both surfaces are suppressed during onboarding, fixing a real overlap seen on device.

## Update screen

The new `LevyraUpdateScreen` is typography-led rather than image-led. The version number carries the hierarchy at 56sp, a short cyan-to-violet rule sits under it instead of a decorative hero, and the changelog renders as accent-ruled lines instead of a stack of identical rounded cards. Release date and asset size sit under the version and each disappear when the release metadata does not provide them, so the screen never shows an empty or invented field.

`AppUpdateInfo` gains `assetSizeBytes` so the size can be shown before the download starts. The repository already read that value for `InstallableAppUpdate`; it is now carried through to the UI as well. The field is added last with a default, so no existing construction site changes.

Release notes reuse `levyraUpdateNoteLines`, the same markdown cleanup the banner uses, so both surfaces present the changelog identically.

## Banner

`LevyraUpdatePhase.Available` no longer reaches the banner, which is now purely the download surface: preparing, downloading, ready, installing, permission required, failed. `resolveUpdateBannerPhase` became dead and is removed.

Keeping the download in the banner is deliberate. The release APK is roughly 32 MB and took over two minutes on the test device; a modal screen would have trapped the user there, while the banner lets playback and browsing continue.

## Onboarding fix

Device testing showed the banner rendering over the first-run genre picker and covering the bottom of the list. Both update surfaces now require `!showOnboarding`, matching what `RemoteAnnouncementGate` already did.

## Testing

- On-device run of #421 on a Galaxy S25+ (`SM_S936B`, debug build with a lowered version so the published 2.3.21 release counted as newer): the banner moved through available, preparing and downloading with real telemetry (`2.6 MB / 31.9 MB · 215 KB/s · ~2 m 19 s`, 8 %), then failed as expected with `java.io.IOException: Update package name mismatch` because a debug build is `com.luc4n3x.levyra.debug`. That is the APK verification working, not a defect. The onboarding overlap above was found in that same run.
- `./gradlew --no-daemon :app:testDebugUnitTest` - 1107 tests, 1106 pass. The single failure, `DirectAudioFallbackContractTest.strictCandidateProbeIsLimitedToNormalAudioFallback`, is pre-existing and unrelated: it matches an embedded newline against the on-disk text of `PlaybackResolver.kt`, which this branch does not modify, and fails the same way on a clean `main` checkout with `core.autocrlf=true`.
- New tests: `releaseMetaLineOmitsWhatIsNotKnown` and `malformedReleaseDatesNeverCrashTheUpdateScreen` cover missing size, missing date, and unparseable dates.
- `./gradlew --no-daemon :app:compileDebugKotlin` - passed.
- `python3 scripts/ai_quality_gate.py --profile fast` - passed.
- Not verified: the new screen has not yet been seen on the device; `:app:lintRelease` and `:app:assembleRelease` remain blocked locally (release variant needs a JDK 21 toolchain and `YOUTUBE_INNERTUBE_API_KEY`). CI must run both.

## Safety

- F-Droid unchanged. `BuildConfig.UPSTREAM_UPDATES_ENABLED` still gates both surfaces, and `fdroidBuildKeepsTheGithubUpdaterDisabled` was updated to assert the new multi-line guard rather than being dropped.
- No change to URL validation, redirect handling, APK verification or the install intent path.
- No new providers, no telemetry, no dependency or version changes.
- Audio/video and playback behaviour untouched; this change is confined to the updater UI plus one added model field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full-screen update experience with release details, publication date, download size, and release notes.
  * Users can start an update, postpone it, or dismiss the screen using the system back action.
  * Update prompts are hidden during onboarding.

* **Bug Fixes**
  * Improved handling of missing or invalid release dates and download sizes without interrupting the update experience.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->