### PR TITLE
Fix launcher icon edge clipping

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_foreground_safe.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground_safe.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@mipmap/ic_launcher_foreground"
+    android:insetLeft="8dp"
+    android:insetTop="8dp"
+    android:insetRight="8dp"
+    android:insetBottom="8dp" />

--- a/app/src/main/res/drawable/ic_launcher_monochrome_safe.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome_safe.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@mipmap/ic_launcher_monochrome"
+    android:insetLeft="8dp"
+    android:insetTop="8dp"
+    android:insetRight="8dp"
+    android:insetBottom="8dp" />

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
-    <foreground android:drawable="@mipmap/ic_launcher_foreground" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_safe" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
-    <foreground android:drawable="@mipmap/ic_launcher_foreground" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_safe" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v33/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v33/ic_launcher.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
-    <foreground android:drawable="@mipmap/ic_launcher_foreground" />
-    <monochrome android:drawable="@mipmap/ic_launcher_monochrome" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_safe" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome_safe" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v33/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v33/ic_launcher_round.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
-    <foreground android:drawable="@mipmap/ic_launcher_foreground" />
-    <monochrome android:drawable="@mipmap/ic_launcher_monochrome" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground_safe" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome_safe" />
 </adaptive-icon>


### PR DESCRIPTION
## Summary

Fixes the Levyra launcher artwork looking cropped/tight against the icon mask, as visible in the supplied Appteka publisher screenshot.

## What changed

- Added a dedicated **8dp safe inset** around the existing launcher foreground artwork.
- Applied the inset to both normal and round adaptive launcher icons on Android 8+.
- Applied the same safe treatment to the Android 13+ monochrome/themed icon layer.
- Reused the current Levyra artwork and background unchanged: no recolor, redesign, version bump, or unrelated UI change.
- Left the dedicated system splash icon untouched; it already has its own larger safe inset.

## Why

The current foreground reaches too close to the adaptive icon mask, so the outer purple/blue curves can look cut off when a launcher or app catalogue renders the APK icon. Giving the foreground a little breathing room keeps the same logo while making the silhouette read cleanly at small sizes.

## Files changed

- `app/src/main/res/drawable/ic_launcher_foreground_safe.xml`
- `app/src/main/res/drawable/ic_launcher_monochrome_safe.xml`
- `app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml`
- `app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml`
- `app/src/main/res/mipmap-anydpi-v33/ic_launcher.xml`
- `app/src/main/res/mipmap-anydpi-v33/ic_launcher_round.xml`

## Validation

- Complete resource diff reviewed against current `main`.
- Change is resource-only and preserves the existing bitmap assets/background.
- Automated Android build/resource validation is left to the PR CI.
- Final Appteka appearance can only be confirmed after a new APK containing this change is published/refreshed by Appteka.

## Risk

Low. The change only adjusts foreground padding inside adaptive launcher icons; application behavior, playback, data, versions, release configuration, and splash handling are unchanged.