### PR TITLE
docs(readme): refine tables and privacy presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,22 +208,11 @@ Levyra is built from the ground up as a native, modular audio suite for Android 
 
 ### ✦ Under the Hood
 
-<table align="center" width="100%">
-  <tr valign="top">
-    <td width="33%">
-      <h4>🔄 <b>State Flow</b></h4>
-      <sub>User actions update immutable ViewModel state, keeping Compose UI, MediaSession, and Android Auto in sync.</sub>
-    </td>
-    <td width="33%">
-      <h4>🎯 <b>Stream Resolver</b></h4>
-      <sub>InnerTube and LevyraExtractor work with automatic fallback, fidelity selection, and queue prefetch.</sub>
-    </td>
-    <td width="34%">
-      <h4>💿 <b>File Vault</b></h4>
-      <sub>Offline tracks are exported as tagged M4A files in <code>Music/Levyra</code>, ready for external players and car systems.</sub>
-    </td>
-  </tr>
-</table>
+<sub>Three core systems keep playback predictable, resilient, and portable.</sub>
+
+* 🔄 **Unidirectional State Flow** — Immutable ViewModel state keeps the Compose UI, MediaSession, and Android Auto synchronized.
+* 🎯 **Dual Stream Resolver** — InnerTube and LevyraExtractor work with automatic fallback, fidelity selection, and queue prefetch.
+* 💿 **Standard File Vault** — Offline tracks are exported as tagged M4A files in `Music/Levyra`, ready for external players and car systems.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -168,12 +168,23 @@ Modern music streaming applications often treat music as temporary, disposable b
 
 ## ✦ Architecture & Engineering Blueprint
 
+<div align="center">
+  <h3>🏗️ <b>Native architecture. Modular by design.</b></h3>
+  <p>
+    <code>ANDROID</code> &nbsp;·&nbsp;
+    <code>WINDOWS</code> &nbsp;·&nbsp;
+    <code>LOW-LATENCY PLAYBACK</code> &nbsp;·&nbsp;
+    <code>LOCAL-FIRST STORAGE</code>
+  </p>
+</div>
+
 Levyra is built from the ground up as a native, modular audio suite for Android and Windows.
 
 <table align="center" width="100%">
   <tr valign="top">
     <td width="50%">
       <h3>📱 <b>Android Native Suite</b> (<code>app/</code>)</h3>
+      <p><b>Modern Android stack.</b><br><sub>Compose-first UI, Media3 playback, offline export, and local data orchestration.</sub></p>
       <ul>
         <li>🎨 <b><a href="app/src/main/java/com/luc4n3x/levyra/ui"><code>ui/</code></a>:</b> Compose & Material 3 screens, gestures, Canvas, and OLED palettes.</li>
         <li>🧠 <b><a href="app/src/main/java/com/luc4n3x/levyra/viewmodel"><code>viewmodel/</code></a>:</b> Immutable UI state and unidirectional coordination.</li>
@@ -184,6 +195,7 @@ Levyra is built from the ground up as a native, modular audio suite for Android 
     </td>
     <td width="50%">
       <h3>💻 <b>Windows Desktop Suite</b> (<code>desktop/</code>)</h3>
+      <p><b>Standalone desktop core.</b><br><sub>Compose Multiplatform interface, libvlc playback, packaging, and desktop-native controls.</sub></p>
       <ul>
         <li>🖥️ <b><a href="desktop/app"><code>app/</code></a>:</b> Compose Multiplatform UI, windows, and updater.</li>
         <li>🔊 <b><a href="desktop/player"><code>player/</code></a>:</b> libvlc playback, hardware acceleration, tray, and global hotkeys.</li>
@@ -195,9 +207,23 @@ Levyra is built from the ground up as a native, modular audio suite for Android 
 </table>
 
 ### ✦ Under the Hood
-* **Unidirectional State Flow**: User actions update immutable state in the ViewModel, dispatching synchronized changes across the Compose UI, MediaSession notification, and Android Auto.
-* **Dual Stream Resolver**: Queries InnerTube and LevyraExtractor with automatic fallback, selecting the highest-fidelity Opus or AAC stream while prefetching upcoming queue tracks.
-* **Standard File Vault**: Offline tracks save as tagged M4A files directly into `Music/Levyra`, playable in external DAPs, car stereos, and third-party media players.
+
+<table align="center" width="100%">
+  <tr valign="top">
+    <td width="33%">
+      <h4>🔄 <b>State Flow</b></h4>
+      <sub>User actions update immutable ViewModel state, keeping Compose UI, MediaSession, and Android Auto in sync.</sub>
+    </td>
+    <td width="33%">
+      <h4>🎯 <b>Stream Resolver</b></h4>
+      <sub>InnerTube and LevyraExtractor work with automatic fallback, fidelity selection, and queue prefetch.</sub>
+    </td>
+    <td width="34%">
+      <h4>💿 <b>File Vault</b></h4>
+      <sub>Offline tracks are exported as tagged M4A files in <code>Music/Levyra</code>, ready for external players and car systems.</sub>
+    </td>
+  </tr>
+</table>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -210,13 +210,13 @@ Levyra is built from the ground up as a native, modular audio suite for Android 
 
 <sub>Three core systems keep Levyra predictable, resilient, and portable.</sub>
 
