### PR TITLE
docs: modernize and elevate Author & Credits section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,80 +298,45 @@ We welcome community contributions, bug fixes, localization, and performance enh
 
 ## ✦ Author & Credits
 
-<div align="center">
-
 <table align="center" width="100%">
   <tr>
-    <td align="center" width="130" style="padding: 16px;">
+    <td align="center" width="110" valign="middle">
       <a href="https://github.com/LUC4N3X">
-        <img src="https://images.weserv.nl/?url=github.com/LUC4N3X.png&h=240&w=240&fit=cover&mask=circle&maxage=7d" width="92" height="92" alt="LUC4N3X — Lead Architect" />
+        <img src="https://images.weserv.nl/?url=github.com/LUC4N3X.png&h=200&w=200&fit=cover&mask=circle&maxage=7d" width="80" height="80" alt="LUC4N3X" />
       </a>
     </td>
-    <td style="padding: 16px;">
-      <h3 style="margin-top: 0; margin-bottom: 6px;">
-        <a href="https://github.com/LUC4N3X">LUC4N3X</a>
-        &nbsp;<sub><code>Lead Architect & Creator</code></sub>
-      </h3>
-      <p style="margin: 4px 0 10px 0;">
-        Architect of the low-latency Media3/ExoPlayer audio pipeline, standalone libvlc Windows core, on-device SQLite pulse telemetry, and real-time synchronized karaoke engine.
-      </p>
-      <div>
-        <a href="https://github.com/LUC4N3X"><img src="https://img.shields.io/badge/GitHub-@LUC4N3X-7F52FF?style=flat-square&logo=github&logoColor=white&labelColor=0d1117" alt="LUC4N3X on GitHub" /></a>&nbsp;
-        <img src="https://img.shields.io/badge/Kotlin-Multiplatform-7F52FF?style=flat-square&logo=kotlin&logoColor=white&labelColor=0d1117" alt="Kotlin Multiplatform" />&nbsp;
-        <img src="https://img.shields.io/badge/AndroidX-Media3%20%2F%20ExoPlayer-38BDF8?style=flat-square&logo=android&logoColor=white&labelColor=0d1117" alt="AndroidX Media3" />&nbsp;
-        <img src="https://img.shields.io/badge/Desktop-libvlc-FF8800?style=flat-square&logo=vlcmediaplayer&logoColor=white&labelColor=0d1117" alt="libvlc Desktop" />
-      </div>
+    <td valign="middle">
+      <strong>LUC4N3X</strong> &nbsp;·&nbsp; <sub><code>Creator & Lead Developer</code></sub><br>
+      <sub>Core audio engine architecture, stream extraction pipeline, Jetpack Compose UI, and offline storage.</sub><br><br>
+      <a href="https://github.com/LUC4N3X"><img src="https://img.shields.io/badge/GitHub-LUC4N3X-7F52FF?style=flat-square&logo=github&logoColor=white&labelColor=0d1117" alt="LUC4N3X on GitHub" /></a>
     </td>
   </tr>
 </table>
 
-</div>
-
-### ✦ Upstream Foundations & Architectural Credits
+### Acknowledgments
 
 <table width="100%">
-  <tr>
-    <td width="50%" valign="top">
-      <h4>🎨 <a href="https://github.com/MetrolistGroup/Metrolist">Metrolist</a></h4>
-      <sub><b>UI/UX Architecture & Dynamic Theming</b><br>
-      Architectural foundation for fluid Jetpack Compose navigation, gesture interactions, and deep OLED visual aesthetics.</sub>
+  <tr valign="top">
+    <td width="50%">
+      <h4><a href="https://github.com/MetrolistGroup/Metrolist">Metrolist</a></h4>
+      <sub>UI/UX architecture foundation, fluid Compose navigation, and dynamic OLED theme inspiration.</sub>
     </td>
