### PR TITLE
fix(ai): make Claude load Levyra context reliably

### DIFF
--- a/.agents/rules/levyra-workspace.md
+++ b/.agents/rules/levyra-workspace.md
@@ -7,7 +7,8 @@ authoritative for the instruction hierarchy, the complete "Native skill
 routing" table, the work method, the quality gate, and publication
 boundaries — do not restate that content here. Apply
 `../../docs/ai/AI_ENGINEERING_GUARDRAILS.md` before production-code
-implementation or broad review.
+implementation or broad review, and apply
+`../../docs/ai/EVIDENCE_GATED_COMPLETION.md` to non-trivial work.
 
 ## Antigravity-specific automation
 
@@ -51,6 +52,18 @@ remediation, human review, revalidation. RTK reduces command output; it is not
 validation authority — rerun the exact command raw whenever compact output
 hides required evidence. Keep exploit evidence, hashes, signatures, secret
 scans, and signing evidence raw.
+
+## Evidence-gated completion
+
+For non-trivial work, define the smallest useful acceptance gates before editing.
+Each required gate needs a condition, a proving check, and direct evidence.
+`FAIL`, `BLOCKED`, and `UNRUN` are not passes. Re-run a gate when later edits can
+invalidate its evidence, then inspect the final diff and perform the required
+pre-delivery review before calling implementation complete.
+
+Keep this lightweight: do not create tracking files or abstractions merely to
+record gates. Use `docs/project/TASKS.md` only when the work is already a tracked
+multi-phase project.
 
 ## Validation and publication
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,8 +1,12 @@
+@../AGENTS.md
+@../docs/ai/EVIDENCE_GATED_COMPLETION.md
+
 # Levyra Claude Code
 
-Use root `AGENTS.md` as the repository contract and
-`docs/ai/AI_ENGINEERING_GUARDRAILS.md` as the shared implementation guardrail.
-Apply nearer path-specific `AGENTS.md` files for files in scope.
+The root `AGENTS.md` imported above is the repository-wide operating contract.
+Apply every nearer path-specific `AGENTS.md` for files in scope. For
+production-code implementation or broad review also read
+`docs/ai/AI_ENGINEERING_GUARDRAILS.md`.
 
 ## Automatic project tooling
 
@@ -47,6 +51,9 @@ baseline without loading extra skill text.
 - For non-trivial implementation, use `Plan -> Execute -> Verify`: make a brief
   evidence-based plan, implement one coherent slice, verify it before expanding.
   Do not stop for approval unless the owner reserved a checkpoint.
+- Apply `docs/ai/EVIDENCE_GATED_COMPLETION.md`: no non-trivial task is complete
+  until every acceptance gate is backed by direct evidence or explicitly
+  reported as blocked/unverified.
 - Match the requested action mode. `inspect`, `review`, `diagnose`, and `report`
   authorize investigation only; `fix`, `update`, `address`, and `implement`
   authorize the requested code change and validation, but never publication.
@@ -58,13 +65,29 @@ baseline without loading extra skill text.
   functions, and explicit structure. Preserve only required license,
   generated/tool, lint/suppression, or real compatibility-contract comments.
 
-## Automatic skill routing
+## Deterministic skill loading
 
-Invoke every matching skill before broad reading/editing. Do not wait for the
-owner to name it.
+Claude must select skills from the task itself; the owner never has to name them.
+
+The `UserPromptSubmit` hook routes the prompt to matching project skills. Every
+skill listed by the hook under **Mandatory skill load** must be invoked before
+broad repository reading or editing. Do not merely mention, plan to use, or
+silently skip a routed skill.
+
+Project skills under `.claude/skills/` are intentionally thin bridges. After
+invoking a bridge, follow it to the canonical
+`.agents/skills/<skill-name>/SKILL.md` and apply that procedure before editing.
+If the hook is unavailable, use the table below manually. Never claim a skill was
+loaded when only its name or description was visible.
+
+Load only matching skills. Do not preload the whole skill tree.
+
+## Automatic skill routing
 
 | Task | Skill |
 | --- | --- |