-**01 · Unidirectional State Flow**  
+**01 · Unidirectional State Flow**<br>
 Immutable ViewModel state keeps the Compose UI, MediaSession, and Android Auto synchronized.
 
-**02 · Dual Stream Resolver**  
+**02 · Dual Stream Resolver**<br>
 InnerTube and LevyraExtractor coordinate automatic fallback, fidelity selection, and queue prefetch.
 
-**03 · Standard File Vault**  
+**03 · Standard File Vault**<br>
 Offline tracks are exported as tagged M4A files in `Music/Levyra`, ready for external players and car systems.
 
 ---

--- a/README.md
+++ b/README.md
@@ -109,57 +109,57 @@ Modern music streaming applications often treat music as temporary, disposable b
 <table align="center" width="100%">
   <tr valign="top">
     <td width="50%">
-      <strong>🎚️ Pure Audio & Playback Engine</strong><br><br>
-      <b>Dual Native Engines:</b> Media3 / ExoPlayer on Android; isolated libvlc on Windows.<br><br>
-      <b>Android Auto:</b> Library, steering-wheel controls, and voice playback.<br><br>
-      <b>Playback Tools:</b> Gapless, shuffle/repeat, speed/pitch, sleep timer presets, and queue swipe-to-remove with Undo.<br><br>
-      <b>Smart Audio:</b> Volume normalization plus intro, sponsor, banter, and silence skipping.<br><br>
-      <b>Audio / Video Toggle:</b> Efficient audio streams or full video playback.
+      <h3>🎚️ <b>Pure Audio & Playback Engine</b></h3>
+      <ul>
+        <li><b>Dual Native Engines:</b> Media3 / ExoPlayer on Android and isolated libvlc on Windows.</li>
+        <li><b>Playback Suite:</b> Gapless, shuffle/repeat, speed/pitch, sleep timer, and queue Undo.</li>
+        <li><b>Smart Playback:</b> Android Auto, volume normalization, SponsorBlock skipping, and Audio / Video toggle.</li>
+      </ul>
     </td>
     <td width="50%">
-      <strong>💾 Offline Audio Vault & File Exports</strong><br><br>
-      <b>Standard M4A Files:</b> Cover art, artist, album, and lyrics embedded in the file.<br><br>
-      <b>Permanent Storage:</b> Saved to <code>Music/Levyra</code> and usable outside the app.<br><br>
-      <b>Local-First Playback:</b> Existing offline files play instantly without a network request.<br><br>
-      <b>Resilient Downloads:</b> HTTP Range resume with atomic verification.<br><br>
-      <b>Portable Backups:</b> Offline JSON export/import for playlists, favorites, and history.
-    </td>
-  </tr>
-  <tr valign="top">
-    <td width="50%">
-      <strong>🔍 Stream Extraction & Discovery</strong><br><br>
-      <b>Dual Resolver:</b> Highest-fidelity Opus or AAC with automatic fallback.<br><br>
-      <b>Queue Prefetch:</b> Upcoming tracks buffer quietly before the skip.<br><br>
-      <b>Global Charts:</b> Country-specific Top 50 and global discovery.<br><br>
-      <b>Smart Orbit:</b> Recommendations rotate with listening context.<br><br>
-      <b>Samples Feed:</b> Short-form music clips with live comment-energy signals.
-    </td>
-    <td width="50%">
-      <strong>📊 Karaoke Lyrics & Visual Immersion</strong><br><br>
-      <b>Synced Lyrics:</b> Millisecond-aligned LRCLIB lyrics with live highlighting.<br><br>
-      <b>Tap-to-Seek:</b> Jump straight to any lyric timestamp.<br><br>
-      <b>Lyric Sharing:</b> Select verses, then copy, share, or export a 1080x1080 Levyra card.<br><br>
-      <b>Living Artwork:</b> No real Canvas? The cover becomes a slow artwork-driven colour field (AGSL on Android 13+, Compose fallback below).<br><br>
-      <b>Canvas Control:</b> Toggle Canvas/Living Artwork directly from Now Playing in Song Mode.<br><br>
-      <b>Artwork Preview:</b> Long-press the cover for a full-screen zoomable view with save-to-gallery.<br><br>
-      <b>Ambient Visuals:</b> Palette-reactive backdrops, waveform, and looping motion art.
+      <h3>💾 <b>Offline Audio Vault & File Exports</b></h3>
+      <ul>
+        <li><b>Tagged M4A Files:</b> Cover art, artist, album, and lyrics embedded directly in the file.</li>
+        <li><b>Local-First Playback:</b> Existing offline files play instantly from <code>Music/Levyra</code>.</li>
+        <li><b>Resilient Storage:</b> HTTP Range resume, atomic verification, and portable JSON backups.</li>
+      </ul>
     </td>
   </tr>
   <tr valign="top">
     <td width="50%">
