### PR TITLE
Add Cast, release alerts, recognition widget, and continuous radio

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -296,6 +296,7 @@ dependencies {
     implementation(libs.androidx.media3.exoplayer.hls)
     implementation(libs.androidx.media3.exoplayer.dash)
     implementation(libs.androidx.media3.session)
+    if (!isFdroidBuild) implementation(libs.androidx.media3.cast)
     implementation(libs.androidx.media3.ui)
     implementation(libs.androidx.car.app)
     implementation(libs.androidx.car.app.projected)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -282,7 +282,7 @@ configurations.configureEach {
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.activity.compose)
-    implementation(libs.androidx.fragment.ktx)
+    if (!isFdroidBuild) implementation(libs.androidx.fragment.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -282,6 +282,7 @@ configurations.configureEach {
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.fragment.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)

--- a/app/schemas/com.luc4n3x.levyra.data.local.LevyraDatabase/18.json
+++ b/app/schemas/com.luc4n3x.levyra.data.local.LevyraDatabase/18.json
@@ -1,0 +1,1859 @@
+{
+    "formatVersion":  1,
+    "database":  {
+                     "version":  18,
+                     "identityHash":  "f4a721cc994996383389c96492877c6f",
+                     "entities":  [
+                                      {
+                                          "tableName":  "favorite_tracks",
+                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `durationMs` INTEGER NOT NULL, `streamUrl` TEXT NOT NULL, `videoUrl` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `largeThumbnailUrl` TEXT NOT NULL, `source` TEXT NOT NULL, `moodTags` TEXT NOT NULL, `energy` INTEGER NOT NULL, `vocal` INTEGER NOT NULL, `replayScore` INTEGER NOT NULL, `cacheScore` INTEGER NOT NULL, `accentStart` INTEGER NOT NULL, `accentEnd` INTEGER NOT NULL, `youtubeLoudnessDb` REAL, `youtubePerceptualLoudnessDb` REAL, `isrc` TEXT NOT NULL, `upc` TEXT NOT NULL, `releaseDate` TEXT NOT NULL, `year` TEXT NOT NULL, `trackNumber` INTEGER NOT NULL, `discNumber` INTEGER NOT NULL, `explicit` INTEGER NOT NULL, `albumBrowseId` TEXT NOT NULL, `artistBrowseIds` TEXT NOT NULL, `counterpartVideoId` TEXT NOT NULL, `videoType` TEXT NOT NULL, `metadataProvider` TEXT NOT NULL, `metadataConfidence` INTEGER NOT NULL, `canonicalAlbumUrl` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+                                          "fields":  [
+                                                         {
+                                                             "fieldPath":  "id",
+                                                             "columnName":  "id",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "title",
+                                                             "columnName":  "title",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "artist",
+                                                             "columnName":  "artist",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "album",
+                                                             "columnName":  "album",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "durationMs",
+                                                             "columnName":  "durationMs",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "streamUrl",
+                                                             "columnName":  "streamUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "videoUrl",
+                                                             "columnName":  "videoUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "thumbnailUrl",
+                                                             "columnName":  "thumbnailUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "largeThumbnailUrl",
+                                                             "columnName":  "largeThumbnailUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "source",
+                                                             "columnName":  "source",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "moodTags",
+                                                             "columnName":  "moodTags",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "energy",
+                                                             "columnName":  "energy",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "vocal",
+                                                             "columnName":  "vocal",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "replayScore",
+                                                             "columnName":  "replayScore",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "cacheScore",
+                                                             "columnName":  "cacheScore",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "accentStart",
+                                                             "columnName":  "accentStart",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "accentEnd",
+                                                             "columnName":  "accentEnd",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "youtubeLoudnessDb",
+                                                             "columnName":  "youtubeLoudnessDb",
+                                                             "affinity":  "REAL"
+                                                         },
+                                                         {
+                                                             "fieldPath":  "youtubePerceptualLoudnessDb",
+                                                             "columnName":  "youtubePerceptualLoudnessDb",
+                                                             "affinity":  "REAL"
+                                                         },
+                                                         {
+                                                             "fieldPath":  "isrc",
+                                                             "columnName":  "isrc",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "upc",
+                                                             "columnName":  "upc",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "releaseDate",
+                                                             "columnName":  "releaseDate",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "year",
+                                                             "columnName":  "year",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "trackNumber",
+                                                             "columnName":  "trackNumber",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "discNumber",
+                                                             "columnName":  "discNumber",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "explicit",
+                                                             "columnName":  "explicit",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "albumBrowseId",
+                                                             "columnName":  "albumBrowseId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "artistBrowseIds",
+                                                             "columnName":  "artistBrowseIds",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "counterpartVideoId",
+                                                             "columnName":  "counterpartVideoId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "videoType",
+                                                             "columnName":  "videoType",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "metadataProvider",
+                                                             "columnName":  "metadataProvider",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "metadataConfidence",
+                                                             "columnName":  "metadataConfidence",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "canonicalAlbumUrl",
+                                                             "columnName":  "canonicalAlbumUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "createdAt",
+                                                             "columnName":  "createdAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         }
+                                                     ],
+                                          "primaryKey":  {
+                                                             "autoGenerate":  false,
+                                                             "columnNames":  [
+                                                                                 "id"
+                                                                             ]
+                                                         }
+                                      },
+                                      {
+                                          "tableName":  "downloaded_tracks",
+                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trackId` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `durationMs` INTEGER NOT NULL, `fileName` TEXT NOT NULL, `uri` TEXT NOT NULL, `mimeType` TEXT NOT NULL, `embeddedMetadata` INTEGER NOT NULL, `downloadPreset` TEXT NOT NULL, `downloadQuality` TEXT NOT NULL, `savedAt` INTEGER NOT NULL)",
+                                          "fields":  [
+                                                         {
+                                                             "fieldPath":  "id",
+                                                             "columnName":  "id",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "trackId",
+                                                             "columnName":  "trackId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "title",
+                                                             "columnName":  "title",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "artist",
+                                                             "columnName":  "artist",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "album",
+                                                             "columnName":  "album",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "durationMs",
+                                                             "columnName":  "durationMs",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "fileName",
+                                                             "columnName":  "fileName",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "uri",
+                                                             "columnName":  "uri",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "mimeType",
+                                                             "columnName":  "mimeType",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "embeddedMetadata",
+                                                             "columnName":  "embeddedMetadata",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "downloadPreset",
+                                                             "columnName":  "downloadPreset",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "downloadQuality",
+                                                             "columnName":  "downloadQuality",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "savedAt",
+                                                             "columnName":  "savedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         }
+                                                     ],
+                                          "primaryKey":  {
+                                                             "autoGenerate":  true,
+                                                             "columnNames":  [
+                                                                                 "id"
+                                                                             ]
+                                                         },
+                                          "indices":  [
+                                                          {
+                                                              "name":  "index_downloaded_tracks_trackId",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "trackId"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_downloaded_tracks_trackId` ON `${TABLE_NAME}` (`trackId`)"
+                                                          },
+                                                          {
+                                                              "name":  "index_downloaded_tracks_savedAt",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "savedAt"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_downloaded_tracks_savedAt` ON `${TABLE_NAME}` (`savedAt`)"
+                                                          },
+                                                          {
+                                                              "name":  "index_downloaded_tracks_trackId_downloadPreset_downloadQuality",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "trackId",
+                                                                                  "downloadPreset",
+                                                                                  "downloadQuality"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_downloaded_tracks_trackId_downloadPreset_downloadQuality` ON `${TABLE_NAME}` (`trackId`, `downloadPreset`, `downloadQuality`)"
+                                                          }
+                                                      ]
+                                      },
+                                      {
+                                          "tableName":  "playlists",
+                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+                                          "fields":  [
+                                                         {
+                                                             "fieldPath":  "id",
+                                                             "columnName":  "id",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "name",
+                                                             "columnName":  "name",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "coverUrl",
+                                                             "columnName":  "coverUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "createdAt",
+                                                             "columnName":  "createdAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "updatedAt",
+                                                             "columnName":  "updatedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         }
+                                                     ],
+                                          "primaryKey":  {
+                                                             "autoGenerate":  false,
+                                                             "columnNames":  [
+                                                                                 "id"
+                                                                             ]
+                                                         }
+                                      },
+                                      {
+                                          "tableName":  "playlist_tracks",
+                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `trackId` TEXT NOT NULL, `position` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `durationMs` INTEGER NOT NULL, `videoUrl` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `largeThumbnailUrl` TEXT NOT NULL, `source` TEXT NOT NULL, `accentStart` INTEGER NOT NULL, `accentEnd` INTEGER NOT NULL, `youtubeLoudnessDb` REAL, `youtubePerceptualLoudnessDb` REAL, `isrc` TEXT NOT NULL, `upc` TEXT NOT NULL, `releaseDate` TEXT NOT NULL, `year` TEXT NOT NULL, `trackNumber` INTEGER NOT NULL, `discNumber` INTEGER NOT NULL, `explicit` INTEGER NOT NULL, `albumBrowseId` TEXT NOT NULL, `artistBrowseIds` TEXT NOT NULL, `counterpartVideoId` TEXT NOT NULL, `videoType` TEXT NOT NULL, `metadataProvider` TEXT NOT NULL, `metadataConfidence` INTEGER NOT NULL, `canonicalAlbumUrl` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`playlistId`, `trackId`), FOREIGN KEY(`playlistId`) REFERENCES `playlists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+                                          "fields":  [
+                                                         {
+                                                             "fieldPath":  "playlistId",
+                                                             "columnName":  "playlistId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "trackId",
+                                                             "columnName":  "trackId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "position",
+                                                             "columnName":  "position",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "title",
+                                                             "columnName":  "title",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "artist",
+                                                             "columnName":  "artist",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "album",
+                                                             "columnName":  "album",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "durationMs",
+                                                             "columnName":  "durationMs",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "videoUrl",
+                                                             "columnName":  "videoUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "thumbnailUrl",
+                                                             "columnName":  "thumbnailUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "largeThumbnailUrl",
+                                                             "columnName":  "largeThumbnailUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "source",
+                                                             "columnName":  "source",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "accentStart",
+                                                             "columnName":  "accentStart",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "accentEnd",
+                                                             "columnName":  "accentEnd",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "youtubeLoudnessDb",
+                                                             "columnName":  "youtubeLoudnessDb",
+                                                             "affinity":  "REAL"
+                                                         },
+                                                         {
+                                                             "fieldPath":  "youtubePerceptualLoudnessDb",
+                                                             "columnName":  "youtubePerceptualLoudnessDb",
+                                                             "affinity":  "REAL"
+                                                         },
+                                                         {
+                                                             "fieldPath":  "isrc",
+                                                             "columnName":  "isrc",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "upc",
+                                                             "columnName":  "upc",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "releaseDate",
+                                                             "columnName":  "releaseDate",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "year",
+                                                             "columnName":  "year",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "trackNumber",
+                                                             "columnName":  "trackNumber",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "discNumber",
+                                                             "columnName":  "discNumber",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "explicit",
+                                                             "columnName":  "explicit",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "albumBrowseId",
+                                                             "columnName":  "albumBrowseId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "artistBrowseIds",
+                                                             "columnName":  "artistBrowseIds",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "counterpartVideoId",
+                                                             "columnName":  "counterpartVideoId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "videoType",
+                                                             "columnName":  "videoType",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "metadataProvider",
+                                                             "columnName":  "metadataProvider",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "metadataConfidence",
+                                                             "columnName":  "metadataConfidence",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "canonicalAlbumUrl",
+                                                             "columnName":  "canonicalAlbumUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "addedAt",
+                                                             "columnName":  "addedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         }
+                                                     ],
+                                          "primaryKey":  {
+                                                             "autoGenerate":  false,
+                                                             "columnNames":  [
+                                                                                 "playlistId",
+                                                                                 "trackId"
+                                                                             ]
+                                                         },
+                                          "indices":  [
+                                                          {
+                                                              "name":  "index_playlist_tracks_playlistId",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "playlistId"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_playlist_tracks_playlistId` ON `${TABLE_NAME}` (`playlistId`)"
+                                                          }
+                                                      ],
+                                          "foreignKeys":  [
+                                                              {
+                                                                  "table":  "playlists",
+                                                                  "onDelete":  "CASCADE",
+                                                                  "onUpdate":  "NO ACTION",
+                                                                  "columns":  [
+                                                                                  "playlistId"
+                                                                              ],
+                                                                  "referencedColumns":  [
+                                                                                            "id"
+                                                                                        ]
+                                                              }
+                                                          ]
+                                      },
+                                      {
+                                          "tableName":  "listen_events",
+                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trackId` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `durationMs` INTEGER NOT NULL, `videoUrl` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `largeThumbnailUrl` TEXT NOT NULL, `source` TEXT NOT NULL, `listenedMs` INTEGER NOT NULL, `completed` INTEGER NOT NULL, `startedAt` INTEGER NOT NULL, `artistBrowseIds` TEXT NOT NULL DEFAULT \u0027\u0027)",
+                                          "fields":  [
+                                                         {
+                                                             "fieldPath":  "id",
+                                                             "columnName":  "id",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "trackId",
+                                                             "columnName":  "trackId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "title",
+                                                             "columnName":  "title",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "artist",
+                                                             "columnName":  "artist",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "album",
+                                                             "columnName":  "album",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "durationMs",
+                                                             "columnName":  "durationMs",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "videoUrl",
+                                                             "columnName":  "videoUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "thumbnailUrl",
+                                                             "columnName":  "thumbnailUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "largeThumbnailUrl",
+                                                             "columnName":  "largeThumbnailUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "source",
+                                                             "columnName":  "source",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "listenedMs",
+                                                             "columnName":  "listenedMs",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "completed",
+                                                             "columnName":  "completed",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "startedAt",
+                                                             "columnName":  "startedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "artistBrowseIds",
+                                                             "columnName":  "artistBrowseIds",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true,
+                                                             "defaultValue":  "\u0027\u0027"
+                                                         }
+                                                     ],
+                                          "primaryKey":  {
+                                                             "autoGenerate":  true,
+                                                             "columnNames":  [
+                                                                                 "id"
+                                                                             ]
+                                                         },
+                                          "indices":  [
+                                                          {
+                                                              "name":  "index_listen_events_startedAt",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "startedAt"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_listen_events_startedAt` ON `${TABLE_NAME}` (`startedAt`)"
+                                                          },
+                                                          {
+                                                              "name":  "index_listen_events_trackId",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "trackId"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_listen_events_trackId` ON `${TABLE_NAME}` (`trackId`)"
+                                                          }
+                                                      ]
+                                      },
+                                      {
+                                          "tableName":  "playback_queue_items",
+                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`position` INTEGER NOT NULL, `payload` TEXT NOT NULL, `identity` TEXT NOT NULL, PRIMARY KEY(`position`))",
+                                          "fields":  [
+                                                         {
+                                                             "fieldPath":  "position",
+                                                             "columnName":  "position",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "payload",
+                                                             "columnName":  "payload",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "identity",
+                                                             "columnName":  "identity",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         }
+                                                     ],
+                                          "primaryKey":  {
+                                                             "autoGenerate":  false,
+                                                             "columnNames":  [
+                                                                                 "position"
+                                                                             ]
+                                                         }
+                                      },
+                                      {
+                                          "tableName":  "playback_queue_state",
+                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`singletonId` INTEGER NOT NULL, `currentIndex` INTEGER NOT NULL, `positionMs` INTEGER NOT NULL, `shuffleEnabled` INTEGER NOT NULL, `shuffleOrder` TEXT NOT NULL, `shuffleCursor` INTEGER NOT NULL, `history` TEXT NOT NULL, `repeatMode` TEXT NOT NULL, `radioEnabled` INTEGER NOT NULL, `generation` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`singletonId`))",
+                                          "fields":  [
+                                                         {
+                                                             "fieldPath":  "singletonId",
+                                                             "columnName":  "singletonId",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "currentIndex",
+                                                             "columnName":  "currentIndex",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "positionMs",
+                                                             "columnName":  "positionMs",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "shuffleEnabled",
+                                                             "columnName":  "shuffleEnabled",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "shuffleOrder",
+                                                             "columnName":  "shuffleOrder",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "shuffleCursor",
+                                                             "columnName":  "shuffleCursor",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "history",
+                                                             "columnName":  "history",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "repeatMode",
+                                                             "columnName":  "repeatMode",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "radioEnabled",
+                                                             "columnName":  "radioEnabled",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "generation",
+                                                             "columnName":  "generation",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "updatedAt",
+                                                             "columnName":  "updatedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         }
+                                                     ],
+                                          "primaryKey":  {
+                                                             "autoGenerate":  false,
+                                                             "columnNames":  [
+                                                                                 "singletonId"
+                                                                             ]
+                                                         }
+                                      },
+                                      {
+                                          "tableName":  "offline_download_tasks",
+                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`taskKey` TEXT NOT NULL, `trackId` TEXT NOT NULL, `payload` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `state` TEXT NOT NULL, `progress` INTEGER NOT NULL, `workId` TEXT NOT NULL, `error` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `batchKey` TEXT NOT NULL, `batchTitle` TEXT NOT NULL, `batchKind` TEXT NOT NULL, `batchArtworkUrl` TEXT NOT NULL, `batchPosition` INTEGER NOT NULL, PRIMARY KEY(`taskKey`))",
+                                          "fields":  [
+                                                         {
+                                                             "fieldPath":  "taskKey",
+                                                             "columnName":  "taskKey",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "trackId",
+                                                             "columnName":  "trackId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "payload",
+                                                             "columnName":  "payload",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "title",
+                                                             "columnName":  "title",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "artist",
+                                                             "columnName":  "artist",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "state",
+                                                             "columnName":  "state",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "progress",
+                                                             "columnName":  "progress",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "workId",
+                                                             "columnName":  "workId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "error",
+                                                             "columnName":  "error",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "createdAt",
+                                                             "columnName":  "createdAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "updatedAt",
+                                                             "columnName":  "updatedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "batchKey",
+                                                             "columnName":  "batchKey",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "batchTitle",
+                                                             "columnName":  "batchTitle",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "batchKind",
+                                                             "columnName":  "batchKind",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "batchArtworkUrl",
+                                                             "columnName":  "batchArtworkUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "batchPosition",
+                                                             "columnName":  "batchPosition",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         }
+                                                     ],
+                                          "primaryKey":  {
+                                                             "autoGenerate":  false,
+                                                             "columnNames":  [
+                                                                                 "taskKey"
+                                                                             ]
+                                                         },
+                                          "indices":  [
+                                                          {
+                                                              "name":  "index_offline_download_tasks_batchKey",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "batchKey"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_offline_download_tasks_batchKey` ON `${TABLE_NAME}` (`batchKey`)"
+                                                          }
+                                                      ]
+                                      },
+                                      {
+                                          "tableName":  "lyrics_cache",
+                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `titleKey` TEXT NOT NULL, `artistKey` TEXT NOT NULL, `durationBucket` INTEGER NOT NULL, `videoId` TEXT NOT NULL, `languageCode` TEXT NOT NULL, `translate` INTEGER NOT NULL, `synced` INTEGER NOT NULL, `provider` TEXT NOT NULL, `confidence` INTEGER NOT NULL, `payload` TEXT NOT NULL, `negative` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `expiresAt` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+                                          "fields":  [
+                                                         {
+                                                             "fieldPath":  "cacheKey",
+                                                             "columnName":  "cacheKey",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "titleKey",
+                                                             "columnName":  "titleKey",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "artistKey",
+                                                             "columnName":  "artistKey",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "durationBucket",
+                                                             "columnName":  "durationBucket",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "videoId",
+                                                             "columnName":  "videoId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "languageCode",
+                                                             "columnName":  "languageCode",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "translate",
+                                                             "columnName":  "translate",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "synced",
+                                                             "columnName":  "synced",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "provider",
+                                                             "columnName":  "provider",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "confidence",
+                                                             "columnName":  "confidence",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "payload",
+                                                             "columnName":  "payload",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "negative",
+                                                             "columnName":  "negative",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "createdAt",
+                                                             "columnName":  "createdAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "updatedAt",
+                                                             "columnName":  "updatedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "lastAccessedAt",
+                                                             "columnName":  "lastAccessedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "expiresAt",
+                                                             "columnName":  "expiresAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         }
+                                                     ],
+                                          "primaryKey":  {
+                                                             "autoGenerate":  false,
+                                                             "columnNames":  [
+                                                                                 "cacheKey"
+                                                                             ]
+                                                         },
+                                          "indices":  [
+                                                          {
+                                                              "name":  "index_lyrics_cache_expiresAt",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "expiresAt"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lyrics_cache_expiresAt` ON `${TABLE_NAME}` (`expiresAt`)"
+                                                          },
+                                                          {
+                                                              "name":  "index_lyrics_cache_lastAccessedAt",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "lastAccessedAt"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lyrics_cache_lastAccessedAt` ON `${TABLE_NAME}` (`lastAccessedAt`)"
+                                                          },
+                                                          {
+                                                              "name":  "index_lyrics_cache_titleKey_artistKey_durationBucket_languageCode_translate",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "titleKey",
+                                                                                  "artistKey",
+                                                                                  "durationBucket",
+                                                                                  "languageCode",
+                                                                                  "translate"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lyrics_cache_titleKey_artistKey_durationBucket_languageCode_translate` ON `${TABLE_NAME}` (`titleKey`, `artistKey`, `durationBucket`, `languageCode`, `translate`)"
+                                                          }
+                                                      ]
+                                      },
+                                      {
+                                          "tableName":  "lyrics_selections",
+                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`trackKey` TEXT NOT NULL, `candidateId` TEXT NOT NULL, `provider` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `durationSec` INTEGER NOT NULL, `payload` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`trackKey`))",
+                                          "fields":  [
+                                                         {
+                                                             "fieldPath":  "trackKey",
+                                                             "columnName":  "trackKey",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "candidateId",
+                                                             "columnName":  "candidateId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "provider",
+                                                             "columnName":  "provider",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "title",
+                                                             "columnName":  "title",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "artist",
+                                                             "columnName":  "artist",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "durationSec",
+                                                             "columnName":  "durationSec",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "payload",
+                                                             "columnName":  "payload",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "updatedAt",
+                                                             "columnName":  "updatedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         }
+                                                     ],
+                                          "primaryKey":  {
+                                                             "autoGenerate":  false,
+                                                             "columnNames":  [
+                                                                                 "trackKey"
+                                                                             ]
+                                                         },
+                                          "indices":  [
+                                                          {
+                                                              "name":  "index_lyrics_selections_updatedAt",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "updatedAt"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_lyrics_selections_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+                                                          }
+                                                      ]
+                                      },
+                                      {
+                                          "tableName":  "motion_artwork",
+                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identityKey` TEXT NOT NULL, `provider` TEXT, `url` TEXT, `mimeType` TEXT, `width` INTEGER, `height` INTEGER, `confidence` INTEGER NOT NULL, `expiresAt` INTEGER NOT NULL, `lastVerifiedAt` INTEGER NOT NULL, `configEpoch` INTEGER NOT NULL, `negative` INTEGER NOT NULL, PRIMARY KEY(`identityKey`))",
+                                          "fields":  [
+                                                         {
+                                                             "fieldPath":  "identityKey",
+                                                             "columnName":  "identityKey",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "provider",
+                                                             "columnName":  "provider",
+                                                             "affinity":  "TEXT"
+                                                         },
+                                                         {
+                                                             "fieldPath":  "url",
+                                                             "columnName":  "url",
+                                                             "affinity":  "TEXT"
+                                                         },
+                                                         {
+                                                             "fieldPath":  "mimeType",
+                                                             "columnName":  "mimeType",
+                                                             "affinity":  "TEXT"
+                                                         },
+                                                         {
+                                                             "fieldPath":  "width",
+                                                             "columnName":  "width",
+                                                             "affinity":  "INTEGER"
+                                                         },
+                                                         {
+                                                             "fieldPath":  "height",
+                                                             "columnName":  "height",
+                                                             "affinity":  "INTEGER"
+                                                         },
+                                                         {
+                                                             "fieldPath":  "confidence",
+                                                             "columnName":  "confidence",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "expiresAt",
+                                                             "columnName":  "expiresAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "lastVerifiedAt",
+                                                             "columnName":  "lastVerifiedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "configEpoch",
+                                                             "columnName":  "configEpoch",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "negative",
+                                                             "columnName":  "negative",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         }
+                                                     ],
+                                          "primaryKey":  {
+                                                             "autoGenerate":  false,
+                                                             "columnNames":  [
+                                                                                 "identityKey"
+                                                                             ]
+                                                         },
+                                          "indices":  [
+                                                          {
+                                                              "name":  "index_motion_artwork_expiresAt",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "expiresAt"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_motion_artwork_expiresAt` ON `${TABLE_NAME}` (`expiresAt`)"
+                                                          },
+                                                          {
+                                                              "name":  "index_motion_artwork_lastVerifiedAt",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "lastVerifiedAt"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_motion_artwork_lastVerifiedAt` ON `${TABLE_NAME}` (`lastVerifiedAt`)"
+                                                          }
+                                                      ]
+                                      },
+                                      {
+                                          "tableName":  "playback_source_matches",
+                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`matchKey` TEXT NOT NULL, `canonicalKey` TEXT NOT NULL, `mode` TEXT NOT NULL, `audioQuality` TEXT NOT NULL, `sourceVideoId` TEXT NOT NULL, `sourceVideoUrl` TEXT NOT NULL, `provider` TEXT NOT NULL, `manifestJson` TEXT NOT NULL, `confidence` INTEGER NOT NULL, `successCount` INTEGER NOT NULL, `failureCount` INTEGER NOT NULL, `blockedUntil` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastValidatedAt` INTEGER NOT NULL, PRIMARY KEY(`matchKey`))",
+                                          "fields":  [
+                                                         {
+                                                             "fieldPath":  "matchKey",
+                                                             "columnName":  "matchKey",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "canonicalKey",
+                                                             "columnName":  "canonicalKey",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "mode",
+                                                             "columnName":  "mode",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "audioQuality",
+                                                             "columnName":  "audioQuality",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "sourceVideoId",
+                                                             "columnName":  "sourceVideoId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "sourceVideoUrl",
+                                                             "columnName":  "sourceVideoUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "provider",
+                                                             "columnName":  "provider",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "manifestJson",
+                                                             "columnName":  "manifestJson",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "confidence",
+                                                             "columnName":  "confidence",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "successCount",
+                                                             "columnName":  "successCount",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "failureCount",
+                                                             "columnName":  "failureCount",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "blockedUntil",
+                                                             "columnName":  "blockedUntil",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "createdAt",
+                                                             "columnName":  "createdAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "updatedAt",
+                                                             "columnName":  "updatedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "lastValidatedAt",
+                                                             "columnName":  "lastValidatedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         }
+                                                     ],
+                                          "primaryKey":  {
+                                                             "autoGenerate":  false,
+                                                             "columnNames":  [
+                                                                                 "matchKey"
+                                                                             ]
+                                                         },
+                                          "indices":  [
+                                                          {
+                                                              "name":  "index_playback_source_matches_canonicalKey",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "canonicalKey"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_playback_source_matches_canonicalKey` ON `${TABLE_NAME}` (`canonicalKey`)"
+                                                          },
+                                                          {
+                                                              "name":  "index_playback_source_matches_sourceVideoId",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "sourceVideoId"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_playback_source_matches_sourceVideoId` ON `${TABLE_NAME}` (`sourceVideoId`)"
+                                                          },
+                                                          {
+                                                              "name":  "index_playback_source_matches_updatedAt",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "updatedAt"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_playback_source_matches_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+                                                          }
+                                                      ]
+                                      },
+                                      {
+                                          "tableName":  "artist_lore",
+                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `artistKey` TEXT NOT NULL, `browseId` TEXT NOT NULL, `languageCode` TEXT NOT NULL, `text` TEXT NOT NULL, `description` TEXT NOT NULL, `pageTitle` TEXT NOT NULL, `pageId` INTEGER NOT NULL, `entityId` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `originalImageUrl` TEXT NOT NULL, `sourceUrl` TEXT NOT NULL, `confidence` INTEGER NOT NULL, `negative` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `expiresAt` INTEGER NOT NULL, `staleUntil` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+                                          "fields":  [
+                                                         {
+                                                             "fieldPath":  "cacheKey",
+                                                             "columnName":  "cacheKey",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "artistKey",
+                                                             "columnName":  "artistKey",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "browseId",
+                                                             "columnName":  "browseId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "languageCode",
+                                                             "columnName":  "languageCode",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "text",
+                                                             "columnName":  "text",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "description",
+                                                             "columnName":  "description",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "pageTitle",
+                                                             "columnName":  "pageTitle",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "pageId",
+                                                             "columnName":  "pageId",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "entityId",
+                                                             "columnName":  "entityId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "thumbnailUrl",
+                                                             "columnName":  "thumbnailUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "originalImageUrl",
+                                                             "columnName":  "originalImageUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "sourceUrl",
+                                                             "columnName":  "sourceUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "confidence",
+                                                             "columnName":  "confidence",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "negative",
+                                                             "columnName":  "negative",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "createdAt",
+                                                             "columnName":  "createdAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "updatedAt",
+                                                             "columnName":  "updatedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "lastAccessedAt",
+                                                             "columnName":  "lastAccessedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "expiresAt",
+                                                             "columnName":  "expiresAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "staleUntil",
+                                                             "columnName":  "staleUntil",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         }
+                                                     ],
+                                          "primaryKey":  {
+                                                             "autoGenerate":  false,
+                                                             "columnNames":  [
+                                                                                 "cacheKey"
+                                                                             ]
+                                                         },
+                                          "indices":  [
+                                                          {
+                                                              "name":  "index_artist_lore_artistKey_languageCode",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "artistKey",
+                                                                                  "languageCode"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_artist_lore_artistKey_languageCode` ON `${TABLE_NAME}` (`artistKey`, `languageCode`)"
+                                                          },
+                                                          {
+                                                              "name":  "index_artist_lore_browseId_languageCode",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "browseId",
+                                                                                  "languageCode"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_artist_lore_browseId_languageCode` ON `${TABLE_NAME}` (`browseId`, `languageCode`)"
+                                                          },
+                                                          {
+                                                              "name":  "index_artist_lore_expiresAt",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "expiresAt"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_artist_lore_expiresAt` ON `${TABLE_NAME}` (`expiresAt`)"
+                                                          },
+                                                          {
+                                                              "name":  "index_artist_lore_lastAccessedAt",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "lastAccessedAt"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_artist_lore_lastAccessedAt` ON `${TABLE_NAME}` (`lastAccessedAt`)"
+                                                          }
+                                                      ]
+                                      },
+                                      {
+                                          "tableName":  "listen_lifetime_tracks",
+                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`trackKey` TEXT NOT NULL, `trackId` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `listenedMs` INTEGER NOT NULL, `countedPlays` INTEGER NOT NULL, `completedCount` INTEGER NOT NULL, `eventCount` INTEGER NOT NULL, `firstPlayedAt` INTEGER NOT NULL, `lastPlayedAt` INTEGER NOT NULL, PRIMARY KEY(`trackKey`))",
+                                          "fields":  [
+                                                         {
+                                                             "fieldPath":  "trackKey",
+                                                             "columnName":  "trackKey",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "trackId",
+                                                             "columnName":  "trackId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "title",
+                                                             "columnName":  "title",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "artist",
+                                                             "columnName":  "artist",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "listenedMs",
+                                                             "columnName":  "listenedMs",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "countedPlays",
+                                                             "columnName":  "countedPlays",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "completedCount",
+                                                             "columnName":  "completedCount",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "eventCount",
+                                                             "columnName":  "eventCount",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "firstPlayedAt",
+                                                             "columnName":  "firstPlayedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "lastPlayedAt",
+                                                             "columnName":  "lastPlayedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         }
+                                                     ],
+                                          "primaryKey":  {
+                                                             "autoGenerate":  false,
+                                                             "columnNames":  [
+                                                                                 "trackKey"
+                                                                             ]
+                                                         }
+                                      },
+                                      {
+                                          "tableName":  "listen_lifetime_artists",
+                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`artistKey` TEXT NOT NULL, `name` TEXT NOT NULL, `listenedMs` INTEGER NOT NULL, `countedPlays` INTEGER NOT NULL, `completedCount` INTEGER NOT NULL, `eventCount` INTEGER NOT NULL, `firstPlayedAt` INTEGER NOT NULL, `lastPlayedAt` INTEGER NOT NULL, PRIMARY KEY(`artistKey`))",
+                                          "fields":  [
+                                                         {
+                                                             "fieldPath":  "artistKey",
+                                                             "columnName":  "artistKey",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "name",
+                                                             "columnName":  "name",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "listenedMs",
+                                                             "columnName":  "listenedMs",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "countedPlays",
+                                                             "columnName":  "countedPlays",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "completedCount",
+                                                             "columnName":  "completedCount",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "eventCount",
+                                                             "columnName":  "eventCount",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "firstPlayedAt",
+                                                             "columnName":  "firstPlayedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "lastPlayedAt",
+                                                             "columnName":  "lastPlayedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         }
+                                                     ],
+                                          "primaryKey":  {
+                                                             "autoGenerate":  false,
+                                                             "columnNames":  [
+                                                                                 "artistKey"
+                                                                             ]
+                                                         }
+                                      },
+                                      {
+                                          "tableName":  "recognition_history",
+                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `recognizedAt` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `artworkUrl` TEXT NOT NULL, `provider` TEXT NOT NULL, `providerTrackId` TEXT NOT NULL, `isrc` TEXT NOT NULL, `youtubeVideoId` TEXT NOT NULL, `year` TEXT NOT NULL, PRIMARY KEY(`id`))",
+                                          "fields":  [
+                                                         {
+                                                             "fieldPath":  "id",
+                                                             "columnName":  "id",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "recognizedAt",
+                                                             "columnName":  "recognizedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "title",
+                                                             "columnName":  "title",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "artist",
+                                                             "columnName":  "artist",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "album",
+                                                             "columnName":  "album",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "artworkUrl",
+                                                             "columnName":  "artworkUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "provider",
+                                                             "columnName":  "provider",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "providerTrackId",
+                                                             "columnName":  "providerTrackId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "isrc",
+                                                             "columnName":  "isrc",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "youtubeVideoId",
+                                                             "columnName":  "youtubeVideoId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "year",
+                                                             "columnName":  "year",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         }
+                                                     ],
+                                          "primaryKey":  {
+                                                             "autoGenerate":  false,
+                                                             "columnNames":  [
+                                                                                 "id"
+                                                                             ]
+                                                         },
+                                          "indices":  [
+                                                          {
+                                                              "name":  "index_recognition_history_recognizedAt",
+                                                              "unique":  false,
+                                                              "columnNames":  [
+                                                                                  "recognizedAt"
+                                                                              ],
+                                                              "orders":  [
+
+                                                                         ],
+                                                              "createSql":  "CREATE INDEX IF NOT EXISTS `index_recognition_history_recognizedAt` ON `${TABLE_NAME}` (`recognizedAt`)"
+                                                          }
+                                                      ]
+                                      },
+                                      {
+                                          "tableName":  "followed_artists",
+                                          "createSql":  "CREATE TABLE IF NOT EXISTS ${TABLE_NAME} (\u0007rtistKey TEXT NOT NULL, \browseId TEXT NOT NULL, \name TEXT NOT NULL, \thumbnailUrl TEXT NOT NULL, \followedAt INTEGER NOT NULL, PRIMARY KEY(\u0007rtistKey))",
+                                          "fields":  [
+                                                         {
+                                                             "fieldPath":  "artistKey",
+                                                             "columnName":  "artistKey",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "browseId",
+                                                             "columnName":  "browseId",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "name",
+                                                             "columnName":  "name",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "thumbnailUrl",
+                                                             "columnName":  "thumbnailUrl",
+                                                             "affinity":  "TEXT",
+                                                             "notNull":  true
+                                                         },
+                                                         {
+                                                             "fieldPath":  "followedAt",
+                                                             "columnName":  "followedAt",
+                                                             "affinity":  "INTEGER",
+                                                             "notNull":  true
+                                                         }
+                                                     ],
+                                          "primaryKey":  {
+                                                             "autoGenerate":  false,
+                                                             "columnNames":  [
+                                                                                 "artistKey"
+                                                                             ]
+                                                         },
+                                          "indices":  [
+
+                                                      ]
+                                      }
+                                  ],
+                     "setupQueries":  [
+                                          "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+                                          "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \u0027f4a721cc994996383389c96492877c6f\u0027)"
+                                      ]
+                 }
+}

--- a/app/src/androidTest/java/com/luc4n3x/levyra/data/local/LevyraDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/luc4n3x/levyra/data/local/LevyraDatabaseMigrationTest.kt
@@ -101,6 +101,28 @@ class LevyraDatabaseMigrationTest {
         migrated.close()
     }
 
+    @Test
+    fun migrate17To18KeepsUserDataAndAddsFollowedArtists() {
+        helper.createDatabase(TEST_DB, 17).use { db ->
+            db.execSQL(
+                "INSERT INTO playlists (id, name, coverUrl, createdAt, updatedAt) " +
+                    "VALUES ('p3', 'Followed releases', '', 300, 300)"
+            )
+        }
+
+        val migrated = helper.runMigrationsAndValidate(TEST_DB, 18, true, *LevyraDatabase.MIGRATIONS)
+
+        migrated.query("SELECT name FROM playlists WHERE id = 'p3'").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("Followed releases", cursor.getString(0))
+        }
+        migrated.query("SELECT COUNT(*) FROM followed_artists").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(0, cursor.getInt(0))
+        }
+        migrated.close()
+    }
+
     private companion object {
         const val TEST_DB = "levyra-migration-test.db"
     }

--- a/app/src/fdroid/AndroidManifest.xml
+++ b/app/src/fdroid/AndroidManifest.xml
@@ -3,9 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application>
-        <meta-data
-            android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
-            tools:node="remove" />
         <receiver
             android:name="androidx.mediarouter.media.MediaTransferReceiver"
             tools:node="remove" />

--- a/app/src/fdroid/AndroidManifest.xml
+++ b/app/src/fdroid/AndroidManifest.xml
@@ -2,6 +2,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <application>
+        <meta-data
+            android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
+            tools:node="remove" />
+        <receiver
+            android:name="androidx.mediarouter.media.MediaTransferReceiver"
+            tools:node="remove" />
+    </application>
+
     <uses-permission
         android:name="android.permission.REQUEST_INSTALL_PACKAGES"
         tools:node="remove" />

--- a/app/src/fdroid/java/com/luc4n3x/levyra/feature/cast/CastRouteButton.kt
+++ b/app/src/fdroid/java/com/luc4n3x/levyra/feature/cast/CastRouteButton.kt
@@ -1,0 +1,7 @@
+package com.luc4n3x.levyra.feature.cast
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun CastRouteButton(modifier: Modifier = Modifier) = Unit

--- a/app/src/fdroid/java/com/luc4n3x/levyra/feature/cast/CastRuntimeInitializer.kt
+++ b/app/src/fdroid/java/com/luc4n3x/levyra/feature/cast/CastRuntimeInitializer.kt
@@ -1,0 +1,7 @@
+package com.luc4n3x.levyra.feature.cast
+
+import android.content.Context
+
+object CastRuntimeInitializer {
+    fun initialize(context: Context) = Unit
+}

--- a/app/src/fdroid/java/com/luc4n3x/levyra/feature/cast/CastRuntimeInitializer.kt
+++ b/app/src/fdroid/java/com/luc4n3x/levyra/feature/cast/CastRuntimeInitializer.kt
@@ -3,5 +3,7 @@ package com.luc4n3x.levyra.feature.cast
 import android.content.Context
 
 object CastRuntimeInitializer {
+    const val available: Boolean = false
+
     fun initialize(context: Context) = Unit
 }

--- a/app/src/fdroid/java/com/luc4n3x/levyra/feature/cast/RemotePlaybackBackendProvider.kt
+++ b/app/src/fdroid/java/com/luc4n3x/levyra/feature/cast/RemotePlaybackBackendProvider.kt
@@ -1,0 +1,7 @@
+package com.luc4n3x.levyra.feature.cast
+
+import android.content.Context
+
+object RemotePlaybackBackendProvider {
+    fun create(context: Context): RemotePlaybackBackend = NoOpCastBackend()
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,14 @@
         android:enableOnBackInvokedCallback="true"
         android:theme="@style/Theme.Levyra">
 
+        <meta-data
+            android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
+            android:value="androidx.media3.cast.DefaultCastOptionsProvider" />
+
+        <receiver
+            android:name="androidx.mediarouter.media.MediaTransferReceiver"
+            android:exported="true" />
+
         <provider
             android:name=".data.SpotifyChartBootstrapProvider"
             android:authorities="${applicationId}.spotify-chart-bootstrap"
@@ -144,6 +152,18 @@
             <meta-data
                 android:name="android.appwidget.provider"
                 android:resource="@xml/levyra_widget_info" />
+        </receiver>
+
+        <receiver
+            android:name=".widget.RecognitionWidgetProvider"
+            android:exported="false"
+            android:label="@string/recognition_widget_description">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/recognition_widget_info" />
         </receiver>
 
         <service

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,10 +32,6 @@
         android:enableOnBackInvokedCallback="true"
         android:theme="@style/Theme.Levyra">
 
-        <meta-data
-            android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
-            android:value="androidx.media3.cast.DefaultCastOptionsProvider" />
-
         <receiver
             android:name="androidx.mediarouter.media.MediaTransferReceiver"
             android:exported="true" />
@@ -102,12 +98,6 @@
             <intent-filter>
                 <action android:name="android.media.action.MEDIA_PLAY_FROM_SEARCH" />
                 <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.SEND" />
-                <action android:name="android.intent.action.SEND_MULTIPLE" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="text/*" />
             </intent-filter>
             <intent-filter android:autoVerify="false">
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -157,7 +157,7 @@
         <receiver
             android:name=".widget.RecognitionWidgetProvider"
             android:exported="false"
-            android:label="@string/recognition_widget_description">
+            android:label="@string/tile_recognize_music">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -99,6 +99,12 @@
                 <action android:name="android.media.action.MEDIA_PLAY_FROM_SEARCH" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/*" />
+            </intent-filter>
             <intent-filter android:autoVerify="false">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/app/src/main/java/com/luc4n3x/levyra/LevyraApplication.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/LevyraApplication.kt
@@ -38,7 +38,13 @@ class LevyraApplication : Application() {
         warmPlaybackPipeline()
         startupScope.launch {
             delay(1800L)
-            runCatching { ReleaseRadarWorker.schedule(this@LevyraApplication) }
+            runCatching {
+                if (com.luc4n3x.levyra.data.FollowedArtistsStore(this@LevyraApplication).load().isEmpty()) {
+                    ReleaseRadarWorker.cancel(this@LevyraApplication)
+                } else {
+                    ReleaseRadarWorker.schedule(this@LevyraApplication)
+                }
+            }
                 .onFailure { Timber.w(it, "Release radar scheduling failed") }
             runCatching {
                 AutomaticBackupScheduler.schedule(

--- a/app/src/main/java/com/luc4n3x/levyra/LevyraApplication.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/LevyraApplication.kt
@@ -11,6 +11,7 @@ import com.luc4n3x.levyra.data.ReleaseRadarWorker
 import com.luc4n3x.levyra.data.AutomaticBackupScheduler
 import com.luc4n3x.levyra.data.LevyraPreferences
 import com.luc4n3x.levyra.data.network.LevyraNetworkController
+import com.luc4n3x.levyra.feature.cast.CastRuntimeInitializer
 import com.luc4n3x.levyra.player.PlaybackNetworkStack
 import com.luc4n3x.levyra.runtime.RuntimeHooks
 import kotlinx.coroutines.CoroutineScope
@@ -25,6 +26,7 @@ class LevyraApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        CastRuntimeInitializer.initialize(this)
         RuntimeHooks.start(this)
         if (BuildConfig.DEBUG) Timber.plant(Timber.DebugTree())
         LevyraArtworkStartupMetrics.beginSession()

--- a/app/src/main/java/com/luc4n3x/levyra/LevyraApplication.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/LevyraApplication.kt
@@ -2,18 +2,20 @@ package com.luc4n3x.levyra
 
 import android.app.Application
 import android.content.ComponentCallbacks2
+import com.luc4n3x.levyra.data.AutomaticBackupScheduler
+import com.luc4n3x.levyra.data.FollowedArtistsStore
 import com.luc4n3x.levyra.data.LevyraArtworkCache
 import com.luc4n3x.levyra.data.LevyraArtworkStartupMetrics
+import com.luc4n3x.levyra.data.LevyraPreferences
 import com.luc4n3x.levyra.data.NewPipeRuntime
 import com.luc4n3x.levyra.data.PlaybackResolver
-import com.luc4n3x.levyra.data.YoutubeLocalDecoder
 import com.luc4n3x.levyra.data.ReleaseRadarWorker
-import com.luc4n3x.levyra.data.AutomaticBackupScheduler
-import com.luc4n3x.levyra.data.LevyraPreferences
+import com.luc4n3x.levyra.data.YoutubeLocalDecoder
 import com.luc4n3x.levyra.data.network.LevyraNetworkController
 import com.luc4n3x.levyra.feature.cast.CastRuntimeInitializer
 import com.luc4n3x.levyra.player.PlaybackNetworkStack
 import com.luc4n3x.levyra.runtime.RuntimeHooks
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -40,14 +42,18 @@ class LevyraApplication : Application() {
         warmPlaybackPipeline()
         startupScope.launch {
             delay(1800L)
-            runCatching {
-                if (com.luc4n3x.levyra.data.FollowedArtistsStore(this@LevyraApplication).load().isEmpty()) {
-                    ReleaseRadarWorker.cancel(this@LevyraApplication)
-                } else {
-                    ReleaseRadarWorker.schedule(this@LevyraApplication)
+            try {
+                when (val followedArtists = FollowedArtistsStore(this@LevyraApplication).loadOrNull()) {
+                    null -> Timber.w("Release radar state unavailable; preserving existing schedule")
+                    emptyList<com.luc4n3x.levyra.domain.FollowedArtist>() ->
+                        ReleaseRadarWorker.cancel(this@LevyraApplication)
+                    else -> ReleaseRadarWorker.schedule(this@LevyraApplication)
                 }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Exception) {
+                Timber.w(error, "Release radar scheduling failed")
             }
-                .onFailure { Timber.w(it, "Release radar scheduling failed") }
             runCatching {
                 AutomaticBackupScheduler.schedule(
                     this@LevyraApplication,

--- a/app/src/main/java/com/luc4n3x/levyra/LevyraLaunchActions.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/LevyraLaunchActions.kt
@@ -10,6 +10,11 @@ object LevyraLaunchActions {
     private const val EXTRA_SHARED_MEDIA_CONSUMED = "levyra.shared_media_consumed"
     const val EXTRA_SHORTCUT = "levyra.shortcut"
     const val EXTRA_ARTIST = "levyra.open_artist"
+    const val EXTRA_RELEASE_ID = "levyra.open_release_id"
+    const val EXTRA_RELEASE_TITLE = "levyra.open_release_title"
+    const val EXTRA_RELEASE_ARTIST = "levyra.open_release_artist"
+    const val EXTRA_RELEASE_ARTWORK = "levyra.open_release_artwork"
+    const val EXTRA_RELEASE_YEAR = "levyra.open_release_year"
     const val EXTRA_RECOGNITION_PERMISSION_REQUEST = "levyra.recognition_permission_request"
     const val SHORTCUT_FAVORITES = "favorites"
     const val SHORTCUT_FLOW = "flow"
@@ -31,6 +36,7 @@ object LevyraLaunchActions {
 
     val pendingShortcut = mutableStateOf<String?>(null)
     val pendingArtist = mutableStateOf<String?>(null)
+    val pendingRelease = mutableStateOf<ReleaseLaunchRequest?>(null)
     val pendingSharedMedia = mutableStateOf<SharedMediaRequest?>(null)
     val pendingJamCode = mutableStateOf<String?>(null)
 
@@ -41,8 +47,25 @@ object LevyraLaunchActions {
         shortcut?.takeIf { it in knownShortcuts }?.let { value ->
             pendingShortcut.value = value
         }
-        intent.getStringExtra(EXTRA_ARTIST)?.takeIf { it.isNotBlank() }?.let { value ->
+        intent.getStringExtra(EXTRA_ARTIST)
+            ?.takeIf { it.isNotBlank() && intent.getStringExtra(EXTRA_RELEASE_ID).isNullOrBlank() }
+            ?.let { value ->
             pendingArtist.value = value
+            intent.removeExtra(EXTRA_ARTIST)
+        }
+        intent.getStringExtra(EXTRA_RELEASE_ID)?.takeIf { it.isNotBlank() }?.let { browseId ->
+            pendingRelease.value = ReleaseLaunchRequest(
+                browseId = browseId,
+                title = intent.getStringExtra(EXTRA_RELEASE_TITLE).orEmpty(),
+                artist = intent.getStringExtra(EXTRA_RELEASE_ARTIST).orEmpty(),
+                artworkUrl = intent.getStringExtra(EXTRA_RELEASE_ARTWORK).orEmpty(),
+                year = intent.getStringExtra(EXTRA_RELEASE_YEAR).orEmpty()
+            )
+            intent.removeExtra(EXTRA_RELEASE_ID)
+            intent.removeExtra(EXTRA_RELEASE_TITLE)
+            intent.removeExtra(EXTRA_RELEASE_ARTIST)
+            intent.removeExtra(EXTRA_RELEASE_ARTWORK)
+            intent.removeExtra(EXTRA_RELEASE_YEAR)
             intent.removeExtra(EXTRA_ARTIST)
         }
         val jamLink = intent.takeIf { it.action == Intent.ACTION_VIEW }?.data
@@ -70,3 +93,11 @@ object LevyraLaunchActions {
         }
     }
 }
+
+data class ReleaseLaunchRequest(
+    val browseId: String,
+    val title: String,
+    val artist: String,
+    val artworkUrl: String,
+    val year: String
+)

--- a/app/src/main/java/com/luc4n3x/levyra/data/FollowedArtistsStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/FollowedArtistsStore.kt
@@ -6,6 +6,10 @@ import com.luc4n3x.levyra.data.local.FollowedArtistEntity
 import com.luc4n3x.levyra.data.local.LevyraDatabase
 import com.luc4n3x.levyra.domain.FollowedArtist
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import timber.log.Timber
 
@@ -17,26 +21,33 @@ class FollowedArtistsStore(context: Context) {
 
     suspend fun load(): List<FollowedArtist> = loadOrNull().orEmpty()
 
-    suspend fun loadOrNull(): List<FollowedArtist>? = try {
-        if (!migrateLegacyRowsIfNeeded()) null else dao.all().map { it.toDomain() }
-    } catch (cancelled: CancellationException) {
-        throw cancelled
-    } catch (error: Exception) {
-        Timber.e(error, "Followed artists load failed")
-        null
+    suspend fun loadOrNull(): List<FollowedArtist>? = mutationMutex.withLock {
+        try {
+            if (!migrateLegacyRowsIfNeeded()) null else dao.all().map { it.toDomain() }
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            Timber.e(error, "Followed artists load failed")
+            null
+        }
     }
 
-    suspend fun contains(artist: FollowedArtist): Boolean = try {
+    suspend fun contains(artist: FollowedArtist): Boolean = containsOrNull(artist) == true
+
+    suspend fun containsOrNull(artist: FollowedArtist): Boolean? = try {
         dao.contains(artist.storageKey())
     } catch (cancelled: CancellationException) {
         throw cancelled
     } catch (error: Exception) {
         Timber.w(error, "Followed artist membership check failed")
-        false
+        null
     }
 
     private suspend fun migrateLegacyRowsIfNeeded(): Boolean {
-        if (dao.all().isNotEmpty()) return true
+        if (dao.all().isNotEmpty()) {
+            clearLegacyPayload()
+            return true
+        }
         val raw = prefs.getString(KEY_ARTISTS, null).orEmpty()
         if (raw.isBlank()) return true
         val legacy = try {
@@ -60,7 +71,9 @@ class FollowedArtistsStore(context: Context) {
         }
         val migrated = try {
             database.withTransaction {
-                if (legacy.isNotEmpty()) dao.upsertAll(legacy.map(FollowedArtist::toEntity))
+                if (dao.all().isEmpty() && legacy.isNotEmpty()) {
+                    dao.upsertAll(legacy.map(FollowedArtist::toEntity))
+                }
             }
             true
         } catch (cancelled: CancellationException) {
@@ -74,7 +87,7 @@ class FollowedArtistsStore(context: Context) {
         return true
     }
 
-    suspend fun save(artists: List<FollowedArtist>) {
+    suspend fun save(artists: List<FollowedArtist>) = mutationMutex.withLock {
         val rows = artists.map(FollowedArtist::toEntity)
         database.withTransaction {
             dao.clear()
@@ -104,7 +117,7 @@ class FollowedArtistsStore(context: Context) {
         prefs.edit().putInt(KEY_RADAR_OFFSET, offset.coerceAtLeast(0)).apply()
     }
 
-    private fun clearLegacyPayload() {
+    private suspend fun clearLegacyPayload() = withContext(Dispatchers.IO) {
         if (prefs.contains(KEY_ARTISTS) && !prefs.edit().remove(KEY_ARTISTS).commit()) {
             Timber.w("Followed artists legacy cleanup was not persisted")
         }
@@ -115,6 +128,7 @@ class FollowedArtistsStore(context: Context) {
         const val KEY_ARTISTS = "artists"
         const val KEY_KNOWN_PREFIX = "known_releases_"
         const val KEY_RADAR_OFFSET = "radar_offset"
+        val mutationMutex = Mutex()
     }
 }
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/FollowedArtistsStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/FollowedArtistsStore.kt
@@ -5,6 +5,7 @@ import androidx.room.withTransaction
 import com.luc4n3x.levyra.data.local.FollowedArtistEntity
 import com.luc4n3x.levyra.data.local.LevyraDatabase
 import com.luc4n3x.levyra.domain.FollowedArtist
+import kotlinx.coroutines.CancellationException
 import org.json.JSONArray
 import timber.log.Timber
 
@@ -14,12 +15,15 @@ class FollowedArtistsStore(context: Context) {
     private val database = LevyraDatabase.get(appContext)
     private val dao = database.followedArtistsDao()
 
-    suspend fun load(): List<FollowedArtist> = runCatching {
+    suspend fun load(): List<FollowedArtist> = try {
         migrateLegacyRowsIfNeeded()
         dao.all().map { it.toDomain() }
-    }.onFailure {
-        Timber.e(it, "Followed artists load failed; continuing without release radar state")
-    }.getOrDefault(emptyList())
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (error: Exception) {
+        Timber.e(error, "Followed artists load failed; continuing without release radar state")
+        emptyList()
+    }
 
     private suspend fun migrateLegacyRowsIfNeeded() {
         if (dao.all().isNotEmpty()) return
@@ -44,12 +48,18 @@ class FollowedArtistsStore(context: Context) {
             Timber.w(error, "Followed artists migration failed; preserving legacy data")
             return
         }
-        val migrated = runCatching {
+        val migrated = try {
             database.withTransaction {
                 if (legacy.isNotEmpty()) dao.upsertAll(legacy.map(FollowedArtist::toEntity))
             }
-        }.onFailure { Timber.w(it, "Followed artists Room migration failed; preserving legacy data") }
-        if (migrated.isFailure) return
+            true
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            Timber.w(error, "Followed artists Room migration failed; preserving legacy data")
+            false
+        }
+        if (!migrated) return
         if (!prefs.edit().remove(KEY_ARTISTS).commit()) {
             Timber.w("Followed artists legacy cleanup was not persisted")
         }

--- a/app/src/main/java/com/luc4n3x/levyra/data/FollowedArtistsStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/FollowedArtistsStore.kt
@@ -1,60 +1,57 @@
 package com.luc4n3x.levyra.data
 
-import android.annotation.SuppressLint
 import android.content.Context
+import androidx.room.withTransaction
+import com.luc4n3x.levyra.data.local.FollowedArtistEntity
+import com.luc4n3x.levyra.data.local.LevyraDatabase
 import com.luc4n3x.levyra.domain.FollowedArtist
 import org.json.JSONArray
-import org.json.JSONObject
 import timber.log.Timber
-import java.io.IOException
 
 class FollowedArtistsStore(context: Context) {
-    private val prefs = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val appContext = context.applicationContext
+    private val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val database = LevyraDatabase.get(appContext)
+    private val dao = database.followedArtistsDao()
 
-    fun load(): List<FollowedArtist> {
+    suspend fun load(): List<FollowedArtist> {
+        migrateLegacyRowsIfNeeded()
+        return dao.all().map { it.toDomain() }
+    }
+
+    private suspend fun migrateLegacyRowsIfNeeded() {
+        if (dao.all().isNotEmpty()) return
         val raw = prefs.getString(KEY_ARTISTS, null).orEmpty()
-        if (raw.isBlank()) return emptyList()
-        return runCatching {
+        if (raw.isBlank()) return
+        val legacy = runCatching {
             val array = JSONArray(raw)
             (0 until array.length()).mapNotNull { index ->
                 array.optJSONObject(index)?.let { json ->
                     val name = json.optString("name").trim()
+                    val browseId = json.optString("browseId").trim()
                     if (name.isBlank()) return@let null
                     FollowedArtist(
-                        browseId = json.optString("browseId"),
+                        browseId = browseId,
                         name = name,
                         thumbnailUrl = json.optString("thumbnailUrl"),
                         followedAt = json.optLong("followedAt", 0L)
                     )
                 }
             }
-        }.onFailure { Timber.w(it, "Followed artists load failed") }.getOrDefault(emptyList())
+        }.onFailure { Timber.w(it, "Followed artists migration failed") }.getOrDefault(emptyList())
+        if (legacy.isNotEmpty()) dao.upsertAll(legacy.map(FollowedArtist::toEntity))
+        prefs.edit().remove(KEY_ARTISTS).apply()
     }
 
-    fun save(artists: List<FollowedArtist>) {
-        prefs.edit().putString(KEY_ARTISTS, encode(artists)).apply()
-    }
-
-    @SuppressLint("ApplySharedPref")
-    fun saveDurable(artists: List<FollowedArtist>) {
-        if (!prefs.edit().putString(KEY_ARTISTS, encode(artists)).commit()) {
-            throw IOException("Impossibile salvare gli artisti seguiti")
+    suspend fun save(artists: List<FollowedArtist>) {
+        val rows = artists.map(FollowedArtist::toEntity)
+        database.withTransaction {
+            dao.clear()
+            dao.upsertAll(rows)
         }
     }
 
-    private fun encode(artists: List<FollowedArtist>): String {
-        val array = JSONArray()
-        artists.forEach { artist ->
-            array.put(
-                JSONObject()
-                    .put("browseId", artist.browseId)
-                    .put("name", artist.name)
-                    .put("thumbnailUrl", artist.thumbnailUrl)
-                    .put("followedAt", artist.followedAt)
-            )
-        }
-        return array.toString()
-    }
+    suspend fun saveDurable(artists: List<FollowedArtist>) = save(artists)
 
     fun hasReleaseBaseline(artistKey: String): Boolean = prefs.contains(KEY_KNOWN_PREFIX + artistKey)
 
@@ -82,3 +79,18 @@ class FollowedArtistsStore(context: Context) {
         const val KEY_RADAR_OFFSET = "radar_offset"
     }
 }
+
+private fun FollowedArtist.toEntity() = FollowedArtistEntity(
+    artistKey = browseId.ifBlank { "legacy:${name.trim().lowercase()}" },
+    browseId = browseId,
+    name = name,
+    thumbnailUrl = thumbnailUrl,
+    followedAt = followedAt
+)
+
+private fun FollowedArtistEntity.toDomain() = FollowedArtist(
+    browseId = browseId,
+    name = name,
+    thumbnailUrl = thumbnailUrl,
+    followedAt = followedAt
+)

--- a/app/src/main/java/com/luc4n3x/levyra/data/FollowedArtistsStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/FollowedArtistsStore.kt
@@ -15,14 +15,16 @@ class FollowedArtistsStore(context: Context) {
     private val database = LevyraDatabase.get(appContext)
     private val dao = database.followedArtistsDao()
 
-    suspend fun load(): List<FollowedArtist> = try {
+    suspend fun load(): List<FollowedArtist> = loadOrNull().orEmpty()
+
+    suspend fun loadOrNull(): List<FollowedArtist>? = try {
         migrateLegacyRowsIfNeeded()
         dao.all().map { it.toDomain() }
     } catch (cancelled: CancellationException) {
         throw cancelled
     } catch (error: Exception) {
-        Timber.e(error, "Followed artists load failed; continuing without release radar state")
-        emptyList()
+        Timber.e(error, "Followed artists load failed")
+        null
     }
 
     suspend fun contains(artist: FollowedArtist): Boolean = try {
@@ -69,9 +71,7 @@ class FollowedArtistsStore(context: Context) {
             false
         }
         if (!migrated) return
-        if (!prefs.edit().remove(KEY_ARTISTS).commit()) {
-            Timber.w("Followed artists legacy cleanup was not persisted")
-        }
+        clearLegacyPayload()
     }
 
     suspend fun save(artists: List<FollowedArtist>) {
@@ -80,6 +80,7 @@ class FollowedArtistsStore(context: Context) {
             dao.clear()
             dao.upsertAll(rows)
         }
+        clearLegacyPayload()
     }
 
     suspend fun saveDurable(artists: List<FollowedArtist>) = save(artists)
@@ -101,6 +102,12 @@ class FollowedArtistsStore(context: Context) {
 
     fun saveRadarOffset(offset: Int) {
         prefs.edit().putInt(KEY_RADAR_OFFSET, offset.coerceAtLeast(0)).apply()
+    }
+
+    private fun clearLegacyPayload() {
+        if (prefs.contains(KEY_ARTISTS) && !prefs.edit().remove(KEY_ARTISTS).commit()) {
+            Timber.w("Followed artists legacy cleanup was not persisted")
+        }
     }
 
     private companion object {

--- a/app/src/main/java/com/luc4n3x/levyra/data/FollowedArtistsStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/FollowedArtistsStore.kt
@@ -25,8 +25,8 @@ class FollowedArtistsStore(context: Context) {
         emptyList()
     }
 
-    suspend fun contains(artistKey: String): Boolean = try {
-        dao.contains(artistKey)
+    suspend fun contains(artist: FollowedArtist): Boolean = try {
+        dao.contains(artist.storageKey())
     } catch (cancelled: CancellationException) {
         throw cancelled
     } catch (error: Exception) {
@@ -111,8 +111,11 @@ class FollowedArtistsStore(context: Context) {
     }
 }
 
+private fun FollowedArtist.storageKey(): String =
+    browseId.ifBlank { "legacy:${name.trim().lowercase()}" }
+
 private fun FollowedArtist.toEntity() = FollowedArtistEntity(
-    artistKey = browseId.ifBlank { "legacy:${name.trim().lowercase()}" },
+    artistKey = storageKey(),
     browseId = browseId,
     name = name,
     thumbnailUrl = thumbnailUrl,

--- a/app/src/main/java/com/luc4n3x/levyra/data/FollowedArtistsStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/FollowedArtistsStore.kt
@@ -18,8 +18,7 @@ class FollowedArtistsStore(context: Context) {
     suspend fun load(): List<FollowedArtist> = loadOrNull().orEmpty()
 
     suspend fun loadOrNull(): List<FollowedArtist>? = try {
-        migrateLegacyRowsIfNeeded()
-        dao.all().map { it.toDomain() }
+        if (!migrateLegacyRowsIfNeeded()) null else dao.all().map { it.toDomain() }
     } catch (cancelled: CancellationException) {
         throw cancelled
     } catch (error: Exception) {
@@ -36,10 +35,10 @@ class FollowedArtistsStore(context: Context) {
         false
     }
 
-    private suspend fun migrateLegacyRowsIfNeeded() {
-        if (dao.all().isNotEmpty()) return
+    private suspend fun migrateLegacyRowsIfNeeded(): Boolean {
+        if (dao.all().isNotEmpty()) return true
         val raw = prefs.getString(KEY_ARTISTS, null).orEmpty()
-        if (raw.isBlank()) return
+        if (raw.isBlank()) return true
         val legacy = try {
             val array = JSONArray(raw)
             (0 until array.length()).mapNotNull { index ->
@@ -57,7 +56,7 @@ class FollowedArtistsStore(context: Context) {
             }
         } catch (error: Exception) {
             Timber.w(error, "Followed artists migration failed; preserving legacy data")
-            return
+            return false
         }
         val migrated = try {
             database.withTransaction {
@@ -70,8 +69,9 @@ class FollowedArtistsStore(context: Context) {
             Timber.w(error, "Followed artists Room migration failed; preserving legacy data")
             false
         }
-        if (!migrated) return
+        if (!migrated) return false
         clearLegacyPayload()
+        return true
     }
 
     suspend fun save(artists: List<FollowedArtist>) {

--- a/app/src/main/java/com/luc4n3x/levyra/data/FollowedArtistsStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/FollowedArtistsStore.kt
@@ -23,7 +23,7 @@ class FollowedArtistsStore(context: Context) {
         if (dao.all().isNotEmpty()) return
         val raw = prefs.getString(KEY_ARTISTS, null).orEmpty()
         if (raw.isBlank()) return
-        val legacy = runCatching {
+        val legacy = try {
             val array = JSONArray(raw)
             (0 until array.length()).mapNotNull { index ->
                 array.optJSONObject(index)?.let { json ->
@@ -38,9 +38,19 @@ class FollowedArtistsStore(context: Context) {
                     )
                 }
             }
-        }.onFailure { Timber.w(it, "Followed artists migration failed") }.getOrDefault(emptyList())
-        if (legacy.isNotEmpty()) dao.upsertAll(legacy.map(FollowedArtist::toEntity))
-        prefs.edit().remove(KEY_ARTISTS).apply()
+        } catch (error: Exception) {
+            Timber.w(error, "Followed artists migration failed; preserving legacy data")
+            return
+        }
+        val migrated = runCatching {
+            database.withTransaction {
+                if (legacy.isNotEmpty()) dao.upsertAll(legacy.map(FollowedArtist::toEntity))
+            }
+        }.onFailure { Timber.w(it, "Followed artists Room migration failed; preserving legacy data") }
+        if (migrated.isFailure) return
+        if (!prefs.edit().remove(KEY_ARTISTS).commit()) {
+            Timber.w("Followed artists legacy cleanup was not persisted")
+        }
     }
 
     suspend fun save(artists: List<FollowedArtist>) {

--- a/app/src/main/java/com/luc4n3x/levyra/data/FollowedArtistsStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/FollowedArtistsStore.kt
@@ -25,6 +25,15 @@ class FollowedArtistsStore(context: Context) {
         emptyList()
     }
 
+    suspend fun contains(artistKey: String): Boolean = try {
+        dao.contains(artistKey)
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (error: Exception) {
+        Timber.w(error, "Followed artist membership check failed")
+        false
+    }
+
     private suspend fun migrateLegacyRowsIfNeeded() {
         if (dao.all().isNotEmpty()) return
         val raw = prefs.getString(KEY_ARTISTS, null).orEmpty()

--- a/app/src/main/java/com/luc4n3x/levyra/data/FollowedArtistsStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/FollowedArtistsStore.kt
@@ -14,10 +14,12 @@ class FollowedArtistsStore(context: Context) {
     private val database = LevyraDatabase.get(appContext)
     private val dao = database.followedArtistsDao()
 
-    suspend fun load(): List<FollowedArtist> {
+    suspend fun load(): List<FollowedArtist> = runCatching {
         migrateLegacyRowsIfNeeded()
-        return dao.all().map { it.toDomain() }
-    }
+        dao.all().map { it.toDomain() }
+    }.onFailure {
+        Timber.e(it, "Followed artists load failed; continuing without release radar state")
+    }.getOrDefault(emptyList())
 
     private suspend fun migrateLegacyRowsIfNeeded() {
         if (dao.all().isNotEmpty()) return

--- a/app/src/main/java/com/luc4n3x/levyra/data/ReleaseRadarWorker.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/ReleaseRadarWorker.kt
@@ -33,7 +33,7 @@ class ReleaseRadarWorker(
 
     override suspend fun doWork(): Result {
         val store = FollowedArtistsStore(applicationContext)
-        val followed = store.load()
+        val followed = store.loadOrNull() ?: return Result.retry()
         if (followed.isEmpty()) return Result.success()
         val artistRepository = ArtistRepository(YoutubeMusicRepository(applicationContext), applicationContext)
         var notified = 0
@@ -43,11 +43,15 @@ class ReleaseRadarWorker(
                 .getOrNull() ?: return@forEach
             val releases = profile.albums + profile.singles
             if (releases.isEmpty()) return@forEach
+            if (!store.contains(artist)) return@forEach
+
             val keys = releases.map { releaseKey(it) }.toSet()
             if (!store.hasReleaseBaseline(artist.key)) {
                 store.saveKnownReleases(artist.key, keys)
+                if (!store.contains(artist)) store.clearKnownReleases(artist.key)
                 return@forEach
             }
+
             val known = store.knownReleases(artist.key)
             val fresh = releases.distinctBy(::releaseKey).filter { releaseKey(it) !in known }
             if (!store.contains(artist)) return@forEach
@@ -59,6 +63,7 @@ class ReleaseRadarWorker(
                 }
             }
             store.saveKnownReleases(artist.key, known + notifiedKeys)
+            if (!store.contains(artist)) store.clearKnownReleases(artist.key)
         }
         return Result.success()
     }

--- a/app/src/main/java/com/luc4n3x/levyra/data/ReleaseRadarWorker.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/ReleaseRadarWorker.kt
@@ -43,18 +43,18 @@ class ReleaseRadarWorker(
                 .getOrNull() ?: return@forEach
             val releases = profile.albums + profile.singles
             if (releases.isEmpty()) return@forEach
-            if (!store.contains(artist)) return@forEach
+            if (store.containsOrNull(artist) != true) return@forEach
 
             val keys = releases.map { releaseKey(it) }.toSet()
             if (!store.hasReleaseBaseline(artist.key)) {
                 store.saveKnownReleases(artist.key, keys)
-                if (!store.contains(artist)) store.clearKnownReleases(artist.key)
+                if (store.containsOrNull(artist) == false) store.clearKnownReleases(artist.key)
                 return@forEach
             }
 
             val known = store.knownReleases(artist.key)
             val fresh = releases.distinctBy(::releaseKey).filter { releaseKey(it) !in known }
-            if (!store.contains(artist)) return@forEach
+            if (store.containsOrNull(artist) != true) return@forEach
             val notifiedKeys = mutableSetOf<String>()
             fresh.take(MAX_NOTIFICATIONS_PER_ARTIST).forEach { release ->
                 if (notified < MAX_NOTIFICATIONS_PER_RUN && notifyRelease(artist, release)) {
@@ -63,7 +63,7 @@ class ReleaseRadarWorker(
                 }
             }
             store.saveKnownReleases(artist.key, known + notifiedKeys)
-            if (!store.contains(artist)) store.clearKnownReleases(artist.key)
+            if (store.containsOrNull(artist) == false) store.clearKnownReleases(artist.key)
         }
         return Result.success()
     }

--- a/app/src/main/java/com/luc4n3x/levyra/data/ReleaseRadarWorker.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/ReleaseRadarWorker.kt
@@ -50,7 +50,7 @@ class ReleaseRadarWorker(
             }
             val known = store.knownReleases(artist.key)
             val fresh = releases.distinctBy(::releaseKey).filter { releaseKey(it) !in known }
-            if (store.load().none { it.key == artist.key }) return@forEach
+            if (!store.contains(artist.key)) return@forEach
             val notifiedKeys = mutableSetOf<String>()
             fresh.take(MAX_NOTIFICATIONS_PER_ARTIST).forEach { release ->
                 if (notified < MAX_NOTIFICATIONS_PER_RUN && notifyRelease(artist, release)) {

--- a/app/src/main/java/com/luc4n3x/levyra/data/ReleaseRadarWorker.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/ReleaseRadarWorker.kt
@@ -50,7 +50,7 @@ class ReleaseRadarWorker(
             }
             val known = store.knownReleases(artist.key)
             val fresh = releases.distinctBy(::releaseKey).filter { releaseKey(it) !in known }
-            if (!store.contains(artist.key)) return@forEach
+            if (!store.contains(artist)) return@forEach
             val notifiedKeys = mutableSetOf<String>()
             fresh.take(MAX_NOTIFICATIONS_PER_ARTIST).forEach { release ->
                 if (notified < MAX_NOTIFICATIONS_PER_RUN && notifyRelease(artist, release)) {

--- a/app/src/main/java/com/luc4n3x/levyra/data/ReleaseRadarWorker.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/ReleaseRadarWorker.kt
@@ -49,11 +49,11 @@ class ReleaseRadarWorker(
                 return@forEach
             }
             val known = store.knownReleases(artist.key)
-            val fresh = releases.filter { releaseKey(it) !in known }
+            val fresh = releases.distinctBy(::releaseKey).filter { releaseKey(it) !in known }
+            if (store.load().none { it.browseId == artist.browseId }) return@forEach
             val notifiedKeys = mutableSetOf<String>()
             fresh.take(MAX_NOTIFICATIONS_PER_ARTIST).forEach { release ->
-                if (notified < MAX_NOTIFICATIONS_PER_RUN) {
-                    notifyRelease(artist, release)
+                if (notified < MAX_NOTIFICATIONS_PER_RUN && notifyRelease(artist, release)) {
                     notified++
                     notifiedKeys += releaseKey(release)
                 }
@@ -70,21 +70,26 @@ class ReleaseRadarWorker(
         return (followed + followed).subList(offset, offset + MAX_ARTISTS_PER_RUN)
     }
 
-    private fun notifyRelease(artist: FollowedArtist, release: ArtistRelease) {
+    private fun notifyRelease(artist: FollowedArtist, release: ArtistRelease): Boolean {
         val manager = NotificationManagerCompat.from(applicationContext)
-        if (!manager.areNotificationsEnabled()) return
+        if (!manager.areNotificationsEnabled()) return false
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             ContextCompat.checkSelfPermission(
                 applicationContext,
                 Manifest.permission.POST_NOTIFICATIONS
             ) != PackageManager.PERMISSION_GRANTED
         ) {
-            return
+            return false
         }
         ensureChannel()
         val intent = Intent(applicationContext, MainActivity::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
             putExtra(LevyraLaunchActions.EXTRA_ARTIST, artist.name)
+            putExtra(LevyraLaunchActions.EXTRA_RELEASE_ID, release.browseId)
+            putExtra(LevyraLaunchActions.EXTRA_RELEASE_TITLE, release.title)
+            putExtra(LevyraLaunchActions.EXTRA_RELEASE_ARTIST, artist.name)
+            putExtra(LevyraLaunchActions.EXTRA_RELEASE_ARTWORK, release.thumbnailUrl)
+            putExtra(LevyraLaunchActions.EXTRA_RELEASE_YEAR, release.year)
         }
         val requestCode = (artist.key + release.title).hashCode()
         val pendingIntent = PendingIntent.getActivity(
@@ -102,8 +107,9 @@ class ReleaseRadarWorker(
             .setAutoCancel(true)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .build()
-        runCatching { manager.notify(requestCode, notification) }
+        return runCatching { manager.notify(requestCode, notification) }
             .onFailure { Timber.w(it, "Release radar notification failed") }
+            .isSuccess
     }
 
     private fun ensureChannel() {
@@ -142,6 +148,10 @@ class ReleaseRadarWorker(
                 ExistingPeriodicWorkPolicy.KEEP,
                 request
             )
+        }
+
+        fun cancel(context: Context) {
+            WorkManager.getInstance(context.applicationContext).cancelUniqueWork(WORK_NAME)
         }
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/ReleaseRadarWorker.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/ReleaseRadarWorker.kt
@@ -50,7 +50,7 @@ class ReleaseRadarWorker(
             }
             val known = store.knownReleases(artist.key)
             val fresh = releases.distinctBy(::releaseKey).filter { releaseKey(it) !in known }
-            if (store.load().none { it.browseId == artist.browseId }) return@forEach
+            if (store.load().none { it.key == artist.key }) return@forEach
             val notifiedKeys = mutableSetOf<String>()
             fresh.take(MAX_NOTIFICATIONS_PER_ARTIST).forEach { release ->
                 if (notified < MAX_NOTIFICATIONS_PER_RUN && notifyRelease(artist, release)) {
@@ -91,7 +91,7 @@ class ReleaseRadarWorker(
             putExtra(LevyraLaunchActions.EXTRA_RELEASE_ARTWORK, release.thumbnailUrl)
             putExtra(LevyraLaunchActions.EXTRA_RELEASE_YEAR, release.year)
         }
-        val requestCode = (artist.key + release.title).hashCode()
+        val requestCode = (artist.key + "|" + releaseKey(release)).hashCode()
         val pendingIntent = PendingIntent.getActivity(
             applicationContext,
             requestCode,

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicRepository.kt
@@ -488,6 +488,7 @@ private const val ALBUM_RESULTS_PER_FALLBACK_QUERY = 8
 private const val ALBUM_RESULT_RANK_PENALTY = 18
 private const val MAX_ALBUM_RECOVERY_ATTEMPTS = 3
 private const val SUGGESTION_RESPONSE_LIMIT_CHARS = 64 * 1024
+private const val MIN_CONTINUOUS_RADIO_CANDIDATES = 20
 internal const val YOUTUBE_MUSIC_VIDEO_SEARCH_PARAMS = "EgWKAQIQAWoMEA4QChADEAQQCRAF"
 internal const val YOUTUBE_MUSIC_SONG_SEARCH_PARAMS = "EgWKAQIIAWoMEA4QChADEAQQCRAF"
 internal const val YOUTUBE_MUSIC_ALBUM_SEARCH_PARAMS = "EgWKAQIYAWoMEA4QChADEAQQCRAF"
@@ -2501,12 +2502,17 @@ class YoutubeMusicRepository(private val context: Context? = null) {
         runCatching { watchRepository.getSongRelated(watch.relatedBrowseId, languageCode) }.getOrDefault(emptyList())
     }
 
+    /**
+     * Returns a discovery pool rather than the exact queue append size. Continuous radio appends
+     * at most five tracks after de-duplication, so a wider pool prevents a duplicate-heavy top five
+     * from starving the tail while keeping the network request bounded.
+     */
     suspend fun radio(
         seed: Track,
         languageCode: String = LevyraLanguageCatalog.deviceDefault(),
         limit: Int = 20
     ): List<Track> = withContext(Dispatchers.IO) {
-        val boundedLimit = limit.coerceIn(1, 30)
+        val boundedLimit = maxOf(limit.coerceIn(1, 30), MIN_CONTINUOUS_RADIO_CANDIDATES)
         val videoId = resolveVideoId(seed)
         if (videoId.isBlank()) return@withContext emptyList()
         val query = "radio ${seed.artist} ${seed.title}".trim()

--- a/app/src/main/java/com/luc4n3x/levyra/data/local/FollowedArtistEntity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/local/FollowedArtistEntity.kt
@@ -1,0 +1,29 @@
+package com.luc4n3x.levyra.data.local
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.PrimaryKey
+import androidx.room.Query
+
+@Entity(tableName = "followed_artists")
+data class FollowedArtistEntity(
+    @PrimaryKey val artistKey: String,
+    val browseId: String,
+    val name: String,
+    val thumbnailUrl: String,
+    val followedAt: Long
+)
+
+@Dao
+interface FollowedArtistsDao {
+    @Query("SELECT * FROM followed_artists ORDER BY followedAt DESC")
+    suspend fun all(): List<FollowedArtistEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertAll(rows: List<FollowedArtistEntity>)
+
+    @Query("DELETE FROM followed_artists")
+    suspend fun clear()
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/local/FollowedArtistEntity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/local/FollowedArtistEntity.kt
@@ -21,6 +21,9 @@ interface FollowedArtistsDao {
     @Query("SELECT * FROM followed_artists ORDER BY followedAt DESC")
     suspend fun all(): List<FollowedArtistEntity>
 
+    @Query("SELECT EXISTS(SELECT 1 FROM followed_artists WHERE artistKey = :artistKey)")
+    suspend fun contains(artistKey: String): Boolean
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertAll(rows: List<FollowedArtistEntity>)
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/local/LevyraDatabase.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/local/LevyraDatabase.kt
@@ -24,9 +24,10 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ArtistLoreEntity::class,
         ListenLifetimeTrackEntity::class,
         ListenLifetimeArtistEntity::class,
-        RecognitionHistoryEntity::class
+        RecognitionHistoryEntity::class,
+        FollowedArtistEntity::class
     ],
-    version = 17,
+    version = 18,
     exportSchema = true
 )
 abstract class LevyraDatabase : RoomDatabase() {
@@ -43,6 +44,7 @@ abstract class LevyraDatabase : RoomDatabase() {
     abstract fun artistLoreDao(): ArtistLoreDao
     abstract fun listenLifetimeDao(): ListenLifetimeDao
     abstract fun recognitionHistoryDao(): RecognitionHistoryDao
+    abstract fun followedArtistsDao(): FollowedArtistsDao
 
     companion object {
         @Volatile private var instance: LevyraDatabase? = null
@@ -530,6 +532,16 @@ abstract class LevyraDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_17_18 = object : Migration(17, 18) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS followed_artists (" +
+                        "artistKey TEXT NOT NULL, browseId TEXT NOT NULL, name TEXT NOT NULL, " +
+                        "thumbnailUrl TEXT NOT NULL, followedAt INTEGER NOT NULL, PRIMARY KEY(artistKey))"
+                )
+            }
+        }
+
         internal val MIGRATIONS: Array<Migration> = arrayOf(
             MIGRATION_1_2,
             MIGRATION_2_3,
@@ -546,7 +558,8 @@ abstract class LevyraDatabase : RoomDatabase() {
             MIGRATION_13_14,
             MIGRATION_14_15,
             MIGRATION_15_16,
-            MIGRATION_16_17
+            MIGRATION_16_17,
+            MIGRATION_17_18
         )
 
         fun get(context: Context): LevyraDatabase {

--- a/app/src/main/java/com/luc4n3x/levyra/feature/cast/CastHandoff.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/cast/CastHandoff.kt
@@ -11,7 +11,7 @@ data class LocalPlaybackSnapshot(
     val repeatMode: RepeatMode
 )
 
-data class CastHandoff(
+data class CastHandoffState(
     val queueWindowIds: List<String>,
     val windowStartIndex: Int,
     val currentIndex: Int,
@@ -30,36 +30,55 @@ data class LocalResumeState(
     val repeatMode: RepeatMode
 )
 
+internal fun castHandoffStartPositionMs(
+    sameMediaItem: Boolean,
+    requestedPositionMs: Long,
+    livePositionMs: Long,
+    remotePlayback: Boolean
+): Long {
+    val requested = requestedPositionMs.coerceAtLeast(0L)
+    if (!remotePlayback || !sameMediaItem) return requested
+    return maxOf(requested, livePositionMs.coerceAtLeast(0L))
+}
+
+internal fun castWindowNeedsRefresh(
+    expectedUpcomingIds: List<String>,
+    remoteForwardIds: List<String>,
+    minimumBufferedItems: Int = 3
+): Boolean {
+    if (expectedUpcomingIds.isEmpty()) return false
+    val comparable = minOf(expectedUpcomingIds.size, remoteForwardIds.size)
+    if (remoteForwardIds.take(comparable) != expectedUpcomingIds.take(comparable)) return true
+    return remoteForwardIds.size < minOf(expectedUpcomingIds.size, minimumBufferedItems.coerceAtLeast(1))
+}
+
 object CastHandoffConverter {
     const val DEFAULT_QUEUE_WINDOW_RADIUS = 2
 
     fun toHandoff(
         snapshot: LocalPlaybackSnapshot,
         windowRadius: Int = DEFAULT_QUEUE_WINDOW_RADIUS
-    ): CastHandoff {
-        require(windowRadius >= 0) { "windowRadius must be >= 0" }
-        val queue = snapshot.queueIds
-        val safePosition = snapshot.positionMs.coerceAtLeast(0L)
-        if (queue.isEmpty()) {
-            return CastHandoff(
+    ): CastHandoffState {
+        if (snapshot.queueIds.isEmpty()) {
+            return CastHandoffState(
                 queueWindowIds = emptyList(),
                 windowStartIndex = 0,
                 currentIndex = -1,
-                positionMs = safePosition,
+                positionMs = snapshot.positionMs.coerceAtLeast(0L),
                 playing = snapshot.playing,
                 shuffle = snapshot.shuffle,
                 repeatMode = snapshot.repeatMode
             )
         }
-        val safeCurrentIndex = snapshot.currentIndex.coerceIn(0, queue.lastIndex)
-        val windowStart = (safeCurrentIndex - windowRadius).coerceAtLeast(0)
-        val windowEnd = (safeCurrentIndex + windowRadius).coerceAtMost(queue.lastIndex)
-        val windowIds = queue.subList(windowStart, windowEnd + 1).toList()
-        return CastHandoff(
-            queueWindowIds = windowIds,
-            windowStartIndex = windowStart,
-            currentIndex = safeCurrentIndex - windowStart,
-            positionMs = safePosition,
+        val safeCurrent = snapshot.currentIndex.coerceIn(0, snapshot.queueIds.lastIndex)
+        val radius = windowRadius.coerceAtLeast(0)
+        val start = (safeCurrent - radius).coerceAtLeast(0)
+        val endExclusive = (safeCurrent + radius + 1).coerceAtMost(snapshot.queueIds.size)
+        return CastHandoffState(
+            queueWindowIds = snapshot.queueIds.subList(start, endExclusive),
+            windowStartIndex = start,
+            currentIndex = safeCurrent - start,
+            positionMs = snapshot.positionMs.coerceAtLeast(0L),
             playing = snapshot.playing,
             shuffle = snapshot.shuffle,
             repeatMode = snapshot.repeatMode
@@ -67,32 +86,16 @@ object CastHandoffConverter {
     }
 
     fun toLocalResumeState(
-        handoff: CastHandoff,
-        localQueueIds: List<String> = handoff.queueWindowIds
+        handoff: CastHandoffState,
+        originalQueueIds: List<String>
     ): LocalResumeState {
-        val queue = localQueueIds.ifEmpty { handoff.queueWindowIds }
-        if (queue.isEmpty()) {
-            return LocalResumeState(
-                queueIds = emptyList(),
-                currentIndex = -1,
-                positionMs = handoff.positionMs.coerceAtLeast(0L),
-                playing = handoff.playing,
-                shuffle = handoff.shuffle,
-                repeatMode = handoff.repeatMode
-            )
-        }
-        val windowIndex = handoff.currentIndex.coerceAtLeast(0)
-        val currentId = handoff.queueWindowIds.getOrNull(windowIndex)
-        val absoluteIndex = when {
-            currentId == null -> (handoff.windowStartIndex + windowIndex).coerceIn(0, queue.lastIndex)
-            queue.getOrNull(handoff.windowStartIndex + windowIndex) == currentId ->
-                handoff.windowStartIndex + windowIndex
-            else -> queue.indexOf(currentId).takeIf { it >= 0 }
-                ?: (handoff.windowStartIndex + windowIndex).coerceIn(0, queue.lastIndex)
-        }
+        val selectedId = handoff.queueWindowIds.getOrNull(handoff.currentIndex)
+        val restoredIndex = selectedId?.let(originalQueueIds::indexOf)?.takeIf { it >= 0 }
+            ?: handoff.windowStartIndex.plus(handoff.currentIndex.coerceAtLeast(0))
+                .coerceIn(0, originalQueueIds.lastIndex.coerceAtLeast(0))
         return LocalResumeState(
-            queueIds = queue,
-            currentIndex = absoluteIndex.coerceIn(0, queue.lastIndex),
+            queueIds = originalQueueIds,
+            currentIndex = if (originalQueueIds.isEmpty()) -1 else restoredIndex,
             positionMs = handoff.positionMs.coerceAtLeast(0L),
             playing = handoff.playing,
             shuffle = handoff.shuffle,

--- a/app/src/main/java/com/luc4n3x/levyra/feature/cast/CastHandoff.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/cast/CastHandoff.kt
@@ -11,7 +11,7 @@ data class LocalPlaybackSnapshot(
     val repeatMode: RepeatMode
 )
 
-data class CastHandoffState(
+data class CastHandoff(
     val queueWindowIds: List<String>,
     val windowStartIndex: Int,
     val currentIndex: Int,
@@ -58,27 +58,30 @@ object CastHandoffConverter {
     fun toHandoff(
         snapshot: LocalPlaybackSnapshot,
         windowRadius: Int = DEFAULT_QUEUE_WINDOW_RADIUS
-    ): CastHandoffState {
-        if (snapshot.queueIds.isEmpty()) {
-            return CastHandoffState(
+    ): CastHandoff {
+        require(windowRadius >= 0) { "windowRadius must be >= 0" }
+        val queue = snapshot.queueIds
+        val safePosition = snapshot.positionMs.coerceAtLeast(0L)
+        if (queue.isEmpty()) {
+            return CastHandoff(
                 queueWindowIds = emptyList(),
                 windowStartIndex = 0,
                 currentIndex = -1,
-                positionMs = snapshot.positionMs.coerceAtLeast(0L),
+                positionMs = safePosition,
                 playing = snapshot.playing,
                 shuffle = snapshot.shuffle,
                 repeatMode = snapshot.repeatMode
             )
         }
-        val safeCurrent = snapshot.currentIndex.coerceIn(0, snapshot.queueIds.lastIndex)
-        val radius = windowRadius.coerceAtLeast(0)
-        val start = (safeCurrent - radius).coerceAtLeast(0)
-        val endExclusive = (safeCurrent + radius + 1).coerceAtMost(snapshot.queueIds.size)
-        return CastHandoffState(
-            queueWindowIds = snapshot.queueIds.subList(start, endExclusive),
-            windowStartIndex = start,
-            currentIndex = safeCurrent - start,
-            positionMs = snapshot.positionMs.coerceAtLeast(0L),
+        val safeCurrentIndex = snapshot.currentIndex.coerceIn(0, queue.lastIndex)
+        val windowStart = (safeCurrentIndex - windowRadius).coerceAtLeast(0)
+        val windowEnd = (safeCurrentIndex + windowRadius).coerceAtMost(queue.lastIndex)
+        val windowIds = queue.subList(windowStart, windowEnd + 1).toList()
+        return CastHandoff(
+            queueWindowIds = windowIds,
+            windowStartIndex = windowStart,
+            currentIndex = safeCurrentIndex - windowStart,
+            positionMs = safePosition,
             playing = snapshot.playing,
             shuffle = snapshot.shuffle,
             repeatMode = snapshot.repeatMode
@@ -86,16 +89,32 @@ object CastHandoffConverter {
     }
 
     fun toLocalResumeState(
-        handoff: CastHandoffState,
-        originalQueueIds: List<String>
+        handoff: CastHandoff,
+        localQueueIds: List<String> = handoff.queueWindowIds
     ): LocalResumeState {
-        val selectedId = handoff.queueWindowIds.getOrNull(handoff.currentIndex)
-        val restoredIndex = selectedId?.let(originalQueueIds::indexOf)?.takeIf { it >= 0 }
-            ?: handoff.windowStartIndex.plus(handoff.currentIndex.coerceAtLeast(0))
-                .coerceIn(0, originalQueueIds.lastIndex.coerceAtLeast(0))
+        val queue = localQueueIds.ifEmpty { handoff.queueWindowIds }
+        if (queue.isEmpty()) {
+            return LocalResumeState(
+                queueIds = emptyList(),
+                currentIndex = -1,
+                positionMs = handoff.positionMs.coerceAtLeast(0L),
+                playing = handoff.playing,
+                shuffle = handoff.shuffle,
+                repeatMode = handoff.repeatMode
+            )
+        }
+        val windowIndex = handoff.currentIndex.coerceAtLeast(0)
+        val currentId = handoff.queueWindowIds.getOrNull(windowIndex)
+        val absoluteIndex = when {
+            currentId == null -> (handoff.windowStartIndex + windowIndex).coerceIn(0, queue.lastIndex)
+            queue.getOrNull(handoff.windowStartIndex + windowIndex) == currentId ->
+                handoff.windowStartIndex + windowIndex
+            else -> queue.indexOf(currentId).takeIf { it >= 0 }
+                ?: (handoff.windowStartIndex + windowIndex).coerceIn(0, queue.lastIndex)
+        }
         return LocalResumeState(
-            queueIds = originalQueueIds,
-            currentIndex = if (originalQueueIds.isEmpty()) -1 else restoredIndex,
+            queueIds = queue,
+            currentIndex = absoluteIndex.coerceIn(0, queue.lastIndex),
             positionMs = handoff.positionMs.coerceAtLeast(0L),
             playing = handoff.playing,
             shuffle = handoff.shuffle,

--- a/app/src/main/java/com/luc4n3x/levyra/feature/cast/CastHandoff.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/cast/CastHandoff.kt
@@ -31,7 +31,7 @@ data class LocalResumeState(
 )
 
 object CastHandoffConverter {
-    const val DEFAULT_QUEUE_WINDOW_RADIUS = 10
+    const val DEFAULT_QUEUE_WINDOW_RADIUS = 2
 
     fun toHandoff(
         snapshot: LocalPlaybackSnapshot,

--- a/app/src/main/java/com/luc4n3x/levyra/feature/cast/CastMediaUrlPolicy.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/cast/CastMediaUrlPolicy.kt
@@ -1,0 +1,17 @@
+package com.luc4n3x.levyra.feature.cast
+
+import java.net.URI
+import java.util.Locale
+
+internal fun isCastReceiverSafeMediaUrl(rawUrl: String): Boolean {
+    val uri = runCatching { URI(rawUrl.trim()) }.getOrNull() ?: return false
+    if (!uri.scheme.equals("https", ignoreCase = true)) return false
+    if (uri.rawUserInfo != null) return false
+    if (uri.port != -1 && uri.port != 443) return false
+
+    val host = uri.host?.trim()?.lowercase(Locale.ROOT) ?: return false
+    if (host != "googlevideo.com" && !host.endsWith(".googlevideo.com")) return false
+
+    val path = uri.rawPath.orEmpty()
+    return path.startsWith('/') && path.length > 1
+}

--- a/app/src/main/java/com/luc4n3x/levyra/feature/cast/NoOpCastBackend.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/cast/NoOpCastBackend.kt
@@ -1,6 +1,7 @@
 package com.luc4n3x.levyra.feature.cast
 
 import com.luc4n3x.levyra.domain.RepeatMode
+import androidx.media3.common.Player
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -36,4 +37,8 @@ class NoOpCastBackend : RemotePlaybackBackend {
     override suspend fun setShuffle(enabled: Boolean) = Unit
 
     override suspend fun setRepeatMode(mode: RepeatMode) = Unit
+
+    override fun attachLocalPlayer(localPlayer: Player): Player = localPlayer
+
+    override fun release() = Unit
 }

--- a/app/src/main/java/com/luc4n3x/levyra/feature/cast/RemotePlaybackBackend.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/cast/RemotePlaybackBackend.kt
@@ -1,6 +1,7 @@
 package com.luc4n3x.levyra.feature.cast
 
 import com.luc4n3x.levyra.domain.RepeatMode
+import androidx.media3.common.Player
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -24,4 +25,7 @@ interface RemotePlaybackBackend {
     suspend fun skipToPrevious()
     suspend fun setShuffle(enabled: Boolean)
     suspend fun setRepeatMode(mode: RepeatMode)
+
+    fun attachLocalPlayer(localPlayer: Player): Player
+    fun release()
 }

--- a/app/src/main/java/com/luc4n3x/levyra/feature/recognition/MusicRecognitionService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/recognition/MusicRecognitionService.kt
@@ -19,6 +19,7 @@ import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import com.luc4n3x.levyra.data.LevyraPreferences
 import com.luc4n3x.levyra.ui.i18n.LevyraStrings
+import com.luc4n3x.levyra.widget.RecognitionWidgetCenter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -108,6 +109,7 @@ class MusicRecognitionService : Service() {
         observerJob = scope.launch {
             LevyraRecognitionCenter.get(this@MusicRecognitionService).state.collect { state ->
                 requestTileRefresh()
+                RecognitionWidgetCenter.render(this@MusicRecognitionService, state)
                 when (state) {
                     RecognitionState.Listening -> notifications.notify(notifications.listening(strings()))
                     RecognitionState.Identifying -> notifications.notify(notifications.processing(strings()))
@@ -160,6 +162,7 @@ class MusicRecognitionService : Service() {
             else -> notifications.cancel()
         }
         requestTileRefresh()
+        RecognitionWidgetCenter.render(this, state)
         stopSelf()
     }
 

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -19,6 +19,7 @@ import android.os.PowerManager
 import android.os.SystemClock
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
+import androidx.media3.common.DeviceInfo
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.PlaybackException
@@ -69,6 +70,9 @@ import com.luc4n3x.levyra.data.playbackRecoveryPlanFor
 import com.luc4n3x.levyra.data.YoutubeMusicRepository
 import com.luc4n3x.levyra.domain.LevyraAudioSettings
 import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.feature.cast.RemotePlaybackBackendProvider
+import com.luc4n3x.levyra.feature.cast.CastHandoffConverter
+import com.luc4n3x.levyra.feature.cast.LocalPlaybackSnapshot
 import com.luc4n3x.levyra.player.queue.PersistentQueueEngine
 import com.luc4n3x.levyra.player.queue.PlaybackQueueSnapshot
 import com.luc4n3x.levyra.player.queue.playbackQueueIdentity
@@ -116,6 +120,7 @@ class PlaybackService : MediaLibraryService() {
     private var queueTransitionJob: Job? = null
     private var queueTransitionMonitorJob: Job? = null
     private var memoryGuardJob: Job? = null
+    private var castHandoffJob: Job? = null
     private var memoryGuardHighSamples = 0
     private var lastMemoryRecycleElapsedMs = 0L
     private var transitionPlayer: ExoPlayer? = null
@@ -704,7 +709,30 @@ class PlaybackService : MediaLibraryService() {
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
 
-        val forwardingPlayer = object : androidx.media3.common.ForwardingPlayer(player) {
+        val sessionPlayer = RemotePlaybackBackendProvider.create(this).attachLocalPlayer(player)
+        sessionPlayer.addListener(object : Player.Listener {
+            override fun onDeviceInfoChanged(deviceInfo: DeviceInfo) {
+                if (deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
+                    cancelQueueTransition()
+                    cancelServicePrefetch()
+                    clearPreparedQueueNextInternal()
+                    handoffQueueToCast(sessionPlayer)
+                } else {
+                    castHandoffJob?.cancel()
+                }
+            }
+
+            override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+                if (sessionPlayer.deviceInfo.playbackType != DeviceInfo.PLAYBACK_TYPE_REMOTE) return
+                val mediaId = mediaItem?.mediaId ?: return
+                val snapshot = queueEngine.state.value
+                val index = snapshot.tracks.indexOfFirst { LevyraMediaItemFactory.metadataOnly(it).mediaId == mediaId }
+                if (index >= 0 && index != snapshot.currentIndex) {
+                    queueEngine.select(index, sessionPlayer.currentPosition, rememberCurrent = true)
+                }
+            }
+        })
+        val forwardingPlayer = object : androidx.media3.common.ForwardingPlayer(sessionPlayer) {
             override fun getDuration(): Long {
                 val realDuration = super.getDuration()
                 if (realDuration > 0L) return realDuration
@@ -754,14 +782,35 @@ class PlaybackService : MediaLibraryService() {
 
             override fun hasPreviousMediaItem(): Boolean = canSkipToPreviousTrack()
 
-            override fun seekToNext() = skipQueue(forward = true, respectRepeatOne = false)
+            override fun seekToNext() = seekRemoteOrLocal(forward = true)
 
-            override fun seekToNextMediaItem() = skipQueue(forward = true, respectRepeatOne = false)
+            override fun seekToNextMediaItem() = seekRemoteOrLocal(forward = true)
 
-            override fun seekToPrevious() = skipQueue(forward = false, respectRepeatOne = false)
+            override fun seekToPrevious() = seekRemoteOrLocal(forward = false)
 
-            override fun seekToPreviousMediaItem() =
-                skipQueue(forward = false, respectRepeatOne = false, allowRewind = false)
+            override fun seekToPreviousMediaItem() = seekRemoteOrLocal(forward = false, allowRewind = false)
+
+            private fun seekRemoteOrLocal(forward: Boolean, allowRewind: Boolean = true) {
+                if (sessionPlayer.deviceInfo.playbackType != DeviceInfo.PLAYBACK_TYPE_REMOTE) {
+                    skipQueue(forward, respectRepeatOne = false, allowRewind = allowRewind)
+                    return
+                }
+                if (!forward && allowRewind && sessionPlayer.currentPosition > 5_000L) {
+                    sessionPlayer.seekTo(0L)
+                    queueEngine.updatePosition(0L)
+                    return
+                }
+                val canMoveInsideWindow = if (forward) {
+                    sessionPlayer.currentMediaItemIndex < sessionPlayer.mediaItemCount - 1
+                } else {
+                    sessionPlayer.currentMediaItemIndex > 0
+                }
+                if (canMoveInsideWindow) {
+                    if (forward) super.seekToNextMediaItem() else super.seekToPreviousMediaItem()
+                } else {
+                    skipCastQueue(forward, sessionPlayer)
+                }
+            }
         }
 
         mediaSession = MediaLibrarySession.Builder(this, forwardingPlayer, callback)
@@ -840,14 +889,23 @@ class PlaybackService : MediaLibraryService() {
     }
 
     private suspend fun expandRadioForSkip(): com.luc4n3x.levyra.domain.Track? {
-        if (!queueEngine.state.value.radioEnabled) return null
-        val seed = queueEngine.state.value.currentTrack ?: return null
+        val initial = queueEngine.state.value
+        if (!initial.radioEnabled) return null
+        val seed = initial.currentTrack ?: return null
         if (isLocalPlaybackTrack(seed) || !hasInternetCapableNetwork()) return null
-        val additions = runCatching {
-            musicRepository.radio(seed, LevyraPreferences(this).languageCode(), 20)
-        }.onFailure { Timber.w(it, "Background radio expansion failed") }
-            .getOrDefault(emptyList())
+        val additions = try {
+            musicRepository.radio(seed, LevyraPreferences(this).languageCode(), 5)
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            Timber.w(error, "Background radio expansion failed")
+            emptyList()
+        }
         if (additions.isEmpty()) return null
+        val current = queueEngine.state.value
+        if (!current.radioEnabled || current.generation != initial.generation ||
+            current.currentTrack?.let(::playbackQueueIdentity) != playbackQueueIdentity(seed)
+        ) return null
         queueEngine.appendRadioTracks(additions)
         return queueEngine.next(respectRepeatOne = false)
     }
@@ -1608,6 +1666,7 @@ class PlaybackService : MediaLibraryService() {
         playbackWatchdogJob?.cancel()
         cancelQueueTransition()
         memoryGuardJob?.cancel()
+        castHandoffJob?.cancel()
         queueTransitionMonitorJob?.cancel()
         sleepTimerStateJob?.cancel()
         sleepTimer.cancel()
@@ -1630,6 +1689,54 @@ class PlaybackService : MediaLibraryService() {
             (getSystemService(Context.AUDIO_SERVICE) as AudioManager).unregisterAudioDeviceCallback(audioDeviceCallback)
         }
         super.onDestroy()
+    }
+
+    private fun handoffQueueToCast(castPlayer: Player) {
+        val snapshot = queueEngine.state.value
+        val current = snapshot.currentTrack ?: return
+        val handoff = CastHandoffConverter.toHandoff(
+            LocalPlaybackSnapshot(
+                queueIds = snapshot.tracks.map(::playbackQueueIdentity),
+                currentIndex = snapshot.currentIndex,
+                positionMs = castPlayer.currentPosition,
+                playing = castPlayer.playWhenReady,
+                shuffle = snapshot.shuffleEnabled,
+                repeatMode = snapshot.repeatMode
+            )
+        )
+        val generation = snapshot.generation
+        val window = snapshot.tracks.subList(
+            handoff.windowStartIndex,
+            handoff.windowStartIndex + handoff.queueWindowIds.size
+        )
+        castHandoffJob?.cancel()
+        castHandoffJob = serviceScope.launch(Dispatchers.IO) {
+            val resolved = window.map { track -> resolver.resolve(track, isVideoMode = false) }
+            val currentState = queueEngine.state.value
+            if (currentState.generation != generation ||
+                currentState.currentTrack?.let(::playbackQueueIdentity) != playbackQueueIdentity(current)
+            ) return@launch
+            withContext(Dispatchers.Main) {
+                if (castPlayer.deviceInfo.playbackType != DeviceInfo.PLAYBACK_TYPE_REMOTE) return@withContext
+                castPlayer.setMediaItems(resolved.map { LevyraMediaItemFactory.build(it) }, handoff.currentIndex, handoff.positionMs)
+                castPlayer.shuffleModeEnabled = handoff.shuffle
+                castPlayer.repeatMode = when (handoff.repeatMode) {
+                    com.luc4n3x.levyra.domain.RepeatMode.One -> Player.REPEAT_MODE_ONE
+                    com.luc4n3x.levyra.domain.RepeatMode.All -> Player.REPEAT_MODE_ALL
+                    com.luc4n3x.levyra.domain.RepeatMode.Off -> Player.REPEAT_MODE_OFF
+                }
+                castPlayer.prepare()
+                if (handoff.playing) castPlayer.play()
+            }
+        }
+    }
+
+    private fun skipCastQueue(forward: Boolean, castPlayer: Player) {
+        queueSkipJob?.cancel()
+        queueSkipJob = serviceScope.launch(Dispatchers.IO) {
+            val selected = if (forward) queueEngine.next(respectRepeatOne = false) else queueEngine.previous()
+            if (selected != null) withContext(Dispatchers.Main) { handoffQueueToCast(castPlayer) }
+        }
     }
 
     private fun refreshAudioOutputProfile() {

--- a/app/src/main/java/com/luc4n3x/levyra/player/queue/PersistentQueueEngine.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/queue/PersistentQueueEngine.kt
@@ -65,6 +65,28 @@ internal fun radioHistoryTrimIndices(
         .toCollection(LinkedHashSet())
 }
 
+internal fun radioCandidateTracks(
+    existingTracks: List<Track>,
+    candidates: List<Track>,
+    limit: Int = 5
+): List<Track> {
+    if (limit <= 0 || candidates.isEmpty()) return emptyList()
+    val existingIds = existingTracks.mapTo(LinkedHashSet(), ::playbackQueueIdentity)
+    val existingTitles = existingTracks.mapTo(LinkedHashSet(), ::radioTitleKey)
+    return candidates
+        .asSequence()
+        .filter { it.title.isNotBlank() }
+        .distinctBy(::playbackQueueIdentity)
+        .distinctBy(::radioTitleKey)
+        .filter { playbackQueueIdentity(it) !in existingIds }
+        .filter { radioTitleKey(it) !in existingTitles }
+        .take(limit)
+        .toList()
+}
+
+private fun radioTitleKey(track: Track): String =
+    "${track.artist.trim().lowercase(Locale.ROOT)}|${track.title.trim().lowercase(Locale.ROOT)}"
+
 class PersistentQueueEngine private constructor(context: Context) {
     private val store = PlaybackQueueStore(context.applicationContext)
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -490,39 +512,20 @@ class PersistentQueueEngine private constructor(context: Context) {
     }
 
     fun appendRadioTracks(tracks: List<Track>): PlaybackQueueSnapshot = mutate(structural = true, immediatePersist = true) { current ->
-        val candidatePool = tracks
-            .asSequence()
-            .filter { it.title.isNotBlank() }
-            .distinctBy(::playbackQueueIdentity)
-            .distinctBy { "${it.artist.trim().lowercase()}|${it.title.trim().lowercase()}" }
-            .take(RADIO_BATCH_SIZE)
-            .toList()
-        if (candidatePool.isEmpty()) return@mutate current
+        val candidates = radioCandidateTracks(
+            existingTracks = current.tracks,
+            candidates = tracks,
+            limit = RADIO_BATCH_SIZE
+        )
+        if (candidates.isEmpty()) return@mutate current
 
-        var prepared = trimPlayedRadioHistory(current, candidatePool.size)
-        var additions = radioAdditions(prepared, candidatePool)
-        val trimmed = current.tracks.size - prepared.tracks.size
-        if (trimmed > additions.size) {
-            prepared = trimPlayedRadioHistory(current, additions.size)
-            additions = radioAdditions(prepared, candidatePool)
-        }
+        val prepared = trimPlayedRadioHistory(current, candidates.size)
+        val available = (MAX_RADIO_QUEUE_SIZE - prepared.tracks.size).coerceAtLeast(0)
+        val additions = candidates
+            .take(minOf(RADIO_BATCH_SIZE, available))
+            .map { it.queueStoredCopy() }
         if (additions.isEmpty()) return@mutate current
         rebuildAfterStructureChange(prepared, prepared.tracks + additions, prepared.currentIndex)
-    }
-
-    private fun radioAdditions(current: PlaybackQueueSnapshot, candidates: List<Track>): List<Track> {
-        val existing = current.tracks.mapTo(LinkedHashSet(), ::playbackQueueIdentity)
-        val existingTitles = current.tracks.mapTo(LinkedHashSet()) {
-            "${it.artist.trim().lowercase()}|${it.title.trim().lowercase()}"
-        }
-        val available = (MAX_RADIO_QUEUE_SIZE - current.tracks.size).coerceAtLeast(0)
-        return candidates
-            .asSequence()
-            .filter { existing.add(playbackQueueIdentity(it)) }
-            .filter { existingTitles.add("${it.artist.trim().lowercase()}|${it.title.trim().lowercase()}") }
-            .map { it.queueStoredCopy() }
-            .take(minOf(RADIO_BATCH_SIZE, available))
-            .toList()
     }
 
     private fun trimPlayedRadioHistory(current: PlaybackQueueSnapshot, desiredSlots: Int): PlaybackQueueSnapshot {

--- a/app/src/main/java/com/luc4n3x/levyra/player/queue/PersistentQueueEngine.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/queue/PersistentQueueEngine.kt
@@ -476,11 +476,16 @@ class PersistentQueueEngine private constructor(context: Context) {
 
     fun appendRadioTracks(tracks: List<Track>): PlaybackQueueSnapshot = mutate(structural = true, immediatePersist = true) { current ->
         val existing = current.tracks.mapTo(LinkedHashSet(), ::playbackQueueIdentity)
+        val existingTitles = current.tracks.mapTo(LinkedHashSet()) {
+            "${it.artist.trim().lowercase()}|${it.title.trim().lowercase()}"
+        }
+        val available = (MAX_RADIO_QUEUE_SIZE - current.tracks.size).coerceAtLeast(0)
         val additions = tracks
             .filter { it.title.isNotBlank() }
             .filter { existing.add(playbackQueueIdentity(it)) }
+            .filter { existingTitles.add("${it.artist.trim().lowercase()}|${it.title.trim().lowercase()}") }
             .map { it.queueStoredCopy() }
-            .take(20)
+            .take(minOf(RADIO_BATCH_SIZE, available))
         if (additions.isEmpty()) return@mutate current
         rebuildAfterStructureChange(current, current.tracks + additions, current.currentIndex)
     }
@@ -669,6 +674,8 @@ class PersistentQueueEngine private constructor(context: Context) {
     private data class QueueRemoval(val track: Track, val index: Int)
 
     companion object {
+        private const val RADIO_BATCH_SIZE = 5
+        private const val MAX_RADIO_QUEUE_SIZE = 100
         @Volatile
         private var instance: PersistentQueueEngine? = null
 

--- a/app/src/main/java/com/luc4n3x/levyra/player/queue/PersistentQueueEngine.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/queue/PersistentQueueEngine.kt
@@ -50,6 +50,21 @@ internal fun replacementQueuePositionMs(
     }
 }
 
+internal fun radioHistoryTrimIndices(
+    history: List<Int>,
+    currentIndex: Int,
+    slotsNeeded: Int,
+    historyReserve: Int = 8
+): Set<Int> {
+    if (slotsNeeded <= 0 || history.isEmpty()) return emptySet()
+    val protected = history.takeLast(historyReserve.coerceAtLeast(0)).toSet() + currentIndex
+    return history.asSequence()
+        .filter { it >= 0 && it !in protected }
+        .distinct()
+        .take(slotsNeeded)
+        .toCollection(LinkedHashSet())
+}
+
 class PersistentQueueEngine private constructor(context: Context) {
     private val store = PlaybackQueueStore(context.applicationContext)
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -475,19 +490,76 @@ class PersistentQueueEngine private constructor(context: Context) {
     }
 
     fun appendRadioTracks(tracks: List<Track>): PlaybackQueueSnapshot = mutate(structural = true, immediatePersist = true) { current ->
+        val candidatePool = tracks
+            .asSequence()
+            .filter { it.title.isNotBlank() }
+            .distinctBy(::playbackQueueIdentity)
+            .distinctBy { "${it.artist.trim().lowercase()}|${it.title.trim().lowercase()}" }
+            .take(RADIO_BATCH_SIZE)
+            .toList()
+        if (candidatePool.isEmpty()) return@mutate current
+
+        var prepared = trimPlayedRadioHistory(current, candidatePool.size)
+        var additions = radioAdditions(prepared, candidatePool)
+        val trimmed = current.tracks.size - prepared.tracks.size
+        if (trimmed > additions.size) {
+            prepared = trimPlayedRadioHistory(current, additions.size)
+            additions = radioAdditions(prepared, candidatePool)
+        }
+        if (additions.isEmpty()) return@mutate current
+        rebuildAfterStructureChange(prepared, prepared.tracks + additions, prepared.currentIndex)
+    }
+
+    private fun radioAdditions(current: PlaybackQueueSnapshot, candidates: List<Track>): List<Track> {
         val existing = current.tracks.mapTo(LinkedHashSet(), ::playbackQueueIdentity)
         val existingTitles = current.tracks.mapTo(LinkedHashSet()) {
             "${it.artist.trim().lowercase()}|${it.title.trim().lowercase()}"
         }
         val available = (MAX_RADIO_QUEUE_SIZE - current.tracks.size).coerceAtLeast(0)
-        val additions = tracks
-            .filter { it.title.isNotBlank() }
+        return candidates
+            .asSequence()
             .filter { existing.add(playbackQueueIdentity(it)) }
             .filter { existingTitles.add("${it.artist.trim().lowercase()}|${it.title.trim().lowercase()}") }
             .map { it.queueStoredCopy() }
             .take(minOf(RADIO_BATCH_SIZE, available))
-        if (additions.isEmpty()) return@mutate current
-        rebuildAfterStructureChange(current, current.tracks + additions, current.currentIndex)
+            .toList()
+    }
+
+    private fun trimPlayedRadioHistory(current: PlaybackQueueSnapshot, desiredSlots: Int): PlaybackQueueSnapshot {
+        if (!current.radioEnabled || desiredSlots <= 0) return current
+        val slotsNeeded = (current.tracks.size + desiredSlots - MAX_RADIO_QUEUE_SIZE).coerceAtLeast(0)
+        if (slotsNeeded == 0) return current
+        val remove = radioHistoryTrimIndices(
+            history = current.history,
+            currentIndex = current.currentIndex,
+            slotsNeeded = slotsNeeded,
+            historyReserve = RADIO_HISTORY_RESERVE
+        ).filterTo(LinkedHashSet()) { it in current.tracks.indices && it != current.currentIndex }
+        if (remove.isEmpty()) return current
+
+        val indexMap = IntArray(current.tracks.size) { -1 }
+        val nextTracks = ArrayList<Track>(current.tracks.size - remove.size)
+        current.tracks.forEachIndexed { oldIndex, track ->
+            if (oldIndex !in remove) {
+                indexMap[oldIndex] = nextTracks.size
+                nextTracks += track
+            }
+        }
+        val nextCurrentIndex = current.currentIndex.takeIf { it in indexMap.indices }
+            ?.let { indexMap[it] }
+            ?.takeIf { it >= 0 }
+            ?: return current
+        val sourceOrder = if (current.shuffleEnabled) normalizedShuffleOrder(current) else emptyList()
+        val nextOrder = sourceOrder.mapNotNull { oldIndex -> indexMap.getOrNull(oldIndex)?.takeIf { it >= 0 } }
+        val nextHistory = current.history.mapNotNull { oldIndex -> indexMap.getOrNull(oldIndex)?.takeIf { it >= 0 } }.takeLast(200)
+        return current.copy(
+            tracks = nextTracks,
+            currentIndex = nextCurrentIndex,
+            shuffleOrder = nextOrder,
+            shuffleCursor = if (current.shuffleEnabled) nextOrder.indexOf(nextCurrentIndex).coerceAtLeast(0) else -1,
+            history = nextHistory,
+            generation = current.generation + 1L
+        )
     }
 
     suspend fun flush() {
@@ -675,6 +747,7 @@ class PersistentQueueEngine private constructor(context: Context) {
 
     companion object {
         private const val RADIO_BATCH_SIZE = 5
+        private const val RADIO_HISTORY_RESERVE = 8
         private const val MAX_RADIO_QUEUE_SIZE = 100
         @Volatile
         private var instance: PersistentQueueEngine? = null

--- a/app/src/main/java/com/luc4n3x/levyra/player/queue/PersistentQueueEngine.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/queue/PersistentQueueEngine.kt
@@ -17,6 +17,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 
+private val YOUTUBE_VIDEO_ID_PATTERN =
+    Regex("(?:v=|youtu\\.be/|shorts/|embed/)([A-Za-z0-9_-]{6,})")
+
 internal fun queuePersistenceAllowed(transientPlaybackActive: Boolean): Boolean =
     !transientPlaybackActive
 
@@ -809,7 +812,7 @@ internal fun stableShuffleOrder(tracks: List<Track>, currentIndex: Int, generati
 }
 
 internal fun playbackQueueIdentity(track: Track): String {
-    val videoId = Regex("(?:v=|youtu\\.be/|shorts/|embed/)([A-Za-z0-9_-]{6,})")
+    val videoId = YOUTUBE_VIDEO_ID_PATTERN
         .find(track.videoUrl)
         ?.groupValues
         ?.getOrNull(1)

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -7,6 +7,7 @@ import com.luc4n3x.levyra.ui.components.PlayerGlassIconButton
 import com.luc4n3x.levyra.ui.components.PlayerTransportControls
 import com.luc4n3x.levyra.feature.settings.SettingsSearchEntry
 import com.luc4n3x.levyra.feature.settings.SettingsSearchIndex
+import com.luc4n3x.levyra.feature.cast.CastRouteButton
 import com.luc4n3x.levyra.ui.components.PremiumSeekbar
 import com.luc4n3x.levyra.ui.components.SpringIconButton
 import com.luc4n3x.levyra.ui.components.formatSeekbarMillis
@@ -1216,6 +1217,22 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
         pendingArtist?.let { artistName ->
             viewModel.openArtistByName(artistName)
             LevyraLaunchActions.pendingArtist.value = null
+        }
+    }
+    val pendingRelease by LevyraLaunchActions.pendingRelease
+    LaunchedEffect(pendingRelease) {
+        pendingRelease?.let { release ->
+            viewModel.openAlbum(
+                AlbumHit(
+                    title = release.title,
+                    artist = release.artist,
+                    year = release.year,
+                    thumbnailUrl = release.artworkUrl,
+                    query = "${release.artist} ${release.title}".trim(),
+                    browseId = release.browseId
+                )
+            )
+            LevyraLaunchActions.pendingRelease.value = null
         }
     }
     val pendingSharedMedia by LevyraLaunchActions.pendingSharedMedia
@@ -12879,6 +12896,7 @@ private fun PlayerScreen(
                         }
                     }
                 }
+                if (!state.isVideoMode) CastRouteButton(modifier = Modifier.size(headerButtonSize))
                 if (!state.isVideoMode && track != null) {
                     val canvasActive = state.motionArtworkEnabled && state.animationsEnabled
                     PlayerGlassIconButton(

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
@@ -74,6 +74,8 @@ data class PlayerControlLabels(
     val repeat: String
 )
 
+private val DensePlayerHorizontalTouchTarget = 40.dp
+
 private fun ioniconForPlayer(icon: ImageVector): ImageVector? {
     return when (icon.name.substringAfterLast('.')) {
         "PlayArrow" -> LevyraIonicons.Play
@@ -148,7 +150,9 @@ fun PlayerGlassIconButton(
     SpringIconButton(
         onClick = onClick,
         modifier = modifier.sizeIn(
-            minWidth = LevyraPlayerDesign.MinimumTouchTarget,
+            // Dense player rows keep the full 48dp vertical target without reserving an
+            // invisible 48dp column around every 36–40dp circular control.
+            minWidth = maxOf(size, DensePlayerHorizontalTouchTarget),
             minHeight = LevyraPlayerDesign.MinimumTouchTarget
         ),
         enabled = enabled,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -17,6 +17,7 @@ import com.luc4n3x.levyra.data.ArtistRepository
 import com.luc4n3x.levyra.data.ChartsRepository
 import com.luc4n3x.levyra.data.FavoritesStore
 import com.luc4n3x.levyra.data.FollowedArtistsStore
+import com.luc4n3x.levyra.data.ReleaseRadarWorker
 import com.luc4n3x.levyra.data.LevyraArtworkCache
 import com.luc4n3x.levyra.data.LevyraBackupManager
 import com.luc4n3x.levyra.data.AutomaticBackupScheduler
@@ -746,6 +747,8 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private var homeArtistsFingerprint: String = ""
     private val deferredHomeArtistsSnapshot = AtomicReference<List<ArtistHit>?>(null)
     private var radarJob: Job? = null
+    private var followedArtistsJob: Job? = null
+    private var followedArtistsGeneration = 0L
     private var radioJob: Job? = null
     private var sponsorSegments: List<SponsorSegment> = emptyList()
     private val tabBackStack = ArrayDeque<LevyraTab>()
@@ -1221,7 +1224,13 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 ?.let { resolver.invalidate(it, _state.value.isVideoMode) }
             _state.update { it.copy(playerError = cleanPlaybackError(errorMsg), isPlaying = false, isResolving = false) }
         }
-        applyFollowedArtists(followedArtistsStore.load())
+        val followedLoadGeneration = followedArtistsGeneration
+        viewModelScope.launch(Dispatchers.IO) {
+            val followed = followedArtistsStore.load()
+            withContext(Dispatchers.Main) {
+                if (followedArtistsGeneration == followedLoadGeneration) applyFollowedArtists(followed)
+            }
+        }
         startTicker()
         observeDownloads()
         observeDownloadTasks()
@@ -1308,22 +1317,46 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     fun toggleFollowArtist() {
         val profile = _state.value.artistProfile ?: return
+        val browseId = profile.browseId.trim()
+        if (browseId.isBlank()) return
         val name = profile.name.trim()
         if (name.isBlank()) return
         val current = _state.value.followedArtists
-        val exists = current.any { sameArtist(it, profile.browseId, name) }
+        val exists = current.any { sameArtist(it, browseId, name) }
         val updated = if (exists) {
-            current.filterNot { sameArtist(it, profile.browseId, name) }
+            current.filterNot { sameArtist(it, browseId, name) }
         } else {
-            listOf(FollowedArtist(profile.browseId, name, profile.thumbnailUrl, System.currentTimeMillis())) + current
+            listOf(FollowedArtist(browseId, name, profile.thumbnailUrl, System.currentTimeMillis())) +
+                current.filterNot { it.browseId.isBlank() && it.name.equals(name, ignoreCase = true) }
         }
-        followedArtistsStore.save(updated)
+        followedArtistsGeneration++
+        val mutationGeneration = followedArtistsGeneration
         applyFollowedArtists(updated)
-        loadReleaseRadar()
+        followedArtistsJob?.cancel()
+        followedArtistsJob = viewModelScope.launch(Dispatchers.IO) {
+            followedArtistsStore.save(updated)
+            if (mutationGeneration != followedArtistsGeneration) return@launch
+            if (exists) {
+                current.filter { sameArtist(it, browseId, name) }
+                    .forEach { followedArtistsStore.clearKnownReleases(it.key) }
+            } else {
+                val currentProfile = runCatching { artistRepository.profile(browseId, name) }.getOrNull()
+                if (currentProfile != null && mutationGeneration == followedArtistsGeneration) {
+                    val baseline = (currentProfile.albums + currentProfile.singles)
+                        .map(ReleaseRadarWorker::releaseKey)
+                        .toSet()
+                    followedArtistsStore.saveKnownReleases(browseId, baseline)
+                }
+            }
+            if (mutationGeneration != followedArtistsGeneration) return@launch
+            if (updated.isEmpty()) ReleaseRadarWorker.cancel(levyraContext)
+            else ReleaseRadarWorker.schedule(levyraContext)
+            withContext(Dispatchers.Main) { loadReleaseRadar() }
+        }
     }
 
     private fun sameArtist(artist: FollowedArtist, browseId: String, name: String): Boolean =
-        (browseId.isNotBlank() && artist.browseId == browseId) || artist.name.equals(name, ignoreCase = true)
+        artist.browseId == browseId || (artist.browseId.isBlank() && artist.name.equals(name, ignoreCase = true))
 
     private fun scheduleColdStartRefresh(initialTracks: List<Track>) {
         val appContext = getApplication<Application>().applicationContext
@@ -3837,7 +3870,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     fun toggleContinuousRadio() {
         val enabled = !queueEngine.state.value.radioEnabled
         queueEngine.setRadioEnabled(enabled)
-        if (enabled) ensureRadioTail(force = true)
+        if (enabled) ensureRadioTail(force = true) else radioJob?.cancel()
     }
 
     fun setLyricsTranslationEnabled(value: Boolean) {
@@ -7549,7 +7582,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private fun ensureRadioTail(force: Boolean, playWhenReady: Boolean = false) {
         val request = radioTailRequest(force) ?: return
         radioJob = viewModelScope.launch(Dispatchers.IO) {
-            appendRadioTail(request, force, playWhenReady)
+            appendRadioTail(request, playWhenReady)
         }
     }
 
@@ -7565,16 +7598,20 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     private suspend fun appendRadioTail(
         request: RadioTailRequest,
-        force: Boolean,
         playWhenReady: Boolean
     ) {
-        val radioTracks = runCatching {
-            repository.radio(request.seed, _state.value.languageCode, 20)
-        }.getOrDefault(emptyList())
+        val radioTracks = try {
+            repository.radio(request.seed, _state.value.languageCode, 5)
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (_: Exception) {
+            emptyList()
+        }
         if (radioTracks.isEmpty()) return
         val current = queueEngine.state.value
+        if (!current.radioEnabled) return
         if (!isSameRadioSeed(current.currentTrack, request.seed)) return
-        if (current.generation != request.generation && !force) return
+        if (current.generation != request.generation) return
         queueEngine.appendRadioTracks(radioTracks)
         if (!playWhenReady) return
         withContext(Dispatchers.Main) {

--- a/app/src/main/java/com/luc4n3x/levyra/widget/LevyraWidgetProvider.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/widget/LevyraWidgetProvider.kt
@@ -2,8 +2,12 @@ package com.luc4n3x.levyra.widget
 
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import androidx.core.content.ContextCompat
+import androidx.media3.session.MediaController
+import androidx.media3.session.SessionToken
 import com.luc4n3x.levyra.LevyraLaunchActions
 import com.luc4n3x.levyra.MainActivity
 import com.luc4n3x.levyra.player.PlaybackService
@@ -24,18 +28,14 @@ class LevyraWidgetProvider : AppWidgetProvider() {
     }
 
     private fun handleToggle(context: Context) {
-        val toggle = LevyraWidgetBridge.onToggle
-        if (toggle != null) {
+        LevyraWidgetBridge.onToggle?.let { toggle ->
             toggle()
             return
         }
-        val player = PlaybackService.activePlayer
-        if (player != null && player.mediaItemCount > 0) {
-            val playing = player.isPlaying
-            if (playing) player.pause() else player.play()
-            LevyraWidgetCenter.setPlaying(context, !playing)
-        } else {
-            openApp(context)
+        withSessionPlayer(context) { controller ->
+            if (controller.mediaItemCount <= 0) return@withSessionPlayer false
+            if (controller.isPlaying) controller.pause() else controller.play()
+            true
         }
     }
 
@@ -44,8 +44,27 @@ class LevyraWidgetProvider : AppWidgetProvider() {
             action()
             return
         }
-        val handled = if (forward) PlaybackService.requestQueueNext() else PlaybackService.requestQueuePrevious()
-        if (!handled) openApp(context)
+        withSessionPlayer(context) { controller ->
+            if (controller.mediaItemCount <= 0) return@withSessionPlayer false
+            if (forward) controller.seekToNext() else controller.seekToPrevious()
+            true
+        }
+    }
+
+    private fun withSessionPlayer(context: Context, command: (MediaController) -> Boolean) {
+        val appContext = context.applicationContext
+        val pending = goAsync()
+        val future = MediaController.Builder(
+            appContext,
+            SessionToken(appContext, ComponentName(appContext, PlaybackService::class.java))
+        ).buildAsync()
+        future.addListener({
+            val controller = runCatching { future.get() }.getOrNull()
+            val handled = controller?.let { runCatching { command(it) }.getOrDefault(false) } == true
+            controller?.release()
+            if (!handled) openApp(appContext)
+            pending.finish()
+        }, ContextCompat.getMainExecutor(appContext))
     }
 
     private fun openApp(context: Context, shortcut: String? = null) {

--- a/app/src/main/java/com/luc4n3x/levyra/widget/LevyraWidgetProvider.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/widget/LevyraWidgetProvider.kt
@@ -6,6 +6,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import androidx.core.content.ContextCompat
+import androidx.media3.common.Player
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import com.luc4n3x.levyra.LevyraLaunchActions
@@ -46,6 +47,8 @@ class LevyraWidgetProvider : AppWidgetProvider() {
         }
         withSessionPlayer(context) { controller ->
             if (controller.mediaItemCount <= 0) return@withSessionPlayer false
+            val command = if (forward) Player.COMMAND_SEEK_TO_NEXT else Player.COMMAND_SEEK_TO_PREVIOUS
+            if (!controller.isCommandAvailable(command)) return@withSessionPlayer false
             if (forward) controller.seekToNext() else controller.seekToPrevious()
             true
         }

--- a/app/src/main/java/com/luc4n3x/levyra/widget/RecognitionWidgetCenter.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/widget/RecognitionWidgetCenter.kt
@@ -15,15 +15,30 @@ import com.luc4n3x.levyra.ui.i18n.LevyraStrings
 import java.io.ByteArrayOutputStream
 import java.net.HttpURLConnection
 import java.net.URL
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 
 object RecognitionWidgetCenter {
     @Volatile private var artworkUrl = ""
     @Volatile private var artwork: Bitmap? = null
-    private val fetching = AtomicBoolean(false)
+    @Volatile private var latestState: RecognitionState = RecognitionState.Idle
+    @Volatile private var desiredArtworkUrl = ""
+    @Volatile private var fetchingArtworkUrl = ""
+    private val artworkGeneration = AtomicLong(0L)
+    private val fetchLock = Any()
 
     fun render(context: Context, state: RecognitionState) {
         val appContext = context.applicationContext
+        latestState = state
+        val resultArtworkUrl = (state as? RecognitionState.Result)?.result?.artworkUrl.orEmpty()
+        if (resultArtworkUrl != desiredArtworkUrl) {
+            desiredArtworkUrl = resultArtworkUrl
+            artworkGeneration.incrementAndGet()
+            if (resultArtworkUrl.isBlank()) {
+                artwork = null
+                artworkUrl = ""
+            }
+        }
+
         val manager = AppWidgetManager.getInstance(appContext)
         val ids = manager.getAppWidgetIds(ComponentName(appContext, RecognitionWidgetProvider::class.java))
         val strings = LevyraStrings.forCode(LevyraPreferences(appContext).snapshot().languageCode)
@@ -52,21 +67,27 @@ object RecognitionWidgetCenter {
                 if (state is RecognitionState.Listening || state is RecognitionState.Identifying) R.drawable.ic_widget_pause
                 else R.drawable.ic_qs_recognize
             )
-            val resultArtworkUrl = (state as? RecognitionState.Result)?.result?.artworkUrl.orEmpty()
             val cached = artwork?.takeIf { resultArtworkUrl.isNotBlank() && artworkUrl == resultArtworkUrl }
             if (cached != null) views.setImageViewBitmap(R.id.recognition_widget_action, cached)
             views.setOnClickPendingIntent(R.id.recognition_widget_root, RecognitionWidgetProvider.toggleIntent(appContext))
             views.setOnClickPendingIntent(R.id.recognition_widget_action, RecognitionWidgetProvider.toggleIntent(appContext))
             manager.updateAppWidget(id, views)
-            if (cached == null && resultArtworkUrl.isNotBlank()) fetchArtwork(appContext, resultArtworkUrl, state)
+        }
+        if (artwork?.takeIf { artworkUrl == resultArtworkUrl } == null && resultArtworkUrl.isNotBlank()) {
+            fetchArtwork(appContext, resultArtworkUrl, artworkGeneration.get())
         }
     }
 
-    private fun fetchArtwork(context: Context, rawUrl: String, state: RecognitionState) {
+    private fun fetchArtwork(context: Context, rawUrl: String, generation: Long) {
         val safeUrl = SafeImageUrlPolicy.sanitize(rawUrl)
-        if (safeUrl.isEmpty() || !fetching.compareAndSet(false, true)) return
+        if (safeUrl.isEmpty()) return
+        synchronized(fetchLock) {
+            if (fetchingArtworkUrl.isNotBlank()) return
+            fetchingArtworkUrl = rawUrl
+        }
         Thread {
             var connection: HttpURLConnection? = null
+            var published = false
             try {
                 connection = URL(safeUrl).openConnection() as HttpURLConnection
                 connection.instanceFollowRedirects = false
@@ -92,17 +113,26 @@ object RecognitionWidgetCenter {
                 BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
                 var sample = 1
                 while (bounds.outWidth / sample > 128 || bounds.outHeight / sample > 128) sample *= 2
-                BitmapFactory.decodeByteArray(bytes, 0, bytes.size, BitmapFactory.Options().apply { inSampleSize = sample })
-                    ?.let { decoded ->
-                        artwork = decoded
-                        artworkUrl = rawUrl
-                        render(context, state)
-                    }
+                val decoded = BitmapFactory.decodeByteArray(
+                    bytes,
+                    0,
+                    bytes.size,
+                    BitmapFactory.Options().apply { inSampleSize = sample }
+                )
+                if (decoded != null && generation == artworkGeneration.get() && desiredArtworkUrl == rawUrl) {
+                    artwork = decoded
+                    artworkUrl = rawUrl
+                    published = true
+                }
             } catch (_: Exception) {
-                Unit
+                // Artwork is optional; keep the recognition state usable without it.
             } finally {
                 connection?.disconnect()
-                fetching.set(false)
+                val superseded = generation != artworkGeneration.get() || desiredArtworkUrl != rawUrl
+                synchronized(fetchLock) {
+                    if (fetchingArtworkUrl == rawUrl) fetchingArtworkUrl = ""
+                }
+                if (published || superseded) render(context, latestState)
             }
         }.start()
     }

--- a/app/src/main/java/com/luc4n3x/levyra/widget/RecognitionWidgetCenter.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/widget/RecognitionWidgetCenter.kt
@@ -13,6 +13,7 @@ import com.luc4n3x.levyra.data.security.SafeImageUrlPolicy
 import com.luc4n3x.levyra.feature.recognition.RecognitionState
 import com.luc4n3x.levyra.ui.i18n.LevyraStrings
 import java.net.HttpURLConnection
+import java.net.InetAddress
 import java.net.URL
 import java.util.concurrent.atomic.AtomicLong
 
@@ -32,8 +33,6 @@ object RecognitionWidgetCenter {
         if (resultArtworkUrl != desiredArtworkUrl) {
             desiredArtworkUrl = resultArtworkUrl
             artworkGeneration.incrementAndGet()
-            // The old tiny bitmap is no longer useful once the requested result changes. Drop the
-            // strong reference immediately instead of retaining two artworks during the next fetch.
             artwork = null
             artworkUrl = ""
         }
@@ -88,7 +87,11 @@ object RecognitionWidgetCenter {
             var connection: HttpURLConnection? = null
             var published = false
             try {
-                connection = URL(safeUrl).openConnection() as HttpURLConnection
+                val targetUrl = URL(safeUrl)
+                val addresses = InetAddress.getAllByName(targetUrl.host)
+                if (addresses.isEmpty() || addresses.any { !SafeImageUrlPolicy.isPublicAddress(it) }) return@Thread
+
+                connection = targetUrl.openConnection() as HttpURLConnection
                 connection.instanceFollowRedirects = false
                 connection.connectTimeout = 5_000
                 connection.readTimeout = 5_000
@@ -99,9 +102,6 @@ object RecognitionWidgetCenter {
                 val declaredLength = connection.contentLengthLong
                 if (declaredLength > MAX_WIDGET_ARTWORK_BYTES) return@Thread
 
-                // A home-screen widget only needs a 128px result. Keep one fixed bounded input
-                // buffer and decode directly from it, avoiding ByteArrayOutputStream + toByteArray()
-                // which previously could retain two multi-megabyte copies of the same response.
                 val bytes = ByteArray(MAX_WIDGET_ARTWORK_BYTES + 1)
                 var total = 0
                 connection.inputStream.use { input ->
@@ -136,7 +136,6 @@ object RecognitionWidgetCenter {
                     published = true
                 }
             } catch (_: Exception) {
-                // Artwork is optional; keep the recognition state usable without it.
             } finally {
                 connection?.disconnect()
                 val superseded = generation != artworkGeneration.get() || desiredArtworkUrl != rawUrl

--- a/app/src/main/java/com/luc4n3x/levyra/widget/RecognitionWidgetCenter.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/widget/RecognitionWidgetCenter.kt
@@ -9,13 +9,18 @@ import android.view.View
 import android.widget.RemoteViews
 import com.luc4n3x.levyra.R
 import com.luc4n3x.levyra.data.LevyraPreferences
+import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
 import com.luc4n3x.levyra.data.security.SafeImageUrlPolicy
 import com.luc4n3x.levyra.feature.recognition.RecognitionState
 import com.luc4n3x.levyra.ui.i18n.LevyraStrings
-import java.net.HttpURLConnection
 import java.net.InetAddress
-import java.net.URL
+import java.net.Proxy
+import java.net.UnknownHostException
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
+import okhttp3.Call
+import okhttp3.Dns
+import okhttp3.Request
 
 object RecognitionWidgetCenter {
     @Volatile private var artworkUrl = ""
@@ -23,8 +28,28 @@ object RecognitionWidgetCenter {
     @Volatile private var latestState: RecognitionState = RecognitionState.Idle
     @Volatile private var desiredArtworkUrl = ""
     @Volatile private var fetchingArtworkUrl = ""
+    @Volatile private var activeArtworkCall: Call? = null
     private val artworkGeneration = AtomicLong(0L)
     private val fetchLock = Any()
+    private val publicOnlyDns = Dns { hostname ->
+        val addresses = InetAddress.getAllByName(hostname).toList()
+        if (addresses.isEmpty() || addresses.any { !SafeImageUrlPolicy.isPublicAddress(it) }) {
+            throw UnknownHostException("Blocked non-public artwork host")
+        }
+        addresses
+    }
+    private val artworkClient by lazy {
+        LevyraHttpClientFactory.externalIntegrations().newBuilder()
+            .dns(publicOnlyDns)
+            .proxy(Proxy.NO_PROXY)
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .retryOnConnectionFailure(false)
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .readTimeout(5, TimeUnit.SECONDS)
+            .callTimeout(8, TimeUnit.SECONDS)
+            .build()
+    }
 
     fun render(context: Context, state: RecognitionState) {
         val appContext = context.applicationContext
@@ -35,6 +60,11 @@ object RecognitionWidgetCenter {
             artworkGeneration.incrementAndGet()
             artwork = null
             artworkUrl = ""
+            synchronized(fetchLock) {
+                activeArtworkCall?.cancel()
+                activeArtworkCall = null
+                fetchingArtworkUrl = ""
+            }
         }
 
         val manager = AppWidgetManager.getInstance(appContext)
@@ -84,62 +114,72 @@ object RecognitionWidgetCenter {
             fetchingArtworkUrl = rawUrl
         }
         Thread {
-            var connection: HttpURLConnection? = null
+            var call: Call? = null
             var published = false
             try {
-                val targetUrl = URL(safeUrl)
-                val addresses = InetAddress.getAllByName(targetUrl.host)
-                if (addresses.isEmpty() || addresses.any { !SafeImageUrlPolicy.isPublicAddress(it) }) return@Thread
-
-                connection = targetUrl.openConnection() as HttpURLConnection
-                connection.instanceFollowRedirects = false
-                connection.connectTimeout = 5_000
-                connection.readTimeout = 5_000
-                if (connection.responseCode != HttpURLConnection.HTTP_OK ||
-                    !SafeImageUrlPolicy.isAllowedImageMimeType(connection.contentType)
-                ) return@Thread
-
-                val declaredLength = connection.contentLengthLong
-                if (declaredLength > MAX_WIDGET_ARTWORK_BYTES) return@Thread
-
-                val bytes = ByteArray(MAX_WIDGET_ARTWORK_BYTES + 1)
-                var total = 0
-                connection.inputStream.use { input ->
-                    while (total < bytes.size) {
-                        val read = input.read(bytes, total, bytes.size - total)
-                        if (read < 0) break
-                        total += read
+                if (generation != artworkGeneration.get() || desiredArtworkUrl != rawUrl) return@Thread
+                val request = Request.Builder().url(safeUrl).get().build()
+                call = artworkClient.newCall(request)
+                synchronized(fetchLock) {
+                    if (generation != artworkGeneration.get() || desiredArtworkUrl != rawUrl) {
+                        call.cancel()
+                        return@synchronized
                     }
+                    activeArtworkCall = call
                 }
-                if (total <= 0 || total > MAX_WIDGET_ARTWORK_BYTES) return@Thread
+                if (call.isCanceled()) return@Thread
 
-                val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-                BitmapFactory.decodeByteArray(bytes, 0, total, bounds)
-                if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return@Thread
+                call.execute().use { response ->
+                    if (!response.isSuccessful ||
+                        !SafeImageUrlPolicy.isAllowedImageMimeType(response.body.contentType()?.toString())
+                    ) return@use
 
-                var sample = 1
-                while (bounds.outWidth / sample > ARTWORK_TARGET_PX || bounds.outHeight / sample > ARTWORK_TARGET_PX) {
-                    sample *= 2
-                }
-                val decoded = BitmapFactory.decodeByteArray(
-                    bytes,
-                    0,
-                    total,
-                    BitmapFactory.Options().apply {
-                        inSampleSize = sample
-                        inPreferredConfig = Bitmap.Config.ARGB_8888
+                    val declaredLength = response.body.contentLength()
+                    if (declaredLength > MAX_WIDGET_ARTWORK_BYTES) return@use
+
+                    val bytes = ByteArray(MAX_WIDGET_ARTWORK_BYTES + 1)
+                    var total = 0
+                    response.body.byteStream().use { input ->
+                        while (total < bytes.size) {
+                            if (generation != artworkGeneration.get() || desiredArtworkUrl != rawUrl) {
+                                call.cancel()
+                                return@use
+                            }
+                            val read = input.read(bytes, total, bytes.size - total)
+                            if (read < 0) break
+                            total += read
+                        }
                     }
-                )
-                if (decoded != null && generation == artworkGeneration.get() && desiredArtworkUrl == rawUrl) {
-                    artwork = decoded
-                    artworkUrl = rawUrl
-                    published = true
+                    if (total <= 0 || total > MAX_WIDGET_ARTWORK_BYTES) return@use
+
+                    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+                    BitmapFactory.decodeByteArray(bytes, 0, total, bounds)
+                    if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return@use
+
+                    var sample = 1
+                    while (bounds.outWidth / sample > ARTWORK_TARGET_PX || bounds.outHeight / sample > ARTWORK_TARGET_PX) {
+                        sample *= 2
+                    }
+                    val decoded = BitmapFactory.decodeByteArray(
+                        bytes,
+                        0,
+                        total,
+                        BitmapFactory.Options().apply {
+                            inSampleSize = sample
+                            inPreferredConfig = Bitmap.Config.ARGB_8888
+                        }
+                    )
+                    if (decoded != null && generation == artworkGeneration.get() && desiredArtworkUrl == rawUrl) {
+                        artwork = decoded
+                        artworkUrl = rawUrl
+                        published = true
+                    }
                 }
             } catch (_: Exception) {
             } finally {
-                connection?.disconnect()
                 val superseded = generation != artworkGeneration.get() || desiredArtworkUrl != rawUrl
                 synchronized(fetchLock) {
+                    if (activeArtworkCall === call) activeArtworkCall = null
                     if (fetchingArtworkUrl == rawUrl) fetchingArtworkUrl = ""
                 }
                 if (published || superseded) render(context, latestState)

--- a/app/src/main/java/com/luc4n3x/levyra/widget/RecognitionWidgetCenter.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/widget/RecognitionWidgetCenter.kt
@@ -119,17 +119,18 @@ object RecognitionWidgetCenter {
             try {
                 if (generation != artworkGeneration.get() || desiredArtworkUrl != rawUrl) return@Thread
                 val request = Request.Builder().url(safeUrl).get().build()
-                call = artworkClient.newCall(request)
+                val artworkCall = artworkClient.newCall(request)
+                call = artworkCall
                 synchronized(fetchLock) {
                     if (generation != artworkGeneration.get() || desiredArtworkUrl != rawUrl) {
-                        call.cancel()
-                        return@synchronized
+                        artworkCall.cancel()
+                    } else {
+                        activeArtworkCall = artworkCall
                     }
-                    activeArtworkCall = call
                 }
-                if (call.isCanceled()) return@Thread
+                if (artworkCall.isCanceled()) return@Thread
 
-                call.execute().use { response ->
+                artworkCall.execute().use { response ->
                     if (!response.isSuccessful ||
                         !SafeImageUrlPolicy.isAllowedImageMimeType(response.body.contentType()?.toString())
                     ) return@use
@@ -139,18 +140,20 @@ object RecognitionWidgetCenter {
 
                     val bytes = ByteArray(MAX_WIDGET_ARTWORK_BYTES + 1)
                     var total = 0
+                    var obsolete = false
                     response.body.byteStream().use { input ->
                         while (total < bytes.size) {
                             if (generation != artworkGeneration.get() || desiredArtworkUrl != rawUrl) {
-                                call.cancel()
-                                return@use
+                                obsolete = true
+                                artworkCall.cancel()
+                                break
                             }
                             val read = input.read(bytes, total, bytes.size - total)
                             if (read < 0) break
                             total += read
                         }
                     }
-                    if (total <= 0 || total > MAX_WIDGET_ARTWORK_BYTES) return@use
+                    if (obsolete || total <= 0 || total > MAX_WIDGET_ARTWORK_BYTES) return@use
 
                     val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
                     BitmapFactory.decodeByteArray(bytes, 0, total, bounds)

--- a/app/src/main/java/com/luc4n3x/levyra/widget/RecognitionWidgetCenter.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/widget/RecognitionWidgetCenter.kt
@@ -1,0 +1,109 @@
+package com.luc4n3x.levyra.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.view.View
+import android.widget.RemoteViews
+import com.luc4n3x.levyra.R
+import com.luc4n3x.levyra.data.LevyraPreferences
+import com.luc4n3x.levyra.data.security.SafeImageUrlPolicy
+import com.luc4n3x.levyra.feature.recognition.RecognitionState
+import com.luc4n3x.levyra.ui.i18n.LevyraStrings
+import java.io.ByteArrayOutputStream
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.atomic.AtomicBoolean
+
+object RecognitionWidgetCenter {
+    @Volatile private var artworkUrl = ""
+    @Volatile private var artwork: Bitmap? = null
+    private val fetching = AtomicBoolean(false)
+
+    fun render(context: Context, state: RecognitionState) {
+        val appContext = context.applicationContext
+        val manager = AppWidgetManager.getInstance(appContext)
+        val ids = manager.getAppWidgetIds(ComponentName(appContext, RecognitionWidgetProvider::class.java))
+        val strings = LevyraStrings.forCode(LevyraPreferences(appContext).snapshot().languageCode)
+        ids.forEach { id ->
+            val width = manager.getAppWidgetOptions(id).getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH)
+            val views = RemoteViews(appContext.packageName, R.layout.recognition_widget)
+            val title = when (state) {
+                RecognitionState.Idle -> strings.recognitionTitle
+                RecognitionState.Listening -> strings.recognitionListening
+                RecognitionState.Identifying -> strings.recognitionProcessing
+                RecognitionState.NoMatch -> strings.recognitionNoMatch
+                is RecognitionState.Error -> strings.recognitionUnavailable
+                is RecognitionState.Result -> state.result.title
+            }
+            val subtitle = when (state) {
+                is RecognitionState.Result -> state.result.artist
+                RecognitionState.Idle -> strings.recognitionTapToListen
+                else -> ""
+            }
+            views.setTextViewText(R.id.recognition_widget_title, title)
+            views.setTextViewText(R.id.recognition_widget_subtitle, subtitle)
+            views.setViewVisibility(R.id.recognition_widget_text, if (width < 110) View.GONE else View.VISIBLE)
+            views.setViewVisibility(R.id.recognition_widget_subtitle, if (width < 220 || subtitle.isBlank()) View.GONE else View.VISIBLE)
+            views.setImageViewResource(
+                R.id.recognition_widget_action,
+                if (state is RecognitionState.Listening || state is RecognitionState.Identifying) R.drawable.ic_widget_pause
+                else R.drawable.ic_qs_recognize
+            )
+            val resultArtworkUrl = (state as? RecognitionState.Result)?.result?.artworkUrl.orEmpty()
+            val cached = artwork?.takeIf { resultArtworkUrl.isNotBlank() && artworkUrl == resultArtworkUrl }
+            if (cached != null) views.setImageViewBitmap(R.id.recognition_widget_action, cached)
+            views.setOnClickPendingIntent(R.id.recognition_widget_root, RecognitionWidgetProvider.toggleIntent(appContext))
+            views.setOnClickPendingIntent(R.id.recognition_widget_action, RecognitionWidgetProvider.toggleIntent(appContext))
+            manager.updateAppWidget(id, views)
+            if (cached == null && resultArtworkUrl.isNotBlank()) fetchArtwork(appContext, resultArtworkUrl, state)
+        }
+    }
+
+    private fun fetchArtwork(context: Context, rawUrl: String, state: RecognitionState) {
+        val safeUrl = SafeImageUrlPolicy.sanitize(rawUrl)
+        if (safeUrl.isEmpty() || !fetching.compareAndSet(false, true)) return
+        Thread {
+            var connection: HttpURLConnection? = null
+            try {
+                connection = URL(safeUrl).openConnection() as HttpURLConnection
+                connection.instanceFollowRedirects = false
+                connection.connectTimeout = 5_000
+                connection.readTimeout = 5_000
+                if (connection.responseCode != HttpURLConnection.HTTP_OK ||
+                    !SafeImageUrlPolicy.isAllowedImageMimeType(connection.contentType)
+                ) return@Thread
+                val output = ByteArrayOutputStream()
+                val buffer = ByteArray(8_192)
+                var total = 0
+                connection.inputStream.use { input ->
+                    while (true) {
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        total += read
+                        if (total > SafeImageUrlPolicy.MAX_IMAGE_PAYLOAD_BYTES) return@Thread
+                        output.write(buffer, 0, read)
+                    }
+                }
+                val bytes = output.toByteArray()
+                val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+                BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+                var sample = 1
+                while (bounds.outWidth / sample > 128 || bounds.outHeight / sample > 128) sample *= 2
+                BitmapFactory.decodeByteArray(bytes, 0, bytes.size, BitmapFactory.Options().apply { inSampleSize = sample })
+                    ?.let { decoded ->
+                        artwork = decoded
+                        artworkUrl = rawUrl
+                        render(context, state)
+                    }
+            } catch (_: Exception) {
+                Unit
+            } finally {
+                connection?.disconnect()
+                fetching.set(false)
+            }
+        }.start()
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/widget/RecognitionWidgetCenter.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/widget/RecognitionWidgetCenter.kt
@@ -12,7 +12,6 @@ import com.luc4n3x.levyra.data.LevyraPreferences
 import com.luc4n3x.levyra.data.security.SafeImageUrlPolicy
 import com.luc4n3x.levyra.feature.recognition.RecognitionState
 import com.luc4n3x.levyra.ui.i18n.LevyraStrings
-import java.io.ByteArrayOutputStream
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.concurrent.atomic.AtomicLong
@@ -33,10 +32,10 @@ object RecognitionWidgetCenter {
         if (resultArtworkUrl != desiredArtworkUrl) {
             desiredArtworkUrl = resultArtworkUrl
             artworkGeneration.incrementAndGet()
-            if (resultArtworkUrl.isBlank()) {
-                artwork = null
-                artworkUrl = ""
-            }
+            // The old tiny bitmap is no longer useful once the requested result changes. Drop the
+            // strong reference immediately instead of retaining two artworks during the next fetch.
+            artwork = null
+            artworkUrl = ""
         }
 
         val manager = AppWidgetManager.getInstance(appContext)
@@ -96,28 +95,40 @@ object RecognitionWidgetCenter {
                 if (connection.responseCode != HttpURLConnection.HTTP_OK ||
                     !SafeImageUrlPolicy.isAllowedImageMimeType(connection.contentType)
                 ) return@Thread
-                val output = ByteArrayOutputStream()
-                val buffer = ByteArray(8_192)
+
+                val declaredLength = connection.contentLengthLong
+                if (declaredLength > MAX_WIDGET_ARTWORK_BYTES) return@Thread
+
+                // A home-screen widget only needs a 128px result. Keep one fixed bounded input
+                // buffer and decode directly from it, avoiding ByteArrayOutputStream + toByteArray()
+                // which previously could retain two multi-megabyte copies of the same response.
+                val bytes = ByteArray(MAX_WIDGET_ARTWORK_BYTES + 1)
                 var total = 0
                 connection.inputStream.use { input ->
-                    while (true) {
-                        val read = input.read(buffer)
+                    while (total < bytes.size) {
+                        val read = input.read(bytes, total, bytes.size - total)
                         if (read < 0) break
                         total += read
-                        if (total > SafeImageUrlPolicy.MAX_IMAGE_PAYLOAD_BYTES) return@Thread
-                        output.write(buffer, 0, read)
                     }
                 }
-                val bytes = output.toByteArray()
+                if (total <= 0 || total > MAX_WIDGET_ARTWORK_BYTES) return@Thread
+
                 val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-                BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+                BitmapFactory.decodeByteArray(bytes, 0, total, bounds)
+                if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return@Thread
+
                 var sample = 1
-                while (bounds.outWidth / sample > 128 || bounds.outHeight / sample > 128) sample *= 2
+                while (bounds.outWidth / sample > ARTWORK_TARGET_PX || bounds.outHeight / sample > ARTWORK_TARGET_PX) {
+                    sample *= 2
+                }
                 val decoded = BitmapFactory.decodeByteArray(
                     bytes,
                     0,
-                    bytes.size,
-                    BitmapFactory.Options().apply { inSampleSize = sample }
+                    total,
+                    BitmapFactory.Options().apply {
+                        inSampleSize = sample
+                        inPreferredConfig = Bitmap.Config.ARGB_8888
+                    }
                 )
                 if (decoded != null && generation == artworkGeneration.get() && desiredArtworkUrl == rawUrl) {
                     artwork = decoded
@@ -134,6 +145,12 @@ object RecognitionWidgetCenter {
                 }
                 if (published || superseded) render(context, latestState)
             }
+        }.apply {
+            name = "Levyra-recognition-widget-art"
+            isDaemon = true
         }.start()
     }
+
+    private const val ARTWORK_TARGET_PX = 128
+    private const val MAX_WIDGET_ARTWORK_BYTES = 1024 * 1024
 }

--- a/app/src/main/java/com/luc4n3x/levyra/widget/RecognitionWidgetCenter.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/widget/RecognitionWidgetCenter.kt
@@ -29,6 +29,7 @@ object RecognitionWidgetCenter {
     @Volatile private var desiredArtworkUrl = ""
     @Volatile private var fetchingArtworkUrl = ""
     @Volatile private var activeArtworkCall: Call? = null
+    private var fetchingArtworkGeneration = -1L
     private val artworkGeneration = AtomicLong(0L)
     private val fetchLock = Any()
     private val publicOnlyDns = Dns { hostname ->
@@ -64,6 +65,7 @@ object RecognitionWidgetCenter {
                 activeArtworkCall?.cancel()
                 activeArtworkCall = null
                 fetchingArtworkUrl = ""
+                fetchingArtworkGeneration = -1L
             }
         }
 
@@ -112,6 +114,7 @@ object RecognitionWidgetCenter {
         synchronized(fetchLock) {
             if (fetchingArtworkUrl.isNotBlank()) return
             fetchingArtworkUrl = rawUrl
+            fetchingArtworkGeneration = generation
         }
         Thread {
             var call: Call? = null
@@ -183,7 +186,10 @@ object RecognitionWidgetCenter {
                 val superseded = generation != artworkGeneration.get() || desiredArtworkUrl != rawUrl
                 synchronized(fetchLock) {
                     if (activeArtworkCall === call) activeArtworkCall = null
-                    if (fetchingArtworkUrl == rawUrl) fetchingArtworkUrl = ""
+                    if (fetchingArtworkUrl == rawUrl && fetchingArtworkGeneration == generation) {
+                        fetchingArtworkUrl = ""
+                        fetchingArtworkGeneration = -1L
+                    }
                 }
                 if (published || superseded) render(context, latestState)
             }

--- a/app/src/main/java/com/luc4n3x/levyra/widget/RecognitionWidgetProvider.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/widget/RecognitionWidgetProvider.kt
@@ -1,0 +1,60 @@
+package com.luc4n3x.levyra.widget
+
+import android.Manifest
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+import com.luc4n3x.levyra.LevyraLaunchActions
+import com.luc4n3x.levyra.MainActivity
+import com.luc4n3x.levyra.feature.recognition.LevyraRecognitionCenter
+import com.luc4n3x.levyra.feature.recognition.MusicRecognitionService
+import com.luc4n3x.levyra.feature.recognition.RecognitionState
+
+class RecognitionWidgetProvider : AppWidgetProvider() {
+    override fun onUpdate(context: Context, manager: AppWidgetManager, ids: IntArray) {
+        RecognitionWidgetCenter.render(context, LevyraRecognitionCenter.get(context).state.value)
+    }
+
+    override fun onAppWidgetOptionsChanged(context: Context, manager: AppWidgetManager, id: Int, options: android.os.Bundle) {
+        RecognitionWidgetCenter.render(context, LevyraRecognitionCenter.get(context).state.value)
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+        if (intent.action != ACTION_TOGGLE) return
+        when (LevyraRecognitionCenter.get(context).state.value) {
+            RecognitionState.Listening, RecognitionState.Identifying ->
+                context.startService(MusicRecognitionService.cancelIntent(context))
+            else -> if (hasPermission(context)) {
+                ContextCompat.startForegroundService(context, MusicRecognitionService.microphoneIntent(context))
+            } else {
+                context.startActivity(permissionIntent(context))
+            }
+        }
+    }
+
+    companion object {
+        const val ACTION_TOGGLE = "com.luc4n3x.levyra.widget.RECOGNIZE"
+
+        fun toggleIntent(context: Context): PendingIntent = PendingIntent.getBroadcast(
+            context,
+            ACTION_TOGGLE.hashCode(),
+            Intent(context, RecognitionWidgetProvider::class.java).setAction(ACTION_TOGGLE),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        private fun hasPermission(context: Context): Boolean = Build.VERSION.SDK_INT < Build.VERSION_CODES.M ||
+            ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED
+
+        private fun permissionIntent(context: Context) = Intent(context, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            putExtra(LevyraLaunchActions.EXTRA_SHORTCUT, LevyraLaunchActions.SHORTCUT_RECOGNITION)
+            putExtra(LevyraLaunchActions.EXTRA_RECOGNITION_PERMISSION_REQUEST, true)
+        }
+    }
+}

--- a/app/src/main/res/layout/recognition_widget.xml
+++ b/app/src/main/res/layout/recognition_widget.xml
@@ -13,7 +13,7 @@
         android:layout_width="52dp"
         android:layout_height="52dp"
         android:background="@drawable/widget_artwork_background"
-        android:contentDescription="@string/recognition_widget_description"
+        android:contentDescription="@string/tile_recognize_music"
         android:padding="13dp"
         android:scaleType="fitCenter"
         android:src="@drawable/ic_qs_recognize" />

--- a/app/src/main/res/layout/recognition_widget.xml
+++ b/app/src/main/res/layout/recognition_widget.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/recognition_widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_background"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:padding="12dp">
+
+    <ImageButton
+        android:id="@+id/recognition_widget_action"
+        android:layout_width="52dp"
+        android:layout_height="52dp"
+        android:background="@drawable/widget_artwork_background"
+        android:contentDescription="@string/recognition_widget_description"
+        android:padding="13dp"
+        android:scaleType="fitCenter"
+        android:src="@drawable/ic_qs_recognize" />
+
+    <LinearLayout
+        android:id="@+id/recognition_widget_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/recognition_widget_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="#F8F7FF"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/recognition_widget_subtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="#B9B2CC"
+            android:textSize="12sp" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="recognition_widget_description">Identify music</string>
     <string name="app_name" translatable="false">LEVYRA</string>
     <string name="widget_description">Mini player, quick favorites, daily flow, offline and lyrics</string>
     <string name="widget_idle_title" translatable="false">LEVYRA</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="recognition_widget_description">Identify music</string>
     <string name="app_name" translatable="false">LEVYRA</string>
     <string name="widget_description">Mini player, quick favorites, daily flow, offline and lyrics</string>
     <string name="widget_idle_title" translatable="false">LEVYRA</string>

--- a/app/src/main/res/xml/recognition_widget_info.xml
+++ b/app/src/main/res/xml/recognition_widget_info.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="60dp"
+    android:minHeight="60dp"
+    android:targetCellWidth="2"
+    android:targetCellHeight="1"
+    android:initialLayout="@layout/recognition_widget"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:description="@string/recognition_widget_description" />

--- a/app/src/main/res/xml/recognition_widget_info.xml
+++ b/app/src/main/res/xml/recognition_widget_info.xml
@@ -7,4 +7,4 @@
     android:initialLayout="@layout/recognition_widget"
     android:resizeMode="horizontal|vertical"
     android:widgetCategory="home_screen"
-    android:description="@string/recognition_widget_description" />
+    android:description="@string/tile_recognize_music" />

--- a/app/src/test/java/com/luc4n3x/levyra/feature/cast/CastHandoffTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/feature/cast/CastHandoffTest.kt
@@ -2,6 +2,7 @@ package com.luc4n3x.levyra.feature.cast
 
 import com.luc4n3x.levyra.domain.RepeatMode
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -106,5 +107,36 @@ class CastHandoffTest {
         assertEquals(-1, handoff.currentIndex)
         assertTrue(resumed.queueIds.isEmpty())
         assertEquals(-1, resumed.currentIndex)
+    }
+
+    @Test
+    fun remoteHandoffNeverRewindsSameMediaItem() {
+        assertEquals(
+            48_000L,
+            castHandoffStartPositionMs(
+                sameMediaItem = true,
+                requestedPositionMs = 42_000L,
+                livePositionMs = 48_000L,
+                remotePlayback = true
+            )
+        )
+        assertEquals(
+            42_000L,
+            castHandoffStartPositionMs(
+                sameMediaItem = false,
+                requestedPositionMs = 42_000L,
+                livePositionMs = 48_000L,
+                remotePlayback = true
+            )
+        )
+    }
+
+    @Test
+    fun managedWindowRefreshesNearEdgeOrWhenLogicalOrderChanges() {
+        val expected = listOf("b", "c", "d", "e")
+        assertFalse(castWindowNeedsRefresh(expected, listOf("b", "c", "d")))
+        assertTrue(castWindowNeedsRefresh(expected, listOf("b", "c")))
+        assertTrue(castWindowNeedsRefresh(expected, listOf("b", "x", "d")))
+        assertFalse(castWindowNeedsRefresh(emptyList(), emptyList()))
     }
 }

--- a/app/src/test/java/com/luc4n3x/levyra/feature/cast/CastHandoffTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/feature/cast/CastHandoffTest.kt
@@ -139,4 +139,35 @@ class CastHandoffTest {
         assertTrue(castWindowNeedsRefresh(expected, listOf("b", "x", "d")))
         assertFalse(castWindowNeedsRefresh(emptyList(), emptyList()))
     }
+
+    @Test
+    fun fiveItemWindowRefreshesBeforeForwardBufferRunsDry() {
+        val expected = listOf("track-6", "track-7", "track-8")
+
+        assertFalse(
+            castWindowNeedsRefresh(
+                expectedUpcomingIds = expected,
+                remoteForwardIds = listOf("track-6", "track-7"),
+                minimumBufferedItems = CastHandoffConverter.DEFAULT_QUEUE_WINDOW_RADIUS
+            )
+        )
+        assertTrue(
+            castWindowNeedsRefresh(
+                expectedUpcomingIds = expected,
+                remoteForwardIds = listOf("track-6"),
+                minimumBufferedItems = CastHandoffConverter.DEFAULT_QUEUE_WINDOW_RADIUS
+            )
+        )
+    }
+
+    @Test
+    fun receiverMediaPolicyAcceptsOnlyGoogleVideoHttps() {
+        assertTrue(isCastReceiverSafeMediaUrl("https://rr1---sn.example.googlevideo.com/videoplayback?id=abc"))
+        assertTrue(isCastReceiverSafeMediaUrl("https://googlevideo.com/videoplayback?id=abc"))
+        assertFalse(isCastReceiverSafeMediaUrl("http://rr1---sn.example.googlevideo.com/videoplayback"))
+        assertFalse(isCastReceiverSafeMediaUrl("https://googlevideo.com.evil.example/videoplayback"))
+        assertFalse(isCastReceiverSafeMediaUrl("https://user:pass@googlevideo.com/videoplayback"))
+        assertFalse(isCastReceiverSafeMediaUrl("https://googlevideo.com:8443/videoplayback"))
+        assertFalse(isCastReceiverSafeMediaUrl("https://127.0.0.1/videoplayback"))
+    }
 }

--- a/app/src/test/java/com/luc4n3x/levyra/feature/cast/CastHandoffTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/feature/cast/CastHandoffTest.kt
@@ -90,8 +90,9 @@ class CastHandoffTest {
     }
 
     @Test
-    fun handoffDefaultWindowRadiusIsTen() {
-        assertEquals(10, CastHandoffConverter.DEFAULT_QUEUE_WINDOW_RADIUS)
+    fun handoffDefaultWindowContainsAtMostFiveItems() {
+        assertEquals(2, CastHandoffConverter.DEFAULT_QUEUE_WINDOW_RADIUS)
+        assertEquals(5, CastHandoffConverter.toHandoff(snapshot(size = 20, currentIndex = 10)).queueWindowIds.size)
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/player/queue/PersistentQueueRadioPolicyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/queue/PersistentQueueRadioPolicyTest.kt
@@ -1,0 +1,48 @@
+package com.luc4n3x.levyra.player.queue
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PersistentQueueRadioPolicyTest {
+
+    @Test
+    fun trimPreservesCurrentAndRecentHistory() {
+        val history = (0..20).toList()
+
+        val removable = radioHistoryTrimIndices(
+            history = history,
+            currentIndex = 20,
+            slotsNeeded = 5,
+            historyReserve = 8
+        )
+
+        assertEquals(setOf(0, 1, 2, 3, 4), removable)
+        assertTrue(20 !in removable)
+        assertTrue((13..20).none(removable::contains))
+    }
+
+    @Test
+    fun trimNeverInventsSlotsWithoutOldHistory() {
+        assertTrue(
+            radioHistoryTrimIndices(
+                history = listOf(1, 2, 3),
+                currentIndex = 3,
+                slotsNeeded = 5,
+                historyReserve = 8
+            ).isEmpty()
+        )
+    }
+
+    @Test
+    fun trimDeduplicatesRepeatedHistoryIndices() {
+        val removable = radioHistoryTrimIndices(
+            history = listOf(1, 2, 1, 3, 4, 5),
+            currentIndex = 5,
+            slotsNeeded = 3,
+            historyReserve = 2
+        )
+
+        assertEquals(setOf(1, 2, 3), removable)
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/player/queue/PersistentQueueRadioPolicyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/queue/PersistentQueueRadioPolicyTest.kt
@@ -1,5 +1,6 @@
 package com.luc4n3x.levyra.player.queue
 
+import com.luc4n3x.levyra.domain.Track
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -45,4 +46,57 @@ class PersistentQueueRadioPolicyTest {
 
         assertEquals(setOf(1, 2, 3), removable)
     }
+
+    @Test
+    fun candidatePoolSkipsExistingTracksBeforeApplyingBatchLimit() {
+        val existing = (1..5).map { track("existing-$it", "Existing $it") }
+        val candidates = existing + (1..5).map { track("fresh-$it", "Fresh $it") }
+
+        val selected = radioCandidateTracks(
+            existingTracks = existing,
+            candidates = candidates,
+            limit = 5
+        )
+
+        assertEquals(
+            listOf("fresh-1", "fresh-2", "fresh-3", "fresh-4", "fresh-5"),
+            selected.map(Track::id)
+        )
+    }
+
+    @Test
+    fun candidatePoolRejectsArtistTitleDuplicatesWithDifferentIds() {
+        val existing = listOf(track("old", "Same song", artist = "Artist"))
+
+        val selected = radioCandidateTracks(
+            existingTracks = existing,
+            candidates = listOf(
+                track("duplicate", " same SONG ", artist = " artist "),
+                track("fresh", "Different song", artist = "Artist")
+            ),
+            limit = 5
+        )
+
+        assertEquals(listOf("fresh"), selected.map(Track::id))
+    }
+
+    private fun track(id: String, title: String, artist: String = "Artist") = Track(
+        id = id,
+        title = title,
+        artist = artist,
+        album = "",
+        durationMs = 0L,
+        streamUrl = "",
+        videoUrl = "",
+        thumbnailUrl = "",
+        largeThumbnailUrl = "",
+        source = "test",
+        moodTags = emptySet(),
+        energy = 0,
+        vocal = 0,
+        replayScore = 0,
+        cacheScore = 0,
+        accentStart = 0,
+        accentEnd = 0
+    )
 }

--- a/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/CastRouteButton.kt
+++ b/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/CastRouteButton.kt
@@ -1,0 +1,25 @@
+package com.luc4n3x.levyra.feature.cast
+
+import android.view.ContextThemeWrapper
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.mediarouter.app.MediaRouteButton
+import com.google.android.gms.cast.framework.CastButtonFactory
+import androidx.mediarouter.R as MediaRouterR
+
+@Composable
+fun CastRouteButton(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    AndroidView(
+        modifier = modifier,
+        factory = {
+            val themed = ContextThemeWrapper(context, MediaRouterR.style.Theme_MediaRouter)
+            MediaRouteButton(themed).apply {
+                CastButtonFactory.setUpMediaRouteButton(context.applicationContext, this)
+                setPadding(0, 0, 0, 0)
+            }
+        }
+    )
+}

--- a/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/CastRouteButton.kt
+++ b/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/CastRouteButton.kt
@@ -1,25 +1,26 @@
+@file:androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+
 package com.luc4n3x.levyra.feature.cast
 
-import android.view.ContextThemeWrapper
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.viewinterop.AndroidView
-import androidx.mediarouter.app.MediaRouteButton
-import com.google.android.gms.cast.framework.CastButtonFactory
-import androidx.mediarouter.R as MediaRouterR
+import androidx.media3.cast.Cast
+import androidx.media3.cast.MediaRouteButton as Media3RouteButton
 
 @Composable
 fun CastRouteButton(modifier: Modifier = Modifier) {
-    val context = LocalContext.current
-    AndroidView(
-        modifier = modifier,
-        factory = {
-            val themed = ContextThemeWrapper(context, MediaRouterR.style.Theme_MediaRouter)
-            MediaRouteButton(themed).apply {
-                CastButtonFactory.setUpMediaRouteButton(context.applicationContext, this)
-                setPadding(0, 0, 0, 0)
+    val appContext = LocalContext.current.applicationContext
+    val castReady = remember(appContext) {
+        runCatching {
+            Cast.getSingletonInstance(appContext).apply {
+                if (needsInitialization()) initialize()
             }
-        }
-    )
+            true
+        }.getOrElse { false }
+    }
+    if (castReady) {
+        Media3RouteButton(modifier = modifier)
+    }
 }

--- a/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/CastRouteButton.kt
+++ b/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/CastRouteButton.kt
@@ -6,10 +6,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.media3.cast.Cast
@@ -38,11 +41,15 @@ fun CastRouteButton(modifier: Modifier = Modifier) {
             ),
             contentAlignment = Alignment.Center
         ) {
-            Media3RouteButton(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(4.dp)
-            )
+            CompositionLocalProvider(
+                LocalContentColor provides Color.White.copy(alpha = 0.86f)
+            ) {
+                Media3RouteButton(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(4.dp)
+                )
+            }
         }
     }
 }

--- a/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/CastRouteButton.kt
+++ b/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/CastRouteButton.kt
@@ -9,47 +9,35 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.media3.cast.Cast
 import androidx.media3.cast.MediaRouteButton as Media3RouteButton
 import com.luc4n3x.levyra.ui.components.playerGlass
 import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
 
 @Composable
 fun CastRouteButton(modifier: Modifier = Modifier) {
-    val appContext = LocalContext.current.applicationContext
-    val castReady = remember(appContext) {
-        runCatching {
-            Cast.getSingletonInstance(appContext).apply {
-                if (needsInitialization()) initialize()
-            }
-            true
-        }.getOrElse { false }
-    }
-    if (castReady) {
-        Box(
-            modifier = modifier.playerGlass(
-                shape = CircleShape,
-                fill = LevyraPlayerDesign.GlassFill,
-                borderTop = LevyraPlayerDesign.GlassBorderTop,
-                borderBottom = LevyraPlayerDesign.GlassBorderBottom
-            ),
-            contentAlignment = Alignment.Center
+    if (!CastRuntimeInitializer.available) return
+
+    Box(
+        modifier = modifier.playerGlass(
+            shape = CircleShape,
+            fill = LevyraPlayerDesign.GlassFill,
+            borderTop = LevyraPlayerDesign.GlassBorderTop,
+            borderBottom = LevyraPlayerDesign.GlassBorderBottom
+        ),
+        contentAlignment = Alignment.Center
+    ) {
+        CompositionLocalProvider(
+            LocalContentColor provides Color.White.copy(alpha = 0.86f)
         ) {
-            CompositionLocalProvider(
-                LocalContentColor provides Color.White.copy(alpha = 0.86f)
-            ) {
-                Media3RouteButton(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(4.dp)
-                )
-            }
+            Media3RouteButton(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(4.dp)
+            )
         }
     }
 }

--- a/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/CastRouteButton.kt
+++ b/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/CastRouteButton.kt
@@ -2,12 +2,20 @@
 
 package com.luc4n3x.levyra.feature.cast
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.media3.cast.Cast
 import androidx.media3.cast.MediaRouteButton as Media3RouteButton
+import com.luc4n3x.levyra.ui.components.playerGlass
+import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
 
 @Composable
 fun CastRouteButton(modifier: Modifier = Modifier) {
@@ -21,6 +29,20 @@ fun CastRouteButton(modifier: Modifier = Modifier) {
         }.getOrElse { false }
     }
     if (castReady) {
-        Media3RouteButton(modifier = modifier)
+        Box(
+            modifier = modifier.playerGlass(
+                shape = CircleShape,
+                fill = LevyraPlayerDesign.GlassFill,
+                borderTop = LevyraPlayerDesign.GlassBorderTop,
+                borderBottom = LevyraPlayerDesign.GlassBorderBottom
+            ),
+            contentAlignment = Alignment.Center
+        ) {
+            Media3RouteButton(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(4.dp)
+            )
+        }
     }
 }

--- a/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/CastRuntimeInitializer.kt
+++ b/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/CastRuntimeInitializer.kt
@@ -7,11 +7,18 @@ import androidx.media3.cast.Cast
 import timber.log.Timber
 
 object CastRuntimeInitializer {
+    @Volatile
+    var available: Boolean = false
+        private set
+
     fun initialize(context: Context) {
-        runCatching {
+        available = runCatching {
             Cast.getSingletonInstance(context.applicationContext).apply {
                 if (needsInitialization()) initialize()
             }
-        }.onFailure { Timber.w(it, "Media3 Cast initialization failed; Cast will stay unavailable") }
+            true
+        }.onFailure {
+            Timber.w(it, "Media3 Cast initialization failed; Cast will stay unavailable")
+        }.getOrDefault(false)
     }
 }

--- a/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/CastRuntimeInitializer.kt
+++ b/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/CastRuntimeInitializer.kt
@@ -1,0 +1,17 @@
+@file:androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+
+package com.luc4n3x.levyra.feature.cast
+
+import android.content.Context
+import androidx.media3.cast.Cast
+import timber.log.Timber
+
+object CastRuntimeInitializer {
+    fun initialize(context: Context) {
+        runCatching {
+            Cast.getSingletonInstance(context.applicationContext).apply {
+                if (needsInitialization()) initialize()
+            }
+        }.onFailure { Timber.w(it, "Media3 Cast initialization failed; Cast will stay unavailable") }
+    }
+}

--- a/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/GoogleCastBackend.kt
+++ b/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/GoogleCastBackend.kt
@@ -1,0 +1,100 @@
+package com.luc4n3x.levyra.feature.cast
+
+import android.content.Context
+import androidx.media3.cast.CastPlayer
+import androidx.media3.common.DeviceInfo
+import androidx.media3.common.Player
+import com.google.android.gms.cast.framework.CastContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flowOf
+
+class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
+    override val id: String = "google-cast"
+    override val available: Boolean = runCatching { CastContext.getSharedInstance(context) }.isSuccess
+
+    private val mutableState = MutableStateFlow(
+        RemotePlaybackState(
+            availability = if (available) RemotePlaybackAvailability.Idle else RemotePlaybackAvailability.Unavailable
+        )
+    )
+    override val state: StateFlow<RemotePlaybackState> = mutableState
+    private var player: CastPlayer? = null
+
+    private val listener = object : Player.Listener {
+        override fun onEvents(player: Player, events: Player.Events) = publish(player)
+        override fun onDeviceInfoChanged(deviceInfo: DeviceInfo) = publish(player ?: return)
+    }
+
+    override fun devices(): Flow<List<RemoteDevice>> = flowOf(emptyList())
+
+    override suspend fun connect(device: RemoteDevice) = Unit
+
+    override suspend fun disconnect() {
+        runCatching { CastContext.getSharedInstance(context).sessionManager.endCurrentSession(true) }
+    }
+
+    override suspend fun load(handoff: CastHandoff) = Unit
+
+    override suspend fun play() { player?.play() }
+    override suspend fun pause() { player?.pause() }
+    override suspend fun stop() { player?.stop() }
+    override suspend fun seekTo(positionMs: Long) { player?.seekTo(positionMs.coerceAtLeast(0L)) }
+    override suspend fun skipToNext() { player?.seekToNextMediaItem() }
+    override suspend fun skipToPrevious() { player?.seekToPreviousMediaItem() }
+    override suspend fun setShuffle(enabled: Boolean) { player?.shuffleModeEnabled = enabled }
+    override suspend fun setRepeatMode(mode: com.luc4n3x.levyra.domain.RepeatMode) {
+        player?.repeatMode = when (mode) {
+            com.luc4n3x.levyra.domain.RepeatMode.One -> Player.REPEAT_MODE_ONE
+            com.luc4n3x.levyra.domain.RepeatMode.All -> Player.REPEAT_MODE_ALL
+            com.luc4n3x.levyra.domain.RepeatMode.Off -> Player.REPEAT_MODE_OFF
+        }
+    }
+
+    override fun attachLocalPlayer(localPlayer: Player): Player {
+        if (!available) return localPlayer
+        return runCatching {
+            CastPlayer.Builder(context)
+                .setLocalPlayer(localPlayer)
+                .build()
+                .also {
+                    player = it
+                    it.addListener(listener)
+                    publish(it)
+                }
+        }.getOrElse { localPlayer }
+    }
+
+    override fun release() {
+        player?.removeListener(listener)
+        player?.release()
+        player = null
+    }
+
+    private fun publish(player: Player) {
+        val connected = player.deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE
+        val deviceName = runCatching {
+            CastContext.getSharedInstance(context).sessionManager.currentCastSession?.castDevice?.friendlyName
+        }.getOrNull()
+        mutableState.value = RemotePlaybackState(
+            availability = when {
+                !available -> RemotePlaybackAvailability.Unavailable
+                connected -> RemotePlaybackAvailability.Connected
+                else -> RemotePlaybackAvailability.Idle
+            },
+            connected = connected,
+            deviceName = deviceName,
+            queueIds = (0 until player.mediaItemCount).map { player.getMediaItemAt(it).mediaId },
+            currentIndex = player.currentMediaItemIndex,
+            positionMs = player.currentPosition.coerceAtLeast(0L),
+            playing = player.playWhenReady,
+            shuffle = player.shuffleModeEnabled,
+            repeatMode = when (player.repeatMode) {
+                Player.REPEAT_MODE_ONE -> com.luc4n3x.levyra.domain.RepeatMode.One
+                Player.REPEAT_MODE_ALL -> com.luc4n3x.levyra.domain.RepeatMode.All
+                else -> com.luc4n3x.levyra.domain.RepeatMode.Off
+            }
+        )
+    }
+}

--- a/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/GoogleCastBackend.kt
+++ b/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/GoogleCastBackend.kt
@@ -3,68 +3,59 @@ package com.luc4n3x.levyra.feature.cast
 import android.content.Context
 import androidx.media3.cast.CastPlayer
 import androidx.media3.common.DeviceInfo
-import androidx.media3.common.ForwardingPlayer
-import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.PlayerTransferState
 import com.google.android.gms.cast.framework.CastContext
-import com.luc4n3x.levyra.data.PlaybackResolver
 import com.luc4n3x.levyra.domain.RepeatMode
-import com.luc4n3x.levyra.domain.Track
-import com.luc4n3x.levyra.player.LevyraMediaItemFactory
-import com.luc4n3x.levyra.player.queue.PersistentQueueEngine
-import com.luc4n3x.levyra.player.queue.playbackQueueIdentity
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 
 class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
     private val appContext = context.applicationContext
-    private val castContext by lazy { CastContext.getSharedInstance(appContext) }
-    private val queueEngine = PersistentQueueEngine.get(appContext)
-    private val resolver = PlaybackResolver.getInstance(appContext)
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
-    private val stateFlow = MutableStateFlow(RemotePlaybackState())
-    private var castPlayer: CastPlayer? = null
-    private var player: ManagedCastPlayer? = null
-    private var queueJob: Job? = null
-    private var refreshJob: Job? = null
-    private var lastQueueFingerprint = ""
-    private var applyingManagedQueue = false
+
+    override val id: String = "google-cast"
+    override val available: Boolean = runCatching { CastContext.getSharedInstance(appContext) }.isSuccess
+
+    private val mutableState = MutableStateFlow(
+        RemotePlaybackState(
+            availability = if (available) RemotePlaybackAvailability.Idle else RemotePlaybackAvailability.Unavailable
+        )
+    )
+    override val state: StateFlow<RemotePlaybackState> = mutableState
+
+    private var player: CastPlayer? = null
 
     private val transferCallback = CastPlayer.TransferCallback { sourcePlayer, targetPlayer ->
-        if (sourcePlayer.deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
-            val current = sourcePlayer.currentMediaItem
-            if (current == null) {
-                CastPlayer.TransferCallback.DEFAULT.transferState(sourcePlayer, targetPlayer)
-            } else {
-                val queue = queueEngine.state.value
-                PlayerTransferState.fromPlayer(sourcePlayer)
-                    .buildUpon()
-                    .setMediaItems(listOf(current))
-                    .setCurrentMediaItemIndex(0)
-                    .setCurrentPosition(sourcePlayer.currentPosition.coerceAtLeast(0L))
-                    .setShuffleModeEnabled(queue.shuffleEnabled)
-                    .setRepeatMode(if (queue.repeatMode == RepeatMode.One) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF)
-                    .build()
-                    .setToPlayer(targetPlayer)
-            }
-        } else {
+        if (sourcePlayer.deviceInfo.playbackType != DeviceInfo.PLAYBACK_TYPE_REMOTE) {
             CastPlayer.TransferCallback.DEFAULT.transferState(sourcePlayer, targetPlayer)
+            return@TransferCallback
         }
+
+        val current = sourcePlayer.currentMediaItem
+        if (current == null) {
+            CastPlayer.TransferCallback.DEFAULT.transferState(sourcePlayer, targetPlayer)
+            return@TransferCallback
+        }
+
+        PlayerTransferState.fromPlayer(sourcePlayer)
+            .buildUpon()
+            .setMediaItems(listOf(current))
+            .setCurrentMediaItemIndex(0)
+            .setCurrentPosition(sourcePlayer.currentPosition.coerceAtLeast(0L))
+            .setShuffleModeEnabled(false)
+            .setRepeatMode(
+                if (sourcePlayer.repeatMode == Player.REPEAT_MODE_ONE) {
+                    Player.REPEAT_MODE_ONE
+                } else {
+                    Player.REPEAT_MODE_OFF
+                }
+            )
+            .build()
+            .setToPlayer(targetPlayer)
     }
 
     private val listener = object : Player.Listener {
@@ -72,84 +63,23 @@ class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
 
         override fun onDeviceInfoChanged(deviceInfo: DeviceInfo) {
             player?.let(::publish)
-            if (deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
-                scheduleManagedQueueRefresh(force = true)
-            } else {
-                refreshJob?.cancel()
-            }
-        }
-
-        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-            if (player?.deviceInfo?.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
-                scheduleManagedQueueRefresh(force = false)
-            }
         }
     }
 
     override fun devices(): Flow<List<RemoteDevice>> = flowOf(emptyList())
 
-    override fun state(): Flow<RemotePlaybackState> = stateFlow.asStateFlow()
-
-    override fun attachLocalPlayer(localPlayer: Player): Player {
-        player?.removeListener(listener)
-        castPlayer?.release()
-        queueJob?.cancel()
-        refreshJob?.cancel()
-
-        val created = CastPlayer.Builder(appContext)
-            .setLocalPlayer(localPlayer)
-            .setTransferCallback(transferCallback)
-            .build()
-        val managed = ManagedCastPlayer(created)
-        castPlayer = created
-        player = managed
-        managed.addListener(listener)
-        publish(managed)
-
-        queueJob = scope.launch {
-            queueEngine.state.collect { snapshot ->
-                val fingerprint = buildString {
-                    append(snapshot.generation)
-                    append('|').append(snapshot.currentIndex)
-                    append('|').append(snapshot.tracks.size)
-                    append('|').append(snapshot.shuffleEnabled)
-                    append('|').append(snapshot.repeatMode.name)
-                }
-                if (fingerprint == lastQueueFingerprint) return@collect
-                lastQueueFingerprint = fingerprint
-                if (managed.deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
-                    scheduleManagedQueueRefresh(force = false)
-                }
-            }
-        }
-        return managed
-    }
-
-    override suspend fun connect(deviceId: String) = Unit
+    override suspend fun connect(device: RemoteDevice) = Unit
 
     override suspend fun disconnect() {
-        val sessionManager = runCatching { castContext.sessionManager }.getOrNull() ?: return
-        withContext(Dispatchers.Main) { sessionManager.endCurrentSession(true) }
-    }
-
-    override suspend fun load(queue: List<MediaItem>, startIndex: Int, positionMs: Long, playWhenReady: Boolean) {
-        val active = player ?: return
+        val sessionManager = runCatching {
+            CastContext.getSharedInstance(appContext).sessionManager
+        }.getOrNull() ?: return
         withContext(Dispatchers.Main) {
-            if (queue.isEmpty()) {
-                active.clearMediaItems()
-                return@withContext
-            }
-            val safeIndex = startIndex.coerceIn(0, queue.lastIndex)
-            active.setMediaItems(queue, safeIndex, positionMs.coerceAtLeast(0L))
-            active.prepare()
-            active.playWhenReady = playWhenReady
-            if (playWhenReady) active.play()
+            sessionManager.endCurrentSession(true)
         }
     }
 
-    override suspend fun seekTo(positionMs: Long) {
-        withContext(Dispatchers.Main) { player?.seekTo(positionMs.coerceAtLeast(0L)) }
-    }
+    override suspend fun load(handoff: CastHandoff) = Unit
 
     override suspend fun play() {
         withContext(Dispatchers.Main) { player?.play() }
@@ -159,99 +89,81 @@ class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
         withContext(Dispatchers.Main) { player?.pause() }
     }
 
-    override suspend fun next() {
+    override suspend fun stop() {
+        withContext(Dispatchers.Main) { player?.stop() }
+    }
+
+    override suspend fun seekTo(positionMs: Long) {
+        withContext(Dispatchers.Main) {
+            player?.seekTo(positionMs.coerceAtLeast(0L))
+        }
+    }
+
+    override suspend fun skipToNext() {
         withContext(Dispatchers.Main) { player?.seekToNextMediaItem() }
     }
 
-    override suspend fun previous() {
+    override suspend fun skipToPrevious() {
         withContext(Dispatchers.Main) { player?.seekToPreviousMediaItem() }
     }
 
-    override fun release() {
-        refreshJob?.cancel()
-        queueJob?.cancel()
-        player?.removeListener(listener)
-        castPlayer?.release()
-        castPlayer = null
-        player = null
-        scope.cancel()
+    override suspend fun setShuffle(enabled: Boolean) {
+        withContext(Dispatchers.Main) {
+            player?.shuffleModeEnabled = enabled
+        }
     }
 
-    private fun scheduleManagedQueueRefresh(force: Boolean) {
-        val active = player ?: return
-        if (active.deviceInfo.playbackType != DeviceInfo.PLAYBACK_TYPE_REMOTE) return
-        val snapshot = queueEngine.state.value
-        val current = snapshot.currentTrack ?: return
-        val currentId = LevyraMediaItemFactory.metadataOnly(current).mediaId
-        if (!force && active.currentMediaItem?.mediaId != currentId) return
-        val upcoming = queueEngine.upcoming(MANAGED_QUEUE_LOOKAHEAD)
-        val expectedUpcomingIds = upcoming.map { LevyraMediaItemFactory.metadataOnly(it).mediaId }
-        val remoteForwardIds = buildList {
-            val start = active.currentMediaItemIndex + 1
-            for (index in start until active.mediaItemCount) add(active.getMediaItemAt(index).mediaId)
-        }
-        if (!force && !castWindowNeedsRefresh(expectedUpcomingIds, remoteForwardIds, MIN_REMOTE_BUFFERED_ITEMS)) return
-
-        refreshJob?.cancel()
-        val expectedGeneration = snapshot.generation
-        val expectedCurrentIdentity = playbackQueueIdentity(current)
-        refreshJob = scope.launch {
-            val currentItem = active.currentMediaItem?.takeIf { it.mediaId == currentId }
-                ?: resolveTrack(current)?.let(LevyraMediaItemFactory::build)
-                ?: return@launch
-            val resolvedUpcoming = coroutineScope {
-                upcoming.map { track -> async(Dispatchers.IO) { resolveTrack(track) } }.awaitAll()
+    override suspend fun setRepeatMode(mode: RepeatMode) {
+        withContext(Dispatchers.Main) {
+            player?.repeatMode = when (mode) {
+                RepeatMode.One -> Player.REPEAT_MODE_ONE
+                RepeatMode.All -> Player.REPEAT_MODE_ALL
+                RepeatMode.Off -> Player.REPEAT_MODE_OFF
             }
-            val items = buildList {
-                add(currentItem)
-                for (track in resolvedUpcoming) {
-                    if (track == null) break
-                    add(LevyraMediaItemFactory.build(track))
+        }
+    }
+
+    override fun attachLocalPlayer(localPlayer: Player): Player {
+        if (!available) return localPlayer
+        return runCatching {
+            CastPlayer.Builder(appContext)
+                .setLocalPlayer(localPlayer)
+                .setTransferCallback(transferCallback)
+                .build()
+                .also { castPlayer ->
+                    player?.removeListener(listener)
+                    player?.release()
+                    player = castPlayer
+                    castPlayer.addListener(listener)
+                    publish(castPlayer)
                 }
-            }
-            val latest = queueEngine.state.value
-            if (latest.generation != expectedGeneration ||
-                latest.currentTrack?.let(::playbackQueueIdentity) != expectedCurrentIdentity ||
-                active.deviceInfo.playbackType != DeviceInfo.PLAYBACK_TYPE_REMOTE
-            ) return@launch
-
-            val playing = active.playWhenReady
-            val livePosition = castHandoffStartPositionMs(
-                sameMediaItem = active.currentMediaItem?.mediaId == currentId,
-                requestedPositionMs = latest.positionMs,
-                livePositionMs = active.currentPosition,
-                remotePlayback = true
-            )
-            applyingManagedQueue = true
-            try {
-                active.applyManagedModes(latest.repeatMode, latest.shuffleEnabled)
-                active.setMediaItems(items, 0, livePosition)
-                active.prepare()
-                active.playWhenReady = playing
-                if (playing) active.play()
-            } finally {
-                applyingManagedQueue = false
-            }
-        }
+        }.getOrElse { localPlayer }
     }
 
-    private suspend fun resolveTrack(track: Track): Track? = try {
-        resolver.resolve(track, isVideoMode = false)
-    } catch (cancelled: CancellationException) {
-        throw cancelled
-    } catch (error: Exception) {
-        Timber.w(error, "Cast queue resolve failed for %s", track.title)
-        null
+    override fun release() {
+        player?.removeListener(listener)
+        player?.release()
+        player = null
     }
 
     private fun publish(active: Player) {
-        val remote = active.deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE
-        val session = runCatching { castContext.sessionManager.currentCastSession }.getOrNull()
-        val device = session?.castDevice
-        stateFlow.value = RemotePlaybackState(
-            connected = remote,
-            device = device?.let { RemoteDevice(it.deviceId.orEmpty(), it.friendlyName.orEmpty().ifBlank { "Google Cast" }) },
-            queue = (0 until active.mediaItemCount).map(active::getMediaItemAt),
+        val connected = active.deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE
+        val deviceName = runCatching {
+            CastContext.getSharedInstance(appContext)
+                .sessionManager
+                .currentCastSession
+                ?.castDevice
+                ?.friendlyName
+        }.getOrNull()
+        mutableState.value = RemotePlaybackState(
+            availability = when {
+                !available -> RemotePlaybackAvailability.Unavailable
+                connected -> RemotePlaybackAvailability.Connected
+                else -> RemotePlaybackAvailability.Idle
+            },
+            connected = connected,
+            deviceName = deviceName,
+            queueIds = (0 until active.mediaItemCount).map { active.getMediaItemAt(it).mediaId },
             currentIndex = active.currentMediaItemIndex,
             positionMs = active.currentPosition.coerceAtLeast(0L),
             playing = active.playWhenReady,
@@ -262,64 +174,5 @@ class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
                 else -> RepeatMode.Off
             }
         )
-    }
-
-    private inner class ManagedCastPlayer(player: CastPlayer) : ForwardingPlayer(player) {
-        private var logicalShuffle = player.shuffleModeEnabled
-        private var logicalRepeat = player.repeatMode
-
-        override fun setMediaItems(mediaItems: List<MediaItem>, startIndex: Int, startPositionMs: Long) {
-            val sameItem = mediaItems.getOrNull(startIndex)?.mediaId == currentMediaItem?.mediaId
-            val safePosition = castHandoffStartPositionMs(
-                sameMediaItem = sameItem,
-                requestedPositionMs = startPositionMs,
-                livePositionMs = currentPosition,
-                remotePlayback = deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE
-            )
-            super.setMediaItems(mediaItems, startIndex, safePosition)
-            if (!applyingManagedQueue && deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
-                scope.launch { scheduleManagedQueueRefresh(force = true) }
-            }
-        }
-
-        override fun setShuffleModeEnabled(shuffleModeEnabled: Boolean) {
-            logicalShuffle = shuffleModeEnabled
-            super.setShuffleModeEnabled(
-                if (deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) false else shuffleModeEnabled
-            )
-        }
-
-        override fun getShuffleModeEnabled(): Boolean =
-            if (deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) logicalShuffle else super.getShuffleModeEnabled()
-
-        override fun setRepeatMode(repeatMode: Int) {
-            logicalRepeat = repeatMode
-            super.setRepeatMode(
-                if (deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE && repeatMode == Player.REPEAT_MODE_ALL) {
-                    Player.REPEAT_MODE_OFF
-                } else {
-                    repeatMode
-                }
-            )
-        }
-
-        override fun getRepeatMode(): Int =
-            if (deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) logicalRepeat else super.getRepeatMode()
-
-        fun applyManagedModes(repeatMode: RepeatMode, shuffleEnabled: Boolean) {
-            logicalShuffle = shuffleEnabled
-            logicalRepeat = when (repeatMode) {
-                RepeatMode.One -> Player.REPEAT_MODE_ONE
-                RepeatMode.All -> Player.REPEAT_MODE_ALL
-                RepeatMode.Off -> Player.REPEAT_MODE_OFF
-            }
-            super.setShuffleModeEnabled(false)
-            super.setRepeatMode(if (repeatMode == RepeatMode.One) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF)
-        }
-    }
-
-    private companion object {
-        const val MANAGED_QUEUE_LOOKAHEAD = 7
-        const val MIN_REMOTE_BUFFERED_ITEMS = 3
     }
 }

--- a/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/GoogleCastBackend.kt
+++ b/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/GoogleCastBackend.kt
@@ -7,15 +7,27 @@ import androidx.media3.cast.Cast
 import androidx.media3.cast.CastPlayer
 import androidx.media3.common.DeviceInfo
 import androidx.media3.common.ForwardingPlayer
+import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.PlayerTransferState
+import com.luc4n3x.levyra.data.PlaybackResolver
 import com.luc4n3x.levyra.domain.RepeatMode
+import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.player.LevyraMediaItemFactory
+import com.luc4n3x.levyra.player.queue.PersistentQueueEngine
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
     private val appContext = context.applicationContext
@@ -35,10 +47,19 @@ class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
     )
     override val state: StateFlow<RemotePlaybackState> = mutableState
 
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val queueEngine by lazy { PersistentQueueEngine.get(appContext) }
+    private val resolver by lazy { PlaybackResolver.getInstance(appContext) }
+    private var managedQueueJob: Job? = null
     private var player: CastPlayer? = null
 
     private val transferCallback = CastPlayer.TransferCallback { sourcePlayer, targetPlayer ->
         if (sourcePlayer.deviceInfo.playbackType != DeviceInfo.PLAYBACK_TYPE_REMOTE) {
+            val current = sourcePlayer.currentMediaItem
+            if (current == null || !isReceiverSafe(current)) {
+                Timber.w("Cast transfer skipped because the local media URL is not receiver-safe")
+                return@TransferCallback
+            }
             CastPlayer.TransferCallback.DEFAULT.transferState(sourcePlayer, targetPlayer)
             return@TransferCallback
         }
@@ -70,7 +91,23 @@ class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
         override fun onEvents(player: Player, events: Player.Events) = publish(player)
 
         override fun onDeviceInfoChanged(deviceInfo: DeviceInfo) {
-            player?.let(::publish)
+            player?.let { active ->
+                publish(active)
+                if (deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
+                    maintainManagedQueue(active)
+                } else {
+                    managedQueueJob?.cancel()
+                }
+            }
+        }
+
+        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+            player?.let { active ->
+                publish(active)
+                if (active.deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
+                    maintainManagedQueue(active)
+                }
+            }
         }
     }
 
@@ -115,17 +152,13 @@ class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
 
     override suspend fun setShuffle(enabled: Boolean) {
         withContext(Dispatchers.Main) {
-            player?.shuffleModeEnabled = enabled
+            player?.shuffleModeEnabled = false
         }
     }
 
     override suspend fun setRepeatMode(mode: RepeatMode) {
         withContext(Dispatchers.Main) {
-            player?.repeatMode = when (mode) {
-                RepeatMode.One -> Player.REPEAT_MODE_ONE
-                RepeatMode.All -> Player.REPEAT_MODE_ALL
-                RepeatMode.Off -> Player.REPEAT_MODE_OFF
-            }
+            player?.repeatMode = remoteRepeatMode(mode)
         }
     }
 
@@ -146,17 +179,155 @@ class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
         }.getOrElse { return localPlayer }
 
         return object : ForwardingPlayer(castPlayer) {
+            override fun setMediaItems(mediaItems: List<MediaItem>, startIndex: Int, startPositionMs: Long) {
+                if (mediaItems.any { !isReceiverSafe(it) }) {
+                    Timber.w("Cast playlist rejected because it contains a non receiver-safe media URL")
+                    return
+                }
+                super.setMediaItems(mediaItems, startIndex, startPositionMs)
+            }
+
             override fun release() {
                 this@GoogleCastBackend.release()
+                runCatching { localPlayer.release() }
+                    .onFailure { Timber.w(it, "Local player release after Cast teardown failed") }
             }
         }
     }
 
     override fun release() {
+        managedQueueJob?.cancel()
+        managedQueueJob = null
         player?.removeListener(listener)
         player?.release()
         player = null
+        scope.cancel()
     }
+
+    private fun maintainManagedQueue(active: CastPlayer) {
+        val currentItem = active.currentMediaItem ?: return
+        if (!isReceiverSafe(currentItem)) {
+            Timber.w("Cast queue maintenance skipped for a non receiver-safe current item")
+            return
+        }
+
+        val before = queueEngine.state.value
+        val currentIndex = before.tracks.indexOfFirst { mediaId(it) == currentItem.mediaId }
+        if (currentIndex >= 0 && currentIndex != before.currentIndex) {
+            queueEngine.select(currentIndex, active.currentPosition.coerceAtLeast(0L), rememberCurrent = true)
+        }
+
+        val snapshot = queueEngine.state.value
+        val currentTrack = snapshot.currentTrack ?: return
+        if (mediaId(currentTrack) != currentItem.mediaId) return
+
+        if (active.shuffleModeEnabled) active.shuffleModeEnabled = false
+        val desiredRepeat = remoteRepeatMode(snapshot.repeatMode)
+        if (active.repeatMode != desiredRepeat) active.repeatMode = desiredRepeat
+
+        val expectedTracks = queueEngine.upcoming(CAST_FORWARD_ITEMS)
+            .asSequence()
+            .filter { mediaId(it) != currentItem.mediaId }
+            .distinctBy(::mediaId)
+            .take(CAST_FORWARD_ITEMS)
+            .toList()
+        val expectedIds = expectedTracks.map(::mediaId)
+        val activeIndex = active.currentMediaItemIndex.takeIf { it >= 0 } ?: return
+        val remoteForwardIds = ((activeIndex + 1) until active.mediaItemCount)
+            .map { active.getMediaItemAt(it).mediaId }
+
+        val comparable = minOf(expectedIds.size, remoteForwardIds.size)
+        val prefixMatches = remoteForwardIds.take(comparable) == expectedIds.take(comparable)
+        val unexpectedTail = remoteForwardIds.size > expectedIds.size
+        val needsTopUp = castWindowNeedsRefresh(
+            expectedUpcomingIds = expectedIds,
+            remoteForwardIds = remoteForwardIds,
+            minimumBufferedItems = expectedIds.size.coerceAtLeast(1)
+        )
+
+        when {
+            !prefixMatches || unexpectedTail -> rebuildManagedQueue(active, currentItem, expectedTracks, desiredRepeat)
+            needsTopUp -> appendManagedQueue(active, currentItem.mediaId, expectedTracks.drop(remoteForwardIds.size))
+            else -> prunePlayedItems(active)
+        }
+    }
+
+    private fun appendManagedQueue(active: CastPlayer, expectedCurrentId: String, tracks: List<Track>) {
+        if (tracks.isEmpty()) {
+            prunePlayedItems(active)
+            return
+        }
+        managedQueueJob?.cancel()
+        managedQueueJob = scope.launch {
+            val resolved = resolveReceiverTracks(tracks) ?: return@launch
+            if (active.deviceInfo.playbackType != DeviceInfo.PLAYBACK_TYPE_REMOTE ||
+                active.currentMediaItem?.mediaId != expectedCurrentId
+            ) return@launch
+            active.addMediaItems(resolved.map { LevyraMediaItemFactory.build(it) })
+            prunePlayedItems(active)
+        }
+    }
+
+    private fun rebuildManagedQueue(
+        active: CastPlayer,
+        currentItem: MediaItem,
+        tracks: List<Track>,
+        repeatMode: Int
+    ) {
+        managedQueueJob?.cancel()
+        val requestedPosition = active.currentPosition.coerceAtLeast(0L)
+        val resumePlayback = active.playWhenReady
+        val expectedCurrentId = currentItem.mediaId
+        managedQueueJob = scope.launch {
+            val resolved = resolveReceiverTracks(tracks) ?: return@launch
+            if (active.deviceInfo.playbackType != DeviceInfo.PLAYBACK_TYPE_REMOTE ||
+                active.currentMediaItem?.mediaId != expectedCurrentId
+            ) return@launch
+            val position = castHandoffStartPositionMs(
+                sameMediaItem = true,
+                requestedPositionMs = requestedPosition,
+                livePositionMs = active.currentPosition,
+                remotePlayback = true
+            )
+            active.setMediaItems(
+                listOf(currentItem) + resolved.map { LevyraMediaItemFactory.build(it) },
+                0,
+                position
+            )
+            active.shuffleModeEnabled = false
+            active.repeatMode = repeatMode
+            active.prepare()
+            if (resumePlayback) active.play()
+        }
+    }
+
+    private suspend fun resolveReceiverTracks(tracks: List<Track>): List<Track>? = withContext(Dispatchers.IO) {
+        try {
+            tracks.map { resolver.resolve(it, isVideoMode = false) }
+                .takeIf { resolved -> resolved.all { isCastReceiverSafeMediaUrl(it.streamUrl) } }
+                .also { resolved ->
+                    if (resolved == null) Timber.w("Cast queue refresh rejected a non receiver-safe resolved URL")
+                }
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            Timber.w(error, "Cast queue refresh failed")
+            null
+        }
+    }
+
+    private fun prunePlayedItems(active: CastPlayer) {
+        val index = active.currentMediaItemIndex
+        if (index > 0) active.removeMediaItems(0, index)
+    }
+
+    private fun isReceiverSafe(item: MediaItem): Boolean =
+        item.localConfiguration?.uri?.toString()?.let(::isCastReceiverSafeMediaUrl) == true
+
+    private fun mediaId(track: Track): String = LevyraMediaItemFactory.metadataOnly(track).mediaId
+
+    private fun remoteRepeatMode(mode: RepeatMode): Int =
+        if (mode == RepeatMode.One) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
 
     private fun publish(active: Player) {
         val connected = active.deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE
@@ -175,12 +346,12 @@ class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
             currentIndex = active.currentMediaItemIndex,
             positionMs = active.currentPosition.coerceAtLeast(0L),
             playing = active.playWhenReady,
-            shuffle = active.shuffleModeEnabled,
-            repeatMode = when (active.repeatMode) {
-                Player.REPEAT_MODE_ONE -> RepeatMode.One
-                Player.REPEAT_MODE_ALL -> RepeatMode.All
-                else -> RepeatMode.Off
-            }
+            shuffle = queueEngine.state.value.shuffleEnabled,
+            repeatMode = queueEngine.state.value.repeatMode
         )
+    }
+
+    private companion object {
+        const val CAST_FORWARD_ITEMS = 4
     }
 }

--- a/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/GoogleCastBackend.kt
+++ b/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/GoogleCastBackend.kt
@@ -3,100 +3,323 @@ package com.luc4n3x.levyra.feature.cast
 import android.content.Context
 import androidx.media3.cast.CastPlayer
 import androidx.media3.common.DeviceInfo
+import androidx.media3.common.ForwardingPlayer
+import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import androidx.media3.common.PlayerTransferState
 import com.google.android.gms.cast.framework.CastContext
+import com.luc4n3x.levyra.data.PlaybackResolver
+import com.luc4n3x.levyra.domain.RepeatMode
+import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.player.LevyraMediaItemFactory
+import com.luc4n3x.levyra.player.queue.PersistentQueueEngine
+import com.luc4n3x.levyra.player.queue.playbackQueueIdentity
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
-    override val id: String = "google-cast"
-    override val available: Boolean = runCatching { CastContext.getSharedInstance(context) }.isSuccess
+    private val appContext = context.applicationContext
+    private val castContext by lazy { CastContext.getSharedInstance(appContext) }
+    private val queueEngine = PersistentQueueEngine.get(appContext)
+    private val resolver = PlaybackResolver.getInstance(appContext)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val stateFlow = MutableStateFlow(RemotePlaybackState())
+    private var castPlayer: CastPlayer? = null
+    private var player: ManagedCastPlayer? = null
+    private var queueJob: Job? = null
+    private var refreshJob: Job? = null
+    private var lastQueueFingerprint = ""
+    private var applyingManagedQueue = false
 
-    private val mutableState = MutableStateFlow(
-        RemotePlaybackState(
-            availability = if (available) RemotePlaybackAvailability.Idle else RemotePlaybackAvailability.Unavailable
-        )
-    )
-    override val state: StateFlow<RemotePlaybackState> = mutableState
-    private var player: CastPlayer? = null
+    private val transferCallback = CastPlayer.TransferCallback { sourcePlayer, targetPlayer ->
+        if (sourcePlayer.deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
+            val current = sourcePlayer.currentMediaItem
+            if (current == null) {
+                CastPlayer.TransferCallback.DEFAULT.transferState(sourcePlayer, targetPlayer)
+            } else {
+                val queue = queueEngine.state.value
+                PlayerTransferState.fromPlayer(sourcePlayer)
+                    .buildUpon()
+                    .setMediaItems(listOf(current))
+                    .setCurrentMediaItemIndex(0)
+                    .setCurrentPosition(sourcePlayer.currentPosition.coerceAtLeast(0L))
+                    .setShuffleModeEnabled(queue.shuffleEnabled)
+                    .setRepeatMode(if (queue.repeatMode == RepeatMode.One) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF)
+                    .build()
+                    .setToPlayer(targetPlayer)
+            }
+        } else {
+            CastPlayer.TransferCallback.DEFAULT.transferState(sourcePlayer, targetPlayer)
+        }
+    }
 
     private val listener = object : Player.Listener {
         override fun onEvents(player: Player, events: Player.Events) = publish(player)
+
         override fun onDeviceInfoChanged(deviceInfo: DeviceInfo) {
             player?.let(::publish)
+            if (deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
+                scheduleManagedQueueRefresh(force = true)
+            } else {
+                refreshJob?.cancel()
+            }
+        }
+
+        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+            if (player?.deviceInfo?.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
+                scheduleManagedQueueRefresh(force = false)
+            }
         }
     }
 
     override fun devices(): Flow<List<RemoteDevice>> = flowOf(emptyList())
 
-    override suspend fun connect(device: RemoteDevice) = Unit
+    override fun state(): Flow<RemotePlaybackState> = stateFlow.asStateFlow()
 
-    override suspend fun disconnect() {
-        runCatching { CastContext.getSharedInstance(context).sessionManager.endCurrentSession(true) }
+    override fun attachLocalPlayer(localPlayer: Player): Player {
+        player?.removeListener(listener)
+        castPlayer?.release()
+        queueJob?.cancel()
+        refreshJob?.cancel()
+
+        val created = CastPlayer.Builder(appContext)
+            .setLocalPlayer(localPlayer)
+            .setTransferCallback(transferCallback)
+            .build()
+        val managed = ManagedCastPlayer(created)
+        castPlayer = created
+        player = managed
+        managed.addListener(listener)
+        publish(managed)
+
+        queueJob = scope.launch {
+            queueEngine.state.collect { snapshot ->
+                val fingerprint = buildString {
+                    append(snapshot.generation)
+                    append('|').append(snapshot.currentIndex)
+                    append('|').append(snapshot.tracks.size)
+                    append('|').append(snapshot.shuffleEnabled)
+                    append('|').append(snapshot.repeatMode.name)
+                }
+                if (fingerprint == lastQueueFingerprint) return@collect
+                lastQueueFingerprint = fingerprint
+                if (managed.deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
+                    scheduleManagedQueueRefresh(force = false)
+                }
+            }
+        }
+        return managed
     }
 
-    override suspend fun load(handoff: CastHandoff) = Unit
+    override suspend fun connect(deviceId: String) = Unit
 
-    override suspend fun play() { player?.play() }
-    override suspend fun pause() { player?.pause() }
-    override suspend fun stop() { player?.stop() }
-    override suspend fun seekTo(positionMs: Long) { player?.seekTo(positionMs.coerceAtLeast(0L)) }
-    override suspend fun skipToNext() { player?.seekToNextMediaItem() }
-    override suspend fun skipToPrevious() { player?.seekToPreviousMediaItem() }
-    override suspend fun setShuffle(enabled: Boolean) { player?.shuffleModeEnabled = enabled }
-    override suspend fun setRepeatMode(mode: com.luc4n3x.levyra.domain.RepeatMode) {
-        player?.repeatMode = when (mode) {
-            com.luc4n3x.levyra.domain.RepeatMode.One -> Player.REPEAT_MODE_ONE
-            com.luc4n3x.levyra.domain.RepeatMode.All -> Player.REPEAT_MODE_ALL
-            com.luc4n3x.levyra.domain.RepeatMode.Off -> Player.REPEAT_MODE_OFF
+    override suspend fun disconnect() {
+        val sessionManager = runCatching { castContext.sessionManager }.getOrNull() ?: return
+        withContext(Dispatchers.Main) { sessionManager.endCurrentSession(true) }
+    }
+
+    override suspend fun load(queue: List<MediaItem>, startIndex: Int, positionMs: Long, playWhenReady: Boolean) {
+        val active = player ?: return
+        withContext(Dispatchers.Main) {
+            if (queue.isEmpty()) {
+                active.clearMediaItems()
+                return@withContext
+            }
+            val safeIndex = startIndex.coerceIn(0, queue.lastIndex)
+            active.setMediaItems(queue, safeIndex, positionMs.coerceAtLeast(0L))
+            active.prepare()
+            active.playWhenReady = playWhenReady
+            if (playWhenReady) active.play()
         }
     }
 
-    override fun attachLocalPlayer(localPlayer: Player): Player {
-        if (!available) return localPlayer
-        return runCatching {
-            CastPlayer.Builder(context)
-                .setLocalPlayer(localPlayer)
-                .build()
-                .also {
-                    player = it
-                    it.addListener(listener)
-                    publish(it)
-                }
-        }.getOrElse { localPlayer }
+    override suspend fun seekTo(positionMs: Long) {
+        withContext(Dispatchers.Main) { player?.seekTo(positionMs.coerceAtLeast(0L)) }
+    }
+
+    override suspend fun play() {
+        withContext(Dispatchers.Main) { player?.play() }
+    }
+
+    override suspend fun pause() {
+        withContext(Dispatchers.Main) { player?.pause() }
+    }
+
+    override suspend fun next() {
+        withContext(Dispatchers.Main) { player?.seekToNextMediaItem() }
+    }
+
+    override suspend fun previous() {
+        withContext(Dispatchers.Main) { player?.seekToPreviousMediaItem() }
     }
 
     override fun release() {
+        refreshJob?.cancel()
+        queueJob?.cancel()
         player?.removeListener(listener)
-        player?.release()
+        castPlayer?.release()
+        castPlayer = null
         player = null
+        scope.cancel()
     }
 
-    private fun publish(player: Player) {
-        val connected = player.deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE
-        val deviceName = runCatching {
-            CastContext.getSharedInstance(context).sessionManager.currentCastSession?.castDevice?.friendlyName
-        }.getOrNull()
-        mutableState.value = RemotePlaybackState(
-            availability = when {
-                !available -> RemotePlaybackAvailability.Unavailable
-                connected -> RemotePlaybackAvailability.Connected
-                else -> RemotePlaybackAvailability.Idle
-            },
-            connected = connected,
-            deviceName = deviceName,
-            queueIds = (0 until player.mediaItemCount).map { player.getMediaItemAt(it).mediaId },
-            currentIndex = player.currentMediaItemIndex,
-            positionMs = player.currentPosition.coerceAtLeast(0L),
-            playing = player.playWhenReady,
-            shuffle = player.shuffleModeEnabled,
-            repeatMode = when (player.repeatMode) {
-                Player.REPEAT_MODE_ONE -> com.luc4n3x.levyra.domain.RepeatMode.One
-                Player.REPEAT_MODE_ALL -> com.luc4n3x.levyra.domain.RepeatMode.All
-                else -> com.luc4n3x.levyra.domain.RepeatMode.Off
+    private fun scheduleManagedQueueRefresh(force: Boolean) {
+        val active = player ?: return
+        if (active.deviceInfo.playbackType != DeviceInfo.PLAYBACK_TYPE_REMOTE) return
+        val snapshot = queueEngine.state.value
+        val current = snapshot.currentTrack ?: return
+        val currentId = LevyraMediaItemFactory.metadataOnly(current).mediaId
+        if (!force && active.currentMediaItem?.mediaId != currentId) return
+        val upcoming = queueEngine.upcoming(MANAGED_QUEUE_LOOKAHEAD)
+        val expectedUpcomingIds = upcoming.map { LevyraMediaItemFactory.metadataOnly(it).mediaId }
+        val remoteForwardIds = buildList {
+            val start = active.currentMediaItemIndex + 1
+            for (index in start until active.mediaItemCount) add(active.getMediaItemAt(index).mediaId)
+        }
+        if (!force && !castWindowNeedsRefresh(expectedUpcomingIds, remoteForwardIds, MIN_REMOTE_BUFFERED_ITEMS)) return
+
+        refreshJob?.cancel()
+        val expectedGeneration = snapshot.generation
+        val expectedCurrentIdentity = playbackQueueIdentity(current)
+        refreshJob = scope.launch {
+            val currentItem = active.currentMediaItem?.takeIf { it.mediaId == currentId }
+                ?: resolveTrack(current)?.let(LevyraMediaItemFactory::build)
+                ?: return@launch
+            val resolvedUpcoming = coroutineScope {
+                upcoming.map { track -> async(Dispatchers.IO) { resolveTrack(track) } }.awaitAll()
+            }
+            val items = buildList {
+                add(currentItem)
+                for (track in resolvedUpcoming) {
+                    if (track == null) break
+                    add(LevyraMediaItemFactory.build(track))
+                }
+            }
+            val latest = queueEngine.state.value
+            if (latest.generation != expectedGeneration ||
+                latest.currentTrack?.let(::playbackQueueIdentity) != expectedCurrentIdentity ||
+                active.deviceInfo.playbackType != DeviceInfo.PLAYBACK_TYPE_REMOTE
+            ) return@launch
+
+            val playing = active.playWhenReady
+            val livePosition = castHandoffStartPositionMs(
+                sameMediaItem = active.currentMediaItem?.mediaId == currentId,
+                requestedPositionMs = latest.positionMs,
+                livePositionMs = active.currentPosition,
+                remotePlayback = true
+            )
+            applyingManagedQueue = true
+            try {
+                active.applyManagedModes(latest.repeatMode, latest.shuffleEnabled)
+                active.setMediaItems(items, 0, livePosition)
+                active.prepare()
+                active.playWhenReady = playing
+                if (playing) active.play()
+            } finally {
+                applyingManagedQueue = false
+            }
+        }
+    }
+
+    private suspend fun resolveTrack(track: Track): Track? = try {
+        resolver.resolve(track, isVideoMode = false)
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (error: Exception) {
+        Timber.w(error, "Cast queue resolve failed for %s", track.title)
+        null
+    }
+
+    private fun publish(active: Player) {
+        val remote = active.deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE
+        val session = runCatching { castContext.sessionManager.currentCastSession }.getOrNull()
+        val device = session?.castDevice
+        stateFlow.value = RemotePlaybackState(
+            connected = remote,
+            device = device?.let { RemoteDevice(it.deviceId.orEmpty(), it.friendlyName.orEmpty().ifBlank { "Google Cast" }) },
+            queue = (0 until active.mediaItemCount).map(active::getMediaItemAt),
+            currentIndex = active.currentMediaItemIndex,
+            positionMs = active.currentPosition.coerceAtLeast(0L),
+            playing = active.playWhenReady,
+            shuffle = active.shuffleModeEnabled,
+            repeatMode = when (active.repeatMode) {
+                Player.REPEAT_MODE_ONE -> RepeatMode.One
+                Player.REPEAT_MODE_ALL -> RepeatMode.All
+                else -> RepeatMode.Off
             }
         )
+    }
+
+    private inner class ManagedCastPlayer(player: CastPlayer) : ForwardingPlayer(player) {
+        private var logicalShuffle = player.shuffleModeEnabled
+        private var logicalRepeat = player.repeatMode
+
+        override fun setMediaItems(mediaItems: List<MediaItem>, startIndex: Int, startPositionMs: Long) {
+            val sameItem = mediaItems.getOrNull(startIndex)?.mediaId == currentMediaItem?.mediaId
+            val safePosition = castHandoffStartPositionMs(
+                sameMediaItem = sameItem,
+                requestedPositionMs = startPositionMs,
+                livePositionMs = currentPosition,
+                remotePlayback = deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE
+            )
+            super.setMediaItems(mediaItems, startIndex, safePosition)
+            if (!applyingManagedQueue && deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) {
+                scope.launch { scheduleManagedQueueRefresh(force = true) }
+            }
+        }
+
+        override fun setShuffleModeEnabled(shuffleModeEnabled: Boolean) {
+            logicalShuffle = shuffleModeEnabled
+            super.setShuffleModeEnabled(
+                if (deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) false else shuffleModeEnabled
+            )
+        }
+
+        override fun getShuffleModeEnabled(): Boolean =
+            if (deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) logicalShuffle else super.getShuffleModeEnabled()
+
+        override fun setRepeatMode(repeatMode: Int) {
+            logicalRepeat = repeatMode
+            super.setRepeatMode(
+                if (deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE && repeatMode == Player.REPEAT_MODE_ALL) {
+                    Player.REPEAT_MODE_OFF
+                } else {
+                    repeatMode
+                }
+            )
+        }
+
+        override fun getRepeatMode(): Int =
+            if (deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE) logicalRepeat else super.getRepeatMode()
+
+        fun applyManagedModes(repeatMode: RepeatMode, shuffleEnabled: Boolean) {
+            logicalShuffle = shuffleEnabled
+            logicalRepeat = when (repeatMode) {
+                RepeatMode.One -> Player.REPEAT_MODE_ONE
+                RepeatMode.All -> Player.REPEAT_MODE_ALL
+                RepeatMode.Off -> Player.REPEAT_MODE_OFF
+            }
+            super.setShuffleModeEnabled(false)
+            super.setRepeatMode(if (repeatMode == RepeatMode.One) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF)
+        }
+    }
+
+    private companion object {
+        const val MANAGED_QUEUE_LOOKAHEAD = 7
+        const val MIN_REMOTE_BUFFERED_ITEMS = 3
     }
 }

--- a/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/GoogleCastBackend.kt
+++ b/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/GoogleCastBackend.kt
@@ -164,11 +164,39 @@ class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
 
         return object : ForwardingPlayer(castPlayer) {
             override fun setMediaItems(mediaItems: List<MediaItem>, startIndex: Int, startPositionMs: Long) {
-                if (mediaItems.any { !isReceiverSafe(it) }) {
-                    Timber.w("Cast playlist rejected because it contains a non receiver-safe media URL")
+                if (castPlayer.deviceInfo.playbackType != DeviceInfo.PLAYBACK_TYPE_REMOTE) {
+                    super.setMediaItems(mediaItems, startIndex, startPositionMs)
                     return
                 }
-                super.setMediaItems(mediaItems, startIndex, startPositionMs)
+                if (mediaItems.isEmpty()) {
+                    super.setMediaItems(mediaItems, startIndex, startPositionMs)
+                    return
+                }
+
+                val selectedIndex = startIndex.coerceIn(0, mediaItems.lastIndex)
+                val requestedCurrent = mediaItems[selectedIndex]
+                if (!isReceiverSafe(requestedCurrent)) {
+                    Timber.w("Cast media item rejected because its URL is not receiver-safe")
+                    return
+                }
+
+                val liveItem = castPlayer.currentMediaItem
+                val sameMediaItem = liveItem?.mediaId == requestedCurrent.mediaId
+                val position = castHandoffStartPositionMs(
+                    sameMediaItem = sameMediaItem,
+                    requestedPositionMs = startPositionMs,
+                    livePositionMs = castPlayer.currentPosition,
+                    remotePlayback = true
+                )
+
+                if (sameMediaItem) {
+                    if (position > castPlayer.currentPosition) castPlayer.seekTo(position)
+                    maintainManagedQueue(castPlayer)
+                    return
+                }
+
+                super.setMediaItems(listOf(requestedCurrent), 0, position)
+                maintainManagedQueue(castPlayer)
             }
 
             override fun setShuffleModeEnabled(shuffleModeEnabled: Boolean) {

--- a/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/GoogleCastBackend.kt
+++ b/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/GoogleCastBackend.kt
@@ -54,19 +54,9 @@ class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
     private var player: CastPlayer? = null
 
     private val transferCallback = CastPlayer.TransferCallback { sourcePlayer, targetPlayer ->
-        if (sourcePlayer.deviceInfo.playbackType != DeviceInfo.PLAYBACK_TYPE_REMOTE) {
-            val current = sourcePlayer.currentMediaItem
-            if (current == null || !isReceiverSafe(current)) {
-                Timber.w("Cast transfer skipped because the local media URL is not receiver-safe")
-                return@TransferCallback
-            }
-            CastPlayer.TransferCallback.DEFAULT.transferState(sourcePlayer, targetPlayer)
-            return@TransferCallback
-        }
-
-        val current = sourcePlayer.currentMediaItem
-        if (current == null) {
-            CastPlayer.TransferCallback.DEFAULT.transferState(sourcePlayer, targetPlayer)
+        val current = sourcePlayer.currentMediaItem ?: return@TransferCallback
+        if (sourcePlayer.deviceInfo.playbackType != DeviceInfo.PLAYBACK_TYPE_REMOTE && !isReceiverSafe(current)) {
+            Timber.w("Cast transfer skipped because the local media URL is not receiver-safe")
             return@TransferCallback
         }
 
@@ -76,13 +66,7 @@ class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
             .setCurrentMediaItemIndex(0)
             .setCurrentPosition(sourcePlayer.currentPosition.coerceAtLeast(0L))
             .setShuffleModeEnabled(false)
-            .setRepeatMode(
-                if (sourcePlayer.repeatMode == Player.REPEAT_MODE_ONE) {
-                    Player.REPEAT_MODE_ONE
-                } else {
-                    Player.REPEAT_MODE_OFF
-                }
-            )
+            .setRepeatMode(remoteRepeatModeFromPlayer(sourcePlayer.repeatMode))
             .build()
             .setToPlayer(targetPlayer)
     }
@@ -185,6 +169,14 @@ class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
                     return
                 }
                 super.setMediaItems(mediaItems, startIndex, startPositionMs)
+            }
+
+            override fun setShuffleModeEnabled(shuffleModeEnabled: Boolean) {
+                super.setShuffleModeEnabled(false)
+            }
+
+            override fun setRepeatMode(repeatMode: Int) {
+                super.setRepeatMode(remoteRepeatModeFromPlayer(repeatMode))
             }
 
             override fun release() {
@@ -328,6 +320,9 @@ class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
 
     private fun remoteRepeatMode(mode: RepeatMode): Int =
         if (mode == RepeatMode.One) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
+
+    private fun remoteRepeatModeFromPlayer(mode: Int): Int =
+        if (mode == Player.REPEAT_MODE_ONE) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
 
     private fun publish(active: Player) {
         val connected = active.deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE

--- a/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/GoogleCastBackend.kt
+++ b/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/GoogleCastBackend.kt
@@ -24,7 +24,9 @@ class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
 
     private val listener = object : Player.Listener {
         override fun onEvents(player: Player, events: Player.Events) = publish(player)
-        override fun onDeviceInfoChanged(deviceInfo: DeviceInfo) = publish(player ?: return)
+        override fun onDeviceInfoChanged(deviceInfo: DeviceInfo) {
+            player?.let(::publish)
+        }
     }
 
     override fun devices(): Flow<List<RemoteDevice>> = flowOf(emptyList())

--- a/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/GoogleCastBackend.kt
+++ b/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/GoogleCastBackend.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import androidx.media3.cast.Cast
 import androidx.media3.cast.CastPlayer
 import androidx.media3.common.DeviceInfo
+import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.Player
 import androidx.media3.common.PlayerTransferState
 import com.luc4n3x.levyra.domain.RepeatMode
@@ -130,19 +131,25 @@ class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
 
     override fun attachLocalPlayer(localPlayer: Player): Player {
         if (!available) return localPlayer
-        return runCatching {
+        val castPlayer = runCatching {
             CastPlayer.Builder(appContext)
                 .setLocalPlayer(localPlayer)
                 .setTransferCallback(transferCallback)
                 .build()
-                .also { castPlayer ->
+                .also { attached ->
                     player?.removeListener(listener)
                     player?.release()
-                    player = castPlayer
-                    castPlayer.addListener(listener)
-                    publish(castPlayer)
+                    player = attached
+                    attached.addListener(listener)
+                    publish(attached)
                 }
-        }.getOrElse { localPlayer }
+        }.getOrElse { return localPlayer }
+
+        return object : ForwardingPlayer(castPlayer) {
+            override fun release() {
+                this@GoogleCastBackend.release()
+            }
+        }
     }
 
     override fun release() {

--- a/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/GoogleCastBackend.kt
+++ b/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/GoogleCastBackend.kt
@@ -1,11 +1,13 @@
+@file:androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+
 package com.luc4n3x.levyra.feature.cast
 
 import android.content.Context
+import androidx.media3.cast.Cast
 import androidx.media3.cast.CastPlayer
 import androidx.media3.common.DeviceInfo
 import androidx.media3.common.Player
 import androidx.media3.common.PlayerTransferState
-import com.google.android.gms.cast.framework.CastContext
 import com.luc4n3x.levyra.domain.RepeatMode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -16,9 +18,14 @@ import kotlinx.coroutines.withContext
 
 class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
     private val appContext = context.applicationContext
+    private val cast = runCatching {
+        Cast.getSingletonInstance(appContext).apply {
+            if (needsInitialization()) initialize()
+        }
+    }.getOrNull()
 
     override val id: String = "google-cast"
-    override val available: Boolean = runCatching { CastContext.getSharedInstance(appContext) }.isSuccess
+    override val available: Boolean = cast != null
 
     private val mutableState = MutableStateFlow(
         RemotePlaybackState(
@@ -71,11 +78,9 @@ class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
     override suspend fun connect(device: RemoteDevice) = Unit
 
     override suspend fun disconnect() {
-        val sessionManager = runCatching {
-            CastContext.getSharedInstance(appContext).sessionManager
-        }.getOrNull() ?: return
+        val castRuntime = cast ?: return
         withContext(Dispatchers.Main) {
-            sessionManager.endCurrentSession(true)
+            runCatching { castRuntime.endCurrentSession(true) }
         }
     }
 
@@ -149,11 +154,7 @@ class GoogleCastBackend(private val context: Context) : RemotePlaybackBackend {
     private fun publish(active: Player) {
         val connected = active.deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE
         val deviceName = runCatching {
-            CastContext.getSharedInstance(appContext)
-                .sessionManager
-                .currentCastSession
-                ?.castDevice
-                ?.friendlyName
+            cast?.getCurrentCastSession()?.castDevice?.friendlyName
         }.getOrNull()
         mutableState.value = RemotePlaybackState(
             availability = when {

--- a/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/RemotePlaybackBackendProvider.kt
+++ b/app/src/upstream/java/com/luc4n3x/levyra/feature/cast/RemotePlaybackBackendProvider.kt
@@ -1,0 +1,7 @@
+package com.luc4n3x.levyra.feature.cast
+
+import android.content.Context
+
+object RemotePlaybackBackendProvider {
+    fun create(context: Context): RemotePlaybackBackend = GoogleCastBackend(context.applicationContext)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,7 @@ androidx-media3-exoplayer = { group = "androidx.media3", name = "media3-exoplaye
 androidx-media3-exoplayer-hls = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3" }
 androidx-media3-exoplayer-dash = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3" }
 androidx-media3-session = { group = "androidx.media3", name = "media3-session", version.ref = "media3" }
+androidx-media3-cast = { group = "androidx.media3", name = "media3-cast", version.ref = "media3" }
 androidx-media3-ui = { group = "androidx.media3", name = "media3-ui", version.ref = "media3" }
 androidx-car-app = { group = "androidx.car.app", name = "app", version.ref = "carApp" }
 androidx-car-app-projected = { group = "androidx.car.app", name = "app-projected", version.ref = "carApp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ kotlin = "2.4.10"
 composeBom = "2026.08.00"
 coreKtx = "1.19.0"
 activityCompose = "1.13.0"
+fragment = "1.9.0"
 lifecycle = "2.11.0"
 media3 = "1.11.0"
 carApp = "1.9.0-alpha01"
@@ -35,6 +36,7 @@ uiautomator = "2.4.0"
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }


### PR DESCRIPTION
## Summary

Adds four focused Android capabilities: upstream-only Google Cast playback, Room-backed artist follows with local release alerts, a music-recognition home-screen widget, and bounded continuous-radio replenishment. Existing playback, recognition, recommendation, and queue owners remain authoritative; the F-Droid variant stays free of Cast/GMS code.

## What changed

- Added Media3 Cast route selection and local/remote player transfer for upstream builds. `PersistentQueueEngine` remains the source of truth; `GoogleCastBackend` maintains a bounded receiver window with the current item plus up to four logical upcoming tracks, replenishes it across remote transitions, and keeps Levyra's shuffle/repeat ordering authoritative instead of letting the small receiver window define queue semantics. Cast media writes are restricted to receiver-safe HTTPS `googlevideo.com` URLs or real subdomains.
- Moved followed artists to Room schema 18, preserved legacy follows safely, established first-follow release baselines, and scheduled one constrained worker only while follows exist. Legacy JSON is removed after successful canonical persistence so stale rows cannot be re-imported, while indeterminate startup loads preserve the existing release-radar schedule.
- Added a separate responsive recognition widget that reuses `MusicRecognitionService` and `LevyraRecognitionCenter`. Widget transport falls back through MediaSession/MediaController, checks command availability, and recognition artwork is generation-guarded, DNS/public-address checked, capped to a 1 MiB input buffer, and decoded to a small widget bitmap.
- Hardened continuous radio with a broader candidate pool before dedupe, five-track append batches, ID/title dedupe, cancellation/generation guards, and a rolling bounded queue that can keep replenishing without unbounded growth.
- Restored the Android text share-sheet entry point and kept the Fragment compatibility override upstream-only so the Cast build satisfies Android lint without widening the F-Droid runtime dependency surface.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactor or maintenance
- [x] UI or UX change
- [ ] Localization or accessibility
- [x] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** Player / Library / UI / System integration / Build and release

## Validation

### Automated checks

- [ ] Android: ./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease
- [ ] Desktop: cd desktop && ./gradlew check assemble
- [x] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

On the latest head, Dependency Review, Release Guard, Editorial Catalog, the AI quality gate, Android runtime compatibility scan, and LevyraExtractor tests have passed. Android Lint, the signed PR Diagnostics APK build, the remaining Android/F-Droid unit and compile checks, and the APK size report are still running.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| CI / Android build | Lint, unit tests, Release/PR Diagnostics compile | Running on latest head |
| Physical Google Cast receiver | Real receiver handoff, rolling queue, disconnect and long-session behavior | Still requires device validation |

## Risk and compatibility

- **Risk level:** High
- **Compatibility or migration notes:** Room migrates 17 to 18. Legacy name-only follows are retained; new follows use the authoritative browse ID. Cast dependencies/components and the Fragment compatibility override exist only in upstream builds.
- **Known limitations:** Real Cast hardware behavior cannot be fully proven by JVM/CI checks alone and should be exercised on a physical receiver before release.
- **Rollback plan:** Revert this PR.

## Reviewer notes

- `PersistentQueueEngine` remains authoritative for persistent order, shuffle and repeat semantics. `GoogleCastBackend` owns Cast transport/session state, receiver-window maintenance, safe local/remote transfer, and backend cleanup.
- The Cast receiver queue is intentionally bounded and uses Levyra's logical `upcoming(...)` order; physical Cast shuffle and Repeat All are not allowed to reinterpret the small receiver window.
- Cast receiver media URLs are restricted at every queue write boundary to HTTPS `googlevideo.com` or real subdomains, with no user info or non-default port.
- The radio repository deliberately gathers more candidates than the queue appends so dedupe cannot starve a five-track replenishment batch.
- Follow migration keeps the legacy payload intact when parsing or Room persistence fails and canonical saves consume it after successful Room persistence.
- Recognition widget artwork uses a generation guard, public-address check and bounded decode path so slow/stale artwork cannot overwrite newer recognition state or allocate unbounded buffers.

## Release note

Cast playback, followed-artist release alerts, one-tap song recognition, and smarter continuous radio are now available on Android.

## Related issues

- Closes N/A
- Related to N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests and localization coverage were updated where required by the changed behavior
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the description reflects the current implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Cast support for remote playback, including queue handoff and playback controls.
  * Added a home-screen music recognition widget with recognition status, artwork, and recording controls.
  * Release notifications can now open the corresponding album directly.
* **Improvements**
  * Followed artists are stored more reliably, with improved release notification scheduling.
  * Improved continuous radio queue management, deduplication, and history handling.
  * Added safer Cast media validation and improved widget playback controls.
  * Improved player control touch targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->