### PR TITLE
fix(android): restore Video Mode subtitles

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -1333,7 +1333,8 @@ class PlaybackResolver private constructor(private val context: Context) {
                 durationMs = duration,
                 thumbnailUrl = thumbnail,
                 source = "YouTube Android Reel · ${selection.reason}",
-                manifest = manifest
+                manifest = manifest,
+                videoSubtitleTracks = videoSubtitleTracks(playerResponse)
             )
         )
     }
@@ -2796,7 +2797,8 @@ class PlaybackResolver private constructor(private val context: Context) {
                 videoStreamUrl = selectedVideoUrl,
                 durationMs = durationMs,
                 source = "LevyraExtractor · ${selection.reason}",
-                playbackManifest = manifest
+                playbackManifest = manifest,
+                videoSubtitleTracks = extractorVideoSubtitleTracks(info)
             )
         }
         val hls = info.hlsUrl.takeIf { it.isNotBlank() && !isPlaybackUrlBlocked(it) && isVerifiedHlsManifest(it) }
@@ -2814,7 +2816,8 @@ class PlaybackResolver private constructor(private val context: Context) {
                 videoStreamUrl = "",
                 durationMs = durationMs,
                 source = LEVYRA_EXTRACTOR_HLS_PROVIDER,
-                playbackManifest = manifest
+                playbackManifest = manifest,
+                videoSubtitleTracks = extractorVideoSubtitleTracks(info)
             )
         }
         throw IllegalStateException("Nessuno stream video compatibile per ${track.title}")
@@ -3333,8 +3336,22 @@ private fun trustedVideoCaptionUrl(value: String): String? {
     if (uri.port !in listOf(-1, 443)) return null
     if (host != "youtube.com" && !host.endsWith(".youtube.com")) return null
     if (uri.path != "/api/timedtext") return null
-    return uri.buildUpon().appendQueryParameter("fmt", "vtt").build().toString()
+    val builder = uri.buildUpon().clearQuery()
+    uri.queryParameterNames
+        .filterNot { it.equals("fmt", ignoreCase = true) }
+        .forEach { name -> uri.getQueryParameters(name).forEach { builder.appendQueryParameter(name, it) } }
+    return builder.appendQueryParameter("fmt", "vtt").build().toString()
 }