-      <strong>📈 Listening Insights</strong><br><br>
-      <b>Real Listening Time:</b> Only actual playback time counts across pause, seek, skip, and background.<br><br>
-      <b>Counted Plays:</b> Roughly 30 seconds, or a genuine completion for short tracks; skipped long tracks never count.<br><br>
-      <b>Lifetime Totals:</b> Compact on-device aggregates keep All Time accurate after raw history is pruned.<br><br>
-      <b>Listening Pulse:</b> Your week, 24-hour listening rhythm, and artist distribution ring.<br><br>
-      <b>Your Sound:</b> Period analysis for 7 days, 30 days, 6 months, and All Time.
+      <h3>🔍 <b>Stream Extraction & Discovery</b></h3>
+      <ul>
+        <li><b>Dual Resolver:</b> Highest-fidelity Opus or AAC with automatic fallback.</li>
+        <li><b>Queue Prefetch:</b> Upcoming tracks buffer quietly before the skip.</li>
+        <li><b>Discovery Engine:</b> Global Top 50, Smart Orbit recommendations, and Samples feed.</li>
+      </ul>
     </td>
     <td width="50%">
-      <strong>🔤 Readability & Typography</strong><br><br>
-      <b>Levyra Type Rhythm:</b> Shared line-height scale for titles, metadata, and multi-line text.<br><br>
-      <b>Balanced Tracking:</b> Letter spacing tuned per role instead of one blanket value.<br><br>
-      <b>No Clipping:</b> Accents and descenders stay intact at large font scales.<br><br>
-      <b>Private by Default:</b> Every statistic is computed on device and never leaves it.
+      <h3>📊 <b>Karaoke Lyrics & Visual Immersion</b></h3>
+      <ul>
+        <li><b>Synced Lyrics:</b> Millisecond-aligned LRCLIB lyrics with tap-to-seek highlighting.</li>
+        <li><b>Lyric Sharing:</b> Select verses, copy, share, or export a 1080×1080 Levyra card.</li>
+        <li><b>Living Artwork:</b> Artwork-driven motion fallback when a real Canvas is unavailable.</li>
+        <li><b>Canvas & Preview:</b> In-player Canvas control plus full-screen zoomable artwork preview.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr valign="top">
+    <td width="50%">
+      <h3>📈 <b>Listening Insights</b></h3>
+      <ul>
+        <li><b>Accurate Listening:</b> Playback time and counted plays respect pause, seek, skip, and completion.</li>
+        <li><b>Listening Pulse:</b> Weekly activity, 24-hour rhythm, and artist distribution.</li>
+        <li><b>Your Sound:</b> 7-day, 30-day, 6-month, and All Time analysis stored on device.</li>
+      </ul>
+    </td>
+    <td width="50%">
+      <h3>🔤 <b>Readability & Typography</b></h3>
+      <ul>
+        <li><b>Levyra Type Rhythm:</b> Shared line-height scale for titles, metadata, and multi-line text.</li>
+        <li><b>Accessible Layout:</b> Role-aware tracking with safe accents, descenders, and large font scales.</li>
+        <li><b>Private by Default:</b> Listening statistics are computed locally and never leave the device.</li>
+      </ul>
     </td>
   </tr>
 </table>
@@ -173,19 +173,23 @@ Levyra is built from the ground up as a native, modular audio suite for Android 
 <table align="center" width="100%">
   <tr valign="top">
     <td width="50%">
