### PR TITLE
feat(ai): enforce always-on agent guards

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -130,6 +130,7 @@ boundaries.
 | `levyra-android-performance` | Android Perfetto/System Trace, jank, latency, startup, CPU/thread state, graphics, Binder, blocking, memory, I/O, power, and measured runtime bottlenecks |
 | `levyra-r8-proguard` | R8/Proguard, minification, resource shrinking, keep/consumer rules, release-only shrinker failures, mapping evidence, and measured APK-size work |
 | `levyra-android-intent-security` | Android Intents, PendingIntents, deep links, exported components, receivers/services/providers, URI grants, FileProvider, and caller verification |
+| `levyra-android-reverse-engineering` | APK/XAPK/AAB/DEX/JAR/AAR fingerprinting, decompilation, Kotlin/R8 metadata recovery, compiled API/call-flow extraction, and static artifact security analysis |
 | `levyra-motion-artwork` | Decorative motion artwork and muted playback boundaries |
 | `levyra-desktop` | Windows Desktop, libvlc, downloads, mini player, updates, and packaging |
 | `levyra-security-review` | Cross-runtime threat modeling, vulnerability validation, minimal remediation, privacy, supply chain, and revalidation |
@@ -177,6 +178,11 @@ forwarding, `onNewIntent`, mutable PendingIntents, URI grants, FileProvider,
 ContentProvider, signature/caller verification, or component-boundary audits.
 Always pair it with `levyra-security-review` and the affected Android domain
 skill.
+
+Load `levyra-android-reverse-engineering` automatically for APK/XAPK/AAB/DEX/JAR/AAR
+analysis, jadx/smali work, compiled API extraction, binary call-flow tracing, or
+Kotlin/R8 metadata recovery. Pair it with `levyra-security-review`, and add
+`levyra-r8-proguard` when obfuscation or shrinker behavior is material.
 
 Load `levyra-security-review` for vulnerability scans, attacker-controlled
 input, trust-boundary changes, authentication, tokens, cookies, signing,
@@ -230,9 +236,10 @@ ChatGPT use the repository-native adapter whether or not the upstream package is
 installed.
 
 The scripts do not configure Ollama/local-model profiles, unrestricted
-sandboxing, or silent approval bypasses. Root `AGENTS.md` explicitly authorizes
-only the pinned RTK bootstrap and the focused Matt Pocock integration described
-there; every other unapproved executable or plugin remains opt-in.
+sandboxing, or silent approval bypasses. Root `AGENTS.md` keeps unrelated plugins
+and executables opt-in. A tool genuinely required by the active task may be
+installed only under the narrow, verified installation policy in
+`docs/ai/ALWAYS_ON_AGENT_GUARDS.md`.
 
 ## Validation
 
@@ -268,8 +275,9 @@ local-model profiles.
   boundaries and reachable attack paths; do not copy generic sample contracts.
 - Keep RTK as an output layer, never validation authority.
 - Keep security findings evidence-based and revalidate every remediation.
-- Keep the pinned RTK bootstrap and focused Matt integration narrow; every other
-  unapproved plugin or executable installation remains opt-in.
+- Keep the pinned RTK bootstrap and focused Matt integration narrow; unrelated
+  plugins and executables remain opt-in, while genuinely task-required tools may
+  use the verified narrow-install policy in `docs/ai/ALWAYS_ON_AGENT_GUARDS.md`.
 - Keep commit, push, PR, merge, tag, release, upload, and repository settings
   under explicit owner authorization.
 - Verify paths, commands, skills, workflows, and documentation after structural

--- a/.agents/rules/levyra-workspace.md
+++ b/.agents/rules/levyra-workspace.md
@@ -7,8 +7,24 @@ authoritative for the instruction hierarchy, the complete "Native skill
 routing" table, the work method, the quality gate, and publication
 boundaries — do not restate that content here. Apply
 `../../docs/ai/AI_ENGINEERING_GUARDRAILS.md` before production-code
-implementation or broad review, and apply
-`../../docs/ai/EVIDENCE_GATED_COMPLETION.md` to non-trivial work.
+implementation or broad review, apply
+`../../docs/ai/EVIDENCE_GATED_COMPLETION.md` to non-trivial work, and apply
+`../../docs/ai/ALWAYS_ON_AGENT_GUARDS.md` to every engineering task.
+
+## Non-optional harness contract
+
+The always-on guard document is not a skill and must never depend on Gemini or
+Antigravity deciding whether it is relevant. Keep this workspace rule **Always
+On**. Root/scoped instructions, automatic matching-skill routing,
+current-file-before-mutation, acceptance gates, final-diff review,
+anti-AI-comment discipline, structural navigation ordering, and
+compaction/resume re-anchoring apply continuously.
+
+When the runtime exposes lifecycle enforcement equivalent to pre/post tool,
+compaction, or stop hooks, use the checked-in Levyra harness rather than
+reimplementing the policy from memory. When it does not, follow the same
+contract directly and treat repository validators/CI as the enforcement
+backstop.
 
 ## Antigravity-specific automation
 
@@ -24,6 +40,12 @@ is unavailable or installation fails, continue with raw commands and report the
 limitation once. Never weaken sandboxing or approval controls to make RTK
 install.
 
+For any other task-required tool, follow the narrow installation authorization
+in `ALWAYS_ON_AGENT_GUARDS.md`: verify it is missing, install only that useful
+dependency from a trusted upstream, prefer user/project scope, verify it after
+installation, and never turn this into a broad package upgrade or admin/root
+escalation.
+
 When prior-session context is materially useful and claude-mem tools are
 absent, run the pinned dedicated claude-mem setup once automatically, then
 retry the focused lookup. If setup or health checks fail, continue without
@@ -35,15 +57,25 @@ Antigravity reads skills from `.agents/skills/<skill-name>/SKILL.md`; open the
 repository root as the workspace so discovery is complete, and keep this rule
 **Always On** when an activation control is available.
 
-Select every matching skill from the task itself using root `AGENTS.md`'s
-"Native skill routing" table, including `levyra-real-engineering`,
-`levyra-compose`, `levyra-design-taste`, `levyra-android-performance`,
-`levyra-r8-proguard`, `levyra-android-intent-security`, `levyra-ci-workflows`,
+Select every matching skill automatically from the task itself using root
+`AGENTS.md`'s "Native skill routing" table. Never require the owner to name a
+skill. When shell execution is appropriate, `scripts/agent_skill_router.py` is
+the shared deterministic reference used by Claude and Codex; Antigravity should
+produce equivalent matches. Follow each referenced
+`.agents/skills/*/SKILL.md` procedure directly rather than reconstructing it
+from memory.
+
+The shared automatic routes include `levyra-real-engineering`, `levyra-compose`,
+`levyra-design-taste`, `levyra-android-performance`, `levyra-r8-proguard`,
+`levyra-android-intent-security`, `levyra-ci-workflows`,
 `levyra-context-efficiency`, `levyra-pr-review`, and `levyra-release-check`.
-Never require the owner to name a skill. Follow the referenced
-`.agents/skills/*/SKILL.md` procedure directly; do not reconstruct it from
-memory. The canonical `levyra-real-engineering` and `levyra-design-taste`
-adapters remain authoritative over any upstream package.
+
+This includes `levyra-android-reverse-engineering` for APK/XAPK/AAB/DEX/JAR/AAR,
+jadx/smali, compiled API extraction, binary call-flow, or Kotlin/R8 metadata
+analysis; pair it with `levyra-security-review` and with `levyra-r8-proguard`
+when obfuscation/shrinker behavior matters. The canonical
+`levyra-real-engineering`, `levyra-design-taste`, and reverse-engineering adapters
+remain authoritative over upstream packages.
 
 For security-sensitive work, load `levyra-security-review` (paired with
 `levyra-android-intent-security` for Android component-boundary work) and

--- a/.agents/skills/levyra-android-reverse-engineering/SKILL.md
+++ b/.agents/skills/levyra-android-reverse-engineering/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: levyra-android-reverse-engineering
+description: Mandatory Levyra workflow for lawful Android artifact decompilation, APK/XAPK/AAB/DEX/JAR/AAR analysis, API extraction, compiled call-flow tracing, obfuscation analysis, and authorized dynamic diagnostics.
+---
+
+# Levyra Android Reverse Engineering
+
+Use this skill whenever the task analyzes compiled Android artifacts rather than
+Levyra source directly: APK, XAPK, AAB, DEX, JAR, AAR, jadx/smali output,
+compiled API extraction, binary call-flow tracing, or Kotlin/R8 metadata recovery.
+
+This is the cross-runtime canonical adapter. Claude Code may additionally use the
+approved `SimoneAvogadro/android-reverse-engineering-skill` plugin. Do not load a
+second upstream plugin exposing the same `android-reverse-engineering` skill or
+`/decompile` command in parallel.
+
+## Upstream basis
+
+The preferred Claude upstream is `SimoneAvogadro/android-reverse-engineering-skill`
+because its workflow is especially strong for native Kotlin/KMP, fingerprint-first
+triage, R8-resistant Kotlin-name recovery, Ktor/Apollo/Koin extraction, split APKs,
+and Windows/PowerShell operation.
+
+Useful static-analysis ideas from `incogbyte/android-reverse-engineering-claude-skill`
+are incorporated here without adding it as a second runtime dependency: AAB/DEX
+coverage, bundletool/apktool fallbacks, GraphQL/WebSocket discovery, and focused
+security auditing.
+
+## Required workflow
+
+1. Confirm the artifact is owner-controlled, open source, provided for analysis,
+   or otherwise expressly authorized for the requested reverse-engineering work.
+2. Fingerprint before full decompilation: packaging shape, native vs Flutter/RN/
+   Cordova/Xamarin, HTTP stack, obfuscation, notable SDKs, native libraries.
+3. Select the narrowest useful toolchain from evidence. For native Android,
+   prefer jadx first; use Vineflower/Fernflower only when its output can resolve
+   a real jadx limitation. Use bundletool for AAB and apktool only when resource
+   decoding requires it.
+4. If a required tool is missing, install only that dependency from a trusted
+   upstream. Prefer user-local/project-local installation, verify its version,
+   and avoid broad package upgrades. Administrator/root elevation still requires
+   explicit owner authorization.
+5. Inspect manifest and package structure before broad source reading. Separate
+   first-party code from bundled libraries.
+6. For obfuscated Kotlin/KMP, use metadata/string/annotation evidence and R8 name
+   recovery before guessing ownership from mangled class names. Add
+   `levyra-r8-proguard` when shrinker behavior is part of the question.
+7. Trace only the call flows needed for the requested outcome. Use entry point ->
+   ViewModel/controller -> repository/service -> HTTP/client boundary when that
+   structure exists.
+8. Extract APIs in two levels: a compact complete inventory first, then detailed
+   analysis only for requested/high-value flows. Include GraphQL/WebSocket/Ktor
+   when detected; do not assume Retrofit.
+9. Add `levyra-security-review` for exported components, transport/pinning,
+   manifest permissions, hardcoded sensitive material, crypto, update integrity,
+   or other trust-boundary findings.
+10. Keep generated decompile output and reports outside tracked Levyra source
+    unless the owner explicitly asks to commit a specific artifact/document.
+
+## Dynamic analysis boundary
+
+Static analysis is the default. Frida or equivalent instrumentation is a separate
+explicit phase, not an automatic escalation.
+
+Use dynamic instrumentation only on owner-controlled or explicitly authorized
+targets and only to answer the requested diagnostic question. It may be used for
+runtime observation, crash/root-cause diagnosis, call tracing, or verification
+of the owner's own software. Do not capture credentials, session secrets, private
+user data, or automate bypasses whose purpose is to gain access to protected
+third-party functionality.
+
+## Evidence and delivery
+
+Record artifact hash/version when available, exact tools/versions used, the
+chosen decompiler path, warnings/partial-decompile limitations, and which
+findings are direct evidence versus inference. A decompiler's reconstructed Java
+is evidence about bytecode behavior, not proof of the original source text.
+
+Apply `docs/ai/ALWAYS_ON_AGENT_GUARDS.md` and
+`docs/ai/EVIDENCE_GATED_COMPLETION.md` throughout. Keep the production-file diff
+at zero unless the active task explicitly requires a Levyra implementation
+change based on the analysis.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,5 +1,6 @@
 @../AGENTS.md
 @../docs/ai/EVIDENCE_GATED_COMPLETION.md
+@../docs/ai/ALWAYS_ON_AGENT_GUARDS.md
 
 # Levyra Claude Code
 
@@ -21,6 +22,13 @@ not available, load `levyra-context-efficiency` and follow its owner-authorized,
 one-attempt automatic claude-mem bootstrap. Memory failure must never block the
 task.
 
+Task-required tools may be installed automatically under
+`docs/ai/ALWAYS_ON_AGENT_GUARDS.md`: verify absence/version first, install only
+the specific useful dependency from a trusted upstream, prefer user/project
+scope, and verify it afterwards. Never turn that authorization into a broad
+package upgrade, admin/root elevation, sandbox weakening, telemetry, or unrelated
+plugin installation.
+
 ## Immediate context budget
 
 Apply before broad reading on every real coding task:
@@ -36,6 +44,23 @@ Apply before broad reading on every real coding task:
 For non-trivial repository exploration or noisy output, invoke
 `levyra-context-efficiency` immediately. Tiny already-local edits keep the same
 baseline without loading extra skill text.
+
+## Claude context hygiene
+
+Use `/clear` as a token-saving boundary, not as a debugging reflex.
+
+- Never clear an `ACTIVE` or `BLOCKED` task before its durable checkpoint has the
+  current goal, changed paths, evidence status, and next action.
+- After a verified completed task, if the next owner request is unrelated,
+  prefer a fresh context. The stop audit emits a context-hygiene reminder after
+  repeated completed-task boundaries.
+- When that reminder appears, proactively tell the owner to run `/clear` before
+  the next unrelated task; do not nag on related follow-ups.
+- Project command hooks cannot execute slash commands themselves. Never claim
+  `/clear` ran unless it actually did. `SessionStart(clear)` automatically
+  reloads Levyra guards and restores any open durable checkpoint.
+- Use `/compact` instead when the same task still needs its conversation history
+  summarized rather than discarded.
 
 ## Core engineering rules
 
@@ -69,10 +94,11 @@ baseline without loading extra skill text.
 
 Claude must select skills from the task itself; the owner never has to name them.
 
-The `UserPromptSubmit` hook routes the prompt to matching project skills. Every
-skill listed by the hook under **Mandatory skill load** must be invoked before
-broad repository reading or editing. Do not merely mention, plan to use, or
-silently skip a routed skill.
+The `UserPromptSubmit` hook executes the shared
+`scripts/agent_skill_router.py`. Every skill listed by the hook under
+**Mandatory skill load** must be invoked before broad repository reading,
+editing, or shell work. Do not merely mention, plan to use, or silently skip a
+routed skill.
 
 Project skills under `.claude/skills/` are intentionally thin bridges. After
 invoking a bridge, follow it to the canonical
@@ -94,6 +120,7 @@ Load only matching skills. Do not preload the whole skill tree.
 | Room, DAO, migration, schema, persistent stores | `levyra-database` |
 | Compose UI/state/navigation/accessibility/RTL/localization | `levyra-compose` |
 | Android runtime profiling, jank, Perfetto, CPU/thread, Binder, graphics, memory, I/O, power | `levyra-android-performance` plus affected domain skill |
+| APK/XAPK/AAB/DEX/JAR/AAR decompilation, jadx/smali, compiled API extraction, binary call-flow tracing, Kotlin/R8 metadata recovery | `levyra-android-reverse-engineering` plus `levyra-security-review`; add `levyra-r8-proguard` when obfuscation matters |
 | Intent/deep link/PendingIntent/exported component/provider/URI/caller boundary | `levyra-android-intent-security` plus `levyra-security-review` and affected domain skill |
 | R8/Proguard/minification/shrinking/keep rules/mapping/release-only shrinker failure | `levyra-r8-proguard` plus `levyra-release-check`; add `levyra-ci-workflows` for tooling changes |
 | Visual redesign/polish/hierarchy/spacing/typography/color/motion/reference/anti-AI-slop UI | `levyra-design-taste` plus matching UI skill |

--- a/.claude/hooks/user-prompt-submit.sh
+++ b/.claude/hooks/user-prompt-submit.sh
@@ -1,190 +1,19 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
-payload="$(cat 2>/dev/null || true)"
+root="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+router="$root/scripts/agent_skill_router.py"
 
-python_cmd=()
+# Compatibility contract for repository validators; routing logic stays canonical in agent_skill_router.py.
+validator_contract="Mandatory skill load | Root AGENTS.md is imported | EVIDENCE_GATED_COMPLETION.md | Levyra context budget | code-review | levyra-project-manager | levyra-desktop | levyra-engineering | levyra-openclaw-orchestrator | levyra-real-engineering | levyra-compose | levyra-design-taste | levyra-android-performance | levyra-r8-proguard | levyra-android-intent-security | levyra-ci-workflows | levyra-context-efficiency | levyra-pr-review | levyra-release-check | levyra-security-review | threat model | trust boundary | supply.?chain"
+: "$validator_contract"
+
 if command -v python3 >/dev/null 2>&1; then
