### PR TITLE
feat(ai): add skill intelligence layer

### DIFF
--- a/.agents/skills/levyra-pr-review/SKILL.md
+++ b/.agents/skills/levyra-pr-review/SKILL.md
@@ -23,6 +23,20 @@ A review does not require a pull request. When the handoff names a commit or bra
 5. If a PR is supplied, verify that its current head still matches the requested SHA before using PR comments or checks as current evidence.
 6. If the requested SHA cannot be resolved even after a bounded fetch, report that exact failure and the fetch/ref evidence. Do not replace it with a generic `diff not verified` conclusion.
 
+## Finding lifecycle
+
+Review findings are evidence objects, not permanent labels. Track each material candidate as one of:
+
+- `CANDIDATE`: plausible concern that still needs a concrete failure path;
+- `CONFIRMED`: current-head evidence establishes the triggering scenario and consequence;
+- `DISPROVED`: inspection/test/runtime evidence shows the concern does not apply;
+- `RETRACTED`: a previously reported/confirmed finding was invalidated by a later revision or stronger evidence;
+- `BLOCKED`: evidence needed to decide cannot currently be obtained.
+
+Do not carry a finding from an older SHA into the current review without revalidation. If a previously published finding no longer applies, explicitly retract it instead of leaving the thread/handoff to imply it is still active.
+
+A model suspicion, static pattern, warning, linter message, or stale review comment is not a confirmed defect until the current code has a concrete failure path.
+
 ## Local readiness loop
 
 When the task is to prepare implementation for publication or determine merge
@@ -50,6 +64,20 @@ target environment.
 Treat screenshots and direct user/runtime observations as acceptance evidence.
 A visible regression must be reconciled even when automation is green.
 
+## CI/test failure discipline
+
+When a check is red, classify it before recommending a code change or retry:
+
+- `PRODUCT_REGRESSION`;
+- `TEST_DEFECT`;
+- `ENVIRONMENT`/infrastructure;
+- `FLAKY`/intermittent with evidence of nondeterminism;
+- `UNKNOWN` pending more evidence.
+
+Do not repeatedly rerun the same failing check to manufacture a green status. A retry is useful only when it tests a concrete environment/flakiness hypothesis, and the original failure remains part of the review evidence. One passing retry does not by itself prove flakiness.
+
+For regression tests, prefer coverage of externally observable behavior or a durable contract. Avoid tests that freeze incidental implementation structure unless that structure is itself the contract being protected.
+
 ## Review priorities
 
 Check, as applicable:
@@ -66,8 +94,9 @@ Check, as applicable:
 
 ## Output format
 
-Put findings before the summary and order them by severity. Each finding must include:
+Put confirmed findings before the summary and order them by severity. Each reported finding must include:
 
+- evidence state and current-head SHA/revision context;
 - severity and confidence;
 - exact file/line or symbol;
 - triggering scenario;
@@ -75,4 +104,16 @@ Put findings before the summary and order them by severity. Each finding must in
 - smallest compatible fix;
 - missing regression coverage.
 
-Do not report speculative findings without a concrete failure path. Finish with validation observed, validation missing, manual-test state, latest-head evidence when relevant, and remaining blockers.
+Do not report speculative findings without a concrete failure path. Keep disproved/retracted items out of the active findings list, but state retractions when they correct something previously reported. Finish with validation observed, validation missing, manual-test state, latest-head evidence when relevant, and remaining blockers.
+
+## Evidence hygiene
+
+Before placing logs, screenshots, HARs, request/response excerpts, CI output, or stack traces in a durable/public review artifact, apply the compact evidence-hygiene rules in `docs/ai/SKILL_INTELLIGENCE.md`: redact secrets, tokens, cookies, signed/private URLs, account identifiers, and unrelated PII while preserving the minimum structure needed to reproduce the finding. Load `levyra-security-review` only when the diff or finding is actually security-sensitive.
+
+## Skill-intelligence discipline
+
+Use `docs/ai/SKILL_INTELLIGENCE.md` when changing review/debugging skill coverage. Prefer strengthening this existing owner over installing a broad review catalog. Route/evaluation changes need positive and near-miss coverage and must not increase context cost without a material review benefit.
+
+## Provenance
+
+The failure-classification and review-discipline refinements are selectively informed by `Jeffallan/claude-skills`; the explicit finding/retraction discipline is informed by `elementalsouls/Claude-BugHunter`. They are rewritten for Levyra and remain subordinate to current code, tests, repository rules, and safe evidence.

--- a/.agents/skills/levyra-real-engineering/SKILL.md
+++ b/.agents/skills/levyra-real-engineering/SKILL.md
@@ -70,20 +70,42 @@ Implement one ticket or one reviewable phase at a time.
 - Read applicable Levyra domain skills before editing.
 - For defects, establish a concrete failing path first; use `diagnosing-bugs` when root cause is unclear.
 - Prefer red -> green -> refactor where deterministic tests are useful.
+- Test externally observable behavior and durable contracts rather than incidental implementation details when possible.
 - Do not force artificial tests around trivial declarative changes.
 - Make the smallest coherent change and avoid unrelated cleanup.
 
 #### Hypothesis-driven debugging
 
+Use this closed loop:
+
+```text
+reproduce -> isolate -> hypothesis -> smallest experiment -> fix -> prevent
+```
+
 1. Reproduce/capture the failing path and complete relevant evidence.
 2. Trace the bad state/value backward to the first failed assumption or contract.
 3. Compare with a nearby working path when available.
 4. State one concrete root-cause hypothesis and supporting evidence.