-      <strong>📱 Android Native Suite (<code>app/</code>)</strong><br><br>
-      🎨 <b><a href="app/src/main/java/com/luc4n3x/levyra/ui"><code>ui/</code></a></b> — Compose & Material 3 screens, gestures, canvas, and OLED palettes.<br><br>
-      🧠 <b><a href="app/src/main/java/com/luc4n3x/levyra/viewmodel"><code>viewmodel/</code></a></b> — Immutable UI state and unidirectional coordination.<br><br>
-      🎧 <b><a href="app/src/main/java/com/luc4n3x/levyra/player"><code>player/</code></a></b> — Media3 / ExoPlayer foreground audio service.<br><br>
-      💾 <b><a href="app/src/main/java/com/luc4n3x/levyra/player/offline"><code>offline/</code></a></b> — WorkManager exports, M4A tagging, and artwork.<br><br>
-      ⚡ <b><a href="app/src/main/java/com/luc4n3x/levyra/data"><code>data/</code></a></b> — Stream resolving, synced lyrics, prefetch, and local Room data.
+      <h3>📱 <b>Android Native Suite</b> (<code>app/</code>)</h3>
+      <ul>
+        <li>🎨 <b><a href="app/src/main/java/com/luc4n3x/levyra/ui"><code>ui/</code></a>:</b> Compose & Material 3 screens, gestures, Canvas, and OLED palettes.</li>
+        <li>🧠 <b><a href="app/src/main/java/com/luc4n3x/levyra/viewmodel"><code>viewmodel/</code></a>:</b> Immutable UI state and unidirectional coordination.</li>
+        <li>🎧 <b><a href="app/src/main/java/com/luc4n3x/levyra/player"><code>player/</code></a>:</b> Media3 / ExoPlayer foreground audio service.</li>
+        <li>💾 <b><a href="app/src/main/java/com/luc4n3x/levyra/player/offline"><code>offline/</code></a>:</b> WorkManager exports, M4A tagging, and artwork.</li>
+        <li>⚡ <b><a href="app/src/main/java/com/luc4n3x/levyra/data"><code>data/</code></a>:</b> Stream resolving, synced lyrics, prefetch, and Room data.</li>
+      </ul>
     </td>
     <td width="50%">
-      <strong>💻 Windows Desktop Suite (<code>desktop/</code>)</strong><br><br>
-      🖥️ <b><a href="desktop/app"><code>app/</code></a></b> — Compose Multiplatform UI, windows, and updater.<br><br>
-      🔊 <b><a href="desktop/player"><code>player/</code></a></b> — libvlc playback, hardware acceleration, tray, and global hotkeys.<br><br>
-      🌐 <b><a href="desktop/core"><code>core/</code></a></b> — Stream resolver, downloads, and local app storage.<br><br>
-      📦 <b><a href="desktop/packaging"><code>packaging/</code></a></b> — WiX MSI installer and portable distributions.
+      <h3>💻 <b>Windows Desktop Suite</b> (<code>desktop/</code>)</h3>
+      <ul>
+        <li>🖥️ <b><a href="desktop/app"><code>app/</code></a>:</b> Compose Multiplatform UI, windows, and updater.</li>
+        <li>🔊 <b><a href="desktop/player"><code>player/</code></a>:</b> libvlc playback, hardware acceleration, tray, and global hotkeys.</li>
+        <li>🌐 <b><a href="desktop/core"><code>core/</code></a>:</b> Stream resolver, downloads, and local app storage.</li>
+        <li>📦 <b><a href="desktop/packaging"><code>packaging/</code></a>:</b> WiX MSI installer and portable distributions.</li>
+      </ul>
     </td>
   </tr>
 </table>
@@ -257,21 +261,25 @@ Levyra is built on strict zero-tracking principles: no advertising identifiers, 
 <table align="center" width="100%">
   <tr valign="top">
     <td width="50%">
-      <strong>🌐 Network Transparency</strong><br><br>
-      <b>Streams:</b> Direct YouTube / YT Music CDN connections without proxy tracking.<br><br>
-      <b>Lyrics:</b> LRCLIB and YouTube Music queries using song metadata.<br><br>
-      <b>Artwork & Metadata:</b> Public catalog lookups across Deezer, Apple Music, and Tidal.<br><br>
-      <b>SponsorBlock:</b> Optional queries using truncated video-ID hash prefixes.<br><br>
-      <b>Updates:</b> GitHub release checks at startup; disabled in F-Droid builds.
+      <h3>🌐 <b>Network Transparency</b></h3>
+      <ul>
+        <li><b>Streams:</b> Direct YouTube / YT Music CDN connections without proxy tracking.</li>
+        <li><b>Lyrics:</b> LRCLIB and YouTube Music queries using song metadata.</li>
+        <li><b>Artwork & Metadata:</b> Public catalog lookups across Deezer, Apple Music, and Tidal.</li>
+        <li><b>SponsorBlock:</b> Optional queries using truncated video-ID hash prefixes.</li>
+        <li><b>Updates:</b> GitHub release checks at startup; disabled in F-Droid builds.</li>
+      </ul>
     </td>
     <td width="50%">
