### PR TITLE
chore(ai): preserve Android memory stability

### DIFF
--- a/.agents/skills/levyra-player/SKILL.md
+++ b/.agents/skills/levyra-player/SKILL.md
@@ -19,7 +19,7 @@ Before editing, identify:
 - the exact playback defect or desired behavior;
 - ownership of every affected coroutine, callback, player, surface, decoder, and in-flight request;
 - behavior that must remain unchanged;
-- whether audio/song mode, native-video mode, queue state, background playback, notification, Android Auto, or lifecycle can be affected.
+- whether audio/song mode, native-video mode, queue state, background playback, notification, Android Auto, lifecycle, or memory behavior can be affected.
 
 ## Guardrails
 
@@ -31,8 +31,24 @@ Before editing, identify:
 - Do not fix races with arbitrary delays, broad retries, duplicated state, or silent exception swallowing.
 - Static artwork must remain the immediate fallback; decorative media must remain muted and independent from audible playback.
 
+## Playback memory invariant
+
+Issue #427 established that apparently small hot-path changes can create catastrophic native-memory growth even when Java heap behavior looks reasonable. Preserve the current stable-memory behavior as part of the playback contract.
+
+- Before adding work to a repeated playback/recommendation/DSP/prefetch callback, ask whether it allocates, compiles, decodes, copies, registers, retains, or grows state on every invocation.
+- Never compile `Regex`/`Pattern` or call `.toRegex()` inside repeated recommendation, metadata, playback-tick, frame, sample, or audio-buffer paths. Reuse immutable instances unless correctness requires otherwise and evidence proves the cost is bounded.
+- Avoid per-buffer/sample/frame object, array, `ByteBuffer`, string-formatting, parser, and collection allocation in DSP/audio hot paths. Reuse the existing buffers/processors where ownership allows.
+- Keep prefetch, resolver/recommendation bookkeeping, retry state, queue-side caches, and media-keyed maps bounded. Track cleanup across NEXT/PREV, replacement, cancellation, mode changes, service recreation, and end of queue.
+- Release obsolete player/controller/decoder/surface/listener/job resources at the owning lifecycle boundary. Do not let stale generations retain the old track graph after a transition.
+- Audio/song mode must not accidentally select or retain video tracks, video decoders, surfaces, or video-sized buffer pools. Native-video mode remains explicitly video-capable.
+- Do not use `System.gc()`, periodic player recycling, forced pause/resume, broad cache clearing, or service/process restart as a substitute for locating an allocation or retention source.
+- For a change that can materially affect playback/native/graphics memory, pair this skill with `levyra-android-performance` and validate the memory trend, not only a point-in-time heap value. Include native heap and process PSS/RSS when possible.
+- Stable acceptance means memory reaches a bounded plateau/oscillation after warm-up and normal track transitions rather than climbing monotonically with playback duration. Device-specific absolute MB values may differ.
+
 ## Validation
 
-Add or update focused regression coverage for relevant cases such as rapid track changes, cancellation, same-identity replacement, queue mutation, mode switching, background/foreground transitions, notification actions, and end-of-queue behavior.
+Add or update focused regression coverage for relevant cases such as rapid track changes, cancellation, same-identity replacement, queue mutation, mode switching, background/foreground transitions, notification actions, end-of-queue behavior, and bounded cache/lifecycle cleanup.
 
-Run focused tests first, then applicable checks from `AGENTS.md`. Report Android Auto, notification, PiP, emulator, physical-device, and real playback checks as unverified unless they were actually performed.
+When a change materially touches playback allocation, buffering, DSP, recommendations, prefetch, decoding, or resource lifetime, prefer a sustained physical-device playback run after warm-up with several normal track transitions. Target 20–30 minutes when practical and inspect native heap plus PSS/RSS; report this as `BLOCKED`/unverified if it cannot be performed rather than claiming memory stability from unit tests alone.
+
+Run focused tests first, then applicable checks from `AGENTS.md`. Report Android Auto, notification, PiP, emulator, physical-device, real playback, and memory-stability checks as unverified unless they were actually performed.

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -26,6 +26,22 @@ For Android Intent/deep-link/PendingIntent/component-boundary work, automaticall
 - Preserve synchronization among the audible player, MediaSession, notification, Android Auto, queue, and background service.
 - Keep optional enrichment behind direct playback in priority.
 
