### PR TITLE
feat(android): redesign player canvas experience

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -91,6 +91,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -115,6 +116,7 @@ import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -275,6 +277,7 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.LocalContext
@@ -11102,92 +11105,6 @@ private fun PlayerArtworkCanvas(
 }
 
 @Composable
-private fun PlayerImmersiveMotionCanvas(
-    track: Track,
-    artworkUrl: String,
-    motionArtwork: com.luc4n3x.levyra.feature.motion.MotionArtwork?,
-    ambience: PlayerAmbience,
-    animationsEnabled: Boolean,
-    isPlaying: Boolean,
-    canvasQuality: LevyraCanvasQuality,
-    modifier: Modifier = Modifier
-) {
-    val context = LocalContext.current
-    Box(modifier = modifier) {
-        MotionArtworkLayer(
-            artwork = motionArtwork,
-            enabled = animationsEnabled,
-            isPlaying = isPlaying,
-            cornerRadius = 0.dp,
-            presentation = MotionArtworkPresentation.Immersive,
-            quality = canvasQuality,
-            modifier = Modifier.fillMaxSize()
-        ) {
-            if (artworkUrl.isNotBlank()) {
-                AsyncImage(
-                    model = ImageRequest.Builder(context)
-                        .data(artworkUrl)
-                        .crossfade(true)
-                        .diskCachePolicy(CachePolicy.ENABLED)
-                        .memoryCachePolicy(CachePolicy.ENABLED)
-                        .build(),
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier.fillMaxSize()
-                )
-            } else {
-                InstantArtworkPlaceholder(track = track, modifier = Modifier.fillMaxSize())
-            }
-        }
-        PlayerCanvasFusionScrim(
-            ambience = ambience,
-            modifier = Modifier.fillMaxSize()
-        )
-    }
-}
-
-@Composable
-private fun PlayerCanvasFusionScrim(
-    ambience: PlayerAmbience,
-    modifier: Modifier = Modifier
-) {
-    val animationsEnabled = LocalAnimationsEnabled.current
-    val base = animateColorAsState(
-        targetValue = ambience.base,
-        animationSpec = if (animationsEnabled) tween(700, easing = LinearOutSlowInEasing) else snap(),
-        label = "player-canvas-fusion-base"
-    )
-    val control = animateColorAsState(
-        targetValue = ambience.control,
-        animationSpec = if (animationsEnabled) tween(700, easing = LinearOutSlowInEasing) else snap(),
-        label = "player-canvas-fusion-control"
-    )
-    Box(
-        modifier = modifier.drawBehind {
-            if (size.minDimension <= 0f) return@drawBehind
-            val baseColor = base.value
-            val controlColor = control.value
-            drawRect(
-                Brush.verticalGradient(
-                    colorStops = arrayOf(
-                        0.00f to baseColor.copy(alpha = 0.75f),
-                        0.06f to baseColor.copy(alpha = 0.45f),
-                        0.14f to baseColor.copy(alpha = 0.15f),
-                        0.22f to Color.Transparent,
-                        0.48f to Color.Transparent,
-                        0.58f to controlColor.copy(alpha = 0.25f),
-                        0.68f to controlColor.copy(alpha = 0.68f),
-                        0.78f to controlColor.copy(alpha = 0.92f),
-                        0.88f to controlColor.playerAmbienceMix(baseColor, 0.45f),
-                        1.00f to baseColor
-                    )
-                )
-            )
-        }
-    )
-}
-
-@Composable
 private fun PlayerModeSwitch(
     isVideoMode: Boolean,
     activeColor: Color,
@@ -11198,7 +11115,7 @@ private fun PlayerModeSwitch(
     val strings = LocalLevyraStrings.current
     val selectedContent = remember(activeColorTarget) {
         Color.White.playerContentColor(
-            listOf(activeColorTarget.copy(alpha = 0.42f).playerCompositeOver(PlayerDarkSurface))
+            listOf(activeColorTarget.copy(alpha = 0.92f).playerCompositeOver(PlayerDarkSurface))
         )
     }
     Row(
@@ -11206,9 +11123,9 @@ private fun PlayerModeSwitch(
             .selectableGroup()
             .playerGlass(
                 shape = CircleShape,
-                fill = Color.Black.copy(alpha = 0.35f),
-                borderTop = Color.White.copy(alpha = 0.14f),
-                borderBottom = Color.White.copy(alpha = 0.08f)
+                fill = LevyraPlayerDesign.HeaderScrim,
+                borderTop = LevyraPlayerDesign.HeaderEdgeTop,
+                borderBottom = LevyraPlayerDesign.HeaderEdgeBottom
             )
             .padding(3.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -11246,14 +11163,23 @@ private fun PlayerModeSwitchTab(
         snap()
     }
     val background by animateColorAsState(
-        targetValue = if (selected) Color.White.copy(alpha = 0.22f) else Color.Transparent,
+        targetValue = if (selected) Color.White.copy(alpha = 0.10f) else Color.Transparent,
         animationSpec = tabSpec,
         label = "player-mode-tab-background"
     )
     val contentColor by animateColorAsState(
-        targetValue = if (selected) Color.White else LevyraPlayerDesign.TextSecondary,
+        targetValue = if (selected) Color.White else LevyraPlayerDesign.TextTertiary,
         animationSpec = tabSpec,
         label = "player-mode-tab-content"
+    )
+    val markerAlpha by animateFloatAsState(
+        targetValue = if (selected) 1f else 0f,
+        animationSpec = if (LocalAnimationsEnabled.current) {
+            LevyraPlayerDesign.standardTween(220)
+        } else {
+            snap()
+        },
+        label = "player-mode-tab-marker"
     )
     Box(
         modifier = Modifier
@@ -11264,25 +11190,39 @@ private fun PlayerModeSwitchTab(
             .then(
                 if (selected) {
                     Modifier
-                        .shadow(3.dp, CircleShape, clip = false)
                         .background(background, CircleShape)
-                        .border(BorderStroke(1.dp, Color.White.copy(alpha = 0.28f)), CircleShape)
+                        .border(BorderStroke(1.dp, Color.White.copy(alpha = 0.16f)), CircleShape)
                 } else {
                     Modifier.background(background, CircleShape)
                 }
             )
             .pressable(enabled = !selected, onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 6.dp)
+            .heightIn(min = 32.dp)
+            .padding(horizontal = 14.dp, vertical = 7.dp)
     ) {
-        Text(
-            text = label,
-            color = contentColor,
-            fontSize = 12.sp,
-            fontWeight = FontWeight.SemiBold,
-            letterSpacing = 0.2.sp,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(5.dp)
+                    .graphicsLayer {
+                        alpha = markerAlpha
+                        val scale = 0.4f + 0.6f * markerAlpha
+                        scaleX = scale
+                        scaleY = scale
+                    }
+                    .background(activeColor, CircleShape)
+            )
+            Spacer(modifier = Modifier.width(7.dp))
+            Text(
+                text = label,
+                color = contentColor,
+                fontSize = 12.sp,
+                fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium,
+                letterSpacing = 0.4.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
     }
 }
 
@@ -12234,6 +12174,12 @@ private fun PlayerScreen(
         label = "artwork-offset"
     )
 
+    val stageSettle by animateFloatAsState(
+        targetValue = if (state.isPlaying) 1f else 1.014f,
+        animationSpec = if (state.animationsEnabled) LevyraPlayerDesign.expressiveSpring() else snap(),
+        label = "player-stage-settle"
+    )
+
     BoxWithConstraints(
         modifier = Modifier
             .fillMaxSize()
@@ -12261,57 +12207,19 @@ private fun PlayerScreen(
             (maxHeight - 220.dp).coerceAtLeast(180.dp)
         )
         val detailMaxWidth = levyraContentMaxWidthDp(layoutMode).dp
-        // Mount the immersive layer immediately in song mode. MotionArtworkLayer owns the
-        // animated static bed and crossfades to a real Canvas only after its first frame, so the
-        // player never has to flash a dead static state while remote artwork is resolving.
-        val immersiveArtworkEnabled = state.motionArtworkEnabled &&
-            state.animationsEnabled &&
-            playerPane == LevyraPlayerPane.Stacked &&
+        val stageLayout = playerPane == LevyraPlayerPane.Stacked &&
             !state.isVideoMode &&
-            track != null
-        val immersiveMotionArtwork = state.motionArtwork.takeIf { immersiveArtworkEnabled }
+            track != null &&
+            maxHeight >= 560.dp
+        val stageMotionArtwork = state.motionArtwork.takeIf { stageLayout && state.motionArtworkEnabled }
 
         PlayerImmersiveBackdrop(
-            // The immersive layer already draws the artwork bed. Avoid decoding/drawing a second
-            // fullscreen copy behind it; keep only the palette backdrop as the safety bed.
-            artworkUrl = if (immersiveArtworkEnabled) "" else artworkUrl,
+            artworkUrl = artworkUrl,
             ambience = ambience,
             isPlaying = state.isPlaying,
             animationsEnabled = state.animationsEnabled,
             modifier = Modifier.fillMaxSize()
         )
-        AnimatedVisibility(
-            visible = immersiveArtworkEnabled,
-            // The generated artwork bed is the immediate first frame. A real Canvas performs its
-            // own first-frame crossfade inside MotionArtworkLayer, so an outer enter fade only
-            // reintroduces the static-to-motion flash we are trying to remove.
-            enter = EnterTransition.None,
-            exit = if (state.animationsEnabled) fadeOut(tween(260, easing = LinearOutSlowInEasing)) else ExitTransition.None,
-            modifier = Modifier.fillMaxSize()
-        ) {
-            val canvasTrack = track ?: state.currentTrack
-            if (canvasTrack != null) {
-                PlayerImmersiveMotionCanvas(
-                    track = canvasTrack,
-                    artworkUrl = artworkUrl,
-                    motionArtwork = immersiveMotionArtwork,
-                    ambience = ambience,
-                    animationsEnabled = state.animationsEnabled,
-                    isPlaying = state.isPlaying,
-                    canvasQuality = state.interfaceSettings.canvasQuality,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .graphicsLayer {
-                            alpha = if (morphActive) {
-                                0f
-                            } else {
-                                playerSwipeContentAlpha(settledSwipeOffset, size.width)
-                            }
-                            translationX = settledSwipeOffset * 0.32f
-                        }
-                )
-            }
-        }
 
         val headerBlock: @Composable () -> Unit = {
             val headerButtonSize = if (compactPlayer) {
@@ -12331,6 +12239,9 @@ private fun PlayerScreen(
                     contentDescription = strings.collapsePlayer,
                     size = headerButtonSize,
                     iconSize = if (compactPlayer) 22.dp else 24.dp,
+                    fill = LevyraPlayerDesign.HeaderScrim,
+                    borderTop = LevyraPlayerDesign.HeaderEdgeTop,
+                    borderBottom = LevyraPlayerDesign.HeaderEdgeBottom,
                     onClick = collapseActions.collapse
                 )
                 Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
@@ -12347,9 +12258,9 @@ private fun PlayerScreen(
                             modifier = Modifier
                                 .playerGlass(
                                     shape = CircleShape,
-                                    fill = Color.Black.copy(alpha = 0.35f),
-                                    borderTop = Color.White.copy(alpha = 0.14f),
-                                    borderBottom = Color.White.copy(alpha = 0.08f)
+                                    fill = LevyraPlayerDesign.HeaderScrim,
+                                    borderTop = LevyraPlayerDesign.HeaderEdgeTop,
+                                    borderBottom = LevyraPlayerDesign.HeaderEdgeBottom
                                 )
                                 .padding(horizontal = 14.dp, vertical = 7.dp)
                         ) {
@@ -12381,71 +12292,15 @@ private fun PlayerScreen(
                     contentDescription = strings.options,
                     size = headerButtonSize,
                     iconSize = if (compactPlayer) 20.dp else 21.dp,
+                    fill = LevyraPlayerDesign.HeaderScrim,
+                    borderTop = LevyraPlayerDesign.HeaderEdgeTop,
+                    borderBottom = LevyraPlayerDesign.HeaderEdgeBottom,
                     onClick = { viewModel.openAudioQualityPanel() }
                 )
             }
         }
 
-        val mediaBlock: @Composable (Track) -> Unit = { activeTrack ->
-            Box(
-                modifier = if (playerPane == LevyraPlayerPane.SideBySide) {
-                    Modifier
-                        .size(width = artworkSize, height = artworkSize)
-                        .padding(vertical = if (compactPlayer) 1.dp else 2.dp)
-                } else {
-                    Modifier
-                        .fillMaxHeight()
-                        .aspectRatio(1f, matchHeightConstraintsFirst = true)
-                        .widthIn(max = maxWidth - playerHorizontalPadding * 2f)
-                        .padding(vertical = if (compactPlayer) 1.dp else 2.dp)
-                }
-            ) {
-                if (state.isVideoMode && activeTrack.videoUrl.isNotBlank()) {
-                    LevyraVideoSurface(
-                        state = state,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(horizontal = 8.dp, vertical = 8.dp)
-                            .graphicsLayer {
-                                scaleX = artScale
-                                scaleY = artScale
-                                translationY = artOffset.toPx()
-                                shadowElevation = artShadow
-                                shape = RoundedCornerShape(artCorner)
-                                clip = true
-                            }
-                            .border(
-                                width = 1.dp,
-                                color = Color.White.copy(alpha = 0.18f),
-                                shape = RoundedCornerShape(artCorner)
-                            )
-                    )
-                } else {
-                    PlayerArtworkCanvas(
-                        track = activeTrack,
-                        artworkUrl = artworkUrl,
-                        motionArtwork = state.motionArtwork.takeUnless { immersiveArtworkEnabled },
-                        animationsEnabled = state.animationsEnabled && !state.isVideoMode,
-                        isPlaying = state.isPlaying,
-                        cornerRadius = artCorner,
-                        canvasQuality = state.interfaceSettings.canvasQuality,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .playerMorphAnchor(morphAnchors, PlayerMorphSlot.Full)
-                            .graphicsLayer {
-                                scaleX = artScale
-                                scaleY = artScale
-                                translationX = settledSwipeOffset
-                                translationY = artOffset.toPx()
-                                alpha = if (morphActive || immersiveArtworkEnabled) {
-                                    0f
-                                } else {
-                                    playerSwipeContentAlpha(settledSwipeOffset, size.width)
-                                }
-                            }
-                    )
-                }
-
+        val mediaOverlayBlock: @Composable BoxScope.(Track) -> Unit = { activeTrack ->
                 if (state.interfaceSettings.playerGesturesEnabled) {
                     PlayerGestureLayer(
                         config = PlayerGestureConfig(
@@ -12535,6 +12390,69 @@ private fun PlayerScreen(
                         }
                     }
                 }
+        }
+
+        val mediaBlock: @Composable (Track) -> Unit = { activeTrack ->
+            Box(
+                modifier = if (playerPane == LevyraPlayerPane.SideBySide) {
+                    Modifier
+                        .size(width = artworkSize, height = artworkSize)
+                        .padding(vertical = if (compactPlayer) 1.dp else 2.dp)
+                } else {
+                    Modifier
+                        .fillMaxHeight()
+                        .aspectRatio(1f, matchHeightConstraintsFirst = true)
+                        .widthIn(max = maxWidth - playerHorizontalPadding * 2f)
+                        .padding(vertical = if (compactPlayer) 1.dp else 2.dp)
+                }
+            ) {
+                if (state.isVideoMode && activeTrack.videoUrl.isNotBlank()) {
+                    LevyraVideoSurface(
+                        state = state,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(horizontal = 8.dp, vertical = 8.dp)
+                            .graphicsLayer {
+                                scaleX = artScale
+                                scaleY = artScale
+                                translationY = artOffset.toPx()
+                                shadowElevation = artShadow
+                                shape = RoundedCornerShape(artCorner)
+                                clip = true
+                            }
+                            .border(
+                                width = 1.dp,
+                                color = Color.White.copy(alpha = 0.18f),
+                                shape = RoundedCornerShape(artCorner)
+                            )
+                    )
+                } else {
+                    PlayerArtworkCanvas(
+                        track = activeTrack,
+                        artworkUrl = artworkUrl,
+                        motionArtwork = state.motionArtwork.takeUnless { stageLayout },
+                        animationsEnabled = state.animationsEnabled && !state.isVideoMode,
+                        isPlaying = state.isPlaying,
+                        cornerRadius = artCorner,
+                        canvasQuality = state.interfaceSettings.canvasQuality,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .playerMorphAnchor(morphAnchors, PlayerMorphSlot.Full)
+                            .graphicsLayer {
+                                scaleX = artScale
+                                scaleY = artScale
+                                translationX = settledSwipeOffset
+                                translationY = artOffset.toPx()
+                                alpha = if (morphActive) {
+                                    0f
+                                } else {
+                                    playerSwipeContentAlpha(settledSwipeOffset, size.width)
+                                }
+                            }
+                    )
+                }
+
+                mediaOverlayBlock(activeTrack)
             }
         }
 
@@ -12745,6 +12663,114 @@ private fun PlayerScreen(
                         PlayerError(state.playerError)
                     }
                 }
+            }
+        } else if (stageLayout && track != null) {
+            val stageDensity = LocalDensity.current
+            var consoleHeightPx by remember { mutableStateOf(0) }
+            val fontScale = stageDensity.fontScale.coerceIn(1f, 1.5f)
+            val fallbackConsoleHeight = (if (compactPlayer) 300.dp else 336.dp) * fontScale
+            val consoleHeight = if (consoleHeightPx > 0) {
+                with(stageDensity) { consoleHeightPx.toDp() }
+            } else {
+                fallbackConsoleHeight
+            }
+            val stageMetrics = playerStageMetrics(
+                availableHeightDp = maxHeight.value,
+                consoleHeightDp = consoleHeight.value
+            )
+            val stageHeight = stageMetrics.stageHeightDp.dp
+            val consoleTop = (maxHeight - consoleHeight).coerceAtLeast(0.dp)
+            val stageWidthPx = with(stageDensity) { maxWidth.toPx() }
+
+            PlayerConsoleSurface(
+                ambience = ambience,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height((maxHeight - stageHeight).coerceAtLeast(0.dp))
+                    .align(Alignment.BottomCenter)
+            )
+            PlayerStage(
+                motionArtwork = stageMotionArtwork,
+                ambience = ambience,
+                animationsEnabled = state.animationsEnabled,
+                isPlaying = state.isPlaying,
+                canvasQuality = state.interfaceSettings.canvasQuality,
+                veilSettleFraction = stageMetrics.veilSettleFraction,
+                contentAlpha = {
+                    if (morphActive) 0f else playerSwipeContentAlpha(settledSwipeOffset, stageWidthPx)
+                },
+                contentTranslationX = { settledSwipeOffset },
+                contentScale = { stageSettle },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(stageHeight)
+                    .align(Alignment.TopCenter)
+                    .playerMorphAnchor(morphAnchors, PlayerMorphSlot.Full),
+                overlay = {
+                    mediaOverlayBlock(track)
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .align(Alignment.TopCenter)
+                            .zIndex(30f)
+                            .statusBarsPadding()
+                            .padding(
+                                horizontal = playerHorizontalPadding,
+                                vertical = if (compactPlayer) 4.dp else 8.dp
+                            )
+                    ) {
+                        headerBlock()
+                    }
+                }
+            ) {
+                if (artworkUrl.isNotBlank()) {
+                    AsyncImage(
+                        model = ImageRequest.Builder(playerContext)
+                            .data(artworkUrl)
+                            .crossfade(true)
+                            .diskCachePolicy(CachePolicy.ENABLED)
+                            .memoryCachePolicy(CachePolicy.ENABLED)
+                            .build(),
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                } else {
+                    InstantArtworkPlaceholder(track = track, modifier = Modifier.fillMaxSize())
+                }
+            }
+            PlayerStageHorizon(
+                ambience = ambience,
+                animationsEnabled = state.animationsEnabled,
+                isPlaying = state.isPlaying,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.TopCenter)
+                    .padding(top = consoleTop)
+                    .height(PlayerStageSpillHeight)
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .widthIn(max = detailMaxWidth)
+                    .wrapContentHeight()
+                    .align(Alignment.BottomCenter)
+                    .onSizeChanged { consoleHeightPx = it.height }
+                    .navigationBarsPadding()
+                    .padding(
+                        start = playerHorizontalPadding,
+                        end = playerHorizontalPadding,
+                        top = if (compactPlayer) 6.dp else 10.dp,
+                        bottom = if (compactPlayer) 10.dp else 16.dp
+                    )
+            ) {
+                metaBlock(track)
+                Spacer(modifier = Modifier.height(playerMetaSpacing))
+                timelineBlock()
+                Spacer(modifier = Modifier.height(playerControlSpacing))
+                transportBlock()
+                quickActionsBlock(track)
+                PlayerError(state.playerError)
             }
         } else {
             val isPortraitScrollable = maxHeight < 540.dp

--- a/app/src/main/java/com/luc4n3x/levyra/ui/MotionArtworkLayer.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/MotionArtworkLayer.kt
@@ -61,7 +61,8 @@ import kotlinx.coroutines.launch
 
 internal enum class MotionArtworkPresentation {
     Card,
-    Immersive
+    Immersive,
+    Stage
 }
 
 @Composable
@@ -79,7 +80,8 @@ internal fun MotionArtworkLayer(
     val environment = rememberMotionArtworkEnvironment(enabled && lifecycleActive)
     val surface = when (presentation) {
         MotionArtworkPresentation.Card -> MotionCanvasSurface.Card
-        MotionArtworkPresentation.Immersive -> MotionCanvasSurface.Immersive
+        MotionArtworkPresentation.Immersive,
+        MotionArtworkPresentation.Stage -> MotionCanvasSurface.Immersive
     }
     val profile = remember(quality, presentation, environment.conditions) {
         MotionCanvasQualityPolicy.profile(
@@ -140,8 +142,9 @@ internal fun MotionArtworkLayer(
         environment.localAllowed &&
         isPlaying &&
         !videoReady
+    val keepStaticBed = presentation == MotionArtworkPresentation.Stage
     val staticBedAlpha by animateFloatAsState(
-        targetValue = if (videoReady) 0f else 1f,
+        targetValue = if (videoReady && !keepStaticBed) 0f else 1f,
         animationSpec = tween(
             durationMillis = STATIC_ARTWORK_BED_FADE_MS,
             delayMillis = if (videoReady) VIDEO_FADE_IN_MS else 0,
@@ -286,7 +289,8 @@ private fun MotionArtworkStaticFallback(
         label = "static-artwork-motion-amount"
     )
 
-    val immersive = presentation == MotionArtworkPresentation.Immersive
+    val stage = presentation == MotionArtworkPresentation.Stage
+    val immersive = presentation == MotionArtworkPresentation.Immersive || stage
     val zoomDurationMs = if (immersive) 14_000 else STATIC_ARTWORK_ZOOM_DURATION_MS
     val horizontalDurationMs = if (immersive) 18_000 else STATIC_ARTWORK_HORIZONTAL_DURATION_MS
     val verticalDurationMs = if (immersive) 21_000 else STATIC_ARTWORK_VERTICAL_DURATION_MS
@@ -372,7 +376,7 @@ private fun MotionArtworkStaticFallback(
                     scaleY = scale
                     translationX = artworkSize.width * horizontalTravel * horizontalDrift.value * amount
                     translationY = artworkSize.height * verticalTravel * verticalDrift.value * amount
-                    rotationZ = if (immersive) horizontalDrift.value * amount * 0.22f else 0f
+                    rotationZ = if (immersive && !stage) horizontalDrift.value * amount * 0.22f else 0f
                 }
         ) {
             content()
@@ -407,6 +411,7 @@ private fun MotionArtworkVideo(
     val maxZoom = when (presentation) {
         MotionArtworkPresentation.Card -> MotionArtworkCardMaxZoom
         MotionArtworkPresentation.Immersive -> MotionArtworkImmersiveMaxZoom
+        MotionArtworkPresentation.Stage -> MotionArtworkStageMaxZoom
     }
     val player = remember(artwork.identityKey, artwork.url, artwork.mimeType, presentation, profile) {
         ExoPlayer.Builder(context).build().apply {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/MotionArtworkScaling.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/MotionArtworkScaling.kt
@@ -9,6 +9,7 @@ internal val MotionArtworkFitIdentity = MotionArtworkFit(1f, 1f)
 
 internal const val MotionArtworkCardMaxZoom = 2.6f
 internal const val MotionArtworkImmersiveMaxZoom = 1.32f
+internal const val MotionArtworkStageMaxZoom = 1.56f
 
 internal fun motionArtworkFit(
     videoWidth: Int,

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
@@ -2,7 +2,9 @@ package com.luc4n3x.levyra.ui
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
@@ -20,6 +22,7 @@ internal const val PlayerStageHeightFraction = 1f
 internal const val PlayerStageMinOverlapDp = 56f
 internal val PlayerStageSpillHeight: Dp = 0.dp
 
+private const val StageInteractionHeightFraction = 0.72f
 private const val StageTopScrimEnd = 0.20f
 private const val StageVeilLead = 0.24f
 private const val StageVeilKnee = 0.50f
@@ -152,7 +155,13 @@ internal fun PlayerStage(
                 staticArtwork = staticArtwork
             )
         }
-        overlay()
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(StageInteractionHeightFraction)
+        ) {
+            overlay()
+        }
     }
 }
 

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
@@ -25,12 +25,12 @@ import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
 
 internal const val PlayerStageHeightFraction = 0.72f
 internal const val PlayerStageMinOverlapDp = 56f
-internal val PlayerStageSpillHeight: Dp = 124.dp
+internal val PlayerStageSpillHeight: Dp = 108.dp
 
-private const val StageTopScrimEnd = 0.22f
-private const val StageVeilLead = 0.46f
-private const val StageVeilKnee = 0.60f
-private const val StageSideVignetteAlpha = 0.16f
+private const val StageTopScrimEnd = 0.20f
+private const val StageVeilLead = 0.42f
+private const val StageVeilKnee = 0.58f
+private const val StageSideVignetteAlpha = 0.10f
 
 @Immutable
 internal data class PlayerStageMetrics(
@@ -68,14 +68,10 @@ internal fun PlayerStage(
     overlay: @Composable BoxScope.() -> Unit = {},
     staticArtwork: @Composable () -> Unit
 ) {
-    val veil = ambience.base
-    val accent = ambience.primary.playerAmbienceMix(ambience.secondary, 0.34f)
-    val handoff = veil.playerAmbienceMix(accent, 0.18f)
     val settle = veilSettleFraction.coerceIn(0.35f, 0.98f)
-    val veilStart = (settle - StageVeilLead).coerceIn(0.10f, settle)
+    val veilStart = (settle - StageVeilLead).coerceIn(0.08f, settle)
     val veilKnee = (veilStart + (settle - veilStart) * StageVeilKnee).coerceIn(veilStart, settle)
-    val glowPeak = (settle + 0.015f).coerceIn(0f, 1f)
-    val glowTail = (settle + 0.10f).coerceIn(glowPeak, 1f)
+    val paletteVeil = ambience.base.playerAmbienceMix(ambience.control, 0.34f)
 
     Box(modifier = modifier) {
         Box(
@@ -95,32 +91,10 @@ internal fun PlayerStage(
                         brush = Brush.horizontalGradient(
                             colorStops = arrayOf(
                                 0.00f to Color.Black.copy(alpha = StageSideVignetteAlpha),
-                                0.18f to Color.Transparent,
-                                0.82f to Color.Transparent,
-                                1.00f to Color.Black.copy(alpha = StageSideVignetteAlpha * 0.80f)
+                                0.14f to Color.Transparent,
+                                0.86f to Color.Transparent,
+                                1.00f to Color.Black.copy(alpha = StageSideVignetteAlpha)
                             )
-                        )
-                    )
-
-                    drawRect(
-                        brush = Brush.radialGradient(
-                            colors = listOf(
-                                accent.copy(alpha = 0.12f),
-                                ambience.primary.copy(alpha = 0.05f),
-                                Color.Transparent
-                            ),
-                            center = Offset(size.width * 0.24f, size.height * settle * 0.92f),
-                            radius = size.maxDimension * 0.62f
-                        )
-                    )
-                    drawRect(
-                        brush = Brush.radialGradient(
-                            colors = listOf(
-                                ambience.secondary.copy(alpha = 0.08f),
-                                Color.Transparent
-                            ),
-                            center = Offset(size.width * 0.78f, size.height * settle * 0.82f),
-                            radius = size.maxDimension * 0.48f
                         )
                     )
 
@@ -129,29 +103,40 @@ internal fun PlayerStage(
                             colorStops = arrayOf(
                                 0.00f to Color.Transparent,
                                 veilStart to Color.Transparent,
-                                veilKnee to handoff.copy(alpha = 0.14f),
-                                (veilKnee + (settle - veilKnee) * 0.56f) to handoff.copy(alpha = 0.42f),
-                                settle to handoff.copy(alpha = 0.78f),
-                                1.00f to handoff.copy(alpha = 0.92f)
+                                veilKnee to paletteVeil.copy(alpha = 0.18f),
+                                (veilKnee + (settle - veilKnee) * 0.58f) to paletteVeil.copy(alpha = 0.50f),
+                                settle to paletteVeil.copy(alpha = 0.82f),
+                                1.00f to paletteVeil.copy(alpha = 0.92f)
                             )
                         )
                     )
+
                     drawRect(
-                        brush = Brush.verticalGradient(
-                            colorStops = arrayOf(
-                                0.00f to Color.Transparent,
-                                (settle - 0.05f).coerceIn(0f, 1f) to Color.Transparent,
-                                glowPeak to Color.White.copy(alpha = 0.035f),
-                                glowTail to Color.Transparent,
-                                1.00f to Color.Transparent
-                            )
+                        brush = Brush.radialGradient(
+                            colors = listOf(
+                                ambience.primary.copy(alpha = 0.065f),
+                                Color.Transparent
+                            ),
+                            center = Offset(size.width * 0.25f, size.height * settle),
+                            radius = size.maxDimension * 0.54f
                         )
                     )
                     drawRect(
+                        brush = Brush.radialGradient(
+                            colors = listOf(
+                                ambience.secondary.copy(alpha = 0.050f),
+                                Color.Transparent
+                            ),
+                            center = Offset(size.width * 0.78f, size.height * settle),
+                            radius = size.maxDimension * 0.44f
+                        )
+                    )
+
+                    drawRect(
                         brush = Brush.verticalGradient(
                             colorStops = arrayOf(
-                                0.00f to Color.Black.copy(alpha = 0.46f),
-                                0.08f to Color.Black.copy(alpha = 0.18f),
+                                0.00f to Color.Black.copy(alpha = 0.40f),
+                                0.07f to Color.Black.copy(alpha = 0.14f),
                                 StageTopScrimEnd to Color.Transparent
                             )
                         )
@@ -181,84 +166,42 @@ internal fun PlayerConsoleSurface(
     val base = ambience.base
     val control = ambience.control
     val elevated = ambience.elevated
-    val mist = base.playerAmbienceMix(control, 0.54f)
-    val deep = elevated.playerAmbienceMix(control, 0.24f)
-    val bloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.40f)
+    val upper = base.playerAmbienceMix(control, 0.28f)
+    val lower = elevated.playerAmbienceMix(base, 0.52f)
+
     Box(
         modifier = modifier.drawBehind {
             if (size.minDimension <= 0f) return@drawBehind
+
             drawRect(
                 brush = Brush.verticalGradient(
                     colorStops = arrayOf(
-                        0.00f to base,
-                        0.18f to mist,
-                        0.54f to elevated.playerAmbienceMix(mist, 0.18f),
-                        0.84f to deep,
-                        1.00f to deep.playerAmbienceMix(base, 0.16f)
+                        0.00f to upper.copy(alpha = 0.76f),
+                        0.22f to upper.copy(alpha = 0.82f),
+                        0.62f to lower.copy(alpha = 0.90f),
+                        1.00f to lower.copy(alpha = 0.96f)
                     )
                 )
             )
-            drawRect(
-                brush = Brush.verticalGradient(
-                    colorStops = arrayOf(
-                        0.00f to Color.White.copy(alpha = 0.06f),
-                        0.10f to Color.White.copy(alpha = 0.022f),
-                        0.26f to Color.Transparent,
-                        1.00f to Color.Transparent
-                    )
-                )
-            )
+
             drawRect(
                 brush = Brush.radialGradient(
                     colors = listOf(
-                        ambience.primary.copy(alpha = 0.15f),
-                        ambience.primary.copy(alpha = 0.05f),
+                        ambience.primary.copy(alpha = 0.09f),
                         Color.Transparent
                     ),
-                    center = Offset(size.width * 0.18f, size.height * 0.06f),
-                    radius = size.maxDimension * 0.82f
+                    center = Offset(size.width * 0.20f, 0f),
+                    radius = size.width * 0.72f
                 )
             )
             drawRect(
                 brush = Brush.radialGradient(
                     colors = listOf(
-                        ambience.secondary.copy(alpha = 0.11f),
+                        ambience.secondary.copy(alpha = 0.07f),
                         Color.Transparent
                     ),
                     center = Offset(size.width * 0.82f, size.height * 0.18f),
-                    radius = size.maxDimension * 0.64f
-                )
-            )
-            drawRect(
-                brush = Brush.radialGradient(
-                    colors = listOf(
-                        bloom.copy(alpha = 0.10f),
-                        Color.Transparent
-                    ),
-                    center = Offset(size.width * 0.50f, size.height * 0.76f),
-                    radius = size.maxDimension * 0.48f
-                )
-            )
-            drawRect(
-                brush = Brush.horizontalGradient(
-                    colorStops = arrayOf(
-                        0.00f to Color.Transparent,
-                        0.24f to ambience.primary.copy(alpha = 0.035f),
-                        0.52f to bloom.copy(alpha = 0.055f),
-                        0.80f to ambience.secondary.copy(alpha = 0.030f),
-                        1.00f to Color.Transparent
-                    )
-                ),
-                topLeft = Offset(0f, size.height * 0.26f),
-                size = Size(size.width, size.height * 0.44f)
-            )
-            drawRect(
-                brush = Brush.verticalGradient(
-                    colorStops = arrayOf(
-                        0.00f to Color.Transparent,
-                        0.82f to Color.Transparent,
-                        1.00f to Color.Black.copy(alpha = 0.10f)
-                    )
+                    radius = size.width * 0.62f
                 )
             )
         }
@@ -272,59 +215,27 @@ internal fun PlayerStageHorizon(
     isPlaying: Boolean,
     modifier: Modifier = Modifier
 ) {
-    val accent = ambience.primary
-    val secondary = ambience.secondary
-    val blend = accent.playerAmbienceMix(secondary, 0.42f)
     val intensity by animateFloatAsState(
-        targetValue = if (isPlaying) 1f else 0.65f,
-        animationSpec = if (animationsEnabled) tween(720, easing = LevyraPlayerDesign.Standard) else snap(),
+        targetValue = if (isPlaying) 1f else 0.72f,
+        animationSpec = if (animationsEnabled) tween(620, easing = LevyraPlayerDesign.Standard) else snap(),
         label = "player-stage-horizon"
     )
+
     Box(
         modifier = modifier.drawBehind {
             if (size.minDimension <= 0f) return@drawBehind
+
             drawRect(
                 brush = Brush.verticalGradient(
                     colorStops = arrayOf(
-                        0.00f to Color.White.copy(alpha = 0.038f * intensity),
-                        0.18f to Color.Transparent,
-                        1.00f to Color.Transparent
-                    )
-                )
-            )
-            drawRect(
-                brush = Brush.radialGradient(
-                    colors = listOf(
-                        accent.copy(alpha = 0.13f * intensity),
-                        accent.copy(alpha = 0.04f * intensity),
-                        Color.Transparent
-                    ),
-                    center = Offset(size.width * 0.26f, 0f),
-                    radius = size.width * 0.70f
-                )
-            )
-            drawRect(
-                brush = Brush.radialGradient(
-                    colors = listOf(
-                        secondary.copy(alpha = 0.10f * intensity),
-                        Color.Transparent
-                    ),
-                    center = Offset(size.width * 0.74f, 0f),
-                    radius = size.width * 0.56f
-                )
-            )
-            drawRect(
-                brush = Brush.horizontalGradient(
-                    colorStops = arrayOf(
                         0.00f to Color.Transparent,
-                        0.28f to blend.copy(alpha = 0.05f * intensity),
-                        0.52f to Color.White.copy(alpha = 0.03f * intensity),
-                        0.76f to blend.copy(alpha = 0.04f * intensity),
+                        0.14f to ambience.base.copy(alpha = 0.12f * intensity),
+                        0.42f to ambience.base.copy(alpha = 0.06f * intensity),
                         1.00f to Color.Transparent
                     )
                 ),
                 topLeft = Offset.Zero,
-                size = Size(size.width, size.height * 0.58f)
+                size = Size(size.width, size.height)
             )
         }
     )

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
@@ -17,12 +16,12 @@ import androidx.compose.ui.unit.dp
 import com.luc4n3x.levyra.domain.LevyraCanvasQuality
 import com.luc4n3x.levyra.feature.motion.MotionArtwork
 
-internal const val PlayerStageHeightFraction = 0.64f
-internal const val PlayerStageMinOverlapDp = 48f
+internal const val PlayerStageHeightFraction = 0.62f
+internal const val PlayerStageMinOverlapDp = 44f
 internal val PlayerStageSpillHeight: Dp = 96.dp
 
 private const val StageTopScrimEnd = 0.20f
-private const val StageSideVignetteAlpha = 0.035f
+private const val StageSideVignetteAlpha = 0.03f
 
 @Immutable
 internal data class PlayerStageMetrics(
@@ -61,16 +60,13 @@ internal fun PlayerStage(
     staticArtwork: @Composable () -> Unit
 ) {
     val settle = veilSettleFraction.coerceIn(0.35f, 0.98f)
-    val fadeStart = (settle - 0.15f).coerceIn(0.66f, 0.76f)
-    val fadeMid = (settle - 0.035f).coerceIn(fadeStart, 0.86f)
-    val fadeStrong = (settle + 0.065f).coerceIn(fadeMid, 0.94f)
-    val songColor = ambience.primary.playerAmbienceMix(ambience.secondary, 0.46f)
-    val handoff = ambience.base
-        .playerAmbienceMix(ambience.tint, 0.34f)
-        .playerAmbienceMix(songColor, 0.10f)
-    val deep = ambience.elevated
-        .playerAmbienceMix(ambience.tint, 0.36f)
-        .playerAmbienceMix(songColor, 0.14f)
+    val fadeStart = (settle - 0.20f).coerceIn(0.58f, 0.70f)
+    val fadeSoft = (fadeStart + 0.08f).coerceAtMost(0.78f)
+    val fadeMid = (fadeStart + 0.16f).coerceAtMost(0.86f)
+    val fadeDeep = (fadeStart + 0.25f).coerceAtMost(0.95f)
+    val songColor = ambience.primary.playerAmbienceMix(ambience.secondary, 0.42f)
+    val handoff = songColor.playerAmbienceMix(Color.Black, 0.60f)
+    val deep = songColor.playerAmbienceMix(Color.Black, 0.74f)
 
     Box(modifier = modifier) {
         Box(
@@ -102,32 +98,11 @@ internal fun PlayerStage(
                             colorStops = arrayOf(
                                 0.00f to Color.Transparent,
                                 fadeStart to Color.Transparent,
-                                fadeMid to handoff.copy(alpha = 0.18f),
-                                fadeStrong to handoff.copy(alpha = 0.48f),
-                                0.965f to deep.copy(alpha = 0.84f),
+                                fadeSoft to handoff.copy(alpha = 0.08f),
+                                fadeMid to handoff.copy(alpha = 0.26f),
+                                fadeDeep to deep.copy(alpha = 0.72f),
                                 1.00f to deep
                             )
-                        )
-                    )
-
-                    drawRect(
-                        brush = Brush.radialGradient(
-                            colors = listOf(
-                                ambience.primary.copy(alpha = 0.055f),
-                                Color.Transparent
-                            ),
-                            center = Offset(size.width * 0.22f, size.height),
-                            radius = size.width * 0.78f
-                        )
-                    )
-                    drawRect(
-                        brush = Brush.radialGradient(
-                            colors = listOf(
-                                ambience.secondary.copy(alpha = 0.045f),
-                                Color.Transparent
-                            ),
-                            center = Offset(size.width * 0.82f, size.height * 0.96f),
-                            radius = size.width * 0.66f
                         )
                     )
 
@@ -162,48 +137,20 @@ internal fun PlayerConsoleSurface(
     ambience: PlayerAmbience,
     modifier: Modifier = Modifier
 ) {
-    val songColor = ambience.primary.playerAmbienceMix(ambience.secondary, 0.46f)
-    val deep = ambience.elevated
-        .playerAmbienceMix(ambience.tint, 0.36f)
-        .playerAmbienceMix(songColor, 0.14f)
-    val middle = deep.playerAmbienceMix(ambience.tint, 0.14f)
-    val lower = deep.playerAmbienceMix(songColor, 0.08f)
+    val songColor = ambience.primary.playerAmbienceMix(ambience.secondary, 0.42f)
+    val deep = songColor.playerAmbienceMix(Color.Black, 0.74f)
+    val lower = songColor.playerAmbienceMix(Color.Black, 0.82f)
 
     Box(
         modifier = modifier.drawBehind {
             if (size.minDimension <= 0f) return@drawBehind
-
             drawRect(
                 brush = Brush.verticalGradient(
                     colorStops = arrayOf(
                         0.00f to deep,
-                        0.36f to middle,
-                        0.72f to lower,
-                        1.00f to deep
+                        0.42f to deep,
+                        1.00f to lower
                     )
-                )
-            )
-
-            drawRect(
-                brush = Brush.radialGradient(
-                    colors = listOf(
-                        ambience.primary.copy(alpha = 0.10f),
-                        ambience.primary.copy(alpha = 0.025f),
-                        Color.Transparent
-                    ),
-                    center = Offset(size.width * 0.16f, size.height * 0.10f),
-                    radius = size.width * 0.88f
-                )
-            )
-            drawRect(
-                brush = Brush.radialGradient(
-                    colors = listOf(
-                        ambience.secondary.copy(alpha = 0.085f),
-                        ambience.secondary.copy(alpha = 0.020f),
-                        Color.Transparent
-                    ),
-                    center = Offset(size.width * 0.84f, size.height * 0.26f),
-                    radius = size.width * 0.76f
                 )
             )
         }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
@@ -63,8 +64,13 @@ internal fun PlayerStage(
     val fadeStart = (settle - 0.15f).coerceIn(0.66f, 0.76f)
     val fadeMid = (settle - 0.035f).coerceIn(fadeStart, 0.86f)
     val fadeStrong = (settle + 0.065f).coerceIn(fadeMid, 0.94f)
-    val handoff = ambience.base.playerAmbienceMix(Color.Black, 0.18f)
-    val deep = handoff.playerAmbienceMix(Color.Black, 0.30f)
+    val songColor = ambience.primary.playerAmbienceMix(ambience.secondary, 0.46f)
+    val handoff = ambience.base
+        .playerAmbienceMix(ambience.tint, 0.34f)
+        .playerAmbienceMix(songColor, 0.10f)
+    val deep = ambience.elevated
+        .playerAmbienceMix(ambience.tint, 0.36f)
+        .playerAmbienceMix(songColor, 0.14f)
 
     Box(modifier = modifier) {
         Box(
@@ -96,11 +102,32 @@ internal fun PlayerStage(
                             colorStops = arrayOf(
                                 0.00f to Color.Transparent,
                                 fadeStart to Color.Transparent,
-                                fadeMid to handoff.copy(alpha = 0.20f),
-                                fadeStrong to handoff.copy(alpha = 0.52f),
-                                0.965f to handoff.copy(alpha = 0.84f),
+                                fadeMid to handoff.copy(alpha = 0.18f),
+                                fadeStrong to handoff.copy(alpha = 0.48f),
+                                0.965f to deep.copy(alpha = 0.84f),
                                 1.00f to deep
                             )
+                        )
+                    )
+
+                    drawRect(
+                        brush = Brush.radialGradient(
+                            colors = listOf(
+                                ambience.primary.copy(alpha = 0.055f),
+                                Color.Transparent
+                            ),
+                            center = Offset(size.width * 0.22f, size.height),
+                            radius = size.width * 0.78f
+                        )
+                    )
+                    drawRect(
+                        brush = Brush.radialGradient(
+                            colors = listOf(
+                                ambience.secondary.copy(alpha = 0.045f),
+                                Color.Transparent
+                            ),
+                            center = Offset(size.width * 0.82f, size.height * 0.96f),
+                            radius = size.width * 0.66f
                         )
                     )
 
@@ -135,19 +162,48 @@ internal fun PlayerConsoleSurface(
     ambience: PlayerAmbience,
     modifier: Modifier = Modifier
 ) {
-    val handoff = ambience.base.playerAmbienceMix(Color.Black, 0.18f)
-    val deep = handoff.playerAmbienceMix(Color.Black, 0.30f)
+    val songColor = ambience.primary.playerAmbienceMix(ambience.secondary, 0.46f)
+    val deep = ambience.elevated
+        .playerAmbienceMix(ambience.tint, 0.36f)
+        .playerAmbienceMix(songColor, 0.14f)
+    val middle = deep.playerAmbienceMix(ambience.tint, 0.14f)
+    val lower = deep.playerAmbienceMix(songColor, 0.08f)
 
     Box(
         modifier = modifier.drawBehind {
             if (size.minDimension <= 0f) return@drawBehind
+
             drawRect(
                 brush = Brush.verticalGradient(
                     colorStops = arrayOf(
                         0.00f to deep,
-                        0.44f to deep,
-                        1.00f to deep.playerAmbienceMix(Color.Black, 0.22f)
+                        0.36f to middle,
+                        0.72f to lower,
+                        1.00f to deep
                     )
+                )
+            )
+
+            drawRect(
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        ambience.primary.copy(alpha = 0.10f),
+                        ambience.primary.copy(alpha = 0.025f),
+                        Color.Transparent
+                    ),
+                    center = Offset(size.width * 0.16f, size.height * 0.10f),
+                    radius = size.width * 0.88f
+                )
+            )
+            drawRect(
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        ambience.secondary.copy(alpha = 0.085f),
+                        ambience.secondary.copy(alpha = 0.020f),
+                        Color.Transparent
+                    ),
+                    center = Offset(size.width * 0.84f, size.height * 0.26f),
+                    radius = size.width * 0.76f
                 )
             )
         }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
@@ -25,11 +25,12 @@ import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
 
 internal const val PlayerStageHeightFraction = 0.72f
 internal const val PlayerStageMinOverlapDp = 56f
-internal val PlayerStageSpillHeight: Dp = 120.dp
+internal val PlayerStageSpillHeight: Dp = 136.dp
 
-private const val StageTopScrimEnd = 0.24f
-private const val StageVeilLead = 0.52f
-private const val StageVeilKnee = 0.58f
+private const val StageTopScrimEnd = 0.22f
+private const val StageVeilLead = 0.46f
+private const val StageVeilKnee = 0.60f
+private const val StageSideVignetteAlpha = 0.24f
 
 @Immutable
 internal data class PlayerStageMetrics(
@@ -68,6 +69,7 @@ internal fun PlayerStage(
     staticArtwork: @Composable () -> Unit
 ) {
     val veil = ambience.base
+    val accent = ambience.primary.playerAmbienceMix(ambience.secondary, 0.34f)
     val settle = veilSettleFraction.coerceIn(0.35f, 0.98f)
     val veilStart = (settle - StageVeilLead).coerceIn(0.10f, settle)
     val veilKnee = (veilStart + (settle - veilStart) * StageVeilKnee).coerceIn(veilStart, settle)
@@ -85,13 +87,47 @@ internal fun PlayerStage(
                 }
                 .drawWithContent {
                     drawContent()
+
+                    drawRect(
+                        brush = Brush.horizontalGradient(
+                            colorStops = arrayOf(
+                                0.00f to Color.Black.copy(alpha = StageSideVignetteAlpha),
+                                0.16f to Color.Transparent,
+                                0.80f to Color.Transparent,
+                                1.00f to Color.Black.copy(alpha = StageSideVignetteAlpha * 0.82f)
+                            )
+                        )
+                    )
+
+                    drawRect(
+                        brush = Brush.radialGradient(
+                            colors = listOf(
+                                accent.copy(alpha = 0.16f),
+                                ambience.primary.copy(alpha = 0.07f),
+                                Color.Transparent
+                            ),
+                            center = Offset(size.width * 0.22f, size.height * settle * 0.92f),
+                            radius = size.maxDimension * 0.64f
+                        )
+                    )
+                    drawRect(
+                        brush = Brush.radialGradient(
+                            colors = listOf(
+                                ambience.secondary.copy(alpha = 0.10f),
+                                Color.Transparent
+                            ),
+                            center = Offset(size.width * 0.82f, size.height * settle * 0.76f),
+                            radius = size.maxDimension * 0.50f
+                        )
+                    )
+
                     drawRect(
                         brush = Brush.verticalGradient(
                             colorStops = arrayOf(
                                 0.00f to Color.Transparent,
                                 veilStart to Color.Transparent,
-                                veilKnee to veil.copy(alpha = 0.34f),
-                                (veilKnee + (settle - veilKnee) * 0.62f) to veil.copy(alpha = 0.78f),
+                                veilKnee to veil.copy(alpha = 0.28f),
+                                (veilKnee + (settle - veilKnee) * 0.58f) to veil.copy(alpha = 0.70f),
                                 settle to veil,
                                 1.00f to veil
                             )
@@ -100,7 +136,8 @@ internal fun PlayerStage(
                     drawRect(
                         brush = Brush.verticalGradient(
                             colorStops = arrayOf(
-                                0.00f to Color.Black.copy(alpha = 0.58f),
+                                0.00f to Color.Black.copy(alpha = 0.52f),
+                                0.08f to Color.Black.copy(alpha = 0.24f),
                                 StageTopScrimEnd to Color.Transparent
                             )
                         )
@@ -130,7 +167,8 @@ internal fun PlayerConsoleSurface(
     val base = ambience.base
     val control = ambience.control
     val elevated = ambience.elevated
-    val floor = control.playerAmbienceMix(base, 0.42f)
+    val floor = control.playerAmbienceMix(base, 0.36f)
+    val mid = base.playerAmbienceMix(control, 0.62f)
     Box(
         modifier = modifier.drawBehind {
             if (size.minDimension <= 0f) return@drawBehind
@@ -138,8 +176,8 @@ internal fun PlayerConsoleSurface(
                 brush = Brush.verticalGradient(
                     colorStops = arrayOf(
                         0.00f to base,
-                        0.34f to base.playerAmbienceMix(control, 0.72f),
-                        0.66f to elevated,
+                        0.22f to mid,
+                        0.64f to elevated,
                         1.00f to floor
                     )
                 )
@@ -147,11 +185,41 @@ internal fun PlayerConsoleSurface(
             drawRect(
                 brush = Brush.radialGradient(
                     colors = listOf(
-                        ambience.primary.copy(alpha = 0.13f),
+                        ambience.primary.copy(alpha = 0.18f),
+                        ambience.primary.copy(alpha = 0.06f),
                         Color.Transparent
                     ),
-                    center = Offset(size.width * 0.18f, size.height * 0.08f),
-                    radius = size.maxDimension * 0.92f
+                    center = Offset(size.width * 0.20f, size.height * 0.02f),
+                    radius = size.maxDimension * 0.76f
+                )
+            )
+            drawRect(
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        ambience.secondary.copy(alpha = 0.11f),
+                        Color.Transparent
+                    ),
+                    center = Offset(size.width * 0.78f, size.height * 0.30f),
+                    radius = size.maxDimension * 0.60f
+                )
+            )
+            drawRect(
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        ambience.primary.copy(alpha = 0.07f),
+                        Color.Transparent
+                    ),
+                    center = Offset(size.width * 0.50f, size.height * 0.78f),
+                    radius = size.maxDimension * 0.44f
+                )
+            )
+            drawRect(
+                brush = Brush.verticalGradient(
+                    colorStops = arrayOf(
+                        0.00f to Color.Transparent,
+                        0.78f to Color.Transparent,
+                        1.00f to Color.Black.copy(alpha = 0.14f)
+                    )
                 )
             )
         }
@@ -168,7 +236,7 @@ internal fun PlayerStageHorizon(
     val accent = ambience.primary
     val secondary = ambience.secondary
     val intensity by animateFloatAsState(
-        targetValue = if (isPlaying) 1f else 0.45f,
+        targetValue = if (isPlaying) 1f else 0.55f,
         animationSpec = if (animationsEnabled) tween(720, easing = LevyraPlayerDesign.Standard) else snap(),
         label = "player-stage-horizon"
     )
@@ -176,23 +244,34 @@ internal fun PlayerStageHorizon(
         modifier = modifier.drawBehind {
             if (size.minDimension <= 0f) return@drawBehind
             drawRect(
-                brush = Brush.verticalGradient(
-                    colorStops = arrayOf(
-                        0.00f to accent.copy(alpha = 0.15f * intensity),
-                        0.45f to secondary.copy(alpha = 0.06f * intensity),
-                        1.00f to Color.Transparent
-                    )
-                ),
-                topLeft = Offset.Zero,
-                size = Size(size.width, size.height)
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        accent.copy(alpha = 0.18f * intensity),
+                        accent.copy(alpha = 0.05f * intensity),
+                        Color.Transparent
+                    ),
+                    center = Offset(size.width * 0.30f, 0f),
+                    radius = size.width * 0.58f
+                )
+            )
+            drawRect(
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        secondary.copy(alpha = 0.12f * intensity),
+                        Color.Transparent
+                    ),
+                    center = Offset(size.width * 0.72f, 0f),
+                    radius = size.width * 0.46f
+                )
             )
             val hairline = LevyraPlayerDesign.Hairline.toPx()
             drawRect(
                 brush = Brush.horizontalGradient(
                     colorStops = arrayOf(
                         0.00f to Color.Transparent,
-                        0.22f to accent.copy(alpha = 0.42f * intensity),
-                        0.58f to secondary.copy(alpha = 0.26f * intensity),
+                        0.18f to accent.copy(alpha = 0.18f * intensity),
+                        0.52f to secondary.copy(alpha = 0.12f * intensity),
+                        0.84f to accent.copy(alpha = 0.08f * intensity),
                         1.00f to Color.Transparent
                     )
                 ),

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
@@ -1,36 +1,27 @@
 package com.luc4n3x.levyra.ui
 
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.snap
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.luc4n3x.levyra.domain.LevyraCanvasQuality
 import com.luc4n3x.levyra.feature.motion.MotionArtwork
-import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
 
-internal const val PlayerStageHeightFraction = 0.58f
-internal const val PlayerStageMinOverlapDp = 32f
-internal val PlayerStageSpillHeight: Dp = 176.dp
+internal const val PlayerStageHeightFraction = 0.64f
+internal const val PlayerStageMinOverlapDp = 48f
+internal val PlayerStageSpillHeight: Dp = 96.dp
 
 private const val StageTopScrimEnd = 0.20f
-private const val StageSideVignetteAlpha = 0.045f
+private const val StageSideVignetteAlpha = 0.035f
 
 @Immutable
 internal data class PlayerStageMetrics(
@@ -69,12 +60,11 @@ internal fun PlayerStage(
     staticArtwork: @Composable () -> Unit
 ) {
     val settle = veilSettleFraction.coerceIn(0.35f, 0.98f)
-    val fadeStart = (settle - 0.26f).coerceIn(0.58f, 0.72f)
-    val fadeSoft = (fadeStart + 0.10f).coerceAtMost(0.82f)
-    val fadeMid = (fadeStart + 0.18f).coerceAtMost(0.90f)
-    val fadeLow = (fadeStart + 0.25f).coerceAtMost(0.96f)
-    val handoff = ambience.base.playerAmbienceMix(ambience.control, 0.18f)
-    val bloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.38f)
+    val fadeStart = (settle - 0.15f).coerceIn(0.66f, 0.76f)
+    val fadeMid = (settle - 0.035f).coerceIn(fadeStart, 0.86f)
+    val fadeStrong = (settle + 0.065f).coerceIn(fadeMid, 0.94f)
+    val handoff = ambience.base.playerAmbienceMix(Color.Black, 0.18f)
+    val deep = handoff.playerAmbienceMix(Color.Black, 0.30f)
 
     Box(modifier = modifier) {
         Box(
@@ -86,7 +76,6 @@ internal fun PlayerStage(
                     val scale = contentScale()
                     scaleX = scale
                     scaleY = scale
-                    compositingStrategy = CompositingStrategy.Offscreen
                 }
                 .drawWithContent {
                     drawContent()
@@ -95,8 +84,8 @@ internal fun PlayerStage(
                         brush = Brush.horizontalGradient(
                             colorStops = arrayOf(
                                 0.00f to Color.Black.copy(alpha = StageSideVignetteAlpha),
-                                0.12f to Color.Transparent,
-                                0.88f to Color.Transparent,
+                                0.10f to Color.Transparent,
+                                0.90f to Color.Transparent,
                                 1.00f to Color.Black.copy(alpha = StageSideVignetteAlpha)
                             )
                         )
@@ -107,33 +96,11 @@ internal fun PlayerStage(
                             colorStops = arrayOf(
                                 0.00f to Color.Transparent,
                                 fadeStart to Color.Transparent,
-                                fadeSoft to handoff.copy(alpha = 0.045f),
-                                fadeMid to handoff.copy(alpha = 0.10f),
-                                fadeLow to handoff.copy(alpha = 0.15f),
-                                1.00f to handoff.copy(alpha = 0.18f)
+                                fadeMid to handoff.copy(alpha = 0.20f),
+                                fadeStrong to handoff.copy(alpha = 0.52f),
+                                0.965f to handoff.copy(alpha = 0.84f),
+                                1.00f to deep
                             )
-                        )
-                    )
-
-                    drawRect(
-                        brush = Brush.radialGradient(
-                            colors = listOf(
-                                bloom.copy(alpha = 0.065f),
-                                ambience.primary.copy(alpha = 0.020f),
-                                Color.Transparent
-                            ),
-                            center = Offset(size.width * 0.24f, size.height * 0.84f),
-                            radius = size.maxDimension * 0.62f
-                        )
-                    )
-                    drawRect(
-                        brush = Brush.radialGradient(
-                            colors = listOf(
-                                ambience.secondary.copy(alpha = 0.045f),
-                                Color.Transparent
-                            ),
-                            center = Offset(size.width * 0.80f, size.height * 0.88f),
-                            radius = size.maxDimension * 0.50f
                         )
                     )
 
@@ -145,20 +112,6 @@ internal fun PlayerStage(
                                 StageTopScrimEnd to Color.Transparent
                             )
                         )
-                    )
-
-                    drawRect(
-                        brush = Brush.verticalGradient(
-                            colorStops = arrayOf(
-                                0.00f to Color.White,
-                                fadeStart to Color.White,
-                                fadeSoft to Color.White.copy(alpha = 0.94f),
-                                fadeMid to Color.White.copy(alpha = 0.70f),
-                                fadeLow to Color.White.copy(alpha = 0.34f),
-                                1.00f to Color.Transparent
-                            )
-                        ),
-                        blendMode = BlendMode.DstIn
                     )
                 }
         ) {
@@ -182,56 +135,19 @@ internal fun PlayerConsoleSurface(
     ambience: PlayerAmbience,
     modifier: Modifier = Modifier
 ) {
-    val handoff = ambience.base.playerAmbienceMix(ambience.control, 0.18f)
-    val lower = ambience.elevated.playerAmbienceMix(ambience.base, 0.46f)
-    val bloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.40f)
+    val handoff = ambience.base.playerAmbienceMix(Color.Black, 0.18f)
+    val deep = handoff.playerAmbienceMix(Color.Black, 0.30f)
 
     Box(
         modifier = modifier.drawBehind {
             if (size.minDimension <= 0f) return@drawBehind
-
             drawRect(
                 brush = Brush.verticalGradient(
                     colorStops = arrayOf(
-                        0.00f to Color.Transparent,
-                        0.18f to handoff.copy(alpha = 0.035f),
-                        0.38f to handoff.copy(alpha = 0.11f),
-                        0.62f to lower.copy(alpha = 0.30f),
-                        0.82f to lower.copy(alpha = 0.52f),
-                        1.00f to lower.copy(alpha = 0.70f)
+                        0.00f to deep,
+                        0.44f to deep,
+                        1.00f to deep.playerAmbienceMix(Color.Black, 0.22f)
                     )
-                )
-            )
-
-            drawRect(
-                brush = Brush.radialGradient(
-                    colors = listOf(
-                        ambience.primary.copy(alpha = 0.070f),
-                        ambience.primary.copy(alpha = 0.020f),
-                        Color.Transparent
-                    ),
-                    center = Offset(size.width * 0.18f, size.height * 0.06f),
-                    radius = size.width * 0.96f
-                )
-            )
-            drawRect(
-                brush = Brush.radialGradient(
-                    colors = listOf(
-                        ambience.secondary.copy(alpha = 0.055f),
-                        Color.Transparent
-                    ),
-                    center = Offset(size.width * 0.84f, size.height * 0.20f),
-                    radius = size.width * 0.82f
-                )
-            )
-            drawRect(
-                brush = Brush.radialGradient(
-                    colors = listOf(
-                        bloom.copy(alpha = 0.035f),
-                        Color.Transparent
-                    ),
-                    center = Offset(size.width * 0.52f, size.height * 0.74f),
-                    radius = size.maxDimension * 0.64f
                 )
             )
         }
@@ -245,52 +161,5 @@ internal fun PlayerStageHorizon(
     isPlaying: Boolean,
     modifier: Modifier = Modifier
 ) {
-    val mist = ambience.base.playerAmbienceMix(ambience.control, 0.16f)
-    val bloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.42f)
-    val intensity by animateFloatAsState(
-        targetValue = if (isPlaying) 0.60f else 0.46f,
-        animationSpec = if (animationsEnabled) tween(760, easing = LevyraPlayerDesign.Standard) else snap(),
-        label = "player-stage-ambient-mist"
-    )
-
-    Box(
-        modifier = modifier.drawBehind {
-            if (size.minDimension <= 0f) return@drawBehind
-
-            drawRect(
-                brush = Brush.verticalGradient(
-                    colorStops = arrayOf(
-                        0.00f to Color.Transparent,
-                        0.24f to mist.copy(alpha = 0.020f * intensity),
-                        0.48f to mist.copy(alpha = 0.060f * intensity),
-                        0.68f to mist.copy(alpha = 0.045f * intensity),
-                        1.00f to Color.Transparent
-                    )
-                ),
-                topLeft = Offset.Zero,
-                size = Size(size.width, size.height)
-            )
-
-            drawRect(
-                brush = Brush.radialGradient(
-                    colors = listOf(
-                        bloom.copy(alpha = 0.050f * intensity),
-                        Color.Transparent
-                    ),
-                    center = Offset(size.width * 0.30f, size.height * 0.46f),
-                    radius = size.width * 0.88f
-                )
-            )
-            drawRect(
-                brush = Brush.radialGradient(
-                    colors = listOf(
-                        ambience.secondary.copy(alpha = 0.038f * intensity),
-                        Color.Transparent
-                    ),
-                    center = Offset(size.width * 0.78f, size.height * 0.54f),
-                    radius = size.width * 0.72f
-                )
-            )
-        }
-    )
+    Box(modifier = modifier)
 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
@@ -25,12 +25,12 @@ import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
 
 internal const val PlayerStageHeightFraction = 0.72f
 internal const val PlayerStageMinOverlapDp = 56f
-internal val PlayerStageSpillHeight: Dp = 108.dp
+internal val PlayerStageSpillHeight: Dp = 184.dp
 
 private const val StageTopScrimEnd = 0.20f
-private const val StageVeilLead = 0.42f
-private const val StageVeilKnee = 0.58f
-private const val StageSideVignetteAlpha = 0.10f
+private const val StageVeilLead = 0.52f
+private const val StageVeilKnee = 0.54f
+private const val StageSideVignetteAlpha = 0.08f
 
 @Immutable
 internal data class PlayerStageMetrics(
@@ -69,9 +69,10 @@ internal fun PlayerStage(
     staticArtwork: @Composable () -> Unit
 ) {
     val settle = veilSettleFraction.coerceIn(0.35f, 0.98f)
-    val veilStart = (settle - StageVeilLead).coerceIn(0.08f, settle)
+    val veilStart = (settle - StageVeilLead).coerceIn(0.06f, settle)
     val veilKnee = (veilStart + (settle - veilStart) * StageVeilKnee).coerceIn(veilStart, settle)
-    val paletteVeil = ambience.base.playerAmbienceMix(ambience.control, 0.34f)
+    val paletteVeil = ambience.base.playerAmbienceMix(ambience.control, 0.22f)
+    val paletteBloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.38f)
 
     Box(modifier = modifier) {
         Box(
@@ -103,10 +104,11 @@ internal fun PlayerStage(
                             colorStops = arrayOf(
                                 0.00f to Color.Transparent,
                                 veilStart to Color.Transparent,
-                                veilKnee to paletteVeil.copy(alpha = 0.18f),
-                                (veilKnee + (settle - veilKnee) * 0.58f) to paletteVeil.copy(alpha = 0.50f),
-                                settle to paletteVeil.copy(alpha = 0.82f),
-                                1.00f to paletteVeil.copy(alpha = 0.92f)
+                                (veilStart + (veilKnee - veilStart) * 0.52f) to paletteVeil.copy(alpha = 0.05f),
+                                veilKnee to paletteVeil.copy(alpha = 0.12f),
+                                (veilKnee + (settle - veilKnee) * 0.55f) to paletteVeil.copy(alpha = 0.27f),
+                                settle to paletteVeil.copy(alpha = 0.42f),
+                                1.00f to paletteVeil.copy(alpha = 0.58f)
                             )
                         )
                     )
@@ -114,29 +116,30 @@ internal fun PlayerStage(
                     drawRect(
                         brush = Brush.radialGradient(
                             colors = listOf(
-                                ambience.primary.copy(alpha = 0.065f),
+                                paletteBloom.copy(alpha = 0.070f),
+                                ambience.primary.copy(alpha = 0.025f),
                                 Color.Transparent
                             ),
-                            center = Offset(size.width * 0.25f, size.height * settle),
-                            radius = size.maxDimension * 0.54f
+                            center = Offset(size.width * 0.28f, size.height * settle * 1.02f),
+                            radius = size.maxDimension * 0.62f
                         )
                     )
                     drawRect(
                         brush = Brush.radialGradient(
                             colors = listOf(
-                                ambience.secondary.copy(alpha = 0.050f),
+                                ambience.secondary.copy(alpha = 0.040f),
                                 Color.Transparent
                             ),
-                            center = Offset(size.width * 0.78f, size.height * settle),
-                            radius = size.maxDimension * 0.44f
+                            center = Offset(size.width * 0.76f, size.height * settle * 1.01f),
+                            radius = size.maxDimension * 0.50f
                         )
                     )
 
                     drawRect(
                         brush = Brush.verticalGradient(
                             colorStops = arrayOf(
-                                0.00f to Color.Black.copy(alpha = 0.40f),
-                                0.07f to Color.Black.copy(alpha = 0.14f),
+                                0.00f to Color.Black.copy(alpha = 0.38f),
+                                0.07f to Color.Black.copy(alpha = 0.12f),
                                 StageTopScrimEnd to Color.Transparent
                             )
                         )
@@ -166,8 +169,10 @@ internal fun PlayerConsoleSurface(
     val base = ambience.base
     val control = ambience.control
     val elevated = ambience.elevated
-    val upper = base.playerAmbienceMix(control, 0.28f)
-    val lower = elevated.playerAmbienceMix(base, 0.52f)
+    val upper = base.playerAmbienceMix(control, 0.20f)
+    val middle = base.playerAmbienceMix(elevated, 0.42f)
+    val lower = elevated.playerAmbienceMix(base, 0.48f)
+    val bloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.40f)
 
     Box(
         modifier = modifier.drawBehind {
@@ -176,10 +181,12 @@ internal fun PlayerConsoleSurface(
             drawRect(
                 brush = Brush.verticalGradient(
                     colorStops = arrayOf(
-                        0.00f to upper.copy(alpha = 0.76f),
-                        0.22f to upper.copy(alpha = 0.82f),
-                        0.62f to lower.copy(alpha = 0.90f),
-                        1.00f to lower.copy(alpha = 0.96f)
+                        0.00f to upper.copy(alpha = 0.06f),
+                        0.14f to upper.copy(alpha = 0.12f),
+                        0.30f to upper.copy(alpha = 0.22f),
+                        0.48f to middle.copy(alpha = 0.40f),
+                        0.70f to lower.copy(alpha = 0.64f),
+                        1.00f to lower.copy(alpha = 0.88f)
                     )
                 )
             )
@@ -187,21 +194,32 @@ internal fun PlayerConsoleSurface(
             drawRect(
                 brush = Brush.radialGradient(
                     colors = listOf(
-                        ambience.primary.copy(alpha = 0.09f),
+                        ambience.primary.copy(alpha = 0.075f),
+                        ambience.primary.copy(alpha = 0.025f),
                         Color.Transparent
                     ),
                     center = Offset(size.width * 0.20f, 0f),
-                    radius = size.width * 0.72f
+                    radius = size.width * 0.88f
                 )
             )
             drawRect(
                 brush = Brush.radialGradient(
                     colors = listOf(
-                        ambience.secondary.copy(alpha = 0.07f),
+                        ambience.secondary.copy(alpha = 0.060f),
                         Color.Transparent
                     ),
-                    center = Offset(size.width * 0.82f, size.height * 0.18f),
-                    radius = size.width * 0.62f
+                    center = Offset(size.width * 0.82f, size.height * 0.16f),
+                    radius = size.width * 0.74f
+                )
+            )
+            drawRect(
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        bloom.copy(alpha = 0.035f),
+                        Color.Transparent
+                    ),
+                    center = Offset(size.width * 0.50f, size.height * 0.54f),
+                    radius = size.maxDimension * 0.58f
                 )
             )
         }
@@ -215,9 +233,11 @@ internal fun PlayerStageHorizon(
     isPlaying: Boolean,
     modifier: Modifier = Modifier
 ) {
+    val bridge = ambience.base.playerAmbienceMix(ambience.control, 0.22f)
+    val bloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.40f)
     val intensity by animateFloatAsState(
-        targetValue = if (isPlaying) 1f else 0.72f,
-        animationSpec = if (animationsEnabled) tween(620, easing = LevyraPlayerDesign.Standard) else snap(),
+        targetValue = if (isPlaying) 0.68f else 0.52f,
+        animationSpec = if (animationsEnabled) tween(700, easing = LevyraPlayerDesign.Standard) else snap(),
         label = "player-stage-horizon"
     )
 
@@ -229,13 +249,27 @@ internal fun PlayerStageHorizon(
                 brush = Brush.verticalGradient(
                     colorStops = arrayOf(
                         0.00f to Color.Transparent,
-                        0.14f to ambience.base.copy(alpha = 0.12f * intensity),
-                        0.42f to ambience.base.copy(alpha = 0.06f * intensity),
+                        0.16f to bridge.copy(alpha = 0.025f * intensity),
+                        0.34f to bridge.copy(alpha = 0.065f * intensity),
+                        0.52f to bridge.copy(alpha = 0.14f * intensity),
+                        0.68f to bridge.copy(alpha = 0.11f * intensity),
+                        0.84f to bridge.copy(alpha = 0.045f * intensity),
                         1.00f to Color.Transparent
                     )
                 ),
                 topLeft = Offset.Zero,
                 size = Size(size.width, size.height)
+            )
+
+            drawRect(
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        bloom.copy(alpha = 0.055f * intensity),
+                        Color.Transparent
+                    ),
+                    center = Offset(size.width * 0.34f, size.height * 0.52f),
+                    radius = size.width * 0.78f
+                )
             )
         }
     )

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
@@ -25,12 +25,12 @@ import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
 
 internal const val PlayerStageHeightFraction = 0.72f
 internal const val PlayerStageMinOverlapDp = 56f
-internal val PlayerStageSpillHeight: Dp = 136.dp
+internal val PlayerStageSpillHeight: Dp = 124.dp
 
 private const val StageTopScrimEnd = 0.22f
 private const val StageVeilLead = 0.46f
 private const val StageVeilKnee = 0.60f
-private const val StageSideVignetteAlpha = 0.24f
+private const val StageSideVignetteAlpha = 0.16f
 
 @Immutable
 internal data class PlayerStageMetrics(
@@ -70,9 +70,12 @@ internal fun PlayerStage(
 ) {
     val veil = ambience.base
     val accent = ambience.primary.playerAmbienceMix(ambience.secondary, 0.34f)
+    val handoff = veil.playerAmbienceMix(accent, 0.18f)
     val settle = veilSettleFraction.coerceIn(0.35f, 0.98f)
     val veilStart = (settle - StageVeilLead).coerceIn(0.10f, settle)
     val veilKnee = (veilStart + (settle - veilStart) * StageVeilKnee).coerceIn(veilStart, settle)
+    val glowPeak = (settle + 0.015f).coerceIn(0f, 1f)
+    val glowTail = (settle + 0.10f).coerceIn(glowPeak, 1f)
 
     Box(modifier = modifier) {
         Box(
@@ -92,9 +95,9 @@ internal fun PlayerStage(
                         brush = Brush.horizontalGradient(
                             colorStops = arrayOf(
                                 0.00f to Color.Black.copy(alpha = StageSideVignetteAlpha),
-                                0.16f to Color.Transparent,
-                                0.80f to Color.Transparent,
-                                1.00f to Color.Black.copy(alpha = StageSideVignetteAlpha * 0.82f)
+                                0.18f to Color.Transparent,
+                                0.82f to Color.Transparent,
+                                1.00f to Color.Black.copy(alpha = StageSideVignetteAlpha * 0.80f)
                             )
                         )
                     )
@@ -102,22 +105,22 @@ internal fun PlayerStage(
                     drawRect(
                         brush = Brush.radialGradient(
                             colors = listOf(
-                                accent.copy(alpha = 0.16f),
-                                ambience.primary.copy(alpha = 0.07f),
+                                accent.copy(alpha = 0.12f),
+                                ambience.primary.copy(alpha = 0.05f),
                                 Color.Transparent
                             ),
-                            center = Offset(size.width * 0.22f, size.height * settle * 0.92f),
-                            radius = size.maxDimension * 0.64f
+                            center = Offset(size.width * 0.24f, size.height * settle * 0.92f),
+                            radius = size.maxDimension * 0.62f
                         )
                     )
                     drawRect(
                         brush = Brush.radialGradient(
                             colors = listOf(
-                                ambience.secondary.copy(alpha = 0.10f),
+                                ambience.secondary.copy(alpha = 0.08f),
                                 Color.Transparent
                             ),
-                            center = Offset(size.width * 0.82f, size.height * settle * 0.76f),
-                            radius = size.maxDimension * 0.50f
+                            center = Offset(size.width * 0.78f, size.height * settle * 0.82f),
+                            radius = size.maxDimension * 0.48f
                         )
                     )
 
@@ -126,18 +129,29 @@ internal fun PlayerStage(
                             colorStops = arrayOf(
                                 0.00f to Color.Transparent,
                                 veilStart to Color.Transparent,
-                                veilKnee to veil.copy(alpha = 0.28f),
-                                (veilKnee + (settle - veilKnee) * 0.58f) to veil.copy(alpha = 0.70f),
-                                settle to veil,
-                                1.00f to veil
+                                veilKnee to handoff.copy(alpha = 0.14f),
+                                (veilKnee + (settle - veilKnee) * 0.56f) to handoff.copy(alpha = 0.42f),
+                                settle to handoff.copy(alpha = 0.78f),
+                                1.00f to handoff.copy(alpha = 0.92f)
                             )
                         )
                     )
                     drawRect(
                         brush = Brush.verticalGradient(
                             colorStops = arrayOf(
-                                0.00f to Color.Black.copy(alpha = 0.52f),
-                                0.08f to Color.Black.copy(alpha = 0.24f),
+                                0.00f to Color.Transparent,
+                                (settle - 0.05f).coerceIn(0f, 1f) to Color.Transparent,
+                                glowPeak to Color.White.copy(alpha = 0.035f),
+                                glowTail to Color.Transparent,
+                                1.00f to Color.Transparent
+                            )
+                        )
+                    )
+                    drawRect(
+                        brush = Brush.verticalGradient(
+                            colorStops = arrayOf(
+                                0.00f to Color.Black.copy(alpha = 0.46f),
+                                0.08f to Color.Black.copy(alpha = 0.18f),
                                 StageTopScrimEnd to Color.Transparent
                             )
                         )
@@ -167,8 +181,9 @@ internal fun PlayerConsoleSurface(
     val base = ambience.base
     val control = ambience.control
     val elevated = ambience.elevated
-    val floor = control.playerAmbienceMix(base, 0.36f)
-    val mid = base.playerAmbienceMix(control, 0.62f)
+    val mist = base.playerAmbienceMix(control, 0.54f)
+    val deep = elevated.playerAmbienceMix(control, 0.24f)
+    val bloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.40f)
     Box(
         modifier = modifier.drawBehind {
             if (size.minDimension <= 0f) return@drawBehind
@@ -176,21 +191,32 @@ internal fun PlayerConsoleSurface(
                 brush = Brush.verticalGradient(
                     colorStops = arrayOf(
                         0.00f to base,
-                        0.22f to mid,
-                        0.64f to elevated,
-                        1.00f to floor
+                        0.18f to mist,
+                        0.54f to elevated.playerAmbienceMix(mist, 0.18f),
+                        0.84f to deep,
+                        1.00f to deep.playerAmbienceMix(base, 0.16f)
+                    )
+                )
+            )
+            drawRect(
+                brush = Brush.verticalGradient(
+                    colorStops = arrayOf(
+                        0.00f to Color.White.copy(alpha = 0.06f),
+                        0.10f to Color.White.copy(alpha = 0.022f),
+                        0.26f to Color.Transparent,
+                        1.00f to Color.Transparent
                     )
                 )
             )
             drawRect(
                 brush = Brush.radialGradient(
                     colors = listOf(
-                        ambience.primary.copy(alpha = 0.18f),
-                        ambience.primary.copy(alpha = 0.06f),
+                        ambience.primary.copy(alpha = 0.15f),
+                        ambience.primary.copy(alpha = 0.05f),
                         Color.Transparent
                     ),
-                    center = Offset(size.width * 0.20f, size.height * 0.02f),
-                    radius = size.maxDimension * 0.76f
+                    center = Offset(size.width * 0.18f, size.height * 0.06f),
+                    radius = size.maxDimension * 0.82f
                 )
             )
             drawRect(
@@ -199,26 +225,39 @@ internal fun PlayerConsoleSurface(
                         ambience.secondary.copy(alpha = 0.11f),
                         Color.Transparent
                     ),
-                    center = Offset(size.width * 0.78f, size.height * 0.30f),
-                    radius = size.maxDimension * 0.60f
+                    center = Offset(size.width * 0.82f, size.height * 0.18f),
+                    radius = size.maxDimension * 0.64f
                 )
             )
             drawRect(
                 brush = Brush.radialGradient(
                     colors = listOf(
-                        ambience.primary.copy(alpha = 0.07f),
+                        bloom.copy(alpha = 0.10f),
                         Color.Transparent
                     ),
-                    center = Offset(size.width * 0.50f, size.height * 0.78f),
-                    radius = size.maxDimension * 0.44f
+                    center = Offset(size.width * 0.50f, size.height * 0.76f),
+                    radius = size.maxDimension * 0.48f
                 )
+            )
+            drawRect(
+                brush = Brush.horizontalGradient(
+                    colorStops = arrayOf(
+                        0.00f to Color.Transparent,
+                        0.24f to ambience.primary.copy(alpha = 0.035f),
+                        0.52f to bloom.copy(alpha = 0.055f),
+                        0.80f to ambience.secondary.copy(alpha = 0.030f),
+                        1.00f to Color.Transparent
+                    )
+                ),
+                topLeft = Offset(0f, size.height * 0.26f),
+                size = Size(size.width, size.height * 0.44f)
             )
             drawRect(
                 brush = Brush.verticalGradient(
                     colorStops = arrayOf(
                         0.00f to Color.Transparent,
-                        0.78f to Color.Transparent,
-                        1.00f to Color.Black.copy(alpha = 0.14f)
+                        0.82f to Color.Transparent,
+                        1.00f to Color.Black.copy(alpha = 0.10f)
                     )
                 )
             )
@@ -235,8 +274,9 @@ internal fun PlayerStageHorizon(
 ) {
     val accent = ambience.primary
     val secondary = ambience.secondary
+    val blend = accent.playerAmbienceMix(secondary, 0.42f)
     val intensity by animateFloatAsState(
-        targetValue = if (isPlaying) 1f else 0.55f,
+        targetValue = if (isPlaying) 1f else 0.65f,
         animationSpec = if (animationsEnabled) tween(720, easing = LevyraPlayerDesign.Standard) else snap(),
         label = "player-stage-horizon"
     )
@@ -244,39 +284,47 @@ internal fun PlayerStageHorizon(
         modifier = modifier.drawBehind {
             if (size.minDimension <= 0f) return@drawBehind
             drawRect(
-                brush = Brush.radialGradient(
-                    colors = listOf(
-                        accent.copy(alpha = 0.18f * intensity),
-                        accent.copy(alpha = 0.05f * intensity),
-                        Color.Transparent
-                    ),
-                    center = Offset(size.width * 0.30f, 0f),
-                    radius = size.width * 0.58f
+                brush = Brush.verticalGradient(
+                    colorStops = arrayOf(
+                        0.00f to Color.White.copy(alpha = 0.038f * intensity),
+                        0.18f to Color.Transparent,
+                        1.00f to Color.Transparent
+                    )
                 )
             )
             drawRect(
                 brush = Brush.radialGradient(
                     colors = listOf(
-                        secondary.copy(alpha = 0.12f * intensity),
+                        accent.copy(alpha = 0.13f * intensity),
+                        accent.copy(alpha = 0.04f * intensity),
                         Color.Transparent
                     ),
-                    center = Offset(size.width * 0.72f, 0f),
-                    radius = size.width * 0.46f
+                    center = Offset(size.width * 0.26f, 0f),
+                    radius = size.width * 0.70f
                 )
             )
-            val hairline = LevyraPlayerDesign.Hairline.toPx()
+            drawRect(
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        secondary.copy(alpha = 0.10f * intensity),
+                        Color.Transparent
+                    ),
+                    center = Offset(size.width * 0.74f, 0f),
+                    radius = size.width * 0.56f
+                )
+            )
             drawRect(
                 brush = Brush.horizontalGradient(
                     colorStops = arrayOf(
                         0.00f to Color.Transparent,
-                        0.18f to accent.copy(alpha = 0.18f * intensity),
-                        0.52f to secondary.copy(alpha = 0.12f * intensity),
-                        0.84f to accent.copy(alpha = 0.08f * intensity),
+                        0.28f to blend.copy(alpha = 0.05f * intensity),
+                        0.52f to Color.White.copy(alpha = 0.03f * intensity),
+                        0.76f to blend.copy(alpha = 0.04f * intensity),
                         1.00f to Color.Transparent
                     )
                 ),
                 topLeft = Offset.Zero,
-                size = Size(size.width, hairline)
+                size = Size(size.width, size.height * 0.58f)
             )
         }
     )

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
@@ -37,14 +37,6 @@ internal data class PlayerStageMetrics(
     val veilSettleFraction: Float
 )
 
-/**
- * Resolves how tall the stage is and where its veil has to be fully settled.
- *
- * The stage keeps one constant height whether a Canvas is rendering or only static artwork is
- * available, so the composition never resizes when motion artwork arrives or disappears. The veil
- * finishes exactly where the console content starts, which is what lets the image hand over to the
- * player surface without a visible seam on any screen size.
- */
 internal fun playerStageMetrics(
     availableHeightDp: Float,
     consoleHeightDp: Float
@@ -60,15 +52,6 @@ internal fun playerStageMetrics(
     return PlayerStageMetrics(stageHeightDp = stage, veilSettleFraction = settle)
 }
 
-/**
- * The cinematic stage: one large, edge-to-edge surface that hosts either a Canvas or the static
- * artwork.
- *
- * Motion artwork and static artwork share the same frame and the same veil, so the player reads as
- * one composition in both cases. The veil is derived from the live artwork palette and resolves to
- * the exact colour the console is painted with, so the image melts into the player surface instead
- * of sitting on top of it like a wallpaper.
- */
 @Composable
 internal fun PlayerStage(
     motionArtwork: MotionArtwork?,
@@ -139,12 +122,6 @@ internal fun PlayerStage(
     }
 }
 
-/**
- * The surface the stage hands the image over to.
- *
- * It starts on the exact veil colour so the two layers read as one continuous material, then loses
- * a little light toward the bottom so the transport still sits on the darkest part of the screen.
- */
 @Composable
 internal fun PlayerConsoleSurface(
     ambience: PlayerAmbience,
@@ -181,13 +158,6 @@ internal fun PlayerConsoleSurface(
     )
 }
 
-/**
- * The horizon: the one structural line of the composition.
- *
- * It marks where the image world ends and the information world begins, and it is the only place
- * the live accent colour is allowed to touch the console. Its brightness follows playback, so the
- * seam breathes with the track instead of being static decoration.
- */
 @Composable
 internal fun PlayerStageHorizon(
     ambience: PlayerAmbience,

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
@@ -14,8 +14,10 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -25,12 +27,10 @@ import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
 
 internal const val PlayerStageHeightFraction = 0.58f
 internal const val PlayerStageMinOverlapDp = 32f
-internal val PlayerStageSpillHeight: Dp = 144.dp
+internal val PlayerStageSpillHeight: Dp = 176.dp
 
 private const val StageTopScrimEnd = 0.20f
-private const val StageVeilLead = 0.48f
-private const val StageVeilKnee = 0.56f
-private const val StageSideVignetteAlpha = 0.055f
+private const val StageSideVignetteAlpha = 0.045f
 
 @Immutable
 internal data class PlayerStageMetrics(
@@ -69,9 +69,11 @@ internal fun PlayerStage(
     staticArtwork: @Composable () -> Unit
 ) {
     val settle = veilSettleFraction.coerceIn(0.35f, 0.98f)
-    val veilStart = (settle - StageVeilLead).coerceIn(0.08f, settle)
-    val veilKnee = (veilStart + (settle - veilStart) * StageVeilKnee).coerceIn(veilStart, settle)
-    val handoff = ambience.base.playerAmbienceMix(ambience.control, 0.20f)
+    val fadeStart = (settle - 0.26f).coerceIn(0.58f, 0.72f)
+    val fadeSoft = (fadeStart + 0.10f).coerceAtMost(0.82f)
+    val fadeMid = (fadeStart + 0.18f).coerceAtMost(0.90f)
+    val fadeLow = (fadeStart + 0.25f).coerceAtMost(0.96f)
+    val handoff = ambience.base.playerAmbienceMix(ambience.control, 0.18f)
     val bloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.38f)
 
     Box(modifier = modifier) {
@@ -84,6 +86,7 @@ internal fun PlayerStage(
                     val scale = contentScale()
                     scaleX = scale
                     scaleY = scale
+                    compositingStrategy = CompositingStrategy.Offscreen
                 }
                 .drawWithContent {
                     drawContent()
@@ -103,13 +106,11 @@ internal fun PlayerStage(
                         brush = Brush.verticalGradient(
                             colorStops = arrayOf(
                                 0.00f to Color.Transparent,
-                                veilStart to Color.Transparent,
-                                (veilStart + (veilKnee - veilStart) * 0.42f) to handoff.copy(alpha = 0.035f),
-                                veilKnee to handoff.copy(alpha = 0.10f),
-                                (veilKnee + (settle - veilKnee) * 0.52f) to handoff.copy(alpha = 0.24f),
-                                settle to handoff.copy(alpha = 0.46f),
-                                (settle + (1f - settle) * 0.46f) to handoff.copy(alpha = 0.68f),
-                                1.00f to handoff.copy(alpha = 0.90f)
+                                fadeStart to Color.Transparent,
+                                fadeSoft to handoff.copy(alpha = 0.045f),
+                                fadeMid to handoff.copy(alpha = 0.10f),
+                                fadeLow to handoff.copy(alpha = 0.15f),
+                                1.00f to handoff.copy(alpha = 0.18f)
                             )
                         )
                     )
@@ -117,33 +118,47 @@ internal fun PlayerStage(
                     drawRect(
                         brush = Brush.radialGradient(
                             colors = listOf(
-                                bloom.copy(alpha = 0.075f),
-                                ambience.primary.copy(alpha = 0.025f),
+                                bloom.copy(alpha = 0.065f),
+                                ambience.primary.copy(alpha = 0.020f),
                                 Color.Transparent
                             ),
-                            center = Offset(size.width * 0.24f, size.height * 0.92f),
-                            radius = size.maxDimension * 0.58f
+                            center = Offset(size.width * 0.24f, size.height * 0.84f),
+                            radius = size.maxDimension * 0.62f
                         )
                     )
                     drawRect(
                         brush = Brush.radialGradient(
                             colors = listOf(
-                                ambience.secondary.copy(alpha = 0.055f),
+                                ambience.secondary.copy(alpha = 0.045f),
                                 Color.Transparent
                             ),
                             center = Offset(size.width * 0.80f, size.height * 0.88f),
-                            radius = size.maxDimension * 0.46f
+                            radius = size.maxDimension * 0.50f
                         )
                     )
 
                     drawRect(
                         brush = Brush.verticalGradient(
                             colorStops = arrayOf(
-                                0.00f to Color.Black.copy(alpha = 0.36f),
-                                0.07f to Color.Black.copy(alpha = 0.11f),
+                                0.00f to Color.Black.copy(alpha = 0.34f),
+                                0.07f to Color.Black.copy(alpha = 0.10f),
                                 StageTopScrimEnd to Color.Transparent
                             )
                         )
+                    )
+
+                    drawRect(
+                        brush = Brush.verticalGradient(
+                            colorStops = arrayOf(
+                                0.00f to Color.White,
+                                fadeStart to Color.White,
+                                fadeSoft to Color.White.copy(alpha = 0.94f),
+                                fadeMid to Color.White.copy(alpha = 0.70f),
+                                fadeLow to Color.White.copy(alpha = 0.34f),
+                                1.00f to Color.Transparent
+                            )
+                        ),
+                        blendMode = BlendMode.DstIn
                     )
                 }
         ) {
@@ -167,8 +182,8 @@ internal fun PlayerConsoleSurface(
     ambience: PlayerAmbience,
     modifier: Modifier = Modifier
 ) {
-    val handoff = ambience.base.playerAmbienceMix(ambience.control, 0.20f)
-    val lower = ambience.elevated.playerAmbienceMix(ambience.base, 0.48f)
+    val handoff = ambience.base.playerAmbienceMix(ambience.control, 0.18f)
+    val lower = ambience.elevated.playerAmbienceMix(ambience.base, 0.46f)
     val bloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.40f)
 
     Box(
@@ -178,10 +193,12 @@ internal fun PlayerConsoleSurface(
             drawRect(
                 brush = Brush.verticalGradient(
                     colorStops = arrayOf(
-                        0.00f to handoff.copy(alpha = 0.90f),
-                        0.24f to handoff.copy(alpha = 0.94f),
-                        0.62f to lower.copy(alpha = 0.96f),
-                        1.00f to lower
+                        0.00f to Color.Transparent,
+                        0.18f to handoff.copy(alpha = 0.035f),
+                        0.38f to handoff.copy(alpha = 0.11f),
+                        0.62f to lower.copy(alpha = 0.30f),
+                        0.82f to lower.copy(alpha = 0.52f),
+                        1.00f to lower.copy(alpha = 0.70f)
                     )
                 )
             )
@@ -189,32 +206,32 @@ internal fun PlayerConsoleSurface(
             drawRect(
                 brush = Brush.radialGradient(
                     colors = listOf(
-                        ambience.primary.copy(alpha = 0.10f),
-                        ambience.primary.copy(alpha = 0.025f),
+                        ambience.primary.copy(alpha = 0.070f),
+                        ambience.primary.copy(alpha = 0.020f),
                         Color.Transparent
                     ),
-                    center = Offset(size.width * 0.18f, 0f),
-                    radius = size.width * 0.92f
+                    center = Offset(size.width * 0.18f, size.height * 0.06f),
+                    radius = size.width * 0.96f
                 )
             )
             drawRect(
                 brush = Brush.radialGradient(
                     colors = listOf(
-                        ambience.secondary.copy(alpha = 0.075f),
+                        ambience.secondary.copy(alpha = 0.055f),
                         Color.Transparent
                     ),
-                    center = Offset(size.width * 0.84f, size.height * 0.16f),
-                    radius = size.width * 0.78f
+                    center = Offset(size.width * 0.84f, size.height * 0.20f),
+                    radius = size.width * 0.82f
                 )
             )
             drawRect(
                 brush = Brush.radialGradient(
                     colors = listOf(
-                        bloom.copy(alpha = 0.045f),
+                        bloom.copy(alpha = 0.035f),
                         Color.Transparent
                     ),
-                    center = Offset(size.width * 0.50f, size.height * 0.72f),
-                    radius = size.maxDimension * 0.62f
+                    center = Offset(size.width * 0.52f, size.height * 0.74f),
+                    radius = size.maxDimension * 0.64f
                 )
             )
         }
@@ -228,12 +245,12 @@ internal fun PlayerStageHorizon(
     isPlaying: Boolean,
     modifier: Modifier = Modifier
 ) {
-    val handoff = ambience.base.playerAmbienceMix(ambience.control, 0.20f)
-    val bloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.40f)
+    val mist = ambience.base.playerAmbienceMix(ambience.control, 0.16f)
+    val bloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.42f)
     val intensity by animateFloatAsState(
-        targetValue = if (isPlaying) 0.72f else 0.54f,
-        animationSpec = if (animationsEnabled) tween(720, easing = LevyraPlayerDesign.Standard) else snap(),
-        label = "player-stage-handoff"
+        targetValue = if (isPlaying) 0.60f else 0.46f,
+        animationSpec = if (animationsEnabled) tween(760, easing = LevyraPlayerDesign.Standard) else snap(),
+        label = "player-stage-ambient-mist"
     )
 
     Box(
@@ -244,10 +261,9 @@ internal fun PlayerStageHorizon(
                 brush = Brush.verticalGradient(
                     colorStops = arrayOf(
                         0.00f to Color.Transparent,
-                        0.16f to handoff.copy(alpha = 0.025f * intensity),
-                        0.38f to handoff.copy(alpha = 0.075f * intensity),
-                        0.58f to handoff.copy(alpha = 0.14f * intensity),
-                        0.78f to handoff.copy(alpha = 0.075f * intensity),
+                        0.24f to mist.copy(alpha = 0.020f * intensity),
+                        0.48f to mist.copy(alpha = 0.060f * intensity),
+                        0.68f to mist.copy(alpha = 0.045f * intensity),
                         1.00f to Color.Transparent
                     )
                 ),
@@ -258,21 +274,21 @@ internal fun PlayerStageHorizon(
             drawRect(
                 brush = Brush.radialGradient(
                     colors = listOf(
-                        bloom.copy(alpha = 0.065f * intensity),
+                        bloom.copy(alpha = 0.050f * intensity),
                         Color.Transparent
                     ),
-                    center = Offset(size.width * 0.30f, size.height * 0.50f),
-                    radius = size.width * 0.82f
+                    center = Offset(size.width * 0.30f, size.height * 0.46f),
+                    radius = size.width * 0.88f
                 )
             )
             drawRect(
                 brush = Brush.radialGradient(
                     colors = listOf(
-                        ambience.secondary.copy(alpha = 0.045f * intensity),
+                        ambience.secondary.copy(alpha = 0.038f * intensity),
                         Color.Transparent
                     ),
-                    center = Offset(size.width * 0.78f, size.height * 0.42f),
-                    radius = size.width * 0.66f
+                    center = Offset(size.width * 0.78f, size.height * 0.54f),
+                    radius = size.width * 0.72f
                 )
             )
         }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
@@ -1,15 +1,19 @@
 package com.luc4n3x.levyra.ui
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
@@ -17,16 +21,16 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.luc4n3x.levyra.domain.LevyraCanvasQuality
 import com.luc4n3x.levyra.feature.motion.MotionArtwork
+import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
 
-internal const val PlayerStageHeightFraction = 1f
-internal const val PlayerStageMinOverlapDp = 56f
-internal val PlayerStageSpillHeight: Dp = 0.dp
+internal const val PlayerStageHeightFraction = 0.58f
+internal const val PlayerStageMinOverlapDp = 32f
+internal val PlayerStageSpillHeight: Dp = 144.dp
 
-private const val StageInteractionHeightFraction = 0.72f
 private const val StageTopScrimEnd = 0.20f
-private const val StageVeilLead = 0.24f
-private const val StageVeilKnee = 0.50f
-private const val StageSideVignetteAlpha = 0.06f
+private const val StageVeilLead = 0.48f
+private const val StageVeilKnee = 0.56f
+private const val StageSideVignetteAlpha = 0.055f
 
 @Immutable
 internal data class PlayerStageMetrics(
@@ -67,9 +71,8 @@ internal fun PlayerStage(
     val settle = veilSettleFraction.coerceIn(0.35f, 0.98f)
     val veilStart = (settle - StageVeilLead).coerceIn(0.08f, settle)
     val veilKnee = (veilStart + (settle - veilStart) * StageVeilKnee).coerceIn(veilStart, settle)
-    val lowerMid = (settle + (1f - settle) * 0.46f).coerceIn(settle, 1f)
-    val paletteVeil = ambience.base.playerAmbienceMix(ambience.control, 0.18f)
-    val paletteBloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.38f)
+    val handoff = ambience.base.playerAmbienceMix(ambience.control, 0.20f)
+    val bloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.38f)
 
     Box(modifier = modifier) {
         Box(
@@ -101,12 +104,12 @@ internal fun PlayerStage(
                             colorStops = arrayOf(
                                 0.00f to Color.Transparent,
                                 veilStart to Color.Transparent,
-                                (veilStart + (veilKnee - veilStart) * 0.48f) to paletteVeil.copy(alpha = 0.04f),
-                                veilKnee to paletteVeil.copy(alpha = 0.10f),
-                                (veilKnee + (settle - veilKnee) * 0.58f) to paletteVeil.copy(alpha = 0.20f),
-                                settle to paletteVeil.copy(alpha = 0.34f),
-                                lowerMid to paletteVeil.copy(alpha = 0.52f),
-                                1.00f to paletteVeil.copy(alpha = 0.72f)
+                                (veilStart + (veilKnee - veilStart) * 0.42f) to handoff.copy(alpha = 0.035f),
+                                veilKnee to handoff.copy(alpha = 0.10f),
+                                (veilKnee + (settle - veilKnee) * 0.52f) to handoff.copy(alpha = 0.24f),
+                                settle to handoff.copy(alpha = 0.46f),
+                                (settle + (1f - settle) * 0.46f) to handoff.copy(alpha = 0.68f),
+                                1.00f to handoff.copy(alpha = 0.90f)
                             )
                         )
                     )
@@ -114,22 +117,22 @@ internal fun PlayerStage(
                     drawRect(
                         brush = Brush.radialGradient(
                             colors = listOf(
-                                paletteBloom.copy(alpha = 0.055f),
-                                ambience.primary.copy(alpha = 0.018f),
+                                bloom.copy(alpha = 0.075f),
+                                ambience.primary.copy(alpha = 0.025f),
                                 Color.Transparent
                             ),
-                            center = Offset(size.width * 0.28f, size.height * 0.70f),
-                            radius = size.maxDimension * 0.68f
+                            center = Offset(size.width * 0.24f, size.height * 0.92f),
+                            radius = size.maxDimension * 0.58f
                         )
                     )
                     drawRect(
                         brush = Brush.radialGradient(
                             colors = listOf(
-                                ambience.secondary.copy(alpha = 0.035f),
+                                ambience.secondary.copy(alpha = 0.055f),
                                 Color.Transparent
                             ),
-                            center = Offset(size.width * 0.78f, size.height * 0.76f),
-                            radius = size.maxDimension * 0.56f
+                            center = Offset(size.width * 0.80f, size.height * 0.88f),
+                            radius = size.maxDimension * 0.46f
                         )
                     )
 
@@ -155,13 +158,7 @@ internal fun PlayerStage(
                 staticArtwork = staticArtwork
             )
         }
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .fillMaxHeight(StageInteractionHeightFraction)
-        ) {
-            overlay()
-        }
+        overlay()
     }
 }
 
@@ -170,7 +167,58 @@ internal fun PlayerConsoleSurface(
     ambience: PlayerAmbience,
     modifier: Modifier = Modifier
 ) {
-    Box(modifier = modifier)
+    val handoff = ambience.base.playerAmbienceMix(ambience.control, 0.20f)
+    val lower = ambience.elevated.playerAmbienceMix(ambience.base, 0.48f)
+    val bloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.40f)
+
+    Box(
+        modifier = modifier.drawBehind {
+            if (size.minDimension <= 0f) return@drawBehind
+
+            drawRect(
+                brush = Brush.verticalGradient(
+                    colorStops = arrayOf(
+                        0.00f to handoff.copy(alpha = 0.90f),
+                        0.24f to handoff.copy(alpha = 0.94f),
+                        0.62f to lower.copy(alpha = 0.96f),
+                        1.00f to lower
+                    )
+                )
+            )
+
+            drawRect(
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        ambience.primary.copy(alpha = 0.10f),
+                        ambience.primary.copy(alpha = 0.025f),
+                        Color.Transparent
+                    ),
+                    center = Offset(size.width * 0.18f, 0f),
+                    radius = size.width * 0.92f
+                )
+            )
+            drawRect(
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        ambience.secondary.copy(alpha = 0.075f),
+                        Color.Transparent
+                    ),
+                    center = Offset(size.width * 0.84f, size.height * 0.16f),
+                    radius = size.width * 0.78f
+                )
+            )
+            drawRect(
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        bloom.copy(alpha = 0.045f),
+                        Color.Transparent
+                    ),
+                    center = Offset(size.width * 0.50f, size.height * 0.72f),
+                    radius = size.maxDimension * 0.62f
+                )
+            )
+        }
+    )
 }
 
 @Composable
@@ -180,5 +228,53 @@ internal fun PlayerStageHorizon(
     isPlaying: Boolean,
     modifier: Modifier = Modifier
 ) {
-    Box(modifier = modifier)
+    val handoff = ambience.base.playerAmbienceMix(ambience.control, 0.20f)
+    val bloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.40f)
+    val intensity by animateFloatAsState(
+        targetValue = if (isPlaying) 0.72f else 0.54f,
+        animationSpec = if (animationsEnabled) tween(720, easing = LevyraPlayerDesign.Standard) else snap(),
+        label = "player-stage-handoff"
+    )
+
+    Box(
+        modifier = modifier.drawBehind {
+            if (size.minDimension <= 0f) return@drawBehind
+
+            drawRect(
+                brush = Brush.verticalGradient(
+                    colorStops = arrayOf(
+                        0.00f to Color.Transparent,
+                        0.16f to handoff.copy(alpha = 0.025f * intensity),
+                        0.38f to handoff.copy(alpha = 0.075f * intensity),
+                        0.58f to handoff.copy(alpha = 0.14f * intensity),
+                        0.78f to handoff.copy(alpha = 0.075f * intensity),
+                        1.00f to Color.Transparent
+                    )
+                ),
+                topLeft = Offset.Zero,
+                size = Size(size.width, size.height)
+            )
+
+            drawRect(
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        bloom.copy(alpha = 0.065f * intensity),
+                        Color.Transparent
+                    ),
+                    center = Offset(size.width * 0.30f, size.height * 0.50f),
+                    radius = size.width * 0.82f
+                )
+            )
+            drawRect(
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        ambience.secondary.copy(alpha = 0.045f * intensity),
+                        Color.Transparent
+                    ),
+                    center = Offset(size.width * 0.78f, size.height * 0.42f),
+                    radius = size.width * 0.66f
+                )
+            )
+        }
+    )
 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
@@ -62,8 +62,9 @@ internal fun PlayerStage(
     val settle = veilSettleFraction.coerceIn(0.35f, 0.98f)
     val fadeStart = (settle - 0.20f).coerceIn(0.58f, 0.70f)
     val fadeSoft = (fadeStart + 0.08f).coerceAtMost(0.78f)
-    val fadeMid = (fadeStart + 0.16f).coerceAtMost(0.86f)
-    val fadeDeep = (fadeStart + 0.25f).coerceAtMost(0.95f)
+    val fadeMid = (fadeStart + 0.16f).coerceAtMost(0.84f)
+    val fadeDeep = (fadeStart + 0.23f).coerceAtMost(0.88f)
+    val solidStart = (fadeStart + 0.30f).coerceAtMost(0.91f)
     val songColor = ambience.primary.playerAmbienceMix(ambience.secondary, 0.42f)
     val handoff = songColor.playerAmbienceMix(Color.Black, 0.60f)
     val deep = songColor.playerAmbienceMix(Color.Black, 0.74f)
@@ -98,9 +99,10 @@ internal fun PlayerStage(
                             colorStops = arrayOf(
                                 0.00f to Color.Transparent,
                                 fadeStart to Color.Transparent,
-                                fadeSoft to handoff.copy(alpha = 0.08f),
-                                fadeMid to handoff.copy(alpha = 0.26f),
-                                fadeDeep to deep.copy(alpha = 0.72f),
+                                fadeSoft to handoff.copy(alpha = 0.10f),
+                                fadeMid to handoff.copy(alpha = 0.32f),
+                                fadeDeep to deep.copy(alpha = 0.76f),
+                                solidStart to deep,
                                 1.00f to deep
                             )
                         )
@@ -148,7 +150,8 @@ internal fun PlayerConsoleSurface(
                 brush = Brush.verticalGradient(
                     colorStops = arrayOf(
                         0.00f to deep,
-                        0.42f to deep,
+                        0.58f to deep,
+                        0.82f to deep.playerAmbienceMix(lower, 0.35f),
                         1.00f to lower
                     )
                 )

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
@@ -1,0 +1,234 @@
+package com.luc4n3x.levyra.ui
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.luc4n3x.levyra.domain.LevyraCanvasQuality
+import com.luc4n3x.levyra.feature.motion.MotionArtwork
+import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
+
+internal const val PlayerStageHeightFraction = 0.72f
+internal const val PlayerStageMinOverlapDp = 56f
+internal val PlayerStageSpillHeight: Dp = 120.dp
+
+private const val StageTopScrimEnd = 0.24f
+private const val StageVeilLead = 0.52f
+private const val StageVeilKnee = 0.58f
+
+@Immutable
+internal data class PlayerStageMetrics(
+    val stageHeightDp: Float,
+    val veilSettleFraction: Float
+)
+
+/**
+ * Resolves how tall the stage is and where its veil has to be fully settled.
+ *
+ * The stage keeps one constant height whether a Canvas is rendering or only static artwork is
+ * available, so the composition never resizes when motion artwork arrives or disappears. The veil
+ * finishes exactly where the console content starts, which is what lets the image hand over to the
+ * player surface without a visible seam on any screen size.
+ */
+internal fun playerStageMetrics(
+    availableHeightDp: Float,
+    consoleHeightDp: Float
+): PlayerStageMetrics {
+    if (availableHeightDp <= 0f) return PlayerStageMetrics(0f, 1f)
+    val console = consoleHeightDp.coerceIn(0f, availableHeightDp)
+    val consoleTop = availableHeightDp - console
+    val minimum = (consoleTop + PlayerStageMinOverlapDp).coerceAtMost(availableHeightDp)
+    val stage = (availableHeightDp * PlayerStageHeightFraction)
+        .coerceAtLeast(minimum)
+        .coerceAtMost(availableHeightDp)
+    val settle = if (stage <= 0f) 1f else (consoleTop / stage).coerceIn(0.35f, 0.98f)
+    return PlayerStageMetrics(stageHeightDp = stage, veilSettleFraction = settle)
+}
+
+/**
+ * The cinematic stage: one large, edge-to-edge surface that hosts either a Canvas or the static
+ * artwork.
+ *
+ * Motion artwork and static artwork share the same frame and the same veil, so the player reads as
+ * one composition in both cases. The veil is derived from the live artwork palette and resolves to
+ * the exact colour the console is painted with, so the image melts into the player surface instead
+ * of sitting on top of it like a wallpaper.
+ */
+@Composable
+internal fun PlayerStage(
+    motionArtwork: MotionArtwork?,
+    ambience: PlayerAmbience,
+    animationsEnabled: Boolean,
+    isPlaying: Boolean,
+    canvasQuality: LevyraCanvasQuality,
+    veilSettleFraction: Float,
+    contentAlpha: () -> Float,
+    contentTranslationX: () -> Float,
+    contentScale: () -> Float,
+    modifier: Modifier = Modifier,
+    overlay: @Composable BoxScope.() -> Unit = {},
+    staticArtwork: @Composable () -> Unit
+) {
+    val veil = ambience.base
+    val settle = veilSettleFraction.coerceIn(0.35f, 0.98f)
+    val veilStart = (settle - StageVeilLead).coerceIn(0.10f, settle)
+    val veilKnee = (veilStart + (settle - veilStart) * StageVeilKnee).coerceIn(veilStart, settle)
+
+    Box(modifier = modifier) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer {
+                    alpha = contentAlpha()
+                    translationX = contentTranslationX()
+                    val scale = contentScale()
+                    scaleX = scale
+                    scaleY = scale
+                }
+                .drawWithContent {
+                    drawContent()
+                    drawRect(
+                        brush = Brush.verticalGradient(
+                            colorStops = arrayOf(
+                                0.00f to Color.Transparent,
+                                veilStart to Color.Transparent,
+                                veilKnee to veil.copy(alpha = 0.34f),
+                                (veilKnee + (settle - veilKnee) * 0.62f) to veil.copy(alpha = 0.78f),
+                                settle to veil,
+                                1.00f to veil
+                            )
+                        )
+                    )
+                    drawRect(
+                        brush = Brush.verticalGradient(
+                            colorStops = arrayOf(
+                                0.00f to Color.Black.copy(alpha = 0.58f),
+                                StageTopScrimEnd to Color.Transparent
+                            )
+                        )
+                    )
+                }
+        ) {
+            MotionArtworkLayer(
+                artwork = motionArtwork,
+                enabled = animationsEnabled,
+                isPlaying = isPlaying,
+                cornerRadius = 0.dp,
+                presentation = MotionArtworkPresentation.Stage,
+                quality = canvasQuality,
+                modifier = Modifier.fillMaxSize(),
+                staticArtwork = staticArtwork
+            )
+        }
+        overlay()
+    }
+}
+
+/**
+ * The surface the stage hands the image over to.
+ *
+ * It starts on the exact veil colour so the two layers read as one continuous material, then loses
+ * a little light toward the bottom so the transport still sits on the darkest part of the screen.
+ */
+@Composable
+internal fun PlayerConsoleSurface(
+    ambience: PlayerAmbience,
+    modifier: Modifier = Modifier
+) {
+    val base = ambience.base
+    val control = ambience.control
+    val elevated = ambience.elevated
+    val floor = control.playerAmbienceMix(base, 0.42f)
+    Box(
+        modifier = modifier.drawBehind {
+            if (size.minDimension <= 0f) return@drawBehind
+            drawRect(
+                brush = Brush.verticalGradient(
+                    colorStops = arrayOf(
+                        0.00f to base,
+                        0.34f to base.playerAmbienceMix(control, 0.72f),
+                        0.66f to elevated,
+                        1.00f to floor
+                    )
+                )
+            )
+            drawRect(
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        ambience.primary.copy(alpha = 0.13f),
+                        Color.Transparent
+                    ),
+                    center = Offset(size.width * 0.18f, size.height * 0.08f),
+                    radius = size.maxDimension * 0.92f
+                )
+            )
+        }
+    )
+}
+
+/**
+ * The horizon: the one structural line of the composition.
+ *
+ * It marks where the image world ends and the information world begins, and it is the only place
+ * the live accent colour is allowed to touch the console. Its brightness follows playback, so the
+ * seam breathes with the track instead of being static decoration.
+ */
+@Composable
+internal fun PlayerStageHorizon(
+    ambience: PlayerAmbience,
+    animationsEnabled: Boolean,
+    isPlaying: Boolean,
+    modifier: Modifier = Modifier
+) {
+    val accent = ambience.primary
+    val secondary = ambience.secondary
+    val intensity by animateFloatAsState(
+        targetValue = if (isPlaying) 1f else 0.45f,
+        animationSpec = if (animationsEnabled) tween(720, easing = LevyraPlayerDesign.Standard) else snap(),
+        label = "player-stage-horizon"
+    )
+    Box(
+        modifier = modifier.drawBehind {
+            if (size.minDimension <= 0f) return@drawBehind
+            drawRect(
+                brush = Brush.verticalGradient(
+                    colorStops = arrayOf(
+                        0.00f to accent.copy(alpha = 0.15f * intensity),
+                        0.45f to secondary.copy(alpha = 0.06f * intensity),
+                        1.00f to Color.Transparent
+                    )
+                ),
+                topLeft = Offset.Zero,
+                size = Size(size.width, size.height)
+            )
+            val hairline = LevyraPlayerDesign.Hairline.toPx()
+            drawRect(
+                brush = Brush.horizontalGradient(
+                    colorStops = arrayOf(
+                        0.00f to Color.Transparent,
+                        0.22f to accent.copy(alpha = 0.42f * intensity),
+                        0.58f to secondary.copy(alpha = 0.26f * intensity),
+                        1.00f to Color.Transparent
+                    )
+                ),
+                topLeft = Offset.Zero,
+                size = Size(size.width, hairline)
+            )
+        }
+    )
+}

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerStage.kt
@@ -1,19 +1,13 @@
 package com.luc4n3x.levyra.ui
 
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.snap
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
@@ -21,16 +15,15 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.luc4n3x.levyra.domain.LevyraCanvasQuality
 import com.luc4n3x.levyra.feature.motion.MotionArtwork
-import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
 
-internal const val PlayerStageHeightFraction = 0.72f
+internal const val PlayerStageHeightFraction = 1f
 internal const val PlayerStageMinOverlapDp = 56f
-internal val PlayerStageSpillHeight: Dp = 184.dp
+internal val PlayerStageSpillHeight: Dp = 0.dp
 
 private const val StageTopScrimEnd = 0.20f
-private const val StageVeilLead = 0.52f
-private const val StageVeilKnee = 0.54f
-private const val StageSideVignetteAlpha = 0.08f
+private const val StageVeilLead = 0.24f
+private const val StageVeilKnee = 0.50f
+private const val StageSideVignetteAlpha = 0.06f
 
 @Immutable
 internal data class PlayerStageMetrics(
@@ -69,9 +62,10 @@ internal fun PlayerStage(
     staticArtwork: @Composable () -> Unit
 ) {
     val settle = veilSettleFraction.coerceIn(0.35f, 0.98f)
-    val veilStart = (settle - StageVeilLead).coerceIn(0.06f, settle)
+    val veilStart = (settle - StageVeilLead).coerceIn(0.08f, settle)
     val veilKnee = (veilStart + (settle - veilStart) * StageVeilKnee).coerceIn(veilStart, settle)
-    val paletteVeil = ambience.base.playerAmbienceMix(ambience.control, 0.22f)
+    val lowerMid = (settle + (1f - settle) * 0.46f).coerceIn(settle, 1f)
+    val paletteVeil = ambience.base.playerAmbienceMix(ambience.control, 0.18f)
     val paletteBloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.38f)
 
     Box(modifier = modifier) {
@@ -92,8 +86,8 @@ internal fun PlayerStage(
                         brush = Brush.horizontalGradient(
                             colorStops = arrayOf(
                                 0.00f to Color.Black.copy(alpha = StageSideVignetteAlpha),
-                                0.14f to Color.Transparent,
-                                0.86f to Color.Transparent,
+                                0.12f to Color.Transparent,
+                                0.88f to Color.Transparent,
                                 1.00f to Color.Black.copy(alpha = StageSideVignetteAlpha)
                             )
                         )
@@ -104,11 +98,12 @@ internal fun PlayerStage(
                             colorStops = arrayOf(
                                 0.00f to Color.Transparent,
                                 veilStart to Color.Transparent,
-                                (veilStart + (veilKnee - veilStart) * 0.52f) to paletteVeil.copy(alpha = 0.05f),
-                                veilKnee to paletteVeil.copy(alpha = 0.12f),
-                                (veilKnee + (settle - veilKnee) * 0.55f) to paletteVeil.copy(alpha = 0.27f),
-                                settle to paletteVeil.copy(alpha = 0.42f),
-                                1.00f to paletteVeil.copy(alpha = 0.58f)
+                                (veilStart + (veilKnee - veilStart) * 0.48f) to paletteVeil.copy(alpha = 0.04f),
+                                veilKnee to paletteVeil.copy(alpha = 0.10f),
+                                (veilKnee + (settle - veilKnee) * 0.58f) to paletteVeil.copy(alpha = 0.20f),
+                                settle to paletteVeil.copy(alpha = 0.34f),
+                                lowerMid to paletteVeil.copy(alpha = 0.52f),
+                                1.00f to paletteVeil.copy(alpha = 0.72f)
                             )
                         )
                     )
@@ -116,30 +111,30 @@ internal fun PlayerStage(
                     drawRect(
                         brush = Brush.radialGradient(
                             colors = listOf(
-                                paletteBloom.copy(alpha = 0.070f),
-                                ambience.primary.copy(alpha = 0.025f),
+                                paletteBloom.copy(alpha = 0.055f),
+                                ambience.primary.copy(alpha = 0.018f),
                                 Color.Transparent
                             ),
-                            center = Offset(size.width * 0.28f, size.height * settle * 1.02f),
-                            radius = size.maxDimension * 0.62f
+                            center = Offset(size.width * 0.28f, size.height * 0.70f),
+                            radius = size.maxDimension * 0.68f
                         )
                     )
                     drawRect(
                         brush = Brush.radialGradient(
                             colors = listOf(
-                                ambience.secondary.copy(alpha = 0.040f),
+                                ambience.secondary.copy(alpha = 0.035f),
                                 Color.Transparent
                             ),
-                            center = Offset(size.width * 0.76f, size.height * settle * 1.01f),
-                            radius = size.maxDimension * 0.50f
+                            center = Offset(size.width * 0.78f, size.height * 0.76f),
+                            radius = size.maxDimension * 0.56f
                         )
                     )
 
                     drawRect(
                         brush = Brush.verticalGradient(
                             colorStops = arrayOf(
-                                0.00f to Color.Black.copy(alpha = 0.38f),
-                                0.07f to Color.Black.copy(alpha = 0.12f),
+                                0.00f to Color.Black.copy(alpha = 0.36f),
+                                0.07f to Color.Black.copy(alpha = 0.11f),
                                 StageTopScrimEnd to Color.Transparent
                             )
                         )
@@ -166,64 +161,7 @@ internal fun PlayerConsoleSurface(
     ambience: PlayerAmbience,
     modifier: Modifier = Modifier
 ) {
-    val base = ambience.base
-    val control = ambience.control
-    val elevated = ambience.elevated
-    val upper = base.playerAmbienceMix(control, 0.20f)
-    val middle = base.playerAmbienceMix(elevated, 0.42f)
-    val lower = elevated.playerAmbienceMix(base, 0.48f)
-    val bloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.40f)
-
-    Box(
-        modifier = modifier.drawBehind {
-            if (size.minDimension <= 0f) return@drawBehind
-
-            drawRect(
-                brush = Brush.verticalGradient(
-                    colorStops = arrayOf(
-                        0.00f to upper.copy(alpha = 0.06f),
-                        0.14f to upper.copy(alpha = 0.12f),
-                        0.30f to upper.copy(alpha = 0.22f),
-                        0.48f to middle.copy(alpha = 0.40f),
-                        0.70f to lower.copy(alpha = 0.64f),
-                        1.00f to lower.copy(alpha = 0.88f)
-                    )
-                )
-            )
-
-            drawRect(
-                brush = Brush.radialGradient(
-                    colors = listOf(
-                        ambience.primary.copy(alpha = 0.075f),
-                        ambience.primary.copy(alpha = 0.025f),
-                        Color.Transparent
-                    ),
-                    center = Offset(size.width * 0.20f, 0f),
-                    radius = size.width * 0.88f
-                )
-            )
-            drawRect(
-                brush = Brush.radialGradient(
-                    colors = listOf(
-                        ambience.secondary.copy(alpha = 0.060f),
-                        Color.Transparent
-                    ),
-                    center = Offset(size.width * 0.82f, size.height * 0.16f),
-                    radius = size.width * 0.74f
-                )
-            )
-            drawRect(
-                brush = Brush.radialGradient(
-                    colors = listOf(
-                        bloom.copy(alpha = 0.035f),
-                        Color.Transparent
-                    ),
-                    center = Offset(size.width * 0.50f, size.height * 0.54f),
-                    radius = size.maxDimension * 0.58f
-                )
-            )
-        }
-    )
+    Box(modifier = modifier)
 }
 
 @Composable
@@ -233,44 +171,5 @@ internal fun PlayerStageHorizon(
     isPlaying: Boolean,
     modifier: Modifier = Modifier
 ) {
-    val bridge = ambience.base.playerAmbienceMix(ambience.control, 0.22f)
-    val bloom = ambience.primary.playerAmbienceMix(ambience.secondary, 0.40f)
-    val intensity by animateFloatAsState(
-        targetValue = if (isPlaying) 0.68f else 0.52f,
-        animationSpec = if (animationsEnabled) tween(700, easing = LevyraPlayerDesign.Standard) else snap(),
-        label = "player-stage-horizon"
-    )
-
-    Box(
-        modifier = modifier.drawBehind {
-            if (size.minDimension <= 0f) return@drawBehind
-
-            drawRect(
-                brush = Brush.verticalGradient(
-                    colorStops = arrayOf(
-                        0.00f to Color.Transparent,
-                        0.16f to bridge.copy(alpha = 0.025f * intensity),
-                        0.34f to bridge.copy(alpha = 0.065f * intensity),
-                        0.52f to bridge.copy(alpha = 0.14f * intensity),
-                        0.68f to bridge.copy(alpha = 0.11f * intensity),
-                        0.84f to bridge.copy(alpha = 0.045f * intensity),
-                        1.00f to Color.Transparent
-                    )
-                ),
-                topLeft = Offset.Zero,
-                size = Size(size.width, size.height)
-            )
-
-            drawRect(
-                brush = Brush.radialGradient(
-                    colors = listOf(
-                        bloom.copy(alpha = 0.055f * intensity),
-                        Color.Transparent
-                    ),
-                    center = Offset(size.width * 0.34f, size.height * 0.52f),
-                    radius = size.width * 0.78f
-                )
-            )
-        }
-    )
+    Box(modifier = modifier)
 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
@@ -247,7 +247,6 @@ private fun PlayerSkipButton(
     iconSize: Dp,
     onClick: () -> Unit
 ) {
-    val shape = LevyraPlayerDesign.ShapeSm
     SpringIconButton(
         onClick = onClick,
         modifier = Modifier.sizeIn(
@@ -259,12 +258,12 @@ private fun PlayerSkipButton(
     ) {
         Box(
             modifier = Modifier
-                .size(42.dp)
-                .background(Color.White.copy(alpha = 0.055f), shape)
+                .size(44.dp)
+                .background(Color.White.copy(alpha = 0.045f), CircleShape)
                 .border(
                     LevyraPlayerDesign.Hairline,
-                    Color.White.copy(alpha = 0.09f),
-                    shape
+                    Color.White.copy(alpha = 0.075f),
+                    CircleShape
                 ),
             contentAlignment = Alignment.Center
         ) {
@@ -288,7 +287,7 @@ private fun PlayerModeToggleButton(
     onClick: () -> Unit
 ) {
     val activeTint = remember(accentTarget) {
-        Color(0xFF1DB954).playerMix(accentTarget, 0.35f)
+        accentTarget.playerMix(Color.White, 0.18f)
     }
     val tint by animateColorAsState(
         targetValue = if (active) activeTint else LevyraPlayerDesign.IconIdle,
@@ -301,12 +300,12 @@ private fun PlayerModeToggleButton(
         label = "player-toggle-indicator"
     )
     val surfaceColor by animateColorAsState(
-        targetValue = if (active) activeTint.copy(alpha = 0.15f) else Color.White.copy(alpha = 0.035f),
+        targetValue = if (active) activeTint.copy(alpha = 0.13f) else Color.White.copy(alpha = 0.025f),
         animationSpec = if (animated) LevyraPlayerDesign.standardTween(180) else snap(),
         label = "player-toggle-surface"
     )
     val surfaceBorder by animateColorAsState(
-        targetValue = if (active) activeTint.copy(alpha = 0.26f) else Color.White.copy(alpha = 0.06f),
+        targetValue = if (active) activeTint.copy(alpha = 0.24f) else Color.White.copy(alpha = 0.05f),
         animationSpec = if (animated) LevyraPlayerDesign.standardTween(180) else snap(),
         label = "player-toggle-border"
     )
@@ -325,11 +324,11 @@ private fun PlayerModeToggleButton(
         Box(
             modifier = Modifier
                 .size(LevyraPlayerDesign.ModeSlot)
-                .background(surfaceColor, LevyraPlayerDesign.ShapeSm)
+                .background(surfaceColor, CircleShape)
                 .border(
                     LevyraPlayerDesign.Hairline,
                     surfaceBorder,
-                    LevyraPlayerDesign.ShapeSm
+                    CircleShape
                 ),
             contentAlignment = Alignment.Center
         ) {
@@ -357,17 +356,21 @@ private fun playerPrimaryIconTransition(): ContentTransform =
             scaleOut(targetScale = 0.82f, animationSpec = LevyraPlayerDesign.standardTween(100)))
 
 private fun Modifier.playerPrimarySurface(
-    shape: Shape
+    shape: Shape,
+    surfaceColor: Color,
+    borderColor: Color
 ): Modifier = this
     .shadow(
         elevation = 10.dp,
         shape = shape,
         clip = false,
-        ambientColor = Color.Black.copy(alpha = 0.35f),
-        spotColor = Color.Black.copy(alpha = 0.60f)
+        ambientColor = Color.Black.copy(alpha = 0.32f),
+        spotColor = Color.Black.copy(alpha = 0.52f)
     )
-    .background(
-        Color.White,
+    .background(surfaceColor, shape)
+    .border(
+        LevyraPlayerDesign.Hairline,
+        borderColor,
         shape
     )
 
@@ -407,13 +410,19 @@ private fun PlayerPrimaryButton(
 ) {
     val contentColor = LevyraPlayerDesign.PrimaryContent
     val haloColor = accentColor.playerMix(Color.White, 0.16f)
+    val surfaceColor = remember(accentColor) {
+        Color.White.playerMix(accentColor, 0.18f)
+    }
+    val borderColor = remember(accentColor) {
+        accentColor.playerMix(Color.White, 0.58f).copy(alpha = 0.46f)
+    }
     val haloAlpha by animateFloatAsState(
-        targetValue = if (isPlaying) 0.22f else 0.10f,
+        targetValue = if (isPlaying) 0.28f else 0.13f,
         animationSpec = if (animated) LevyraPlayerDesign.standardTween(260) else snap(),
         label = "player-primary-halo"
     )
     val corner by animateDpAsState(
-        targetValue = if (isPlaying) LevyraPlayerDesign.CornerMd else size * 0.5f,
+        targetValue = if (isPlaying) LevyraPlayerDesign.CornerLg else size * 0.5f,
         animationSpec = if (animated) LevyraPlayerDesign.expressiveSpring() else snap(),
         label = "player-primary-corner"
     )
@@ -427,12 +436,12 @@ private fun PlayerPrimaryButton(
             modifier = Modifier
                 .size(size)
                 .drawBehind {
-                    val radius = this.size.minDimension * 0.72f
+                    val radius = this.size.minDimension * 0.80f
                     drawCircle(
                         brush = Brush.radialGradient(
                             colors = listOf(
                                 haloColor.copy(alpha = haloAlpha),
-                                haloColor.copy(alpha = haloAlpha * 0.30f),
+                                haloColor.copy(alpha = haloAlpha * 0.26f),
                                 Color.Transparent
                             ),
                             center = center,
@@ -443,7 +452,9 @@ private fun PlayerPrimaryButton(
                     )
                 }
                 .playerPrimarySurface(
-                    shape = RoundedCornerShape(corner)
+                    shape = RoundedCornerShape(corner),
+                    surfaceColor = surfaceColor,
+                    borderColor = borderColor
                 ),
             contentAlignment = Alignment.Center
         ) {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
@@ -2,10 +2,9 @@ package com.luc4n3x.levyra.ui.components
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ContentTransform
-import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.snap
 import androidx.compose.animation.fadeIn
@@ -25,8 +24,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
@@ -44,10 +41,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.toggleableState
@@ -188,9 +185,9 @@ fun PlayerTransportControls(
     onRepeat: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val skipIconSize = if (compact) LevyraPlayerDesign.SkipGlyphCompact else LevyraPlayerDesign.SkipGlyph
-    val modeIconSize = if (compact) LevyraPlayerDesign.ModeGlyphCompact else LevyraPlayerDesign.ModeGlyph
-    val primarySize = if (compact) LevyraPlayerDesign.PrimarySizeCompact else LevyraPlayerDesign.PrimarySize
+    val skipIconSize = if (compact) 34.dp else 38.dp
+    val modeIconSize = if (compact) 20.dp else 22.dp
+    val primaryIconSize = if (compact) 36.dp else 40.dp
 
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -215,7 +212,7 @@ fun PlayerTransportControls(
         PlayerPrimaryButton(
             isPlaying = isPlaying,
             isResolving = isResolving,
-            size = primarySize,
+            iconSize = primaryIconSize,
             accentColor = accents.primaryTarget,
             animated = animated,
             playLabel = labels.play,
@@ -250,29 +247,17 @@ private fun PlayerSkipButton(
     SpringIconButton(
         onClick = onClick,
         modifier = Modifier.sizeIn(
-            minWidth = LevyraPlayerDesign.MinimumTouchTarget,
-            minHeight = LevyraPlayerDesign.MinimumTouchTarget
+            minWidth = 58.dp,
+            minHeight = 58.dp
         ),
-        pressedScale = 0.88f,
+        pressedScale = 0.86f,
         contentDescription = contentDescription
     ) {
-        Box(
-            modifier = Modifier
-                .size(44.dp)
-                .background(Color.White.copy(alpha = 0.045f), CircleShape)
-                .border(
-                    LevyraPlayerDesign.Hairline,
-                    Color.White.copy(alpha = 0.075f),
-                    CircleShape
-                ),
-            contentAlignment = Alignment.Center
-        ) {
-            PlayerIcon(
-                icon = icon,
-                tint = Color.White.copy(alpha = 0.94f),
-                modifier = Modifier.size(iconSize)
-            )
-        }
+        PlayerIcon(
+            icon = icon,
+            tint = Color.White.copy(alpha = 0.96f),
+            modifier = Modifier.size(iconSize)
+        )
     }
 }
 
@@ -287,27 +272,17 @@ private fun PlayerModeToggleButton(
     onClick: () -> Unit
 ) {
     val activeTint = remember(accentTarget) {
-        accentTarget.playerMix(Color.White, 0.18f)
+        accentTarget.playerMix(Color.White, 0.40f)
     }
     val tint by animateColorAsState(
-        targetValue = if (active) activeTint else LevyraPlayerDesign.IconIdle,
+        targetValue = if (active) activeTint else Color.White.copy(alpha = 0.46f),
         animationSpec = if (animated) LevyraPlayerDesign.standardTween() else snap(),
         label = "player-toggle-tint"
     )
     val indicatorAlpha by animateFloatAsState(
         targetValue = if (active) 1f else 0f,
-        animationSpec = if (animated) LevyraPlayerDesign.standardTween() else snap(),
+        animationSpec = if (animated) LevyraPlayerDesign.standardTween(180) else snap(),
         label = "player-toggle-indicator"
-    )
-    val surfaceColor by animateColorAsState(
-        targetValue = if (active) activeTint.copy(alpha = 0.13f) else Color.White.copy(alpha = 0.025f),
-        animationSpec = if (animated) LevyraPlayerDesign.standardTween(180) else snap(),
-        label = "player-toggle-surface"
-    )
-    val surfaceBorder by animateColorAsState(
-        targetValue = if (active) activeTint.copy(alpha = 0.24f) else Color.White.copy(alpha = 0.05f),
-        animationSpec = if (animated) LevyraPlayerDesign.standardTween(180) else snap(),
-        label = "player-toggle-border"
     )
 
     SpringIconButton(
@@ -318,18 +293,11 @@ private fun PlayerModeToggleButton(
                 minHeight = LevyraPlayerDesign.MinimumTouchTarget
             )
             .semantics { toggleableState = ToggleableState(active) },
-        pressedScale = 0.86f,
+        pressedScale = 0.84f,
         contentDescription = contentDescription
     ) {
         Box(
-            modifier = Modifier
-                .size(LevyraPlayerDesign.ModeSlot)
-                .background(surfaceColor, CircleShape)
-                .border(
-                    LevyraPlayerDesign.Hairline,
-                    surfaceBorder,
-                    CircleShape
-                ),
+            modifier = Modifier.size(LevyraPlayerDesign.MinimumTouchTarget),
             contentAlignment = Alignment.Center
         ) {
             PlayerIcon(
@@ -340,8 +308,8 @@ private fun PlayerModeToggleButton(
             Box(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
-                    .padding(bottom = LevyraPlayerDesign.SpaceXxs)
-                    .size(LevyraPlayerDesign.ModeIndicator)
+                    .padding(bottom = 2.dp)
+                    .size(3.dp)
                     .graphicsLayer { alpha = indicatorAlpha }
                     .background(activeTint, CircleShape)
             )
@@ -350,32 +318,13 @@ private fun PlayerModeToggleButton(
 }
 
 private fun playerPrimaryIconTransition(): ContentTransform =
-    (fadeIn(LevyraPlayerDesign.standardTween(140)) +
-        scaleIn(initialScale = 0.82f, animationSpec = LevyraPlayerDesign.standardTween(140))) togetherWith
-        (fadeOut(LevyraPlayerDesign.standardTween(100)) +
-            scaleOut(targetScale = 0.82f, animationSpec = LevyraPlayerDesign.standardTween(100)))
-
-private fun Modifier.playerPrimarySurface(
-    shape: Shape,
-    surfaceColor: Color,
-    borderColor: Color
-): Modifier = this
-    .shadow(
-        elevation = 10.dp,
-        shape = shape,
-        clip = false,
-        ambientColor = Color.Black.copy(alpha = 0.32f),
-        spotColor = Color.Black.copy(alpha = 0.52f)
-    )
-    .background(surfaceColor, shape)
-    .border(
-        LevyraPlayerDesign.Hairline,
-        borderColor,
-        shape
-    )
+    (fadeIn(LevyraPlayerDesign.standardTween(130)) +
+        scaleIn(initialScale = 0.88f, animationSpec = LevyraPlayerDesign.standardTween(130))) togetherWith
+        (fadeOut(LevyraPlayerDesign.standardTween(90)) +
+            scaleOut(targetScale = 0.88f, animationSpec = LevyraPlayerDesign.standardTween(90)))
 
 @Composable
-private fun PlayerPrimaryIcon(isPlaying: Boolean, iconSize: Dp, tint: Color, animated: Boolean) {
+private fun PlayerPrimaryIcon(isPlaying: Boolean, iconSize: Dp, animated: Boolean) {
     AnimatedContent(
         targetState = isPlaying,
         transitionSpec = {
@@ -389,7 +338,7 @@ private fun PlayerPrimaryIcon(isPlaying: Boolean, iconSize: Dp, tint: Color, ani
     ) { playing ->
         PlayerIcon(
             icon = if (playing) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
-            tint = tint,
+            tint = Color.White,
             modifier = Modifier
                 .size(iconSize)
                 .offset(x = if (playing) 0.dp else 1.5.dp)
@@ -401,47 +350,35 @@ private fun PlayerPrimaryIcon(isPlaying: Boolean, iconSize: Dp, tint: Color, ani
 private fun PlayerPrimaryButton(
     isPlaying: Boolean,
     isResolving: Boolean,
-    size: Dp,
+    iconSize: Dp,
     accentColor: Color,
     animated: Boolean,
     playLabel: String,
     pauseLabel: String,
     onClick: () -> Unit
 ) {
-    val contentColor = LevyraPlayerDesign.PrimaryContent
-    val haloColor = accentColor.playerMix(Color.White, 0.16f)
-    val surfaceColor = remember(accentColor) {
-        Color.White.playerMix(accentColor, 0.18f)
-    }
-    val borderColor = remember(accentColor) {
-        accentColor.playerMix(Color.White, 0.58f).copy(alpha = 0.46f)
-    }
+    val halo = remember(accentColor) { accentColor.playerMix(Color.White, 0.22f) }
     val haloAlpha by animateFloatAsState(
-        targetValue = if (isPlaying) 0.28f else 0.13f,
-        animationSpec = if (animated) LevyraPlayerDesign.standardTween(260) else snap(),
+        targetValue = if (isPlaying) 0.10f else 0.05f,
+        animationSpec = if (animated) LevyraPlayerDesign.standardTween(240) else snap(),
         label = "player-primary-halo"
-    )
-    val corner by animateDpAsState(
-        targetValue = if (isPlaying) LevyraPlayerDesign.CornerLg else size * 0.5f,
-        animationSpec = if (animated) LevyraPlayerDesign.expressiveSpring() else snap(),
-        label = "player-primary-corner"
     )
 
     SpringIconButton(
         onClick = onClick,
-        pressedScale = 0.90f,
+        modifier = Modifier.sizeIn(minWidth = 72.dp, minHeight = 72.dp),
+        pressedScale = 0.88f,
         contentDescription = if (isPlaying) pauseLabel else playLabel
     ) {
         Box(
             modifier = Modifier
-                .size(size)
+                .size(68.dp)
                 .drawBehind {
-                    val radius = this.size.minDimension * 0.80f
+                    val radius = size.minDimension * 0.62f
                     drawCircle(
                         brush = Brush.radialGradient(
                             colors = listOf(
-                                haloColor.copy(alpha = haloAlpha),
-                                haloColor.copy(alpha = haloAlpha * 0.26f),
+                                halo.copy(alpha = haloAlpha),
                                 Color.Transparent
                             ),
                             center = center,
@@ -450,25 +387,19 @@ private fun PlayerPrimaryButton(
                         radius = radius,
                         center = center
                     )
-                }
-                .playerPrimarySurface(
-                    shape = RoundedCornerShape(corner),
-                    surfaceColor = surfaceColor,
-                    borderColor = borderColor
-                ),
+                },
             contentAlignment = Alignment.Center
         ) {
             if (isResolving) {
                 CircularProgressIndicator(
-                    modifier = Modifier.size(LevyraPlayerDesign.PrimaryGlyph * 0.8f),
-                    strokeWidth = 2.6.dp,
-                    color = contentColor
+                    modifier = Modifier.size(iconSize * 0.74f),
+                    strokeWidth = 2.8.dp,
+                    color = Color.White
                 )
             } else {
                 PlayerPrimaryIcon(
                     isPlaying = isPlaying,
-                    iconSize = LevyraPlayerDesign.PrimaryGlyph,
-                    tint = contentColor,
+                    iconSize = iconSize,
                     animated = animated
                 )
             }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
@@ -188,52 +188,64 @@ fun PlayerTransportControls(
     val skipIconSize = if (compact) 34.dp else 38.dp
     val modeIconSize = if (compact) 20.dp else 22.dp
     val primaryIconSize = if (compact) 36.dp else 40.dp
+    val mainGap = if (compact) 22.dp else 28.dp
 
-    Row(
+    Box(
         modifier = modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
+        contentAlignment = Alignment.Center
     ) {
-        PlayerModeToggleButton(
-            icon = Icons.Rounded.Shuffle,
-            contentDescription = labels.shuffle,
-            active = shuffleOn,
-            accentTarget = accents.primaryTarget,
-            iconSize = modeIconSize,
-            animated = animated,
-            onClick = onShuffle
-        )
-        PlayerSkipButton(
-            icon = Icons.Rounded.SkipPrevious,
-            contentDescription = labels.previous,
-            iconSize = skipIconSize,
-            onClick = onPrevious
-        )
-        PlayerPrimaryButton(
-            isPlaying = isPlaying,
-            isResolving = isResolving,
-            iconSize = primaryIconSize,
-            accentColor = accents.primaryTarget,
-            animated = animated,
-            playLabel = labels.play,
-            pauseLabel = labels.pause,
-            onClick = onToggle
-        )
-        PlayerSkipButton(
-            icon = Icons.Rounded.SkipNext,
-            contentDescription = labels.next,
-            iconSize = skipIconSize,
-            onClick = onNext
-        )
-        PlayerModeToggleButton(
-            icon = if (repeatOne) Icons.Rounded.RepeatOne else Icons.Rounded.Repeat,
-            contentDescription = labels.repeat,
-            active = repeatOn,
-            accentTarget = accents.secondaryTarget,
-            iconSize = modeIconSize,
-            animated = animated,
-            onClick = onRepeat
-        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            PlayerModeToggleButton(
+                icon = Icons.Rounded.Shuffle,
+                contentDescription = labels.shuffle,
+                active = shuffleOn,
+                accentTarget = accents.primaryTarget,
+                iconSize = modeIconSize,
+                animated = animated,
+                onClick = onShuffle
+            )
+            PlayerModeToggleButton(
+                icon = if (repeatOne) Icons.Rounded.RepeatOne else Icons.Rounded.Repeat,
+                contentDescription = labels.repeat,
+                active = repeatOn,
+                accentTarget = accents.secondaryTarget,
+                iconSize = modeIconSize,
+                animated = animated,
+                onClick = onRepeat
+            )
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(mainGap)
+        ) {
+            PlayerSkipButton(
+                icon = Icons.Rounded.SkipPrevious,
+                contentDescription = labels.previous,
+                iconSize = skipIconSize,
+                onClick = onPrevious
+            )
+            PlayerPrimaryButton(
+                isPlaying = isPlaying,
+                isResolving = isResolving,
+                iconSize = primaryIconSize,
+                accentColor = accents.primaryTarget,
+                animated = animated,
+                playLabel = labels.play,
+                pauseLabel = labels.pause,
+                onClick = onToggle
+            )
+            PlayerSkipButton(
+                icon = Icons.Rounded.SkipNext,
+                contentDescription = labels.next,
+                iconSize = skipIconSize,
+                onClick = onNext
+            )
+        }
     }
 }
 
@@ -275,7 +287,7 @@ private fun PlayerModeToggleButton(
         accentTarget.playerMix(Color.White, 0.40f)
     }
     val tint by animateColorAsState(
-        targetValue = if (active) activeTint else Color.White.copy(alpha = 0.46f),
+        targetValue = if (active) activeTint else Color.White.copy(alpha = 0.42f),
         animationSpec = if (animated) LevyraPlayerDesign.standardTween() else snap(),
         label = "player-toggle-tint"
     )
@@ -357,9 +369,9 @@ private fun PlayerPrimaryButton(
     pauseLabel: String,
     onClick: () -> Unit
 ) {
-    val halo = remember(accentColor) { accentColor.playerMix(Color.White, 0.22f) }
+    val halo = remember(accentColor) { accentColor.playerMix(Color.White, 0.18f) }
     val haloAlpha by animateFloatAsState(
-        targetValue = if (isPlaying) 0.10f else 0.05f,
+        targetValue = if (isPlaying) 0.075f else 0.035f,
         animationSpec = if (animated) LevyraPlayerDesign.standardTween(240) else snap(),
         label = "player-primary-halo"
     )

--- a/app/src/main/java/com/luc4n3x/levyra/ui/theme/PlayerDesign.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/theme/PlayerDesign.kt
@@ -92,9 +92,9 @@ object LevyraPlayerDesign {
     val GlassFill: Color = Color.White.copy(alpha = 0.08f)
     val GlassFillStrong: Color = Color.White.copy(alpha = 0.14f)
     val GlassFillSunken: Color = Color.Black.copy(alpha = 0.32f)
-    val HeaderScrim: Color = Color.Black.copy(alpha = 0.46f)
-    val HeaderEdgeTop: Color = Color.White.copy(alpha = 0.26f)
-    val HeaderEdgeBottom: Color = Color.White.copy(alpha = 0.12f)
+    val HeaderScrim: Color = Color.Black.copy(alpha = 0.36f)
+    val HeaderEdgeTop: Color = Color.White.copy(alpha = 0.22f)
+    val HeaderEdgeBottom: Color = Color.White.copy(alpha = 0.08f)
     val GlassBorderTop: Color = Color.White.copy(alpha = 0.14f)
     val GlassBorderBottom: Color = Color.White.copy(alpha = 0.06f)
 

--- a/app/src/main/java/com/luc4n3x/levyra/ui/theme/PlayerDesign.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/theme/PlayerDesign.kt
@@ -92,6 +92,9 @@ object LevyraPlayerDesign {
     val GlassFill: Color = Color.White.copy(alpha = 0.08f)
     val GlassFillStrong: Color = Color.White.copy(alpha = 0.14f)
     val GlassFillSunken: Color = Color.Black.copy(alpha = 0.32f)
+    val HeaderScrim: Color = Color.Black.copy(alpha = 0.46f)
+    val HeaderEdgeTop: Color = Color.White.copy(alpha = 0.26f)
+    val HeaderEdgeBottom: Color = Color.White.copy(alpha = 0.12f)
     val GlassBorderTop: Color = Color.White.copy(alpha = 0.14f)
     val GlassBorderBottom: Color = Color.White.copy(alpha = 0.06f)
 

--- a/app/src/test/java/com/luc4n3x/levyra/ui/PlayerStageTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/PlayerStageTest.kt
@@ -49,7 +49,7 @@ class PlayerStageTest {
             videoHeight = 1920,
             pixelWidthHeightRatio = 1f,
             containerWidth = 1080,
-            containerHeight = 1551,
+            containerHeight = 1503,
             maxZoom = MotionArtworkStageMaxZoom
         )
         val epsilon = 0.0001f

--- a/app/src/test/java/com/luc4n3x/levyra/ui/PlayerStageTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/PlayerStageTest.kt
@@ -1,0 +1,64 @@
+package com.luc4n3x.levyra.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlayerStageTest {
+
+    @Test
+    fun `veil settles exactly where the console content starts`() {
+        val metrics = playerStageMetrics(availableHeightDp = 920f, consoleHeightDp = 336f)
+        val consoleTop = 920f - 336f
+        assertEquals(consoleTop / metrics.stageHeightDp, metrics.veilSettleFraction, 0.0001f)
+    }
+
+    @Test
+    fun `stage height only depends on the layout, never on canvas availability`() {
+        val first = playerStageMetrics(availableHeightDp = 920f, consoleHeightDp = 336f)
+        val second = playerStageMetrics(availableHeightDp = 920f, consoleHeightDp = 336f)
+        assertEquals(first.stageHeightDp, second.stageHeightDp, 0.0001f)
+        assertEquals(920f * PlayerStageHeightFraction, first.stageHeightDp, 0.0001f)
+    }
+
+    @Test
+    fun `stage always overlaps the console so the handover never leaves a gap`() {
+        val metrics = playerStageMetrics(availableHeightDp = 640f, consoleHeightDp = 400f)
+        val consoleTop = 640f - 400f
+        assertTrue(metrics.stageHeightDp >= consoleTop + PlayerStageMinOverlapDp)
+    }
+
+    @Test
+    fun `stage never exceeds the available height`() {
+        val metrics = playerStageMetrics(availableHeightDp = 520f, consoleHeightDp = 500f)
+        assertTrue(metrics.stageHeightDp <= 520f)
+        assertTrue(metrics.veilSettleFraction in 0.35f..0.98f)
+    }
+
+    @Test
+    fun `degenerate constraints stay finite`() {
+        val metrics = playerStageMetrics(availableHeightDp = 0f, consoleHeightDp = 300f)
+        assertEquals(0f, metrics.stageHeightDp, 0.0001f)
+        assertTrue(metrics.veilSettleFraction.isFinite())
+    }
+
+    @Test
+    fun `a nine by sixteen canvas covers the stage without leaving side bars`() {
+        val fit = motionArtworkFit(
+            videoWidth = 1080,
+            videoHeight = 1920,
+            pixelWidthHeightRatio = 1f,
+            containerWidth = 1080,
+            containerHeight = 1745,
+            maxZoom = MotionArtworkStageMaxZoom
+        )
+        assertTrue(fit.scaleX >= 1f)
+        assertTrue(fit.scaleY >= 1f)
+    }
+
+    @Test
+    fun `the immersive crop budget is left untouched`() {
+        assertEquals(1.32f, MotionArtworkImmersiveMaxZoom, 0.0001f)
+        assertEquals(2.6f, MotionArtworkCardMaxZoom, 0.0001f)
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/ui/PlayerStageTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/PlayerStageTest.kt
@@ -15,8 +15,8 @@ class PlayerStageTest {
 
     @Test
     fun `stage height only depends on the layout, never on canvas availability`() {
-        val first = playerStageMetrics(availableHeightDp = 920f, consoleHeightDp = 336f)
-        val second = playerStageMetrics(availableHeightDp = 920f, consoleHeightDp = 336f)
+        val first = playerStageMetrics(availableHeightDp = 920f, consoleHeightDp = 450f)
+        val second = playerStageMetrics(availableHeightDp = 920f, consoleHeightDp = 450f)
         assertEquals(first.stageHeightDp, second.stageHeightDp, 0.0001f)
         assertEquals(920f * PlayerStageHeightFraction, first.stageHeightDp, 0.0001f)
     }
@@ -43,13 +43,13 @@ class PlayerStageTest {
     }
 
     @Test
-    fun `a nine by sixteen canvas covers a fullscreen stage without side bars`() {
+    fun `a nine by sixteen canvas covers the staged player area without side bars`() {
         val fit = motionArtworkFit(
             videoWidth = 1080,
             videoHeight = 1920,
             pixelWidthHeightRatio = 1f,
             containerWidth = 1080,
-            containerHeight = 2424,
+            containerHeight = 1406,
             maxZoom = MotionArtworkStageMaxZoom
         )
         val epsilon = 0.0001f

--- a/app/src/test/java/com/luc4n3x/levyra/ui/PlayerStageTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/PlayerStageTest.kt
@@ -49,7 +49,7 @@ class PlayerStageTest {
             videoHeight = 1920,
             pixelWidthHeightRatio = 1f,
             containerWidth = 1080,
-            containerHeight = 1406,
+            containerHeight = 1551,
             maxZoom = MotionArtworkStageMaxZoom
         )
         val epsilon = 0.0001f

--- a/app/src/test/java/com/luc4n3x/levyra/ui/PlayerStageTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/PlayerStageTest.kt
@@ -57,8 +57,9 @@ class PlayerStageTest {
     }
 
     @Test
-    fun `the immersive crop budget is left untouched`() {
+    fun `the crop budgets stay pinned`() {
         assertEquals(1.32f, MotionArtworkImmersiveMaxZoom, 0.0001f)
         assertEquals(2.6f, MotionArtworkCardMaxZoom, 0.0001f)
+        assertEquals(1.56f, MotionArtworkStageMaxZoom, 0.0001f)
     }
 }

--- a/app/src/test/java/com/luc4n3x/levyra/ui/PlayerStageTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/PlayerStageTest.kt
@@ -52,8 +52,9 @@ class PlayerStageTest {
             containerHeight = 2424,
             maxZoom = MotionArtworkStageMaxZoom
         )
-        assertTrue(fit.scaleX >= 1f)
-        assertTrue(fit.scaleY >= 1f)
+        val epsilon = 0.0001f
+        assertTrue(fit.scaleX >= 1f - epsilon)
+        assertTrue(fit.scaleY >= 1f - epsilon)
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/ui/PlayerStageTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/PlayerStageTest.kt
@@ -43,13 +43,13 @@ class PlayerStageTest {
     }
 
     @Test
-    fun `a nine by sixteen canvas covers the stage without leaving side bars`() {
+    fun `a nine by sixteen canvas covers a fullscreen stage without side bars`() {
         val fit = motionArtworkFit(
             videoWidth = 1080,
             videoHeight = 1920,
             pixelWidthHeightRatio = 1f,
             containerWidth = 1080,
-            containerHeight = 1745,
+            containerHeight = 2424,
             maxZoom = MotionArtworkStageMaxZoom
         )
         assertTrue(fit.scaleX >= 1f)


### PR DESCRIPTION
## Summary

The Android fullscreen player treated a Canvas as a wallpaper: motion artwork was stretched across the whole 9:19.5 screen, title, artist and engagement chips floated directly on the moving image, and the lower half was buried under a near-opaque scrim. Without a Canvas the same surface collapsed into a centred square card, so the player effectively had two unrelated geometries and only looked designed when motion artwork happened to be available.

This PR rebuilds the visual composition around a single **stage and console** structure that is identical whether a Canvas is playing or only static artwork exists. One edge-to-edge stage owns the upper part of the screen and hosts either surface; its lower part is veiled with a colour taken from the live artwork palette, and the veil resolves exactly where the console content begins, so the image hands over to the player surface instead of being cut off. The console is painted from the same palette rather than fading to black, an accent horizon marks the seam, and metadata now sits on a controlled surface instead of on top of moving video.

The audio progress bar and its time readouts are deliberately not part of this change.

## What changed

- New `ui/PlayerStage.kt`: `playerStageMetrics` (pure geometry: stage height plus the veil settle point derived from the measured console height), `PlayerStage` (the edge-to-edge media surface with the palette veil and the top legibility scrim), `PlayerConsoleSurface` (the palette-derived surface the image hands over to) and `PlayerStageHorizon` (the single accent seam between the image and the controls).
- `ui/MotionArtworkLayer.kt`: added a `Stage` presentation that maps to the existing immersive quality profile, uses a dedicated crop budget, keeps the static artwork bed composited beneath a live Canvas so an uncovered aspect never exposes a bare background, and drops the immersive rotation drift on the framed surface. `Card` and `Immersive` behaviour is unchanged.
- `ui/MotionArtworkScaling.kt`: added `MotionArtworkStageMaxZoom`. The existing `Card` and `Immersive` crop budgets are untouched.
- `ui/LevyraApp.kt`: the stacked song-mode player now renders the stage/console composition; the header floats inside the stage; the gesture, gesture-feedback and seek-feedback overlays were extracted into a shared `mediaOverlayBlock` used by both layouts; the now unused `PlayerImmersiveMotionCanvas` and `PlayerCanvasFusionScrim` are deleted; `PlayerImmersiveBackdrop` receives the artwork again so the atmospheric bed is derived from the cover. Header controls use a legible scrim so they survive bright artwork, and the song/video switch was reworked into a quiet marker-dot segmented control instead of a washed-out translucent pill.
- `ui/theme/PlayerDesign.kt`: added `HeaderScrim`, `HeaderEdgeTop` and `HeaderEdgeBottom` tokens.
- New `PlayerStageTest` covering the stage geometry, the veil settle point, the console overlap guarantee, degenerate constraints, Canvas coverage at the stage aspect, and a regression guard that the card and immersive crop budgets did not move.

## Type of change

- [x] UI or UX change

## Scope

- **Platform:** Android
- **Area:** Player / UI

## Validation

### Automated checks

- [x] `./gradlew --no-daemon :app:lintRelease -PlevyraFdroidBuild=true` — passed
- [x] `./gradlew --no-daemon --no-configuration-cache :app:assembleRelease -PlevyraFdroidBuild=true` — passed
- [x] `./gradlew --no-daemon :app:testDebugUnitTest` — passed
- [x] `python3 scripts/ai_quality_gate.py --profile fast` — passed
- [x] `git diff --check` — clean
- [x] Targeted tests were added or updated
- [ ] Desktop: not applicable, no Desktop file is touched

The release variant needs a JDK 21 toolchain for the `LevyraNexus` dependency, which is not the default JDK on the machine used here, so `lintRelease` and `assembleRelease` were run with the Android Studio JBR explicitly selected via `-Porg.gradle.java.installations.paths`. Both passed.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Emulator `Levyra_API36`, Android 16, 1080x2424 | Song mode, track with motion artwork, fullscreen player | Canvas fills the stage, the veil hands over to the console with no hard cut, controls stay legible |
| Emulator `Levyra_API36` | Song mode, track with static artwork only | Same geometry and same identity; the composition does not change shape when motion artwork is absent |
| Emulator `Levyra_API36` | Bright, near-white cover art | Header collapse, options and the mode switch remain legible against the artwork |
| Emulator `Levyra_API36` | Song to Video switch and back | Video mode layout, native video surface and the PiP action are unchanged |
| Emulator `Levyra_API36` | Progress bar | Elapsed time, total duration, waveform, thumb and seek behaviour identical to `main` |

Screenshots were captured with `adb exec-out screencap` and inspected before and after each iteration; the first implementation was reworked twice on the basis of what the screenshots actually showed.

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** None. No playback, resolver, extractor, download, database, version or Desktop file is touched.
- **Known limitations:**
  - The redesigned composition applies to the stacked song-mode player. The side-by-side pane and video mode keep their existing layout on purpose.
  - Very short screens (below 560 dp of height) keep the previous scrollable layout, so the console can never be clipped.
  - The official Spotify Canvas provider did not resolve in the environment used for this review, so the motion path was exercised through the community Canvas source and the animated static bed. The composition is identical for every motion source because the stage does not change shape when a Canvas appears.
- **Rollback plan:** Revert this PR

## Reviewer notes

- **The audio progress bar is unchanged.** `PremiumSeekbar`, `WaveformVisualizer` and `PlayerTimeline` are not in this diff, and the elapsed/total time row, the drag and seek behaviour, the colours, the sizes and the semantics are exactly the ones on `main`. The new composition was built around the existing timeline, not the other way round.
- `playerStageMetrics` is the piece worth reading first: it derives the veil settle point from the measured console height, which is what keeps the handover seamless across screen sizes and font scales instead of relying on hardcoded fractions.
- The stage height never depends on Canvas availability. That is deliberate: it removes the geometry jump, the resize and the black flash when motion artwork arrives mid-track, and it is asserted by `PlayerStageTest`.
- Motion artwork remains decorative, muted, subordinate to playback and confined to song mode. The `Stage` presentation reuses the existing immersive quality profile, so decoder, bitrate and viewport bounds are unchanged.
- The stage draws through a plain `graphicsLayer` and two gradients, with no blur, no offscreen compositing and no per-tick animation, so nothing new recomposes on playback position updates.

## Release note

The Android Now Playing screen has been redesigned so motion artwork and album art share one cinematic composition.

## Related issues

- N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a staged player layout for non-video playback on taller screens.
  * Enhanced artwork presentation with motion, static artwork, overlays, horizon effects, and improved sizing.
  * Added smoother mode selection indicators and refined header visuals.

* **Style**
  * Updated playback controls with lighter, more circular styling and improved visual feedback.

* **Bug Fixes**
  * Improved artwork behavior and scaling across regular, immersive, and staged playback layouts.

* **Tests**
  * Added coverage for stage sizing, artwork fitting, overlays, and edge-case layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->