### PR TITLE
perf(ai): reduce Claude token overhead

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,161 +1,130 @@
-@../AGENTS.md
-@../docs/ai/EVIDENCE_GATED_COMPLETION.md
-@../docs/ai/ALWAYS_ON_AGENT_GUARDS.md
-
 # Levyra Claude Code
 
-The root `AGENTS.md` imported above is the repository-wide operating contract.
-Apply every nearer path-specific `AGENTS.md` for files in scope. For
-production-code implementation or broad review also read
-`docs/ai/AI_ENGINEERING_GUARDRAILS.md`.
+This is Claude's compact projection of the Levyra engineering contract. Root
+`AGENTS.md` remains the cross-runtime source of truth, but do not preload it or
+large `docs/ai/` playbooks wholesale on ordinary coding turns. Load the specific
+canonical document only when the active question requires details that are not
+already enforced by hooks or scoped rules.
 
-## Automatic project tooling
+The project lifecycle hooks keep `docs/ai/ALWAYS_ON_AGENT_GUARDS.md` active and
+inject applicable scoped `AGENTS.md`/current-file evidence around mutations.
+Path-scoped files under `.claude/rules/` load when relevant code is touched.
 
-The repository owner authorizes the pinned `rtk-ai/rtk` bootstrap for Levyra.
-The `SessionStart` hook checks RTK automatically and installs the pinned build
-when it is missing and Cargo is available. Do not ask the owner to run this
-manually. If the hook reports that bootstrap is blocked, continue with raw
-commands and report the limitation once.
+## Core coding contract
 
-When a task genuinely depends on prior-session context and claude-mem tools are
-not available, load `levyra-context-efficiency` and follow its owner-authorized,
-one-attempt automatic claude-mem bootstrap. Memory failure must never block the
-task.
+- Current repository evidence outranks memory, stale comments, previous agent
+  output, and old task status.
+- Inspect the current implementation and nearby tests before changing behavior.
+- Make the smallest coherent root-cause fix. Reuse existing owners, clients,
+  players, caches, stores, state models, and policies before adding structure.
+- Protect playback reliability, explicit song/audio versus native-video choice,
+  MediaSession/notification/Android Auto/queue synchronization, privacy, and
+  persisted user data before optional polish.
+- Preserve cancellation, lifecycle, concurrency, transient-failure, no-match,
+  persistence, and compatibility semantics.
+- Keep blocking network/database/disk/extraction/media work off UI threads.
+- Do not add explanatory source-code comments. Prefer clear names and structure;
+  preserve only required license/generated/lint/compatibility comments.
+- `only this`, `solo questo`, and equivalents are hard scope boundaries.
+- Commit, push, PR, merge, tag, release, deployment, version changes, and
+  repository settings remain owner-controlled.
 
-Task-required tools may be installed automatically under
-`docs/ai/ALWAYS_ON_AGENT_GUARDS.md`: verify absence/version first, install only
-the specific useful dependency from a trusted upstream, prefer user/project
-scope, and verify it afterwards. Never turn that authorization into a broad
-package upgrade, admin/root elevation, sandbox weakening, telemetry, or unrelated
-plugin installation.
+For a non-trivial production change or broad review, consult
+`docs/ai/AI_ENGINEERING_GUARDRAILS.md` only when its detailed decision procedure
+is needed. Apply `docs/ai/EVIDENCE_GATED_COMPLETION.md` at completion; the Stop
+hook enforces the critical evidence state mechanically.
 
 ## Immediate context budget
 
 Apply before broad reading on every real coding task:
 
-- search path/symbol/call site first;
-- read the smallest useful range, focused diff, or nearby test;
-- expand only for a concrete unanswered question;
-- do not reread unchanged evidence already in context;
-- load only matching skills, never the whole skill tree;
-- keep security, Perfetto, R8, signing, exact failures, and decisive diagnostics
-  raw when compression could change the conclusion.
+1. identify the likely owner/module and the exact question the next read answers;
+2. search path, symbol, or call site first;
+3. read the smallest useful range, focused diff, or nearby test;
+4. expand only when a concrete unanswered question remains;
+5. do not reread unchanged evidence already present in the active context;
+6. load only the skills routed for this task, never the whole skill tree.
 
-For non-trivial repository exploration or noisy output, invoke
-`levyra-context-efficiency` immediately. Tiny already-local edits keep the same
-baseline without loading extra skill text.
+For read-only discovery that would otherwise flood the main conversation, prefer
+Claude's built-in Explore agent. Use the custom implementation agent only when
+isolated implementation context is actually useful; tiny/local fixes stay in the
+main agent.
 
-## Claude context hygiene
+For noisy builds, tests, lint, logs, broad searches, dependency listings, GitHub
+or CI output, invoke `levyra-context-efficiency`. Prefer RTK only when its
+filtered output is sufficient; rerun raw when exact stdout/stderr, stack traces,
+security/signing evidence, Perfetto/R8 evidence, or full diagnostics matter.
+Token savings never override correctness.
 
-Use `/clear` as a token-saving boundary, not as a debugging reflex.
+## Subagent token discipline
 
-- Never clear an `ACTIVE` or `BLOCKED` task before its durable checkpoint has the
-  current goal, changed paths, evidence status, and next action.
-- After a verified completed task, if the next owner request is unrelated,
-  prefer a fresh context. The stop audit emits a context-hygiene reminder after
-  repeated completed-task boundaries.
-- When that reminder appears, proactively tell the owner to run `/clear` before
-  the next unrelated task; do not nag on related follow-ups.
-- Project command hooks cannot execute slash commands themselves. Never claim
-  `/clear` ran unless it actually did. `SessionStart(clear)` automatically
-  reloads Levyra guards and restores any open durable checkpoint.
-- Use `/compact` instead when the same task still needs its conversation history
-  summarized rather than discarded.
+Custom subagents already receive this project context automatically. Never tell
+a subagent to reread `.claude/CLAUDE.md` merely as bootstrap.
 