+## Memory regression guard
+
+The stability reached after issue #427 is a preserved product invariant. Any Android change that touches playback, recommendations, resolver/extractor loops, DSP/audio processors, Media3 track selection, prefetch, artwork/Canvas decoding, caches, buffering, coroutines/listeners, or other repeated hot paths must be reviewed for memory behavior before completion.
+
+- Treat continuously rising memory during steady playback as a regression until evidence explains and bounds it. A one-time warm-up peak or device-specific high RSS is not by itself proof of a leak; the trend matters.
+- Never compile `Regex`/`Pattern`, call `.toRegex()`, construct parsers, or create equivalent reusable matchers inside per-item, recommendation-candidate, polling, playback-tick, frame, sample, or audio-buffer loops. Hoist immutable/reusable instances or prove why reuse is unsafe. Issue #427 demonstrated that repeated regex compilation can create extreme native allocation churn even when the Java heap looks acceptable.
+- Avoid per-sample/per-buffer/per-frame allocations in DSP and playback callbacks. Reuse existing `ByteBuffer`, arrays, scratch buffers, processors, decoders, and immutable helpers when ownership permits; do not add copying merely for convenience.
+- Keep caches, prefetch sets, recommendation state, queues, histories, maps keyed by media IDs/URLs, decoded artwork, and retry bookkeeping explicitly bounded with eviction or lifecycle cleanup. No collection may grow with playback duration without a documented finite bound.
+- Cancel obsolete coroutines/jobs, unregister listeners/callbacks, close response bodies/files/cursors, and release Media3 players/controllers/decoders/surfaces only at the owning lifecycle boundary. Identity/generation checks must prevent stale work from retaining large graphs after track changes.
+- Song/audio-only mode must not keep a video decoder, video track, surface, or video-sized buffer pool alive unless that mode explicitly requires it. Preserve native-video mode separately rather than weakening it globally.
+- Do not introduce `System.gc()`, periodic player/service recycling, arbitrary pause/restart loops, cache purges, or process restarts as the primary fix for unexplained growth. Find and remove the allocation/retention source first; resilience guards may remain a fallback only when independently justified.
+- Artwork and Canvas work must avoid duplicate full-resolution bitmaps, unbounded animated-frame retention, and unnecessary intermediate render targets. Decode/retain only what the visible lifecycle needs.
+- A memory-sensitive change is not validated by Java/Kotlin heap inspection alone. When the task can affect native/media/graphics memory, inspect at least native heap plus process PSS/RSS (for example via `dumpsys meminfo`, Perfetto/heapprofd, or equivalent device profiling) and distinguish allocation churn from retention.
+- For materially memory-sensitive playback changes, prefer a sustained real-playback validation after warm-up with normal track transitions; 20–30 minutes on a physical device is the target when practical. Include screen/background transitions when the changed path remains active there. If this cannot be run, report the memory regression check as `BLOCKED`/unverified rather than claiming stability.
+- Acceptance is a stable plateau or bounded oscillation appropriate to the workload, with no persistent monotonic climb across track transitions. Do not hard-code one universal MB threshold across devices/OEMs.
+
 ## Compose and resources
 
 - Keep orchestration outside composables and observe the smallest stable state required by each screen.
@@ -67,4 +83,4 @@ For Android Intent/deep-link/PendingIntent/component-boundary work, automaticall
 
 Start with focused unit tests for the affected class or feature. Then run applicable checks from the root `AGENTS.md`.
 
-Manual playback, notification, Android Auto, PiP, emulator, device, background restriction, OEM behavior, visual polish, TalkBack, Intent/deep-link/component security, and measured UI-performance claims remain unverified unless directly tested and reported with evidence.
+Manual playback, notification, Android Auto, PiP, emulator, device, background restriction, OEM behavior, visual polish, TalkBack, Intent/deep-link/component security, memory stability, and measured UI-performance claims remain unverified unless directly tested and reported with evidence.