+| Requirements, roadmap, active phase, acceptance criteria, task status, implementation handoff | `levyra-project-manager` |
+| OpenClaw delegation, Levyra worker/reviewer/CI coordination, evidence handoff | `levyra-openclaw-orchestrator` |
 | Non-trivial feature, architecture, unclear bug/regression, build/test failure, multi-step work | `levyra-real-engineering` |
 | Playback, queue, Media3, MediaSession, notification, Android Auto, audio/video mode | `levyra-player` |
 | InnerTube, extractor, stream resolution, retry/cache/fallback | `levyra-extractor` |
@@ -75,11 +98,13 @@ owner to name it.
 | R8/Proguard/minification/shrinking/keep rules/mapping/release-only shrinker failure | `levyra-r8-proguard` plus `levyra-release-check`; add `levyra-ci-workflows` for tooling changes |
 | Visual redesign/polish/hierarchy/spacing/typography/color/motion/reference/anti-AI-slop UI | `levyra-design-taste` plus matching UI skill |
 | Decorative motion artwork | `levyra-motion-artwork` |
+| Windows Desktop, Compose Multiplatform, libvlc, downloads, mini player, deep links, updates, packaging | `levyra-desktop` |
 | GitHub Actions/CI/F-Droid/Gradle/AGP/Kotlin/KSP/build cache/artifacts | `levyra-ci-workflows` |
 | Repository exploration, builds/tests/lint/logs/search/dependencies/Git/GitHub/CI/CodeRabbit/setup | `levyra-context-efficiency` |
 | Security/privacy/trust-boundary/supply-chain work | `levyra-security-review` |
 | Branch/commit/diff/pull-request review | `levyra-pr-review` plus affected skills |
 | Device/runtime/pre-merge/release/signing/APK validation | `levyra-release-check` |
+| Genuine cross-domain work or initial architecture orientation | `levyra-engineering` |
 
 ## Mandatory pre-delivery review
 
@@ -105,4 +130,5 @@ checks are not passes. Never claim unrun validation.
 
 Commit, push, PR, merge, tag, release, version changes, deployment, and
 repository settings remain owner-controlled. A `UserPromptSubmit` hook reinforces
-context budgeting and matching skill routes each turn.
+context budgeting, mandatory matching-skill loading, and evidence-gated
+completion each turn.

--- a/.claude/hooks/user-prompt-submit.sh
+++ b/.claude/hooks/user-prompt-submit.sh
@@ -2,9 +2,19 @@
 set -uo pipefail
 
 payload="$(cat 2>/dev/null || true)"
-command -v python3 >/dev/null 2>&1 || exit 0
 
-printf '%s' "$payload" | python3 -c '
+python_cmd=()
+if command -v python3 >/dev/null 2>&1; then
+  python_cmd=(python3)
+elif command -v python >/dev/null 2>&1; then
+  python_cmd=(python)
+elif command -v py >/dev/null 2>&1; then
+  python_cmd=(py -3)
+else
+  exit 0
+fi
+
+printf '%s' "$payload" | "${python_cmd[@]}" -c '
 import json
 import re
 import sys