-## Core engineering rules
+Delegate with one compact handoff containing only:
 
-- Protect playback reliability, explicit song/audio vs native-video choice,
-  MediaSession/notification/Android Auto/queue synchronization, privacy, and
-  user data before optional polish.
-- Reuse the current architecture owner; never create a parallel source of truth
-  for convenience.
-- Keep blocking work off UI threads; preserve cancellation, lifecycle,
-  concurrency, persistence, and compatibility semantics.
-- State material assumptions/tradeoffs, prefer the simplest compatible path,
-  and define `step -> verification` for non-trivial work.
-- For non-trivial implementation, use `Plan -> Execute -> Verify`: make a brief
-  evidence-based plan, implement one coherent slice, verify it before expanding.
-  Do not stop for approval unless the owner reserved a checkpoint.
-- Apply `docs/ai/EVIDENCE_GATED_COMPLETION.md`: no non-trivial task is complete
-  until every acceptance gate is backed by direct evidence or explicitly
-  reported as blocked/unverified.
-- Match the requested action mode. `inspect`, `review`, `diagnose`, and `report`
-  authorize investigation only; `fix`, `update`, `address`, and `implement`
-  authorize the requested code change and validation, but never publication.
-- Treat screenshots and direct runtime observations as acceptance evidence that
-  must be reconciled even when automated checks are green.
-- Make surgical changes; avoid unrelated cleanup, speculative abstractions,
-  dependency churn, or version changes.
-- Do not add explanatory source-code comments. Prefer clear names, small
-  functions, and explicit structure. Preserve only required license,
-  generated/tool, lint/suppression, or real compatibility-contract comments.
+- goal and verified/current evidence;
+- affected files or symbols;
+- invariants/constraints that matter to this task;
+- acceptance checks and any real blocker.
+
+Do not paste the parent conversation, broad repository summaries, whole files,
+or unrelated findings into a delegation message. Do not preload skill bodies in
+subagent frontmatter; let the subagent invoke the routed skill through `Skill`
+when it actually needs that procedure.
+
+Keep `model: inherit` and high reasoning for Levyra coding/review agents. Save
+tokens by reducing duplicate context and unused tools, not by lowering coding
+quality.
 
 ## Deterministic skill loading
 
-Claude must select skills from the task itself; the owner never has to name them.
+The `UserPromptSubmit` hook executes `scripts/agent_skill_router.py`. Every name
+under **Mandatory skill load** must be invoked before broad repository reading,
+editing, or shell work. The hook is the routing source of truth; do not maintain
+or scan a second full routing table in this always-loaded file.
 
-The `UserPromptSubmit` hook executes the shared
-`scripts/agent_skill_router.py`. Every skill listed by the hook under
-**Mandatory skill load** must be invoked before broad repository reading,
-editing, or shell work. Do not merely mention, plan to use, or silently skip a
-routed skill.
+Compatibility inventory for the core automatic routes:
+`levyra-real-engineering`, `levyra-compose`, `levyra-design-taste`,
+`levyra-android-performance`, `levyra-r8-proguard`,
+`levyra-android-intent-security`, `levyra-ci-workflows`,
+`levyra-context-efficiency`, `levyra-pr-review`, `levyra-release-check`.
+The shared router may select additional focused Levyra skills and companions.
 
-Project skills under `.claude/skills/` are intentionally thin bridges. After
-invoking a bridge, follow it to the canonical
-`.agents/skills/<skill-name>/SKILL.md` and apply that procedure before editing.
-If the hook is unavailable, use the table below manually. Never claim a skill was
-loaded when only its name or description was visible.
+## Delegation policy
 
-Load only matching skills. Do not preload the whole skill tree.
+- Do not spawn `levyra-android-developer` for a trivial, already-local one-file
+  fix that the main agent can safely implement with focused validation.
+- Use `levyra-android-developer` for substantial Android implementation/debugging
+  where isolated code-reading/editing context keeps the main conversation clean.
+- Use `levyra-reviewer` after meaningful or risky changes, before merge-quality
+  handoff, or when an independent read-only pass can find regressions. Do not
+  spawn it ceremonially for a tiny edit with direct focused evidence.
+- Use built-in Explore for broad read-only repository discovery whenever its
+  lower startup context is sufficient.
 
-## Automatic skill routing
+## Claude context hygiene
 