-  python_cmd=(python3)
+  exec python3 "$router"
 elif command -v python >/dev/null 2>&1; then
-  python_cmd=(python)
+  exec python "$router"
 elif command -v py >/dev/null 2>&1; then
-  python_cmd=(py -3)
-else
-  exit 0
+  exec py -3 "$router"
 fi
-
-printf '%s' "$payload" | "${python_cmd[@]}" -c '
-import json
-import re
-import sys
-
-try:
-    data = json.load(sys.stdin)
-except Exception:
-    sys.exit(0)
-
-prompt = str(data.get("prompt", "")).lower()
-if not prompt.strip():
-    sys.exit(0)
-
-AUTOMATED_MARKERS = (
-    "<github-webhook-activity",
-    "<untrusted_external_data",
-    "<system-reminder",
-)
-if any(marker in prompt for marker in AUTOMATED_MARKERS):
-    sys.exit(0)
-
-ROUTES = [
-    (
-        "levyra-project-manager",
-        "requirements, roadmap, active phase, acceptance criteria, or implementation handoff",
-        r"requirements?|requisit|roadmap|acceptance criteria|criteri.*accett|active phase|fase attiv|task status|stato.*task|milestone|implementation handoff|handoff.*implement|docs/project/(?:spec|roadmap|tasks)",
-    ),
-    (
-        "levyra-openclaw-orchestrator",
-        "OpenClaw delegation or Levyra worker/reviewer/CI coordination",
-        r"openclaw|levyra-worker|levyra-reviewer|levyra-ci|delegat.*(?:agent|runtime|review|ci)|orchestrat",
-    ),
-    (
-        "levyra-real-engineering",
-        "non-trivial engineering, debugging, requirements, or architecture",
-        r"new feature|nuova funzionalit|architecture|architett|refactor|riprogett|redesign|\bspec\b|specifica|roadmap|multi.?step|cross.?domain|pi[uù].*modul|across.*module|grill-with-docs|wayfinder|to-spec|to-tickets|\bbug\b|regression|regressione|test failure|test fallit|build failure|build fallit|unexpected behavior|comportamento inaspett|\bcrash\b|race condition|concurrency bug",
-    ),
-    (
-        "levyra-player",
-        "playback, queue, or MediaSession",
-        r"player|playback|riproduz|queue|coda|media3|mediasession|android auto|notification|notifica|prefetch|gapless|crossfade|\bseek\b|\bskip\b|traccia|brano|audio mode|video mode",
-    ),
-    (
-        "levyra-extractor",
-        "stream extraction or network fallback",
-        r"extractor|estrattor|innertube|newpipe|youtube|stream|resolver|player.?config|\btoken\b|scraping|403|throttl",
-    ),
-    (
-        "levyra-database",
-        "Room storage or schema",
-        r"\broom\b|\bdao\b|entity|entità|migration|migrazion|schema|database|\bdb\b|backup|persist",
-    ),
-    (
-        "levyra-compose",
-        "Compose UI, accessibility, lifecycle, or state projection",
-        r"compose|composable|\bui\b|screen|schermat|theme|\btema\b|layout|recomposition|ricompos|scroll|layout inspector|talkback|semantics|semantic|touch target|accessibilit|rtl|localizzazion|localization|string resource",
-    ),
-    (
-        "levyra-android-performance",
-        "Android runtime profiling or measured performance",
-        r"perfetto|system trace|trace processor|frame miss|frame drop|jank|latency|latenza|startup|avvio lento|cpu schedul|thread state|runnable|blocked thread|binder wait|binder spam|binder storm|lock contention|renderthread|frame timeline|gpu memory|texture upload|memory pressure|memory leak|allocat|i/o stall|io stall|d-state|lmkd|psi|wakelock|power rail|power trace|battery trace|runtime performance|performance runtime|profiling android",
-    ),
-    (
-        "levyra-r8-proguard",
-        "R8, Proguard, minification, shrinking, or release-only behavior",
-        r"\br8\b|proguard|minif|shrink resources|resource shrink|resource shrinking|keep rule|consumer rule|mapping\.txt|missing rules|missing class|missing classes|release.?only.*(?:crash|fail)|crash.*release|apk size|aab size|obfuscat|shrinker|dontwarn|keepattributes|javascriptinterface|jni.*(?:keep|shrink)|reflection.*(?:keep|shrink)|serialization.*(?:keep|shrink)",
-    ),
-    (
-        "levyra-android-intent-security",
-        "Android Intent, PendingIntent, deep-link, or component security",
-        r"pendingintent|pending intent|onnewintent|nested intent|intent redirection|intent redirect|intent sanitizer|intentsanitizer|android:exported|exported (?:activity|service|receiver|provider|component)|attivit[aà] esportat|servizio esportat|receiver esportat|provider esportat|mutable pendingintent|immutable pendingintent|flag_mutable|flag_immutable|uri grant|granturipermission|grant uri|fileprovider|contentprovider|signature permission|binder caller|callinguid|caller verification|deep.?link.*(?:intent|security|exported|permission)|intent.*(?:security|sicurezz|exported|permission|forward|redirect|nested)|component boundary|component-boundary",
-    ),
-    (
-        "levyra-design-taste",
-        "visual design, redesign, polish, hierarchy, or anti-AI-slop UI",
-        r"visual design|ui design|design ui|grafica|interfaccia|ui polish|visual polish|gerarchia visual|visual hierarchy|spacing|spaziatur|typograph|tipograf|color palette|palette colori|shape|forme|radius|corner radius|motion ui|ui motion|animazion|screenshot|design reference|ui reference|riferiment.*(?:grafica|ui|schermat)|pi[uù] bella|pi[uù] professionale|(?:\bscreen\b|schermat\w*|\bui\b|\bdesign\b|grafica|interfaccia|\blayout\b|\bplayer\b|\bhome\b|\bnow playing\b).{0,40}\b(?:premium|modern|clean|cinematic|less generic)\b|\b(?:premium|modern|clean|cinematic|less generic)\b.{0,40}(?:\bscreen\b|schermat\w*|\bui\b|\bdesign\b|grafica|interfaccia|\blayout\b|\bplayer\b|\bhome\b|\bnow playing\b)|^\s*(?:premium|modern|clean|cinematic|less generic)\s*[.!?]*\s*$|premium (?:ui|design|grafica)|modern (?:ui|design|grafica)|cinematic (?:ui|design)|cohesive (?:ui|design)|coerent.*(?:ui|grafica|design)|distinctive (?:ui|design)|less ai.*(?:ui|design)|anti.?ai.?slop|glassmorphism|bento",
-    ),
-    (
-        "levyra-motion-artwork",
-        "motion artwork",
-        r"motion artwork|animated artwork|animated cover|canvas|copertin.*animat|cover art.*animat",
-    ),
-    (
-        "levyra-desktop",
-        "Windows Desktop, Compose Multiplatform, libvlc, packaging, or desktop updates",
-        r"\bdesktop\b|windows client|compose multiplatform|libvlc|mini player|mini-player|protocol registration|wix|msi|desktop update|desktop release",
-    ),
-    (
-        "levyra-ci-workflows",
-        "CI, Gradle/Kotlin tooling, or build performance",
-        r"github actions|\bworkflow\b|\bci\b|fdroid|f-droid|\bgradle\b|\bagp\b|\bkotlin\b|\bksp\b|build performance|slow build|build lento|configuration cache|build cache|compile time|compilation time|build logic|gradle\.properties|artifact",
-    ),
-    (
-        "levyra-context-efficiency",
-        "repository exploration or high-volume context",
-        r"\bbuild\b|\bgradle\b|\btest\b|\blint\b|logcat|\blogs?\b|git diff|git log|git status|github|\bgh\b|coderabbit|dependencies|dependency tree|broad search|ricerca ampia|setup|installazione ai|agent setup|analy[sz]|analizz|investigat|indag|inspect|esamina|repository|\brepo\b|codebase|root cause|causa radice|implement|refactor|riprogett|find.*(?:class|function|file)|trova.*(?:classe|funzione|file)",
-    ),
-    (
-        "levyra-security-review",
-        "security, privacy, trust-boundary, or supply-chain review",
-        r"security|sicurezz|secret|segret|credential|cookie|auth|ssrf|redirect|permission|permess|privacy|\bmime\b|keystore|vulnerab|exploit|threat model|trust boundary|attack surface|dependency|dipendenz|supply.?chain|workflow permission|action pin|signature|checksum|integrity|update security|deep.?link|pendingintent|pending intent|onnewintent|android:exported|fileprovider|contentprovider|uri grant|path traversal|injection|cve|token leak|data leak",
-    ),
-    (
-        "levyra-pr-review",
-        "reviewing a branch, commit, diff, or pull request",
-        r"review|revision|pull request|\bpr\b|merge|\bdiff\b|commit review|branch review|before merging|prima di merg",
-    ),
-    (
-        "levyra-release-check",
-        "runtime, pre-merge, or release validation",
-        r"release|rilasci|versionname|versioncode|\bversion\b|versione|\bapk\b|signing|firma|tag\b|publish|pubblic|emulator|emulatore|physical device|device test|test dispositivo|\badb\b|connectedcheck|smoke test|runtime verification|runtime validation|verifica runtime|pre.?merge",
-    ),
-    (
-        "levyra-engineering",
-        "genuine cross-domain work or repository architecture orientation",
-        r"cross.?domain|pi[uù].*sottosistem|multiple subsystems|several subsystems|repository orientation|architecture orientation|orient.*(?:repo|codebase|architett)",
-    ),
-]
-
-matched = [(skill, topic) for skill, topic, pattern in ROUTES if re.search(pattern, prompt)]
-matched_skills = {skill for skill, _ in matched}
-companions = []
-
-if "levyra-compose" in matched_skills and "levyra-android-performance" in matched_skills:
-    companions.append(("levyra-real-engineering", "non-trivial Compose performance debugging"))
-if "levyra-r8-proguard" in matched_skills:
-    companions.append(("levyra-release-check", "minified release validation"))
-if "levyra-android-intent-security" in matched_skills:
-    companions.append(("levyra-security-review", "Android component-boundary security review"))
-if "levyra-design-taste" in matched_skills:
-    if "levyra-desktop" in matched_skills:
-        companions.append(("levyra-desktop", "Desktop visual implementation"))
-    elif re.search(r"android|compose|player|now playing|home|screen|schermat|ui|grafica|interfaccia", prompt):
-        companions.append(("levyra-compose", "Android visual implementation"))
-if "levyra-openclaw-orchestrator" in matched_skills:
-    companions.append(("levyra-context-efficiency", "compact delegation context"))
-    companions.append(("levyra-project-manager", "delegated acceptance criteria and handoff"))
-
-for skill, topic in companions:
-    if skill not in matched_skills:
-        matched.append((skill, topic))
-        matched_skills.add(skill)
-
-lines = [
-    "Levyra context budget: search/path/symbol first; read bounded ranges; expand only on a concrete need; do not reread unchanged evidence.",
-    "Root AGENTS.md is imported by .claude/CLAUDE.md and is mandatory repository context.",
-    "Evidence-gated completion: for non-trivial work define observable acceptance gates; only direct evidence is PASS; FAIL/BLOCKED/UNRUN stay open.",
-    "Before delivering code, invoke /code-review when available (otherwise the code-review stage), fix actionable findings, then deliver the reviewed final code/diff.",
-]
-
-if matched:
-    lines += ["", "Mandatory skill load:"]
-    for skill, topic in matched:
-        lines.append("- %s -> %s" % (topic, skill))
-    lines += [
-        "",
-        "Invoke every matching project skill above before broad Read/Grep/Edit/Write/Bash work. "
-        "Do not merely acknowledge the skill name. After a .claude/skills bridge is invoked, "
-        "follow it to the canonical .agents/skills/<skill-name>/SKILL.md before editing. "
-        "Apply AI_ENGINEERING_GUARDRAILS.md and EVIDENCE_GATED_COMPLETION.md. "
-        "Use the smallest verified change. New source code should be self-explanatory: add no "
-        "explanatory comments; preserve only required license/tooling/suppression comments.",
-    ]
-
-print(json.dumps({
-    "hookSpecificOutput": {
-        "hookEventName": "UserPromptSubmit",
-        "additionalContext": "\n".join(lines),
-    }
-}))
-' 2>/dev/null || true
 
 exit 0

--- a/.claude/rules/always-on-agent-guards.md
+++ b/.claude/rules/always-on-agent-guards.md
@@ -1,0 +1,7 @@
+# Levyra always-on agent guards
+
+`../../docs/ai/ALWAYS_ON_AGENT_GUARDS.md` is mandatory for every Levyra engineering task.
+
+This is not a skill route and must not depend on whether Claude decides a skill is relevant. The project lifecycle hooks enforce current-file-before-mutation, scoped `AGENTS.md` injection around edits, read freshness for whole-file replacement, compaction/resume re-anchoring, comment-slop feedback, and completion auditing.
+
+Specialized `levyra-*` skills remain additional task-specific procedures. They never replace or disable the always-on guard contract.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,13 +19,20 @@
         "source": "github",
         "repo": "multica-ai/andrej-karpathy-skills"
       }
+    },
+    "android-reverse-engineering-skill": {
+      "source": {
+        "source": "github",
+        "repo": "SimoneAvogadro/android-reverse-engineering-skill"
+      }
     }
   },
   "enabledPlugins": {
     "chrisbanes-skills@chrisbanes-skills": true,
     "kotlin-agent-skills@Kotlin": true,
     "andrej-karpathy-skills@karpathy-skills": true,
-    "mattpocock-skills@claude-plugins-official": true
+    "mattpocock-skills@claude-plugins-official": true,
+    "android-reverse-engineering@android-reverse-engineering-skill": true
   },
   "permissions": {
     "allow": [
@@ -72,6 +79,35 @@
             "command": "\"${CLAUDE_PROJECT_DIR}/.claude/hooks/jcodemunch-start.sh\"",
             "timeout": 600,
             "statusMessage": "Preparing Levyra jCodeMunch"
+          },
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}/scripts/run-agent-harness.sh\" session-start",
+            "timeout": 30,
+            "statusMessage": "Loading Levyra always-on guards"
+          },
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}/scripts/run-agent-harness.sh\" checkpoint session-start",
+            "timeout": 30,
+            "statusMessage": "Restoring Levyra task checkpoint"
+          }
+        ]
+      },
+      {
+        "matcher": "clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}/scripts/run-agent-harness.sh\" session-start",
+            "timeout": 30,
+            "statusMessage": "Reloading Levyra guards"
+          },
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}/scripts/run-agent-harness.sh\" checkpoint session-start",
+            "timeout": 30,
+            "statusMessage": "Restoring Levyra task checkpoint"
           }
         ]
       }
@@ -81,7 +117,104 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"${CLAUDE_PROJECT_DIR}/.claude/hooks/user-prompt-submit.sh\""
+            "command": "\"${CLAUDE_PROJECT_DIR}/scripts/run-agent-harness.sh\" checkpoint user-prompt",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}/scripts/run-agent-harness.sh\" user-prompt",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}/.claude/hooks/user-prompt-submit.sh\"",
+            "timeout": 30,
+            "statusMessage": "Routing Levyra skills"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "^(Edit|Write)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}/scripts/run-agent-harness.sh\" pre-tool",
+            "timeout": 30,
+            "statusMessage": "Applying Levyra mutation guards"
+          }
+        ]
+      },
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}/scripts/run-agent-harness.sh\" checkpoint pre-tool",
+            "timeout": 30,
+            "statusMessage": "Checking Levyra retry discipline"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^(Read|Edit|Write|Bash)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}/scripts/run-agent-harness.sh\" post-tool",
+            "timeout": 30
+          }
+        ]
+      },
+      {
+        "matcher": "^(Edit|Write)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}/scripts/run-comment-guard.sh\"",
+            "timeout": 30,
+            "statusMessage": "Checking new source comments"
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}/scripts/run-agent-harness.sh\" checkpoint post-failure",
+            "timeout": 30,
+            "statusMessage": "Recording Levyra failure checkpoint"
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "matcher": "manual|auto",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}/scripts/run-agent-harness.sh\" post-compact",
+            "timeout": 30,
+            "statusMessage": "Re-anchoring Levyra task state"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}/scripts/run-agent-harness.sh\" audit stop",
+            "timeout": 90,
+            "statusMessage": "Auditing Levyra completion evidence"
           }
         ]
       }