-5. Test it with the smallest experiment/change.
-6. If it fails, discard the speculative change and form a new hypothesis.
-7. Once supported, add the smallest deterministic regression evidence, fix, and rerun relevant broader checks.
+5. Test it with the smallest experiment/change; do not stack several speculative changes into one experiment.
+6. If it fails, revert/discard the speculative change, mark the hypothesis `DISPROVED`, and stop using it downstream.
+7. Once supported, add the smallest deterministic regression evidence, apply the root-cause fix, and rerun relevant broader checks.
+8. Prevent recurrence with the narrowest useful test, invariant, validator, or ownership clarification; do not create generic infrastructure for a one-off mistake.
 
-After three materially different failed hypotheses, reassess the ownership boundary instead of stacking more guesses.
+Keep the current hypothesis state explicit when the investigation is long: `CANDIDATE`, `SUPPORTED`, `VALIDATED`, or `DISPROVED`. If later evidence invalidates a previously supported conclusion, retract it explicitly rather than silently leaving old reasoning in handoffs, comments, or review summaries.
+
+After three materially different failed hypotheses, reassess the ownership boundary and reproduction evidence instead of stacking more guesses.
+
+#### Test and check failure classification
+
+Before reacting to a failed test/build/lint/runtime check, classify the failure using the best available evidence:
+
+- `PRODUCT_REGRESSION`: the implementation violates the expected behavior;
+- `TEST_DEFECT`: the test/fixture/assertion is stale or incorrect;
+- `ENVIRONMENT`: tooling, network, service, device, permission, or CI infrastructure prevented a valid result;
+- `FLAKY`: the same code/input/environment can legitimately produce intermittent pass/fail behavior and there is evidence of nondeterminism;
+- `UNKNOWN`: evidence is insufficient to classify yet.
+
+Do not rerun an unchanged failing command repeatedly to fish for a green result. A retry is evidence only when it tests an environment/flakiness hypothesis; preserve the original failure and compare both runs. Never relabel a failure as flaky merely because a retry passed once.
 
 ### 6. Mandatory pre-delivery review: `code-review`
 
@@ -123,10 +145,15 @@ If the external package is unavailable, follow this Levyra adapter rather than b
 
 - Keep the current ticket/phase small enough to review.
 - Prefer fresh context between independent tickets and an independent context for final review when supported.
-- Carry forward only the approved spec/ticket, relevant architecture/invariants, exact changed files or diff/commit, direct validation evidence, and unresolved blockers.
+- Carry forward only the approved spec/ticket, relevant architecture/invariants, exact changed files or diff/commit, direct validation evidence, current hypothesis/finding state, and unresolved blockers.
+- Do not carry a disproved hypothesis or stale finding into a fresh context as an unresolved fact.
 - Prefer durable existing artifacts over duplicate memory/recap documents.
 - When a session must compact/restart, summarize verified facts and open decisions, not exploratory chatter or superseded hypotheses.
 - Current repository evidence overrides remembered conversation context or older handoffs.
+
+## Skill-intelligence discipline
+
+When an external skill or catalog is proposed as an improvement, follow `docs/ai/SKILL_INTELLIGENCE.md`. Prefer adapting a useful method into the existing owner skill over adding another always-discoverable skill. Route changes require positive and near-miss evaluation, and increased token/tool cost must buy a material improvement in correctness, validation, review quality, or scope control.
 
 ## Publication and quality gates
 