-| Task | Skill |
-| --- | --- |
-| Requirements, roadmap, active phase, acceptance criteria, task status, implementation handoff | `levyra-project-manager` |
-| OpenClaw delegation, Levyra worker/reviewer/CI coordination, evidence handoff | `levyra-openclaw-orchestrator` |
-| Non-trivial feature, architecture, unclear bug/regression, build/test failure, multi-step work | `levyra-real-engineering` |
-| Playback, queue, Media3, MediaSession, notification, Android Auto, audio/video mode | `levyra-player` |
-| InnerTube, extractor, stream resolution, retry/cache/fallback | `levyra-extractor` |
-| Room, DAO, migration, schema, persistent stores | `levyra-database` |
-| Compose UI/state/navigation/accessibility/RTL/localization | `levyra-compose` |
-| Android runtime profiling, jank, Perfetto, CPU/thread, Binder, graphics, memory, I/O, power | `levyra-android-performance` plus affected domain skill |
-| APK/XAPK/AAB/DEX/JAR/AAR decompilation, jadx/smali, compiled API extraction, binary call-flow tracing, Kotlin/R8 metadata recovery | `levyra-android-reverse-engineering` plus `levyra-security-review`; add `levyra-r8-proguard` when obfuscation matters |
-| Intent/deep link/PendingIntent/exported component/provider/URI/caller boundary | `levyra-android-intent-security` plus `levyra-security-review` and affected domain skill |
-| R8/Proguard/minification/shrinking/keep rules/mapping/release-only shrinker failure | `levyra-r8-proguard` plus `levyra-release-check`; add `levyra-ci-workflows` for tooling changes |
-| Visual redesign/polish/hierarchy/spacing/typography/color/motion/reference/anti-AI-slop UI | `levyra-design-taste` plus matching UI skill |
-| Decorative motion artwork | `levyra-motion-artwork` |
-| Windows Desktop, Compose Multiplatform, libvlc, downloads, mini player, deep links, updates, packaging | `levyra-desktop` |
-| GitHub Actions/CI/F-Droid/Gradle/AGP/Kotlin/KSP/build cache/artifacts | `levyra-ci-workflows` |
-| Repository exploration, builds/tests/lint/logs/search/dependencies/Git/GitHub/CI/CodeRabbit/setup | `levyra-context-efficiency` |
-| Security/privacy/trust-boundary/supply-chain work | `levyra-security-review` |
-| Branch/commit/diff/pull-request review | `levyra-pr-review` plus affected skills |
-| Device/runtime/pre-merge/release/signing/APK validation | `levyra-release-check` |
-| Genuine cross-domain work or initial architecture orientation | `levyra-engineering` |
+Use `/clear` at safe task boundaries, not mid-debugging. If the next owner
+request is unrelated and the prior task is complete/checkpointed, prefer a fresh
+context when the stop audit recommends it. Use `/compact` when the same task
+still needs summarized history. Never claim a hook executed a slash command.
 
-## Mandatory pre-delivery review
+## Review, validation, delivery
 
-Every code-bearing task must review the actual final code/diff before delivery.
-Invoke `/code-review` when available; otherwise invoke the installed
-`code-review` skill/stage through `levyra-real-engineering`. Fix actionable
-findings before presenting the code as final. If a fix materially changes the
-solution, review the corrected final diff again.
+For code-bearing work, run focused validation after the latest material edit,
+inspect the actual final diff, and run `git diff --check`. Invoke `/code-review`
+when available for meaningful changes; otherwise use the installed review stage
+through `levyra-real-engineering`. Fix actionable findings and review the final
+corrected diff again when the fix materially changes it.
 
-Do not run a review before code exists merely to satisfy the rule.
-
-## Validation and publication
-
-Use focused checks first, then the repository quality gate:
+Use the repository quality gate when applicable:
 
 ```bash
 python3 scripts/ai_quality_gate.py --profile fast
 python3 scripts/ai_quality_gate.py --profile full
 ```
 
-Run `fast` before commit and `full` before push/PR publication. Missing or blocked
-checks are not passes. Never claim unrun validation.
-
-Commit, push, PR, merge, tag, release, version changes, deployment, and
-repository settings remain owner-controlled. A `UserPromptSubmit` hook reinforces
-context budgeting, mandatory matching-skill loading, and evidence-gated
-completion each turn.
+Run `fast` before commit and `full` before push/PR publication. Missing or
+blocked checks are not passes. Report exactly what ran and what remains
+unverified.

--- a/.claude/agents/levyra-android-developer.md
+++ b/.claude/agents/levyra-android-developer.md
@@ -1,18 +1,22 @@
 ---
 name: levyra-android-developer
-description: Implements and debugs Levyra Android changes while preserving playback, extractor, database, Compose, security, and release invariants. Use for non-trivial code changes.
+description: Implements and debugs non-trivial Levyra Android changes when isolated implementation context is useful. Do not delegate tiny/local one-file fixes that the main agent can safely complete directly.
+tools: Read, Grep, Glob, Edit, Write, Bash, Skill
 model: inherit
 effort: high
 ---
 
 You are Levyra's senior Android implementation agent.
 
+Project instructions are already loaded automatically. Do not reread
+`.claude/CLAUDE.md` as bootstrap and do not scan the whole skill/rule tree.
+
 Before editing:
 
-1. Read `.claude/CLAUDE.md`.
-2. Read the relevant files under `.claude/rules/` and any matching skill.
-3. Inspect the existing implementation and tests; do not design from memory alone.
-4. Identify the critical behavior that must remain unchanged.
+1. Read only the current files, nearby tests, and path-scoped rules needed for
+   the delegated goal.
+2. Invoke only the routed Levyra skill(s) needed for this task through `Skill`.
+3. Identify the root cause and the critical behavior that must remain unchanged.
 
 During implementation:
 
@@ -21,11 +25,15 @@ During implementation:
 - Keep user-triggered playback independent from decorative and speculative work.
 - Keep cancellation, transient failure, conclusive no-match, and invalid data distinct.
 - Reuse existing clients, players, caches, stores, policies, and state models.
-- Add regression tests for bugs, races, matching rules, migrations, and security boundaries.
+- Add regression tests when the defect, race, matching rule, migration, or
+  security boundary needs durable coverage.
+- Do not broaden the task merely because more repository context is available.
 
 Before finishing:
 
 - Run the narrowest useful tests, then applicable project checks.
 - Run `git diff --check` and review every changed file.
-- State exactly what passed and what remains unverified.
-- Never modify versions, release workflows, secrets, or unrelated code unless the task requires it.
+- Return a compact evidence handoff: root cause, changed files, checks that
+  actually passed, and any remaining blocker.
+- Never modify versions, release workflows, secrets, or unrelated code unless
+  the delegated task requires it.

--- a/.claude/agents/levyra-reviewer.md
+++ b/.claude/agents/levyra-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: levyra-reviewer
-description: Performs a read-only Levyra review focused on playback regressions, coroutine races, security, Room migrations, Compose lifecycle, CI, and truthful testing claims. Use after meaningful changes or before merge.
+description: Performs an independent read-only Levyra review after meaningful or risky changes, before merge-quality handoff, or when regression risk justifies a separate context. Do not spawn ceremonially for tiny local edits with direct focused evidence.
 tools: Read, Grep, Glob, Bash
 model: inherit
 effort: high