-    <td width="50%" valign="top">
-      <h4>⚡ <a href="https://github.com/LUC4N3X/Levyra-deepsound/tree/main/third_party/LevyraExtractor">LevyraExtractor</a></h4>
-      <sub><b>Dedicated Audio Stream Resolution</b><br>
-      Bespoke streaming extractor and parser engine optimized specifically for bit-perfect Opus (160 kbps) and AAC (256 kbps) delivery.</sub>
+    <td width="50%">
+      <h4><a href="https://github.com/LUC4N3X/Levyra-deepsound/tree/main/third_party/LevyraExtractor">LevyraExtractor</a></h4>
+      <sub>Dedicated audio stream extraction and metadata parser maintained for high-fidelity playback.</sub>
     </td>
   </tr>
-  <tr>
-    <td width="50%" valign="top">
-      <h4>🌐 <a href="https://github.com/InfinityLoop1308/PipePipeExtractor">PipePipe & NewPipe Communities</a></h4>
-      <sub><b>Open-Source Extractor Ecosystem</b><br>
-      Pioneering upstream extractor protocols, parser foundations, and resilient media stream routing.</sub>
+  <tr valign="top">
+    <td width="50%">
+      <h4><a href="https://github.com/InfinityLoop1308/PipePipeExtractor">PipePipe & NewPipe Communities</a></h4>
+      <sub>Foundational stream extraction logic, parser protocols, and open-source media routing.</sub>
     </td>
-    <td width="50%" valign="top">
-      <h4>🎙️ <a href="https://lrclib.net/">LRCLIB</a></h4>
-      <sub><b>Real-Time Synchronized Lyrics Database</b><br>
-      Open community synchronized lyrics API powering millisecond-accurate karaoke line highlighting and interactive scrubbing.</sub>
+    <td width="50%">
+      <h4><a href="https://lrclib.net/">LRCLIB</a></h4>
+      <sub>Synchronized lyric database and API powering real-time karaoke synchronization.</sub>
     </td>
   </tr>
 </table>
-
-<br>
-
-<div align="center">
-
-<p>
-  <sub><b>Powered by Open-Source Pillars</b></sub><br>
-  <a href="https://developer.android.com/media/media3"><img src="https://img.shields.io/badge/AndroidX-Media3-3DDC84?style=flat-square&logo=android&logoColor=white&labelColor=0d1117" alt="Media3" /></a>&nbsp;
-  <a href="https://www.videolan.org/vlc/libvlc.html"><img src="https://img.shields.io/badge/VideoLAN-libvlc-FF8800?style=flat-square&logo=vlcmediaplayer&logoColor=white&labelColor=0d1117" alt="libvlc" /></a>&nbsp;
-  <a href="https://developer.android.com/jetpack/compose"><img src="https://img.shields.io/badge/UI-Jetpack%20Compose-4285F4?style=flat-square&logo=jetpackcompose&logoColor=white&labelColor=0d1117" alt="Jetpack Compose" /></a>&nbsp;
-  <a href="https://developer.android.com/training/data-storage/room"><img src="https://img.shields.io/badge/Room-SQLite%20Vault-003B57?style=flat-square&logo=sqlite&logoColor=white&labelColor=0d1117" alt="Room SQLite" /></a>&nbsp;
-  <a href="https://insert-koin.io/"><img src="https://img.shields.io/badge/Koin-DI-AB47BC?style=flat-square&logo=kotlin&logoColor=white&labelColor=0d1117" alt="Koin" /></a>&nbsp;
-  <a href="https://coil-kt.github.io/coil/"><img src="https://img.shields.io/badge/Coil-Async%20Image-6200EE?style=flat-square&logo=kotlin&logoColor=white&labelColor=0d1117" alt="Coil" /></a>&nbsp;
-  <a href="https://sponsor.ajay.app/"><img src="https://img.shields.io/badge/SponsorBlock-API-CC0000?style=flat-square&logo=youtube&logoColor=white&labelColor=0d1117" alt="SponsorBlock" /></a>
-</p>
-
-</div>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -298,46 +298,27 @@ We welcome community contributions, bug fixes, localization, and performance enh
 
 ## ✦ Author & Credits
 