--- a/scripts/agent_skill_router.py
+++ b/scripts/agent_skill_router.py
@@ -60,8 +60,8 @@ ROUTES = (
     ),
     route(
         "levyra-android-performance",
-        "Android runtime profiling or measured performance",
-        r"perfetto|system trace|trace processor|frame miss|frame drop|jank|latency|latenza|startup|avvio lento|cpu schedul|thread state|runnable|blocked thread|binder wait|binder spam|binder storm|lock contention|renderthread|frame timeline|gpu memory|texture upload|memory pressure|memory leak|allocat|i/o stall|io stall|d-state|lmkd|psi|wakelock|power rail|power trace|battery trace|runtime performance|performance runtime|profiling android",
+        "Android runtime profiling, memory stability, or measured performance",
+        r"perfetto|system trace|trace processor|frame miss|frame drop|jank|latency|latenza|startup|avvio lento|cpu schedul|thread state|runnable|blocked thread|binder wait|binder spam|binder storm|lock contention|renderthread|frame timeline|gpu memory|texture upload|memory pressure|memory leak|memory growth|memory churn|native memory|native heap|\bram\b|\boom\b|out of memory|low memory|\bpss\b|\brss\b|dumpsys meminfo|heapprofd|bufferpool|bytebuffer|bitmap memory|allocat|i/o stall|io stall|d-state|lmkd|psi|wakelock|power rail|power trace|battery trace|runtime performance|performance runtime|profiling android",
     ),
     route(
         "levyra-r8-proguard",
@@ -131,6 +131,11 @@ AUTOMATED_MARKERS = (
     "<system-reminder",
 )
 
+MEMORY_RE = re.compile(
+    r"memory|\bram\b|\boom\b|out of memory|native heap|native allocat|memory churn|memory growth|\bpss\b|\brss\b|lmkd|dumpsys meminfo|heapprofd|bufferpool",
+    re.I,
+)
+
 
 def route_prompt(prompt: str) -> list[tuple[str, str]]:
     text = prompt.strip().lower()
@@ -151,6 +156,8 @@ def route_prompt(prompt: str) -> list[tuple[str, str]]:
 
     if "levyra-compose" in seen and "levyra-android-performance" in seen:
         add("levyra-real-engineering", "non-trivial Compose performance debugging")
+    if "levyra-android-performance" in seen and MEMORY_RE.search(text):
+        add("levyra-real-engineering", "memory-regression root-cause analysis and evidence")
     if "levyra-r8-proguard" in seen:
         add("levyra-release-check", "minified release validation")
     if "levyra-android-intent-security" in seen:

--- a/scripts/agent_skill_router.py
+++ b/scripts/agent_skill_router.py
@@ -132,7 +132,7 @@ AUTOMATED_MARKERS = (
 )
 
 MEMORY_RE = re.compile(
-    r"memory|\bram\b|\boom\b|out of memory|native heap|native allocat|memory churn|memory growth|\bpss\b|\brss\b|lmkd|dumpsys meminfo|heapprofd|bufferpool",
+    r"memory|\bram\b|\boom\b|out of memory|native heap|allocat|memory churn|memory growth|\bpss\b|\brss\b|lmkd|dumpsys meminfo|heapprofd|bufferpool",
     re.I,
 )
 
@@ -154,10 +154,17 @@ def route_prompt(prompt: str) -> list[tuple[str, str]]:
             matched.append((skill, topic))
             seen.add(skill)
 
+    def set_topic(skill: str, topic: str) -> None:
+        for index, (matched_skill, _) in enumerate(matched):
+            if matched_skill == skill:
+                matched[index] = (skill, topic)
+                return
+        add(skill, topic)
+
     if "levyra-compose" in seen and "levyra-android-performance" in seen:
         add("levyra-real-engineering", "non-trivial Compose performance debugging")
     if "levyra-android-performance" in seen and MEMORY_RE.search(text):
-        add("levyra-real-engineering", "memory-regression root-cause analysis and evidence")
+        set_topic("levyra-real-engineering", "memory-regression root-cause analysis and evidence")
     if "levyra-r8-proguard" in seen:
         add("levyra-release-check", "minified release validation")
     if "levyra-android-intent-security" in seen:

--- a/scripts/tests/test_claude_prompt_routing.py
+++ b/scripts/tests/test_claude_prompt_routing.py
@@ -91,13 +91,21 @@ class ClaudePromptRoutingTest(unittest.TestCase):
                 context = route(prompt)
                 self.assertIn("levyra-android-performance", context)
                 self.assertIn("levyra-real-engineering", context)
+                self.assertIn("memory-regression root-cause analysis and evidence", context)
 
-    def test_playback_memory_routes_player_too(self) -> None:
-        context = route("Player native allocations grow on every track change")
+    def test_playback_allocation_growth_routes_memory_analysis(self) -> None:
+        context = route("Player allocations grow on every track change")
 
         self.assertIn("levyra-player", context)
         self.assertIn("levyra-android-performance", context)
         self.assertIn("levyra-real-engineering", context)
+        self.assertIn("memory-regression root-cause analysis and evidence", context)
+
+    def test_memory_route_upgrades_existing_real_engineering_topic(self) -> None:
+        context = route("Root cause of native memory growth during playback")
+
+        self.assertIn("levyra-real-engineering", context)
+        self.assertIn("memory-regression root-cause analysis and evidence", context)
 
     def test_r8_adds_release_validation(self) -> None:
         context = route("R8 missing classes")

--- a/scripts/tests/test_claude_prompt_routing.py
+++ b/scripts/tests/test_claude_prompt_routing.py
@@ -78,6 +78,27 @@ class ClaudePromptRoutingTest(unittest.TestCase):
         self.assertIn("levyra-android-performance", context)
         self.assertIn("levyra-real-engineering", context)
 
+    def test_memory_terms_add_performance_and_real_engineering(self) -> None:
+        prompts = (
+            "RAM keeps climbing during playback",
+            "Investigate native memory growth",
+            "OOM after 20 minutes of music",
+            "Check PSS RSS and dumpsys meminfo",
+        )
+
+        for prompt in prompts:
+            with self.subTest(prompt=prompt):
+                context = route(prompt)
+                self.assertIn("levyra-android-performance", context)
+                self.assertIn("levyra-real-engineering", context)
+
+    def test_playback_memory_routes_player_too(self) -> None:
+        context = route("Player native allocations grow on every track change")
+
+        self.assertIn("levyra-player", context)
+        self.assertIn("levyra-android-performance", context)
+        self.assertIn("levyra-real-engineering", context)
+
     def test_r8_adds_release_validation(self) -> None:
         context = route("R8 missing classes")
 

--- a/scripts/tests/test_memory_guard_contract.py
+++ b/scripts/tests/test_memory_guard_contract.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class MemoryGuardContractTest(unittest.TestCase):
+    def test_android_memory_guard_is_scoped_and_concrete(self) -> None:
+        text = (ROOT / "app" / "AGENTS.md").read_text(encoding="utf-8")
+
+        for term in (
+            "Memory regression guard",
+            "issue #427",
+            "Regex",
+            ".toRegex()",
+            "native heap",
+            "PSS/RSS",
+            "20–30 minutes",
+            "monotonic climb",
+            "System.gc()",
+            "video decoder",
+        ):
+            with self.subTest(term=term):
+                self.assertIn(term, text)
+
+    def test_player_skill_preserves_memory_stability(self) -> None:
+        text = (
+            ROOT / ".agents" / "skills" / "levyra-player" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+
+        for term in (
+            "Playback memory invariant",
+            "Issue #427",
+            "Regex",
+            "ByteBuffer",
+            "bounded plateau",
+            "levyra-android-performance",
+            "native heap",
+            "PSS/RSS",
+        ):
+            with self.subTest(term=term):
+                self.assertIn(term, text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Make Levyra's post-#427 memory stability a permanent cross-runtime agent invariant so future Android/playback changes do not accidentally reintroduce runaway RAM/native-memory growth.

## What changed

- add an `app/AGENTS.md` memory regression guard that automatically applies to Android edits touching playback, recommendations, DSP/audio processing, Media3 track selection, prefetch, artwork/Canvas decoding, caches, buffering, lifecycle jobs/listeners, and repeated hot paths
- preserve the key #427 lesson: never repeatedly compile `Regex`/`Pattern`/`.toRegex()` in recommendation/playback/audio loops; hoist and reuse immutable matchers
- require bounded caches/prefetch/retry/media-keyed state and deterministic coroutine/listener/resource cleanup
- protect audio/song mode from accidentally retaining video decoders/tracks/surfaces/video-sized buffer pools while leaving native-video mode intact
- reject `System.gc()`, forced pause/restart loops, broad cache purges, periodic player/service recycling, or process restart as substitutes for finding the real allocation/retention source
- require memory-sensitive validation to inspect native heap plus process PSS/RSS, not Java heap alone
- define acceptance by a stable plateau/bounded oscillation after warm-up and normal track transitions, not one universal device-independent MB threshold
- target a 20–30 minute sustained physical-device playback run for materially memory-sensitive playback changes when practical; unavailable runs must be reported as BLOCKED/unverified
- extend the canonical `levyra-player` skill with the same playback-memory invariant
- extend the shared cross-runtime router so RAM/OOM/native-memory/PSS/RSS/heapprofd/dumpsys-meminfo prompts automatically load `levyra-android-performance` plus `levyra-real-engineering`; playback memory prompts also load `levyra-player`
- add regression tests locking both the routing behavior and the memory-guard contract

## Why

Issue #427 showed that an apparently small hot-path mistake could create severe native allocation churn while Java heap behavior remained misleadingly acceptable. One recommendation path was recompiling regex patterns thousands of times; after that source was fixed, Levyra-attributed native allocations in profiling dropped dramatically and playback became stable. The goal here is to keep that lesson encoded in the repository rather than relying on future agents to remember it.

## Scope

5 AI/rules/test files only. No Android production source, dependencies, version, signing, release, or runtime behavior changes.

## Commit

`92b83fb91ebfeecefded78dc223ed861c9e91738` — `chore(ai): preserve Android memory stability`

No merge or release is performed by this PR.