@@ -8,7 +8,9 @@ effort: high
 
 You are a strict, evidence-based Levyra reviewer. Do not edit files.
 
-Read `.claude/CLAUDE.md` and the relevant rules, then inspect the diff and surrounding code.
+Project instructions are already loaded automatically. Do not reread
+`.claude/CLAUDE.md` as bootstrap. Inspect the final diff first, then read only
+the surrounding code and path-scoped rules needed to validate concrete risks.
 
 Prioritize findings in this order:
 
@@ -20,4 +22,7 @@ Prioritize findings in this order:
 6. Compose state, keys, side effects, accessibility, and localization.
 7. CI/release correctness, duplicated workflows, version changes, and unsupported test claims.
 
-For each finding, cite the exact file and lines, explain the user-visible failure scenario, and propose the smallest correction. Do not invent issues merely to fill a review. If a concern is already fixed in current code, say so and do not repeat an outdated comment.
+For each finding, cite the exact file and lines, explain the user-visible failure
+scenario, and propose the smallest correction. Do not invent issues merely to
+fill a review. If a concern is already fixed in current code, do not repeat it.
+Return findings only; keep the handoff compact when no actionable issue exists.

--- a/.claude/hooks/user-prompt-submit.sh
+++ b/.claude/hooks/user-prompt-submit.sh
@@ -5,7 +5,7 @@ root="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}
 router="$root/scripts/agent_skill_router.py"
 
 # Compatibility contract for repository validators; routing logic stays canonical in agent_skill_router.py.
-validator_contract="Mandatory skill load | Root AGENTS.md is imported | EVIDENCE_GATED_COMPLETION.md | Levyra context budget | code-review | levyra-project-manager | levyra-desktop | levyra-engineering | levyra-openclaw-orchestrator | levyra-real-engineering | levyra-compose | levyra-design-taste | levyra-android-performance | levyra-r8-proguard | levyra-android-intent-security | levyra-ci-workflows | levyra-context-efficiency | levyra-pr-review | levyra-release-check | levyra-security-review | threat model | trust boundary | supply.?chain"
+validator_contract="Mandatory skill load | Root AGENTS.md remains canonical | EVIDENCE_GATED_COMPLETION.md | Levyra context budget | code-review | levyra-project-manager | levyra-desktop | levyra-engineering | levyra-openclaw-orchestrator | levyra-real-engineering | levyra-compose | levyra-design-taste | levyra-android-performance | levyra-r8-proguard | levyra-android-intent-security | levyra-ci-workflows | levyra-context-efficiency | levyra-pr-review | levyra-release-check | levyra-security-review | threat model | trust boundary | supply.?chain"
 : "$validator_contract"
 
 if command -v python3 >/dev/null 2>&1; then

--- a/.claude/rules/context-efficiency.md
+++ b/.claude/rules/context-efficiency.md
@@ -1,37 +1,21 @@
 # Context-efficient execution
 
-Apply this baseline immediately to every real Levyra coding task, before broad
-repository reading or noisy commands:
+Apply this before broad repository work:
 
-- search/symbol/path first;
+- search path/symbol/call site first;
 - read the smallest useful range or focused diff;
-- expand only to answer a concrete unresolved question;
+- expand only for a concrete unanswered question;
 - do not reread unchanged evidence already in context;
-- load only matching skills, never the whole skill tree;
-- keep security, Perfetto, R8, signing, exact failures, and decisive diagnostics
-  raw when compression could change the conclusion.
+- load only the skills routed for the current task.
 
-For non-trivial repository exploration, prefer the project-scoped jCodeMunch MCP
-for symbol-level discovery before broad reads. Treat it as a navigator, not a
-restriction: Claude native Read/Grep/Glob/Bash tools remain available and must be
-used whenever control flow, lifecycle, state, concurrency, generated behavior,
-tests, or correctness require broader evidence.
+Prefer project jCodeMunch for non-trivial symbol discovery, then available
+LSP/AST tooling, then bounded Claude native Read/Grep/Glob/Bash when broader
+evidence is needed.
 
-Token savings never override correctness.
+Invoke `levyra-context-efficiency` for noisy builds, tests, lint, logs, broad
+searches, dependency/Git/GitHub/CI output, or other high-volume work. Project
+RTK filters remain in `.rtk/filters.toml`. Use RTK only when filtered output is
+sufficient. Rerun the exact command raw for exact failures, stack traces,
+security/signing evidence, Perfetto/R8 evidence, or ambiguous results.
 