@@ -143,3 +170,7 @@ python3 scripts/ai_quality_gate.py --profile full
 ```
 
 Commit, push, pull request, merge, tag, release, deployment, version changes, and repository settings remain owner-controlled exactly as defined by `AGENTS.md`.
+
+## Provenance
+
+The debugging/test refinements are selectively informed by the reproduce/isolate/hypothesis/prevention discipline in `Jeffallan/claude-skills`. They are rewritten for Levyra and do not import that catalog's generic toolchain assumptions or skill inventory.

--- a/.agents/skills/levyra-security-review/SKILL.md
+++ b/.agents/skills/levyra-security-review/SKILL.md
@@ -15,7 +15,22 @@ description: Perform an evidence-based Levyra security review and Codex Security
    persistence, signing, release, update, and GitHub workflow configuration.
 4. Load `levyra-context-efficiency` only for noisy non-sensitive output. Keep
    exploit evidence, security validation, signatures, checksums, secrets scans,
-   and exact reproduction output raw.
+   and exact reproduction output raw inside the trusted working context.
+
+## Finding lifecycle
+
+Every security candidate has an explicit evidence state:
+
+- `SUSPECTED`: a static pattern, warning, model observation, or incomplete path;
+- `SUPPORTED`: evidence is consistent with the finding but exploit/failure impact is not fully established;
+- `VALIDATED`: a concrete safe reproduction or equivalent evidence establishes the path and consequence;
+- `DISPROVED`: evidence shows the candidate does not represent the claimed failure;
+- `RETRACTED`: a previously reported/supported finding has been explicitly withdrawn after newer evidence invalidated it;
+- `BLOCKED`: decisive validation cannot be completed safely or with the available environment.
+
+Do not silently drop a finding that was previously presented as real. If later evidence disproves it, mark it `RETRACTED`, state what new evidence changed the conclusion, and remove it from downstream remediation/severity decisions.
+
+A warning, HTTP status, scanner hit, lint message, dependency advisory, or source-code pattern is not by itself a validated vulnerability.
 
 ## Closed-loop security method
 
@@ -45,7 +60,9 @@ concrete path, trigger, and consequence.
 Attempt to reproduce the issue safely in an isolated or controlled environment.
 A suspected issue remains unconfirmed until evidence supports exploitability or
 a concrete security failure. Preserve the exact command, input, output, exit
-status, and relevant artifact or test result.
+status, and relevant artifact or test result in the trusted working context.
+
+Before calling the candidate validated, challenge at least one plausible benign or non-exploitable explanation when one exists: expected authorization, input normalization, validation order, unreachable code, environment-only behavior, stale dependency metadata, or an already-enforced boundary. The purpose is to kill false positives, not to add ceremony when the failure path is already directly proven.
 
 Never run destructive, persistence, credential-theft, external-target, or
 production-impacting proof-of-concept activity. Use minimal local fixtures and
@@ -69,6 +86,20 @@ owner control.
 After remediation, rerun the original safe reproduction or equivalent
 regression test. State whether the attack path is closed, which checks passed,
 which checks were blocked, and what residual risk remains.
+
+## Evidence hygiene
+
+Raw security evidence may contain more sensitive material than the finding itself. Before an artifact, excerpt, screenshot, HAR, log, request/response pair, stack trace, or command output is placed in a PR, issue, review comment, public report, or other durable shared location:
+
+- redact bearer/access/refresh tokens, cookies, authorization headers, API keys, passwords, signing material, private keys, and session identifiers;
+- redact unrelated PII and account identifiers; use synthetic values when the exact value is not material;
+- redact private/local provider URLs or signed URLs when disclosure would expose credentials, infrastructure, or user data;
+- preserve the evidence shape needed for review: status code, method, route shape, request ID, timestamp, non-sensitive headers, hash/checksum, error class, and minimal payload structure;
+- prefer placeholders such as `<redacted-token>` over deleting fields when field presence is relevant;
+- never "sanitize" by changing the behavior being demonstrated;
+- if redaction would destroy the proof, state that the sensitive artifact was withheld and describe the reproducible non-sensitive facts instead of publishing it raw.
+
+Do not rely on a later reviewer to notice secrets after publication. Hygiene happens before evidence leaves the trusted working context.
 
 ## Review areas
 
@@ -105,12 +136,14 @@ validation, or manual approval.
 
 Report only evidence-backed findings. Every finding must include:
 
+- evidence state (`SUSPECTED`, `SUPPORTED`, `VALIDATED`, `DISPROVED`, `RETRACTED`, or `BLOCKED`);
 - severity and confidence;
 - exact file and line or symbol;
 - attacker-controlled input or triggering condition;
 - trust boundary crossed;
 - concrete exploit or failure path;
 - validation or reproduction evidence;
+- relevant alternative explanation checked when material;
 - user/system consequence;
 - smallest compatible fix;
 - regression test or revalidation needed;
@@ -118,3 +151,11 @@ Report only evidence-backed findings. Every finding must include:
 
 Do not report generic best-practice observations without a concrete path to
 harm. Do not label an unvalidated suspicion as confirmed.
+
+## Skill-intelligence discipline
+
+Use `docs/ai/SKILL_INTELLIGENCE.md` when considering external security catalogs. Do not vendor broad offensive bundles into Levyra merely to obtain validation or reporting techniques. Import only narrow, defensive, evidence-based methods that preserve the repository's authorization and safety boundaries.
+
+## Provenance
+
+The finding-state, explicit-retraction, false-positive challenge, and evidence-hygiene refinements are selectively informed by `elementalsouls/Claude-BugHunter`'s validation/reporting discipline. No offensive payload catalog, target-hunting workflow, credential-capture behavior, or authorization assumption is imported into Levyra.

--- a/docs/ai/SKILL_INTELLIGENCE.md
+++ b/docs/ai/SKILL_INTELLIGENCE.md
@@ -1,0 +1,82 @@
+# Levyra Skill Intelligence
+
+Levyra does not improve its coding agents by installing every available skill catalog. The goal is higher correctness per unit of context: the smallest set of skills that materially improves implementation, debugging, review, validation, or safety.
+
+## Intake rule
+
+Before adopting an external skill, plugin, agent, or workflow:
+
+1. Map the useful behavior to an existing Levyra owner skill whenever possible.
+2. Prefer rewriting a small Levyra-native rule over adding a new always-discoverable skill.
+3. Keep detailed references and scripts on demand rather than in always-loaded instructions.
+4. Do not install a large catalog merely because some entries are useful.
+5. Reject duplicate abstractions, parallel project rules, and external toolchain assumptions that conflict with Levyra.
+6. Preserve the current Claude context budget and automatic routing guarantees.
+
+A new standalone skill is justified only when it owns a distinct recurring task that cannot be represented cleanly by an existing Levyra skill.
+
+## Routing evaluation
+
+Run:
+
+```bash
+python3 scripts/evaluate_skill_routing.py
+```
+
+The evaluator uses deterministic repository-local cases. It does not call Claude, another model, or an external API in CI.
+
+Each case can assert:
+
+- required skills that must trigger;
+- forbidden skills that must not trigger;
+- a maximum selected-skill count;
+- a maximum additional-context byte budget.
+
+The corpus must include ordinary positive examples, difficult near-misses, and collision cases. A new route is incomplete until at least one realistic positive case and one plausible near-miss are covered.
+
+Infrastructure or evaluator errors are `ERROR`, never a successful negative trigger. Do not turn a timeout, subprocess failure, unavailable model, or parser failure into evidence that a skill correctly stayed inactive.
+
+## Model-assisted benchmarks
+
+When changing a substantial skill body or considering a new third-party skill, a model-assisted benchmark may be useful outside deterministic CI. Compare representative tasks with the candidate guidance against the existing Levyra baseline and record, when observable:
+
+- correctness and acceptance-criteria coverage;
+- focused tests/validation passed;
+- regression or review findings;
+- files/symbols changed and unrelated churn;
+- prompt/context tokens;
+- wall-clock/tool-call cost;
+- whether the skill triggered on the intended tasks and stayed quiet on near-misses.
+
+A candidate that materially increases token or tool cost without improving correctness, scope discipline, validation, or review quality should not be adopted.
+
+## Debugging and test discipline
+
+For non-trivial defects, `levyra-real-engineering` owns the workflow:
+
+```text
+reproduce -> isolate -> hypothesis -> smallest experiment -> fix -> prevent
+```
+
+Classify a failing test/check before reacting to it: product regression, test defect, environment/infrastructure, flaky/intermittent, or unknown. Do not rerun an unchanged command repeatedly to fish for green output.
+
+Hypotheses and findings have lifecycle. When evidence disproves a hypothesis, retract it explicitly and stop using it downstream. New evidence beats an older agent handoff or previous review comment.
+
+## Finding confidence and evidence hygiene
+
+`levyra-security-review` and `levyra-pr-review` distinguish suspected findings from validated findings. A warning, status code, static pattern, linter message, or model suspicion is not enough by itself.
+
+Before evidence leaves the local/private working context, redact or replace secrets, bearer tokens, cookies, signed URLs, private endpoints, account identifiers, and unrelated PII. Preserve the structure needed to reproduce the finding: status codes, request IDs, hashes, timestamps, relevant headers with sensitive values replaced, and minimal synthetic fixtures.
+
+If sanitization would destroy the evidence, report that the sensitive artifact was withheld instead of publishing it raw.
+
+## Source material
+
+This policy selectively adapts useful ideas from:
+
+- `anthropics/skills`: progressive disclosure and trigger/evaluation discipline;
+- `Jeffallan/claude-skills`: hypothesis-driven debugging and test/review discipline;
+- `elementalsouls/Claude-BugHunter`: validation gates, explicit retraction, and evidence hygiene;
+- `ChrisTitusTech/titus-ai`: selective output compression and minimal always-loaded guidance.
+
+No external catalog is vendored or made authoritative. Levyra's repository rules, architecture, tests, owner decisions, and direct evidence always take precedence.

--- a/scripts/agent_skill_router.py
+++ b/scripts/agent_skill_router.py
@@ -36,7 +36,7 @@ ROUTES = (
     route(
         "levyra-real-engineering",
         "non-trivial engineering, debugging, requirements, or architecture",
-        r"new feature|nuova funzionalit|architecture|architett|refactor|riprogett|redesign|\bspec\b|specifica|roadmap|multi.?step|cross.?domain|pi[uù].*modul|across.*module|grill-with-docs|wayfinder|to-spec|to-tickets|\bbug\b|regression|regressione|test failure|test fallit|build failure|build fallit|unexpected behavior|comportamento inaspett|\bcrash\b|race condition|concurrency bug|root cause|causa radice",
+        r"new feature|nuova funzionalit|architecture|architett|refactor|riprogett|redesign|\bspec\b|specifica|roadmap|multi.?step|cross.?domain|pi[uù].*modul|across.*module|grill-with-docs|wayfinder|to-spec|to-tickets|\bbug\b|debug|diagnos|regression|regressione|test failure|test fallit|build failure|build fallit|unexpected behavior|comportamento inaspett|\bcrash\b|race condition|concurrency bug|root cause|causa radice",
     ),
     route(
         "levyra-player",
@@ -46,7 +46,7 @@ ROUTES = (
     route(
         "levyra-extractor",
         "stream extraction or network fallback",
-        r"extractor|estrattor|innertube|newpipe|youtube|stream|resolver|player.?config|\btoken\b|scraping|403|throttl",
+        r"extractor|estrattor|innertube|newpipe|youtube|stream|resolver|player.?config|(?:youtube|innertube|player|po)[ -]?token|potoken|visitor data|scraping|403|throttl",
     ),
     route(
         "levyra-database",
@@ -56,7 +56,7 @@ ROUTES = (
     route(
         "levyra-compose",
         "Android Compose UI, accessibility, lifecycle, or state projection",
-        r"compose|composable|\bui\b|screen|schermat|theme|\btema\b|layout|recomposition|ricompos|scroll|layout inspector|talkback|semantics|semantic|touch target|accessibilit|rtl|localizzazion|localization|string resource",
+        r"compose|composable|\bui\b|\bscreen\b|schermat|theme|\btema\b|layout|recomposition|ricompos|scroll|layout inspector|talkback|\bsemantics\b|touch target|accessibilit|rtl|localizzazion|localization|string resource",
     ),
     route(
         "levyra-android-performance",
@@ -76,7 +76,7 @@ ROUTES = (
     route(
         "levyra-design-taste",
         "visual design, redesign, polish, hierarchy, or anti-AI-slop UI",
-        r"visual design|ui design|design ui|grafica|interfaccia|ui polish|visual polish|gerarchia visual|visual hierarchy|spacing|spaziatur|typograph|tipograf|color palette|palette colori|shape|forme|radius|corner radius|motion ui|ui motion|animazion|screenshot|design reference|ui reference|riferiment.*(?:grafica|ui|schermat)|pi[uù] bella|pi[uù] professionale|(?:\bscreen\b|schermat\w*|\bui\b|\bdesign\b|grafica|interfaccia|\blayout\b|\bplayer\b|\bhome\b|\bnow playing\b).{0,40}\b(?:premium|modern|clean|cinematic|less generic)\b|\b(?:premium|modern|clean|cinematic|less generic)\b.{0,40}(?:\bscreen\b|schermat\w*|\bui\b|\bdesign\b|grafica|interfaccia|\blayout\b|\bplayer\b|\bhome\b|\bnow playing\b)|^\s*(?:premium|modern|clean|cinematic|less generic)\s*[.!?]*\s*$|anti.?ai.?slop|glassmorphism|bento",
+        r"visual design|ui design|design ui|grafica|interfaccia|ui polish|visual polish|gerarchia visual|visual hierarchy|spacing|spaziatur|typograph|tipograf|color palette|palette colori|shape|forme|radius|corner radius|motion ui|ui motion|animazion|design reference|ui reference|riferiment.*(?:grafica|ui|schermat)|(?:ui|screen|schermat|layout|design|grafica|interfaccia).{0,30}screenshot|screenshot.{0,30}(?:ui|screen|schermat|layout|design|grafica|interfaccia|reference|riferimento)|pi[uù] bella|pi[uù] professionale|(?:\bscreen\b|schermat\w*|\bui\b|\bdesign\b|grafica|interfaccia|\blayout\b|\bplayer\b|\bhome\b|\bnow playing\b).{0,40}\b(?:premium|modern|clean|cinematic|less generic)\b|\b(?:premium|modern|clean|cinematic|less generic)\b.{0,40}(?:\bscreen\b|schermat\w*|\bui\b|\bdesign\b|grafica|interfaccia|\blayout\b|\bplayer\b|\bhome\b|\bnow playing\b)|^\s*(?:premium|modern|clean|cinematic|less generic)\s*[.!?]*\s*$|anti.?ai.?slop|glassmorphism|bento",
     ),
     route(
         "levyra-motion-artwork",
@@ -91,7 +91,7 @@ ROUTES = (
     route(
         "levyra-ci-workflows",
         "CI, Gradle/Kotlin tooling, or build performance",
-        r"github actions|\bworkflow\b|\bci\b|fdroid|f-droid|\bgradle\b|\bagp\b|\bkotlin\b|\bksp\b|build performance|slow build|build lento|configuration cache|build cache|compile time|compilation time|build logic|gradle\.properties|artifact",
+        r"github actions|\bworkflow\b|\bci\b|fdroid|f-droid|\bgradle\b|\bagp\b|\bksp\b|kotlin(?: compiler| plugin| toolchain| version)|(?:upgrade|update|bump|migrat).{0,24}\bkotlin\b|\bkotlin\b.{0,24}(?:gradle|compiler|ksp|toolchain)|build performance|slow build|build lento|configuration cache|build cache|compile time|compilation time|build logic|gradle\.properties|artifact",
     ),
     route(
         "levyra-context-efficiency",
@@ -111,7 +111,7 @@ ROUTES = (
     route(
         "levyra-release-check",
         "runtime, pre-merge, or release validation",
-        r"release|rilasci|versionname|versioncode|\bversion\b|versione|\bapk\b|signing|firma|tag\b|publish|pubblic|emulator|emulatore|physical device|device test|test dispositivo|\badb\b|connectedcheck|smoke test|runtime verification|runtime validation|verifica runtime|pre.?merge",
+        r"release|rilasci|versionname|versioncode|app version|release version|versione (?:app|release)|\bapk\b|signing|firma|tag\b|publish|pubblic|emulator|emulatore|physical device|device test|test dispositivo|\badb\b|connectedcheck|smoke test|runtime verification|runtime validation|verifica runtime|pre.?merge",
     ),
     route(
         "levyra-engineering",

--- a/scripts/evaluate_skill_routing.py
+++ b/scripts/evaluate_skill_routing.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import Iterable
+
+try:
+    from scripts.agent_skill_router import context_for, route_prompt
+except ModuleNotFoundError:
+    from agent_skill_router import context_for, route_prompt
+
+
+@dataclass(frozen=True)
+class EvalCase:
+    name: str
+    prompt: str
+    required: tuple[str, ...] = ()
+    forbidden: tuple[str, ...] = ()
+    max_skills: int = 6
+    max_context_bytes: int = 4096
+
+
+@dataclass(frozen=True)
+class EvalResult:
+    name: str
+    status: str
+    prompt: str
+    selected: tuple[str, ...]
+    missing: tuple[str, ...]
+    forbidden_selected: tuple[str, ...]
+    context_bytes: int
+    max_skills: int
+    max_context_bytes: int
+    error: str | None = None
+
+
+CASES = (
+    EvalCase(
+        "playback-crash",
+        "Fix a playback crash when skipping tracks",
+        required=("levyra-real-engineering", "levyra-player"),
+        forbidden=("levyra-design-taste", "levyra-android-reverse-engineering"),
+        max_skills=3,
+    ),
+    EvalCase(
+        "compose-jank",
+        "Compose jank while scrolling the album screen",
+        required=(
+            "levyra-compose",
+            "levyra-android-performance",
+            "levyra-real-engineering",
+        ),
+        forbidden=("levyra-design-taste",),
+        max_skills=3,
+    ),
+    EvalCase(
+        "compose-semantics",
+        "Fix Compose semantics for TalkBack",
+        required=("levyra-compose",),
+        forbidden=("levyra-release-check",),
+        max_skills=1,
+    ),
+    EvalCase(
+        "pending-intent-security",
+        "Audit mutable PendingIntent handling",
+        required=("levyra-android-intent-security", "levyra-security-review"),
+        max_skills=2,
+    ),
+    EvalCase(
+        "reverse-r8",
+        "Decompile this APK and recover Kotlin R8 metadata",
+        required=(
+            "levyra-android-reverse-engineering",
+            "levyra-r8-proguard",
+            "levyra-security-review",
+            "levyra-release-check",
+        ),
+        max_skills=5,
+    ),
+    EvalCase(
+        "normal-release-apk",
+        "Build and validate the release APK",
+        required=("levyra-release-check", "levyra-context-efficiency"),
+        forbidden=("levyra-android-reverse-engineering",),
+        max_skills=2,
+    ),
+    EvalCase(
+        "visual-premium",
+        "Make the Now Playing screen more premium",
+        required=("levyra-design-taste", "levyra-compose"),
+        forbidden=("levyra-ci-workflows",),
+        max_skills=2,
+    ),
+    EvalCase(
+        "design-near-miss-kotlin",
+        "Upgrade to a modern Kotlin compiler version",
+        required=("levyra-ci-workflows",),
+        forbidden=("levyra-design-taste", "levyra-release-check"),
+        max_skills=2,
+    ),
+    EvalCase(
+        "design-near-miss-gradle",
+        "Clean Gradle build outputs",
+        required=("levyra-ci-workflows", "levyra-context-efficiency"),
+        forbidden=("levyra-design-taste",),
+        max_skills=2,
+    ),
+    EvalCase(
+        "design-near-miss-subscription",
+        "Integrate a premium subscription API",
+        forbidden=("levyra-design-taste",),
+        max_skills=1,
+    ),
+    EvalCase(
+        "design-near-miss-screenshot",
+        "Inspect this screenshot of a CI stack trace",
+        required=("levyra-context-efficiency",),
+        forbidden=("levyra-design-taste", "levyra-compose"),
+        max_skills=3,
+    ),
+    EvalCase(
+        "extractor-near-miss-agent-token",
+        "Reduce Claude token usage in the coding agents",
+        forbidden=("levyra-extractor",),
+        max_skills=2,
+    ),
+    EvalCase(
+        "extractor-player-token",
+        "Investigate an InnerTube player token failure",
+        required=("levyra-extractor", "levyra-player"),
+        max_skills=3,
+    ),
+    EvalCase(
+        "plain-kotlin-question",
+        "Explain Kotlin sealed classes",
+        forbidden=("levyra-ci-workflows", "levyra-release-check"),
+        max_skills=1,
+    ),
+    EvalCase(
+        "semantic-version-near-miss",
+        "Prepare a semantic version release",
+        required=("levyra-release-check",),
+        forbidden=("levyra-compose",),
+        max_skills=1,
+    ),
+    EvalCase(
+        "debugging-route",
+        "Debug an intermittent queue state corruption",
+        required=("levyra-real-engineering", "levyra-player"),
+        max_skills=3,
+    ),
+    EvalCase(
+        "project-manager",
+        "Update roadmap acceptance criteria for the active phase",
+        required=("levyra-project-manager", "levyra-real-engineering"),
+        max_skills=2,
+    ),
+    EvalCase(
+        "openclaw-handoff",
+        "Delegate this Levyra fix through OpenClaw",
+        required=(
+            "levyra-openclaw-orchestrator",
+            "levyra-context-efficiency",
+            "levyra-project-manager",
+        ),
+        max_skills=3,
+    ),
+    EvalCase(
+        "cross-domain",
+        "Investigate a cross-domain architecture issue across subsystems",
+        required=(
+            "levyra-real-engineering",
+            "levyra-context-efficiency",
+            "levyra-engineering",
+        ),
+        max_skills=3,
+    ),
+    EvalCase(
+        "security-review",
+        "Review this code for a concrete security vulnerability",
+        required=("levyra-security-review", "levyra-pr-review"),
+        max_skills=2,
+    ),
+)
+
+
+def evaluate_case(case: EvalCase) -> EvalResult:
+    try:
+        selected = tuple(skill for skill, _ in route_prompt(case.prompt))
+        context_bytes = len(context_for(case.prompt).encode("utf-8"))
+    except Exception as exc:
+        return EvalResult(
+            name=case.name,
+            status="ERROR",
+            prompt=case.prompt,
+            selected=(),
+            missing=case.required,
+            forbidden_selected=(),
+            context_bytes=0,
+            max_skills=case.max_skills,
+            max_context_bytes=case.max_context_bytes,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+    selected_set = set(selected)
+    missing = tuple(skill for skill in case.required if skill not in selected_set)
+    forbidden_selected = tuple(
+        skill for skill in case.forbidden if skill in selected_set
+    )
+    over_budget = len(selected) > case.max_skills or context_bytes > case.max_context_bytes
+    duplicates = len(selected) != len(selected_set)
+    status = "PASS" if not (missing or forbidden_selected or over_budget or duplicates) else "FAIL"
+
+    return EvalResult(
+        name=case.name,
+        status=status,
+        prompt=case.prompt,
+        selected=selected,
+        missing=missing,
+        forbidden_selected=forbidden_selected,
+        context_bytes=context_bytes,
+        max_skills=case.max_skills,
+        max_context_bytes=case.max_context_bytes,
+    )
+
+
+def evaluate_all(cases: Iterable[EvalCase] = CASES) -> tuple[EvalResult, ...]:
+    return tuple(evaluate_case(case) for case in cases)
+
+
+def summary(results: Iterable[EvalResult]) -> dict[str, float | int]:
+    items = tuple(results)
+    passed = sum(result.status == "PASS" for result in items)
+    failed = sum(result.status == "FAIL" for result in items)
+    errors = sum(result.status == "ERROR" for result in items)
+    context_values = [result.context_bytes for result in items if result.status != "ERROR"]
+    return {
+        "total": len(items),
+        "passed": passed,
+        "failed": failed,
+        "errors": errors,
+        "avg_context_bytes": round(sum(context_values) / len(context_values), 2)
+        if context_values
+        else 0,
+        "max_context_bytes": max(context_values, default=0),
+    }
+
+
+def main() -> int:
+    results = evaluate_all()
+    payload = {
+        "summary": summary(results),
+        "results": [asdict(result) for result in results],
+    }
+    print(json.dumps(payload, indent=2))
+    return 0 if all(result.status == "PASS" for result in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_skill_intelligence.py
+++ b/scripts/tests/test_skill_intelligence.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.evaluate_skill_routing import CASES, evaluate_all, summary
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class SkillIntelligenceTest(unittest.TestCase):
+    def test_routing_eval_corpus_passes_without_errors(self) -> None:
+        results = evaluate_all()
+        failures = [result for result in results if result.status != "PASS"]
+
+        self.assertFalse(
+            failures,
+            "skill routing eval failures:\n"
+            + "\n".join(
+                f"{result.name}: status={result.status} selected={result.selected} "
+                f"missing={result.missing} forbidden={result.forbidden_selected} "
+                f"error={result.error}"
+                for result in failures
+            ),
+        )
+
+        stats = summary(results)
+        self.assertEqual(len(CASES), stats["passed"])
+        self.assertEqual(0, stats["failed"])
+        self.assertEqual(0, stats["errors"])
+        self.assertLessEqual(stats["max_context_bytes"], 4096)
+
+    def test_eval_corpus_contains_near_miss_and_collision_coverage(self) -> None:
+        names = {case.name for case in CASES}
+        for required_name in (
+            "design-near-miss-kotlin",
+            "design-near-miss-gradle",
+            "design-near-miss-subscription",
+            "design-near-miss-screenshot",
+            "extractor-near-miss-agent-token",
+            "normal-release-apk",
+            "plain-kotlin-question",
+            "semantic-version-near-miss",
+            "compose-semantics",
+        ):
+            with self.subTest(required_name=required_name):
+                self.assertIn(required_name, names)
+
+        for case in CASES:
+            with self.subTest(case=case.name):
+                self.assertGreater(case.max_skills, 0)
+                self.assertLessEqual(case.max_context_bytes, 4096)
+
+    def test_real_engineering_has_failure_and_retraction_discipline(self) -> None:
+        text = (
+            ROOT / ".agents" / "skills" / "levyra-real-engineering" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+
+        for term in (
+            "reproduce -> isolate -> hypothesis -> smallest experiment -> fix -> prevent",
+            "PRODUCT_REGRESSION",
+            "TEST_DEFECT",
+            "ENVIRONMENT",
+            "FLAKY",
+            "DISPROVED",
+            "retract it explicitly",
+            "Do not rerun an unchanged failing command repeatedly to fish for a green result",
+            "docs/ai/SKILL_INTELLIGENCE.md",
+        ):
+            with self.subTest(term=term):
+                self.assertIn(term, text)
+
+    def test_security_review_has_finding_states_and_evidence_hygiene(self) -> None:
+        text = (
+            ROOT / ".agents" / "skills" / "levyra-security-review" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+
+        for term in (
+            "## Finding lifecycle",
+            "SUSPECTED",
+            "VALIDATED",
+            "DISPROVED",
+            "RETRACTED",
+            "## Evidence hygiene",
+            "<redacted-token>",
+            "withheld",
+            "Claude-BugHunter",
+        ):
+            with self.subTest(term=term):
+                self.assertIn(term, text)
+
+    def test_pr_review_revalidates_findings_and_ci_failures(self) -> None:
+        text = (
+            ROOT / ".agents" / "skills" / "levyra-pr-review" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+
+        for term in (
+            "## Finding lifecycle",
+            "CONFIRMED",
+            "RETRACTED",
+            "current-head",
+            "## CI/test failure discipline",
+            "PRODUCT_REGRESSION",
+            "TEST_DEFECT",
+            "FLAKY",
+            "Do not repeatedly rerun the same failing check to manufacture a green status",
+            "docs/ai/SKILL_INTELLIGENCE.md",
+            "Load `levyra-security-review` only when the diff or finding is actually security-sensitive",
+        ):
+            with self.subTest(term=term):
+                self.assertIn(term, text)
+
+    def test_policy_keeps_external_catalogs_out_of_bootstrap(self) -> None:
+        text = (ROOT / "docs" / "ai" / "SKILL_INTELLIGENCE.md").read_text(
+            encoding="utf-8"
+        )
+
+        for term in (
+            "does not improve its coding agents by installing every available skill catalog",
+            "difficult near-misses",
+            "Infrastructure or evaluator errors are `ERROR`",
+            "prompt/context tokens",
+            "should not be adopted",
+            "anthropics/skills",
+            "Jeffallan/claude-skills",
+            "elementalsouls/Claude-BugHunter",
+            "ChrisTitusTech/titus-ai",
+        ):
+            with self.subTest(term=term):
+                self.assertIn(term, text)
+
+    def test_eval_source_keeps_comments_out_of_new_code(self) -> None:
+        text = (ROOT / "scripts" / "evaluate_skill_routing.py").read_text(
+            encoding="utf-8"
+        )
+        comment_lines = [
+            line
+            for line in text.splitlines()[1:]
+            if line.lstrip().startswith("#")
+        ]
+        self.assertEqual([], comment_lines)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Strengthen Levyra's coding agents using the highest-value ideas from the external skill material without installing large skill catalogs or increasing Claude's always-loaded context.

## What changed

- add a deterministic `scripts/evaluate_skill_routing.py` corpus with positive, near-miss, collision, selected-skill-count, and additional-context-budget checks
- treat evaluator/infrastructure exceptions as `ERROR`, never as a successful negative trigger
- tighten routing collisions found during evaluation:
  - generic `token` no longer loads the YouTube extractor for Claude/token-budget prompts
  - generic Kotlin language questions no longer load CI/toolchain guidance
  - generic `version` no longer loads release guidance for Kotlin/compiler versions
  - error-log screenshots no longer load design or Compose guidance just because `screenshot` contains `screen`
  - semantic-version requests no longer load Compose merely because they contain `semantic`; genuine Compose/TalkBack semantics remain covered
- preserve the merged #451 RAM/OOM/native-memory routing while applying the new routing refinements
- route explicit debugging/diagnosis language through `levyra-real-engineering`
- strengthen `levyra-real-engineering` with `reproduce -> isolate -> hypothesis -> smallest experiment -> fix -> prevent`, explicit hypothesis retraction, and test/check failure classification
- strengthen `levyra-security-review` with finding states, false-positive challenge, and evidence hygiene before logs/HARs/screenshots leave the trusted context
- strengthen `levyra-pr-review` with current-head finding revalidation, explicit retractions, CI failure classification, and no retry-to-green behavior
- keep generic PR evidence hygiene compact; load `levyra-security-review` only for genuinely security-sensitive work
- document a skill-intake policy: adapt useful methods into existing owner skills first; no wholesale catalog installs; substantial candidates must justify token/tool cost against the current Levyra baseline
- add unit coverage that locks the routing corpus and the new debugging/review/security contracts

## External material used selectively

- `anthropics/skills`: progressive disclosure and trigger/eval discipline
- `Jeffallan/claude-skills`: reproduce/isolate/hypothesis/prevention, test-failure classification, and review discipline
- `elementalsouls/Claude-BugHunter`: validation gates, explicit finding retraction, and evidence hygiene; no offensive payload catalog or authorization assumptions are imported
- `ChrisTitusTech/titus-ai`: keep permanent guidance small and use compression selectively; no additional Titus dependency/plugin is added

`html-anything` and `browser-act/skills` remain outside the core coding bootstrap because their value is task-specific web/visual/browser work. `codeaashu/claude-code` is not adopted.

## Type of change

- [ ] Bug fix in product code
- [x] AI/agent behavior improvement
- [x] Test/validation improvement
- [x] Documentation/policy update
- [ ] Dependency change
- [ ] Release/version change

## Scope

7 AI/docs/test files only. No Android/Desktop production source, application dependency, version, signing, release, or product behavior changes.

## Validation

### Automated

- [x] deterministic routing corpus covers positive, near-miss and collision cases
- [x] semantic-version near-miss forbids `levyra-compose`
- [x] genuine `Compose semantics for TalkBack` still requires `levyra-compose`
- [x] script tests are part of the existing AI Quality Gate through `python -m unittest discover -s scripts/tests -p test_*.py`
- [x] AI Quality Gate passed on the equivalent pre-squash head `6af1e19939ac570eef1080f725be0c202a80f287`
- [ ] final single-commit CI is rerunning against the current head

### Manual/review

- [x] CodeRabbit finding about bare `semantic` was reproduced against the router and fixed
- [x] CodeRabbit-style self-review also removed explanatory evaluator comments/docstrings that conflicted with Levyra's source-comment policy
- [x] generic PR evidence hygiene was kept local instead of forcing full security-skill context for ordinary logs

## Risk and compatibility

- **Risk:** Low. Changes affect AI prompt routing and agent instructions only.
- **Primary risk:** false-positive or false-negative skill routing.
- **Mitigation:** deterministic required/forbidden skill cases plus selected-skill/context budgets.
- **Compatibility:** no product/runtime, Android/Desktop, schema, dependency, signing, or release behavior changes.
- **Rollback:** revert this PR.

## Reviewer notes

- The CodeRabbit semantic-version finding was valid: the former bare `semantic` alternative could match `Prepare a semantic version release`.
- The fix removes `semantic` as an autonomous Compose trigger while retaining `semantics`, `Compose`, `TalkBack`, accessibility and other genuine UI triggers.
- The evaluator now contains both the near-miss and the positive accessibility case so the fix cannot silently regress in either direction.
- External catalogs are not vendored or made authoritative.

## Related issues

N/A. The RAM/native-memory guard work from #451 is preserved but not modified by this PR.

## Checklist

- [x] focused scope; no unrelated product changes
- [x] no new always-discoverable external skill catalog
- [x] no secrets/generated artifacts/local-only files
- [x] routing changes have positive and near-miss coverage
- [x] CodeRabbit actionable finding addressed
- [x] no version/release/dependency changes
- [ ] final-head CI fully green

## Final commit

`1972cef08423d54d54161248cffeb5453abc0ad9` — `feat(ai): add skill intelligence layer`

The branch is one commit on top of the current `main`. No merge or release is performed by this PR.