-<div align="center">
-
-<a href="https://github.com/LUC4N3X">
-  <img src="https://images.weserv.nl/?url=github.com/LUC4N3X.png&h=260&w=260&fit=cover&mask=circle&maxage=7d" width="105" height="105" alt="LUC4N3X — Creator & Lead Developer" />
-</a>
-
-<br><br>
-
-### <a href="https://github.com/LUC4N3X">LUC4N3X</a>
-**Creator & Lead Systems Architect**
-
-<sub>Dedicated to audio sovereignty, bit-perfect playback engines, and zero-telemetry client architecture.</sub>
-
-<br><br>
-
-<p align="center">
-  <a href="https://github.com/LUC4N3X"><img src="https://img.shields.io/badge/GitHub-@LUC4N3X-7F52FF?style=for-the-badge&logo=github&logoColor=white&labelColor=0d1117" alt="LUC4N3X on GitHub" /></a>&nbsp;&nbsp;
-  <a href="https://github.com/LUC4N3X?tab=repositories"><img src="https://img.shields.io/badge/Portfolio-Repositories-00D2FF?style=for-the-badge&logo=git&logoColor=black&labelColor=0d1117" alt="Repositories" /></a>
-</p>
-
-<table align="center">
+<table width="100%">
   <tr>
-    <td align="center" width="220">
-      <sub><b>Audio Core & Playback</b></sub><br>
-      <sub>Media3 · ExoPlayer · libvlc Engine</sub>
+    <td width="130" align="center" valign="middle">
+      <a href="https://github.com/LUC4N3X">
+        <img src="https://images.weserv.nl/?url=github.com/LUC4N3X.png&h=260&w=260&fit=cover&mask=circle&maxage=7d" width="96" height="96" alt="LUC4N3X" />
+      </a>
     </td>
-    <td align="center" width="220">
-      <sub><b>Modern UI Canvas</b></sub><br>
-      <sub>Jetpack Compose · Compose Multiplatform</sub>
-    </td>
-    <td align="center" width="220">
-      <sub><b>Pipeline & Security</b></sub><br>
-      <sub>Stream Extractors · 100% Offline Vault</sub>
+    <td valign="middle">
+      <h3><a href="https://github.com/LUC4N3X">LUC4N3X</a> &nbsp;<sub><code>Lead Systems Architect & Creator</code></sub></h3>
+      <p>
+        Creator and core architect of Levyra. Specializing in low-latency Android audio pipelines (Media3 & ExoPlayer), standalone libvlc desktop cores, zero-telemetry SQLite vaults, and synchronized LRCLIB karaoke engines.
+      </p>
+      <div>
+        <a href="https://github.com/LUC4N3X"><img src="https://img.shields.io/badge/GitHub-@LUC4N3X-7F52FF?style=flat-square&logo=github&logoColor=white&labelColor=0d1117" alt="GitHub Profile" /></a>&nbsp;
+        <img src="https://img.shields.io/badge/Kotlin-Multiplatform-7F52FF?style=flat-square&logo=kotlin&logoColor=white&labelColor=0d1117" alt="Kotlin Multiplatform" />&nbsp;
+        <img src="https://img.shields.io/badge/Android-Media3%20%2F%20Compose-38BDF8?style=flat-square&logo=android&logoColor=white&labelColor=0d1117" alt="Android Media3" />&nbsp;
+        <img src="https://img.shields.io/badge/Desktop-libvlc%20Core-FF8800?style=flat-square&logo=vlcmediaplayer&logoColor=white&labelColor=0d1117" alt="libvlc Desktop" />
+      </div>
     </td>
   </tr>
 </table>
-
-</div>
-
-<br>
 
 ### Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -300,15 +300,18 @@ We welcome community contributions, bug fixes, localization, and performance enh
 
 <table width="100%">
   <tr>
-    <td width="130" align="center" valign="middle">
+    <td width="125" align="center" valign="middle">
       <a href="https://github.com/LUC4N3X">
-        <img src="https://images.weserv.nl/?url=github.com/LUC4N3X.png&h=260&w=260&fit=cover&mask=circle&maxage=7d" width="96" height="96" alt="LUC4N3X" />
+        <img src="https://images.weserv.nl/?url=github.com/LUC4N3X.png&h=260&w=260&fit=cover&mask=circle&maxage=7d" width="88" height="88" alt="LUC4N3X" />
       </a>
     </td>
     <td valign="middle">
