### PR TITLE
refactor(player): harden playback resource lifecycle

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/ExpiringCachePolicy.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/ExpiringCachePolicy.kt
@@ -1,0 +1,35 @@
+package com.luc4n3x.levyra.data
+
+import org.json.JSONObject
+
+internal fun parsePersistedCacheEntry(value: Any?): JSONObject? {
+    val raw = value as? String ?: return null
+    return runCatching { JSONObject(raw) }.getOrNull()
+}
+
+internal fun expiringCacheKeysToRemove(
+    entries: Map<String, Long>,
+    nowMs: Long,
+    maxEntries: Int,
+    incomingKey: String? = null
+): Set<String> {
+    require(maxEntries > 0)
+    val removals = entries
+        .filterValues { it <= nowMs }
+        .keys
+        .toMutableSet()
+    val retained = entries.filterKeys { it !in removals }
+    var projectedSize = retained.size + if (incomingKey != null && incomingKey !in retained) 1 else 0
+    if (projectedSize <= maxEntries) return removals
+
+    retained.entries
+        .asSequence()
+        .filter { it.key != incomingKey }
+        .sortedWith(compareBy<Map.Entry<String, Long>> { it.value }.thenBy { it.key })
+        .forEach { entry ->
+            if (projectedSize <= maxEntries) return@forEach
+            removals += entry.key
+            projectedSize -= 1
+        }
+    return removals
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraVideoStreamSelector.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraVideoStreamSelector.kt
@@ -64,18 +64,32 @@ internal fun reliableVideoCandidate(
 ): LevyraVideoCandidate? = muxed ?: videoOnly
 
 internal class LevyraVideoStreamSelector(context: Context) {
+    private companion object {
+        const val MAX_REJECTED_URLS = 128
+    }
+
     private val appContext = context.applicationContext
     private val activityManager = appContext.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
     private val connectivityManager = appContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
     private val powerManager = appContext.getSystemService(Context.POWER_SERVICE) as PowerManager
     private val decoderCapabilities by lazy { readDecoderCapabilities() }
     private val rejectedUrls = ConcurrentHashMap<String, Long>()
+    private val rejectedUrlsMutationLock = Any()
 
     fun reportPlaybackFailure(url: String, reason: String) {
         if (url.isBlank()) return
         val lower = reason.lowercase()
         val ttl = if (lower.contains("decoder") || lower.contains("codec") || lower.contains("format")) 30L * 60L * 1000L else 2L * 60L * 1000L
-        rejectedUrls[url] = System.currentTimeMillis() + ttl
+        val now = System.currentTimeMillis()
+        synchronized(rejectedUrlsMutationLock) {
+            expiringCacheKeysToRemove(
+                entries = rejectedUrls,
+                nowMs = now,
+                maxEntries = MAX_REJECTED_URLS,
+                incomingKey = url
+            ).forEach(rejectedUrls::remove)
+            rejectedUrls[url] = now + ttl
+        }
     }
 
     fun select(

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicy.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicy.kt
@@ -55,13 +55,14 @@ internal data class PlaybackCompatibilityPolicy(
 ) {
     companion object {
         const val SCHEMA = 1
-        const val BUNDLED_REVISION = 2026081801L
+        const val BUNDLED_REVISION = 2026082101L
         const val DEFAULT_ANDROID_REEL_CLIENT_VERSION = "21.03.36"
 
         fun bundled(): PlaybackCompatibilityPolicy = PlaybackCompatibilityPolicy(
             schema = SCHEMA,
             revision = BUNDLED_REVISION,
             audioStrategies = listOf(
+                PlaybackAudioStrategy.REEL_AUDIO,
                 PlaybackAudioStrategy.REEL_MUXED,
                 PlaybackAudioStrategy.PERSISTED,
                 PlaybackAudioStrategy.DIRECT,

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -272,6 +272,8 @@ class PlaybackResolver private constructor(private val context: Context) {
         private const val LEVYRA_EXTRACTOR_HLS_PROVIDER = "LevyraExtractor HLS"
         private const val AUDIO_HEALTH_MODE = "audio"
         private const val VIDEO_HEALTH_MODE = "video"
+        private const val MAX_STREAM_CACHE_ENTRIES = 128
+        private const val MAX_FAILED_PLAYBACK_URLS = 256
         private const val MAX_STRATEGY_ORIGINS = 256
         private val youtubeVideoIdRegex = Regex(YOUTUBE_VIDEO_ID_PATTERN)
         private val youtubeVideoUrlRegex = Regex("(?:v=|/shorts/|/embed/|/live/|youtu\\.be/)($YOUTUBE_VIDEO_ID_PATTERN)")
@@ -293,10 +295,12 @@ class PlaybackResolver private constructor(private val context: Context) {
     private val clientHealthPrefs = context.getSharedPreferences("levyra_innertube_client_health", Context.MODE_PRIVATE)
     private val userPreferences = LevyraPreferences(context)
     private val streamCache = ConcurrentHashMap<String, CachedStream>()
+    private val streamCacheMutationLock = Any()
     private val resolveScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val singleFlight = PlaybackSingleFlight<String, Track>(resolveScope)
     private val clientHealth = ConcurrentHashMap<String, ClientHealth>()
     private val failedPlaybackUrls = ConcurrentHashMap<String, Long>()
+    private val failedPlaybackUrlsMutationLock = Any()
     private val youtubeEngagementCache = ConcurrentHashMap<String, CachedYoutubeEngagement>()
     private val videoSelector = LevyraVideoStreamSelector(context)
     private val youtubeHttpClient = LevyraHttpClientFactory.youtubePlayer()
@@ -373,9 +377,11 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     private suspend fun clearResolvedStreamCaches() {
-        streamCache.clear()
+        synchronized(streamCacheMutationLock) {
+            streamCache.clear()
+            prefs.edit().clear().apply()
+        }
         strategyOriginByUrl.clear()
-        prefs.edit().clear().apply()
         sourceMatchStore.clearOnline()
     }
 
@@ -522,7 +528,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         val recovery = resilienceEngine.recoveryPlan(reason)
         listOf(track.streamUrl, track.videoStreamUrl)
             .filter { it.isNotBlank() }
-            .forEach { failedPlaybackUrls[it] = now + recovery.quarantineMs }
+            .forEach { quarantinePlaybackUrl(it, now + recovery.quarantineMs, now) }
         if (recovery.rotateClient) {
             profileFromSource(track.source)?.let { profile ->
                 recordClientFailure(profile, null, PlaybackBlockedException(reason))
@@ -658,6 +664,18 @@ class PlaybackResolver private constructor(private val context: Context) {
         if (until > System.currentTimeMillis()) return true
         failedPlaybackUrls.remove(url, until)
         return false
+    }
+
+    private fun quarantinePlaybackUrl(url: String, untilMs: Long, nowMs: Long) {
+        synchronized(failedPlaybackUrlsMutationLock) {
+            expiringCacheKeysToRemove(
+                entries = failedPlaybackUrls,
+                nowMs = nowMs,
+                maxEntries = MAX_FAILED_PLAYBACK_URLS,
+                incomingKey = url
+            ).forEach(failedPlaybackUrls::remove)
+            failedPlaybackUrls[url] = untilMs
+        }
     }
 
     suspend fun resolve(track: Track, isVideoMode: Boolean = false): Track {
@@ -1141,79 +1159,7 @@ class PlaybackResolver private constructor(private val context: Context) {
             )
         }
 
-        val formats = androidReelFormats(root)
-        val muxedCandidates = buildList {
-            for (i in 0 until formats.length()) {
-                val format = formats.optJSONObject(i) ?: continue
-                val mime = format.optString("mimeType")
-                if (!mime.startsWith("video/", true)) continue
-                val url = format.resolveFormatUrl(
-                    videoId = sourceVideoId,
-                    streamingPoToken = null,
-                    transformThrottling = true
-                ).takeIf { it.isNotBlank() }
-                    ?.withQueryParameterReplacing("cpn", cpn)
-                    .orEmpty()
-                if (url.isBlank() || isPlaybackUrlBlocked(url) || !streamStillFresh(url)) continue
-                add(
-                    Triple(
-                        format,
-                        url,
-                        if (format.optInt("itag", 0) == 18) Int.MIN_VALUE else format.optInt("bitrate", Int.MAX_VALUE)
-                    )
-                )
-            }
-        }.sortedBy { it.third }
-        var selectedMuxed: Triple<JSONObject, String, Int>? = null
-        for (candidate in muxedCandidates) {
-            if (verifyDirectAudioUrlFast(candidate.second)) {
-                selectedMuxed = candidate
-                break
-            }
-        }
-        val muxed = selectedMuxed
-            ?: throw YoutubePlayerRequestException(null, "Android Reel non ha restituito uno stream audio riproducibile")
-        val (muxedFormat, muxedUrl, _) = muxed
-        val details = playerResponse.optJSONObject("videoDetails")
-        val duration = details?.optString("lengthSeconds")?.toLongOrNull()?.times(1000L)
-            ?.takeIf { it > 0L }
-            ?: track.durationMs
-        val thumbnail = details
-            ?.optJSONObject("thumbnail")
-            ?.optJSONArray("thumbnails")
-            ?.bestThumbnail()
-            .orEmpty()
-            .ifBlank { track.largeThumbnailUrl.ifBlank { track.thumbnailUrl } }
-        val muxedCandidate = LevyraVideoCandidate(
-            url = muxedUrl,
-            mimeType = muxedFormat.optString("mimeType").substringBefore(';'),
-            codec = codecFromMimeType(muxedFormat.optString("mimeType")),
-            width = muxedFormat.optInt("width", 0),
-            height = muxedFormat.optInt("height", 0),
-            fps = muxedFormat.optInt("fps", 0),
-            bitrate = muxedFormat.optInt("bitrate", 0),
-            itag = muxedFormat.optInt("itag", 0),
-            muxed = true,
-            label = "android-reel-audio-fallback"
-        )
-        val manifest = buildManifest(
-            sourceVideoId = sourceVideoId,
-            provider = "YouTube Android Reel Audio",
-            durationMs = duration,
-            selectedAudioUrl = muxedUrl,
-            selectedVideoUrl = "",
-            streams = listOf(videoDescriptor(muxedCandidate, true))
-        )
-        return track.withDirectStream(
-            DirectStream(
-                url = muxedUrl,
-                videoUrl = "",
-                durationMs = duration,
-                thumbnailUrl = thumbnail,
-                source = "YouTube Android Reel Audio · muxed fallback",
-                manifest = manifest
-            )
-        )
+        throw YoutubePlayerRequestException(null, "Android Reel non ha restituito uno stream solo audio riproducibile")
     }
 
     private suspend fun resolveVideoWithAndroidReel(track: Track): Track {
@@ -2030,8 +1976,12 @@ class PlaybackResolver private constructor(private val context: Context) {
             val editor = prefs.edit()
             var modified = false
             prefs.all.forEach { (key, value) ->
-                val raw = value as? String ?: return@forEach
-                val json = runCatching { JSONObject(raw) }.getOrNull() ?: return@forEach
+                val json = parsePersistedCacheEntry(value)
+                if (json == null) {
+                    editor.remove(key)
+                    modified = true
+                    return@forEach
+                }
                 val streamUrl = json.optString("streamUrl")
                 val expiresAt = json.optLong("expiresAt", json.optLong("at", 0L) + fallbackTtlMs)
                 val manifest = PlaybackManifestCodec.decode(json.optString("manifestJson"))
@@ -2046,6 +1996,15 @@ class PlaybackResolver private constructor(private val context: Context) {
                     editor.remove(key)
                     modified = true
                 }
+            }
+            expiringCacheKeysToRemove(
+                entries = streamCache.mapValues { it.value.expiresAt },
+                nowMs = now,
+                maxEntries = MAX_STREAM_CACHE_ENTRIES
+            ).forEach { key ->
+                streamCache.remove(key)
+                editor.remove(key)
+                modified = true
             }
             if (modified) editor.apply()
         }
@@ -2066,19 +2025,43 @@ class PlaybackResolver private constructor(private val context: Context) {
             ?.takeIf { it > System.currentTimeMillis() }
             ?.let { minOf(it, expiresAtFor(resolvedTrack.streamUrl)) }
             ?: expiresAtFor(resolvedTrack.streamUrl)
-        streamCache[key] = CachedStream(resolvedTrack, expiresAt)
-        if (isVideoMode || resolvedTrack.videoStreamUrl.isNotBlank()) return
-        val json = JSONObject()
-            .put("expiresAt", expiresAt)
-            .put("streamUrl", resolvedTrack.streamUrl)
-            .put("manifestJson", resolvedTrack.playbackManifest?.let(PlaybackManifestCodec::encode).orEmpty())
-            .put("track", TrackJson.toJson(resolvedTrack.copy(streamUrl = "", playbackManifest = null)))
-        prefs.edit().putString(key, json.toString()).apply()
+        val persistedValue = if (isVideoMode || resolvedTrack.videoStreamUrl.isNotBlank()) {
+            null
+        } else {
+            JSONObject()
+                .put("expiresAt", expiresAt)
+                .put("streamUrl", resolvedTrack.streamUrl)
+                .put("manifestJson", resolvedTrack.playbackManifest?.let(PlaybackManifestCodec::encode).orEmpty())
+                .put("track", TrackJson.toJson(resolvedTrack.copy(streamUrl = "", playbackManifest = null)))
+                .toString()
+        }
+        synchronized(streamCacheMutationLock) {
+            val editor = prefs.edit()
+            var preferencesChanged = false
+            expiringCacheKeysToRemove(
+                entries = streamCache.mapValues { it.value.expiresAt },
+                nowMs = System.currentTimeMillis(),
+                maxEntries = MAX_STREAM_CACHE_ENTRIES,
+                incomingKey = key
+            ).forEach { expiredKey ->
+                streamCache.remove(expiredKey)
+                editor.remove(expiredKey)
+                preferencesChanged = true
+            }
+            streamCache[key] = CachedStream(resolvedTrack, expiresAt)
+            if (persistedValue != null) {
+                editor.putString(key, persistedValue)
+                preferencesChanged = true
+            }
+            if (preferencesChanged) editor.apply()
+        }
     }
 
     private fun remove(key: String) {
-        streamCache.remove(key)
-        prefs.edit().remove(key).apply()
+        synchronized(streamCacheMutationLock) {
+            streamCache.remove(key)
+            prefs.edit().remove(key).apply()
+        }
     }
 
     private fun isFresh(expiresAt: Long): Boolean = System.currentTimeMillis() < expiresAt

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -26,6 +26,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
@@ -55,6 +57,7 @@ import java.security.SecureRandom
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
 internal const val EDITORIAL_ARTWORK_LOCK_TAG = "editorial-artwork-lock"
@@ -296,6 +299,7 @@ class PlaybackResolver private constructor(private val context: Context) {
     private val userPreferences = LevyraPreferences(context)
     private val streamCache = ConcurrentHashMap<String, CachedStream>()
     private val streamCacheMutationLock = Any()
+    private val resolverGeneration = AtomicLong(0L)
     private val resolveScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val singleFlight = PlaybackSingleFlight<String, Track>(resolveScope)
     private val clientHealth = ConcurrentHashMap<String, ClientHealth>()
@@ -315,6 +319,7 @@ class PlaybackResolver private constructor(private val context: Context) {
     private val strategyHealth = PlaybackStrategyHealthStore(context)
     private val strategyOriginByUrl = ConcurrentHashMap<String, PlaybackStrategyOrigin>()
     private val sourceMatchStore = PlaybackSourceMatchStore(LevyraDatabase.get(context).playbackSourceMatchDao())
+    private val sourceMatchMutationMutex = Mutex()
     private val sourceMatchScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val fallbackTtlMs = 90L * 60L * 1000L
     private val maxTtlMs = 5L * 60L * 60L * 1000L
@@ -377,12 +382,15 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     private suspend fun clearResolvedStreamCaches() {
-        synchronized(streamCacheMutationLock) {
-            streamCache.clear()
-            prefs.edit().clear().apply()
+        sourceMatchMutationMutex.withLock {
+            synchronized(streamCacheMutationLock) {
+                resolverGeneration.incrementAndGet()
+                streamCache.clear()
+                prefs.edit().clear().apply()
+                strategyOriginByUrl.clear()
+            }
+            sourceMatchStore.clearOnline()
         }
-        strategyOriginByUrl.clear()
-        sourceMatchStore.clearOnline()
     }
 
     private fun normalizeAudioQuality(value: String): String {
@@ -573,12 +581,20 @@ class PlaybackResolver private constructor(private val context: Context) {
         }
     }
 
-    private fun rememberStrategyOrigin(track: Track, mode: String, strategy: String) {
-        if (strategyOriginByUrl.size >= MAX_STRATEGY_ORIGINS) strategyOriginByUrl.clear()
-        val origin = PlaybackStrategyOrigin(mode, strategy)
-        listOf(track.streamUrl, track.videoStreamUrl)
-            .filter { it.isNotBlank() }
-            .forEach { strategyOriginByUrl[strategyOriginKey(mode, it)] = origin }
+    private fun rememberStrategyOrigin(
+        track: Track,
+        mode: String,
+        strategy: String,
+        expectedGeneration: Long
+    ) {
+        synchronized(streamCacheMutationLock) {
+            if (resolverGeneration.get() != expectedGeneration) return
+            if (strategyOriginByUrl.size >= MAX_STRATEGY_ORIGINS) strategyOriginByUrl.clear()
+            val origin = PlaybackStrategyOrigin(mode, strategy)
+            listOf(track.streamUrl, track.videoStreamUrl)
+                .filter { it.isNotBlank() }
+                .forEach { strategyOriginByUrl[strategyOriginKey(mode, it)] = origin }
+        }
     }
 
     private fun strategyOriginFor(track: Track, isVideoMode: Boolean): PlaybackStrategyOrigin? {
@@ -726,6 +742,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         if (requestKind == "playback") {
             refreshPlaybackPolicyInBackground(force = false, reason = "resolve")
         }
+        val expectedGeneration = resolverGeneration.get()
         if (isLocalPlaybackTrack(track)) {
             if (!isLocalPlaybackUri(track.streamUrl)) {
                 throw PlaybackBlockedException("File offline non disponibile per ${track.title}")
@@ -760,19 +777,28 @@ class PlaybackResolver private constructor(private val context: Context) {
                     preferMp4Audio = preferMp4Audio,
                     audioQuality = audioQuality,
                     errors = mutableListOf(),
-                    allowNetworkRefresh = false
-                )?.also { store(offlineTrack, it, isVideoMode, audioQuality, preferMp4Audio) }
+                    allowNetworkRefresh = false,
+                    expectedGeneration = expectedGeneration
+                )?.also {
+                    store(offlineTrack, it, isVideoMode, audioQuality, preferMp4Audio, expectedGeneration)
+                }
             }
             restored?.let { return@coroutineScope it }
             throw PlaybackBlockedException("Connessione Internet non disponibile")
         }
 
-        val key = "${cacheKey(track, isVideoMode, audioQuality)}_$requestKind"
+        val key = "${cacheKey(track, isVideoMode, audioQuality)}_${requestKind}_$expectedGeneration"
         Timber.d("resolver start kind=%s mode=%s id=%s quality=%s", requestKind, if (isVideoMode) "video" else "audio", track.id, audioQuality)
         return@coroutineScope singleFlight.run(key) {
             try {
                 withTimeout(timeoutMs) {
-                    resolveUncached(track.copy(streamUrl = "", videoStreamUrl = ""), isVideoMode, preferMp4Audio, audioQuality)
+                    resolveUncached(
+                        track.copy(streamUrl = "", videoStreamUrl = ""),
+                        isVideoMode,
+                        preferMp4Audio,
+                        audioQuality,
+                        expectedGeneration
+                    )
                 }
             } catch (error: TimeoutCancellationException) {
                 val label = if (requestKind == "offline") "Download" else "YouTube"
@@ -787,7 +813,7 @@ class PlaybackResolver private constructor(private val context: Context) {
             if (!isVideoMode && !isPlayableAudioUrl(track.streamUrl)) return null
             if (isVideoMode && !track.hasVideoPlaybackPayload()) return null
             if (streamStillFresh(track.streamUrl)) {
-                store(track, track, isVideoMode)
+                store(track, track, isVideoMode, expectedGeneration = resolverGeneration.get())
                 return track
             }
             return null
@@ -801,12 +827,13 @@ class PlaybackResolver private constructor(private val context: Context) {
         track: Track,
         isVideoMode: Boolean = false,
         preferMp4Audio: Boolean = false,
-        audioQuality: String = selectedAudioQuality
+        audioQuality: String = selectedAudioQuality,
+        expectedGeneration: Long
     ): Track = withContext(Dispatchers.IO) {
         val errors = Collections.synchronizedList(mutableListOf<String>())
 
         if (!preferMp4Audio && !isVideoMode) {
-            val resolved = resolveAudioByCompatibilityPolicy(track, audioQuality, errors)
+            val resolved = resolveAudioByCompatibilityPolicy(track, audioQuality, errors, expectedGeneration)
             if (resolved != null) return@withContext resolved
 
             val reason = errors.firstOrNull { it.startsWith("LevyraExtractor:") }
@@ -827,14 +854,21 @@ class PlaybackResolver private constructor(private val context: Context) {
         }
 
         if (preferMp4Audio) {
-            restorePersistentSource(track, isVideoMode, preferMp4Audio, audioQuality, errors)?.let { restored ->
-                store(track, restored, isVideoMode, audioQuality, preferMp4Audio)
+            restorePersistentSource(
+                track,
+                isVideoMode,
+                preferMp4Audio,
+                audioQuality,
+                errors,
+                expectedGeneration = expectedGeneration
+            )?.let { restored ->
+                store(track, restored, isVideoMode, audioQuality, preferMp4Audio, expectedGeneration)
                 return@withContext restored
             }
         }
 
         if (isVideoMode) {
-            val resolved = resolveVideoByCompatibilityPolicy(track, audioQuality, errors)
+            val resolved = resolveVideoByCompatibilityPolicy(track, audioQuality, errors, expectedGeneration)
             if (resolved != null) return@withContext resolved
 
             val reason = errors.firstOrNull { it.contains("age", true) || it.contains("login", true) }
@@ -845,15 +879,31 @@ class PlaybackResolver private constructor(private val context: Context) {
 
         val resolved = resolveAudioFast(track, errors, preferMp4Audio, audioQuality)
         if (resolved != null) {
-            store(track, resolved, isVideoMode, audioQuality, preferMp4Audio)
-            persistResolvedSource(track, resolved, isVideoMode, audioQuality, 90, preferMp4Audio)
+            store(track, resolved, isVideoMode, audioQuality, preferMp4Audio, expectedGeneration)
+            persistResolvedSource(
+                track,
+                resolved,
+                isVideoMode,
+                audioQuality,
+                90,
+                preferMp4Audio,
+                expectedGeneration
+            )
             return@withContext resolved
         }
 
         val alternate = resolveAudioWithSearchFallback(track, errors, preferMp4Audio, audioQuality)
         if (alternate != null) {
-            store(track, alternate, isVideoMode, audioQuality, preferMp4Audio)
-            persistResolvedSource(track, alternate, isVideoMode, audioQuality, 84, preferMp4Audio)
+            store(track, alternate, isVideoMode, audioQuality, preferMp4Audio, expectedGeneration)
+            persistResolvedSource(
+                track,
+                alternate,
+                isVideoMode,
+                audioQuality,
+                84,
+                preferMp4Audio,
+                expectedGeneration
+            )
             return@withContext alternate
         }
 
@@ -872,7 +922,8 @@ class PlaybackResolver private constructor(private val context: Context) {
     private suspend fun resolveAudioByCompatibilityPolicy(
         track: Track,
         audioQuality: String,
-        errors: MutableList<String>
+        errors: MutableList<String>,
+        expectedGeneration: Long
     ): Track? {
         val policy = playbackPolicyStore.current()
         for (strategy in strategyHealth.order(AUDIO_HEALTH_MODE, policy.audioStrategies)) {
@@ -897,7 +948,8 @@ class PlaybackResolver private constructor(private val context: Context) {
                     isVideoMode = false,
                     preferMp4Audio = false,
                     audioQuality = audioQuality,
-                    errors = errors
+                    errors = errors,
+                    expectedGeneration = expectedGeneration
                 )
 
                 PlaybackAudioStrategy.DIRECT -> resolveAudioFast(
@@ -917,8 +969,8 @@ class PlaybackResolver private constructor(private val context: Context) {
             val elapsedMs = System.currentTimeMillis() - startedAt
             if (resolved != null) {
                 strategyHealth.recordSuccess(AUDIO_HEALTH_MODE, strategy.name, elapsedMs)
-                rememberStrategyOrigin(resolved, AUDIO_HEALTH_MODE, strategy.name)
-                store(track, resolved, false, audioQuality, false)
+                rememberStrategyOrigin(resolved, AUDIO_HEALTH_MODE, strategy.name, expectedGeneration)
+                store(track, resolved, false, audioQuality, false, expectedGeneration)
                 val confidence = when (strategy) {
                     PlaybackAudioStrategy.REEL_MUXED,
                     PlaybackAudioStrategy.REEL_AUDIO -> 96
@@ -927,7 +979,15 @@ class PlaybackResolver private constructor(private val context: Context) {
                     PlaybackAudioStrategy.PERSISTED -> null
                 }
                 confidence?.let {
-                    persistResolvedSource(track, resolved, false, audioQuality, it, false)
+                    persistResolvedSource(
+                        track,
+                        resolved,
+                        false,
+                        audioQuality,
+                        it,
+                        false,
+                        expectedGeneration
+                    )
                 }
                 return resolved
             }
@@ -947,7 +1007,8 @@ class PlaybackResolver private constructor(private val context: Context) {
     private suspend fun resolveVideoByCompatibilityPolicy(
         track: Track,
         audioQuality: String,
-        errors: MutableList<String>
+        errors: MutableList<String>,
+        expectedGeneration: Long
     ): Track? {
         val policy = playbackPolicyStore.current()
         for (strategy in strategyHealth.order(VIDEO_HEALTH_MODE, policy.videoStrategies)) {
@@ -960,7 +1021,8 @@ class PlaybackResolver private constructor(private val context: Context) {
                     isVideoMode = true,
                     preferMp4Audio = false,
                     audioQuality = audioQuality,
-                    errors = errors
+                    errors = errors,
+                    expectedGeneration = expectedGeneration
                 )
 
                 PlaybackVideoStrategy.STANDARD -> resolveStandardVideo(track, audioQuality, errors)
@@ -973,8 +1035,8 @@ class PlaybackResolver private constructor(private val context: Context) {
             val elapsedMs = System.currentTimeMillis() - startedAt
             if (resolved != null) {
                 strategyHealth.recordSuccess(VIDEO_HEALTH_MODE, strategy.name, elapsedMs)
-                rememberStrategyOrigin(resolved, VIDEO_HEALTH_MODE, strategy.name)
-                store(track, resolved, true, audioQuality)
+                rememberStrategyOrigin(resolved, VIDEO_HEALTH_MODE, strategy.name, expectedGeneration)
+                store(track, resolved, true, audioQuality, expectedGeneration = expectedGeneration)
                 val confidence = when (strategy) {
                     PlaybackVideoStrategy.PERSISTED -> null
                     PlaybackVideoStrategy.STANDARD -> 92
@@ -987,7 +1049,8 @@ class PlaybackResolver private constructor(private val context: Context) {
                         isVideoMode = true,
                         audioQuality = audioQuality,
                         confidence = it,
-                        preferMp4Audio = false
+                        preferMp4Audio = false,
+                        expectedGeneration = expectedGeneration
                     )
                 }
                 return resolved
@@ -1432,7 +1495,8 @@ class PlaybackResolver private constructor(private val context: Context) {
         preferMp4Audio: Boolean,
         audioQuality: String,
         errors: MutableList<String>,
-        allowNetworkRefresh: Boolean = true
+        allowNetworkRefresh: Boolean = true,
+        expectedGeneration: Long
     ): Track? {
         val stored = runCatchingPreservingCancellation { sourceMatchStore.load(track, isVideoMode, audioQuality, preferMp4Audio) }
             .onFailure { error ->
@@ -1484,7 +1548,8 @@ class PlaybackResolver private constructor(private val context: Context) {
             isVideoMode,
             audioQuality,
             stored.entity.confidence.coerceAtLeast(88),
-            preferMp4Audio
+            preferMp4Audio,
+            expectedGeneration
         )
         return rebased
     }
@@ -1603,16 +1668,20 @@ class PlaybackResolver private constructor(private val context: Context) {
         isVideoMode: Boolean,
         audioQuality: String,
         confidence: Int,
-        preferMp4Audio: Boolean = false
+        preferMp4Audio: Boolean = false,
+        expectedGeneration: Long
     ) {
         val manifest = resolved.playbackManifest ?: return
         if (preferMp4Audio && !supportsOfflineExport(manifest)) return
-        try {
-            sourceMatchStore.save(original, resolved, isVideoMode, audioQuality, confidence, preferMp4Audio)
-        } catch (error: CancellationException) {
-            throw error
-        } catch (error: Throwable) {
-            Timber.w(error, "persistent source match save failed")
+        sourceMatchMutationMutex.withLock {
+            if (resolverGeneration.get() != expectedGeneration) return
+            try {
+                sourceMatchStore.save(original, resolved, isVideoMode, audioQuality, confidence, preferMp4Audio)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                Timber.w(error, "persistent source match save failed")
+            }
         }
     }
 
@@ -2015,7 +2084,8 @@ class PlaybackResolver private constructor(private val context: Context) {
         resolvedTrack: Track,
         isVideoMode: Boolean = false,
         audioQuality: String = selectedAudioQuality,
-        preferMp4Audio: Boolean = false
+        preferMp4Audio: Boolean = false,
+        expectedGeneration: Long
     ) {
         if (preferMp4Audio) return
         if (resolvedTrack.streamUrl.isBlank() || !streamStillFresh(resolvedTrack.streamUrl)) return
@@ -2036,6 +2106,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 .toString()
         }
         synchronized(streamCacheMutationLock) {
+            if (resolverGeneration.get() != expectedGeneration) return
             val editor = prefs.edit()
             var preferencesChanged = false
             expiringCacheKeysToRemove(

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackStrategyHealth.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackStrategyHealth.kt
@@ -77,6 +77,7 @@ internal fun <T : Enum<T>> orderPlaybackStrategiesByHealth(
     nowMs: Long
 ): List<T> {
     if (strategies.size <= 1) return strategies
+    if (statsFor(strategies.first().name) == null) return strategies
     val hasHealthData = strategies.any { statsFor(it.name) != null }
     if (!hasHealthData) return strategies
 

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -14,6 +14,7 @@ import android.os.Bundle
 import android.app.ActivityManager
 import android.os.Debug
 import android.os.Build
+import android.os.Handler
 import android.os.PowerManager
 import android.os.SystemClock
 import androidx.media3.common.AudioAttributes
@@ -31,15 +32,18 @@ import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.Renderer
 import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.audio.DefaultAudioSink
 import androidx.media3.exoplayer.dash.DashMediaSource
 import androidx.media3.exoplayer.hls.HlsMediaSource
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.MergingMediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
+import androidx.media3.exoplayer.video.VideoRendererEventListener
 import androidx.media3.session.CommandButton
 import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.LibraryResult
@@ -82,6 +86,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import timber.log.Timber
 import java.io.IOException
+import java.util.ArrayList
 
 @UnstableApi
 class PlaybackService : MediaLibraryService() {
@@ -110,6 +115,12 @@ class PlaybackService : MediaLibraryService() {
     private var transitionPlayer: ExoPlayer? = null
     private var currentAudioSettings = LevyraAudioSettings()
     private var currentAudioNormalization = false
+    private val normalizationProcessor = NormalizationAudioProcessor()
+    private val equalizerProcessor = LevyraEqualizerAudioProcessor()
+    private val spatialAudioProcessor = StereoSpatialAudioProcessor()
+    private val limiterProcessor = TruePeakLimiterAudioProcessor()
+    private val visualizerProcessor = VisualizerAudioProcessor()
+    private val pcm16OutputProcessor = Pcm16OutputAudioProcessor()
     private lateinit var playbackWakeLock: PowerManager.WakeLock
     private lateinit var playbackStateStore: SharedPreferences
     private var serviceRecoveryAttempts = 0
@@ -185,6 +196,10 @@ class PlaybackService : MediaLibraryService() {
         @Volatile
         private var activeService: PlaybackService? = null
 
+        private val premiumAudioSettingsLock = Any()
+        private var pendingAudioSettings: LevyraAudioSettings? = null
+        private var pendingAudioNormalization = false
+
         @Volatile
         private var uiRecoveryAvailable = false
 
@@ -223,27 +238,16 @@ class PlaybackService : MediaLibraryService() {
         var isQueueTransitionInProgress: Boolean = false
             private set
 
-        val normalizationProcessor = NormalizationAudioProcessor()
-        val equalizerProcessor = LevyraEqualizerAudioProcessor()
-        val spatialAudioProcessor = StereoSpatialAudioProcessor()
-        val limiterProcessor = TruePeakLimiterAudioProcessor()
-        val visualizerProcessor = VisualizerAudioProcessor()
-        val pcm16OutputProcessor = Pcm16OutputAudioProcessor()
-
         fun applyPremiumAudioSettings(
             settings: LevyraAudioSettings,
             audioNormalization: Boolean
         ) {
             val normalized = settings.normalized()
-            equalizerProcessor.enabled = normalized.equalizerEnabled
-            equalizerProcessor.setBandLevels(normalized.bandLevels)
-            equalizerProcessor.bassBoost = normalized.bassBoost
-            equalizerProcessor.preampDb = normalized.preampDb
-            spatialAudioProcessor.strength = if (normalized.equalizerEnabled) normalized.virtualizer else 0
-            limiterProcessor.enabled = normalized.limiterEnabled &&
-                (normalized.equalizerEnabled || normalized.virtualizer > 0 ||
-                    normalized.replayGainEnabled || audioNormalization)
-            activeService?.updateQueueTransitionSettings(normalized, audioNormalization)
+            synchronized(premiumAudioSettingsLock) {
+                pendingAudioSettings = normalized
+                pendingAudioNormalization = audioNormalization
+                activeService?.applyPremiumAudioSettingsInternal(normalized, audioNormalization)
+            }
         }
     }
 
@@ -251,6 +255,32 @@ class PlaybackService : MediaLibraryService() {
     private val queueShuffleCommand by lazy { SessionCommand("levyra.queue.shuffle", Bundle.EMPTY) }
     private val queueLikeCommand by lazy { SessionCommand("levyra.favorite.like", Bundle.EMPTY) }
     private val platformTokenCommand by lazy { SessionCommand(ACTION_GET_PLATFORM_TOKEN, Bundle.EMPTY) }
+
+    private fun applyPremiumAudioSettingsInternal(
+        settings: LevyraAudioSettings,
+        audioNormalization: Boolean
+    ) {
+        val normalized = settings.normalized()
+        normalizationProcessor.enabled = audioNormalization || normalized.replayGainEnabled
+        equalizerProcessor.enabled = normalized.equalizerEnabled
+        equalizerProcessor.setBandLevels(normalized.bandLevels)
+        equalizerProcessor.bassBoost = normalized.bassBoost
+        equalizerProcessor.preampDb = normalized.preampDb
+        spatialAudioProcessor.strength = if (normalized.equalizerEnabled) normalized.virtualizer else 0
+        limiterProcessor.enabled = normalized.limiterEnabled &&
+            (normalized.equalizerEnabled || normalized.virtualizer > 0 ||
+                normalized.replayGainEnabled || audioNormalization)
+        updateQueueTransitionSettings(normalized, audioNormalization)
+    }
+
+    private fun activateServiceAndApplyPendingAudioSettings() {
+        synchronized(premiumAudioSettingsLock) {
+            activeService = this
+            pendingAudioSettings?.let { settings ->
+                applyPremiumAudioSettingsInternal(settings, pendingAudioNormalization)
+            }
+        }
+    }
 
     override fun onCreate() {
         super.onCreate()
@@ -348,8 +378,7 @@ class PlaybackService : MediaLibraryService() {
         currentAudioSettings = snapshot.audioSettings.normalized()
         currentAudioNormalization = snapshot.audioNormalization
         player.skipSilenceEnabled = snapshot.skipSilence
-        normalizationProcessor.enabled = snapshot.audioNormalization || snapshot.audioSettings.replayGainEnabled
-        applyPremiumAudioSettings(snapshot.audioSettings, snapshot.audioNormalization)
+        applyPremiumAudioSettingsInternal(snapshot.audioSettings, snapshot.audioNormalization)
         (getSystemService(Context.AUDIO_SERVICE) as AudioManager).registerAudioDeviceCallback(audioDeviceCallback, null)
         refreshAudioOutputProfile()
 
@@ -651,7 +680,7 @@ class PlaybackService : MediaLibraryService() {
 
         val notificationProvider = DefaultMediaNotificationProvider(this)
         setMediaNotificationProvider(notificationProvider)
-        activeService = this
+        activateServiceAndApplyPendingAudioSettings()
         startQueueTransitionMonitor(player)
         startMemoryGuard(player)
     }
@@ -1127,13 +1156,7 @@ class PlaybackService : MediaLibraryService() {
         } finally {
             isQueueTransitionInProgress = false
             primary.volume = 1f
-            if (transitionPlayer === secondary) {
-                transitionPlayer = null
-                secondary?.let { player ->
-                    runCatching { player.release() }
-                        .onFailure { Timber.w(it, "Queue crossfade secondary release failed") }
-                }
-            }
+            releaseTransitionPlayer(secondary)
         }
     }
 
@@ -1237,6 +1260,17 @@ class PlaybackService : MediaLibraryService() {
                     currentAudioSettings.replayGainEnabled || currentAudioNormalization)
         }
         val renderers = object : DefaultRenderersFactory(this) {
+            override fun buildVideoRenderers(
+                context: Context,
+                extensionRendererMode: Int,
+                mediaCodecSelector: MediaCodecSelector,
+                enableDecoderFallback: Boolean,
+                eventHandler: Handler,
+                eventListener: VideoRendererEventListener,
+                allowedVideoJoiningTimeMs: Long,
+                out: ArrayList<Renderer>
+            ) = Unit
+
             override fun buildAudioSink(
                 context: Context,
                 enableFloatOutput: Boolean,
@@ -1327,9 +1361,14 @@ class PlaybackService : MediaLibraryService() {
                     memoryGuardHighSamples = 0
                     continue
                 }
+                val nativeAllocatedBytes = withContext(Dispatchers.Default) { Debug.getNativeHeapAllocatedSize() }
+                if (activePlayer !== player || !player.isPlaying) {
+                    memoryGuardHighSamples = 0
+                    continue
+                }
                 memoryGuardHighSamples = PlaybackMemoryGuardPolicy.nextHighSampleCount(
                     current = memoryGuardHighSamples,
-                    nativeAllocatedBytes = Debug.getNativeHeapAllocatedSize(),
+                    nativeAllocatedBytes = nativeAllocatedBytes,
                     thresholdBytes = threshold
                 )
                 val now = SystemClock.elapsedRealtime()
@@ -1342,19 +1381,23 @@ class PlaybackService : MediaLibraryService() {
                 ) {
                     memoryGuardHighSamples = 0
                     lastMemoryRecycleElapsedMs = now
-                    recyclePlaybackPipeline(player, threshold)
+                    recyclePlaybackPipeline(player, threshold, nativeAllocatedBytes)
                 }
             }
         }
     }
 
-    private fun recyclePlaybackPipeline(player: ExoPlayer, thresholdBytes: Long) {
+    private fun recyclePlaybackPipeline(
+        player: ExoPlayer,
+        thresholdBytes: Long,
+        nativeAllocatedBytes: Long
+    ) {
         val item = player.currentMediaItem ?: return
         val position = player.currentPosition.coerceAtLeast(0L)
         val resumePlayback = player.playWhenReady
         Timber.w(
             "Native playback memory %d bytes above %d, recycling playback pipeline",
-            Debug.getNativeHeapAllocatedSize(),
+            nativeAllocatedBytes,
             thresholdBytes
         )
         cancelQueueTransition()
@@ -1371,16 +1414,21 @@ class PlaybackService : MediaLibraryService() {
     private fun cancelQueueTransition() {
         queueTransitionJob?.cancel()
         queueTransitionJob = null
-        val secondary = transitionPlayer
-        transitionPlayer = null
         isQueueTransitionInProgress = false
         activePlayer?.volume = 1f
-        secondary?.let { player ->
-            runCatching {
-                player.pause()
-                player.release()
-            }.onFailure { Timber.w(it, "Queue crossfade cancellation release failed") }
-        }
+        releaseTransitionPlayer()
+    }
+
+    private fun releaseTransitionPlayer(expected: ExoPlayer? = null) {
+        val player = transitionPlayer ?: return
+        if (expected != null && player !== expected) return
+        transitionPlayer = null
+        runCatching { player.pause() }
+            .onFailure { Timber.w(it, "Queue crossfade secondary pause failed") }
+        runCatching { player.clearMediaItems() }
+            .onFailure { Timber.w(it, "Queue crossfade secondary clear failed") }
+        runCatching { player.release() }
+            .onFailure { Timber.w(it, "Queue crossfade secondary release failed") }
     }
 
     override fun onTrimMemory(level: Int) {
@@ -1419,7 +1467,9 @@ class PlaybackService : MediaLibraryService() {
         queueTransitionMonitorJob?.cancel()
         mediaSession?.player?.let { queueEngine.updatePosition(it.currentPosition) }
         releasePlaybackWakeLock()
-        if (activeService === this) activeService = null
+        synchronized(premiumAudioSettingsLock) {
+            if (activeService === this) activeService = null
+        }
         if (::autoLibrary.isInitialized) autoLibrary.close()
         serviceScope.cancel()
         mediaSession?.run {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -2278,8 +2278,6 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             delay(120L)
             audioSettingsPersistence.persist(normalized)
         }
-        com.luc4n3x.levyra.player.PlaybackService.normalizationProcessor.enabled =
-            audioNormalization || normalized.replayGainEnabled
         player.setPremiumAudioSettings(normalized, audioNormalization)
         player.setPlayback(normalized.playbackSpeed, normalized.pitch)
         _state.update { it.copy(audioSettings = normalized, playbackSpeed = normalized.playbackSpeed, audioNormalization = audioNormalization) }
@@ -3047,7 +3045,6 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         player.setSkipSilence(snapshot.skipSilence)
         player.setPremiumAudioSettings(snapshot.audioSettings, snapshot.audioNormalization)
         player.setPlayback(snapshot.audioSettings.playbackSpeed, snapshot.audioSettings.pitch)
-        com.luc4n3x.levyra.player.PlaybackService.normalizationProcessor.enabled = snapshot.audioNormalization || snapshot.audioSettings.replayGainEnabled
         resolver.setAudioQuality(snapshot.audioQuality)
         withContext(Dispatchers.IO) {
             queueEngine.restore(

--- a/app/src/test/java/com/luc4n3x/levyra/data/ExpiringCachePolicyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/ExpiringCachePolicyTest.kt
@@ -1,0 +1,87 @@
+package com.luc4n3x.levyra.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ExpiringCachePolicyTest {
+    @Test
+    fun `persisted cache parser rejects malformed and non string entries`() {
+        assertNull(parsePersistedCacheEntry(42L))
+        assertNull(parsePersistedCacheEntry("{not-json"))
+        assertNotNull(parsePersistedCacheEntry("""{"expiresAt": 100}"""))
+    }
+
+    @Test
+    fun `expired entries provide capacity before live entries are evicted`() {
+        val entries = mapOf(
+            "expired" to 10L,
+            "older-live" to 30L,
+            "newer-live" to 40L
+        )
+
+        val removed = expiringCacheKeysToRemove(
+            entries = entries,
+            nowMs = 20L,
+            maxEntries = 3,
+            incomingKey = "incoming"
+        )
+
+        assertEquals(setOf("expired"), removed)
+    }
+
+    @Test
+    fun `earliest expiry is evicted when a new entry reaches capacity`() {
+        val entries = mapOf(
+            "first" to 30L,
+            "second" to 40L,
+            "third" to 50L
+        )
+
+        val removed = expiringCacheKeysToRemove(
+            entries = entries,
+            nowMs = 20L,
+            maxEntries = 3,
+            incomingKey = "incoming"
+        )
+
+        assertEquals(setOf("first"), removed)
+    }
+
+    @Test
+    fun `updating a live entry does not evict another entry`() {
+        val entries = mapOf(
+            "first" to 30L,
+            "second" to 40L,
+            "third" to 50L
+        )
+
+        val removed = expiringCacheKeysToRemove(
+            entries = entries,
+            nowMs = 20L,
+            maxEntries = 3,
+            incomingKey = "second"
+        )
+
+        assertEquals(emptySet<String>(), removed)
+    }
+
+    @Test
+    fun `restored entries are reduced to the configured bound`() {
+        val entries = mapOf(
+            "first" to 30L,
+            "second" to 40L,
+            "third" to 50L,
+            "fourth" to 60L
+        )
+
+        val removed = expiringCacheKeysToRemove(
+            entries = entries,
+            nowMs = 20L,
+            maxEntries = 2
+        )
+
+        assertEquals(setOf("first", "second"), removed)
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackAudioStrategyContractTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackAudioStrategyContractTest.kt
@@ -1,0 +1,46 @@
+package com.luc4n3x.levyra.data
+
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaybackAudioStrategyContractTest {
+    @Test
+    fun `reel audio strategy cannot consume the muxed fallback`() {
+        val resolver = readResolverSource()
+        val policyDispatch = resolver
+            .substringAfter("private suspend fun resolveAudioByCompatibilityPolicy")
+            .substringBefore("private suspend fun resolveVideoByCompatibilityPolicy")
+        val reelAudio = resolver
+            .substringAfter("private suspend fun resolveAudioWithAndroidReel")
+            .substringBefore("private suspend fun resolveVideoWithAndroidReel")
+
+        assertTrue(policyDispatch.contains("PlaybackAudioStrategy.REEL_AUDIO"))
+        assertTrue(policyDispatch.contains("resolveAudioWithAndroidReel(track, audioQuality)"))
+        assertTrue(policyDispatch.contains("PlaybackAudioStrategy.REEL_MUXED"))
+        assertTrue(policyDispatch.contains("resolveVideoWithAndroidReel(track)"))
+        assertTrue(reelAudio.contains("mime.startsWith(\"audio/\", true)"))
+        assertFalse(reelAudio.contains("mime.startsWith(\"video/\", true)"))
+        assertTrue(reelAudio.contains("stream solo audio riproducibile"))
+    }
+
+    @Test
+    fun `malformed persisted stream entries are removed during restore`() {
+        val restore = readResolverSource()
+            .substringAfter("private fun restoreCache()")
+            .substringBefore("private fun store(")
+
+        assertTrue(restore.contains("val json = parsePersistedCacheEntry(value)"))
+        assertTrue(restore.contains("if (json == null)"))
+        assertTrue(restore.contains("editor.remove(key)"))
+    }
+
+    private fun readResolverSource(): String = Files.readString(resolverSource()).replace("\r\n", "\n")
+
+    private fun resolverSource(): Path = sequenceOf(
+        Path.of("app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt"),
+        Path.of("src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt")
+    ).firstOrNull(Files::exists) ?: error("PlaybackResolver source not found")
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicyTest.kt
@@ -14,6 +14,7 @@ class PlaybackCompatibilityPolicyTest {
 
         assertEquals(
             listOf(
+                PlaybackAudioStrategy.REEL_AUDIO,
                 PlaybackAudioStrategy.REEL_MUXED,
                 PlaybackAudioStrategy.PERSISTED,
                 PlaybackAudioStrategy.DIRECT,

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackResolverGenerationContractTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackResolverGenerationContractTest.kt
@@ -1,0 +1,43 @@
+package com.luc4n3x.levyra.data
+
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaybackResolverGenerationContractTest {
+    @Test
+    fun `policy refresh invalidates stale cache publications`() {
+        val resolver = readResolverSource()
+        val clear = resolver
+            .substringAfter("private suspend fun clearResolvedStreamCaches")
+            .substringBefore("private fun normalizeAudioQuality")
+        val resolution = resolver
+            .substringAfter("private suspend fun resolveInternal")
+            .substringBefore("suspend fun prefetch")
+        val store = resolver
+            .substringAfter("private fun store(")
+            .substringBefore("private fun remove(")
+        val persist = resolver
+            .substringAfter("private suspend fun persistResolvedSource")
+            .substringBefore("private suspend fun findAlternativeAudioCandidates")
+
+        assertTrue(
+            clear.indexOf("sourceMatchMutationMutex.withLock") <
+                clear.indexOf("resolverGeneration.incrementAndGet()")
+        )
+        assertTrue(resolution.contains("val expectedGeneration = resolverGeneration.get()"))
+        assertTrue(resolution.contains("_${'$'}expectedGeneration"))
+        assertTrue(store.contains("resolverGeneration.get() != expectedGeneration"))
+        assertTrue(persist.contains("sourceMatchMutationMutex.withLock"))
+        assertTrue(persist.contains("resolverGeneration.get() != expectedGeneration"))
+    }
+
+    private fun readResolverSource(): String =
+        Files.readString(sourceFile()).replace("\r\n", "\n")
+
+    private fun sourceFile(): Path = sequenceOf(
+        Path.of("app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt"),
+        Path.of("src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt")
+    ).firstOrNull(Files::exists) ?: error("PlaybackResolver source file not found")
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackStrategyHealthTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackStrategyHealthTest.kt
@@ -46,6 +46,22 @@ class PlaybackStrategyHealthTest {
     }
 
     @Test
+    fun unseenPolicyFirstStrategyGetsCanaryBeforePreviouslyHealthyFallback() {
+        val strategies = listOf(SampleStrategy.InnerTube, SampleStrategy.WebEmbedded)
+        val statsMap = mapOf(
+            SampleStrategy.WebEmbedded.name to PlaybackStrategyStats(successes = 20)
+        )
+
+        val result = orderPlaybackStrategiesByHealth(
+            strategies = strategies,
+            statsFor = { statsMap[it] },
+            nowMs = 1_000L
+        )
+
+        assertEquals(strategies, result)
+    }
+
+    @Test
     fun threeConsecutiveForbiddenFailuresMovesStrategyToBack() {
         val now = 5_000_000L
         val failing = statsAfterConsecutiveFailures(

--- a/app/src/test/java/com/luc4n3x/levyra/player/PlaybackResourceLifecycleContractTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/PlaybackResourceLifecycleContractTest.kt
@@ -13,8 +13,13 @@ class PlaybackResourceLifecycleContractTest {
         val transitionStart = service.indexOf("private fun buildTransitionPlayer")
         val transitionEnd = service.indexOf("private suspend fun fadePlayers", transitionStart)
         val transition = service.substring(transitionStart, transitionEnd)
+        val videoRendererOverride = transition
+            .substringAfter("override fun buildVideoRenderers")
+            .substringBefore("override fun buildAudioSink")
 
         assertTrue(transition.contains("override fun buildVideoRenderers"))
+        assertTrue(Regex("""\)\s*=\s*Unit""").containsMatchIn(videoRendererOverride))
+        assertFalse(videoRendererOverride.contains("super.buildVideoRenderers"))
         assertTrue(service.contains("private fun releaseTransitionPlayer"))
         assertTrue(service.contains("releaseTransitionPlayer(secondary)"))
         assertTrue(service.contains("releaseTransitionPlayer()"))

--- a/app/src/test/java/com/luc4n3x/levyra/player/PlaybackResourceLifecycleContractTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/PlaybackResourceLifecycleContractTest.kt
@@ -1,0 +1,58 @@
+package com.luc4n3x.levyra.player
+
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaybackResourceLifecycleContractTest {
+    @Test
+    fun `transition player excludes video renderers and has one release path`() {
+        val service = readSource("player/PlaybackService.kt")
+        val transitionStart = service.indexOf("private fun buildTransitionPlayer")
+        val transitionEnd = service.indexOf("private suspend fun fadePlayers", transitionStart)
+        val transition = service.substring(transitionStart, transitionEnd)
+
+        assertTrue(transition.contains("override fun buildVideoRenderers"))
+        assertTrue(service.contains("private fun releaseTransitionPlayer"))
+        assertTrue(service.contains("releaseTransitionPlayer(secondary)"))
+        assertTrue(service.contains("releaseTransitionPlayer()"))
+    }
+
+    @Test
+    fun `native heap sampling stays off main and recovery reuses the sample`() {
+        val service = readSource("player/PlaybackService.kt")
+        val recovery = service
+            .substringAfter("private fun recyclePlaybackPipeline")
+            .substringBefore("private fun cancelQueueTransition")
+
+        assertTrue(
+            service.contains(
+                "withContext(Dispatchers.Default) { Debug.getNativeHeapAllocatedSize() }"
+            )
+        )
+        assertTrue(service.contains("recyclePlaybackPipeline(player, threshold, nativeAllocatedBytes)"))
+        assertFalse(recovery.contains("Debug.getNativeHeapAllocatedSize()"))
+    }
+
+    @Test
+    fun `primary audio processors are owned by the service instance`() {
+        val service = readSource("player/PlaybackService.kt")
+        val viewModel = readSource("viewmodel/LevyraViewModel.kt")
+
+        assertTrue(service.contains("private val normalizationProcessor = NormalizationAudioProcessor()"))
+        assertTrue(service.contains("private fun applyPremiumAudioSettingsInternal"))
+        assertTrue(service.contains("private var pendingAudioSettings: LevyraAudioSettings? = null"))
+        assertTrue(service.contains("activateServiceAndApplyPendingAudioSettings()"))
+        assertFalse(viewModel.contains("PlaybackService.normalizationProcessor"))
+    }
+
+    private fun readSource(relativePath: String): String =
+        Files.readString(sourceFile(relativePath)).replace("\r\n", "\n")
+
+    private fun sourceFile(relativePath: String): Path = sequenceOf(
+        Path.of("app/src/main/java/com/luc4n3x/levyra/$relativePath"),
+        Path.of("src/main/java/com/luc4n3x/levyra/$relativePath")
+    ).firstOrNull(Files::exists) ?: error("Source file not found: $relativePath")
+}

--- a/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineDownloadPlaybackIsolationTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineDownloadPlaybackIsolationTest.kt
@@ -240,9 +240,21 @@ class OfflineDownloadPlaybackIsolationTest {
         assertTrue(storeSignature > 0)
         assertTrue(skip > storeSignature)
         assertTrue(storeKey > skip)
-        assertTrue(resolver.contains("store(track, resolved, isVideoMode, audioQuality, preferMp4Audio)"))
-        assertTrue(resolver.contains("store(track, alternate, isVideoMode, audioQuality, preferMp4Audio)"))
-        assertTrue(resolver.contains("store(track, restored, isVideoMode, audioQuality, preferMp4Audio)"))
+        assertTrue(
+            resolver.contains(
+                "store(track, resolved, isVideoMode, audioQuality, preferMp4Audio, expectedGeneration)"
+            )
+        )
+        assertTrue(
+            resolver.contains(
+                "store(track, alternate, isVideoMode, audioQuality, preferMp4Audio, expectedGeneration)"
+            )
+        )
+        assertTrue(
+            resolver.contains(
+                "store(track, restored, isVideoMode, audioQuality, preferMp4Audio, expectedGeneration)"
+            )
+        )
         assertTrue(resolver.contains("if (offlineExport) return"))
     }
 

--- a/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineDownloadPlaybackIsolationTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineDownloadPlaybackIsolationTest.kt
@@ -226,7 +226,7 @@ class OfflineDownloadPlaybackIsolationTest {
 
         assertTrue(recoveryStart > 0)
         assertTrue(rotateClient > recoveryStart)
-        assertEquals(1, occurrences(quarantineBlock, "failedPlaybackUrls[it] = now + recovery.quarantineMs"))
+        assertEquals(1, occurrences(quarantineBlock, "quarantinePlaybackUrl(it, now + recovery.quarantineMs, now)"))
         assertFalse(quarantineBlock.contains("if (!isOfflineExport)"))
     }
 

--- a/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineDownloadReliabilityContractTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/offline/OfflineDownloadReliabilityContractTest.kt
@@ -114,7 +114,7 @@ class OfflineDownloadReliabilityContractTest {
 
         assertTrue(player.contains("mediaItem.localConfiguration?.uri?.toString()"))
         assertTrue(player.contains("queueTrack.copy(streamUrl = playingUri)"))
-        assertTrue(resolver.contains("failedPlaybackUrls[it] = now + recovery.quarantineMs"))
+        assertTrue(resolver.contains("quarantinePlaybackUrl(it, now + recovery.quarantineMs, now)"))
         assertTrue(resolver.contains("!isPlaybackUrlBlocked(it.content)"))
     }
 

--- a/config/playback_policy.json
+++ b/config/playback_policy.json
@@ -1,7 +1,8 @@
 {
   "schema": 1,
-  "revision": 2026081801,
+  "revision": 2026082101,
   "audioStrategy": [
+    "REEL_AUDIO",
     "REEL_MUXED",
     "PERSISTED",
     "DIRECT",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -277,6 +277,8 @@ resolve(track)
 
 Individual strategies may still hedge LevyraExtractor and InnerTube work internally. The first valid result wins and losing work is cancelled when safe.
 
+The bundled song policy tries the existing Reel audio-only formats before Reel muxed media, persisted URLs, direct resolution and search fallback. Muxed playback remains available for compatibility, but it is not the preferred Music Mode resource shape.
+
 ### 6.2 In-flight deduplication
  
 Concurrent requests for the same media key share one `Deferred`.
@@ -318,11 +320,13 @@ The resolver tracks per-client:
 - temporary blocks;
 - last update time.
 
-It also keeps local, privacy-preserving health for the higher-level audio and video strategies. Server policy remains the authority for which strategies are allowed; local health can only reorder that allowlist. Repeated resolution failures open a temporary circuit, while a hard runtime rejection such as `403`, `410`, `429`, `LOGIN_REQUIRED`, or a signature/PO-Token failure can quarantine the strategy immediately. Open strategies remain last-resort fallbacks and become half-open after cooldown.
+It also keeps local, privacy-preserving health for the higher-level audio and video strategies. Server policy remains the authority for which strategies are allowed; local health can only reorder that allowlist. A newly introduced first strategy receives one policy-order canary before historical health may reorder it. Repeated resolution failures open a temporary circuit, while a hard runtime rejection such as `403`, `410`, `429`, `LOGIN_REQUIRED`, or a signature/PO-Token failure can quarantine the strategy immediately. Open strategies remain last-resort fallbacks and become half-open after cooldown.
 
 The URL that reached Media3 is associated in memory with the strategy that produced it, so a later player-side rejection is charged to the correct strategy instead of being mistaken for a successful resolve.
 
 Dynamic client health can delay unhealthy fallback clients, but it does not demote Android VR inside the standard InnerTube client path.
+
+Resolved stream entries, failed-playback URL quarantine and rejected-video URL quarantine prune expired entries when updated and enforce fixed entry limits. The Media3 disk cache remains a separate bounded LRU owner.
 
 ### 6.5 Server-driven compatibility policy
 
@@ -544,7 +548,7 @@ The processor:
  
 ## 12. Media3 playback service
  
-`PlaybackService` owns the long-running ExoPlayer and MediaSession lifecycle.
+`PlaybackService` owns the long-running audible ExoPlayer, its audio processors and the MediaSession lifecycle.
  
 Responsibilities include:
  
@@ -558,7 +562,9 @@ Responsibilities include:
 - media-session commands;
 - player state publication to the application layer.
  
-The UI does not own ExoPlayer directly.
+The UI does not own audible playback. Decorative Canvas artwork is the narrow exception: its muted, audio-disabled ExoPlayer is owned by the mounted artwork layer and releases its listener, surface and player on disposal.
+
+The service memory guard samples native allocation outside the Main dispatcher, then returns to Main and revalidates the active playing instance before any player mutation. Recovery reuses the measured value and the existing primary ExoPlayer while restoring the current item, position and play intent.
 
 ### 12.1 Real crossfade and AutoMix
 
@@ -566,7 +572,9 @@ The UI does not own ExoPlayer directly.
 audio-mode track it resolves and prepares the next persistent-queue item in a
 secondary ExoPlayer that does not request audio focus. The secondary player has
 independent normalization, equalizer, spatial, limiter, and PCM processors
-configured from the same settings as the primary player.
+configured from the same settings as the primary player. Its renderer factory
+does not create video renderers, so muxed compatibility fallback cannot allocate
+a video decoder during an audio-mode overlap.
 
 The transition uses equal-power gains. After the overlap, the resolved queue
 item is selected once, the primary player resumes at the secondary player's
@@ -574,6 +582,9 @@ position, and a short handoff returns sole ownership to the MediaSession player.
 Queue generation and durable track identity cancel stale work. Pause, backward
 seek, queue mutation, repeat-one, native-video mode, low-memory pressure, and
 service destruction also cancel and release the secondary player.
+Cancellation and normal completion converge on one idempotent secondary cleanup
+path that clears the service reference before pausing, clearing and releasing the
+player.
 
 AutoMix changes only the bounded overlap duration, using local energy and vocal
 metadata. It does not claim beat, BPM, or key matching.

--- a/docs/project/TASKS.md
+++ b/docs/project/TASKS.md
@@ -2,65 +2,59 @@
 
 ## Active phase
 
-**Name:** Desktop owned-music playback and Android immersion/replay
+**Name:** Android playback resource lifecycle hardening
 
-**Roadmap tracks:** Track 1 - Playback critical path; Track 2 - Persistence, offline use, and recovery; Track 3 - Responsive, accessible interface; Track 5 - Windows Desktop reliability
+**Roadmap tracks:** Track 1 - Playback critical path; Track 4 - Performance and efficiency
 
-**Status:** Implementation complete; latest-head CI and native/device checks pending
-**Scope:** Add Desktop audio output-device selection, equalizer presets, an owned local-music library, M3U transfer and dual-player transitions. Add Android pure-black surfaces, centralized haptics, local Listening Replay, high-resolution lyrics share cards and artwork-driven ambient chroma. Preserve the online catalog, downloads, queue, session restore, favorites, playlists, lyrics, history, settings, localization, Android/Desktop versions, signing, packaging and release behavior.
+**Status:** Implementation, independent review, local full quality gate and unsigned release build complete; physical-device and exact-head CI checks pending
+**Scope:** Make every playback resource owner and terminal path explicit, prevent the audio-mode transition player from creating video renderers, keep native-heap sampling off the service Main dispatcher, prefer existing audio-only Reel streams before muxed fallback, and bound long-lived resolver URL caches. Preserve playback modes, Canvas isolation, queue/session state, audio settings, offline playback, compatibility fallbacks, versions, signing and release behavior.
 
 ## Acceptance criteria
 
-- Desktop output-device selection persists, applies live, falls back to the system default on device loss and recovers when the selected device returns.
-- Equalizer presets preserve headroom; manual band edits resolve to Custom without a second source of truth.
-- The local library indexes owned files, preserves missing-file identity, keeps scans/search off the UI path and never routes local tracks through the online resolver.
-- M3U import is host-independent and export is atomic and overwrite-safe.
-- Dual-player handoff/crossfade advances only a still-matching prepared track and cancels safely on seek, pause, manual changes, queue mutation, sleep/end-of-track and shutdown.
-- Android Pure Black is opt-in and remains distinct from the existing AMOLED palette.
-- Haptic feedback has one semantic owner and a user preference.
-- Listening Replay is computed locally from existing listen events, with rolling 30/365-day summaries, completion, streaks and top music; no new telemetry or Room migration.
-- Lyrics sharing preserves the existing verse-selection flow and can create a bounded high-resolution image in private cache, using cached artwork when available and a narrow non-exported FileProvider grant.
-- Ambient chroma derives player surfaces from existing artwork/palette data while preserving readable content hierarchy and fallback behavior.
-- No account, cookie, private token, telemetry, tracking, new dangerous/storage permission, version change, merge, tag or release.
+- The primary ExoPlayer, transition ExoPlayer, Canvas player, listeners, surfaces, jobs and audio processors each retain one clear owner and deterministic release path.
+- Audio-mode crossfade never creates a video renderer or decoder, including when resolution falls back to a muxed stream.
+- Music resolution prefers the existing audio-only Reel path, while preserving muxed and later compatibility fallbacks.
+- Native-heap sampling runs outside the service Main dispatcher; recovery reuses that sample and preserves the current item, position and play intent.
+- In-memory and persisted stream URL caches, failed-playback URL quarantine and video rejection quarantine prune expiry and remain within fixed bounds.
+- Canvas remains decorative, muted and independently owned; native Video Mode retains its video renderer and explicit user choice.
+- No new player, resolver, cache source of truth, dependency, permission, telemetry, version change, merge, tag or release.
 
 ## Work items
 
-- [x] Desktop audio output-device selection with availability watch.
-- [x] Desktop equalizer presets with derived preamp headroom.
-- [x] Desktop local music library: tag reader, scanner, watcher, index and UI.
-- [x] Desktop M3U/M3U8 import and atomic export.
-- [x] Desktop dual-player gapless handoff and equal-power crossfade.
-- [x] Android Pure Black and centralized haptics.
-- [x] Android Listening Replay using the existing local 365-day event store.
-- [x] Android lyrics share cards with private cache, scoped FileProvider and text fallback.
-- [x] Android artwork-driven ambient chroma/mesh integrated from the already-reviewed player ambience work, including its contrast/palette tests.
-- [x] Review current Canvas architecture: no refactor required because MotionArtworkEngine already owns multi-provider ordering, timeout, cache, ranking, URL verification and in-flight deduplication.
-- [x] Review Desktop ReplayGain/spectrum boundary: do not ship a fake spectrum or silently change global libVLC audio behavior when the current engine has no clean runtime API for those features.
-- [x] Review hardening for player lifecycle, transition failure paths, local path identity, scan serialization, output-device semantics, parser bounds, large embedded artwork and narrow-width playlist actions.
-- [x] Focused regression tests for parser, path, transition, Pure Black, Replay and ambient-color logic.
-- [ ] Latest-head GitHub PR workflows all complete successfully.
-- [ ] Verify real libVLC output-device switching, hot-plug and audible crossfade/gapless handoff on Windows hardware.
-- [ ] Verify a large real local library, watcher behavior and representative supported containers on Windows.
-- [ ] Verify Android Pure Black, haptics, Replay layout, lyrics share output and ambient chroma on a physical device.
+- [x] Audit current Levyra ownership and cleanup paths against the pinned vivi reference without importing its weaker lifecycle implementation.
+- [x] Give primary audio processors service-instance ownership and retain the existing public settings route through the active service.
+- [x] Remove video renderers from the audio-only transition player and centralize idempotent secondary cleanup.
+- [x] Move native-heap sampling off Main and pass the measured value into recovery.
+- [x] Put Reel audio-only before muxed fallback in bundled and repository compatibility policy revision `2026082101`.
+- [x] Add deterministic expiry pruning and bounds for stream and failed/rejected URL caches.
+- [x] Add focused lifecycle, cache-policy, compatibility-policy and offline isolation regression tests.
+- [x] Resolve independent review findings: separate audio-only/muxed strategy responsibility, guarantee a new first-strategy canary, preserve pre-activation audio settings and remove malformed persisted cache records.
+- [x] Run the complete Android debug unit-test suite on the implementation head.
+- [x] Build the current unsigned F-Droid release APK and run the repository fast/full AI quality gates.
+- [x] Complete independent diff review and resolve valid findings.
+- [ ] Verify 50 queue transitions, crossfade on/off, Canvas enter/leave and repeated Music/Video switching on the owner's physical device, recording memory and codec evidence.
+- [ ] Verify Draft PR workflows for the exact published head.
 
 ## Current validation evidence
 
-- Earlier branch heads passed the complete Desktop Windows workflow (compile/tests plus installer), Android lint/full unit/release/F-Droid checks, signed APK artifact, APK size, dependency review and editorial checks. Those results are not treated as proof for a later head.
-- Latest-head GitHub PR workflows are the authoritative automated validation target. Record completion only after every workflow for the exact final SHA succeeds.
-- Focused coverage includes M3U Windows/UNC paths across hosts, path-boundary identity, output-module/device persistence, Opus multi-page embedded artwork and pre-skip semantics, equalizer presets, scanner behavior, AMOLED versus explicit Pure Black, Replay rolling windows/streaks/top day and player ambience contrast/palette behavior.
-- Lyrics share output is bounded to private cache files, uses a read-only URI grant and falls back to text sharing if card generation fails.
+- `:app:testDebugUnitTest` passes on the implementation worktree, including the new resource-lifecycle and expiring-cache policy tests.
+- The focused lifecycle/cache/policy/offline contract set passes separately.
+- The full AI quality gate passes, including Android release lint and an R8-minified unsigned F-Droid release build with JBR 21.
+- The normal signed release task remains unavailable locally because `YOUTUBE_INNERTUBE_API_KEY` is not configured; no credential was invented or exposed.
+- No device or emulator was connected during implementation. Existing APKs predate version 2.3.22 and are not accepted as runtime evidence.
+- PR #431 historical measurements inform the risk model but are not treated as a baseline for this branch.
 
 ## Preserved behavior and explicit boundaries
 
-- Existing online catalog, discovery, downloads, queue, session restore, favorites, playlists, lyrics, history, settings, localization and onboarding remain under their existing owners.
-- Direct playback stays the critical path; file scanning, metadata parsing, local search, artwork work and transition preparation remain bounded/cancellable and off UI/native critical paths where applicable.
-- The current MotionArtworkEngine already provides Community, Apple and Tidal providers with policy, verification, caching, ranking and concurrency controls; duplicating that provider layer would add churn without capability.
-- A real Desktop PCM spectrum would require taking audio samples through the libVLC callback/output path. Runtime ReplayGain is likewise not exposed as a clean per-track toggle by the current player abstraction. Neither is simulated or enabled globally by surprise.
-- Android and Desktop versions, packages, artifacts, signing, tags and releases remain independent and unchanged.
+- Primary audible playback and the MediaSession remain owned by `PlaybackService`; transition playback is still temporary and queue-identity checked.
+- Resolver fallbacks remain available after the new audio-only-first attempt. The disk Media3 LRU cache is unchanged.
+- Canvas already has a dedicated muted UI player with explicit listener/surface disposal, so this phase does not duplicate or move that owner.
+- Memory recovery retains the existing ExoPlayer and queue engine rather than introducing a second restore path.
+- Android and Desktop versions, packages, artifacts, signing, tags and releases remain unchanged.
 
 ## Rollback boundary
 
-Revert the Desktop local-music/output-device/transition/settings additions and the Android Pure Black/haptics/Replay/lyrics-share/ambient additions with their tests and this planning file. Local Desktop data is additive (`localmusic.json`), Android Replay reuses existing listen events, and lyrics share files live only in app cache.
+Revert the playback service lifecycle changes, compatibility-policy revision, bounded-cache helper/integration, related tests and architecture/task documentation. Persisted stream-cache entries remain disposable URL cache data; no user-owned library, queue or settings migration is involved.
 
 ## Update rule
 


### PR DESCRIPTION
## Summary

Hardens long-session Android playback ownership and memory behavior without replacing the existing queue, MediaSession, resolver, Canvas engine, or Music/Video mode choice.

## Changes

- Makes primary DSP processors service-instance owned while retaining the existing active-service settings route and replaying pre-activation updates.
- Gives the audio transition player no video renderers and converges completion/cancellation on one idempotent cleanup path.
- Samples native heap allocation off the service Main dispatcher, revalidates the active player and reuses the sample during recovery.
- Tries true Reel audio-only before muxed fallback; the two policy strategies no longer overlap, and a newly introduced first strategy gets one canary before historical health may reorder it.
- Bounds and expiry-prunes stream, failed-playback and rejected-video URL caches with atomic mutation/persistence updates; malformed persisted entries are removed.
- Updates architecture and active task documentation plus focused regression coverage.

## Risk reduction

- Music crossfade cannot instantiate a video decoder even if resolution later uses a muxed compatibility source.
- Service recreation cannot retain process-global mutable audio processors.
- Long sessions cannot grow the audited URL maps without a fixed bound.
- Native heap sampling no longer blocks ExoPlayer state work on Main.

## Explicitly unchanged

- Primary audible player, MediaSession, notification, Android Auto and persistent queue ownership.
- Canvas remains muted, audio-disabled, UI-owned and independently disposed.
- Native Video Mode and the explicit user Music/Video choice.
- Muxed, persisted, direct and search compatibility fallbacks.
- Media3 disk LRU cache, downloads, user data, versions, signing and release configuration.

## Validation

- [x] Focused lifecycle, strategy, cache and offline isolation tests
- [x] Complete app debug unit-test suite
- [x] Android release lint
- [x] R8-minified unsigned F-Droid release build
- [x] AI quality gate fast
- [x] AI quality gate full
- [x] Independent implementation review; four valid findings fixed and regression-tested
- [x] CI on `e1d1104`: signed release artifact, PR check, lint/full tests/release compile and size report
- [x] CodeRabbit review: stale resolver publication and renderer-contract findings verified, fixed and regression-tested in `53404d0c`
- [x] Local post-review gate on `53404d0c`: 1,155 unit tests, release lint, R8 F-Droid release, fast and full AI quality gates
- [ ] CI rerun on current head `53404d0c`
- [x] Physical-device 50-NEXT memory/codec run
- [x] Repeated Music → Video → Music renderer checks
- [x] Canvas visible/leave plus repeated mount/unmount decoder checks
- [ ] Crossfade on/off rapid NEXT/PREV/pause/error matrix
- [ ] Forced memory-guard recovery state-preservation check
- [ ] Multi-run Canvas memory plateau classification

The normal signed release task was attempted locally but the local environment has no `YOUTUBE_INNERTUBE_API_KEY`. No credential was invented or exposed; the repository full gate built the unsigned F-Droid release, and GitHub's signed-release workflow completed successfully.

## Real-device evidence — 2026-08-21

Target: Samsung Galaxy S25+ (`SM-S936B`), Android 16 / API 36, build fingerprint ending `S936BXXSBCZG3_OXMBCZG3`. Installed production package `com.luc4n3x.levyra`, version `2.3.22` / versionCode `2032200`. The owner installed the GitHub-built artifact; package and version were verified on-device, but the installed binary was not independently checksum-correlated to the workflow artifact.

The active MediaSession belonged to Levyra for every media-key operation. The process stayed at PID `30058` for the complete run. No crash, ANR, OOM or LMKD restart was observed.

### 50-NEXT Music-mode run

50 NEXT commands were dispatched with bounded MediaSession polling. 48 title changes were observed inside the polling window; two transitions exceeded that window, and subsequent transitions continued normally. Playback remained `PLAYING`.

| Sample | Total PSS | Native heap PSS | Native allocated | Graphics PSS | Current codecs |
| --- | ---: | ---: | ---: | ---: | --- |
| T0 | 501.3 MB | 185.5 MB | 215.6 MB | 199.9 MB | 1 audio, 0 video |
| T5 | 490.4 MB | 232.0 MB | 332.6 MB | 135.5 MB | 1 audio, 0 video |
| T20 | 521.7 MB | 255.7 MB | 225.8 MB | 141.9 MB | 1 audio, 0 video |
| T35 | 498.0 MB | 243.7 MB | 293.8 MB | 130.7 MB | 1 audio, 0 video |
| T50 | 507.7 MB | 245.4 MB | 294.9 MB | 121.5 MB | 1 audio, 0 video |
| After Video cycles | 501.8 MB | 250.3 MB | 269.6 MB | 114.4 MB | 1 audio, 0 video |

Total PSS oscillated between 490.4 and 521.7 MB and ended 6.3 MB above T0, then returned to 501.8 MB after the mode-cycle test. Native allocation was also non-monotonic. This single run supports plateau/oscillation rather than the prior runaway pattern; it is not a substitute for three identical long runs.

Samsung Android 16 does not expose `dumpsys media.codec`. Codec ownership was therefore read from `dumpsys media.resource_manager`, correlated to Levyra PID `30058`. Music Mode held one software AAC decoder and no video decoder throughout; peak Music usage also remained one audio decoder.

### Music ↔ Video lifecycle

Five consecutive Video → Music cycles were observed. Every Video phase held exactly one audio decoder plus one hardware AVC video decoder. Every return to Music settled at one audio decoder and zero video decoders. PSS rose to 602.4 MB with Video active and returned to 515.0 MB after the first return to Music; after all five cycles it settled at 501.8 MB.

### Canvas lifecycle and residual memory risk

Canvas was visually verified on `AL MIO PAESE` in Music Mode. While visible, Levyra held one audio decoder plus one hardware video decoder. The first visible sample was 693.3 MB PSS; leaving the full player released the video decoder and reduced PSS to 577.1 MB.

Across ten Canvas mount/unmount cycles, the video decoder appeared on every mount and disappeared on every settled unmount. Release was not consistently visible at 3 seconds, but was consistently absent after the 5–10 second settled checks. There was no codec-instance accumulation.

Memory did not fully return to the pre-Canvas 501.8 MB sample: after nine cycles it measured 701.1 MB at 10 seconds and 652.5 MB after another 30 seconds; after cycle ten it measured 644.0 MB at 10 seconds. Native/graphics allocation fluctuated substantially and the decoder was already released, so this run does not prove a codec leak. It does show residual post-Canvas retention that requires a longer repeated plateau run before merge/release confidence. No claim is made that Canvas memory is fully resolved.

## Remaining manual/device risk

- Classify Canvas retention with repeated identical runs and longer settled sampling.
- Exercise crossfade enabled/disabled with rapid NEXT/PREV/pause and cancellation/error paths.
- Force the memory guard under a temporary local-only threshold and verify exact item, position, play state, queue, DSP and mode restoration; restore production constants afterward.
- Verify background/notification/Android Auto control synchronization and latency under the same stress sequence.
