### PR TITLE
Harden YouTube Music search suggestions and parser fallbacks

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/ArtistRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/ArtistRepository.kt
@@ -10,6 +10,8 @@ import com.luc4n3x.levyra.domain.ArtistProfile
 import com.luc4n3x.levyra.domain.ArtistRelease
 import com.luc4n3x.levyra.domain.LevyraPersonalOrbit
 import com.luc4n3x.levyra.domain.artistIdentityKey
+import com.luc4n3x.levyra.domain.artistAudienceWeight
+import com.luc4n3x.levyra.domain.artistIdentityMatches
 import com.luc4n3x.levyra.domain.isArtistShelfNameEligible
 import com.luc4n3x.levyra.domain.primaryArtistSegment
 import com.luc4n3x.levyra.domain.LevyraContentLocales
@@ -345,8 +347,7 @@ class ArtistRepository(private val music: YoutubeMusicRepository, private val co
         val expectedPrimary = primaryArtistSegment(expected).ifBlank { expected }
         val resolved = resolvedName.cleanAlbumArtistLabel()
         if (expected.isBlank() || resolved.isBlank()) return true
-        val resolvedKey = artistIdentityKey(resolved)
-        return resolvedKey == artistIdentityKey(expected) || resolvedKey == artistIdentityKey(expectedPrimary)
+        return artistIdentityMatches(resolved, expected) || artistIdentityMatches(resolved, expectedPrimary)
     }
 
     suspend fun artistHit(browseId: String, fallbackName: String): ArtistHit? = withContext(Dispatchers.IO) {
@@ -423,17 +424,14 @@ class ArtistRepository(private val music: YoutubeMusicRepository, private val co
         if (cleanQuery.length < 2) return null
 
         val primaryName = primaryArtistSegment(cleanQuery).ifBlank { cleanQuery }
-        val acceptedKeys = linkedSetOf(
-            artistIdentityKey(cleanQuery),
-            artistIdentityKey(primaryName)
-        ).filter { it.isNotBlank() }.toSet()
         val candidates = findArtistSearchCandidates(cleanQuery)
 
         candidates.forEach { candidate ->
             val official = runCatching { verifyArtistCandidate(candidate, cleanQuery) }.getOrNull()
-            if (official != null && official.officialArtwork && artistIdentityKey(official.name) in acceptedKeys) {
-                return official
-            }
+            val accepted = official != null &&
+                official.officialArtwork &&
+                (artistIdentityMatches(official.name, cleanQuery) || artistIdentityMatches(official.name, primaryName))
+            if (accepted) return official
         }
         return null
     }
@@ -453,10 +451,6 @@ class ArtistRepository(private val music: YoutubeMusicRepository, private val co
         val cleanQuery = query.trim()
         if (cleanQuery.length < 2) return emptyList()
         val primaryName = primaryArtistSegment(cleanQuery).ifBlank { cleanQuery }
-        val acceptedKeys = linkedSetOf(
-            artistIdentityKey(cleanQuery),
-            artistIdentityKey(primaryName)
-        ).filter { it.isNotBlank() }.toSet()
         val candidates = LinkedHashMap<String, ArtistHit>()
 
         linkedSetOf(cleanQuery, primaryName).forEach { searchQuery ->
@@ -465,14 +459,18 @@ class ArtistRepository(private val music: YoutubeMusicRepository, private val co
                 .asSequence()
                 .filter { candidate ->
                     candidate.browseId.isNotBlank() &&
-                        artistIdentityKey(candidate.name) in acceptedKeys
+                        (artistIdentityMatches(candidate.name, cleanQuery) ||
+                            artistIdentityMatches(candidate.name, primaryName))
                 }
-                .sortedByDescending { it.thumbnailUrl.isNotBlank() }
+                .sortedWith(
+                    compareByDescending<ArtistHit> { it.thumbnailUrl.isNotBlank() }
+                        .thenByDescending { artistAudienceWeight(it.subscribers) }
+                )
                 .forEach { candidate ->
                     candidates.putIfAbsent(candidate.browseId.lowercase(Locale.ROOT), candidate)
                 }
         }
-        return candidates.values.toList()
+        return candidates.values.sortedByDescending { artistAudienceWeight(it.subscribers) }
     }
 
     private suspend fun verifyArtistCandidate(
@@ -571,9 +569,9 @@ class ArtistRepository(private val music: YoutubeMusicRepository, private val co
         val albumPointer = findReleasePointer(root, "Album")
         val singlePointer = findReleasePointer(root, "Singol")
         val videoPointer = findVideoPointer(root)
-        val initialSongs = extractTopSongs(root)
+        val initialSongs = extractTopSongs(root, name)
         val expanded = coroutineScope {
-            val songsJob = async { songsPointer?.let(::fetchSongs).orEmpty() }
+            val songsJob = async { songsPointer?.let { pointer -> fetchSongs(pointer, name) }.orEmpty() }
             val albumsJob = async { albumPointer?.let(::fetchReleases).orEmpty() }
             val singlesJob = async { singlePointer?.let(::fetchReleases).orEmpty() }
             val videosJob = async { videoPointer?.let { fetchVideos(it, name) }.orEmpty() }
@@ -763,7 +761,7 @@ class ArtistRepository(private val music: YoutubeMusicRepository, private val co
     }
 
 
-    private fun extractTopSongs(root: JSONObject): List<Track> {
+    private fun extractTopSongs(root: JSONObject, fallbackArtist: String): List<Track> {
         val renderers = mutableListOf<JSONObject>()
         collectByKey(root, "musicResponsiveListItemRenderer", renderers)
         val tracks = LinkedHashMap<String, Track>()
@@ -781,7 +779,7 @@ class ArtistRepository(private val music: YoutubeMusicRepository, private val co
                 tracks[videoId] = Track(
                     id = videoId,
                     title = title,
-                    artist = artist.ifBlank { "YouTube Music" },
+                    artist = artist.ifBlank { fallbackArtist },
                     album = album.ifBlank { "YouTube Music" },
                     durationMs = durationOf(renderer.toString()),
                     streamUrl = "",
@@ -955,12 +953,12 @@ class ArtistRepository(private val music: YoutubeMusicRepository, private val co
         return releases.values.take(100).toList()
     }
 
-    private fun fetchSongs(pointer: ArtistSectionPointer): List<Track> {
+    private fun fetchSongs(pointer: ArtistSectionPointer, fallbackArtist: String): List<Track> {
         val songs = LinkedHashMap<String, Track>()
         var response = runCatching { postBrowse(pointer.browseId, pointer.params) }.getOrDefault(JSONObject())
         var pages = 0
         while (response.length() > 0 && pages < MAX_RELEASE_PAGES) {
-            extractTopSongs(response).forEach { track -> songs.putIfAbsent(track.id, track) }
+            extractTopSongs(response, fallbackArtist).forEach { track -> songs.putIfAbsent(track.id, track) }
             val continuation = findContinuation(response)
             if (continuation.isBlank() || songs.size >= 100) break
             response = runCatching { postBrowse("", continuation = continuation) }.getOrDefault(JSONObject())

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
@@ -391,6 +391,7 @@ private const val ALBUM_RECOMMENDATION_CONCURRENCY = 4
 private const val ALBUM_RESULTS_PER_SEED = 8
 private const val ALBUM_RESULTS_PER_FALLBACK_QUERY = 8
 private const val ALBUM_RESULT_RANK_PENALTY = 18
+private const val SUGGESTION_RESPONSE_LIMIT_CHARS = 64 * 1024
 internal const val YOUTUBE_MUSIC_VIDEO_SEARCH_PARAMS = "EgWKAQIQAWoMEA4QChADEAQQCRAF"
 internal const val YOUTUBE_MUSIC_SONG_SEARCH_PARAMS = "EgWKAQIIAWoMEA4QChADEAQQCRAF"
 internal const val YOUTUBE_MUSIC_ALBUM_SEARCH_PARAMS = "EgWKAQIYAWoMEA4QChADEAQQCRAF"
@@ -1615,7 +1616,7 @@ class YoutubeMusicRepository(private val context: Context? = null) {
         collectObjectsByKey(card, "watchEndpoint", watchEndpoints)
         val audioPlaylistId = watchEndpoints.firstNotNullOfOrNull { endpoint -> endpoint.optString("playlistId").takeIf { it.isNotBlank() } }.orEmpty()
         val artistReference = extractYoutubeMusicArtistReference(card, artist)
-        val resolvedArtist = artistReference?.name.orEmpty().ifBlank { artist }.ifBlank { "YouTube Music" }
+        val resolvedArtist = artistReference?.name.orEmpty().ifBlank { artist }
         return AlbumHit(
             title = title.cleanLabel(),
             artist = resolvedArtist.cleanLabel(),
@@ -2405,7 +2406,7 @@ class YoutubeMusicRepository(private val context: Context? = null) {
         return buildTrack(
             id = item.videoId,
             title = item.title,
-            artist = item.artists.joinToString(", ") { it.name }.ifBlank { seed.artist.ifBlank { "YouTube Music" } },
+            artist = item.artists.joinToString(", ") { it.name }.ifBlank { seed.artist },
             album = item.albumTitle.ifBlank { "YouTube Music Radio" },
             durationMs = item.durationMs,
             thumbnailUrl = thumbnail,
@@ -2427,7 +2428,7 @@ class YoutubeMusicRepository(private val context: Context? = null) {
         return buildTrack(
             id = item.videoId,
             title = item.title,
-            artist = item.artists.joinToString(", ") { it.name }.ifBlank { seed.artist.ifBlank { "YouTube Music" } },
+            artist = item.artists.joinToString(", ") { it.name }.ifBlank { seed.artist },
             album = item.albumTitle.ifBlank { "YouTube Music Related" },
             durationMs = item.durationMs,
             thumbnailUrl = thumbnail,
@@ -2458,7 +2459,11 @@ class YoutubeMusicRepository(private val context: Context? = null) {
                 connection.requestMethod = "GET"
                 connection.connectTimeout = 5000
                 connection.readTimeout = 5000
-                val response = connection.inputStream.bufferedReader().use { it.readText() }
+                val response = connection.inputStream.bufferedReader().use { reader ->
+                    val buffer = CharArray(SUGGESTION_RESPONSE_LIMIT_CHARS)
+                    val read = reader.read(buffer)
+                    if (read <= 0) "" else String(buffer, 0, read)
+                }
                 val root = JSONArray(response)
                 val suggestions = root.optJSONArray(1) ?: return@runCatching emptyList()
                 val result = mutableListOf<String>()
@@ -2482,7 +2487,7 @@ class YoutubeMusicRepository(private val context: Context? = null) {
         val tokens = subtitle.split(" • ", " · ", " - ").map { it.trim() }
         if (tokens.isNotEmpty() && tokens[0].lowercase() in excludedTypes) return null
 
-        val fallbackArtist = tokens.firstOrNull(::isPlausibleSearchMetadataLabel) ?: "YouTube Music"
+        val fallbackArtist = tokens.firstOrNull(::isPlausibleSearchMetadataLabel).orEmpty()
         val artistReferences = extractYoutubeMusicArtistReferences(two, fallbackArtist)
         val artist = artistReferences.creditLabel(fallbackArtist)
         val thumbnail = findBestThumbnail(two)
@@ -2623,7 +2628,7 @@ class YoutubeMusicRepository(private val context: Context? = null) {
 
         val fallbackArtist = tokens
             .firstOrNull(::isPlausibleSearchMetadataLabel)
-            ?: "YouTube Music"
+            .orEmpty()
         val artistReferences = extractYoutubeMusicArtistReferences(renderer, fallbackArtist)
         val artist = artistReferences.creditLabel(fallbackArtist)
         val albumReference = extractYoutubeMusicAlbumReference(renderer)

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
@@ -790,7 +790,8 @@ class YoutubeMusicRepository(private val context: Context? = null) {
             when {
                 pageType == MUSIC_PAGE_TYPE_ALBUM || browseId.startsWith("MPRE", ignoreCase = true) -> album = true
                 pageType == MUSIC_PAGE_TYPE_PLAYLIST || browseId.startsWith("VL", ignoreCase = true) -> playlist = true
-                pageType == MUSIC_PAGE_TYPE_ARTIST || browseId.startsWith("UC") -> artist = true
+                pageType == MUSIC_PAGE_TYPE_ARTIST ||
+                    browseId.startsWith("MPLA", ignoreCase = true) -> artist = true
             }
         }
         if (album) return SearchEntityKind.Album
@@ -912,10 +913,13 @@ class YoutubeMusicRepository(private val context: Context? = null) {
         }.orEmpty()
     }
 
-    private fun findSearchContinuation(root: JSONObject): String {
+    internal fun findSearchContinuation(root: JSONObject): String {
         val legacy = mutableListOf<JSONObject>()
         collectObjectsByKey(root, "nextContinuationData", legacy)
         legacy.firstNotNullOfOrNull { it.optString("continuation").takeIf(String::isNotBlank) }?.let { return it }
+        val reload = mutableListOf<JSONObject>()
+        collectObjectsByKey(root, "reloadContinuationData", reload)
+        reload.firstNotNullOfOrNull { it.optString("continuation").takeIf(String::isNotBlank) }?.let { return it }
         val commands = mutableListOf<JSONObject>()
         collectObjectsByKey(root, "continuationCommand", commands)
         return commands.firstNotNullOfOrNull { it.optString("token").takeIf(String::isNotBlank) }.orEmpty()
@@ -1793,7 +1797,7 @@ class YoutubeMusicRepository(private val context: Context? = null) {
         "artiest", "artysta", "artis", "canal", "chaîne", "kanal",
         "فنان", "قناة", "ملف شخصي", "قائمة تشغيل", "歌手", "频道", "个人资料", "播放列表",
         "アーティスト", "チャンネル", "プロフィール", "プレイリスト", "再生リスト",
-        "아티스트", "채널", "프로필", "재생목록", "플레이리スト",
+        "아티스트", "채널", "프로필", "재생목록", "플레이리스트",
         "कलाकार", "चैनल", "प्रोफ़ाइल", "प्लेलिस्ट",
         "saluran", "daftar putar", "nghệ sĩ", "kênh", "hồ sơ", "danh sách phát",
         "ศิลปิน", "ช่อง", "โปรไฟล์", "เพลย์ลิสต์",
@@ -2163,7 +2167,9 @@ class YoutubeMusicRepository(private val context: Context? = null) {
                 ?.optJSONObject("browseEndpointContextMusicConfig")
                 ?.optString("pageType")
                 .orEmpty()
-            if (browseId.isBlank() || !pageType.contains("ARTIST", ignoreCase = true)) return null
+            val isArtistEndpoint = browseId.startsWith("MPLA", ignoreCase = true) ||
+                pageType.contains("ARTIST", ignoreCase = true)
+            if (browseId.isBlank() || !isArtistEndpoint) return null
             val name = run.optString("text").cleanAlbumArtistLabel().trim()
             if (name.isBlank()) return null
             return YoutubeMusicArtistReference(name = name, browseId = browseId)
@@ -2233,7 +2239,7 @@ class YoutubeMusicRepository(private val context: Context? = null) {
                 ?.optJSONObject("browseEndpointContextMusicConfig")
                 ?.optString("pageType")
                 .orEmpty()
-            val isArtistEndpoint = browseId.startsWith("UC", ignoreCase = true) ||
+            val isArtistEndpoint = browseId.startsWith("MPLA", ignoreCase = true) ||
                 pageType.contains("ARTIST", ignoreCase = true)
             if (browseId.isBlank() || !isArtistEndpoint) return null
             val title = renderer.optJSONObject("title")
@@ -2437,24 +2443,32 @@ class YoutubeMusicRepository(private val context: Context? = null) {
     }
 
     fun searchSuggestions(query: String, languageCode: String = LevyraLanguageCatalog.deviceDefault()): List<String> {
-        if (query.isBlank()) return emptyList()
+        val cleanQuery = query.trim()
+        if (cleanQuery.isBlank()) return emptyList()
         val locale = LevyraContentLocales.forLanguage(languageCode)
-        val url = "https://suggestqueries.google.com/complete/search?client=firefox&ds=yt&hl=${locale.hl}&gl=${locale.gl}&q=${java.net.URLEncoder.encode(query, "UTF-8")}"
-        val remote = runCatching {
-            val connection = URL(url).openConnection() as HttpURLConnection
-            connection.requestMethod = "GET"
-            connection.connectTimeout = 5000
-            connection.readTimeout = 5000
-            val response = connection.inputStream.bufferedReader().use { it.readText() }
-            val root = JSONArray(response)
-            val suggestions = root.optJSONArray(1) ?: return@runCatching emptyList()
-            val result = mutableListOf<String>()
-            for (i in 0 until suggestions.length()) {
-                result += suggestions.optString(i)
-            }
-            result
+        val native = runCatching {
+            parseYoutubeMusicSearchSuggestions(
+                resilienceClient.searchSuggestions(cleanQuery, languageCode)
+            )
         }.getOrDefault(emptyList())
-        return LevyraLocalizedDiscovery.suggestions(query, locale.languageCode, remote)
+        val remote = native.ifEmpty {
+            val url = "https://suggestqueries.google.com/complete/search?client=firefox&ds=yt&hl=${locale.hl}&gl=${locale.gl}&q=${java.net.URLEncoder.encode(cleanQuery, "UTF-8")}"
+            runCatching {
+                val connection = URL(url).openConnection() as HttpURLConnection
+                connection.requestMethod = "GET"
+                connection.connectTimeout = 5000
+                connection.readTimeout = 5000
+                val response = connection.inputStream.bufferedReader().use { it.readText() }
+                val root = JSONArray(response)
+                val suggestions = root.optJSONArray(1) ?: return@runCatching emptyList()
+                val result = mutableListOf<String>()
+                for (i in 0 until suggestions.length()) {
+                    result += suggestions.optString(i)
+                }
+                result
+            }.getOrDefault(emptyList())
+        }
+        return LevyraLocalizedDiscovery.suggestions(cleanQuery, locale.languageCode, remote)
     }
 
     internal fun parseCarouselItem(item: JSONObject): Track? {

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicResilienceClient.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicResilienceClient.kt
@@ -123,6 +123,19 @@ internal class YoutubeMusicResilienceClient(
         )
     }
 
+    fun searchSuggestions(query: String, languageCode: String): JSONObject? {
+        val clean = query.trim()
+        if (apiKey.isBlank() || clean.length < 2) return null
+        return request(
+            kind = YoutubeMusicRequestKind.SEARCH_SUGGESTIONS,
+            languageCode = languageCode,
+            browseId = "",
+            params = "",
+            continuation = "",
+            query = clean
+        )
+    }
+
     fun browse(
         languageCode: String,
         browseId: String,
@@ -209,7 +222,14 @@ internal class YoutubeMusicResilienceClient(
         query: String
     ): JSONObject? {
         val deadline = monotonicClock() + TOTAL_REQUEST_BUDGET_MS
-        val orderedProfiles = orderedProfiles(clock())
+        val affectsProfileHealth = kind != YoutubeMusicRequestKind.SEARCH_SUGGESTIONS
+        val orderedProfiles = orderedProfiles(clock()).let { candidates ->
+            if (kind == YoutubeMusicRequestKind.SEARCH_SUGGESTIONS) {
+                candidates.filter { it.id == "web-remix" }
+            } else {
+                candidates
+            }
+        }
         val deferredDenials = mutableListOf<YoutubeMusicDeferredFailure>()
         var lastFailure: Throwable? = null
 
@@ -221,7 +241,11 @@ internal class YoutubeMusicResilienceClient(
             }
 
             val request = YoutubeMusicTransportRequest(
-                path = if (kind == YoutubeMusicRequestKind.SEARCH) "search" else "browse",
+                path = when (kind) {
+                    YoutubeMusicRequestKind.SEARCH -> "search"
+                    YoutubeMusicRequestKind.SEARCH_SUGGESTIONS -> "music/get_search_suggestions"
+                    YoutubeMusicRequestKind.BROWSE -> "browse"
+                },
                 apiKey = apiKey,
                 profile = profile,
                 payload = payload(profile, kind, languageCode, browseId, params, continuation, query).toString(),
@@ -238,28 +262,32 @@ internal class YoutubeMusicResilienceClient(
                     return null
                 }
                 lastFailure = error
-                recordFailure(
-                    profile = profile,
-                    statusCode = null,
-                    reason = error.message.orEmpty(),
-                    latencyMs = (monotonicClock() - attemptStartedAt).takeIf { it > 0L },
-                    now = clock()
-                )
+                if (affectsProfileHealth) {
+                    recordFailure(
+                        profile = profile,
+                        statusCode = null,
+                        reason = error.message.orEmpty(),
+                        latencyMs = (monotonicClock() - attemptStartedAt).takeIf { it > 0L },
+                        now = clock()
+                    )
+                }
                 continue
             }
 
             if (response.code !in 200..299) {
                 lastFailure = IOException("HTTP ${response.code}")
-                if (isRequestScopedDenial(response.code, response.body)) {
-                    deferredDenials += YoutubeMusicDeferredFailure(
-                        profile = profile,
-                        statusCode = response.code,
-                        reason = response.body,
-                        latencyMs = response.latencyMs,
-                        now = clock()
-                    )
-                } else {
-                    recordFailure(profile, response.code, response.body, response.latencyMs, clock())
+                if (affectsProfileHealth) {
+                    if (isRequestScopedDenial(response.code, response.body)) {
+                        deferredDenials += YoutubeMusicDeferredFailure(
+                            profile = profile,
+                            statusCode = response.code,
+                            reason = response.body,
+                            latencyMs = response.latencyMs,
+                            now = clock()
+                        )
+                    } else {
+                        recordFailure(profile, response.code, response.body, response.latencyMs, clock())
+                    }
                 }
                 continue
             }
@@ -268,36 +296,46 @@ internal class YoutubeMusicResilienceClient(
             val root = parsed.getOrNull()
             if (root == null) {
                 lastFailure = parsed.exceptionOrNull() ?: IOException("Invalid JSON")
-                recordFailure(profile, response.code, "invalid json", response.latencyMs, clock())
+                if (affectsProfileHealth) {
+                    recordFailure(profile, response.code, "invalid json", response.latencyMs, clock())
+                }
                 continue
             }
             if (!isUseful(kind, root)) {
-                if (isRequestScopedDenial(response.code, response.body)) {
-                    deferredDenials += YoutubeMusicDeferredFailure(
-                        profile = profile,
-                        statusCode = response.code,
-                        reason = response.body,
-                        latencyMs = response.latencyMs,
-                        now = clock()
-                    )
-                } else {
-                    recordFailure(profile, response.code, "empty response", response.latencyMs, clock())
+                if (affectsProfileHealth) {
+                    if (isRequestScopedDenial(response.code, response.body)) {
+                        deferredDenials += YoutubeMusicDeferredFailure(
+                            profile = profile,
+                            statusCode = response.code,
+                            reason = response.body,
+                            latencyMs = response.latencyMs,
+                            now = clock()
+                        )
+                    } else {
+                        recordFailure(profile, response.code, "empty response", response.latencyMs, clock())
+                    }
                 }
                 continue
             }
 
-            deferredDenials.forEach { recordRequestScopedDenial(it, recoveredByFallback = true) }
+            if (affectsProfileHealth) {
+                deferredDenials.forEach { recordRequestScopedDenial(it, recoveredByFallback = true) }
+            }
             root.optJSONObject("responseContext")
                 ?.optString("visitorData")
                 ?.trim()
                 ?.takeIf(String::isNotBlank)
                 ?.let { visitorData[profile.id] = it }
 
-            recordSuccess(profile, response.latencyMs, clock())
+            if (affectsProfileHealth) {
+                recordSuccess(profile, response.latencyMs, clock())
+            }
             return root
         }
 
-        deferredDenials.forEach { recordRequestScopedDenial(it, recoveredByFallback = false) }
+        if (affectsProfileHealth) {
+            deferredDenials.forEach { recordRequestScopedDenial(it, recoveredByFallback = false) }
+        }
         lastFailure?.let { Timber.d(it, "YouTube Music fallback chain exhausted") }
         return null
     }
@@ -329,6 +367,9 @@ internal class YoutubeMusicResilienceClient(
                 if (query.isNotBlank()) root.put("query", query)
                 if (params.isNotBlank()) root.put("params", params)
                 if (continuation.isNotBlank()) root.put("continuation", continuation)
+            }
+            YoutubeMusicRequestKind.SEARCH_SUGGESTIONS -> {
+                if (query.isNotBlank()) root.put("input", query)
             }
             YoutubeMusicRequestKind.BROWSE -> {
                 if (browseId.isNotBlank()) root.put("browseId", browseId)
@@ -437,6 +478,7 @@ internal class YoutubeMusicResilienceClient(
         val raw = root.toString()
         return when (kind) {
             YoutubeMusicRequestKind.SEARCH -> SEARCH_MARKERS.any(raw::contains)
+            YoutubeMusicRequestKind.SEARCH_SUGGESTIONS -> SEARCH_SUGGESTION_MARKERS.any(raw::contains)
             YoutubeMusicRequestKind.BROWSE -> BROWSE_MARKERS.any(raw::contains)
         }
     }
@@ -447,6 +489,7 @@ internal class YoutubeMusicResilienceClient(
                 val encoded = URLEncoder.encode(query, StandardCharsets.UTF_8.name())
                 "https://music.youtube.com/search?q=$encoded"
             }
+            YoutubeMusicRequestKind.SEARCH_SUGGESTIONS -> "https://music.youtube.com/"
             YoutubeMusicRequestKind.BROWSE -> browseId
                 .takeIf(String::isNotBlank)
                 ?.let { "https://music.youtube.com/browse/$it" }
@@ -522,7 +565,16 @@ internal class YoutubeMusicResilienceClient(
             "musicResponsiveListItemRenderer",
             "musicTwoRowItemRenderer",
             "videoRenderer",
-            "musicShelfRenderer"
+            "musicShelfRenderer",
+            "musicShelfContinuation",
+            "musicCardShelfRenderer",
+            "tabbedSearchResultsRenderer",
+            "itemSectionRenderer"
+        )
+        val SEARCH_SUGGESTION_MARKERS = arrayOf(
+            "searchSuggestionsSectionRenderer",
+            "searchSuggestionRenderer",
+            "historySuggestionRenderer"
         )
         val BROWSE_MARKERS = arrayOf(
             "musicCarouselShelfRenderer",
@@ -655,6 +707,7 @@ private class YoutubeMusicInFlightRequest {
 
 private enum class YoutubeMusicRequestKind {
     SEARCH,
+    SEARCH_SUGGESTIONS,
     BROWSE
 }
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicResilienceClient.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicResilienceClient.kt
@@ -561,15 +561,19 @@ internal class YoutubeMusicResilienceClient(
         const val IOS_USER_AGENT =
             "com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3 like Mac OS X)"
 
+        /**
+         * Renderers the search parser can actually read. Structural wrappers such as
+         * `tabbedSearchResultsRenderer` or `itemSectionRenderer` are deliberately absent: they are
+         * present on empty and blocked responses too, so on their own they must not stop the
+         * fallback chain. A wrapper carrying real results still matches through the item renderers
+         * nested inside it.
+         */
         val SEARCH_MARKERS = arrayOf(
             "musicResponsiveListItemRenderer",
             "musicTwoRowItemRenderer",
             "videoRenderer",
-            "musicShelfRenderer",
-            "musicShelfContinuation",
             "musicCardShelfRenderer",
-            "tabbedSearchResultsRenderer",
-            "itemSectionRenderer"
+            "playlistPanelVideoRenderer"
         )
         val SEARCH_SUGGESTION_MARKERS = arrayOf(
             "searchSuggestionsSectionRenderer",

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicSearchSuggestions.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicSearchSuggestions.kt
@@ -1,0 +1,45 @@
+package com.luc4n3x.levyra.data
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal fun parseYoutubeMusicSearchSuggestions(root: JSONObject?): List<String> {
+    root ?: return emptyList()
+    val contents = root.optJSONArray("contents") ?: return emptyList()
+    val suggestions = LinkedHashSet<String>()
+
+    for (sectionIndex in 0 until contents.length()) {
+        val section = contents.optJSONObject(sectionIndex)
+            ?.optJSONObject("searchSuggestionsSectionRenderer")
+            ?: continue
+        val items = section.optJSONArray("contents") ?: continue
+        for (itemIndex in 0 until items.length()) {
+            val item = items.optJSONObject(itemIndex) ?: continue
+            val renderer = item.optJSONObject("historySuggestionRenderer")
+                ?: item.optJSONObject("searchSuggestionRenderer")
+                ?: continue
+            val query = renderer.optJSONObject("navigationEndpoint")
+                ?.optJSONObject("searchEndpoint")
+                ?.optString("query")
+                .orEmpty()
+                .trim()
+                .ifBlank { suggestionText(renderer.optJSONObject("suggestion")?.optJSONArray("runs")) }
+            if (query.isNotBlank()) suggestions += query
+            if (suggestions.size >= MAX_SEARCH_SUGGESTIONS) return suggestions.toList()
+        }
+    }
+
+    return suggestions.toList()
+}
+
+private fun suggestionText(runs: JSONArray?): String {
+    runs ?: return ""
+    val text = StringBuilder()
+    for (index in 0 until runs.length()) {
+        val part = runs.optJSONObject(index)?.optString("text").orEmpty()
+        if (part.isNotEmpty()) text.append(part)
+    }
+    return text.toString().trim()
+}
+
+private const val MAX_SEARCH_SUGGESTIONS = 12

--- a/app/src/main/java/com/luc4n3x/levyra/domain/ArtistIdentity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/ArtistIdentity.kt
@@ -11,6 +11,11 @@ private val ARTIST_EXPLICIT_SEPARATOR =
     Regex("""(?i)\s+(?:feat(?:uring)?\.?|ft\.?|with|con|vs\.?)\s+|,\s*|;\s*|\s+[x×/]\s+""")
 private val ARTIST_JOINED_SEPARATOR = Regex("""(?i)\s+(?:&|and|e|y|et|und)\s+""")
 private val ARTIST_YEAR_TOKEN = Regex("""\b(?:19|20)\d{2}\b""")
+private val ARTIST_AUDIENCE_PATTERN =
+    Regex("""(\d[\d.,\s\u00A0]*)\s*(k|m|b|mln|mld|mrd|mio|mila|tys)?""", RegexOption.IGNORE_CASE)
+private val ARTIST_LEADING_ARTICLES = setOf(
+    "the", "a", "an", "el", "la", "las", "los", "le", "les", "il", "lo", "gli", "der", "die", "das", "os", "as"
+)
 
 internal fun artistIdentityKey(value: String): String {
     return Normalizer.normalize(value, Normalizer.Form.NFKD)
@@ -20,6 +25,47 @@ internal fun artistIdentityKey(value: String): String {
         .replace(ARTIST_NON_ALPHANUMERIC, " ")
         .replace(ARTIST_WHITESPACE, " ")
         .trim()
+}
+
+/**
+ * Identity keys a name can be matched by: the plain key plus, when the name starts with a common
+ * leading article, the key without it. Lets "weeknd" match "The Weeknd" without dropping articles
+ * from anything shown to the user.
+ */
+internal fun artistIdentityKeys(value: String): Set<String> {
+    val key = artistIdentityKey(value)
+    if (key.isBlank()) return emptySet()
+    val article = key.substringBefore(' ')
+    val remainder = key.substringAfter(' ', "")
+    if (remainder.isBlank() || article !in ARTIST_LEADING_ARTICLES) return setOf(key)
+    return setOf(key, remainder)
+}
+
+internal fun artistIdentityMatches(first: String, second: String): Boolean {
+    val firstKeys = artistIdentityKeys(first)
+    if (firstKeys.isEmpty()) return false
+    return artistIdentityKeys(second).any(firstKeys::contains)
+}
+
+/**
+ * Rough audience size parsed from a search subtitle ("274M monthly audience", "7 subscribers").
+ * Ranks equally matching artists only; it never filters a candidate out.
+ */
+internal fun artistAudienceWeight(value: String): Long {
+    val match = ARTIST_AUDIENCE_PATTERN.find(value) ?: return 0L
+    val multiplier = when (match.groupValues[2].lowercase(Locale.ROOT)) {
+        "k", "mila", "tys" -> 1_000.0
+        "m", "mln", "mio" -> 1_000_000.0
+        "b", "mrd", "mld" -> 1_000_000_000.0
+        else -> 1.0
+    }
+    val digits = match.groupValues[1].filter { it.isDigit() || it == '.' || it == ',' }
+    val amount = if (multiplier > 1.0) {
+        digits.replace(',', '.').toDoubleOrNull()
+    } else {
+        digits.filter(Char::isDigit).toDoubleOrNull()
+    } ?: return 0L
+    return (amount * multiplier).toLong()
 }
 
 internal fun primaryArtistSegment(value: String): String {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -7867,6 +7867,20 @@ private fun hasSquareAlbumArtwork(track: Track): Boolean {
         SQUARE_ART_SIZE_PATTERN.containsMatchIn(url)
 }
 
+internal fun displayableAlbumLabel(track: Track): String? {
+    val album = track.album.trim()
+    if (album.isBlank() || album.equals(track.title.trim(), ignoreCase = true)) return null
+    if (album.equals("YouTube", ignoreCase = true) || album.startsWith("YouTube Music", ignoreCase = true)) return null
+    return album
+}
+
+internal fun displayableArtistCredit(artist: String): String? {
+    val credit = artist.trim()
+    if (credit.isBlank()) return null
+    if (credit.equals("YouTube Music", ignoreCase = true) || credit.equals("YouTube", ignoreCase = true)) return null
+    return credit
+}
+
 private fun isReliableMusicUpdateCandidate(track: Track): Boolean {
     val title = track.title.trim()
     val artist = track.artist.trim()
@@ -16680,7 +16694,7 @@ private fun AlbumArtworkCard(
     )
     val accentStart = Color(track.accentStart)
     val accentEnd = Color(track.accentEnd)
-    val meta = track.album.takeIf { it.isNotBlank() && it != track.title } ?: track.artist
+    val meta = displayableAlbumLabel(track) ?: track.artist
     Column(
         modifier = Modifier
             .graphicsLayer {
@@ -17350,15 +17364,17 @@ private fun TopResultCard(
                     CoverImage(track, Modifier.size(76.dp).clip(RoundedCornerShape(14.dp)), highRes = true)
                     Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
                         Text(track.title, color = LevyraText, fontSize = 20.sp, fontWeight = FontWeight.Black, maxLines = 2, overflow = TextOverflow.Ellipsis)
-                        Text(
-                            track.artist,
-                            color = LevyraMuted,
-                            fontSize = 14.sp,
-                            fontWeight = FontWeight.Bold,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.clickable { onArtist() }
-                        )
+                        displayableArtistCredit(track.artist)?.let { credit ->
+                            Text(
+                                credit,
+                                color = LevyraMuted,
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Bold,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.clickable { onArtist() }
+                            )
+                        }
                     }
                 }
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
@@ -19184,7 +19200,7 @@ private fun VideoGlassCard(
             }
         }
         Text(
-            text = track.album.takeIf { it.isNotBlank() && it != track.title } ?: LocalLevyraStrings.current.video,
+            text = displayableAlbumLabel(track) ?: LocalLevyraStrings.current.video,
             color = accentStart.playerAdjustBackgroundFor(Color.White, PlayerStrongContrast).color.copy(alpha = 0.82f),
             fontSize = 11.5.sp,
             lineHeight = 14.sp,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/ReliableArtistSearch.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/ReliableArtistSearch.kt
@@ -3,7 +3,9 @@ package com.luc4n3x.levyra.viewmodel
 import com.luc4n3x.levyra.domain.ArtistHit
 import com.luc4n3x.levyra.domain.SearchResults
 import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.domain.artistAudienceWeight
 import com.luc4n3x.levyra.domain.artistIdentityKey
+import com.luc4n3x.levyra.domain.artistIdentityMatches
 
 /**
  * Merges the exact, independently verified artist lookup with the artists returned by the
@@ -16,7 +18,6 @@ internal fun mergeReliableArtistSearchResults(
     verifiedArtists: List<ArtistHit>,
     limit: Int = 12
 ): List<ArtistHit> {
-    val queryKey = artistIdentityKey(query)
     val merged = LinkedHashMap<String, ArtistHit>()
 
     fun add(hit: ArtistHit) {
@@ -28,20 +29,29 @@ internal fun mergeReliableArtistSearchResults(
         }
     }
 
-    exactArtist
-        ?.takeIf { queryKey.isNotBlank() && artistIdentityKey(it.name) == queryKey }
-        ?.let(::add)
+    val candidates = (listOfNotNull(exactArtist) + verifiedArtists)
+    val queryMatches = candidates.filter { artistIdentityMatches(it.name, query) }
+    queryMatches.maxWithOrNull(artistAuthorityOrder)?.let(::add)
 
     verifiedArtists
         .sortedWith(
-            compareByDescending<ArtistHit> { queryKey.isNotBlank() && artistIdentityKey(it.name) == queryKey }
-                .thenByDescending { it.officialArtwork }
+            compareByDescending<ArtistHit> { artistIdentityMatches(it.name, query) }
+                .then(artistAuthorityOrder.reversed())
                 .thenBy { it.name.lowercase() }
         )
         .forEach(::add)
 
     return merged.values.take(limit.coerceIn(1, 24))
 }
+
+/**
+ * Ranks artists that match the query equally well: a verified official page and a real audience
+ * beat a same-named channel with a handful of subscribers.
+ */
+private val artistAuthorityOrder: Comparator<ArtistHit> =
+    compareBy<ArtistHit> { it.officialArtwork }
+        .thenBy { artistAudienceWeight(it.subscribers) }
+        .thenBy { it.thumbnailUrl.isNotBlank() }
 
 /**
  * Replaces provider placeholders on song results only when the search query exactly matches an
@@ -52,10 +62,10 @@ internal fun enrichSearchTracksWithExactArtist(
     results: SearchResults,
     reliableArtists: List<ArtistHit>
 ): SearchResults {
-    val queryKey = artistIdentityKey(query)
-    val exactArtist = reliableArtists.firstOrNull { artist ->
-        queryKey.isNotBlank() && artistIdentityKey(artist.name) == queryKey
-    } ?: return results
+    val exactArtist = reliableArtists
+        .filter { artist -> artistIdentityMatches(artist.name, query) }
+        .maxWithOrNull(artistAuthorityOrder)
+        ?: return results
 
     fun Track.withExactArtistWhenMissing(): Track {
         val hasProviderPlaceholder = artist.isBlank() ||

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicResilienceClientTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicResilienceClientTest.kt
@@ -115,6 +115,60 @@ class YoutubeMusicResilienceClientTest {
     }
 
     @Test
+    fun searchSuggestionsUsesMusicEndpointAndInputPayload() {
+        val requests = mutableListOf<YoutubeMusicTransportRequest>()
+        val client = client { request ->
+            requests += request
+            YoutubeMusicTransportResponse(200, validSuggestions(), 9L)
+        }
+
+        val result = client.searchSuggestions("daft punk", "it")
+
+        assertNotNull(result)
+        assertEquals(1, requests.size)
+        assertEquals("music/get_search_suggestions", requests.single().path)
+        assertEquals("web-remix", requests.single().profile.id)
+        assertEquals("daft punk", JSONObject(requests.single().payload).optString("input"))
+    }
+
+    @Test
+    fun suggestionFailureDoesNotPenalizePrimarySearchProfile() {
+        val calls = mutableListOf<String>()
+        var suggestionRequest = true
+        val client = client { request ->
+            calls += "${request.path}:${request.profile.id}"
+            if (suggestionRequest) {
+                YoutubeMusicTransportResponse(500, "suggestion endpoint failure", 10L)
+            } else {
+                YoutubeMusicTransportResponse(200, validSearch(), 10L)
+            }
+        }
+
+        assertNull(client.searchSuggestions("daft punk", "it"))
+        assertTrue(client.diagnostics().isEmpty())
+
+        suggestionRequest = false
+        assertNotNull(client.search("public search", "it"))
+
+        assertEquals("search:web-remix", calls.last())
+        assertEquals(0, client.diagnostics().getValue("web-remix").failures)
+        assertEquals(1, client.diagnostics().getValue("web-remix").successes)
+    }
+
+    @Test
+    fun searchAcceptsTabbedSearchResultsRenderer() {
+        val client = client { _ ->
+            YoutubeMusicTransportResponse(
+                200,
+                """{"contents":{"tabbedSearchResultsRenderer":{"tabs":[]}}}""",
+                10L
+            )
+        }
+
+        assertNotNull(client.search("alternate renderer", "it"))
+    }
+
+    @Test
     fun expiredCachePerformsANewRequest() {
         var now = 1_700_000_000_000L
         var calls = 0
@@ -298,4 +352,7 @@ class YoutubeMusicResilienceClientTest {
 
     private fun validSearch(): String =
         """{"contents":{"musicResponsiveListItemRenderer":{"title":"Track"}}}"""
+
+    private fun validSuggestions(): String =
+        """{"contents":[{"searchSuggestionsSectionRenderer":{"contents":[{"searchSuggestionRenderer":{"navigationEndpoint":{"searchEndpoint":{"query":"daft punk"}}}}]}}]}"""
 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicResilienceClientTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicResilienceClientTest.kt
@@ -156,16 +156,58 @@ class YoutubeMusicResilienceClientTest {
     }
 
     @Test
-    fun searchAcceptsTabbedSearchResultsRenderer() {
+    fun searchAcceptsTabbedSearchResultsRendererCarryingResults() {
         val client = client { _ ->
             YoutubeMusicTransportResponse(
                 200,
-                """{"contents":{"tabbedSearchResultsRenderer":{"tabs":[]}}}""",
+                """{"contents":{"tabbedSearchResultsRenderer":{"tabs":[{"tabRenderer":{"content":{"sectionListRenderer":{"contents":[{"itemSectionRenderer":{"contents":[{"musicResponsiveListItemRenderer":{"title":"Track"}}]}}]}}}}]}}}""",
                 10L
             )
         }
 
         assertNotNull(client.search("alternate renderer", "it"))
+    }
+
+    @Test
+    fun emptyTabbedSearchResultsRendererKeepsTheFallbackChainRunning() {
+        val calls = mutableListOf<String>()
+        val client = client { request ->
+            calls += request.profile.id
+            if (calls.size < 2) {
+                YoutubeMusicTransportResponse(200, """{"contents":{"tabbedSearchResultsRenderer":{"tabs":[]}}}""", 10L)
+            } else {
+                YoutubeMusicTransportResponse(200, validSearch(), 10L)
+            }
+        }
+
+        assertNotNull(client.search("structural wrapper only", "it"))
+        assertTrue(calls.size >= 2)
+    }
+
+    @Test
+    fun emptyItemSectionRendererIsNotAcceptedAsSearchContent() {
+        val client = client { _ ->
+            YoutubeMusicTransportResponse(
+                200,
+                """{"contents":{"sectionListRenderer":{"contents":[{"itemSectionRenderer":{"contents":[]}}]}}}""",
+                10L
+            )
+        }
+
+        assertNull(client.search("empty item section", "it"))
+    }
+
+    @Test
+    fun searchContinuationWithResultsRemainsUseful() {
+        val client = client { _ ->
+            YoutubeMusicTransportResponse(
+                200,
+                """{"continuationContents":{"musicShelfContinuation":{"contents":[{"musicResponsiveListItemRenderer":{"title":"Track"}}]}}}""",
+                10L
+            )
+        }
+
+        assertNotNull(client.search("continuation", "it", continuation = "TOKEN"))
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicSearchEntityKindTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicSearchEntityKindTest.kt
@@ -31,6 +31,74 @@ class YoutubeMusicSearchEntityKindTest {
     }
 
     @Test
+    fun `MPLA browse id is recognized as an artist without page type metadata`() {
+        val renderer = JSONObject().put(
+            "flexColumns",
+            JSONArray().put(
+                runLine(
+                    browseRun(
+                        text = "Coldplay",
+                        browseId = "MPLAUC123456",
+                        pageType = ""
+                    )
+                )
+            )
+        )
+
+        assertEquals(SearchEntityKind.Artist, repository.searchEntityKind(renderer))
+        val artist = repository.parseSearchOverview(
+            JSONObject().put(
+                "contents",
+                JSONArray().put(JSONObject().put("musicResponsiveListItemRenderer", renderer))
+            ),
+            "coldplay"
+        ).artists.single()
+        assertEquals("MPLAUC123456", artist.browseId)
+    }
+
+    @Test
+    fun `bare UC browse id is not classified as an artist without page type metadata`() {
+        val renderer = JSONObject().put(
+            "flexColumns",
+            JSONArray().put(
+                runLine(
+                    browseRun(
+                        text = "Curator Channel",
+                        browseId = "UC_CURATOR_CHANNEL",
+                        pageType = ""
+                    )
+                )
+            )
+        )
+
+        assertEquals(SearchEntityKind.Track, repository.searchEntityKind(renderer))
+    }
+
+    @Test
+    fun `direct artist reference rejects bare UC browse id without artist page type`() {
+        val renderer = JSONObject()
+            .put(
+                "navigationEndpoint",
+                JSONObject().put(
+                    "browseEndpoint",
+                    JSONObject().put("browseId", "UC_CURATOR_CHANNEL")
+                )
+            )
+            .put(
+                "title",
+                JSONObject().put(
+                    "runs",
+                    JSONArray().put(JSONObject().put("text", "Curator Channel"))
+                )
+            )
+
+        assertEquals(
+            null,
+            repository.extractYoutubeMusicArtistReference(renderer, "Curator Channel")
+        )
+    }
+
+    @Test
     fun `album row wins over the artist endpoint it also carries`() {
         val renderer = JSONObject().put(
             "flexColumns",
@@ -129,6 +197,27 @@ class YoutubeMusicSearchEntityKindTest {
     }
 
     @Test
+    fun `reload continuation data is accepted for search pagination`() {
+        val root = JSONObject().put(
+            "continuationContents",
+            JSONObject().put(
+                "musicShelfContinuation",
+                JSONObject().put(
+                    "continuations",
+                    JSONArray().put(
+                        JSONObject().put(
+                            "reloadContinuationData",
+                            JSONObject().put("continuation", "RELOAD_TOKEN")
+                        )
+                    )
+                )
+            )
+        )
+
+        assertEquals("RELOAD_TOKEN", repository.findSearchContinuation(root))
+    }
+
+    @Test
     fun `overview is empty for an unparsable payload`() {
         val overview = repository.parseSearchOverview(JSONObject().put("contents", JSONArray()), "query")
 
@@ -158,23 +247,21 @@ class YoutubeMusicSearchEntityKindTest {
 
     private fun runLine(run: JSONObject): JSONObject = flexColumn(JSONArray().put(run))
 
-    private fun browseRun(text: String, browseId: String, pageType: String): JSONObject = JSONObject()
-        .put("text", text)
-        .put(
-            "navigationEndpoint",
-            JSONObject().put(
-                "browseEndpoint",
-                JSONObject()
-                    .put("browseId", browseId)
-                    .put(
-                        "browseEndpointContextSupportedConfigs",
-                        JSONObject().put(
-                            "browseEndpointContextMusicConfig",
-                            JSONObject().put("pageType", pageType)
-                        )
-                    )
+    private fun browseRun(text: String, browseId: String, pageType: String): JSONObject {
+        val endpoint = JSONObject().put("browseId", browseId)
+        if (pageType.isNotBlank()) {
+            endpoint.put(
+                "browseEndpointContextSupportedConfigs",
+                JSONObject().put(
+                    "browseEndpointContextMusicConfig",
+                    JSONObject().put("pageType", pageType)
+                )
             )
-        )
+        }
+        return JSONObject()
+            .put("text", text)
+            .put("navigationEndpoint", JSONObject().put("browseEndpoint", endpoint))
+    }
 
     private fun flexColumn(runs: JSONArray): JSONObject = JSONObject().put(
         "musicResponsiveListItemFlexColumnRenderer",

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicSearchRendererTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicSearchRendererTest.kt
@@ -4,6 +4,7 @@ import com.luc4n3x.levyra.domain.AlbumHit
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 class YoutubeMusicSearchRendererTest {
@@ -25,8 +26,23 @@ class YoutubeMusicSearchRendererTest {
         )
 
         requireNotNull(track)
-        assertEquals("YouTube Music", track.artist)
+        assertEquals("", track.artist)
         assertEquals("YouTube Music", track.album)
+    }
+
+    @Test
+    fun `provider name is never surfaced as artist credit`() {
+        val track = repository.parseMusicRenderer(
+            renderer(
+                line("O"),
+                line("27M plays")
+            ),
+            query = "Coldplay"
+        )
+
+        requireNotNull(track)
+        assertNotEquals("YouTube Music", track.artist)
+        assertNotEquals("YouTube", track.artist)
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicSearchSuggestionsTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicSearchSuggestionsTest.kt
@@ -1,0 +1,80 @@
+package com.luc4n3x.levyra.data
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class YoutubeMusicSearchSuggestionsTest {
+    @Test
+    fun parsesSearchAndHistorySuggestionsInServerOrder() {
+        val root = JSONObject(
+            """
+            {
+              "contents": [
+                {
+                  "searchSuggestionsSectionRenderer": {
+                    "contents": [
+                      {
+                        "historySuggestionRenderer": {
+                          "suggestion": {"runs": [{"text": "daft punk"}]},
+                          "navigationEndpoint": {"searchEndpoint": {"query": "daft punk"}}
+                        }
+                      },
+                      {
+                        "searchSuggestionRenderer": {
+                          "suggestion": {"runs": [{"text": "daft punk "}, {"text": "get lucky"}]},
+                          "navigationEndpoint": {"searchEndpoint": {"query": "daft punk get lucky"}}
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        assertEquals(
+            listOf("daft punk", "daft punk get lucky"),
+            parseYoutubeMusicSearchSuggestions(root)
+        )
+    }
+
+    @Test
+    fun fallsBackToRenderedTextAndSkipsMalformedEntries() {
+        val root = JSONObject(
+            """
+            {
+              "contents": [
+                {
+                  "searchSuggestionsSectionRenderer": {
+                    "contents": [
+                      {
+                        "searchSuggestionRenderer": {
+                          "suggestion": {"runs": [{"text": "radio"}, {"text": "head"}]},
+                          "navigationEndpoint": {"searchEndpoint": {"query": ""}}
+                        }
+                      },
+                      {"unknownRenderer": {}},
+                      {
+                        "searchSuggestionRenderer": {
+                          "suggestion": {"runs": [{"text": "radiohead"}]},
+                          "navigationEndpoint": {"searchEndpoint": {"query": "radiohead"}}
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        assertEquals(listOf("radiohead"), parseYoutubeMusicSearchSuggestions(root))
+    }
+
+    @Test
+    fun returnsEmptyForMissingSuggestionSection() {
+        assertEquals(emptyList<String>(), parseYoutubeMusicSearchSuggestions(JSONObject("{}")))
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/ReliableArtistSearchTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/ReliableArtistSearchTest.kt
@@ -136,14 +136,83 @@ class ReliableArtistSearchTest {
         assertEquals(listOf("UC-existing"), result.topTrack?.artistBrowseIds)
     }
 
-    private fun artist(name: String, browseId: String) = ArtistHit(
+    @Test
+    fun leadingArticleArtistWinsOverTinyHomonym() {
+        val official = artist("The Weeknd", "UC-official", subscribers = "Artist · 274M monthly audience")
+        val homonym = artist("Weeknd", "UC-homonym", subscribers = "Artist · 7 subscribers")
+
+        val result = mergeReliableArtistSearchResults(
+            query = "weeknd",
+            exactArtist = homonym,
+            verifiedArtists = listOf(homonym, official)
+        )
+
+        assertEquals("The Weeknd", result.first().name)
+    }
+
+    @Test
+    fun tinyHomonymIsNotPropagatedToSongCredits() {
+        val placeholder = track("After Hours", "YouTube Music")
+
+        val result = enrichSearchTracksWithExactArtist(
+            query = "weeknd",
+            results = SearchResults(topTrack = placeholder, songs = listOf(placeholder)),
+            reliableArtists = listOf(
+                artist("Weeknd", "UC-homonym", subscribers = "Artist · 7 subscribers"),
+                artist("The Weeknd", "UC-official", subscribers = "Artist · 274M monthly audience")
+            )
+        )
+
+        assertEquals("The Weeknd", result.topTrack?.artist)
+        assertEquals(listOf("UC-official"), result.topTrack?.artistBrowseIds)
+        assertEquals("The Weeknd", result.songs.single().artist)
+    }
+
+    @Test
+    fun unverifiedLargeChannelDoesNotBeatVerifiedExactArtist() {
+        val verified = artist("HUGEL", "UC-hugel", subscribers = "Artist · 900K subscribers")
+        val unverified = artist(
+            "Hugel",
+            "UC-copycat",
+            subscribers = "Artist · 40M subscribers",
+            officialArtwork = false
+        )
+
+        val result = mergeReliableArtistSearchResults(
+            query = "hugel",
+            exactArtist = verified,
+            verifiedArtists = listOf(unverified, verified)
+        )
+
+        assertEquals("UC-hugel", result.first().browseId)
+    }
+
+    @Test
+    fun realSongArtistSurvivesArticleAwareMatching() {
+        val collaboration = track("Pray For Me", "The Weeknd, Kendrick Lamar")
+
+        val result = enrichSearchTracksWithExactArtist(
+            query = "weeknd",
+            results = SearchResults(topTrack = collaboration, songs = listOf(collaboration)),
+            reliableArtists = listOf(artist("The Weeknd", "UC-official"))
+        )
+
+        assertEquals("The Weeknd, Kendrick Lamar", result.topTrack?.artist)
+    }
+
+    private fun artist(
+        name: String,
+        browseId: String,
+        subscribers: String = "",
+        officialArtwork: Boolean = true
+    ) = ArtistHit(
         name = name,
-        subscribers = "",
+        subscribers = subscribers,
         thumbnailUrl = "https://example.com/$browseId.jpg",
         accentStart = 0,
         accentEnd = 0,
         browseId = browseId,
-        officialArtwork = true
+        officialArtwork = officialArtwork
     )
 
     private fun track(


### PR DESCRIPTION
## Summary

Improve Levyra's YouTube Music search reliability by using the native YouTube Music suggestion endpoint first and by accepting additional response and continuation shapes already seen in real InnerTube responses. The existing suggestion fallback remains in place, and autocomplete failures are kept isolated from the health scoring used by normal catalog search.

## What changed

- use `music/get_search_suggestions` for native YouTube Music suggestions, with the existing generic YouTube suggestion service kept as fallback
- parse `searchSuggestionRenderer` and `historySuggestionRenderer`, deduplicate suggestions, and keep the result set bounded
- accept alternate search shapes through the renderers the parser can actually read (`musicCardShelfRenderer`, item renderers nested in `tabbedSearchResultsRenderer` / `itemSectionRenderer` wrappers); a bare structural wrapper no longer counts as a useful response, so the profile fallback chain keeps running on empty or blocked replies
- resolve the requested artist by authority: identity matching also accepts a leading-article variant (`weeknd` → `The Weeknd`) and equally matching artists are ranked by verified artwork and parsed audience, so a same-named channel with a handful of subscribers no longer wins or leaks into song credits
- never surface the provider label as an artist or album credit
- support `reloadContinuationData` and `continuationCommand` in addition to the existing continuation path
- recognize `MPLA...` artist browse IDs without treating bare `UC...` uploader/channel IDs as artists
- keep suggestion requests out of the primary YouTube Music client-health score
- add regression coverage for suggestions, resilience, artist classification, and continuation parsing

`ytmusicapi` was used only as a behavioral reference for YouTube Music request/response shapes. No Python runtime, dependency, bridge, or second API layer is added.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor or maintenance
- [ ] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** Streaming / UI

## Validation

### Automated checks

- [x] Android: full `:app:testDebugUnitTest` suite (179 test classes), `:app:lintDebug`, `:app:assembleDebug`
- [ ] Desktop: `cd desktop && ./gradlew check assemble` — N/A, Android-only change
- [x] Targeted tests were added or updated

`:app:lintRelease` / `:app:assembleRelease` cannot run on the verification machine (`Missing YOUTUBE_INNERTUBE_API_KEY`, CI-only secret); the debug equivalents were run instead and are green. Before opening the PR the repository validation pipeline passed `:app:lintRelease`, the full unit suite, `assembleRelease`, Android/F-Droid regression tests, LevyraExtractor tests, the AI Quality Gate, Android runtime compatibility checks, the updater manifest contract, and the F-Droid release build.

Targeted suites re-run after every fix:

- `YoutubeMusicResilienceClientTest` — profile fallback, suggestion health isolation, `isUseful` wrappers, continuations
- `YoutubeMusicSearchSuggestionsTest` — suggestion parsing, dedup, malformed entries
- `YoutubeMusicSearchEntityKindTest` — `MPLA` / bare `UC` classification
- `YoutubeMusicSearchRendererTest` — renderer credits and album labels
- `ReliableArtistSearchTest` — artist ranking and song-credit enrichment

### Manual testing

Emulator: Pixel 8, Android API 37 (x86_64). Release APK `LEVYRA-2.3.33` first, then debug builds after each fix.

| Scenario | Steps | Result |
|---|---|---|
| Search suggestions | `shiva`, `shivaa`, `annalisa`, `geolier`, `weeknd`, `the weeknd`, including progressively typed queries and query clearing | Pass — suggestions relevant, no duplicates, no corrupted strings, no crash |
| Search categories | All / Songs / Artists / Albums / Playlists for `the weeknd` and `geolier` | Pass — correct titles, artists, artwork, years; playlist owners (`Felipe`, `giu`) stay owners |
| `MPLA` / `UC` handling | Real artist, generic uploader/channel, plain Song result | Pass — uploaders never appear in song credits |
| Continuation | Songs list scrolled plus explicit "More" on `the weeknd` | Pass — two pages loaded, new results each page, no loop, no duplicate flood, no stuck spinner |
| Artist ranking | `weeknd` and `the weeknd`, control queries `geolier`, `annalisa` | Pass — `weeknd` resolves to The Weeknd for top result, artist shelf and song credits; unrelated queries unchanged |
| Resilience / `isUseful` | Normal searches after tightening the SEARCH markers | Pass — results still returned through the fallback chain, no empty screens |
| Playback sanity | Play a search result, Next, back to search, play a second track | Pass — playback starts, metadata correct, no crash or freeze |
| Logcat | Watched during the whole session | Clean — no FATAL EXCEPTION, ANR, JSON parsing or coroutine errors from the app |

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** None. No schema, preference, dependency, authentication, playback, or release changes.
- **Known limitations:** Release-variant Gradle tasks need the CI-only InnerTube API key, so they were validated as debug variants locally.
- **Rollback plan:** Revert this PR

## Reviewer notes

- `MPLA...` is intentionally accepted as an artist reference even when explicit artist page metadata is missing.
- Bare `UC...` IDs are intentionally not promoted to artists without artist metadata; the full unit suite caught this regression during development and it is now covered.
- Suggestion failures do not update primary client health, so best-effort autocomplete cannot degrade normal search/browse strategy selection.

## Release note

Improved YouTube Music search suggestions and resilience to alternate search response formats.

## Related issues

N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR — PR CI is still running; the complete pre-PR validation was green