-      <strong>🛡️ Android Permissions</strong><br><br>
-      <code>INTERNET</code> / <code>ACCESS_<wbr>NETWORK_STATE</code> — Streaming and metadata resolution.<br><br>
-      <code>FOREGROUND_<wbr>SERVICE_<wbr>MEDIA_<wbr>PLAYBACK</code> — Background playback and media controls.<br><br>
-      <code>POST_<wbr>NOTIFICATIONS</code> — Lockscreen controls and download updates.<br><br>
-      <code>RECORD_<wbr>AUDIO</code> — Optional music-recognition capture; unused when no provider is configured.<br><br>
-      <code>WAKE_<wbr>LOCK</code> — Keeps playback active with the screen off.<br><br>
-      <code>WRITE_<wbr>EXTERNAL_<wbr>STORAGE</code> (Android ≤ 9) — Tagged M4A export to <code>Music/Levyra</code>.
+      <h3>🛡️ <b>Android Permissions</b></h3>
+      <ul>
+        <li><code>INTERNET</code> / <code>ACCESS_<wbr>NETWORK_STATE</code> — Streaming and metadata resolution.</li>
+        <li><code>FOREGROUND_<wbr>SERVICE_<wbr>MEDIA_<wbr>PLAYBACK</code> — Background playback and media controls.</li>
+        <li><code>POST_<wbr>NOTIFICATIONS</code> — Lockscreen controls and download updates.</li>
+        <li><code>RECORD_<wbr>AUDIO</code> — Optional music recognition; unused without a provider.</li>
+        <li><code>WAKE_<wbr>LOCK</code> — Keeps playback active with the screen off.</li>
+        <li><code>WRITE_<wbr>EXTERNAL_<wbr>STORAGE</code> (Android ≤ 9) — Tagged M4A export to <code>Music/Levyra</code>.</li>
+      </ul>
     </td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -256,30 +256,73 @@ levyraDesktopVersion=1.2.0
 
 ## ✦ Privacy Blueprint & Permissions
 
-Levyra is built on strict zero-tracking principles: no advertising identifiers, no user profiling, and no background telemetry.
+<div align="center">
+  <strong>Privacy is part of the architecture, not a settings toggle.</strong><br>
+  <sub>No advertising identifiers · no user profiling · no background telemetry</sub>
+  <br><br>
 
-<table align="center" width="100%">
+  <table width="92%" cellpadding="8" cellspacing="0">
+    <tr valign="middle">
+      <td width="33%" align="center">
+        <b>🛡️ ZERO TRACKERS</b><br>
+        <sub>No analytics or profiling</sub>
+      </td>
+      <td width="33%" align="center">
+        <b>💾 LOCAL DATA</b><br>
+        <sub>History and stats stay on device</sub>
+      </td>
+      <td width="34%" align="center">
+        <b>🌐 DIRECT CONNECTIONS</b><br>
+        <sub>No Levyra tracking proxy</sub>
+      </td>
+    </tr>
+  </table>
+</div>
+
+<br>
+
+<table align="center" width="100%" cellpadding="10" cellspacing="0">
   <tr valign="top">
     <td width="50%">
       <h3>🌐 <b>Network Transparency</b></h3>
-      <ul>
-        <li><b>Streams:</b> Direct YouTube / YT Music CDN connections without proxy tracking.</li>
-        <li><b>Lyrics:</b> LRCLIB and YouTube Music queries using song metadata.</li>
-        <li><b>Artwork & Metadata:</b> Public catalog lookups across Deezer, Apple Music, and Tidal.</li>
-        <li><b>SponsorBlock:</b> Optional queries using truncated video-ID hash prefixes.</li>
-        <li><b>Updates:</b> GitHub release checks at startup; disabled in F-Droid builds.</li>
-      </ul>
+      <sub>Every external connection has a clear playback or metadata purpose.</sub>
+      <br><br>
+      <b>🎵 Streams</b><br>
+      <small>Direct YouTube / YT Music CDN connections without proxy tracking.</small>
+      <hr width="88%">
+      <b>📝 Lyrics</b><br>
+      <small>LRCLIB and YouTube Music queries using song metadata.</small>
+      <hr width="88%">
+      <b>🖼️ Artwork & Metadata</b><br>
+      <small>Public catalog lookups across Deezer, Apple Music, and Tidal.</small>
+      <hr width="88%">
+      <b>✂️ SponsorBlock</b><br>
+      <small>Optional queries using truncated video-ID hash prefixes.</small>
+      <hr width="88%">
+      <b>🚀 Updates</b><br>
+      <small>GitHub release checks at startup; disabled in F-Droid builds.</small>
     </td>
     <td width="50%">
       <h3>🛡️ <b>Android Permissions</b></h3>
