### PR TITLE
fix(android): reuse lyrics matcher regex patterns

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/LyricsParsing.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LyricsParsing.kt
@@ -784,6 +784,11 @@ object LyricsMatcher {
     private val versionTerms = setOf(
         "live", "remix", "acoustic", "instrumental", "karaoke", "sped", "slowed", "nightcore", "remaster", "demo", "edit", "version", "cover"
     )
+    private val featuringSuffixRegex = Regex("(?i)\\b(feat(?:uring)?|ft\\.?|con|with)\\b.*$")
+    private val officialMetadataRegex = Regex("(?i)[(\\[][^)\\]]*(official|video|audio|lyrics?|visuali[sz]er|mv)[^)\\]]*[)\\]]")
+    private val combiningMarksRegex = Regex("\\p{M}+")
+    private val nonWordRegex = Regex("[^\\p{L}\\p{N} ]+")
+    private val whitespaceRegex = Regex("\\s+")
 
     fun similarity(left: String, right: String): Int {
         val normalizedLeft = normalize(left)
@@ -814,14 +819,14 @@ object LyricsMatcher {
 
     fun normalize(value: String): String {
         val withoutFeaturing = value
-            .replace(Regex("(?i)\\b(feat(?:uring)?|ft\\.?|con|with)\\b.*$"), " ")
-            .replace(Regex("(?i)[(\\[][^)\\]]*(official|video|audio|lyrics?|visuali[sz]er|mv)[^)\\]]*[)\\]]"), " ")
+            .replace(featuringSuffixRegex, " ")
+            .replace(officialMetadataRegex, " ")
         return Normalizer.normalize(withoutFeaturing, Normalizer.Form.NFD)
-            .replace(Regex("\\p{M}+"), "")
+            .replace(combiningMarksRegex, "")
             .lowercase(Locale.ROOT)
             .replace("&", " and ")
-            .replace(Regex("[^\\p{L}\\p{N} ]+"), " ")
-            .replace(Regex("\\s+"), " ")
+            .replace(nonWordRegex, " ")
+            .replace(whitespaceRegex, " ")
             .trim()
     }
 


### PR DESCRIPTION
## Summary

- compile the five `LyricsMatcher.normalize` regex patterns once per process
- reuse the immutable patterns for every candidate and lyric-line normalization
- preserve matching order, expressions, replacements, scoring, playback, and UI behavior

## Root cause and evidence

Heapprofd attributed the strongest app-controlled native allocation stack to repeated `java.util.regex.Pattern.compile` calls from `LyricsMatcher.normalize`. The compiled ICU regex objects accumulated in Scudo-backed anonymous memory until ART/allocator reclamation caught up.

The focused Pixel 8 API 37 emulator comparison separated this from the audio pipeline:

- continuous single-track playback with the complete audio pipeline: RSS slope `-7.45 MiB/min`
- 20 rapid NEXT transitions before the fix: RSS `+28.48 MiB/min`, PSS anonymous `+26.83 MiB/min`
- 20 rapid NEXT transitions after the fix from a stable baseline: RSS `+5.10 MiB/min`, PSS anonymous `+3.97 MiB/min`
- after the post-fix NEXT sequence ended: PSS anonymous `-1.86 MiB/min`

The stable post-fix run reduces the transition-driven RSS slope by about 82%. Perfetto independently showed anonymous-memory churn and delayed reclaim while the AAC decoder, Binder, file RSS, shared memory, and swap remained stable.

## Validation

- `:app:testDebugUnitTest --tests com.luc4n3x.levyra.data.LyricsParsingTest`
- `:app:testDebugUnitTest`
- `:app:lintRelease -PlevyraFdroidBuild=true`
- `:app:assembleRelease -PlevyraFdroidBuild=true`
- `python3 scripts/ai_quality_gate.py --profile fast` through the configured Windows Python runtime
- `python3 scripts/ai_quality_gate.py --profile full` through the configured Windows Python runtime
- signed release-like APK installed and exercised only on `Levyra_Pixel8_API37` / `emulator-5554`
- independent diff review: no findings
- `git diff --check`

## Scope and remaining manual evidence

- no UI, version, dependency, database, permission, or release change
- no physical device was used; the Samsung device was explicitly excluded
- physical Pixel/GrapheneOS confirmation remains manual and unverified
- the local Codex CLI review command was unavailable because Windows denied execution from the packaged `WindowsApps` location; the owner explicitly authorized proceeding with the completed independent review

Refs #427