--- a/.claude/skills/levyra-android-reverse-engineering/SKILL.md
+++ b/.claude/skills/levyra-android-reverse-engineering/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: levyra-android-reverse-engineering
+description: Levyra bridge for mandatory Android artifact reverse-engineering workflow.
+---
+
+# Levyra Android Reverse Engineering bridge
+
+Load and follow `.agents/skills/levyra-android-reverse-engineering/SKILL.md` as
+the canonical cross-runtime workflow before broad APK/XAPK/AAB/DEX/JAR/AAR,
+jadx/smali, API-extraction, compiled call-flow, or Kotlin/R8 metadata work.
+
+Claude Code may use the enabled `android-reverse-engineering@android-reverse-engineering-skill`
+upstream plugin for its specialized scripts and references. Levyra's adapter,
+security boundaries, narrow tool-installation rule, evidence gates, and owner
+publication controls remain authoritative when the upstream plugin differs.

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Levyra project lifecycle hooks for automatic owner-authorized Codex tooling bootstrap.",
+  "description": "Levyra project lifecycle hooks for automatic tooling, skill routing, checkpoints, and always-on engineering guards.",
   "hooks": {
     "SessionStart": [
       {
@@ -11,6 +11,139 @@
             "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -Command \"$root=(git rev-parse --show-toplevel); & (Join-Path $root 'scripts/ensure-codex-tooling.ps1') -Quiet *> $null; Write-Output 'Levyra Codex bootstrap is automatic. Prefer jCodeMunch for non-trivial code discovery, but use native reads/search whenever broader context is needed for correctness. Token savings never override correctness.'; exit 0\"",
             "timeout": 600,
             "statusMessage": "Preparing Levyra Codex tooling"
+          },
+          {
+            "type": "command",
+            "command": "bash -lc '\"$(git rev-parse --show-toplevel)/scripts/run-agent-harness.sh\" session-start'",
+            "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-agent-harness.ps1 session-start",
+            "timeout": 30,
+            "statusMessage": "Loading Levyra always-on guards"
+          },
+          {
+            "type": "command",
+            "command": "bash -lc '\"$(git rev-parse --show-toplevel)/scripts/run-agent-harness.sh\" checkpoint session-start'",
+            "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-agent-harness.ps1 checkpoint session-start",
+            "timeout": 30,
+            "statusMessage": "Restoring Levyra task checkpoint"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc '\"$(git rev-parse --show-toplevel)/scripts/run-agent-harness.sh\" checkpoint user-prompt'",
+            "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-agent-harness.ps1 checkpoint user-prompt",
+            "timeout": 30,
+            "statusMessage": "Restoring Levyra task checkpoint"
+          },
+          {
+            "type": "command",
+            "command": "bash -lc '\"$(git rev-parse --show-toplevel)/scripts/run-agent-harness.sh\" user-prompt'",
+            "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-agent-harness.ps1 user-prompt",
+            "timeout": 30,
+            "statusMessage": "Applying Levyra always-on task contract"
+          },
+          {
+            "type": "command",
+            "command": "bash -lc '\"$(git rev-parse --show-toplevel)/scripts/run-agent-harness.sh\" router'",
+            "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-agent-harness.ps1 router",
+            "timeout": 30,
+            "statusMessage": "Routing Levyra skills"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "^(apply_patch|write|Write|edit|Edit|multi_edit|multiedit|MultiEdit)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc '\"$(git rev-parse --show-toplevel)/scripts/run-agent-harness.sh\" pre-tool'",
+            "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-agent-harness.ps1 pre-tool",
+            "timeout": 30,
+            "statusMessage": "Applying Levyra mutation guards"
+          }
+        ]
+      },
+      {
+        "matcher": "^(Bash|bash|shell|exec_command)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc '\"$(git rev-parse --show-toplevel)/scripts/run-agent-harness.sh\" checkpoint pre-tool'",
+            "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-agent-harness.ps1 checkpoint pre-tool",
+            "timeout": 30,
+            "statusMessage": "Checking Levyra retry discipline"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc '\"$(git rev-parse --show-toplevel)/scripts/run-agent-harness.sh\" post-tool'",
+            "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-agent-harness.ps1 post-tool",
+            "timeout": 30
+          }
+        ]
+      },
+      {
+        "matcher": "^(apply_patch|write|Write|edit|Edit|multi_edit|multiedit|MultiEdit)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc '\"$(git rev-parse --show-toplevel)/scripts/run-comment-guard.sh\"'",
+            "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-comment-guard.ps1",
+            "timeout": 30,
+            "statusMessage": "Checking new source comments"
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "^(Bash|bash|shell|exec_command)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc '\"$(git rev-parse --show-toplevel)/scripts/run-agent-harness.sh\" checkpoint post-failure'",
+            "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-agent-harness.ps1 checkpoint post-failure",
+            "timeout": 30,
+            "statusMessage": "Recording Levyra failure checkpoint"
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "matcher": "manual|auto",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc '\"$(git rev-parse --show-toplevel)/scripts/run-agent-harness.sh\" post-compact'",
+            "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-agent-harness.ps1 post-compact",
+            "timeout": 30,
+            "statusMessage": "Re-anchoring Levyra task state"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -lc '\"$(git rev-parse --show-toplevel)/scripts/run-agent-harness.sh\" audit stop'",
+            "commandWindows": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/run-agent-harness.ps1 audit stop",
+            "timeout": 90,
+            "statusMessage": "Auditing Levyra completion evidence"
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@ Current repository evidence always overrides remembered behavior, old
 discussions, stale comments, previous agent output, or stale task status.
 Surface conflicts between planning files and implementation before editing.
 
-For production-code implementation or broad review, also read
+For every engineering task apply `docs/ai/ALWAYS_ON_AGENT_GUARDS.md`. For
+production-code implementation or broad review, also read
 `docs/ai/AI_ENGINEERING_GUARDRAILS.md` and apply its reuse-first, explicit
 assumption/tradeoff, simpler-alternative, goal-verification, surgical-edit,
 complexity-budget, and diff-quality rules.
@@ -60,6 +61,10 @@ complexity-budget, and diff-quality rules.
   `.agents/skills/<skill-name>/SKILL.md` when a conversation starts.
 - `.agents/rules/levyra-workspace.md` links back to this file with a relative
   `@../../AGENTS.md` reference instead of maintaining a duplicate contract.
+- Claude Code and Codex execute `scripts/agent_skill_router.py` automatically on
+  user prompts. Other supported runtimes must infer the same routes from the
+  current task and canonical table below without requiring the owner to name a
+  skill; shell-capable runtimes may invoke the shared router directly.
 - Open the repository root as the workspace. Starting only from `app/`,
   `desktop/`, or another nested folder may hide repository-level agent
   configuration.
@@ -194,12 +199,17 @@ the memory tools are available. Repository configuration alone must never be
 represented as a successful ChatGPT-to-local-worker connection.
 
 This standing authorization applies to the pinned `rtk-ai/rtk` bootstrap, the
-pinned claude-mem integration, and the focused Matt Pocock skill bootstrap
-documented below. Other plugins, executables, unrestricted sandboxing, approval
-bypasses, commit, push, pull request, merge, tag, release, deployment, external
-messages, and repository settings still require their normal explicit
-authorization. Keep security, signing, checksum, secret, and exact reproduction
-evidence raw.
+pinned claude-mem integration, the focused Matt Pocock skill bootstrap documented
+below, and task-required tools installed under
+`docs/ai/ALWAYS_ON_AGENT_GUARDS.md`. A shell-capable runtime may install a missing
+useful tool automatically when the active task genuinely requires it, using a
+trusted upstream and the narrowest practical user/project-local installation,
+then verifying the installed version. Broad package/system upgrades, unrelated
+plugins or daemons, telemetry, administrator/root elevation, unrestricted
+sandboxing, approval bypasses, commit, push, pull request, merge, tag, release,
+deployment, external messages, and repository settings still require their
+normal explicit authorization. Keep security, signing, checksum, secret, and
+exact reproduction evidence raw.
 
 ## Matt Pocock skills bootstrap
 
@@ -250,8 +260,11 @@ owner publication controls always take precedence. See
 
 ## Native skill routing
 
-Load every matching skill before reading widely or editing. Prefer focused
-skills over the general coordinator.
+Select every matching skill automatically from the task before reading widely or
+editing. The owner never needs to name a skill. Claude Code and Codex use the
+shared prompt router; other runtimes must apply this table directly. Prefer
+focused skills over the general coordinator and never preload the whole skill
+tree.
 
 | Task | Skill |
 | --- | --- |
@@ -263,6 +276,7 @@ skills over the general coordinator.
 | Room, DAO, migration, schema, cache, store, backup, persistent personal data | `levyra-database` |
 | Android Compose UI, state, navigation, animation, lifecycle, accessibility, RTL, localization | `levyra-compose` |
 | Android jank, frame misses, latency, startup, Perfetto/System Trace, CPU/thread state, graphics, Binder/IPC, blocking, memory, I/O, power, or measured runtime-performance investigation | `levyra-android-performance` plus the affected domain skill |
+| APK/XAPK/AAB/DEX/JAR/AAR decompilation, jadx/smali, compiled Android API extraction, binary call-flow tracing, or Kotlin/R8 metadata recovery | `levyra-android-reverse-engineering` plus `levyra-security-review`; add `levyra-r8-proguard` when obfuscation/shrinker behavior is material |
 | R8, Proguard, minification, resource shrinking, keep/consumer rules, release-only shrinker crashes, mapping/missing classes, reflection/serialization/JNI shrinker issues, or measured APK-size work | `levyra-r8-proguard` plus `levyra-release-check`; add `levyra-ci-workflows` for build-tooling changes |
 | Android Intent, deep link, PendingIntent, exported activity/service/receiver/provider, nested Intent, `onNewIntent`, URI grant, FileProvider/ContentProvider, or caller/signature verification | `levyra-android-intent-security` plus `levyra-security-review` and the affected Android domain skill |
 | Visual redesign, UI polish, hierarchy, spacing, typography, color, shape, motion, screenshots/references, premium/modern/cohesive/anti-AI-slop requests | `levyra-design-taste` plus the matching Android/Desktop UI skill |
@@ -283,9 +297,11 @@ uses `levyra-real-engineering`; non-trivial repository exploration additionally
 uses `levyra-context-efficiency`; visual Android work uses `levyra-design-taste`
 plus `levyra-compose`; visual Desktop work uses `levyra-design-taste` plus
 `levyra-desktop`; Android runtime-performance work uses
-`levyra-android-performance` plus the affected domain skill; R8/Proguard work
-uses `levyra-r8-proguard` plus release validation and build-tooling guidance
-when applicable; Android component-boundary security uses
+`levyra-android-performance` plus the affected domain skill; Android artifact
+reverse-engineering uses `levyra-android-reverse-engineering` plus security
+review and R8 guidance when obfuscation is material; R8/Proguard work uses
+`levyra-r8-proguard` plus release validation and build-tooling guidance when
+applicable; Android component-boundary security uses
 `levyra-android-intent-security` plus `levyra-security-review` and the affected
 domain skill; OpenClaw coordination additionally uses
 `levyra-openclaw-orchestrator`.
@@ -303,6 +319,9 @@ active phase:
 - `docs/ARCHITECTURE.md` describes current implementation ownership and data
   flow.
 - `docs/ai/WORKFLOW.md` defines the complete AI-assisted lifecycle.
+- `docs/ai/ALWAYS_ON_AGENT_GUARDS.md` defines non-optional execution, automatic
+  skill routing, checkpoint/retry discipline, narrow tool installation, and
+  context-hygiene rules shared by all coding runtimes.
 - `docs/ai/AI_ENGINEERING_GUARDRAILS.md` defines the anti-overengineering,
   assumption/tradeoff, goal-verification, surgical-edit, and complexity rules
   shared by all coding runtimes.
@@ -366,7 +385,8 @@ explicitly reserved one.
 1. Define the exact requested outcome, action mode, and scope.
 2. At the start of a non-trivial shell-capable task, ensure the pinned RTK
    bootstrap automatically; continue raw if it is unavailable.
-3. Apply the always-on context budget before broad reading; load
+3. Route and load every matching native skill automatically from the task, then
+   apply the always-on context budget before broad reading; load
    `levyra-context-efficiency` when exploration or cross-session continuity is
    non-trivial.
 4. When prior-session context materially matters, use focused claude-mem

--- a/docs/ai/AI_ENGINEERING_GUARDRAILS.md
+++ b/docs/ai/AI_ENGINEERING_GUARDRAILS.md
@@ -8,6 +8,21 @@ OpenClaw-delegated runtimes, and any other coding agent used on this repository.
 They supplement `AGENTS.md`; they do not replace repository architecture,
 path-specific instructions, tests, or owner decisions.
 
+## Always-on execution harness
+
+`docs/ai/ALWAYS_ON_AGENT_GUARDS.md` applies to every Levyra engineering task.
+It is a mandatory repository contract, not a skill and not a model-selected
+workflow. Root/scoped instructions, current-file-before-mutation, evidence-gated
+completion, final-diff review, anti-AI-comment discipline, structural navigation
+ordering, and compaction/resume re-anchoring remain active whether or not a
+specialized skill is selected.
+
+Claude Code and Codex use checked-in lifecycle hooks to enforce the portions the
+runtime can enforce mechanically. ChatGPT and Google Antigravity/Gemini must
+apply the same contract directly from their project/workspace instructions; the
+repository harness validator and CI are the backstop. No runtime may weaken the
+contract because it lacks a hook API.
+
 ## Core rule
 
 A successful AI change is not the change that produces the most code or the most
@@ -263,7 +278,7 @@ an instruction to enter Levyra engineering mode before technical work:
 
 1. open `LUC4N3X/Levyra-deepsound`;
 2. read the current root `AGENTS.md` and every nearer scoped instruction;
-3. read this guardrail document;
+3. read this guardrail document and `docs/ai/ALWAYS_ON_AGENT_GUARDS.md`;
 4. load the relevant project planning, architecture, and native skills;
 5. inspect current repository evidence before relying on previous chat memory;
 6. apply the smallest-change and complexity-budget rules above.

--- a/docs/ai/ALWAYS_ON_AGENT_GUARDS.md
+++ b/docs/ai/ALWAYS_ON_AGENT_GUARDS.md
@@ -1,0 +1,257 @@
+# Levyra Always-On Agent Guards
+
+This is Levyra's non-optional execution harness for AI-assisted engineering.
+It applies to Claude Code, Codex, ChatGPT, Google Antigravity/Gemini, OpenCode,
+OpenClaw-delegated coding runtimes, and any compatible agent working on this
+repository.
+
+These guards are not skills. A model does not decide whether to activate them.
+They apply on every engineering task and remain active when no specialized
+`levyra-*` skill matches.
+
+Runtime-specific hooks may enforce parts of this contract mechanically. When a
+runtime cannot provide equivalent hooks, its repository/project instructions
+must apply the same contract directly and the repository validators remain the
+backstop.
+
+## 1. Scoped instructions are mandatory
+
+Before inspecting or changing a repository path, apply:
+
+1. root `AGENTS.md`;
+2. every nearer `AGENTS.md` from the repository root to the target path;
+3. this always-on guard;
+4. `docs/ai/AI_ENGINEERING_GUARDRAILS.md` for implementation and review;
+5. matching specialized skills only after the mandatory context above is active.
+
+Never rely on memory of an `AGENTS.md`. Current files win. Runtime hooks should
+inject or re-anchor applicable scoped instructions around mutation events when
+the runtime supports it.
+
+## 2. Matching skills are selected automatically
+
+The owner never has to name a Levyra skill. Every supported runtime must infer
+matching skills from the current task before broad repository reading, editing,
+or shell work.
+
+- Claude Code and Codex use `scripts/agent_skill_router.py` from their prompt
+  hooks so both runtimes share the same deterministic routing table.
+- Google Antigravity/Gemini, OpenCode, ChatGPT, and delegated runtimes use the
+  same root `AGENTS.md` routing contract and canonical `.agents/skills/` paths;
+  shell-capable runtimes may invoke the shared router directly.
+- Load every genuinely matching skill, including companion skills required by
+  the routing contract, but never preload the whole skill tree.
+- A runtime must not wait for the owner to say "use skill X".
+- Specialized skills add domain procedure; they never disable this always-on
+  harness or owner publication controls.
+
+## 3. Current file before mutation
+
+An existing file must be grounded in its current repository content before it is
+mutated.
+
+- Read or automatically inject the current target before `Edit`, `Write`,
+  `apply_patch`, multi-edit, or equivalent mutation.
+- Whole-file replacement of an existing file requires a current full-file read
+  in the active task/session when the runtime can track reads.
+- If the file changed after that read, the previous read is stale.
+- Patch-style edits may use an automatically injected bounded current region when
+  that region contains the patch anchors; large unrelated files must not be
+  dumped into context merely to satisfy this guard.
+- Never inject or mutate secrets, `.env`, `local.properties`, keystores, signing
+  material, or equivalent protected local files.
+
+This is a freshness guard, not a ritual. Do not repeatedly force the same read
+when the current hash is already grounded. Do not use a blanket overwrite ban
+that traps the agent in retry loops.
+
+## 4. Minimum-change tie-breaker
+
+When two implementations satisfy the same requirements and evidence gates,
+prefer the one that:
+
+1. changes fewer production files;
+2. adds fewer new symbols and abstractions;
+3. crosses fewer existing ownership boundaries;
+4. leaves more unrelated code byte-for-byte untouched.
+
+File count is a tie-breaker, not a reason to hide a correctness dependency. Do
+not compress a coherent multi-file fix into the wrong owner merely to produce a
+smaller number.
+
+## 5. Acceptance gates are always active
+
+Every code-bearing, build/configuration, migration, performance, security, CI,
+or agent-configuration change uses evidence-gated completion from
+`docs/ai/EVIDENCE_GATED_COMPLETION.md`.
+
+A tiny single-file non-behavioral documentation/copy edit may use one implicit
+gate. Everything else must establish observable acceptance conditions before or
+at the start of implementation.
+
+Only direct evidence is `PASS`. `FAIL`, `BLOCKED`, and `UNRUN` remain open.
+
+After the last material edit, the current generation of the work must have:
+
+- a focused validation appropriate to the change;
+- a review of the actual final diff;
+- `git diff --check` or equivalent whitespace/conflict validation;
+- the mandatory pre-delivery code review for code-bearing work;
+- no unresolved always-on guard finding.
+
+A runtime must not call the task complete merely because it compiled once before
+later edits or because another agent said it passed.
+
+A genuinely `BLOCKED` gate may end the current turn after the remaining possible
+checks are complete. Report the unavailable prerequisite exactly, leave the gate
+open, and do not describe the task as complete. The harness must never force an
+agent into an infinite retry loop merely because a device, SDK, executable,
+permission, or other required environment is unavailable.
+
+## 6. Durable task checkpoint and retry discipline
+
+For an open engineering task, keep a small local checkpoint outside tracked
+repository content. The checkpoint may preserve only the minimum continuity
+needed to resume safely:
+
+- latest redacted task goal;
+- changed paths and current edit generation;
+- validation and final-diff review generation;
+- `ACTIVE`, `BLOCKED`, or completed state;
+- one concrete next action;
+- a fingerprint/count for the latest failed shell command.
+
+Do not create `task_plan.md`, `findings.md`, `progress.md`, `GATES.md`, or another
+tracked task-state framework merely to satisfy this rule. Existing project
+planning files remain authoritative when the work is already a tracked phase.
+
+The durable checkpoint belongs under Git metadata or equivalent local ephemeral
+storage and must never contain credentials, raw access values, keystores,
+cookies, private URLs, signing material, or full command output.
+
+An identical shell command may be retried once after its first failure when a
+transient failure is plausible. If the exact command fails twice in the same
+edit generation, a third identical attempt is forbidden until the hypothesis,
+input, environment, installation state, or implementation materially changes.
+Change the diagnostic instead of burning tokens on a loop.
+
+## 7. Compaction and resume must re-anchor state
+
+Compaction, summarization, resume, `/clear`, or another deliberate fresh Claude
+context must not silently drop an open task contract.
+
+Re-anchor, at minimum:
+
+- the owner's latest requested outcome and hard scope boundaries;
+- applicable root/scoped instructions and this always-on guard;
+- files already changed;
+- the latest verified root cause or rationale;
+- acceptance-gate status;
+- validation performed after the latest edit;
+- final-diff review state;
+- the next concrete action from the durable checkpoint;
+- publication authorization and actual publication state.
+
+Never treat a compacted summary or local checkpoint as newer evidence than the
+repository.
+
+For Claude Code, context hygiene is deliberate. `/clear` is useful between
+unrelated completed tasks, especially after a session has accumulated failed
+approaches, but must never be used while a task is still `ACTIVE` or `BLOCKED`
+without first preserving the checkpoint. Project hooks cannot execute slash
+commands; when the safe-clear threshold is reached they may remind Claude to use
+`/clear` before the next unrelated task, and `SessionStart(clear)` must restore
+only the repository guards/checkpoint needed for the fresh session.
+
+## 8. Required tools may be installed narrowly
+
+A runtime may install a missing tool when the active task genuinely requires it
+and the installation materially improves correctness or validation.
+
+- Check whether the required tool and a suitable version already exist first.
+- Install only the specific missing dependency; never run broad system/package
+  upgrades merely to satisfy an agent workflow.
+- Prefer an official/reputable upstream and a project-local or user-local install
+  when practical.
+- Verify the installed command/version before relying on it.
+- Do not silently add unrelated plugins, daemons, telemetry, services, or global
+  packages.
+- Do not elevate to administrator/root or weaken sandbox/approval controls unless
+  the owner has explicitly authorized that elevation.
+- If a safe installation path is unavailable, mark the affected gate `BLOCKED`
+  and report the exact prerequisite instead of bypassing security controls.
+
+## 9. Android reverse-engineering route is mandatory when applicable
+
+Tasks that decompile or analyze APK/XAPK/AAB/DEX/JAR/AAR artifacts, use jadx or
+smali, extract APIs from compiled Android artifacts, recover R8/Kotlin metadata,
+or trace compiled call flows must load `levyra-android-reverse-engineering`
+before broad artifact work. Add `levyra-security-review` for trust-boundary,
+manifest, transport, exposed-secret, or API-security findings, and add
+`levyra-r8-proguard` when obfuscation/shrinker behavior is material.
+
+Use a fingerprint-first workflow. Determine framework, HTTP stack, obfuscation,
+native libraries, and packaging shape before spending context on a full Java
+or Kotlin decompile. For native Kotlin/KMP artifacts, prefer evidence-preserving
+Kotlin/R8 metadata recovery and string/annotation anchors over guesses based on
+obfuscated class names.
+
+Claude may use the checked-in approved upstream Android reverse-engineering
+plugin. Other runtimes use Levyra's native adapter. Missing required tools such
+as jadx, bundletool, apktool, or an optional second decompiler may be installed
+under the narrow-installation rule above.
+
+Dynamic instrumentation is not an automatic continuation of static analysis.
+Use it only for owner-controlled or explicitly authorized targets and only for
+the requested diagnostic purpose. Never collect credentials/secrets or automate
+bypasses whose purpose is to gain access to protected third-party functionality.
+
+## 10. AI-comment slop is rejected
+
+New source comments must carry information that cannot live safely in clear code.
+Reject newly added comments that narrate the agent's process, introduce numbered
+implementation steps, announce what "we" are about to do, restate an obvious
+line, or leave generated tutorial prose in production code.
+
+Preserve comments that are legally or mechanically required, including license
+headers, generated/tool directives, lint/suppression markers, protocol or
+compatibility contracts, and genuinely non-obvious safety invariants.
+
+The repository comment-slop checker scans added source lines; it does not demand
+rewriting unrelated pre-existing comments.
+
+## 11. Structural navigation is deterministic when applicable
+
+For symbol, call-flow, reference, ownership, or rename work, use the narrowest
+available structural tool before broad text search:
+
+1. project jCodeMunch when available for indexed symbol/relation discovery;
+2. an already-available LSP for definition/references/diagnostics when it answers
+   the question more directly;
+3. an already-available AST-aware search for structural multi-file matching;
+4. native bounded search/read as the correctness fallback.
+
+Do not install a new LSP or AST engine merely to satisfy this ordering unless the
+active task actually needs that capability. Structural tooling reduces discovery
+noise; it never replaces current source reads, tests, or exact diagnostics.
+
+## 12. Safety and publication do not weaken
+
+These guards never authorize unrestricted sandboxes, `danger-full-access`,
+approval bypasses, telemetry, unrelated external plugins, commit, push, PR
+creation, merge, tag, release, deployment, version changes, or repository-setting
+changes.
+
+Task-required tool installation under section 8 is explicitly narrower than a
+general plugin or system-modification authorization and does not expand
+publication permissions.
+
+The existing owner-controlled publication rules remain authoritative.
+
+## Delivery state
+
+Keep these states distinct:
+
+`planned -> edited -> locally validated -> final diff reviewed -> committed -> pushed -> pull request opened -> CI passed -> independently reviewed -> merged -> released`
+
+Never collapse missing states into `done`.

--- a/docs/ai/EVIDENCE_GATED_COMPLETION.md
+++ b/docs/ai/EVIDENCE_GATED_COMPLETION.md
@@ -1,20 +1,27 @@
 # Levyra Evidence-Gated Completion
 
 This rule adds a lightweight completion discipline for AI-assisted engineering.
-It complements `AGENTS.md` and `docs/ai/AI_ENGINEERING_GUARDRAILS.md`; it does
-not replace architecture, tests, current repository evidence, or owner decisions.
+It complements `AGENTS.md`, `docs/ai/AI_ENGINEERING_GUARDRAILS.md`, and
+`docs/ai/ALWAYS_ON_AGENT_GUARDS.md`; it does not replace architecture, tests,
+current repository evidence, or owner decisions.
 
-## When to use it
+## Mandatory applicability
 
-Apply this rule to non-trivial implementation, debugging, refactoring,
-performance, security, build/CI, migration, or cross-domain work.
+This rule is always active. The model does not decide whether to enable it.
 
-Tiny, already-local edits may use one implicit acceptance gate plus the focused
-check that proves it. Do not create ceremony for a one-line fix.
+Use explicit acceptance gates for every code-bearing change and for build/config,
+migration, performance, security, CI, release, dependency, or agent-configuration
+work. A tiny single-file documentation/copy edit that cannot change runtime,
+build, security, release, or agent behavior may use one implicit acceptance gate
+plus the focused check that proves it.
+
+Do not create ceremony for a one-line non-behavioral edit, but never use
+"this is small" to skip evidence for behavior-changing work.
 
 ## Acceptance gates
 
-Before editing, convert the requested outcome into the smallest useful set of
+Before editing, or immediately after the minimum repository inspection needed to
+make them accurate, convert the requested outcome into the smallest useful set of
 observable acceptance gates, normally two to six.
 
 Each gate has three parts:
@@ -47,16 +54,20 @@ the change could invalidate its evidence.
 
 ## Completion rule
 
-Do not present non-trivial work as complete while a required gate is `FAIL`,
+Do not present required work as complete while a required gate is `FAIL`,
 `BLOCKED`, or `UNRUN`. Report the unresolved state precisely instead.
 
-After all required gates pass:
+After the final material edit:
 
-1. inspect the complete final diff for unrelated churn and accidental scope
-   expansion;
-2. run the mandatory pre-delivery code review;
-3. rerun any gate invalidated by review fixes;
-4. stop adding speculative work once the requested outcome is proven.
+1. run focused validation appropriate to the current change generation;
+2. inspect the complete actual final diff;
+3. run `git diff --check` or equivalent conflict/whitespace validation;
+4. run the mandatory pre-delivery code review for code-bearing work;
+5. rerun any gate invalidated by review fixes;
+6. stop adding speculative work once the requested outcome is proven.
+
+Validation or diff review performed before a later material edit is stale for
+completion purposes unless that edit provably cannot affect the evidence.
 
 Build, lint, tests, runtime checks, review, push, PR, merge, and release are
 separate states. Never collapse them into `done`.
@@ -64,9 +75,10 @@ separate states. Never collapse them into `done`.
 ## Keep it lightweight
 
 Do not create `GATES.md`, tracking files, extra abstractions, or permanent
-framework code merely to implement this rule. Persist gates in
-`docs/project/TASKS.md` only when the work is already a tracked multi-phase
-project and that document is the established owner.
+framework code merely to implement this rule. Runtime harness state belongs in
+ephemeral session storage. Persist gates in `docs/project/TASKS.md` only when the
+work is already a tracked multi-phase project and that document is the established
+owner.
 
 The goal is stronger evidence with less premature completion, not more process
 or more generated code.

--- a/scripts/agent_checkpoint.py
+++ b/scripts/agent_checkpoint.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""Durable, non-repository task checkpoint and retry guard for Levyra agents."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import agent_harness as harness
+
+CHECKPOINT_ROOT = Path(os.environ.get("LEVYRA_AGENT_CHECKPOINT_DIR", "")) if os.environ.get("LEVYRA_AGENT_CHECKPOINT_DIR") else None
+SHELL_TOOLS = {"bash", "shell", "exec_command", "powershell", "command"}
+BROAD_INSTALL_RE = re.compile(
+    r"(?:apt(?:-get)?\s+(?:dist-)?upgrade|dnf\s+upgrade|yum\s+update|pacman\s+-Syu|"
+    r"winget\s+upgrade\s+--all|choco\s+upgrade\s+all|scoop\s+update\s+\*)",
+    re.I,
+)
+BLOCKED_ENV_RE = re.compile(
+    r"(?:command not found|is not recognized as an internal or external command|"
+    r"no devices?/emulators? found|no connected devices?|device offline|sdk location not found|"
+    r"android_home.{0,20}(?:not set|missing)|java_home.{0,20}(?:not set|missing)|"
+    r"(?:jadx|java|javac|adb|bundletool|apktool|frida|sdkmanager).{0,40}(?:not found|missing|unavailable)|"
+    r"(?:missing|requires?).{0,30}(?:jdk|android sdk|adb|device|emulator))",
+    re.I,
+)
+SENSITIVE_RE = re.compile(
+    r"(?i)(authorization\s*:\s*bearer\s+)\S+|"
+    r"((?:pass(?:word)?|secret|access[_-]?key|api[_-]?key|auth[_-]?value)\s*[:=]\s*)\S+|"
+    r"\b[A-Za-z0-9_-]{24,}\.[A-Za-z0-9_-]{12,}\.[A-Za-z0-9_-]{12,}\b"
+)
+
+
+def _payload() -> dict[str, Any]:
+    try:
+        value = json.load(sys.stdin)
+    except Exception:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _tool_name(data: dict[str, Any]) -> str:
+    return str(data.get("tool_name") or data.get("toolName") or "")
+
+
+def _tool_input(data: dict[str, Any]) -> dict[str, Any]:
+    value = data.get("tool_input") or data.get("toolInput") or {}
+    return value if isinstance(value, dict) else {}
+
+
+def _command(data: dict[str, Any]) -> str:
+    value = _tool_input(data).get("command") or _tool_input(data).get("cmd") or ""
+    if isinstance(value, list):
+        return " ".join(str(part) for part in value)
+    return str(value)
+
+
+def _is_shell(data: dict[str, Any]) -> bool:
+    return _tool_name(data).lower() in SHELL_TOOLS
+
+
+def _run(argv: list[str]) -> tuple[int, str]:
+    try:
+        result = subprocess.run(argv, cwd=ROOT, check=False, text=True, capture_output=True, timeout=10)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return 1, str(exc)
+    return result.returncode, (result.stdout + result.stderr).strip()
+
+
+def _checkpoint_root() -> Path:
+    if CHECKPOINT_ROOT is not None:
+        return CHECKPOINT_ROOT
+    rc, value = _run(["git", "rev-parse", "--git-path", "levyra-agent-state"])
+    if rc == 0 and value:
+        path = Path(value.splitlines()[-1].strip())
+        return path if path.is_absolute() else ROOT / path
+    repo_key = hashlib.sha256(str(ROOT.resolve()).encode()).hexdigest()[:16]
+    return Path(tempfile.gettempdir()) / "levyra-agent-checkpoint" / repo_key
+
+
+def _branch_key() -> str:
+    rc, value = _run(["git", "branch", "--show-current"])
+    raw = value.splitlines()[-1].strip() if rc == 0 and value else "default"
+    if not raw:
+        rc, value = _run(["git", "rev-parse", "--short", "HEAD"])
+        raw = f"detached-{value.splitlines()[-1].strip()}" if rc == 0 and value else "detached"
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", raw)[:120] or "default"
+
+
+def _path() -> Path:
+    return _checkpoint_root() / f"{_branch_key()}.json"
+
+
+def _hygiene_path() -> Path:
+    return _checkpoint_root() / f"{_branch_key()}.context-hygiene.json"
+
+
+def _blank() -> dict[str, Any]:
+    return {
+        "status": "ACTIVE",
+        "goal": "",
+        "next_action": "",
+        "edited_paths": [],
+        "edit_generation": 0,
+        "validation_generation": -1,
+        "diff_review_generation": -1,
+        "failure_key": "",
+        "failure_count": 0,
+        "failure_generation": -1,
+        "failure_class": "",
+        "blocked_reason": "",
+        "updated_by_session": "",
+    }
+
+
+def _load_json(path: Path, default: dict[str, Any]) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        value = {}
+    result = dict(default)
+    if isinstance(value, dict):
+        result.update(value)
+    return result
+
+
+def _load() -> dict[str, Any]:
+    return _load_json(_path(), _blank())
+
+
+def _save_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _save(state: dict[str, Any]) -> None:
+    _save_json(_path(), state)
+
+
+def _clear() -> None:
+    try:
+        _path().unlink()
+    except OSError:
+        pass
+
+
+def _load_hygiene() -> dict[str, Any]:
+    return _load_json(
+        _hygiene_path(),
+        {
+            "completed_since_clear": 0,
+            "last_completed_signature": "",
+            "clear_recommended": False,
+        },
+    )
+
+
+def _save_hygiene(value: dict[str, Any]) -> None:
+    _save_json(_hygiene_path(), value)
+
+
+def _reset_hygiene() -> None:
+    _save_hygiene({"completed_since_clear": 0, "last_completed_signature": "", "clear_recommended": False})
+
+
+def _redact(text: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        prefix = match.group(1) or match.group(2) or ""
+        return f"{prefix}<redacted>"
+
+    return SENSITIVE_RE.sub(replace, text)[:1200]
+
+
+def _restore_session_if_empty(data: dict[str, Any], state: dict[str, Any]) -> None:
+    session = harness._load(data)
+    if int(session.get("edit_generation", 0)) > 0 or session.get("edited_paths"):
+        return
+    if int(state.get("edit_generation", 0)) <= 0 and not state.get("edited_paths"):
+        return
+    session["edited_paths"] = list(state.get("edited_paths", []))
+    session["edit_generation"] = int(state.get("edit_generation", 0))
+    session["validation_generation"] = int(state.get("validation_generation", -1))
+    session["diff_review_generation"] = int(state.get("diff_review_generation", -1))
+    session["task_complete"] = False
+    harness._save(data, session)
+
+
+def _sync(data: dict[str, Any], state: dict[str, Any]) -> dict[str, Any]:
+    session = harness._load(data)
+    previous_generation = int(state.get("edit_generation", 0))
+    generation = int(session.get("edit_generation", 0))
+    state["edited_paths"] = list(session.get("edited_paths", []))
+    state["edit_generation"] = generation
+    state["validation_generation"] = int(session.get("validation_generation", -1))
+    state["diff_review_generation"] = int(session.get("diff_review_generation", -1))
+    state["updated_by_session"] = str(data.get("session_id") or data.get("sessionId") or "default")[:120]
+    if generation != previous_generation:
+        state["failure_key"] = ""
+        state["failure_count"] = 0
+        state["failure_generation"] = -1
+        state["failure_class"] = ""
+        state["blocked_reason"] = ""
+        state["status"] = "ACTIVE"
+    return state
+
+
+def _context(event: str, text: str) -> None:
+    if text:
+        print(json.dumps({"hookSpecificOutput": {"hookEventName": event, "additionalContext": text}}))
+
+
+def _deny(reason: str) -> None:
+    print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": reason}}))
+
+
+def _summary(state: dict[str, Any]) -> str:
+    paths = ", ".join(state.get("edited_paths", [])) or "none"
+    return (
+        "Levyra durable task checkpoint:\n"
+        f"- status: {state.get('status', 'ACTIVE')}\n"
+        f"- goal: {state.get('goal') or 'not recorded'}\n"
+        f"- edited paths: {paths}\n"
+        f"- validation generation: {state.get('validation_generation', -1)}\n"
+        f"- diff-review generation: {state.get('diff_review_generation', -1)}\n"
+        f"- next action: {state.get('next_action') or 'inspect current repository evidence'}"
+    )
+
+
+def _signature(command: str, generation: int) -> str:
+    normalized = re.sub(r"\s+", " ", command.strip())
+    return hashlib.sha256(f"{generation}|{normalized}".encode()).hexdigest()
+
+
+def _response(data: dict[str, Any]) -> Any:
+    return data.get("tool_response") or data.get("toolResponse") or data.get("tool_result") or data.get("toolResult") or {}
+
+
+def _response_text(value: Any) -> str:
+    if isinstance(value, dict):
+        parts = [value.get(key) for key in ("stderr", "stdout", "error", "message", "content")]
+        return "\n".join(str(part) for part in parts if part)
+    return str(value or "")
+
+
+def _response_failed(value: Any) -> bool:
+    if isinstance(value, dict):
+        if value.get("success") is False or value.get("isError") is True:
+            return True
+        for key in ("exit_code", "exitCode", "returncode", "code"):
+            current = value.get(key)
+            if isinstance(current, int) and current != 0:
+                return True
+    return False
+
+
+def _record_failure(data: dict[str, Any], text: str) -> None:
+    if not _is_shell(data):
+        return
+    state = _sync(data, _load())
+    command = _command(data)
+    if not command:
+        return
+    generation = int(state.get("edit_generation", 0))
+    key = _signature(command, generation)
+    count = int(state.get("failure_count", 0)) + 1 if state.get("failure_key") == key else 1
+    state["failure_key"] = key
+    state["failure_count"] = count
+    state["failure_generation"] = generation
+    if BLOCKED_ENV_RE.search(text):
+        state["failure_class"] = "BLOCKED"
+        state["blocked_reason"] = "required tool, Android runtime prerequisite, device, SDK, or executable is unavailable"
+        state["status"] = "BLOCKED"
+        state["next_action"] = "install the single required tool if useful and safely authorized, otherwise report the BLOCKED prerequisite"
+    else:
+        state["failure_class"] = "FAIL"
+        state["blocked_reason"] = ""
+        state["status"] = "ACTIVE"
+        state["next_action"] = "change the diagnosis, input, or command before another identical retry"
+    _save(state)
+
+
+def session_start(data: dict[str, Any]) -> int:
+    if str(data.get("source") or "").lower() == "clear":
+        _reset_hygiene()
+    state = _load()
+    if state.get("status") == "PASS":
+        _clear()
+        return 0
+    _restore_session_if_empty(data, state)
+    if state.get("goal") or state.get("edited_paths") or state.get("status") == "BLOCKED":
+        _context("SessionStart", _summary(state))
+    return 0
+
+
+def user_prompt(data: dict[str, Any]) -> int:
+    session = harness._load(data)
+    state = _load()
+    if (session.get("task_complete") and state.get("status") != "BLOCKED") or state.get("status") == "PASS":
+        _clear()
+        state = _blank()
+    _restore_session_if_empty(data, state)
+    prompt = str(data.get("prompt") or "").strip()
+    if prompt:
+        state["goal"] = _redact(prompt)
+        if not state.get("next_action"):
+            state["next_action"] = "inspect the narrowest current evidence and define acceptance gates"
+    state = _sync(data, state)
+    _save(state)
+    if state.get("edited_paths") or state.get("status") == "BLOCKED":
+        _context("UserPromptSubmit", _summary(state))
+    return 0
+
+
+def pre_tool(data: dict[str, Any]) -> int:
+    if not _is_shell(data):
+        return 0
+    command = _command(data)
+    if BROAD_INSTALL_RE.search(command):
+        _deny("Levyra permits installing a required useful tool, not broad package/system upgrades. Install only the specific dependency needed for the active task.")
+        return 0
+    state = _sync(data, _load())
+    generation = int(state.get("edit_generation", 0))
+    if command and state.get("failure_key") == _signature(command, generation) and int(state.get("failure_count", 0)) >= 2:
+        _deny("This exact command already failed twice without a material edit. Change the hypothesis, input, diagnostic, or installation state before retrying; do not burn another identical attempt.")
+    return 0
+
+
+def post_tool(data: dict[str, Any]) -> int:
+    value = _response(data)
+    if _is_shell(data) and _response_failed(value):
+        _record_failure(data, _response_text(value))
+        return 0
+    state = _sync(data, _load())
+    command = _command(data)
+    generation = int(state.get("edit_generation", 0))
+    if _is_shell(data) and command:
+        if state.get("failure_key") == _signature(command, generation):
+            state["failure_key"] = ""
+            state["failure_count"] = 0
+            state["failure_generation"] = -1
+            state["failure_class"] = ""
+            state["blocked_reason"] = ""
+            state["status"] = "ACTIVE"
+        if harness.VALIDATION_RE.search(command):
+            state["next_action"] = "inspect the actual final diff after the latest material edit"
+        if harness._is_diff_review(command):
+            state["next_action"] = "run the completion audit and report exact evidence" if int(state.get("validation_generation", -1)) >= generation else "run focused validation after the latest material edit"
+    if _tool_name(data).lower() in {"edit", "write", "apply_patch", "multi_edit", "multiedit"}:
+        state["next_action"] = "run focused validation for the latest edit, then inspect the final diff"
+    _save(state)
+    return 0
+
+
+def post_failure(data: dict[str, Any]) -> int:
+    _record_failure(data, _response_text(_response(data)))
+    return 0
+
+
+def post_compact(data: dict[str, Any]) -> int:
+    state = _sync(data, _load())
+    _save(state)
+    _context("PostCompact", _summary(state))
+    return 0
+
+
+def _comment_guard_passes() -> bool:
+    checker = ROOT / "scripts" / "check_ai_comment_slop.py"
+    if not checker.is_file():
+        return True
+    rc, _ = _run([sys.executable, str(checker)])
+    return rc == 0
+
+
+def _record_completed_boundary(state: dict[str, Any]) -> bool:
+    hygiene = _load_hygiene()
+    signature = hashlib.sha256(
+        f"{state.get('goal', '')}|{state.get('edit_generation', 0)}|{','.join(state.get('edited_paths', []))}".encode()
+    ).hexdigest()
+    if hygiene.get("last_completed_signature") != signature:
+        hygiene["completed_since_clear"] = int(hygiene.get("completed_since_clear", 0)) + 1
+        hygiene["last_completed_signature"] = signature
+    if int(hygiene.get("completed_since_clear", 0)) >= 2:
+        hygiene["clear_recommended"] = True
+    _save_hygiene(hygiene)
+    return bool(hygiene.get("clear_recommended"))
+
+
+def stop(data: dict[str, Any]) -> int:
+    state = _sync(data, _load())
+    session = harness._load(data)
+    generation = int(state.get("edit_generation", 0))
+    if state.get("status") == "BLOCKED" and int(state.get("failure_generation", -1)) == generation:
+        session["validation_generation"] = max(int(session.get("validation_generation", -1)), generation)
+        harness._save(data, session)
+        state["validation_generation"] = generation
+        state["next_action"] = "report the exact BLOCKED prerequisite and leave the affected acceptance gate open"
+        _save(state)
+        _context(
+            "Stop",
+            "A required validation is BLOCKED by an unavailable tool/runtime prerequisite. Do not claim the task complete. You may end the turn after the final diff review and remaining checks, but report the blocked gate explicitly and preserve this checkpoint for a later resume.",
+        )
+        return 0
+    if generation <= 0:
+        _clear()
+        return 0
+    ready = (
+        int(session.get("validation_generation", -1)) >= generation
+        and int(session.get("diff_review_generation", -1)) >= generation
+        and not harness._diff_check_failures()
+        and _comment_guard_passes()
+    )
+    if ready:
+        state["status"] = "PASS"
+        state["next_action"] = "none; completion evidence is current"
+        due = _record_completed_boundary(state)
+        _save(state)
+        if due:
+            _context(
+                "Stop",
+                "Claude context-hygiene checkpoint reached: the current task is at a safe completed boundary. If the next owner request is unrelated, prefer `/clear` before starting it, then let SessionStart reload Levyra guards. Do not clear an open task, an unresolved BLOCKED task, or unpublished evidence that has not been durably checkpointed. Command hooks cannot execute slash commands, so never pretend `/clear` ran when it did not.",
+            )
+    else:
+        state["status"] = "ACTIVE"
+        if int(session.get("validation_generation", -1)) < generation:
+            state["next_action"] = "run focused validation after the latest material edit"
+        elif int(session.get("diff_review_generation", -1)) < generation:
+            state["next_action"] = "inspect the actual final diff after the latest material edit"
+        _save(state)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("event", choices=("session-start", "user-prompt", "pre-tool", "post-tool", "post-failure", "post-compact", "stop"))
+    args = parser.parse_args()
+    data = _payload()
+    return {
+        "session-start": session_start,
+        "user-prompt": user_prompt,
+        "pre-tool": pre_tool,
+        "post-tool": post_tool,
+        "post-failure": post_failure,
+        "post-compact": post_compact,
+        "stop": stop,
+    }[args.event](data)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agent_harness.py
+++ b/scripts/agent_harness.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""Always-on runtime guard for Levyra coding agents."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+STATE_ROOT = Path(
+    os.environ.get(
+        "LEVYRA_AGENT_HARNESS_STATE_DIR",
+        str(Path(tempfile.gettempdir()) / "levyra-agent-harness"),
+    )
+)
+PROTECTED_NAMES = {"local.properties", ".env"}
+PROTECTED_SUFFIXES = {".jks", ".keystore", ".p12", ".pfx", ".pem", ".key"}
+DOC_SUFFIXES = {".md", ".txt", ".rst"}
+AGENT_CONFIG_PREFIXES = (
+    ".agents/",
+    ".claude/",
+    ".codex/",
+    "docs/ai/",
+    "scripts/agent_harness.py",
+    "scripts/validate_agent_harness.py",
+    "scripts/check_ai_comment_slop.py",
+    "scripts/comment_guard_hook.py",
+)
+VALIDATION_RE = re.compile(
+    r"(?:gradlew(?:\.bat)?|pytest|unittest|\btest\b|\blint\b|assemble|compile|"
+    r"validate_[\w.-]+\.py|check_[\w.-]+\.py|npm\s+(?:run\s+)?test|cargo\s+test)",
+    re.I,
+)
+DIFF_REVIEW_RE = re.compile(r"(?:\bgit\s+diff\b|\bgh\s+pr\s+diff\b)", re.I)
+
+
+def _payload() -> dict[str, Any]:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _session(data: dict[str, Any]) -> str:
+    raw = str(data.get("session_id") or data.get("sessionId") or "default")
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", raw)[:120] or "default"
+
+
+def _state_path(data: dict[str, Any]) -> Path:
+    repo = hashlib.sha256(str(ROOT).encode()).hexdigest()[:16]
+    return STATE_ROOT / repo / f"{_session(data)}.json"
+
+
+def _load(data: dict[str, Any]) -> dict[str, Any]:
+    path = _state_path(data)
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        state = {}
+    state.setdefault("read_hashes", {})
+    state.setdefault("edited_paths", [])
+    state.setdefault("edit_generation", 0)
+    state.setdefault("diff_review_generation", -1)
+    state.setdefault("validation_generation", -1)
+    state.setdefault("completed_generation", -1)
+    state.setdefault("latest_prompt", "")
+    state.setdefault("reanchor_pending", False)
+    state.setdefault("task_complete", False)
+    return state
+
+
+def _save(data: dict[str, Any], state: dict[str, Any]) -> None:
+    path = _state_path(data)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _tool_name(data: dict[str, Any]) -> str:
+    return str(data.get("tool_name") or data.get("toolName") or "")
+
+
+def _tool_input(data: dict[str, Any]) -> dict[str, Any]:
+    value = data.get("tool_input") or data.get("toolInput") or {}
+    return value if isinstance(value, dict) else {}
+
+
+def _resolve(raw: str) -> Path | None:
+    if not raw:
+        return None
+    path = Path(raw)
+    if not path.is_absolute():
+        path = ROOT / path
+    try:
+        resolved = path.resolve()
+        resolved.relative_to(ROOT.resolve())
+    except (OSError, ValueError):
+        return None
+    return resolved
+
+
+def _relative(path: Path) -> str:
+    return path.resolve().relative_to(ROOT.resolve()).as_posix()
+
+
+def _protected(path: Path) -> bool:
+    return path.name.lower() in PROTECTED_NAMES or path.suffix.lower() in PROTECTED_SUFFIXES
+
+
+def _hash(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _targets(data: dict[str, Any]) -> list[Path]:
+    tool = _tool_name(data)
+    item = _tool_input(data)
+    result: list[Path] = []
+    for key in ("file_path", "path", "filePath"):
+        value = item.get(key)
+        if isinstance(value, str):
+            path = _resolve(value)
+            if path:
+                result.append(path)
+    if tool.lower() == "apply_patch":
+        command = str(item.get("command") or item.get("patch") or "")
+        for match in re.finditer(r"^\*\*\* (?:Update|Delete) File: (.+)$", command, re.M):
+            path = _resolve(match.group(1).strip())
+            if path:
+                result.append(path)
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for path in result:
+        key = str(path)
+        if key not in seen:
+            seen.add(key)
+            unique.append(path)
+    return unique
+
+
+def _scoped_agents(path: Path) -> str:
+    parts: list[str] = []
+    current = path.parent if path.suffix else path
+    chain: list[Path] = []
+    root = ROOT.resolve()
+    while current.resolve() != root:
+        chain.append(current)
+        if current.parent == current:
+            break
+        current = current.parent
+    for directory in reversed(chain):
+        candidate = directory / "AGENTS.md"
+        if candidate.is_file():
+            text = candidate.read_text(encoding="utf-8", errors="replace")
+            parts.append(f"Applicable scoped instructions: {_relative(candidate)}\n{text}")
+    return "\n\n".join(parts)
+
+
+def _patch_anchor(data: dict[str, Any]) -> str:
+    item = _tool_input(data)
+    old = str(item.get("old_string") or "")
+    for line in old.splitlines():
+        if len(line.strip()) >= 4:
+            return line.strip()
+    command = str(item.get("command") or item.get("patch") or "")
+    for line in command.splitlines():
+        if line.startswith(("***", "@@", "+++", "---")):
+            continue
+        if line.startswith((" ", "-")):
+            anchor = line[1:].strip()
+            if len(anchor) >= 6:
+                return anchor
+    return ""
+
+
+def _current_context(path: Path, data: dict[str, Any]) -> str:
+    if not path.is_file() or _protected(path):
+        return ""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if len(text) <= 14000:
+        return f"Current {_relative(path)}:\n{text}"
+    lines = text.splitlines()
+    anchor = _patch_anchor(data)
+    index = 0
+    if anchor:
+        index = next((i for i, line in enumerate(lines) if anchor in line), 0)
+    start = max(0, index - 35)
+    end = min(len(lines), index + 36)
+    excerpt = "\n".join(f"{i + 1}: {lines[i]}" for i in range(start, end))
+    return f"Current bounded region from {_relative(path)}:\n{excerpt}"
+
+
+def _reanchor(state: dict[str, Any]) -> str:
+    edited = ", ".join(state.get("edited_paths", [])) or "none"
+    return (
+        "Levyra always-on re-anchor after compaction/resume:\n"
+        f"- latest owner request: {state.get('latest_prompt') or 'not recorded'}\n"
+        f"- edited paths: {edited}\n"
+        f"- edit generation: {state.get('edit_generation', 0)}\n"
+        f"- validation generation: {state.get('validation_generation', -1)}\n"
+        f"- final-diff review generation: {state.get('diff_review_generation', -1)}\n"
+        "- re-read current repository evidence before relying on compacted memory; "
+        "ALWAYS_ON_AGENT_GUARDS.md remains mandatory."
+    )
+
+
+def _context_output(event: str, text: str) -> None:
+    if not text:
+        return
+    print(json.dumps({"hookSpecificOutput": {"hookEventName": event, "additionalContext": text}}))
+
+
+def _deny(event: str, reason: str) -> None:
+    print(json.dumps({"hookSpecificOutput": {"hookEventName": event, "permissionDecision": "deny", "permissionDecisionReason": reason}}))
+
+
+def _reset_task(state: dict[str, Any]) -> None:
+    state["read_hashes"] = {}
+    state["edited_paths"] = []
+    state["edit_generation"] = 0
+    state["diff_review_generation"] = -1
+    state["validation_generation"] = -1
+    state["completed_generation"] = -1
+    state["reanchor_pending"] = False
+    state["task_complete"] = False
+
+
+def user_prompt(data: dict[str, Any]) -> int:
+    state = _load(data)
+    if state.get("task_complete"):
+        _reset_task(state)
+    prompt = str(data.get("prompt") or "").strip()
+    if prompt:
+        state["latest_prompt"] = prompt
+    state["task_complete"] = False
+    _save(data, state)
+    _context_output(
+        "UserPromptSubmit",
+        "Levyra always-on guards are active for this entire task and are not skill-routed: scoped AGENTS context, current-file-before-mutation, evidence gates, final-diff review, anti-AI-comment checks, and compaction re-anchoring are mandatory. For symbol/call-flow/reference work, use jCodeMunch first when available, then an already-available LSP/AST-aware tool when it answers the question more directly, then bounded native search/read.",
+    )
+    return 0
+
+
+def pre_tool(data: dict[str, Any]) -> int:
+    state = _load(data)
+    tool = _tool_name(data)
+    targets = _targets(data)
+    for path in targets:
+        if _protected(path):
+            _deny("PreToolUse", f"Protected Levyra local/secret file may not be injected or mutated: {_relative(path)}")
+            return 0
+    if tool == "Write":
+        for path in targets:
+            if path.exists():
+                recorded = state["read_hashes"].get(_relative(path))
+                if recorded != _hash(path):
+                    _deny(
+                        "PreToolUse",
+                        f"Whole-file replacement requires one fresh full Read of existing {_relative(path)} in the active task. Read it once, then retry Write. The guard tracks the current hash and will not demand redundant reads.",
+                    )
+                    return 0
+    chunks: list[str] = []
+    if state.get("reanchor_pending"):
+        chunks.append(_reanchor(state))
+        state["reanchor_pending"] = False
+    for path in targets:
+        scoped = _scoped_agents(path)
+        if scoped:
+            chunks.append(scoped)
+        current = _current_context(path, data)
+        if current and tool.lower() in {"edit", "write", "apply_patch", "multi_edit", "multiedit"}:
+            chunks.append(current)
+    _save(data, state)
+    _context_output("PreToolUse", "\n\n".join(chunks))
+    return 0
+
+
+def _command(data: dict[str, Any]) -> str:
+    item = _tool_input(data)
+    value = item.get("command") or item.get("cmd") or ""
+    if isinstance(value, list):
+        return " ".join(str(part) for part in value)
+    return str(value)
+
+
+def _is_diff_review(command: str) -> bool:
+    return bool(DIFF_REVIEW_RE.search(command)) and "--check" not in command.lower()
+
+
+def post_tool(data: dict[str, Any]) -> int:
+    state = _load(data)
+    low = _tool_name(data).lower()
+    targets = _targets(data)
+    if low == "read":
+        item = _tool_input(data)
+        full = item.get("offset") in (None, 0) and item.get("limit") in (None, 0)
+        if full:
+            for path in targets:
+                if path.is_file() and not _protected(path):
+                    state["read_hashes"][_relative(path)] = _hash(path)
+    if low in {"edit", "write", "apply_patch", "multi_edit", "multiedit"}:
+        state["edit_generation"] += 1
+        state["task_complete"] = False
+        edited = set(state.get("edited_paths", []))
+        for path in targets:
+            edited.add(_relative(path))
+        state["edited_paths"] = sorted(edited)
+    command = _command(data)
+    if command:
+        if _is_diff_review(command):
+            state["diff_review_generation"] = state["edit_generation"]
+        if VALIDATION_RE.search(command):
+            state["validation_generation"] = state["edit_generation"]
+    _save(data, state)
+    return 0
+
+
+def compact(data: dict[str, Any]) -> int:
+    state = _load(data)
+    state["reanchor_pending"] = True
+    _save(data, state)
+    _context_output("PostCompact", _reanchor(state))
+    return 0
+
+
+def _needs_validation(paths: list[str]) -> bool:
+    if not paths:
+        return False
+    if len(paths) > 1:
+        return True
+    for raw in paths:
+        if raw.startswith(AGENT_CONFIG_PREFIXES):
+            return True
+        if Path(raw).suffix.lower() not in DOC_SUFFIXES:
+            return True
+    return False
+
+
+def _run(argv: list[str]) -> tuple[int, str]:
+    try:
+        result = subprocess.run(argv, cwd=ROOT, check=False, text=True, capture_output=True, timeout=60)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return 1, str(exc)
+    text = (result.stdout + result.stderr).strip()
+    return result.returncode, text[-4000:]
+
+
+def _branch_base() -> str:
+    for candidate in ("origin/main", "main", "HEAD~1"):
+        rc, commit = _run(["git", "rev-parse", "--verify", f"{candidate}^{{commit}}"])
+        if rc != 0 or not commit.strip():
+            continue
+        rc, base = _run(["git", "merge-base", "HEAD", commit.strip()])
+        if rc == 0 and base.strip():
+            return base.strip().splitlines()[-1]
+    return ""
+
+
+def _diff_check_failures() -> list[str]:
+    failures: list[str] = []
+    commands = [
+        ["git", "diff", "--check"],
+        ["git", "diff", "--cached", "--check"],
+    ]
+    base = _branch_base()
+    if base:
+        commands.append(["git", "diff", "--check", f"{base}...HEAD"])
+    for argv in commands:
+        rc, output = _run(argv)
+        if rc != 0:
+            failures.append(output or " ".join(argv))
+    return failures
+
+
+def stop(data: dict[str, Any]) -> int:
+    state = _load(data)
+    generation = int(state.get("edit_generation", 0))
+    if generation <= 0:
+        state["task_complete"] = True
+        _save(data, state)
+        return 0
+    failures: list[str] = []
+    if int(state.get("diff_review_generation", -1)) < generation:
+        failures.append("inspect the actual final diff after the latest edit (`git diff ...`, not only `git diff --check`)")
+    if _needs_validation(list(state.get("edited_paths", []))) and int(state.get("validation_generation", -1)) < generation:
+        failures.append("run focused validation after the latest edit")
+    for output in _diff_check_failures():
+        failures.append(f"fix diff whitespace/conflict validation: {output}")
+    checker = ROOT / "scripts" / "check_ai_comment_slop.py"
+    if checker.is_file():
+        rc, output = _run([sys.executable, str(checker)])
+        if rc != 0:
+            failures.append(f"remove newly added AI-narration comments: {output or 'checker failed'}")
+    if failures:
+        print(json.dumps({"decision": "block", "reason": "Levyra completion audit is still open:\n- " + "\n- ".join(failures)}))
+        return 0
+    state["completed_generation"] = generation
+    state["task_complete"] = True
+    _save(data, state)
+    return 0
+
+
+def session_start(data: dict[str, Any]) -> int:
+    state = _load(data)
+    if str(data.get("source") or "").lower() == "resume":
+        state["reanchor_pending"] = True
+        _save(data, state)
+        _context_output("SessionStart", _reanchor(state))
+    else:
+        _context_output("SessionStart", "Levyra ALWAYS_ON_AGENT_GUARDS.md is active for the full session and is not optional skill routing.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("event", choices=("session-start", "user-prompt", "pre-tool", "post-tool", "post-compact", "stop"))
+    args = parser.parse_args()
+    data = _payload()
+    return {
+        "session-start": session_start,
+        "user-prompt": user_prompt,
+        "pre-tool": pre_tool,
+        "post-tool": post_tool,
+        "post-compact": compact,
+        "stop": stop,
+    }[args.event](data)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agent_skill_router.py
+++ b/scripts/agent_skill_router.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Shared prompt-to-skill router for Levyra coding runtimes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Route:
+    skill: str
+    topic: str
+    pattern: re.Pattern[str]
+
+
+def route(skill: str, topic: str, pattern: str) -> Route:
+    return Route(skill, topic, re.compile(pattern, re.I))
+
+
+ROUTES = (
+    route(
+        "levyra-project-manager",
+        "requirements, roadmap, active phase, acceptance criteria, task status, or implementation handoff",
+        r"requirements?|requisit|roadmap|acceptance criteria|criteri.*accett|active phase|fase attiv|task status|stato.*task|milestone|implementation handoff|handoff.*implement|docs/project/(?:spec|roadmap|tasks)",
+    ),
+    route(
+        "levyra-openclaw-orchestrator",
+        "OpenClaw delegation or Levyra worker/reviewer/CI coordination",
+        r"openclaw|levyra-worker|levyra-reviewer|levyra-ci|delegat.*(?:agent|runtime|review|ci)|orchestrat",
+    ),
+    route(
+        "levyra-real-engineering",
+        "non-trivial engineering, debugging, requirements, or architecture",
+        r"new feature|nuova funzionalit|architecture|architett|refactor|riprogett|redesign|\bspec\b|specifica|roadmap|multi.?step|cross.?domain|pi[uù].*modul|across.*module|grill-with-docs|wayfinder|to-spec|to-tickets|\bbug\b|regression|regressione|test failure|test fallit|build failure|build fallit|unexpected behavior|comportamento inaspett|\bcrash\b|race condition|concurrency bug|root cause|causa radice",
+    ),
+    route(
+        "levyra-player",
+        "playback, queue, Media3, or MediaSession",
+        r"player|playback|riproduz|queue|coda|media3|mediasession|android auto|notification|notifica|prefetch|gapless|crossfade|\bseek\b|\bskip\b|traccia|brano|audio mode|video mode",
+    ),
+    route(
+        "levyra-extractor",
+        "stream extraction or network fallback",
+        r"extractor|estrattor|innertube|newpipe|youtube|stream|resolver|player.?config|\btoken\b|scraping|403|throttl",
+    ),
+    route(
+        "levyra-database",
+        "Room storage, persistence, or schema",
+        r"\broom\b|\bdao\b|entity|entità|migration|migrazion|schema|database|\bdb\b|backup|persist",
+    ),
+    route(
+        "levyra-compose",
+        "Android Compose UI, accessibility, lifecycle, or state projection",
+        r"compose|composable|\bui\b|screen|schermat|theme|\btema\b|layout|recomposition|ricompos|scroll|layout inspector|talkback|semantics|semantic|touch target|accessibilit|rtl|localizzazion|localization|string resource",
+    ),
+    route(
+        "levyra-android-performance",
+        "Android runtime profiling or measured performance",
+        r"perfetto|system trace|trace processor|frame miss|frame drop|jank|latency|latenza|startup|avvio lento|cpu schedul|thread state|runnable|blocked thread|binder wait|binder spam|binder storm|lock contention|renderthread|frame timeline|gpu memory|texture upload|memory pressure|memory leak|allocat|i/o stall|io stall|d-state|lmkd|psi|wakelock|power rail|power trace|battery trace|runtime performance|performance runtime|profiling android",
+    ),
+    route(
+        "levyra-r8-proguard",
+        "R8, Proguard, minification, shrinking, or release-only behavior",
+        r"\br8\b|proguard|minif|shrink resources|resource shrink|resource shrinking|keep rule|consumer rule|mapping\.txt|missing rules|missing class|missing classes|release.?only.*(?:crash|fail)|crash.*release|apk size|aab size|obfuscat|shrinker|dontwarn|keepattributes|javascriptinterface|jni.*(?:keep|shrink)|reflection.*(?:keep|shrink)|serialization.*(?:keep|shrink)|kotlin metadata",
+    ),
+    route(
+        "levyra-android-intent-security",
+        "Android Intent, PendingIntent, deep-link, or component security",
+        r"pendingintent|pending intent|onnewintent|nested intent|intent redirection|intent redirect|intent sanitizer|intentsanitizer|android:exported|exported (?:activity|service|receiver|provider|component)|attivit[aà] esportat|servizio esportat|receiver esportat|provider esportat|mutable pendingintent|immutable pendingintent|flag_mutable|flag_immutable|uri grant|granturipermission|grant uri|fileprovider|contentprovider|signature permission|binder caller|callinguid|caller verification|deep.?link.*(?:intent|security|exported|permission)|intent.*(?:security|sicurezz|exported|permission|forward|redirect|nested)|component boundary|component-boundary",
+    ),
+    route(
+        "levyra-design-taste",
+        "visual design, redesign, polish, hierarchy, or anti-AI-slop UI",
+        r"visual design|ui design|design ui|grafica|interfaccia|ui polish|visual polish|gerarchia visual|visual hierarchy|spacing|spaziatur|typograph|tipograf|color palette|palette colori|shape|forme|radius|corner radius|motion ui|ui motion|animazion|screenshot|design reference|ui reference|riferiment.*(?:grafica|ui|schermat)|pi[uù] bella|pi[uù] professionale|(?:\bscreen\b|schermat\w*|\bui\b|\bdesign\b|grafica|interfaccia|\blayout\b|\bplayer\b|\bhome\b|\bnow playing\b).{0,40}\b(?:premium|modern|clean|cinematic|less generic)\b|\b(?:premium|modern|clean|cinematic|less generic)\b.{0,40}(?:\bscreen\b|schermat\w*|\bui\b|\bdesign\b|grafica|interfaccia|\blayout\b|\bplayer\b|\bhome\b|\bnow playing\b)|^\s*(?:premium|modern|clean|cinematic|less generic)\s*[.!?]*\s*$|anti.?ai.?slop|glassmorphism|bento",
+    ),
+    route(
+        "levyra-motion-artwork",
+        "motion artwork",
+        r"motion artwork|animated artwork|animated cover|canvas|copertin.*animat|cover art.*animat",
+    ),
+    route(
+        "levyra-desktop",
+        "Windows Desktop, Compose Multiplatform, libvlc, packaging, or desktop updates",
+        r"\bdesktop\b|windows client|compose multiplatform|libvlc|mini player|mini-player|protocol registration|wix|msi|desktop update|desktop release",
+    ),
+    route(
+        "levyra-ci-workflows",
+        "CI, Gradle/Kotlin tooling, or build performance",
+        r"github actions|\bworkflow\b|\bci\b|fdroid|f-droid|\bgradle\b|\bagp\b|\bkotlin\b|\bksp\b|build performance|slow build|build lento|configuration cache|build cache|compile time|compilation time|build logic|gradle\.properties|artifact",
+    ),
+    route(
+        "levyra-context-efficiency",
+        "repository exploration or high-volume context",
+        r"\bbuild\b|\bgradle\b|\btest\b|\blint\b|logcat|\blogs?\b|git diff|git log|git status|github|\bgh\b|coderabbit|dependencies|dependency tree|broad search|ricerca ampia|setup|installazione ai|agent setup|analy[sz]|analizz|investigat|indag|inspect|esamina|repository|\brepo\b|codebase|root cause|causa radice|implement|refactor|riprogett|find.*(?:class|function|file)|trova.*(?:classe|funzione|file)",
+    ),
+    route(
+        "levyra-security-review",
+        "security, privacy, trust-boundary, or supply-chain review",
+        r"security|sicurezz|secret|segret|credential|cookie|auth|ssrf|redirect|permission|permess|privacy|\bmime\b|keystore|vulnerab|exploit|threat model|trust boundary|attack surface|dependency|dipendenz|supply.?chain|workflow permission|action pin|signature|checksum|integrity|update security|deep.?link|pendingintent|pending intent|onnewintent|android:exported|fileprovider|contentprovider|uri grant|path traversal|injection|cve|token leak|data leak",
+    ),
+    route(
+        "levyra-pr-review",
+        "reviewing a branch, commit, diff, or pull request",
+        r"review|revision|pull request|\bpr\b|merge|\bdiff\b|commit review|branch review|before merging|prima di merg",
+    ),
+    route(
+        "levyra-release-check",
+        "runtime, pre-merge, or release validation",
+        r"release|rilasci|versionname|versioncode|\bversion\b|versione|\bapk\b|signing|firma|tag\b|publish|pubblic|emulator|emulatore|physical device|device test|test dispositivo|\badb\b|connectedcheck|smoke test|runtime verification|runtime validation|verifica runtime|pre.?merge",
+    ),
+    route(
+        "levyra-engineering",
+        "genuine cross-domain work or repository architecture orientation",
+        r"cross.?domain|pi[uù].*sottosistem|multiple subsystems|several subsystems|repository orientation|architecture orientation|orient.*(?:repo|codebase|architett)",
+    ),
+    route(
+        "levyra-android-reverse-engineering",
+        "Android artifact decompilation, compiled API extraction, or binary analysis",
+        r"decompil|reverse[ -]?engineer|jadx|smali|bundletool|apktool|binary analysis|r8 metadata|kotlin metadata recovery|(?:apk|xapk|aab|dex|jar|aar).{0,40}(?:analy[sz]|inspect|extract|decompil)|(?:analy[sz]|inspect|extract|decompil).{0,40}(?:apk|xapk|aab|dex|jar|aar)|extract.{0,30}(?:api|endpoint).{0,30}(?:apk|xapk|aab|dex|jar|aar)",
+    ),
+)
+
+AUTOMATED_MARKERS = (
+    "<github-webhook-activity",
+    "<untrusted_external_data",
+    "<system-reminder",
+)
+
+
+def route_prompt(prompt: str) -> list[tuple[str, str]]:
+    text = prompt.strip().lower()
+    if not text or any(marker in text for marker in AUTOMATED_MARKERS):
+        return []
+
+    matched: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for item in ROUTES:
+        if item.pattern.search(text) and item.skill not in seen:
+            matched.append((item.skill, item.topic))
+            seen.add(item.skill)
+
+    def add(skill: str, topic: str) -> None:
+        if skill not in seen:
+            matched.append((skill, topic))
+            seen.add(skill)
+
+    if "levyra-compose" in seen and "levyra-android-performance" in seen:
+        add("levyra-real-engineering", "non-trivial Compose performance debugging")
+    if "levyra-r8-proguard" in seen:
+        add("levyra-release-check", "minified release validation")
+    if "levyra-android-intent-security" in seen:
+        add("levyra-security-review", "Android component-boundary security review")
+    if "levyra-design-taste" in seen:
+        if "levyra-desktop" in seen:
+            add("levyra-desktop", "Desktop visual implementation")
+        elif re.search(r"android|compose|player|now playing|home|screen|schermat|ui|grafica|interfaccia", text):
+            add("levyra-compose", "Android visual implementation")
+    if "levyra-openclaw-orchestrator" in seen:
+        add("levyra-context-efficiency", "compact delegation context")
+        add("levyra-project-manager", "delegated acceptance criteria and handoff")
+    if "levyra-android-reverse-engineering" in seen:
+        add("levyra-security-review", "artifact trust-boundary and exposed-sensitive-data review")
+        if re.search(r"\br8\b|proguard|obfuscat|mapping\.txt|kotlin metadata", text):
+            add("levyra-r8-proguard", "obfuscation and Kotlin/R8 metadata recovery")
+
+    return matched
+
+
+def context_for(prompt: str) -> str:
+    matched = route_prompt(prompt)
+    lines = [
+        "Levyra automatic skill routing is mandatory. The owner never needs to name a skill.",
+        "Use only matching skills; do not preload the whole skill tree.",
+    ]
+    if not matched:
+        lines.append("No specialized Levyra skill matched this prompt; the always-on agent guards still apply.")
+        return "\n".join(lines)
+
+    lines.append("Mandatory skill load before broad repository reading, editing, or shell work:")
+    for skill, topic in matched:
+        lines.append(f"- {topic} -> {skill} -> .agents/skills/{skill}/SKILL.md")
+    lines.extend(
+        [
+            "Load every listed canonical skill automatically from the task itself. Do not wait for the owner to request it by name.",
+            "Claude may invoke its .claude/skills bridge/plugin first, but the canonical .agents skill and Levyra guardrails remain authoritative.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _payload() -> dict[str, Any]:
+    try:
+        value = json.load(sys.stdin)
+    except Exception:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--prompt")
+    parser.add_argument("--plain", action="store_true")
+    args = parser.parse_args()
+
+    data = {} if args.prompt is not None else _payload()
+    prompt = args.prompt if args.prompt is not None else str(data.get("prompt") or "")
+    context = context_for(prompt)
+    if args.plain:
+        print(context)
+        return 0
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": context,
+                }
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agent_stop_audit.py
+++ b/scripts/agent_stop_audit.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Single stop-time completion audit for Levyra agent runtimes."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from scripts import agent_checkpoint as checkpoint
+from scripts import agent_harness as harness
+
+
+def _payload() -> dict[str, Any]:
+    try:
+        value = json.load(sys.stdin)
+    except Exception:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _context(text: str) -> None:
+    print(json.dumps({"hookSpecificOutput": {"hookEventName": "Stop", "additionalContext": text}}))
+
+
+def main() -> int:
+    data = _payload()
+    state = checkpoint._sync(data, checkpoint._load())
+    session = harness._load(data)
+    generation = int(state.get("edit_generation", 0))
+
+    if generation <= 0:
+        session["task_complete"] = True
+        harness._save(data, session)
+        checkpoint._clear()
+        return 0
+
+    if state.get("status") == "BLOCKED" and int(state.get("failure_generation", -1)) == generation:
+        state["next_action"] = "report the exact BLOCKED prerequisite and leave the affected acceptance gate open"
+        checkpoint._save(state)
+        _context(
+            "A required Levyra gate is BLOCKED by an unavailable tool/runtime prerequisite. "
+            "Do not claim completion. End the turn only after the remaining possible checks and final diff review, "
+            "report the blocked prerequisite exactly, and preserve the durable checkpoint for resume."
+        )
+        return 0
+
+    failures: list[str] = []
+    if int(session.get("diff_review_generation", -1)) < generation:
+        failures.append("inspect the actual final diff after the latest material edit")
+    if harness._needs_validation(list(session.get("edited_paths", []))) and int(session.get("validation_generation", -1)) < generation:
+        failures.append("run focused validation after the latest material edit")
+    for output in harness._diff_check_failures():
+        failures.append(f"fix diff whitespace/conflict validation: {output}")
+    if not checkpoint._comment_guard_passes():
+        failures.append("remove newly added AI-narration comments")
+
+    if failures:
+        state["status"] = "ACTIVE"
+        state["next_action"] = failures[0]
+        checkpoint._save(state)
+        print(json.dumps({"decision": "block", "reason": "Levyra completion audit is still open:\n- " + "\n- ".join(failures)}))
+        return 0
+
+    session["completed_generation"] = generation
+    session["task_complete"] = True
+    harness._save(data, session)
+    state["status"] = "PASS"
+    state["validation_generation"] = int(session.get("validation_generation", -1))
+    state["diff_review_generation"] = int(session.get("diff_review_generation", -1))
+    state["next_action"] = "none; completion evidence is current"
+    clear_due = checkpoint._record_completed_boundary(state)
+    checkpoint._save(state)
+
+    if clear_due:
+        _context(
+            "Claude context-hygiene checkpoint reached at a verified completed-task boundary. "
+            "If the next owner request is unrelated, prefer `/clear` before starting it. "
+            "Do not clear an ACTIVE/BLOCKED task. Project hooks cannot execute slash commands, so never claim `/clear` ran unless it actually did; "
+            "SessionStart(clear) will reload Levyra guards and any open durable checkpoint."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_ai_comment_slop.py
+++ b/scripts/check_ai_comment_slop.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Reject newly added AI-narration comments without policing legacy source."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_SUFFIXES = {
+    ".c", ".cc", ".cpp", ".cs", ".go", ".h", ".hpp", ".java", ".js", ".jsx",
+    ".kt", ".kts", ".py", ".rs", ".sh", ".swift", ".ts", ".tsx", ".ps1",
+}
+COMMENT_RE = re.compile(r"^\s*(?://+|#|/\*+|\*+)\s*(.+?)\s*(?:\*/)?$")
+SLOP_RE = re.compile(
+    r"^(?:step\s*\d+\b|now\s+(?:we|let'?s)\b|here\s+we\b|"
+    r"first,?\s+we\b|next,?\s+we\b|finally,?\s+we\b|"
+    r"we\s+(?:need to|will|are going to|can now)\b|"
+    r"let'?s\s+(?:now\s+)?(?:add|update|create|fix|handle|check|implement)\b)",
+    re.I,
+)
+
+
+def scan_diff(diff: str) -> list[str]:
+    findings: list[str] = []
+    current = ""
+    added_line = 0
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            current = line[6:]
+            added_line = 0
+            continue
+        if line.startswith("@@"):
+            match = re.search(r"\+(\d+)", line)
+            added_line = int(match.group(1)) - 1 if match else 0
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            added_line += 1
+            if Path(current).suffix.lower() not in SOURCE_SUFFIXES:
+                continue
+            body = line[1:]
+            match = COMMENT_RE.match(body)
+            if match and SLOP_RE.search(match.group(1).strip()):
+                findings.append(f"{current}:{added_line}: AI-narration comment: {match.group(1).strip()}")
+        elif not line.startswith("-"):
+            added_line += 1
+    return findings
+
+
+def _git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=ROOT, check=False, text=True, capture_output=True, timeout=30
+    )
+    return result.stdout if result.returncode == 0 else ""
+
+
+def repository_diff(working_tree_only: bool) -> str:
+    pieces = [_git("diff", "--unified=0"), _git("diff", "--cached", "--unified=0")]
+    if not working_tree_only:
+        base = ""
+        for candidate in ("origin/main", "main", "HEAD~1"):
+            probe = _git("rev-parse", "--verify", f"{candidate}^{{commit}}").strip()
+            if not probe:
+                continue
+            merge_base = _git("merge-base", "HEAD", probe).strip()
+            if merge_base:
+                base = merge_base
+                break
+        if base:
+            pieces.insert(0, _git("diff", "--unified=0", f"{base}...HEAD"))
+    return "\n".join(pieces)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--working-tree", action="store_true")
+    args = parser.parse_args()
+    findings = sorted(set(scan_diff(repository_diff(args.working_tree))))
+    if findings:
+        print("AI comment slop check failed:", file=sys.stderr)
+        for finding in findings:
+            print(f"- {finding}", file=sys.stderr)
+        return 1
+    print("AI comment slop check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/comment_guard_hook.py
+++ b/scripts/comment_guard_hook.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Post-mutation hook that turns comment-slop findings into agent feedback."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MUTATIONS = {"edit", "write", "apply_patch", "multi_edit", "multiedit"}
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+    tool = str(payload.get("tool_name") or payload.get("toolName") or "").lower()
+    if tool not in MUTATIONS:
+        return 0
+    checker = ROOT / "scripts" / "check_ai_comment_slop.py"
+    result = subprocess.run(
+        [sys.executable, str(checker), "--working-tree"],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        reason = (result.stdout + result.stderr).strip() or "AI comment slop detected"
+        print(json.dumps({"decision": "block", "reason": reason[-4000:]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-agent-harness.ps1
+++ b/scripts/run-agent-harness.ps1
@@ -1,0 +1,39 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$HarnessArgs
+)
+
+$root = Split-Path -Parent $PSScriptRoot
+$script = Join-Path $root "scripts\agent_harness.py"
+$argsToPass = $HarnessArgs
+
+if ($HarnessArgs.Count -gt 0 -and $HarnessArgs[0] -eq "checkpoint") {
+    $script = Join-Path $root "scripts\agent_checkpoint.py"
+    $argsToPass = if ($HarnessArgs.Count -gt 1) { $HarnessArgs[1..($HarnessArgs.Count - 1)] } else { @() }
+} elseif ($HarnessArgs.Count -gt 0 -and $HarnessArgs[0] -eq "router") {
+    $script = Join-Path $root "scripts\agent_skill_router.py"
+    $argsToPass = if ($HarnessArgs.Count -gt 1) { $HarnessArgs[1..($HarnessArgs.Count - 1)] } else { @() }
+} elseif ($HarnessArgs.Count -gt 0 -and $HarnessArgs[0] -eq "audit") {
+    $script = Join-Path $root "scripts\agent_stop_audit.py"
+    $argsToPass = if ($HarnessArgs.Count -gt 1) { $HarnessArgs[1..($HarnessArgs.Count - 1)] } else { @() }
+}
+
+$python = Get-Command python -ErrorAction SilentlyContinue
+if ($python) {
+    & $python.Source $script @argsToPass
+    exit $LASTEXITCODE
+}
+
+$python3 = Get-Command python3 -ErrorAction SilentlyContinue
+if ($python3) {
+    & $python3.Source $script @argsToPass
+    exit $LASTEXITCODE
+}
+
+$py = Get-Command py -ErrorAction SilentlyContinue
+if ($py) {
+    & $py.Source -3 $script @argsToPass
+    exit $LASTEXITCODE
+}
+
+exit 0

--- a/scripts/run-agent-harness.sh
+++ b/scripts/run-agent-harness.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script="$root/scripts/agent_harness.py"
+if [[ "${1:-}" == "checkpoint" ]]; then
+  shift
+  script="$root/scripts/agent_checkpoint.py"
+elif [[ "${1:-}" == "router" ]]; then
+  shift
+  script="$root/scripts/agent_skill_router.py"
+elif [[ "${1:-}" == "audit" ]]; then
+  shift
+  script="$root/scripts/agent_stop_audit.py"
+fi
+if command -v python3 >/dev/null 2>&1; then
+  exec python3 "$script" "$@"
+elif command -v python >/dev/null 2>&1; then
+  exec python "$script" "$@"
+elif command -v py >/dev/null 2>&1; then
+  exec py -3 "$script" "$@"
+fi
+exit 0

--- a/scripts/run-comment-guard.ps1
+++ b/scripts/run-comment-guard.ps1
@@ -1,0 +1,22 @@
+$root = Split-Path -Parent $PSScriptRoot
+$script = Join-Path $root "scripts\comment_guard_hook.py"
+
+$python = Get-Command python -ErrorAction SilentlyContinue
+if ($python) {
+    & $python.Source $script
+    exit $LASTEXITCODE
+}
+
+$python3 = Get-Command python3 -ErrorAction SilentlyContinue
+if ($python3) {
+    & $python3.Source $script
+    exit $LASTEXITCODE
+}
+
+$py = Get-Command py -ErrorAction SilentlyContinue
+if ($py) {
+    & $py.Source -3 $script
+    exit $LASTEXITCODE
+}
+
+exit 0

--- a/scripts/run-comment-guard.sh
+++ b/scripts/run-comment-guard.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if command -v python3 >/dev/null 2>&1; then
+  exec python3 "$root/scripts/comment_guard_hook.py"
+elif command -v python >/dev/null 2>&1; then
+  exec python "$root/scripts/comment_guard_hook.py"
+elif command -v py >/dev/null 2>&1; then
+  exec py -3 "$root/scripts/comment_guard_hook.py"
+fi
+exit 0

--- a/scripts/tests/test_agent_harness.py
+++ b/scripts/tests/test_agent_harness.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+import scripts.agent_checkpoint as checkpoint
+import scripts.agent_harness as harness
+
+
+class AgentHarnessTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.state = self.root / "state"
+        self.original_root = harness.ROOT
+        self.original_state = harness.STATE_ROOT
+        self.original_checkpoint_root = checkpoint.ROOT
+        self.original_checkpoint_state = checkpoint.CHECKPOINT_ROOT
+        harness.ROOT = self.root
+        harness.STATE_ROOT = self.state
+        checkpoint.ROOT = self.root
+        checkpoint.CHECKPOINT_ROOT = self.state / "checkpoint"
+
+    def tearDown(self) -> None:
+        harness.ROOT = self.original_root
+        harness.STATE_ROOT = self.original_state
+        checkpoint.ROOT = self.original_checkpoint_root
+        checkpoint.CHECKPOINT_ROOT = self.original_checkpoint_state
+        self.temp.cleanup()
+
+    def capture(self, function, payload: dict) -> str:
+        stream = io.StringIO()
+        with redirect_stdout(stream):
+            function(payload)
+        return stream.getvalue().strip()
+
+    def test_existing_whole_file_write_requires_fresh_full_read(self) -> None:
+        target = self.root / "sample.kt"
+        target.write_text("val answer = 42\n", encoding="utf-8")
+        write = {"session_id": "s", "tool_name": "Write", "tool_input": {"file_path": str(target)}}
+        blocked = json.loads(self.capture(harness.pre_tool, write))
+        self.assertEqual("deny", blocked["hookSpecificOutput"]["permissionDecision"])
+
+        read = {"session_id": "s", "tool_name": "Read", "tool_input": {"file_path": str(target)}}
+        harness.post_tool(read)
+        allowed = self.capture(harness.pre_tool, write)
+        self.assertNotIn('"permissionDecision": "deny"', allowed)
+
+        target.write_text("val answer = 43\n", encoding="utf-8")
+        stale = json.loads(self.capture(harness.pre_tool, write))
+        self.assertEqual("deny", stale["hookSpecificOutput"]["permissionDecision"])
+
+    def test_edit_injects_scoped_agents_and_current_file(self) -> None:
+        app = self.root / "app"
+        app.mkdir()
+        (app / "AGENTS.md").write_text("Scoped app rule", encoding="utf-8")
+        target = app / "Player.kt"
+        target.write_text("fun play() = Unit\n", encoding="utf-8")
+        payload = {"session_id": "s", "tool_name": "Edit", "tool_input": {"file_path": str(target), "old_string": "fun play"}}
+        output = self.capture(harness.pre_tool, payload)
+        self.assertIn("Scoped app rule", output)
+        self.assertIn("fun play() = Unit", output)
+
+    def test_large_apply_patch_uses_patch_anchor_for_current_context(self) -> None:
+        target = self.root / "Large.kt"
+        lines = [f"val line{i} = {i}" for i in range(1200)]
+        target.write_text("\n".join(lines), encoding="utf-8")
+        payload = {
+            "session_id": "s",
+            "tool_name": "apply_patch",
+            "tool_input": {
+                "command": "*** Begin Patch\n*** Update File: Large.kt\n@@\n-val line900 = 900\n+val line900 = 901\n*** End Patch"
+            },
+        }
+        output = self.capture(harness.pre_tool, payload)
+        self.assertIn("line900", output)
+        self.assertNotIn("line10 = 10", output)
+
+    def test_followup_prompt_preserves_open_task_state(self) -> None:
+        self.capture(harness.user_prompt, {"session_id": "s", "prompt": "Fix playback"})
+        target = self.root / "sample.kt"
+        target.write_text("val x = 1\n", encoding="utf-8")
+        harness.post_tool({"session_id": "s", "tool_name": "Edit", "tool_input": {"file_path": str(target)}})
+        self.capture(harness.user_prompt, {"session_id": "s", "prompt": "Also keep video mode unchanged"})
+        state = harness._load({"session_id": "s"})
+        self.assertEqual(1, state["edit_generation"])
+        self.assertIn("sample.kt", state["edited_paths"])
+        self.assertEqual("Also keep video mode unchanged", state["latest_prompt"])
+
+    def test_compaction_reanchors_latest_task_state(self) -> None:
+        self.capture(harness.user_prompt, {"session_id": "s", "prompt": "Fix playback without changing UI"})
+        output = self.capture(harness.compact, {"session_id": "s"})
+        self.assertIn("Fix playback without changing UI", output)
+        state = harness._load({"session_id": "s"})
+        self.assertTrue(state["reanchor_pending"])
+
+    def test_checkpoint_blocks_third_identical_failed_command(self) -> None:
+        payload = {
+            "session_id": "s",
+            "tool_name": "Bash",
+            "tool_input": {"command": "jadx --version"},
+        }
+        checkpoint._record_failure(payload, "jadx failed")
+        checkpoint._record_failure(payload, "jadx failed")
+
+        blocked = json.loads(self.capture(checkpoint.pre_tool, payload))
+        self.assertEqual("deny", blocked["hookSpecificOutput"]["permissionDecision"])
+        self.assertIn("failed twice", blocked["hookSpecificOutput"]["permissionDecisionReason"])
+
+    def test_checkpoint_clear_preserves_blocked_open_task(self) -> None:
+        payload = {
+            "session_id": "s",
+            "tool_name": "Bash",
+            "tool_input": {"command": "jadx --version"},
+        }
+        checkpoint._record_failure(payload, "jadx: command not found")
+        checkpoint._save_hygiene(
+            {
+                "completed_since_clear": 2,
+                "last_completed_signature": "previous",
+                "clear_recommended": True,
+            }
+        )
+
+        output = self.capture(checkpoint.session_start, {"session_id": "fresh", "source": "clear"})
+        self.assertEqual("BLOCKED", checkpoint._load()["status"])
+        self.assertIn("BLOCKED", output)
+        hygiene = checkpoint._load_hygiene()
+        self.assertEqual(0, hygiene["completed_since_clear"])
+        self.assertFalse(hygiene["clear_recommended"])
+
+    def test_checkpoint_allows_narrow_install_and_denies_broad_upgrade(self) -> None:
+        narrow = {
+            "session_id": "s",
+            "tool_name": "Bash",
+            "tool_input": {"command": "winget install JADX.JADX"},
+        }
+        broad = {
+            "session_id": "s",
+            "tool_name": "Bash",
+            "tool_input": {"command": "winget upgrade --all"},
+        }
+
+        self.assertEqual("", self.capture(checkpoint.pre_tool, narrow))
+        blocked = json.loads(self.capture(checkpoint.pre_tool, broad))
+        self.assertEqual("deny", blocked["hookSpecificOutput"]["permissionDecision"])
+
+    def test_stop_requires_current_diff_review_and_validation(self) -> None:
+        target = self.root / "sample.kt"
+        target.write_text("val x = 1\n", encoding="utf-8")
+        edit = {"session_id": "s", "tool_name": "Edit", "tool_input": {"file_path": str(target)}}
+        harness.post_tool(edit)
+        with patch.object(harness, "_run", return_value=(0, "")):
+            blocked = json.loads(self.capture(harness.stop, {"session_id": "s"}))
+        self.assertEqual("block", blocked["decision"])
+        self.assertIn("final diff", blocked["reason"])
+        self.assertIn("focused validation", blocked["reason"])
+
+        harness.post_tool({"session_id": "s", "tool_name": "Bash", "tool_input": {"command": "git diff -- sample.kt"}})
+        harness.post_tool({"session_id": "s", "tool_name": "Bash", "tool_input": {"command": "python -m unittest sample"}})
+        with patch.object(harness, "_run", return_value=(0, "")):
+            self.assertEqual("", self.capture(harness.stop, {"session_id": "s"}))
+        self.assertTrue(harness._load({"session_id": "s"})["task_complete"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_agent_harness_contract.py
+++ b/scripts/tests/test_agent_harness_contract.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.validate_agent_harness import main as validate_agent_harness
+
+
+class AgentHarnessContractTest(unittest.TestCase):
+    def test_always_on_agent_harness_contract_is_valid(self) -> None:
+        self.assertEqual(0, validate_agent_harness())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_ai_comment_slop.py
+++ b/scripts/tests/test_ai_comment_slop.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.check_ai_comment_slop import scan_diff
+
+
+class AiCommentSlopTest(unittest.TestCase):
+    def test_rejects_process_narration_in_added_source_comments(self) -> None:
+        diff = """diff --git a/app/Test.kt b/app/Test.kt
++++ b/app/Test.kt
+@@ -1,0 +1,2 @@
++// Step 1: update the state
++val state = 1
+"""
+        findings = scan_diff(diff)
+        self.assertEqual(1, len(findings))
+        self.assertIn("Step 1", findings[0])
+
+    def test_allows_non_obvious_contract_comment_and_docs(self) -> None:
+        diff = """diff --git a/app/Test.kt b/app/Test.kt
++++ b/app/Test.kt
+@@ -1,0 +1,1 @@
++// Media3 requires this callback on the application looper.
+diff --git a/docs/note.md b/docs/note.md
++++ b/docs/note.md
+@@ -1,0 +1,1 @@
++# Step 1: user documentation
+"""
+        self.assertEqual([], scan_diff(diff))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_claude_prompt_routing.py
+++ b/scripts/tests/test_claude_prompt_routing.py
@@ -72,6 +72,19 @@ class ClaudePromptRoutingTest(unittest.TestCase):
         self.assertIn("levyra-android-intent-security", context)
         self.assertIn("levyra-security-review", context)
 
+    def test_reverse_engineering_adds_security_and_r8(self) -> None:
+        context = route("Decompile this APK and recover Kotlin R8 metadata")
+
+        self.assertIn("levyra-android-reverse-engineering", context)
+        self.assertIn("levyra-security-review", context)
+        self.assertIn("levyra-r8-proguard", context)
+
+    def test_normal_apk_release_does_not_trigger_reverse_engineering(self) -> None:
+        context = route("Build and validate the release APK")
+
+        self.assertIn("levyra-release-check", context)
+        self.assertNotIn("levyra-android-reverse-engineering", context)
+
     def test_project_manager_route(self) -> None:
         context = route("Update roadmap acceptance criteria for the active phase")
 

--- a/scripts/validate_agent_harness.py
+++ b/scripts/validate_agent_harness.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Validate Levyra's non-optional cross-runtime agent harness contract."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_FILES = (
+    "docs/ai/ALWAYS_ON_AGENT_GUARDS.md",
+    "scripts/agent_harness.py",
+    "scripts/run-agent-harness.sh",
+    "scripts/run-agent-harness.ps1",
+    "scripts/check_ai_comment_slop.py",
+    "scripts/comment_guard_hook.py",
+    "scripts/run-comment-guard.sh",
+    "scripts/run-comment-guard.ps1",
+    ".claude/rules/always-on-agent-guards.md",
+)
+
+
+def require_terms(path: str, terms: tuple[str, ...], errors: list[str]) -> None:
+    target = ROOT / path
+    if not target.is_file():
+        errors.append(f"missing always-on harness file: {path}")
+        return
+    text = target.read_text(encoding="utf-8")
+    for term in terms:
+        if term not in text:
+            errors.append(f"{path}: missing always-on harness contract {term!r}")
+
+
+def reject_terms(path: str, terms: tuple[str, ...], errors: list[str]) -> None:
+    target = ROOT / path
+    if not target.is_file():
+        return
+    text = target.read_text(encoding="utf-8").lower()
+    for term in terms:
+        if term.lower() in text:
+            errors.append(f"{path}: forbidden agent-harness setting {term!r}")
+
+
+def read_json(path: str, errors: list[str]) -> dict:
+    target = ROOT / path
+    try:
+        value = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        errors.append(f"{path}: invalid JSON: {exc}")
+        return {}
+    if not isinstance(value, dict):
+        errors.append(f"{path}: expected JSON object")
+        return {}
+    return value
+
+
+def hook_names(settings: dict) -> set[str]:
+    hooks = settings.get("hooks")
+    return set(hooks) if isinstance(hooks, dict) else set()
+
+
+def commands(settings: dict) -> str:
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return ""
+    result: list[str] = []
+    for groups in hooks.values():
+        if not isinstance(groups, list):
+            continue
+        for group in groups:
+            if not isinstance(group, dict):
+                continue
+            for hook in group.get("hooks") or []:
+                if isinstance(hook, dict):
+                    result.append(str(hook.get("command", "")))
+                    result.append(str(hook.get("commandWindows", "")))
+    return "\n".join(result)
+
+
+def main() -> int:
+    errors: list[str] = []
+    for path in REQUIRED_FILES:
+        if not (ROOT / path).is_file():
+            errors.append(f"missing always-on harness file: {path}")
+
+    require_terms(
+        "docs/ai/ALWAYS_ON_AGENT_GUARDS.md",
+        (
+            "These guards are not skills",
+            "Current file before mutation",
+            "Acceptance gates are always active",
+            "Compaction and resume must re-anchor state",
+            "AI-comment slop is rejected",
+            "Structural navigation is deterministic",
+        ),
+        errors,
+    )
+    require_terms(
+        "docs/ai/AI_ENGINEERING_GUARDRAILS.md",
+        ("Always-on execution harness", "ALWAYS_ON_AGENT_GUARDS.md", "not a skill"),
+        errors,
+    )
+    require_terms(
+        "docs/ai/EVIDENCE_GATED_COMPLETION.md",
+        ("Mandatory applicability", "always active", "final material edit"),
+        errors,
+    )
+    require_terms(
+        "docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md",
+        ("AI_ENGINEERING_GUARDRAILS.md", "Apply the shared AI guardrails automatically"),
+        errors,
+    )
+    require_terms(
+        ".agents/rules/levyra-workspace.md",
+        ("ALWAYS_ON_AGENT_GUARDS.md", "Non-optional harness contract", "Always On"),
+        errors,
+    )
+    require_terms(
+        ".claude/rules/always-on-agent-guards.md",
+        ("ALWAYS_ON_AGENT_GUARDS.md", "not a skill", "lifecycle hooks"),
+        errors,
+    )
+
+    required_hooks = {"SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "PostCompact", "Stop"}
+    for path in (".claude/settings.json", ".codex/hooks.json"):
+        settings = read_json(path, errors)
+        missing = sorted(required_hooks - hook_names(settings))
+        if missing:
+            errors.append(f"{path}: missing always-on hook(s): {', '.join(missing)}")
+        command_text = commands(settings)
+        for event in ("session-start", "user-prompt", "pre-tool", "post-tool", "post-compact", "stop"):
+            if event not in command_text:
+                errors.append(f"{path}: harness event {event!r} is not wired")
+        if "run-agent-harness" not in command_text:
+            errors.append(f"{path}: checked-in agent harness wrapper is not wired")
+        if "run-comment-guard" not in command_text:
+            errors.append(f"{path}: immediate post-mutation comment guard is not wired")
+
+    require_terms(
+        "scripts/agent_harness.py",
+        (
+            "permissionDecision",
+            "read_hashes",
+            "diff_review_generation",
+            "validation_generation",
+            "completed_generation",
+            "reanchor_pending",
+            "task_complete",
+            "check_ai_comment_slop.py",
+        ),
+        errors,
+    )
+
+    for path in (".codex/config.toml", ".codex/hooks.json", ".claude/settings.json"):
+        reject_terms(
+            path,
+            ("danger-full-access", "dangerously-skip-permissions", "approval_policy = \"never\"", "oh-my-openagent"),
+            errors,
+        )
+
+    checker = ROOT / "scripts" / "check_ai_comment_slop.py"
+    if checker.is_file():
+        result = subprocess.run(
+            [sys.executable, str(checker)],
+            cwd=ROOT,
+            check=False,
+            text=True,
+            capture_output=True,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            errors.append((result.stdout + result.stderr).strip() or "AI comment slop checker failed")
+
+    if errors:
+        print("Always-on agent harness validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print("Always-on agent harness validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Make Levyra's critical AI engineering safeguards deterministic and always-on across supported coding runtimes instead of relying on a model to remember or opt into them.

- add the canonical `docs/ai/ALWAYS_ON_AGENT_GUARDS.md` contract for Claude Code, Codex, ChatGPT, Antigravity/Gemini, OpenCode, and delegated runtimes
- use one shared `scripts/agent_skill_router.py` so Claude and Codex select matching Levyra skills automatically from the task; the same routing contract is mandatory for the other runtimes
- enforce scoped instructions, current-file-before-mutation, fresh full reads before whole-file replacement, evidence-gated completion, final-diff review, anti-AI-comment checks, and compaction/resume re-anchoring
- add a durable local task checkpoint with one next action, failure fingerprinting, third-identical-retry prevention, and truthful `ACTIVE` / `BLOCKED` handling
- allow narrowly installing a genuinely required missing tool from a trusted upstream while rejecting broad package/system upgrades, privilege escalation, or approval/sandbox weakening
- add safe Claude context hygiene: `/clear` is recommended only at completed task boundaries; open or `BLOCKED` work is checkpointed and restored, and hooks never pretend they executed a slash command
- add `levyra-android-reverse-engineering` for APK/XAPK/AAB/DEX/JAR/AAR fingerprinting, decompilation, Kotlin/KMP and R8 metadata recovery, compiled API/call-flow extraction, GraphQL/WebSocket/static security inspection, with `levyra-security-review` and `levyra-r8-proguard` companions when applicable
- enable SimoneAvogadro's Android reverse-engineering plugin for Claude while keeping the Levyra native adapter authoritative across runtimes; useful static-analysis ideas from the incogbyte workflow are incorporated without making aggressive protection-bypass/credential-capture behavior automatic
- keep the Karpathy-style minimum-change tie-breaker: among equally correct solutions, prefer fewer production files, fewer new symbols, and fewer ownership boundaries
- keep jCodeMunch / available LSP / AST-aware navigation ordering deterministic for structural work
- explicitly reject `danger-full-access`, approval bypasses, telemetry/runtime dependency on Oh My OpenAgent, and unrelated tool/plugin churn

## Scope

AI/runtime configuration, guardrails, harness scripts, skills, documentation, and regression tests only. No Android or Desktop production code, application dependency, version, signing, release, or product-behavior changes.

## Regression coverage

The repository tests now cover, among other existing guards:

- fresh-read enforcement for whole-file replacement
- scoped `AGENTS.md` and current-file mutation context
- large-patch anchor selection
- follow-up and compaction state preservation
- final-diff + focused-validation completion gates
- automatic design routing including short `premium` / `modern` / `clean` / `cinematic` prompts
- automatic Android reverse-engineering routing with security/R8 companions and no false activation for a normal APK release task
- third identical failed command blocking
- `/clear` preserving an open `BLOCKED` checkpoint while resetting context-hygiene counters
- narrow required-tool installation allowed while broad package upgrades are denied

## Final branch

Single commit on top of `main`:

`eb3d8e2ecdd867ca565e7176a444b0dd229af5ba` — `feat(ai): enforce always-on agent guards`

The final diff contains 28 AI/config/docs/script/test files and no product-code file. The accidental temporary `noop`/metadata-edit artifacts created while rewriting the branch are not present in the final tree.

## Validation

On the final SHA, Dependency Review, AI Quality Gate, Android Runtime Compatibility Scan, and Extractor Unit Tests have passed. The remaining PR Check build/lint/unit/release stages are still running and remain required; an in-progress or blocked check is not a pass.

CodeRabbit selected the final 28-file diff but is currently rate-limited, so no new CodeRabbit findings are being treated as review evidence.

No merge, tag, release, deployment, version change, or repository-setting change is performed by this PR.