-      <ul>
-        <li><code>INTERNET</code> / <code>ACCESS_<wbr>NETWORK_STATE</code> — Streaming and metadata resolution.</li>
-        <li><code>FOREGROUND_<wbr>SERVICE_<wbr>MEDIA_<wbr>PLAYBACK</code> — Background playback and media controls.</li>
-        <li><code>POST_<wbr>NOTIFICATIONS</code> — Lockscreen controls and download updates.</li>
-        <li><code>RECORD_<wbr>AUDIO</code> — Optional music recognition; unused without a provider.</li>
-        <li><code>WAKE_<wbr>LOCK</code> — Keeps playback active with the screen off.</li>
-        <li><code>WRITE_<wbr>EXTERNAL_<wbr>STORAGE</code> (Android ≤ 9) — Tagged M4A export to <code>Music/Levyra</code>.</li>
-      </ul>
+      <sub>Only permissions required for playback, notifications, recognition, and offline export.</sub>
+      <br><br>
+      <b><code>INTERNET</code> / <code>ACCESS_<wbr>NETWORK_STATE</code></b><br>
+      <small>Streaming and metadata resolution.</small>
+      <hr width="88%">
+      <b><code>FOREGROUND_<wbr>SERVICE_<wbr>MEDIA_<wbr>PLAYBACK</code></b><br>
+      <small>Background playback and media controls.</small>
+      <hr width="88%">
+      <b><code>POST_<wbr>NOTIFICATIONS</code></b><br>
+      <small>Lockscreen controls and download updates.</small>
+      <hr width="88%">
+      <b><code>RECORD_<wbr>AUDIO</code></b><br>
+      <small>Optional music recognition; unused without a configured provider.</small>
+      <hr width="88%">
+      <b><code>WAKE_<wbr>LOCK</code></b><br>
+      <small>Keeps playback active with the screen off.</small>
+      <hr width="88%">
+      <b><code>WRITE_<wbr>EXTERNAL_<wbr>STORAGE</code> · Android ≤ 9</b><br>
+      <small>Tagged M4A export to <code>Music/Levyra</code>.</small>
     </td>
   </tr>
 </table>
@@ -338,7 +381,7 @@ We welcome community contributions, bug fixes, localization, and performance enh
 
 ### Acknowledgments
 
