### PR TITLE
fix(player): prevent native memory runaway during music playback (#427)

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackMemoryGuard.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackMemoryGuard.kt
@@ -1,0 +1,39 @@
+package com.luc4n3x.levyra.player
+
+internal object PlaybackTrackSelectionPolicy {
+    fun disableVideoTracks(videoMode: Boolean): Boolean = !videoMode
+}
+
+internal object PlaybackMemoryGuardPolicy {
+    const val SAMPLE_INTERVAL_MS = 15_000L
+    const val REQUIRED_HIGH_SAMPLES = 3
+    const val COOLDOWN_MS = 120_000L
+
+    private const val MIN_THRESHOLD_BYTES = 512L * 1024L * 1024L
+    private const val MAX_THRESHOLD_BYTES = 2048L * 1024L * 1024L
+    private const val STANDARD_FRACTION = 0.18
+    private const val LOW_RAM_FRACTION = 0.10
+
+    fun thresholdBytes(totalDeviceMemoryBytes: Long, lowRamDevice: Boolean): Long {
+        if (totalDeviceMemoryBytes <= 0L) return MIN_THRESHOLD_BYTES
+        val fraction = if (lowRamDevice) LOW_RAM_FRACTION else STANDARD_FRACTION
+        val scaled = (totalDeviceMemoryBytes.toDouble() * fraction).toLong()
+        return scaled.coerceIn(MIN_THRESHOLD_BYTES, MAX_THRESHOLD_BYTES)
+    }
+
+    fun nextHighSampleCount(current: Int, nativeAllocatedBytes: Long, thresholdBytes: Long): Int {
+        return if (nativeAllocatedBytes >= thresholdBytes) current + 1 else 0
+    }
+
+    fun shouldRecycle(
+        highSamples: Int,
+        nowElapsedMs: Long,
+        lastRecycleElapsedMs: Long,
+        requiredSamples: Int = REQUIRED_HIGH_SAMPLES,
+        cooldownMs: Long = COOLDOWN_MS
+    ): Boolean {
+        if (highSamples < requiredSamples) return false
+        if (lastRecycleElapsedMs <= 0L) return true
+        return nowElapsedMs - lastRecycleElapsedMs >= cooldownMs
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -11,6 +11,8 @@ import android.media.AudioDeviceInfo
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Bundle
+import android.app.ActivityManager
+import android.os.Debug
 import android.os.Build
 import android.os.PowerManager
 import android.os.SystemClock
@@ -101,6 +103,9 @@ class PlaybackService : MediaLibraryService() {
     private var playbackWatchdogJob: Job? = null
     private var queueTransitionJob: Job? = null
     private var queueTransitionMonitorJob: Job? = null
+    private var memoryGuardJob: Job? = null
+    private var memoryGuardHighSamples = 0
+    private var lastMemoryRecycleElapsedMs = 0L
     private var transitionPlayer: ExoPlayer? = null
     private var currentAudioSettings = LevyraAudioSettings()
     private var currentAudioNormalization = false
@@ -345,6 +350,7 @@ class PlaybackService : MediaLibraryService() {
         player.addListener(object : Player.Listener {
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
                 updatePlayerWakeMode(player, mediaItem)
+                applyPlaybackTrackSelection(player, mediaItem)
                 if (serviceRecoveryJob?.isActive != true && stickyRestoreJob?.isActive != true) {
                     serviceRecoveryExhausted = false
                     serviceRecoveryAttempts = 0
@@ -634,6 +640,7 @@ class PlaybackService : MediaLibraryService() {
         setMediaNotificationProvider(notificationProvider)
         activeService = this
         startQueueTransitionMonitor(player)
+        startMemoryGuard(player)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -1282,6 +1289,72 @@ class PlaybackService : MediaLibraryService() {
             player.currentMediaItem?.mediaMetadata?.extras?.getBoolean(EXTRA_VIDEO_MODE, false) != true
     }
 
+    private fun applyPlaybackTrackSelection(player: ExoPlayer, mediaItem: MediaItem?) {
+        val videoMode = mediaItem?.mediaMetadata?.extras?.getBoolean(EXTRA_VIDEO_MODE, false) == true
+        val disableVideo = PlaybackTrackSelectionPolicy.disableVideoTracks(videoMode)
+        runCatching {
+            player.trackSelectionParameters = player.trackSelectionParameters.buildUpon()
+                .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, disableVideo)
+                .build()
+        }.onFailure { Timber.w(it, "Track selection update failed") }
+    }
+
+    private fun startMemoryGuard(player: ExoPlayer) {
+        memoryGuardJob?.cancel()
+        val activityManager = getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        val memoryInfo = ActivityManager.MemoryInfo().also(activityManager::getMemoryInfo)
+        val threshold = PlaybackMemoryGuardPolicy.thresholdBytes(
+            totalDeviceMemoryBytes = memoryInfo.totalMem,
+            lowRamDevice = activityManager.isLowRamDevice
+        )
+        memoryGuardJob = serviceScope.launch {
+            while (isActive) {
+                delay(PlaybackMemoryGuardPolicy.SAMPLE_INTERVAL_MS)
+                if (!player.isPlaying) {
+                    memoryGuardHighSamples = 0
+                    continue
+                }
+                memoryGuardHighSamples = PlaybackMemoryGuardPolicy.nextHighSampleCount(
+                    current = memoryGuardHighSamples,
+                    nativeAllocatedBytes = Debug.getNativeHeapAllocatedSize(),
+                    thresholdBytes = threshold
+                )
+                val now = SystemClock.elapsedRealtime()
+                if (
+                    PlaybackMemoryGuardPolicy.shouldRecycle(
+                        highSamples = memoryGuardHighSamples,
+                        nowElapsedMs = now,
+                        lastRecycleElapsedMs = lastMemoryRecycleElapsedMs
+                    )
+                ) {
+                    memoryGuardHighSamples = 0
+                    lastMemoryRecycleElapsedMs = now
+                    recyclePlaybackPipeline(player, threshold)
+                }
+            }
+        }
+    }
+
+    private fun recyclePlaybackPipeline(player: ExoPlayer, thresholdBytes: Long) {
+        val item = player.currentMediaItem ?: return
+        val position = player.currentPosition.coerceAtLeast(0L)
+        val resumePlayback = player.playWhenReady
+        Timber.w(
+            "Native playback memory %d bytes above %d, recycling playback pipeline",
+            Debug.getNativeHeapAllocatedSize(),
+            thresholdBytes
+        )
+        cancelQueueTransition()
+        clearPreparedQueueNextInternal()
+        runCatching { player.stop() }.onFailure { Timber.w(it, "Memory guard stop failed") }
+        runCatching { player.clearMediaItems() }.onFailure { Timber.w(it, "Memory guard clear failed") }
+        runCatching {
+            player.setMediaItem(item, position)
+            player.prepare()
+            player.playWhenReady = resumePlayback
+        }.onFailure { Timber.w(it, "Memory guard playback restore failed") }
+    }
+
     private fun cancelQueueTransition() {
         queueTransitionJob?.cancel()
         queueTransitionJob = null
@@ -1330,6 +1403,7 @@ class PlaybackService : MediaLibraryService() {
         stickyRestoreJob?.cancel()
         playbackWatchdogJob?.cancel()
         cancelQueueTransition()
+        memoryGuardJob?.cancel()
         queueTransitionMonitorJob?.cancel()
         mediaSession?.player?.let { queueEngine.updatePosition(it.currentPosition) }
         releasePlaybackWakeLock()

--- a/app/src/test/java/com/luc4n3x/levyra/player/PlaybackMemoryGuardPolicyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/PlaybackMemoryGuardPolicyTest.kt
@@ -1,0 +1,96 @@
+package com.luc4n3x.levyra.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaybackMemoryGuardPolicyTest {
+
+    private val gib = 1024L * 1024L * 1024L
+
+    @Test
+    fun `threshold scales with device memory`() {
+        val eightGb = PlaybackMemoryGuardPolicy.thresholdBytes(8L * gib, lowRamDevice = false)
+        val twelveGb = PlaybackMemoryGuardPolicy.thresholdBytes(12L * gib, lowRamDevice = false)
+        assertTrue(twelveGb > eightGb)
+    }
+
+    @Test
+    fun `threshold stays inside safety bounds`() {
+        val tiny = PlaybackMemoryGuardPolicy.thresholdBytes(1L * gib, lowRamDevice = true)
+        val huge = PlaybackMemoryGuardPolicy.thresholdBytes(64L * gib, lowRamDevice = false)
+        assertEquals(512L * 1024L * 1024L, tiny)
+        assertEquals(2048L * 1024L * 1024L, huge)
+    }
+
+    @Test
+    fun `unknown device memory falls back to minimum threshold`() {
+        assertEquals(512L * 1024L * 1024L, PlaybackMemoryGuardPolicy.thresholdBytes(0L, lowRamDevice = false))
+    }
+
+    @Test
+    fun `low ram devices trip earlier than standard devices`() {
+        val low = PlaybackMemoryGuardPolicy.thresholdBytes(8L * gib, lowRamDevice = true)
+        val standard = PlaybackMemoryGuardPolicy.thresholdBytes(8L * gib, lowRamDevice = false)
+        assertTrue(low < standard)
+    }
+
+    @Test
+    fun `single spike does not count as sustained pressure`() {
+        val threshold = 1024L
+        val afterSpike = PlaybackMemoryGuardPolicy.nextHighSampleCount(0, 2048L, threshold)
+        assertEquals(1, afterSpike)
+        assertFalse(
+            PlaybackMemoryGuardPolicy.shouldRecycle(
+                highSamples = afterSpike,
+                nowElapsedMs = 10_000L,
+                lastRecycleElapsedMs = 0L
+            )
+        )
+    }
+
+    @Test
+    fun `sample counter resets when memory returns below threshold`() {
+        assertEquals(0, PlaybackMemoryGuardPolicy.nextHighSampleCount(2, 512L, 1024L))
+    }
+
+    @Test
+    fun `sustained pressure trips the guard`() {
+        assertTrue(
+            PlaybackMemoryGuardPolicy.shouldRecycle(
+                highSamples = PlaybackMemoryGuardPolicy.REQUIRED_HIGH_SAMPLES,
+                nowElapsedMs = 10_000L,
+                lastRecycleElapsedMs = 0L
+            )
+        )
+    }
+
+    @Test
+    fun `cooldown blocks a second recycle loop`() {
+        assertFalse(
+            PlaybackMemoryGuardPolicy.shouldRecycle(
+                highSamples = PlaybackMemoryGuardPolicy.REQUIRED_HIGH_SAMPLES,
+                nowElapsedMs = 30_000L,
+                lastRecycleElapsedMs = 10_000L
+            )
+        )
+        assertTrue(
+            PlaybackMemoryGuardPolicy.shouldRecycle(
+                highSamples = PlaybackMemoryGuardPolicy.REQUIRED_HIGH_SAMPLES,
+                nowElapsedMs = 10_000L + PlaybackMemoryGuardPolicy.COOLDOWN_MS,
+                lastRecycleElapsedMs = 10_000L
+            )
+        )
+    }
+
+    @Test
+    fun `music playback disables video tracks`() {
+        assertTrue(PlaybackTrackSelectionPolicy.disableVideoTracks(videoMode = false))
+    }
+
+    @Test
+    fun `video mode keeps video tracks enabled`() {
+        assertFalse(PlaybackTrackSelectionPolicy.disableVideoTracks(videoMode = true))
+    }
+}


### PR DESCRIPTION
Fixes #427 — *[Bug] Excessive RAM usage causes OS to kill process*

## Problem

During normal music playback and navigation, native playback memory could grow aggressively on certain content/stream sequences until Android terminated the process.

The issue was reproduced on a connected Galaxy S25+ running Android 16: repeated track transitions could push `Native Heap Alloc` from roughly 170 MB to well over 1 GB, eventually resulting in ANR/process termination.

This PR addresses the problem at the playback-pipeline level with two complementary changes.

## Fix

### 1. Music playback no longer decodes an unnecessary video track

Some YouTube music streams arrive in muxed containers. During audio-only listening, the player could still select the video track and instantiate a hardware AVC decoder together with its native codec buffers even though no video was being displayed.

`PlaybackService` now disables `TRACK_TYPE_VIDEO` for normal music items while leaving real Video Mode unchanged.

Verified on device: normal music playback now uses only the audio decoder (`c2.android.aac.decoder`) and no video decoder is created.

### 2. Native-memory protection for the playback pipeline

A lightweight `PlaybackMemoryGuardPolicy` monitors native heap usage while playback is active and reacts only to sustained abnormal growth.

- samples every 15 seconds while playback is active
- threshold scales with total device RAM (18%, 10% on low-RAM devices)
- threshold is bounded between 512 MB and 2 GB
- requires 3 consecutive high samples to ignore normal temporary spikes
- uses a 120-second cooldown to prevent recovery loops

If sustained native-memory pressure is detected, Levyra performs a controlled playback-pipeline recycle before Android has to terminate the process.

The recovery preserves the current track, playback position, play/pause state, queue, repeat/shuffle state, audio settings and metadata, then resumes playback automatically.

## Intentionally unchanged

The fix is deliberately isolated from the stream-resolution stack and unrelated playback behavior.

Unchanged:

- `PlaybackResolver`
- PipePipe/NewPipe extraction
- InnerTube client fallbacks
- PoToken and anti-bot behavior
- SABR / DASH / HLS / progressive fallback
- audio-quality selection
- original/non-dubbed audio preference
- downloads
- playback recovery rules
- crossfade / `transitionPlayer`
- normal Video Mode

## Canvas

**Canvas is untouched and remains independent from this change.**

No files under `feature/motion/` and no `MotionArtworkLayer.kt` code were modified. Canvas continues to use its existing UI-layer playback path.

The player screen was verified on device after the fix: artwork, Brano/Video toggle and transport controls all work normally.

## Validation

Connected device: **SM-S936B, Android 16**

- 32 track transitions completed with no crash, ANR or OS kill
- measured 12-transition series remained bounded:
  - PSS: **444–513 MB**
  - Native Heap Alloc: **67–107 MB**
- before the fix, the reproduced failing run showed monotonic native-memory growth into the multi-GB range
- normal music playback uses only the AAC decoder; no video decoder is instantiated
- NEXT/PREV, autoplay, queue transitions and background playback verified
- memory recovery path explicitly tested with a temporarily lowered threshold; playback recovered and remained `PLAYING`
- production thresholds restored after the test
- `PlaybackMemoryGuardPolicyTest`: **10/10 passing**
- `:app:assembleRelease` with R8/resource shrinking: **BUILD SUCCESSFUL**
- `python3 scripts/ai_quality_gate.py --profile fast`: **passed**

## Scope / validation note

The original runaway is content-dependent and was not consistently reproducible with every queue, so the fix is intentionally designed at the playback-resource level rather than around one specific song or stream sequence.

Device testing used a separate debug application ID to protect the installed production app and its data. The release variant was compile-verified successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback stability on devices experiencing sustained high memory usage.
  * Automatically recycles playback resources when memory pressure remains elevated, while restoring the current item and position when possible.
  * Video tracks are now disabled when video mode is not active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->