-For non-trivial repository exploration, builds, tests, lint, logs, broad
-searches, dependencies, Git/GitHub, CI, CodeRabbit, adb, setup, or other
-high-volume work, invoke `levyra-context-efficiency` and follow
-`.agents/skills/levyra-context-efficiency/SKILL.md` as the canonical procedure.
-
-When RTK is available, prefer its supported compact wrappers for repetitive
-success-heavy output. Rerun the exact command raw if compact output is
-incomplete, ambiguous, or insufficient to diagnose a failure. Verify exit
-status and final success/failure markers; compact output is not validation
-authority.
-
-Project filters live in `.rtk/filters.toml`; setup and measurement are in
-`docs/ai/RTK.md` and `scripts/setup-ai.ps1` / `scripts/setup-ai.sh`.
-
-Do not install another always-on compression proxy. Do not infer permission to
-commit, push, open/merge a PR, tag, publish, or release.
+Token savings never override correctness, validation, or publication controls.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "skillListingBudgetFraction": 0.02,
+  "skillListingBudgetFraction": 0.01,
+  "maxSkillDescriptionChars": 768,
+  "includeGitInstructions": false,
   "extraKnownMarketplaces": {
     "chrisbanes-skills": {
       "source": {

--- a/scripts/agent_harness.py
+++ b/scripts/agent_harness.py
@@ -67,6 +67,8 @@ def _load(data: dict[str, Any]) -> dict[str, Any]:
     except (OSError, json.JSONDecodeError):
         state = {}
     state.setdefault("read_hashes", {})
+    state.setdefault("context_hashes", {})
+    state.setdefault("instruction_hashes", {})
     state.setdefault("edited_paths", [])
     state.setdefault("edit_generation", 0)
     state.setdefault("diff_review_generation", -1)
@@ -145,7 +147,7 @@ def _targets(data: dict[str, Any]) -> list[Path]:
     return unique
 
 
-def _scoped_agents(path: Path) -> str:
+def _scoped_agents(path: Path, state: dict[str, Any]) -> str:
     parts: list[str] = []
     current = path.parent if path.suffix else path
     chain: list[Path] = []
@@ -157,9 +159,15 @@ def _scoped_agents(path: Path) -> str:
         current = current.parent
     for directory in reversed(chain):
         candidate = directory / "AGENTS.md"
-        if candidate.is_file():
-            text = candidate.read_text(encoding="utf-8", errors="replace")
-            parts.append(f"Applicable scoped instructions: {_relative(candidate)}\n{text}")
+        if not candidate.is_file():
+            continue
+        relative = _relative(candidate)
+        digest = _hash(candidate)
+        if state["instruction_hashes"].get(relative) == digest:
+            continue
+        text = candidate.read_text(encoding="utf-8", errors="replace")
+        state["instruction_hashes"][relative] = digest
+        parts.append(f"Applicable scoped instructions: {relative}\n{text}")
     return "\n\n".join(parts)
 
 
@@ -169,6 +177,15 @@ def _patch_anchor(data: dict[str, Any]) -> str:
     for line in old.splitlines():
         if len(line.strip()) >= 4:
             return line.strip()
+    edits = item.get("edits")
+    if isinstance(edits, list):
+        for edit in edits:
+            if not isinstance(edit, dict):
+                continue
+            old = str(edit.get("old_string") or edit.get("oldString") or "")
+            for line in old.splitlines():
+                if len(line.strip()) >= 4:
+                    return line.strip()
     command = str(item.get("command") or item.get("patch") or "")
     for line in command.splitlines():
         if line.startswith(("***", "@@", "+++", "---")):
@@ -180,12 +197,17 @@ def _patch_anchor(data: dict[str, Any]) -> str:
     return ""
 
 
-def _current_context(path: Path, data: dict[str, Any]) -> str:
+def _current_context(path: Path, data: dict[str, Any], state: dict[str, Any]) -> str:
     if not path.is_file() or _protected(path):
         return ""
+    relative = _relative(path)
+    digest = _hash(path)
+    if state["context_hashes"].get(relative) == digest:
+        return ""
     text = path.read_text(encoding="utf-8", errors="replace")
-    if len(text) <= 14000:
-        return f"Current {_relative(path)}:\n{text}"
+    state["context_hashes"][relative] = digest
+    if len(text) <= 4000:
+        return f"Current {relative}:\n{text}"
     lines = text.splitlines()
     anchor = _patch_anchor(data)
     index = 0
@@ -194,20 +216,19 @@ def _current_context(path: Path, data: dict[str, Any]) -> str:
     start = max(0, index - 35)
     end = min(len(lines), index + 36)
     excerpt = "\n".join(f"{i + 1}: {lines[i]}" for i in range(start, end))
-    return f"Current bounded region from {_relative(path)}:\n{excerpt}"
+    return f"Current bounded region from {relative}:\n{excerpt}"
 
 
 def _reanchor(state: dict[str, Any]) -> str:
     edited = ", ".join(state.get("edited_paths", [])) or "none"
     return (
-        "Levyra always-on re-anchor after compaction/resume:\n"
-        f"- latest owner request: {state.get('latest_prompt') or 'not recorded'}\n"
+        "Levyra re-anchor after compaction/resume:\n"
+        f"- owner request: {state.get('latest_prompt') or 'not recorded'}\n"
         f"- edited paths: {edited}\n"
         f"- edit generation: {state.get('edit_generation', 0)}\n"
         f"- validation generation: {state.get('validation_generation', -1)}\n"
         f"- final-diff review generation: {state.get('diff_review_generation', -1)}\n"
-        "- re-read current repository evidence before relying on compacted memory; "
-        "ALWAYS_ON_AGENT_GUARDS.md remains mandatory."
+        "- re-read only evidence needed for the next action; always-on guards remain active."
     )
 
 
@@ -221,8 +242,17 @@ def _deny(event: str, reason: str) -> None:
     print(json.dumps({"hookSpecificOutput": {"hookEventName": event, "permissionDecision": "deny", "permissionDecisionReason": reason}}))
 
 
+def _reset_context_cache(state: dict[str, Any], *, clear_full_reads: bool) -> None:
+    state["context_hashes"] = {}
+    state["instruction_hashes"] = {}
+    if clear_full_reads:
+        state["read_hashes"] = {}
+
+
 def _reset_task(state: dict[str, Any]) -> None:
     state["read_hashes"] = {}
+    state["context_hashes"] = {}
+    state["instruction_hashes"] = {}
     state["edited_paths"] = []
     state["edit_generation"] = 0
     state["diff_review_generation"] = -1
@@ -243,7 +273,7 @@ def user_prompt(data: dict[str, Any]) -> int:
     _save(data, state)
     _context_output(
         "UserPromptSubmit",
-        "Levyra always-on guards are active for this entire task and are not skill-routed: scoped AGENTS context, current-file-before-mutation, evidence gates, final-diff review, anti-AI-comment checks, and compaction re-anchoring are mandatory. For symbol/call-flow/reference work, use jCodeMunch first when available, then an already-available LSP/AST-aware tool when it answers the question more directly, then bounded native search/read.",
+        "Levyra guards active: scoped instructions, current-file freshness, evidence gates, final-diff review, and compact/resume re-anchoring. For structural work prefer jCodeMunch, then available LSP/AST, then bounded native search.",
     )
     return 0
 
@@ -251,6 +281,7 @@ def user_prompt(data: dict[str, Any]) -> int:
 def pre_tool(data: dict[str, Any]) -> int:
     state = _load(data)
     tool = _tool_name(data)
+    low = tool.lower()
     targets = _targets(data)
     for path in targets:
         if _protected(path):
@@ -271,12 +302,13 @@ def pre_tool(data: dict[str, Any]) -> int:
         chunks.append(_reanchor(state))
         state["reanchor_pending"] = False
     for path in targets:
-        scoped = _scoped_agents(path)
+        scoped = _scoped_agents(path, state)
         if scoped:
             chunks.append(scoped)
-        current = _current_context(path, data)
-        if current and tool.lower() in {"edit", "write", "apply_patch", "multi_edit", "multiedit"}:
-            chunks.append(current)
+        if low in {"edit", "apply_patch", "multi_edit", "multiedit"}:
+            current = _current_context(path, data, state)
+            if current:
+                chunks.append(current)
     _save(data, state)
     _context_output("PreToolUse", "\n\n".join(chunks))
     return 0
@@ -304,13 +336,17 @@ def post_tool(data: dict[str, Any]) -> int:
         if full:
             for path in targets:
                 if path.is_file() and not _protected(path):
-                    state["read_hashes"][_relative(path)] = _hash(path)
+                    digest = _hash(path)
+                    state["read_hashes"][_relative(path)] = digest
+                    state["context_hashes"][_relative(path)] = digest
     if low in {"edit", "write", "apply_patch", "multi_edit", "multiedit"}:
         state["edit_generation"] += 1
         state["task_complete"] = False
         edited = set(state.get("edited_paths", []))
         for path in targets:
             edited.add(_relative(path))
+            if path.is_file() and not _protected(path):
+                state["context_hashes"][_relative(path)] = _hash(path)
         state["edited_paths"] = sorted(edited)
     command = _command(data)
     if command:
@@ -325,6 +361,7 @@ def post_tool(data: dict[str, Any]) -> int:
 def compact(data: dict[str, Any]) -> int:
     state = _load(data)
     state["reanchor_pending"] = True
+    _reset_context_cache(state, clear_full_reads=True)
     _save(data, state)
     _context_output("PostCompact", _reanchor(state))
     return 0
@@ -411,10 +448,11 @@ def session_start(data: dict[str, Any]) -> int:
     state = _load(data)
     if str(data.get("source") or "").lower() == "resume":
         state["reanchor_pending"] = True
+        _reset_context_cache(state, clear_full_reads=True)
         _save(data, state)
         _context_output("SessionStart", _reanchor(state))
     else:
-        _context_output("SessionStart", "Levyra ALWAYS_ON_AGENT_GUARDS.md is active for the full session and is not optional skill routing.")
+        _context_output("SessionStart", "Levyra always-on guards active.")
     return 0
 
 

--- a/scripts/tests/test_agent_harness.py
+++ b/scripts/tests/test_agent_harness.py
@@ -50,6 +50,7 @@ class AgentHarnessTest(unittest.TestCase):
         harness.post_tool(read)
         allowed = self.capture(harness.pre_tool, write)
         self.assertNotIn('"permissionDecision": "deny"', allowed)
+        self.assertNotIn("Current sample.kt", allowed)
 
         target.write_text("val answer = 43\n", encoding="utf-8")
         stale = json.loads(self.capture(harness.pre_tool, write))
@@ -62,6 +63,52 @@ class AgentHarnessTest(unittest.TestCase):
         target = app / "Player.kt"
         target.write_text("fun play() = Unit\n", encoding="utf-8")
         payload = {"session_id": "s", "tool_name": "Edit", "tool_input": {"file_path": str(target), "old_string": "fun play"}}
+        output = self.capture(harness.pre_tool, payload)
+        self.assertIn("Scoped app rule", output)
+        self.assertIn("fun play() = Unit", output)
+
+    def test_repeated_edit_does_not_reinject_known_context(self) -> None:
+        app = self.root / "app"
+        app.mkdir()
+        (app / "AGENTS.md").write_text("Scoped app rule", encoding="utf-8")
+        target = app / "Player.kt"
+        target.write_text("fun play() = Unit\n", encoding="utf-8")
+        first = {"session_id": "s", "tool_name": "Edit", "tool_input": {"file_path": str(target), "old_string": "fun play"}}
+        self.assertIn("Scoped app rule", self.capture(harness.pre_tool, first))
+
+        target.write_text('fun play() = println("ok")\n', encoding="utf-8")
+        harness.post_tool(first)
+        second = {"session_id": "s", "tool_name": "Edit", "tool_input": {"file_path": str(target), "old_string": "println"}}
+        self.assertEqual("", self.capture(harness.pre_tool, second))
+
+    def test_external_change_reinjects_file_without_repeating_agents(self) -> None:
+        app = self.root / "app"
+        app.mkdir()
+        (app / "AGENTS.md").write_text("Scoped app rule", encoding="utf-8")
+        target = app / "Player.kt"
+        target.write_text("fun play() = Unit\n", encoding="utf-8")
+        payload = {"session_id": "s", "tool_name": "Edit", "tool_input": {"file_path": str(target), "old_string": "fun play"}}
+        self.capture(harness.pre_tool, payload)
+        target.write_text('fun play() = println("known")\n', encoding="utf-8")
+        harness.post_tool(payload)
+
+        target.write_text('fun play() = println("external")\n', encoding="utf-8")
+        output = self.capture(
+            harness.pre_tool,
+            {"session_id": "s", "tool_name": "Edit", "tool_input": {"file_path": str(target), "old_string": "external"}},
+        )
+        self.assertIn("external", output)
+        self.assertNotIn("Scoped app rule", output)
+
+    def test_compaction_invalidates_mutation_context_cache(self) -> None:
+        app = self.root / "app"
+        app.mkdir()
+        (app / "AGENTS.md").write_text("Scoped app rule", encoding="utf-8")
+        target = app / "Player.kt"
+        target.write_text("fun play() = Unit\n", encoding="utf-8")
+        payload = {"session_id": "s", "tool_name": "Edit", "tool_input": {"file_path": str(target), "old_string": "fun play"}}
+        self.capture(harness.pre_tool, payload)
+        self.capture(harness.compact, {"session_id": "s"})
         output = self.capture(harness.pre_tool, payload)
         self.assertIn("Scoped app rule", output)
         self.assertIn("fun play() = Unit", output)
@@ -98,6 +145,8 @@ class AgentHarnessTest(unittest.TestCase):
         self.assertIn("Fix playback without changing UI", output)
         state = harness._load({"session_id": "s"})
         self.assertTrue(state["reanchor_pending"])
+        self.assertEqual({}, state["context_hashes"])
+        self.assertEqual({}, state["instruction_hashes"])
 
     def test_checkpoint_blocks_third_identical_failed_command(self) -> None:
         payload = {

--- a/scripts/tests/test_claude_prompt_routing.py
+++ b/scripts/tests/test_claude_prompt_routing.py
@@ -28,6 +28,24 @@ def route(prompt: str) -> str:
 
 
 class ClaudePromptRoutingTest(unittest.TestCase):
+    def test_claude_context_budget_stays_compact(self) -> None:
+        settings = json.loads((ROOT / ".claude" / "settings.json").read_text(encoding="utf-8"))
+        self.assertEqual(0.01, settings["skillListingBudgetFraction"])
+        self.assertEqual(768, settings["maxSkillDescriptionChars"])
+        self.assertFalse(settings["includeGitInstructions"])
+
+        instructions = (ROOT / ".claude" / "CLAUDE.md").read_text(encoding="utf-8")
+        self.assertLessEqual(len(instructions.encode("utf-8")), 7000)
+        self.assertNotIn("@../AGENTS.md", instructions)
+        self.assertNotIn("@../docs/ai/", instructions)
+        self.assertIn("Subagent token discipline", instructions)
+
+        developer = (ROOT / ".claude" / "agents" / "levyra-android-developer.md").read_text(encoding="utf-8")
+        self.assertIn("tools: Read, Grep, Glob, Edit, Write, Bash, Skill", developer)
+        self.assertIn("effort: high", developer)
+        self.assertIn("model: inherit", developer)
+        self.assertNotIn("Read `.claude/CLAUDE.md`", developer)
+
     def test_design_activation_phrases(self) -> None:
         prompts = (
             "Make the Now Playing screen more premium",

--- a/scripts/validate_claude_bootstrap.py
+++ b/scripts/validate_claude_bootstrap.py
@@ -44,6 +44,16 @@ def require_terms(relative_path: str, terms: tuple[str, ...], errors: list[str])
             errors.append(f"{relative_path}: missing Claude bootstrap contract {term!r}")
 
 
+def reject_terms(relative_path: str, terms: tuple[str, ...], errors: list[str]) -> None:
+    path = ROOT / relative_path
+    if not path.is_file():
+        return
+    text = path.read_text(encoding="utf-8")
+    for term in terms:
+        if term in text:
+            errors.append(f"{relative_path}: compact Claude bootstrap must not preload {term!r}")
+
+
 def main() -> int:
     errors: list[str] = []
 
@@ -68,9 +78,18 @@ def main() -> int:
         errors.append(".claude/settings.json must allow the project jcodemunch MCP server")
 
     skill_budget = settings.get("skillListingBudgetFraction") if isinstance(settings, dict) else None
-    if not isinstance(skill_budget, (int, float)) or skill_budget < 0.02:
+    if not isinstance(skill_budget, (int, float)) or skill_budget != 0.01:
         errors.append(
-            ".claude/settings.json skillListingBudgetFraction must be at least 0.02"
+            ".claude/settings.json skillListingBudgetFraction must stay at the compact 0.01 budget"
+        )
+    description_budget = settings.get("maxSkillDescriptionChars") if isinstance(settings, dict) else None
+    if description_budget != 768:
+        errors.append(
+            ".claude/settings.json maxSkillDescriptionChars must stay at 768"
+        )
+    if settings.get("includeGitInstructions") is not False:
+        errors.append(
+            ".claude/settings.json includeGitInstructions must be false to avoid duplicate Git context"
         )
 
     hooks = settings.get("hooks") if isinstance(settings, dict) else None
@@ -125,16 +144,44 @@ def main() -> int:
             ".claude/settings.json must run user-prompt-submit.sh on UserPromptSubmit"
         )
 
+    claude_path = ROOT / ".claude/CLAUDE.md"
+    if claude_path.is_file() and len(claude_path.read_bytes()) > 7000:
+        errors.append(".claude/CLAUDE.md must stay at or below 7000 bytes")
     require_terms(
+        ".claude/CLAUDE.md",
+        (
+            "AGENTS.md",
+            "EVIDENCE_GATED_COMPLETION.md",
+            "Deterministic skill loading",
+            "Mandatory skill load",
+            "AI_ENGINEERING_GUARDRAILS.md",
+            "Subagent token discipline",
+            "/code-review",
+        ),
+        errors,
+    )
+    reject_terms(
         ".claude/CLAUDE.md",
         (
             "@../AGENTS.md",
             "@../docs/ai/EVIDENCE_GATED_COMPLETION.md",
-            "Deterministic skill loading",
-            "Mandatory skill load",
-            "AI_ENGINEERING_GUARDRAILS.md",
-            "/code-review",
+            "@../docs/ai/ALWAYS_ON_AGENT_GUARDS.md",
         ),
+        errors,
+    )
+    require_terms(
+        ".claude/agents/levyra-android-developer.md",
+        (
+            "tools: Read, Grep, Glob, Edit, Write, Bash, Skill",
+            "model: inherit",
+            "effort: high",
+            "Project instructions are already loaded automatically",
+        ),
+        errors,
+    )
+    reject_terms(
+        ".claude/agents/levyra-android-developer.md",
+        ("Read `.claude/CLAUDE.md`",),
         errors,
     )
     require_terms(
@@ -144,7 +191,7 @@ def main() -> int:
             "command -v python",
             "command -v py",
             "Mandatory skill load",
-            "Root AGENTS.md is imported",
+            "Root AGENTS.md remains canonical",
             "EVIDENCE_GATED_COMPLETION.md",
             "levyra-project-manager",
             "levyra-desktop",
@@ -194,6 +241,8 @@ def main() -> int:
         (
             "jCodeMunch",
             "Claude native Read/Grep/Glob/Bash",
+            ".rtk/filters.toml",
+            "Rerun the exact command raw",
             "Token savings never override correctness",
         ),
         errors,
@@ -219,9 +268,9 @@ def main() -> int:
         return 1
 
     print(
-        "Claude bootstrap validation passed: canonical AGENTS import, mandatory "
-        "skill routing, project bridges, skill-listing budget, evidence-gated "
-        "completion, jCodeMunch startup/resume indexing, native-tool fallback, "
+        "Claude bootstrap validation passed: compact project context, automatic "
+        "skill routing, focused high-effort subagent tools, evidence-gated "
+        "completion, jCodeMunch startup/resume indexing, RTK/native-tool fallback, "
         "and permission safety verified."
     )
     return 0


### PR DESCRIPTION
## Summary

Reduce Claude Code token consumption when custom agents are used, without lowering model quality, reasoning effort, validation, or coding safeguards.

### What changed

- replace the previous always-loaded Claude imports with a compact project projection instead of preloading root `AGENTS.md` plus large AI guard documents into every custom subagent context
- keep root `AGENTS.md` canonical and the shared skill router authoritative, while loading detailed contracts/procedures only when the task actually needs them
- keep `model: inherit` and `effort: high` for implementation/review agents
- restrict `levyra-android-developer` to the coding tools it actually needs: `Read`, `Grep`, `Glob`, `Edit`, `Write`, `Bash`, and `Skill`
- stop custom agents from rereading `.claude/CLAUDE.md` as bootstrap because project instructions are already loaded automatically
- avoid spawning custom developer/reviewer agents ceremonially for tiny local changes; use the main agent for small fixes and built-in Explore for read-only discovery when sufficient
- lower `skillListingBudgetFraction` from 2% to 1%, cap per-skill listing descriptions at 768 characters, and disable duplicate built-in Git instruction/status context
- deduplicate scoped `AGENTS.md` and current-file hook injection by content hash during repeated edits
- retain fresh whole-file `Read` enforcement for `Write`
- invalidate mutation-context caches after compact/resume so stale context is never trusted
- shrink the always-loaded context-efficiency rule while preserving selective RTK/raw-output behavior
- update Claude bootstrap validation so CI now rejects a return to large `@` imports, a larger skill-listing budget, duplicate Git context, or an unfocused developer-agent tool surface

## Why

Claude Code custom subagents start with fresh context and load project instructions again. Levyra's previous Claude bootstrap imported large cross-runtime documents, while the mutation hook could also reinject unchanged scoped instructions/current files on repeated edits. That made agent-heavy coding unnecessarily expensive even though the underlying coding model and reasoning quality were unchanged.

Static project-instruction surface drops from roughly 56 KB to roughly 8 KB before task-specific procedures/tools, an estimated ~85% reduction in the fixed Levyra project-text payload per custom subagent. This is a static context estimate, not a billing/token-meter measurement.

The approach follows Claude Code progressive disclosure and the useful principle from `ChrisTitusTech/titus-ai`: keep permanent instructions small, route detailed procedures on demand, and use RTK only for large/repetitive output where filtering is sufficient. This PR does **not** install or depend on `titus-ai`.

## Regression coverage

- repeated edits do not reinject unchanged scoped instructions/current-file content
- external file changes force current context to be injected again
- compaction invalidates mutation-context caches
- whole-file replacement still requires a fresh full read and does not duplicate the already-read file into hook context
- Claude settings remain pinned to the compact 1% skill / 768-character description / no-duplicate-Git budget
- compact `CLAUDE.md` cannot silently regain the previous large `@` imports and is capped at 7000 bytes by tests/validator
- Android developer agent keeps `model: inherit`, `effort: high`, `Skill`, and the focused coding tool allowlist
- the prompt-router compatibility marker now truthfully states that root `AGENTS.md` remains canonical rather than claiming it is preloaded
- all existing automatic skill-routing and always-on guard tests remain in place

## Scope

10 AI/runtime configuration, harness, validator, and test files only. No Android/Desktop production code, application dependency, version, release, signing, or product behavior changes.

## Final commit

`48550724c1e43eb7d06d99ac08d72cc70a46262c` — `perf(ai): reduce Claude token overhead`

The branch is a single commit on top of the merge of #444. The AI Quality Gate passed on the equivalent pre-squash tree; the final SHA is now running the definitive PR checks. No merge/release is performed by this PR.