-* **[Metrolist](https://github.com/MetrolistGroup/Metrolist)** — Architectural inspiration for fluid Compose UI navigation and dynamic OLED palettes.
+* **[Metrolist](https://github.com/MetrolistGroup/Metrolist)** — Reference for Levyra's renderer-recovery backoff policy and BetterLyrics TTML parsing behavior, reimplemented for Levyra.
 * **[PipePipeExtractor](https://github.com/InfinityLoop1308/PipePipeExtractor)** — LevyraExtractor is maintained as a Levyra-specific fork of this project, with additional stream-resolution, playback-reliability, diagnostics, and fallback work.
 * **[NewPipe & PipePipe Communities](https://github.com/TeamNewPipe/NewPipeExtractor)** — Foundational extractor architecture, service implementations, parser protocols, and downstream ecosystem work retained in LevyraExtractor.
 * **[LRCLIB](https://lrclib.net/)** — Community synchronized lyric database and open API powering real-time karaoke synchronization.

--- a/README.md
+++ b/README.md
@@ -257,72 +257,34 @@ levyraDesktopVersion=1.2.0
 ## ✦ Privacy Blueprint & Permissions
 
 <div align="center">
-  <strong>Privacy is part of the architecture, not a settings toggle.</strong><br>
-  <sub>No advertising identifiers · no user profiling · no background telemetry</sub>
-  <br><br>
-
-  <table width="92%" cellpadding="8" cellspacing="0">
-    <tr valign="middle">
-      <td width="33%" align="center">
-        <b>🛡️ ZERO TRACKERS</b><br>
-        <sub>No analytics or profiling</sub>
-      </td>
-      <td width="33%" align="center">
-        <b>💾 LOCAL DATA</b><br>
-        <sub>History and stats stay on device</sub>
-      </td>
-      <td width="34%" align="center">
-        <b>🌐 DIRECT CONNECTIONS</b><br>
-        <sub>No Levyra tracking proxy</sub>
-      </td>
-    </tr>
-  </table>
+  <b>Zero tracking by design.</b><br>
+  <sub>No ads · no analytics · listening data stays on device</sub>
 </div>
 
 <br>
 
-<table align="center" width="100%" cellpadding="10" cellspacing="0">
+<table align="center" width="100%">
   <tr valign="top">
     <td width="50%">
       <h3>🌐 <b>Network Transparency</b></h3>
-      <sub>Every external connection has a clear playback or metadata purpose.</sub>
-      <br><br>
-      <b>🎵 Streams</b><br>
-      <small>Direct YouTube / YT Music CDN connections without proxy tracking.</small>
-      <hr width="88%">
-      <b>📝 Lyrics</b><br>
-      <small>LRCLIB and YouTube Music queries using song metadata.</small>
-      <hr width="88%">
-      <b>🖼️ Artwork & Metadata</b><br>
-      <small>Public catalog lookups across Deezer, Apple Music, and Tidal.</small>
-      <hr width="88%">
-      <b>✂️ SponsorBlock</b><br>
-      <small>Optional queries using truncated video-ID hash prefixes.</small>
-      <hr width="88%">
-      <b>🚀 Updates</b><br>
-      <small>GitHub release checks at startup; disabled in F-Droid builds.</small>
+      <ul>
+        <li><b>Streams:</b> Direct YouTube / YT Music CDN connections without proxy tracking.</li>
+        <li><b>Lyrics:</b> LRCLIB and YouTube Music queries using song metadata.</li>
+        <li><b>Artwork & Metadata:</b> Public catalog lookups across Deezer, Apple Music, and Tidal.</li>
+        <li><b>SponsorBlock:</b> Optional requests using truncated video-ID hash prefixes.</li>
+        <li><b>Updates:</b> GitHub release checks at startup; disabled in F-Droid builds.</li>
+      </ul>
     </td>
     <td width="50%">
       <h3>🛡️ <b>Android Permissions</b></h3>
-      <sub>Only permissions required for playback, notifications, recognition, and offline export.</sub>
-      <br><br>
-      <b><code>INTERNET</code> / <code>ACCESS_<wbr>NETWORK_STATE</code></b><br>
-      <small>Streaming and metadata resolution.</small>
-      <hr width="88%">
-      <b><code>FOREGROUND_<wbr>SERVICE_<wbr>MEDIA_<wbr>PLAYBACK</code></b><br>
-      <small>Background playback and media controls.</small>
-      <hr width="88%">
-      <b><code>POST_<wbr>NOTIFICATIONS</code></b><br>
-      <small>Lockscreen controls and download updates.</small>
-      <hr width="88%">
-      <b><code>RECORD_<wbr>AUDIO</code></b><br>
-      <small>Optional music recognition; unused without a configured provider.</small>
-      <hr width="88%">
-      <b><code>WAKE_<wbr>LOCK</code></b><br>
-      <small>Keeps playback active with the screen off.</small>
-      <hr width="88%">
-      <b><code>WRITE_<wbr>EXTERNAL_<wbr>STORAGE</code> · Android ≤ 9</b><br>
-      <small>Tagged M4A export to <code>Music/Levyra</code>.</small>
+      <ul>
+        <li><code>INTERNET</code> / <code>ACCESS_<wbr>NETWORK_STATE</code> — Streaming and metadata.</li>
+        <li><code>FOREGROUND_<wbr>SERVICE_<wbr>MEDIA_<wbr>PLAYBACK</code> — Background playback and media controls.</li>
+        <li><code>POST_<wbr>NOTIFICATIONS</code> — Lockscreen controls and download updates.</li>
+        <li><code>RECORD_<wbr>AUDIO</code> — Optional music recognition.</li>
+        <li><code>WAKE_<wbr>LOCK</code> — Keeps playback active with the screen off.</li>
+        <li><code>WRITE_<wbr>EXTERNAL_<wbr>STORAGE</code> (Android ≤ 9) — Tagged M4A export to <code>Music/Levyra</code>.</li>
+      </ul>
     </td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -208,11 +208,16 @@ Levyra is built from the ground up as a native, modular audio suite for Android 
 
 ### ✦ Under the Hood
 
-<sub>Three core systems keep playback predictable, resilient, and portable.</sub>
+<sub>Three core systems keep Levyra predictable, resilient, and portable.</sub>
 
-* 🔄 **Unidirectional State Flow** — Immutable ViewModel state keeps the Compose UI, MediaSession, and Android Auto synchronized.
-* 🎯 **Dual Stream Resolver** — InnerTube and LevyraExtractor work with automatic fallback, fidelity selection, and queue prefetch.
-* 💿 **Standard File Vault** — Offline tracks are exported as tagged M4A files in `Music/Levyra`, ready for external players and car systems.
+**01 · Unidirectional State Flow**  
+Immutable ViewModel state keeps the Compose UI, MediaSession, and Android Auto synchronized.
+
+**02 · Dual Stream Resolver**  
+InnerTube and LevyraExtractor coordinate automatic fallback, fidelity selection, and queue prefetch.
+
+**03 · Standard File Vault**  
+Offline tracks are exported as tagged M4A files in `Music/Levyra`, ready for external players and car systems.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -257,33 +257,38 @@ levyraDesktopVersion=1.2.0
 ## ✦ Privacy Blueprint & Permissions
 
 <div align="center">
-  <b>Zero tracking by design.</b><br>
-  <sub>No ads · no analytics · listening data stays on device</sub>
+  <h3>🛡️ <b>Private by default. Transparent by design.</b></h3>
+  <p>
+    <code>NO ADS</code> &nbsp;·&nbsp;
+    <code>NO ANALYTICS</code> &nbsp;·&nbsp;
+    <code>LOCAL LISTENING DATA</code> &nbsp;·&nbsp;
+    <code>DIRECT CONNECTIONS</code>
+  </p>
 </div>
-
-<br>
 
 <table align="center" width="100%">
   <tr valign="top">
     <td width="50%">
       <h3>🌐 <b>Network Transparency</b></h3>
+      <p><b>Only what playback needs.</b><br><sub>Connections go directly to the services Levyra uses—never through a Levyra tracking proxy.</sub></p>
       <ul>
-        <li><b>Streams:</b> Direct YouTube / YT Music CDN connections without proxy tracking.</li>
-        <li><b>Lyrics:</b> LRCLIB and YouTube Music queries using song metadata.</li>
-        <li><b>Artwork & Metadata:</b> Public catalog lookups across Deezer, Apple Music, and Tidal.</li>
-        <li><b>SponsorBlock:</b> Optional requests using truncated video-ID hash prefixes.</li>
-        <li><b>Updates:</b> GitHub release checks at startup; disabled in F-Droid builds.</li>
+        <li><b>🎵 Streams:</b> Direct YouTube / YT Music CDN connections.</li>
+        <li><b>📝 Lyrics:</b> LRCLIB and YouTube Music metadata queries.</li>
+        <li><b>🖼️ Artwork:</b> Public Deezer, Apple Music, and Tidal catalog lookups.</li>
+        <li><b>✂️ SponsorBlock:</b> Optional truncated video-ID hash requests.</li>
+        <li><b>🚀 Updates:</b> GitHub release checks; disabled in F-Droid builds.</li>
       </ul>
     </td>
     <td width="50%">
-      <h3>🛡️ <b>Android Permissions</b></h3>
+      <h3>🔐 <b>Permission Surface</b></h3>
+      <p><b>Access stays narrow.</b><br><sub>Android permissions are limited to playback, notifications, optional recognition, and offline export.</sub></p>
       <ul>
-        <li><code>INTERNET</code> / <code>ACCESS_<wbr>NETWORK_STATE</code> — Streaming and metadata.</li>
-        <li><code>FOREGROUND_<wbr>SERVICE_<wbr>MEDIA_<wbr>PLAYBACK</code> — Background playback and media controls.</li>
-        <li><code>POST_<wbr>NOTIFICATIONS</code> — Lockscreen controls and download updates.</li>
-        <li><code>RECORD_<wbr>AUDIO</code> — Optional music recognition.</li>
-        <li><code>WAKE_<wbr>LOCK</code> — Keeps playback active with the screen off.</li>
-        <li><code>WRITE_<wbr>EXTERNAL_<wbr>STORAGE</code> (Android ≤ 9) — Tagged M4A export to <code>Music/Levyra</code>.</li>
+        <li><b><code>INTERNET</code> / <code>ACCESS_<wbr>NETWORK_STATE</code></b><br><sub>Streaming and metadata.</sub></li>
+        <li><b><code>FOREGROUND_<wbr>SERVICE_<wbr>MEDIA_<wbr>PLAYBACK</code></b><br><sub>Background playback and media controls.</sub></li>
+        <li><b><code>POST_<wbr>NOTIFICATIONS</code></b><br><sub>Lockscreen controls and download updates.</sub></li>
+        <li><b><code>RECORD_<wbr>AUDIO</code></b><br><sub>Optional music recognition only.</sub></li>
+        <li><b><code>WAKE_<wbr>LOCK</code></b><br><sub>Keeps playback active with the screen off.</sub></li>
+        <li><b><code>WRITE_<wbr>EXTERNAL_<wbr>STORAGE</code></b> <sub>Android ≤ 9</sub><br><sub>Tagged M4A export to <code>Music/Levyra</code>.</sub></li>
       </ul>
     </td>
   </tr>


### PR DESCRIPTION
## Summary

Refine the README tables for a cleaner, bolder presentation while keeping Levyra's existing structure and content intact.

## Changes

- adopt a stronger two-column presentation for the dense feature and architecture tables
- keep headings and key labels bold and easy to scan
- redesign the Privacy Blueprint into a more premium section with a compact privacy status strip and clearer grouped details
- preserve mobile-safe breaks for long Android permission names
- correct the Metrolist acknowledgment to state the actual upstream behaviors reused in Levyra: renderer-recovery backoff policy and BetterLyrics TTML parsing behavior
- keep the rest of the README, screenshots, badges, build instructions, footer sizing, and project structure unchanged

## Validation

- documentation-only change
- only `README.md` is modified
- no application code, dependencies, versions, workflows, releases, or runtime behavior changed
- Metrolist attribution matches the existing `docs/THIRD_PARTY_NOTICES.md`

## Scope

README presentation and attribution only.