+
+private fun extractorVideoSubtitleTracks(info: StreamInfo): List<com.luc4n3x.levyra.domain.VideoSubtitleTrack> =
+    info.subtitles.orEmpty().mapIndexedNotNull { index, subtitle ->
+        if (!subtitle.isUrl) return@mapIndexedNotNull null
+        val vttUrl = trustedVideoCaptionUrl(subtitle.content.orEmpty()) ?: return@mapIndexedNotNull null
+        val languageCode = subtitle.languageTag.orEmpty().ifBlank { subtitle.locale?.language.orEmpty() }
+        val label = subtitle.displayLanguageName.orEmpty().ifBlank { languageCode }
+        if (label.isBlank()) return@mapIndexedNotNull null
+        com.luc4n3x.levyra.domain.VideoSubtitleTrack("$languageCode:$index", label, languageCode, vttUrl)
+    }
 
 private data class DirectStream(
     val url: String,


### PR DESCRIPTION
## Summary

The subtitle button never appeared in Video Mode, so captions could not be turned on at all. The player only builds that control when the current track carries caption tracks, and the primary video resolution path was returning tracks with an empty caption list. This restores caption discovery on that path, so official videos that publish captions now expose a working subtitle selector.

## What changed

- `resolveVideoWithLevyraExtractor` now maps `StreamInfo.getSubtitles()` onto `VideoSubtitleTrack` and attaches the result to the resolved track. It previously built the track through `artworkSafe.copy(...)` without ever touching `videoSubtitleTracks`, and it is the path tried first for video, so the InnerTube caption discovery already in the codebase almost never ran. Both return sites are covered, the selected stream branch and the HLS branch.
- `resolveVideoWithAndroidReel` reads captions from its `playerResponse`. This is the fallback path and had the same gap.
- `trustedVideoCaptionUrl` drops an existing `fmt` parameter before appending `fmt=vtt`. NewPipe resolves captions through `getSubtitlesDefault()`, which requests `MediaFormat.TTML`, so those URLs already carry `fmt=ttml`. Appending a second `fmt` left the format ambiguous while `LevyraMediaItemFactory` declares `MimeTypes.TEXT_VTT`. The host, scheme, port and path validation is unchanged.

## Type of change

- [x] Bug fix

## Scope

- **Platform:** Android
- **Area:** Player / Streaming

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [ ] Targeted tests were added or updated
- [x] Not applicable, with the reason explained below

The release gate cannot run locally. It stops at `app/build.gradle.kts:68` with `Missing YOUTUBE_INNERTUBE_API_KEY`, which is only available as a CI secret. CI runs it. What ran locally, offline:

- `:app:compileDebugKotlin` passes
- `:app:testDebugUnitTest` passes
- `git diff --check` clean

No unit test was added. The caption list comes from a live `StreamInfo` fetch and the existing suite has no extractor fixture, so a unit test here would only assert the mapping against a hand built stub. The behavior was verified on a device instead, see below.

### Manual testing

Verified on a Samsung SM-S936B running Android 16, against the signed release APK produced by this PR. The installed APK was checked against the CI artifact by hash, both `eac7a4d70844db64602d0ab960cec10bbdc031502b615ad88ddb090c979f4f73`.

| Environment | Scenario | Result |
|---|---|---|
| Instrumented test on device, release APK build | `StreamInfo.getSubtitles()` for a video that publishes captions (`dQw4w9WgXcQ`) | Pass. Six tracks returned, `errors=0`. All carry `isUrl=true` and a `https://www.youtube.com/api/timedtext?...` URL, so `trustedVideoCaptionUrl` accepts every one and the mapping yields six `VideoSubtitleTrack` entries: `en`, `en` auto generated, `de-DE`, `ja`, `pt-BR`, `es-419`. |
| Instrumented test on device, release APK build | Same call for a video that publishes no captions (`kqTEc17L2Os`) | Pass. `subtitles=0` with `errors=0`, and the subtitle button correctly stays hidden. Confirmed against the source: the watch page for that video contains no `captionTracks` entry at all. |
| Device, Video Mode | Playback and player header | No crash, no ANR. Video Mode plays the official video and the header renders normally. |

The diagnostic test used for these runs was temporary and is not part of this branch.

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** None
- **Known limitations:** Only videos that actually publish caption tracks get a selector, so the button stays hidden on the many music videos that ship without captions. Auto generated captions are included, since NewPipe returns them in the same list.
- **Rollback plan:** Revert this PR

Nothing in the resolution or playback flow changes when a video has no captions, because the mapping returns an empty list and the player keeps its current behavior. Audio mode is untouched.

## Reviewer notes

- The interesting file is `PlaybackResolver.kt`. Worth checking that `extractorVideoSubtitleTracks` filters correctly: it drops streams that are not direct URLs, drops anything `trustedVideoCaptionUrl` rejects, and falls back to the language code when the display name is blank.
- The `isUrl` check is not cosmetic. `SubtitleDeduplicator` can return already downloaded subtitle text instead of a URL, and that value would be meaningless as a `MediaItem.SubtitleConfiguration` URI.
- Caption IDs are `"$languageCode:$index"`, which matches the shape the InnerTube path already produces and stays unique when a video ships two tracks for the same language, as `dQw4w9WgXcQ` does with its manual and auto generated English tracks.
- The `fmt` rewrite in `trustedVideoCaptionUrl` also affects the InnerTube path, but those base URLs carry no `fmt`, so the output there is unchanged.

## Release note

Subtitles can now be turned on for official videos in Video Mode.

## Related issues

- Related to #470

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [ ] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