-      <h3><a href="https://github.com/LUC4N3X">LUC4N3X</a> &nbsp;<sub><code>Lead Systems Architect & Creator</code></sub></h3>
-      <p>
-        Creator and core architect of Levyra. Specializing in low-latency Android audio pipelines (Media3 & ExoPlayer), standalone libvlc desktop cores, zero-telemetry SQLite vaults, and synchronized LRCLIB karaoke engines.
+      <h3 style="margin: 0 0 6px 0;">
+        <a href="https://github.com/LUC4N3X">LUC4N3X</a>
+        &nbsp;<sub><code>Lead Systems Architect & Creator</code></sub>
+      </h3>
+      <p style="margin: 0 0 10px 0;">
+        Creator and lead systems architect of Levyra. Engineering low-latency Android audio pipelines (Media3 & ExoPlayer), standalone libvlc desktop cores, zero-telemetry SQLite vaults, and synchronized LRCLIB karaoke engines.
       </p>
       <div>
         <a href="https://github.com/LUC4N3X"><img src="https://img.shields.io/badge/GitHub-@LUC4N3X-7F52FF?style=flat-square&logo=github&logoColor=white&labelColor=0d1117" alt="GitHub Profile" /></a>&nbsp;
@@ -319,6 +322,8 @@ We welcome community contributions, bug fixes, localization, and performance enh
     </td>
   </tr>
 </table>
+
+<br>
 
 ### Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -298,27 +298,80 @@ We welcome community contributions, bug fixes, localization, and performance enh
 
 ## ✦ Author & Credits
 
-<table align="center">
+<div align="center">
+
+<table align="center" width="100%">
   <tr>
-    <td align="center" width="110">
+    <td align="center" width="130" style="padding: 16px;">
       <a href="https://github.com/LUC4N3X">
-        <img src="https://images.weserv.nl/?url=github.com/LUC4N3X.png&h=160&w=160&fit=cover&mask=circle" width="75" alt="LUC4N3X" />
+        <img src="https://images.weserv.nl/?url=github.com/LUC4N3X.png&h=240&w=240&fit=cover&mask=circle&maxage=7d" width="92" height="92" alt="LUC4N3X — Lead Architect" />
       </a>
     </td>
-    <td>
-      <strong>LUC4N3X</strong><br>
-      Creator & Lead Developer<br>
-      <sub>Audio engine architecture, stream extraction, Compose UI design, and offline pipelines.</sub><br>
-      <a href="https://github.com/LUC4N3X"><img src="https://img.shields.io/badge/GitHub-LUC4N3X-7F52FF?style=flat-square&logo=github&logoColor=white&labelColor=0d1117" alt="LUC4N3X on GitHub"></a>
+    <td style="padding: 16px;">
+      <h3 style="margin-top: 0; margin-bottom: 6px;">
+        <a href="https://github.com/LUC4N3X">LUC4N3X</a>
+        &nbsp;<sub><code>Lead Architect & Creator</code></sub>
+      </h3>
+      <p style="margin: 4px 0 10px 0;">
+        Architect of the low-latency Media3/ExoPlayer audio pipeline, standalone libvlc Windows core, on-device SQLite pulse telemetry, and real-time synchronized karaoke engine.
+      </p>
+      <div>
+        <a href="https://github.com/LUC4N3X"><img src="https://img.shields.io/badge/GitHub-@LUC4N3X-7F52FF?style=flat-square&logo=github&logoColor=white&labelColor=0d1117" alt="LUC4N3X on GitHub" /></a>&nbsp;
+        <img src="https://img.shields.io/badge/Kotlin-Multiplatform-7F52FF?style=flat-square&logo=kotlin&logoColor=white&labelColor=0d1117" alt="Kotlin Multiplatform" />&nbsp;
+        <img src="https://img.shields.io/badge/AndroidX-Media3%20%2F%20ExoPlayer-38BDF8?style=flat-square&logo=android&logoColor=white&labelColor=0d1117" alt="AndroidX Media3" />&nbsp;
+        <img src="https://img.shields.io/badge/Desktop-libvlc-FF8800?style=flat-square&logo=vlcmediaplayer&logoColor=white&labelColor=0d1117" alt="libvlc Desktop" />
+      </div>
     </td>
   </tr>
 </table>
 