@@ -28,6 +38,16 @@ if any(marker in prompt for marker in AUTOMATED_MARKERS):
 
 ROUTES = [
     (
+        "levyra-project-manager",
+        "requirements, roadmap, active phase, acceptance criteria, or implementation handoff",
+        r"requirements?|requisit|roadmap|acceptance criteria|criteri.*accett|active phase|fase attiv|task status|stato.*task|milestone|implementation handoff|handoff.*implement|docs/project/(?:spec|roadmap|tasks)",
+    ),
+    (
+        "levyra-openclaw-orchestrator",
+        "OpenClaw delegation or Levyra worker/reviewer/CI coordination",
+        r"openclaw|levyra-worker|levyra-reviewer|levyra-ci|delegat.*(?:agent|runtime|review|ci)|orchestrat",
+    ),
+    (
         "levyra-real-engineering",
         "non-trivial engineering, debugging, requirements, or architecture",
         r"new feature|nuova funzionalit|architecture|architett|refactor|riprogett|redesign|\bspec\b|specifica|roadmap|multi.?step|cross.?domain|pi[uù].*modul|across.*module|grill-with-docs|wayfinder|to-spec|to-tickets|\bbug\b|regression|regressione|test failure|test fallit|build failure|build fallit|unexpected behavior|comportamento inaspett|\bcrash\b|race condition|concurrency bug",
@@ -49,13 +69,13 @@ ROUTES = [
     ),
     (
         "levyra-compose",
-        "Compose UI, performance, accessibility, or state projection",
-        r"compose|composable|\bui\b|screen|schermat|theme|\btema\b|animation|animazion|layout|jank|recomposition|ricompos|scroll|perfetto|layout inspector|talkback|semantics|semantic|touch target|accessibilit|rtl|localizzazion|localization|string resource",
+        "Compose UI, accessibility, lifecycle, or state projection",
+        r"compose|composable|\bui\b|screen|schermat|theme|\btema\b|layout|recomposition|ricompos|scroll|layout inspector|talkback|semantics|semantic|touch target|accessibilit|rtl|localizzazion|localization|string resource",
     ),
     (
         "levyra-android-performance",
         "Android runtime profiling or measured performance",
-        r"perfetto|system trace|trace processor|frame miss|frame drop|jank|latency|latenza|startup|avvio lento|cpu schedul|thread state|runnable|blocked thread|binder wait|binder spam|binder storm|lock contention|renderthread|frame timeline|gpu memory|texture upload|memory pressure|allocat|i/o stall|io stall|d-state|lmkd|psi|wakelock|power rail|power trace|battery trace|runtime performance|performance runtime|profiling android",
+        r"perfetto|system trace|trace processor|frame miss|frame drop|jank|latency|latenza|startup|avvio lento|cpu schedul|thread state|runnable|blocked thread|binder wait|binder spam|binder storm|lock contention|renderthread|frame timeline|gpu memory|texture upload|memory pressure|memory leak|allocat|i/o stall|io stall|d-state|lmkd|psi|wakelock|power rail|power trace|battery trace|runtime performance|performance runtime|profiling android",
     ),
     (
         "levyra-r8-proguard",
@@ -75,7 +95,12 @@ ROUTES = [
     (
         "levyra-motion-artwork",
         "motion artwork",
-        r"motion artwork|motion|artwork|copertin|cover art",
+        r"motion artwork|animated artwork|animated cover|canvas|copertin.*animat|cover art.*animat",
+    ),
+    (
+        "levyra-desktop",
+        "Windows Desktop, Compose Multiplatform, libvlc, packaging, or desktop updates",
+        r"\bdesktop\b|windows client|compose multiplatform|libvlc|mini player|mini-player|protocol registration|wix|msi|desktop update|desktop release",
     ),
     (
         "levyra-ci-workflows",
@@ -102,17 +127,32 @@ ROUTES = [
         "runtime, pre-merge, or release validation",
         r"release|rilasci|versionname|versioncode|\bversion\b|versione|\bapk\b|signing|firma|tag\b|publish|pubblic|emulator|emulatore|physical device|device test|test dispositivo|\badb\b|connectedcheck|smoke test|runtime verification|runtime validation|verifica runtime|pre.?merge",
     ),
+    (
+        "levyra-engineering",
+        "genuine cross-domain work or repository architecture orientation",
+        r"cross.?domain|pi[uù].*sottosistem|multiple subsystems|several subsystems|repository orientation|architecture orientation|orient.*(?:repo|codebase|architett)",
+    ),
 ]
 
 matched = [(skill, topic) for skill, topic, pattern in ROUTES if re.search(pattern, prompt)]
 matched_skills = {skill for skill, _ in matched}
 companions = []
+
 if "levyra-compose" in matched_skills and "levyra-android-performance" in matched_skills:
     companions.append(("levyra-real-engineering", "non-trivial Compose performance debugging"))
 if "levyra-r8-proguard" in matched_skills:
     companions.append(("levyra-release-check", "minified release validation"))
 if "levyra-android-intent-security" in matched_skills:
     companions.append(("levyra-security-review", "Android component-boundary security review"))
+if "levyra-design-taste" in matched_skills:
+    if "levyra-desktop" in matched_skills:
+        companions.append(("levyra-desktop", "Desktop visual implementation"))
+    elif re.search(r"android|compose|player|now playing|home|screen|schermat|ui|grafica|interfaccia", prompt):
+        companions.append(("levyra-compose", "Android visual implementation"))
+if "levyra-openclaw-orchestrator" in matched_skills:
+    companions.append(("levyra-context-efficiency", "compact delegation context"))
+    companions.append(("levyra-project-manager", "delegated acceptance criteria and handoff"))
+
 for skill, topic in companions:
     if skill not in matched_skills:
         matched.append((skill, topic))
@@ -120,17 +160,21 @@ for skill, topic in companions:
 
 lines = [
     "Levyra context budget: search/path/symbol first; read bounded ranges; expand only on a concrete need; do not reread unchanged evidence.",
-    "Keep security, Perfetto, R8, signing, exact failures, and decisive diagnostics raw when compression could change the conclusion.",
+    "Root AGENTS.md is imported by .claude/CLAUDE.md and is mandatory repository context.",
+    "Evidence-gated completion: for non-trivial work define observable acceptance gates; only direct evidence is PASS; FAIL/BLOCKED/UNRUN stay open.",
     "Before delivering code, invoke /code-review when available (otherwise the code-review stage), fix actionable findings, then deliver the reviewed final code/diff.",
 ]
 
 if matched:
-    lines += ["", "Matching skills:"]
+    lines += ["", "Mandatory skill load:"]
     for skill, topic in matched:
         lines.append("- %s -> %s" % (topic, skill))
     lines += [
         "",
-        "Invoke matching skills before broad reading/editing. Apply AI_ENGINEERING_GUARDRAILS.md. "
+        "Invoke every matching project skill above before broad Read/Grep/Edit/Write/Bash work. "
+        "Do not merely acknowledge the skill name. After a .claude/skills bridge is invoked, "
+        "follow it to the canonical .agents/skills/<skill-name>/SKILL.md before editing. "
+        "Apply AI_ENGINEERING_GUARDRAILS.md and EVIDENCE_GATED_COMPLETION.md. "
         "Use the smallest verified change. New source code should be self-explanatory: add no "
         "explanatory comments; preserve only required license/tooling/suppression comments.",
     ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "skillListingBudgetFraction": 0.02,
   "extraKnownMarketplaces": {
     "chrisbanes-skills": {
       "source": {

--- a/.claude/skills/levyra-desktop/SKILL.md
+++ b/.claude/skills/levyra-desktop/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: levyra-desktop
+description: Implement, debug, or review Levyra Desktop for Windows, including Kotlin/JVM, Compose Multiplatform, libvlc, queue, downloads, persistence, mini player, deep links, updates, packaging, and desktop releases.
+---
+
+# Levyra Desktop bridge
+
+Read and follow the canonical skill at:
+
+```text
+.agents/skills/levyra-desktop/SKILL.md
+```
+
+That file owns Desktop architecture boundaries, native-resource lifecycle, validation, packaging, and release separation. Apply `desktop/AGENTS.md` for every Desktop file in scope.

--- a/.claude/skills/levyra-engineering/SKILL.md
+++ b/.claude/skills/levyra-engineering/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: levyra-engineering
+description: Coordinate cross-domain Levyra work that spans multiple subsystems, or orient an agent when no single specialized Levyra skill is sufficient. Prefer a specialized levyra-* skill for focused tasks.
+---
+
+# Levyra engineering bridge
+
+Read and follow the canonical skill at:
+
+```text
+.agents/skills/levyra-engineering/SKILL.md
+```
+
+Use this coordinator only for genuine cross-domain work or architecture orientation. It never replaces the focused Levyra domain skills selected by the canonical procedure.

--- a/.claude/skills/levyra-openclaw-orchestrator/SKILL.md
+++ b/.claude/skills/levyra-openclaw-orchestrator/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: levyra-openclaw-orchestrator
+description: Coordinate Levyra work through OpenClaw using a dedicated repository workspace, compact delegation, specialized review and CI agents, project-native skills, evidence collection, durable memory, and owner-controlled publication.
+---
+
+# Levyra OpenClaw bridge
+
+Read and follow the canonical skill at:
+
+```text
+.agents/skills/levyra-openclaw-orchestrator/SKILL.md
+```
+
+That file owns delegation boundaries, compact handoffs, reviewer/CI evidence, status vocabulary, and owner-controlled publication. Do not recreate its orchestration contract from memory.

--- a/.claude/skills/levyra-project-manager/SKILL.md
+++ b/.claude/skills/levyra-project-manager/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: levyra-project-manager
+description: Turn Levyra requirements and roadmap outcomes into one reviewable active phase using docs/project/SPEC.md, docs/project/ROADMAP.md, docs/project/TASKS.md, acceptance criteria, validation, owner checkpoints, and domain-skill routing.
+---
+
+# Levyra project-manager bridge
+
+Read and follow the canonical skill at:
+
+```text
+.agents/skills/levyra-project-manager/SKILL.md
+```
+
+That file owns the project-management workflow, acceptance evidence, status truthfulness, and publication boundaries. Load every matching domain skill as required by the canonical procedure.

--- a/docs/ai/EVIDENCE_GATED_COMPLETION.md
+++ b/docs/ai/EVIDENCE_GATED_COMPLETION.md
@@ -1,0 +1,85 @@
+# Levyra Evidence-Gated Completion
+
+This rule adds a lightweight completion discipline for AI-assisted engineering.
+It complements `AGENTS.md` and `docs/ai/AI_ENGINEERING_GUARDRAILS.md`; it does
+not replace architecture, tests, current repository evidence, or owner decisions.
+
+## When to use it
+
+Apply this rule to non-trivial implementation, debugging, refactoring,
+performance, security, build/CI, migration, or cross-domain work.
+
+Tiny, already-local edits may use one implicit acceptance gate plus the focused
+check that proves it. Do not create ceremony for a one-line fix.
+
+## Acceptance gates
+
+Before editing, convert the requested outcome into the smallest useful set of
+observable acceptance gates, normally two to six.
+
+Each gate has three parts:
+
+1. **Condition** — the behavior or property that must be true.
+2. **Check** — the command, test, inspection, reproduction, trace, diff review,
+   or direct runtime observation that can prove it.
+3. **Evidence** — the actual result from that check.
+
+Use only gates that matter to the owner's request or to a real correctness,
+compatibility, security, lifecycle, persistence, performance, or publication
+boundary. Generic busywork is not a gate.
+
+## Truthful status
+
+A gate may be:
+
+- `PASS` — direct evidence proves the condition;
+- `FAIL` — direct evidence disproves it;
+- `BLOCKED` — the required environment, dependency, credential, device, SDK,
+  service, or permission is unavailable;
+- `UNRUN` — the check has not been executed.
+
+Only `PASS` means passed. Intention, confidence, compilation alone, another
+agent's narrative, stale CI, or a previous run on different code is not evidence
+for the current gate.
+
+If a fix materially changes code covered by a passed gate, rerun that gate when
+the change could invalidate its evidence.
+
+## Completion rule
+
+Do not present non-trivial work as complete while a required gate is `FAIL`,
+`BLOCKED`, or `UNRUN`. Report the unresolved state precisely instead.
+
+After all required gates pass:
+
+1. inspect the complete final diff for unrelated churn and accidental scope
+   expansion;
+2. run the mandatory pre-delivery code review;
+3. rerun any gate invalidated by review fixes;
+4. stop adding speculative work once the requested outcome is proven.
+
+Build, lint, tests, runtime checks, review, push, PR, merge, and release are
+separate states. Never collapse them into `done`.
+
+## Keep it lightweight
+
+Do not create `GATES.md`, tracking files, extra abstractions, or permanent
+framework code merely to implement this rule. Persist gates in
+`docs/project/TASKS.md` only when the work is already a tracked multi-phase
+project and that document is the established owner.
+
+The goal is stronger evidence with less premature completion, not more process
+or more generated code.
+
+## Delivery
+
+For substantial work, map each requested outcome to its direct evidence and
+report:
+
+- passed gates and the exact checks that proved them;
+- failed, blocked, or unrun gates;
+- final diff/review state;
+- publication state separately from implementation state.
+
+If a required check cannot run, say so plainly and leave the corresponding gate
+open.

--- a/scripts/tests/test_claude_prompt_routing.py
+++ b/scripts/tests/test_claude_prompt_routing.py
@@ -11,9 +11,6 @@ ROOT = Path(__file__).resolve().parents[2]
 HOOK = ROOT / ".claude" / "hooks" / "user-prompt-submit.sh"
 
 
-from scripts.ai_quality_gate import find_bash
-
-
 def route(prompt: str) -> str:
     bash = find_bash()
     if not bash:
@@ -74,6 +71,30 @@ class ClaudePromptRoutingTest(unittest.TestCase):
 
         self.assertIn("levyra-android-intent-security", context)
         self.assertIn("levyra-security-review", context)
+
+    def test_project_manager_route(self) -> None:
+        context = route("Update roadmap acceptance criteria for the active phase")
+
+        self.assertIn("Mandatory skill load", context)
+        self.assertIn("levyra-project-manager", context)
+
+    def test_desktop_route(self) -> None:
+        context = route("Work on the Windows Desktop mini player")
+
+        self.assertIn("levyra-desktop", context)
+
+    def test_openclaw_route_adds_handoff_companions(self) -> None:
+        context = route("Delegate this Levyra fix through OpenClaw")
+
+        self.assertIn("levyra-openclaw-orchestrator", context)
+        self.assertIn("levyra-project-manager", context)
+        self.assertIn("levyra-context-efficiency", context)
+
+    def test_cross_domain_route_adds_engineering_coordinator(self) -> None:
+        context = route("Investigate a cross-domain architecture issue across subsystems")
+
+        self.assertIn("levyra-engineering", context)
+        self.assertIn("levyra-real-engineering", context)
 
 
 if __name__ == "__main__":

--- a/scripts/validate_claude_bootstrap.py
+++ b/scripts/validate_claude_bootstrap.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate Levyra's automatic Claude Code jCodeMunch bootstrap contract."""
+"""Validate Levyra's automatic Claude Code bootstrap and context-loading contract."""
 
 from __future__ import annotations
 
@@ -8,6 +8,13 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+
+CLAUDE_BRIDGES = (
+    "levyra-project-manager",
+    "levyra-desktop",
+    "levyra-engineering",
+    "levyra-openclaw-orchestrator",
+)
 
 
 def read_json(relative_path: str, errors: list[str]) -> dict:
@@ -60,6 +67,12 @@ def main() -> int:
     if not isinstance(allowed, list) or "mcp__jcodemunch" not in allowed:
         errors.append(".claude/settings.json must allow the project jcodemunch MCP server")
 
+    skill_budget = settings.get("skillListingBudgetFraction") if isinstance(settings, dict) else None
+    if not isinstance(skill_budget, (int, float)) or skill_budget < 0.02:
+        errors.append(
+            ".claude/settings.json skillListingBudgetFraction must be at least 0.02"
+        )
+
     hooks = settings.get("hooks") if isinstance(settings, dict) else None
     groups = hooks.get("SessionStart") if isinstance(hooks, dict) else None
     matching_group = None
@@ -98,6 +111,68 @@ def main() -> int:
         if jcodemunch_handler is not None and jcodemunch_handler.get("timeout") != 600:
             errors.append("Claude jCodeMunch SessionStart timeout must be 600 seconds")
 
+    prompt_groups = hooks.get("UserPromptSubmit") if isinstance(hooks, dict) else None
+    prompt_commands: list[str] = []
+    if isinstance(prompt_groups, list):
+        for group in prompt_groups:
+            if not isinstance(group, dict):
+                continue
+            for handler in group.get("hooks") or []:
+                if isinstance(handler, dict) and handler.get("type") == "command":
+                    prompt_commands.append(str(handler.get("command", "")))
+    if not any("user-prompt-submit.sh" in command for command in prompt_commands):
+        errors.append(
+            ".claude/settings.json must run user-prompt-submit.sh on UserPromptSubmit"
+        )
+
+    require_terms(
+        ".claude/CLAUDE.md",
+        (
+            "@../AGENTS.md",
+            "@../docs/ai/EVIDENCE_GATED_COMPLETION.md",
+            "Deterministic skill loading",
+            "Mandatory skill load",
+            "AI_ENGINEERING_GUARDRAILS.md",
+            "/code-review",
+        ),
+        errors,
+    )
+    require_terms(
+        ".claude/hooks/user-prompt-submit.sh",
+        (
+            "command -v python3",
+            "command -v python",
+            "command -v py",
+            "Mandatory skill load",
+            "Root AGENTS.md is imported",
+            "EVIDENCE_GATED_COMPLETION.md",
+            "levyra-project-manager",
+            "levyra-desktop",
+            "levyra-engineering",
+            "levyra-openclaw-orchestrator",
+        ),
+        errors,
+    )
+    require_terms(
+        "docs/ai/EVIDENCE_GATED_COMPLETION.md",
+        (
+            "Acceptance gates",
+            "PASS",
+            "FAIL",
+            "BLOCKED",
+            "UNRUN",
+            "Do not create `GATES.md`",
+        ),
+        errors,
+    )
+
+    for skill in CLAUDE_BRIDGES:
+        require_terms(
+            f".claude/skills/{skill}/SKILL.md",
+            (f".agents/skills/{skill}/SKILL.md",),
+            errors,
+        )
+
     require_terms(
         "scripts/claude-jcodemunch-mcp.sh",
         ("codex_jcodemunch.py", "serve", "python3", "python", "py"),
@@ -128,6 +203,7 @@ def main() -> int:
         ".mcp.json",
         ".claude/settings.json",
         ".claude/hooks/jcodemunch-start.sh",
+        ".claude/hooks/user-prompt-submit.sh",
         "scripts/claude-jcodemunch-mcp.sh",
     ):
         path = ROOT / relative_path
@@ -143,9 +219,10 @@ def main() -> int:
         return 1
 
     print(
-        "Claude bootstrap validation passed: project jCodeMunch MCP, automatic "
-        "startup/resume indexing, server-level tool permission, native-tool fallback, "
-        "and correctness-first context policy verified."
+        "Claude bootstrap validation passed: canonical AGENTS import, mandatory "
+        "skill routing, project bridges, skill-listing budget, evidence-gated "
+        "completion, jCodeMunch startup/resume indexing, native-tool fallback, "
+        "and permission safety verified."
     )
     return 0
 


### PR DESCRIPTION
## Summary

- import the canonical root `AGENTS.md` directly from `.claude/CLAUDE.md` so Claude Code actually receives the repository contract at startup
- make prompt skill routing explicit and mandatory, with Windows-safe Python fallback (`python3` / `python` / `py -3`)
- add missing Claude project bridges for project management, Desktop, cross-domain engineering, and OpenClaw orchestration
- raise the Claude skill-listing budget modestly so project skill descriptions are less likely to be truncated when plugins are enabled
- add lightweight evidence-gated completion rules inspired by the useful part of unlazy: observable acceptance gates, direct evidence, no fake PASS states, and no mandatory tracking-file bloat
- extend the existing Claude bootstrap validator and prompt-routing tests for the new contract

## Scope

AI/agent configuration and documentation only. No Android/Desktop production code, version, dependency, release, or runtime behavior changes.

## Validation

Direct targeted checks performed on the changed configuration:

- Bash syntax check for `.claude/hooks/user-prompt-submit.sh`
- router execution for project-manager, Desktop, OpenClaw, and cross-domain prompts
- Python syntax compilation for the updated Claude bootstrap validator and routing tests
- JSON parse of `.claude/settings.json`
- final commit diff reviewed for scope and accidental churn

Repository `ai_quality_gate.py --profile fast/full` was not run in this connector-only environment. CI should be treated as the authoritative repository-level validation before this draft is marked ready.

## Publication state

Branch pushed and draft PR opened. No merge, tag, release, deployment, or version change is authorized or performed.