-### Acknowledgments
-* [**Metrolist**](https://github.com/MetrolistGroup/Metrolist): Design inspiration for Compose UI architecture and theming.
-* [**LevyraExtractor**](https://github.com/LUC4N3X/Levyra-deepsound/tree/main/third_party/LevyraExtractor): Custom stream extraction engine maintained for Levyra.
-* [**PipePipeExtractor**](https://github.com/InfinityLoop1308/PipePipeExtractor): Extractor foundation from the NewPipe and PipePipe open-source communities.
-* [**LRCLIB**](https://lrclib.net/): Synchronized lyric database powering real-time karaoke sync.
+</div>
+
+### ✦ Upstream Foundations & Architectural Credits
+
+<table width="100%">
+  <tr>
+    <td width="50%" valign="top">
+      <h4>🎨 <a href="https://github.com/MetrolistGroup/Metrolist">Metrolist</a></h4>
+      <sub><b>UI/UX Architecture & Dynamic Theming</b><br>
+      Architectural foundation for fluid Jetpack Compose navigation, gesture interactions, and deep OLED visual aesthetics.</sub>
+    </td>
+    <td width="50%" valign="top">
+      <h4>⚡ <a href="https://github.com/LUC4N3X/Levyra-deepsound/tree/main/third_party/LevyraExtractor">LevyraExtractor</a></h4>
+      <sub><b>Dedicated Audio Stream Resolution</b><br>
+      Bespoke streaming extractor and parser engine optimized specifically for bit-perfect Opus (160 kbps) and AAC (256 kbps) delivery.</sub>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%" valign="top">
+      <h4>🌐 <a href="https://github.com/InfinityLoop1308/PipePipeExtractor">PipePipe & NewPipe Communities</a></h4>
+      <sub><b>Open-Source Extractor Ecosystem</b><br>
+      Pioneering upstream extractor protocols, parser foundations, and resilient media stream routing.</sub>
+    </td>
+    <td width="50%" valign="top">
+      <h4>🎙️ <a href="https://lrclib.net/">LRCLIB</a></h4>
+      <sub><b>Real-Time Synchronized Lyrics Database</b><br>
+      Open community synchronized lyrics API powering millisecond-accurate karaoke line highlighting and interactive scrubbing.</sub>
+    </td>
+  </tr>
+</table>
+
+<br>
+
+<div align="center">
+
+<p>
+  <sub><b>Powered by Open-Source Pillars</b></sub><br>
+  <a href="https://developer.android.com/media/media3"><img src="https://img.shields.io/badge/AndroidX-Media3-3DDC84?style=flat-square&logo=android&logoColor=white&labelColor=0d1117" alt="Media3" /></a>&nbsp;
+  <a href="https://www.videolan.org/vlc/libvlc.html"><img src="https://img.shields.io/badge/VideoLAN-libvlc-FF8800?style=flat-square&logo=vlcmediaplayer&logoColor=white&labelColor=0d1117" alt="libvlc" /></a>&nbsp;
+  <a href="https://developer.android.com/jetpack/compose"><img src="https://img.shields.io/badge/UI-Jetpack%20Compose-4285F4?style=flat-square&logo=jetpackcompose&logoColor=white&labelColor=0d1117" alt="Jetpack Compose" /></a>&nbsp;
+  <a href="https://developer.android.com/training/data-storage/room"><img src="https://img.shields.io/badge/Room-SQLite%20Vault-003B57?style=flat-square&logo=sqlite&logoColor=white&labelColor=0d1117" alt="Room SQLite" /></a>&nbsp;
+  <a href="https://insert-koin.io/"><img src="https://img.shields.io/badge/Koin-DI-AB47BC?style=flat-square&logo=kotlin&logoColor=white&labelColor=0d1117" alt="Koin" /></a>&nbsp;
+  <a href="https://coil-kt.github.io/coil/"><img src="https://img.shields.io/badge/Coil-Async%20Image-6200EE?style=flat-square&logo=kotlin&logoColor=white&labelColor=0d1117" alt="Coil" /></a>&nbsp;
+  <a href="https://sponsor.ajay.app/"><img src="https://img.shields.io/badge/SponsorBlock-API-CC0000?style=flat-square&logo=youtube&logoColor=white&labelColor=0d1117" alt="SponsorBlock" /></a>
+</p>
+
+</div>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -307,8 +307,7 @@ We welcome community contributions, bug fixes, localization, and performance enh
     </td>
     <td valign="middle">
       <h3 style="margin: 0 0 6px 0;">
-        <a href="https://github.com/LUC4N3X">LUC4N3X</a>
-        &nbsp;<sub><code>Lead Systems Architect & Creator</code></sub>
+        <a href="https://github.com/LUC4N3X">LUC4N3X</a> &nbsp;·&nbsp; <code>Lead Systems Architect & Creator</code>
       </h3>
       <p style="margin: 0 0 10px 0;">
         Creator and lead systems architect of Levyra. Engineering low-latency Android audio pipelines (Media3 & ExoPlayer), standalone libvlc desktop cores, zero-telemetry SQLite vaults, and synchronized LRCLIB karaoke engines.

--- a/README.md
+++ b/README.md
@@ -298,45 +298,53 @@ We welcome community contributions, bug fixes, localization, and performance enh
 
 ## ✦ Author & Credits
 
-<table align="center" width="100%">
+<div align="center">
+
+<a href="https://github.com/LUC4N3X">
+  <img src="https://images.weserv.nl/?url=github.com/LUC4N3X.png&h=260&w=260&fit=cover&mask=circle&maxage=7d" width="105" height="105" alt="LUC4N3X — Creator & Lead Developer" />
+</a>
+
+<br><br>
+
+### <a href="https://github.com/LUC4N3X">LUC4N3X</a>
+**Creator & Lead Systems Architect**
+
+<sub>Dedicated to audio sovereignty, bit-perfect playback engines, and zero-telemetry client architecture.</sub>
+
+<br><br>
+
+<p align="center">
+  <a href="https://github.com/LUC4N3X"><img src="https://img.shields.io/badge/GitHub-@LUC4N3X-7F52FF?style=for-the-badge&logo=github&logoColor=white&labelColor=0d1117" alt="LUC4N3X on GitHub" /></a>&nbsp;&nbsp;
+  <a href="https://github.com/LUC4N3X?tab=repositories"><img src="https://img.shields.io/badge/Portfolio-Repositories-00D2FF?style=for-the-badge&logo=git&logoColor=black&labelColor=0d1117" alt="Repositories" /></a>
+</p>
+
+<table align="center">
   <tr>
-    <td align="center" width="110" valign="middle">
-      <a href="https://github.com/LUC4N3X">
-        <img src="https://images.weserv.nl/?url=github.com/LUC4N3X.png&h=200&w=200&fit=cover&mask=circle&maxage=7d" width="80" height="80" alt="LUC4N3X" />
-      </a>
+    <td align="center" width="220">
+      <sub><b>Audio Core & Playback</b></sub><br>
+      <sub>Media3 · ExoPlayer · libvlc Engine</sub>
     </td>
-    <td valign="middle">
-      <strong>LUC4N3X</strong> &nbsp;·&nbsp; <sub><code>Creator & Lead Developer</code></sub><br>
-      <sub>Core audio engine architecture, stream extraction pipeline, Jetpack Compose UI, and offline storage.</sub><br><br>
-      <a href="https://github.com/LUC4N3X"><img src="https://img.shields.io/badge/GitHub-LUC4N3X-7F52FF?style=flat-square&logo=github&logoColor=white&labelColor=0d1117" alt="LUC4N3X on GitHub" /></a>
+    <td align="center" width="220">
+      <sub><b>Modern UI Canvas</b></sub><br>
+      <sub>Jetpack Compose · Compose Multiplatform</sub>
+    </td>
+    <td align="center" width="220">
+      <sub><b>Pipeline & Security</b></sub><br>
+      <sub>Stream Extractors · 100% Offline Vault</sub>
     </td>
   </tr>
 </table>
+
+</div>
+
+<br>
 
 ### Acknowledgments
 
-<table width="100%">
-  <tr valign="top">
-    <td width="50%">
-      <h4><a href="https://github.com/MetrolistGroup/Metrolist">Metrolist</a></h4>
-      <sub>UI/UX architecture foundation, fluid Compose navigation, and dynamic OLED theme inspiration.</sub>
-    </td>
-    <td width="50%">
-      <h4><a href="https://github.com/LUC4N3X/Levyra-deepsound/tree/main/third_party/LevyraExtractor">LevyraExtractor</a></h4>
-      <sub>Dedicated audio stream extraction and metadata parser maintained for high-fidelity playback.</sub>
-    </td>
-  </tr>
-  <tr valign="top">
-    <td width="50%">
-      <h4><a href="https://github.com/InfinityLoop1308/PipePipeExtractor">PipePipe & NewPipe Communities</a></h4>
-      <sub>Foundational stream extraction logic, parser protocols, and open-source media routing.</sub>
-    </td>
-    <td width="50%">
-      <h4><a href="https://lrclib.net/">LRCLIB</a></h4>
-      <sub>Synchronized lyric database and API powering real-time karaoke synchronization.</sub>
-    </td>
-  </tr>
-</table>
+* **[Metrolist](https://github.com/MetrolistGroup/Metrolist)** — Architectural inspiration for fluid Compose UI navigation and dynamic OLED palettes.
+* **[LevyraExtractor](https://github.com/LUC4N3X/Levyra-deepsound/tree/main/third_party/LevyraExtractor)** — Dedicated audio stream extraction and metadata parser maintained for high-fidelity playback.
+* **[PipePipe & NewPipe Communities](https://github.com/InfinityLoop1308/PipePipeExtractor)** — Foundational open-source stream extraction logic, parser protocols, and media routing.
+* **[LRCLIB](https://lrclib.net/)** — Community synchronized lyric database and open API powering real-time karaoke synchronization.
 
 ---
 


### PR DESCRIPTION
## Summary

- Modernize and elevate the `✦ Author & Credits` presentation in root `README.md`
- Integrate a compact, horizontal developer card for **LUC4N3X** with high-resolution circular avatar, technical role (`Lead Systems Architect & Creator`), and brand-palette badges (`#7F52FF`, `#38BDF8`, `#FF8800`)
- Simplify and refine the Acknowledgments section into a clean, professional, emoji-free markdown bullet list
- Fix inline baseline alignment between author name and role title

## Changes & Rationale

- **Author Developer Card**:
  - Replaced the legacy detached vertical layout with a structured horizontal presentation (`<table width="100%">`)
  - Rendered a high-resolution 260px circular masked avatar (`images.weserv.nl`) aligned vertically alongside developer credentials
  - Aligned `Lead Systems Architect & Creator` directly on the primary text baseline with `LUC4N3X` by removing disruptive `<sub>` subscript offset
  - Added focused technical stack pill badges: `GitHub @LUC4N3X`, `Kotlin Multiplatform`, `Android Media3 / Compose`, and `Desktop libvlc Core`
- **Acknowledgments**:
  - Formatted upstream dependencies and inspirations (`Metrolist`, `LevyraExtractor`, `PipePipe & NewPipe Communities`, and `LRCLIB`) as an austere, technical markdown bullet list without informal emoji clutter or redundant nested tables
- **Visual Polish & Spacing**:
  - Calibrated padding and margins for seamless cross-platform rendering across GitHub Dark, GitHub Light, and mobile viewports

## Validation

- Verified all badge and avatar image endpoints with `HTTP/1.1 200 OK`
- Executed `git diff --check` with zero whitespace/formatting defects
- Verified HTML tag pairing, markdown nesting, and responsive table scaling
- Ran repository script tests (`python scripts/ai_quality_gate.py`)

## Scope & Invariants

- Strictly documentation-only (`README.md`)
- Zero changes to application logic, dependencies, database schemas, versions, permissions, or CI configurations
- Preserved all existing documentation anchors, legal notices, and repository metadata
