### PR TITLE
Add SABR playback delivery, candidate recovery and Googlevideo failover

### DIFF
--- a/app/src/androidTest/java/com/luc4n3x/levyra/player/sabr/SabrDataSourceTest.kt
+++ b/app/src/androidTest/java/com/luc4n3x/levyra/player/sabr/SabrDataSourceTest.kt
@@ -1,0 +1,382 @@
+package com.luc4n3x.levyra.player.sabr
+
+import android.net.Uri
+import androidx.media3.common.C
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.HttpDataSource
+import androidx.media3.datasource.TransferListener
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.io.IOException
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Exercises the SABR transport end to end against a scripted server: request building, UMP parsing,
+ * byte-accurate seeking, continuation, end of stream, redirects and media-network failover, with no
+ * network access.
+ */
+@RunWith(AndroidJUnit4::class)
+class SabrDataSourceTest {
+    private val endpoint = "https://rr5---sn-a.googlevideo.com/videoplayback?mn=sn-a,sn-b&sabr=1"
+    private val itag = 140
+    private val lastModified = 1_766_955_925_572_207L
+    private val initSegment = ByteArray(1_019) { (it % 251).toByte() }
+    private val firstSegment = ByteArray(4_000) { ((it * 7) % 251).toByte() }
+    private val secondSegment = ByteArray(3_000) { ((it * 11) % 251).toByte() }
+    private val stream = initSegment + firstSegment + secondSegment
+
+    @Test
+    fun readsTheWholeStreamAcrossSeveralRequests() {
+        val factory = ScriptedHttpDataSourceFactory(
+            listOf(
+                Response.media(listOf(chunk(0, 0L, initSegment), chunk(1, 1_019L, firstSegment))),
+                Response.media(listOf(chunk(0, 5_019L, secondSegment)))
+            )
+        )
+        val source = SabrDataSource(factory)
+
+        val length = source.open(DataSpec(Uri.parse(spec().toUri())))
+        val read = source.readFully()
+        source.close()
+
+        assertEquals(stream.size.toLong(), length)
+        assertArrayEquals(stream, read)
+        assertEquals(2, factory.requests.size)
+    }
+
+    @Test
+    fun aForwardSeekTrimsTheSegmentTheServerStartsFrom() {
+        val position = 2_000L
+        val factory = ScriptedHttpDataSourceFactory(
+            listOf(
+                Response.media(listOf(chunk(0, 1_019L, firstSegment))),
+                Response.media(listOf(chunk(0, 5_019L, secondSegment)))
+            )
+        )
+        val source = SabrDataSource(factory)
+
+        val length = source.open(
+            DataSpec.Builder().setUri(Uri.parse(spec().toUri())).setPosition(position).build()
+        )
+        val read = source.readFully()
+        source.close()
+
+        assertEquals(stream.size - position, length)
+        assertArrayEquals(stream.copyOfRange(position.toInt(), stream.size), read)
+    }
+
+    @Test
+    fun aBackwardSeekRestartsFromTheEarlierByteInsteadOfStalling() {
+        val factory = ScriptedHttpDataSourceFactory(
+            listOf(
+                Response.media(listOf(chunk(0, 5_019L, secondSegment))),
+                Response.media(listOf(chunk(0, 1_019L, firstSegment))),
+                Response.media(listOf(chunk(0, 5_019L, secondSegment)))
+            )
+        )
+        val source = SabrDataSource(factory)
+        source.open(DataSpec.Builder().setUri(Uri.parse(spec().toUri())).setPosition(5_019L).build())
+        source.readFully()
+        source.close()
+
+        val backward = SabrDataSource(factory)
+        backward.open(DataSpec.Builder().setUri(Uri.parse(spec().toUri())).setPosition(1_019L).build())
+        val read = backward.readFully()
+        backward.close()
+
+        assertArrayEquals(stream.copyOfRange(1_019, stream.size), read)
+    }
+
+    @Test
+    fun aBoundedRangeStopsAtItsOwnEndOfStream() {
+        val factory = ScriptedHttpDataSourceFactory(
+            listOf(Response.media(listOf(chunk(0, 0L, initSegment), chunk(1, 1_019L, firstSegment))))
+        )
+        val source = SabrDataSource(factory)
+
+        val length = source.open(
+            DataSpec.Builder().setUri(Uri.parse(spec().toUri())).setPosition(0L).setLength(500L).build()
+        )
+        val read = source.readFully()
+        source.close()
+
+        assertEquals(500L, length)
+        assertArrayEquals(stream.copyOfRange(0, 500), read)
+    }
+
+    @Test
+    fun openingPastTheEndOfTheStreamReportsEndOfInputImmediately() {
+        val source = SabrDataSource(ScriptedHttpDataSourceFactory(emptyList()))
+
+        val length = source.open(
+            DataSpec.Builder()
+                .setUri(Uri.parse(spec().toUri()))
+                .setPosition(stream.size.toLong())
+                .build()
+        )
+        val read = source.read(ByteArray(16), 0, 16)
+        source.close()
+
+        assertEquals(0L, length)
+        assertEquals(C.RESULT_END_OF_INPUT, read)
+    }
+
+    @Test
+    fun anEmptyResponseIsRetriedAndThenGivesUpWithoutLooping() {
+        val factory = ScriptedHttpDataSourceFactory(List(8) { Response.media(emptyList()) })
+        val source = SabrDataSource(factory)
+        source.open(DataSpec(Uri.parse(spec().toUri())))
+
+        val failure = runCatching { source.readFully() }.exceptionOrNull()
+        source.close()
+
+        assertTrue(failure is IOException)
+        assertTrue(factory.requests.size <= 4)
+    }
+
+    @Test
+    fun aRedirectMovesTheSessionToTheHostTheServerNames() {
+        val redirect = "https://rr9---sn-c.googlevideo.com/videoplayback?mn=sn-c&sabr=1"
+        val factory = ScriptedHttpDataSourceFactory(
+            listOf(
+                Response.parts(
+                    listOf(SabrPart.SABR_REDIRECT to ProtoWriter().string(1, redirect).toByteArray())
+                ),
+                Response.media(listOf(chunk(0, 0L, initSegment), chunk(1, 1_019L, firstSegment))),
+                Response.media(listOf(chunk(0, 5_019L, secondSegment)))
+            )
+        )
+        val source = SabrDataSource(factory)
+
+        source.open(DataSpec(Uri.parse(spec().toUri())))
+        val read = source.readFully()
+        source.close()
+
+        assertArrayEquals(stream, read)
+        assertEquals(redirect, factory.requests[1])
+    }
+
+    @Test
+    fun aRedirectToAForeignHostIsRefused() {
+        val factory = ScriptedHttpDataSourceFactory(
+            listOf(
+                Response.parts(
+                    listOf(
+                        SabrPart.SABR_REDIRECT to
+                            ProtoWriter().string(1, "https://evil.test/steal").toByteArray()
+                    )
+                )
+            )
+        )
+        val source = SabrDataSource(factory)
+        source.open(DataSpec(Uri.parse(spec().toUri())))
+
+        val failure = runCatching { source.readFully() }.exceptionOrNull()
+        source.close()
+
+        assertTrue(failure is SabrProtocolException)
+        assertEquals(1, factory.requests.size)
+    }
+
+    @Test
+    fun anUnreachableEndpointFailsOverToTheDeclaredMediaNetwork() {
+        val factory = ScriptedHttpDataSourceFactory(
+            listOf(
+                Response.openFailure(IOException("connection reset")),
+                Response.media(listOf(chunk(0, 0L, initSegment), chunk(1, 1_019L, firstSegment))),
+                Response.media(listOf(chunk(0, 5_019L, secondSegment)))
+            )
+        )
+        val source = SabrDataSource(factory)
+
+        source.open(DataSpec(Uri.parse(spec().toUri())))
+        val read = source.readFully()
+        source.close()
+
+        assertArrayEquals(stream, read)
+        assertTrue(factory.requests[0].contains("sn-a"))
+        assertTrue(factory.requests[1].contains("sn-b"))
+    }
+
+    @Test
+    fun aSecurityAnswerIsNeverRetriedOnAnotherMediaNetwork() {
+        val forbidden = HttpDataSource.InvalidResponseCodeException(
+            403,
+            "Forbidden",
+            null,
+            emptyMap(),
+            DataSpec(Uri.parse(endpoint)),
+            ByteArray(0)
+        )
+        val factory = ScriptedHttpDataSourceFactory(listOf(Response.openFailure(forbidden)))
+        val source = SabrDataSource(factory)
+        source.open(DataSpec(Uri.parse(spec().toUri())))
+
+        val failure = runCatching { source.readFully() }.exceptionOrNull()
+        source.close()
+
+        assertTrue(failure is HttpDataSource.InvalidResponseCodeException)
+        assertEquals(1, factory.requests.size)
+    }
+
+    @Test
+    fun aServerErrorFrameStopsTheSessionForTheRecoveryLadder() {
+        val factory = ScriptedHttpDataSourceFactory(
+            listOf(Response.parts(listOf(SabrPart.SABR_ERROR to ByteArray(4))))
+        )
+        val source = SabrDataSource(factory)
+        source.open(DataSpec(Uri.parse(spec().toUri())))
+
+        val failure = runCatching { source.readFully() }.exceptionOrNull()
+        source.close()
+
+        assertTrue(failure is SabrProtocolException)
+    }
+
+    @Test
+    fun mediaBelongingToAnotherFormatIsDiscarded() {
+        val factory = ScriptedHttpDataSourceFactory(
+            listOf(
+                Response.media(
+                    listOf(
+                        chunk(0, 0L, ByteArray(64), itag = 133),
+                        chunk(1, 0L, initSegment),
+                        chunk(2, 1_019L, firstSegment)
+                    )
+                ),
+                Response.media(listOf(chunk(0, 5_019L, secondSegment)))
+            )
+        )
+        val source = SabrDataSource(factory)
+
+        source.open(DataSpec(Uri.parse(spec().toUri())))
+        val read = source.readFully()
+        source.close()
+
+        assertArrayEquals(stream, read)
+    }
+
+    private fun SabrDataSource.readFully(): ByteArray {
+        val output = ArrayList<Byte>()
+        val buffer = ByteArray(1_024)
+        while (true) {
+            val count = read(buffer, 0, buffer.size)
+            if (count == C.RESULT_END_OF_INPUT) break
+            for (index in 0 until count) output.add(buffer[index])
+        }
+        return output.toByteArray()
+    }
+
+    private fun spec() = SabrStreamSpec(
+        endpointUrl = endpoint,
+        ustreamerConfig = byteArrayOf(1, 2, 3),
+        format = SabrFormatId(itag, lastModified),
+        companionAudioFormat = null,
+        contentLength = stream.size.toLong(),
+        durationMs = 213_090L,
+        videoTrack = false,
+        clientName = 5,
+        clientVersion = "20.10.4",
+        userAgent = "com.google.ios.youtube/20.10.4"
+    )
+
+    private fun chunk(
+        headerId: Int,
+        startDataRange: Long,
+        payload: ByteArray,
+        itag: Int = this.itag
+    ): Pair<ByteArray, ByteArray> {
+        val header = ProtoWriter()
+            .varint(1, headerId.toLong())
+            .varint(3, itag.toLong())
+            .varint(4, lastModified)
+            .varint(6, startDataRange)
+            .varint(14, payload.size.toLong())
+            .toByteArray()
+        return header to (byteArrayOf(headerId.toByte()) + payload)
+    }
+
+    private class Response private constructor(
+        val body: ByteArray,
+        val openFailure: IOException?
+    ) {
+        companion object {
+            fun parts(parts: List<Pair<Int, ByteArray>>): Response {
+                var body = ByteArray(0)
+                parts.forEach { (type, payload) -> body += umpPart(type, payload) }
+                return Response(body, null)
+            }
+
+            fun media(chunks: List<Pair<ByteArray, ByteArray>>): Response = parts(
+                chunks.flatMap { (header, payload) ->
+                    listOf(SabrPart.MEDIA_HEADER to header, SabrPart.MEDIA to payload)
+                }
+            )
+
+            fun openFailure(error: IOException): Response = Response(ByteArray(0), error)
+        }
+    }
+
+    private class ScriptedHttpDataSourceFactory(
+        private val responses: List<Response>
+    ) : HttpDataSource.Factory {
+        val requests = ArrayList<String>()
+
+        override fun createDataSource(): HttpDataSource = ScriptedHttpDataSource(this)
+
+        override fun setDefaultRequestProperties(
+            defaultRequestProperties: MutableMap<String, String>
+        ): HttpDataSource.Factory = this
+
+        fun next(url: String): Response {
+            val index = requests.size
+            requests += url
+            return responses.getOrElse(index) { Response.media(emptyList()) }
+        }
+    }
+
+    private class ScriptedHttpDataSource(
+        private val factory: ScriptedHttpDataSourceFactory
+    ) : HttpDataSource {
+        private var body: ByteArray = ByteArray(0)
+        private var position = 0
+
+        override fun open(dataSpec: DataSpec): Long {
+            val response = factory.next(dataSpec.uri.toString())
+            response.openFailure?.let { throw it }
+            body = response.body
+            position = 0
+            return body.size.toLong()
+        }
+
+        override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+            if (position >= body.size) return C.RESULT_END_OF_INPUT
+            val count = minOf(length, body.size - position)
+            System.arraycopy(body, position, buffer, offset, count)
+            position += count
+            return count
+        }
+
+        override fun close() {
+            body = ByteArray(0)
+            position = 0
+        }
+
+        override fun getUri(): Uri? = null
+
+        override fun addTransferListener(transferListener: TransferListener) = Unit
+
+        override fun getResponseHeaders(): MutableMap<String, MutableList<String>> = mutableMapOf()
+
+        override fun setRequestProperty(name: String, value: String) = Unit
+
+        override fun clearRequestProperty(name: String) = Unit
+
+        override fun clearAllRequestProperties() = Unit
+
+        override fun getResponseCode(): Int = 200
+    }
+}

--- a/app/src/fdroid/AndroidManifest.xml
+++ b/app/src/fdroid/AndroidManifest.xml
@@ -5,7 +5,8 @@
     <application>
         <receiver
             android:name="androidx.mediarouter.media.MediaTransferReceiver"
-            tools:node="remove" />
+            tools:node="remove"
+            tools:ignore="MissingClass" />
     </application>
 
     <uses-permission

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,8 @@
 
         <receiver
             android:name="androidx.mediarouter.media.MediaTransferReceiver"
-            android:exported="true" />
+            android:exported="true"
+            tools:ignore="MissingClass" />
 
         <provider
             android:name=".data.SpotifyChartBootstrapProvider"

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackCandidateRecovery.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackCandidateRecovery.kt
@@ -1,0 +1,98 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.domain.PlaybackStreamDescriptor
+import com.luc4n3x.levyra.domain.PlaybackStreamKind
+import com.luc4n3x.levyra.domain.ResolvedPlaybackManifest
+
+/**
+ * Number of streams of one manifest that may be burned by candidate promotion before the resolver
+ * has to go back to a fresh player response. It bounds the promotion ladder without extra state.
+ */
+internal const val MAX_PROMOTED_PLAYBACK_CANDIDATES = 3
+
+/**
+ * A failure that describes one media candidate rather than the client, the security state or the
+ * resolver. Rotating clients or regenerating tokens for these only multiplies traffic.
+ */
+internal fun isCandidateLevelPlaybackFailure(kind: PlaybackFailureKind): Boolean = when (kind) {
+    PlaybackFailureKind.NotFound,
+    PlaybackFailureKind.ServerError,
+    PlaybackFailureKind.Truncated -> true
+    else -> false
+}
+
+/**
+ * Re-selects the manifest around the streams that are still usable, keeping the same resolved
+ * player response. Returns null when no equivalent candidate survives, so the caller falls back to
+ * its normal recovery ladder.
+ */
+internal fun promoteAlternatePlaybackCandidate(
+    manifest: ResolvedPlaybackManifest,
+    isVideoMode: Boolean,
+    nowMs: Long = System.currentTimeMillis(),
+    isBlocked: (String) -> Boolean
+): ResolvedPlaybackManifest? {
+    val audioFailed = manifest.selectedAudioUrl.isBlank() || isBlocked(manifest.selectedAudioUrl)
+    val videoFailed = manifest.selectedVideoUrl.isNotBlank() && isBlocked(manifest.selectedVideoUrl)
+    if (!audioFailed && !videoFailed) return null
+
+    val currentAudio = manifest.streams.firstOrNull { it.url == manifest.selectedAudioUrl }
+    val currentVideo = manifest.streams.firstOrNull { it.url == manifest.selectedVideoUrl }
+
+    val nextAudio = if (audioFailed) {
+        val kinds = if (currentAudio != null) {
+            setOf(currentAudio.kind)
+        } else if (isVideoMode) {
+            setOf(PlaybackStreamKind.MUXED, PlaybackStreamKind.AUDIO)
+        } else {
+            setOf(PlaybackStreamKind.AUDIO, PlaybackStreamKind.MUXED)
+        }
+        bestAlternative(manifest, kinds, currentAudio, nowMs, isBlocked) ?: return null
+    } else {
+        currentAudio
+    }
+
+    val nextVideo = if (videoFailed) {
+        bestAlternative(manifest, setOf(PlaybackStreamKind.VIDEO), currentVideo, nowMs, isBlocked) ?: return null
+    } else {
+        currentVideo
+    }
+
+    val audioUrl = nextAudio?.url ?: manifest.selectedAudioUrl
+    if (audioUrl.isBlank() || isBlocked(audioUrl)) return null
+    val videoUrl = nextVideo?.url.orEmpty()
+    if (audioUrl == manifest.selectedAudioUrl && videoUrl == manifest.selectedVideoUrl) return null
+
+    val promotedUrls = setOfNotNull(audioUrl, videoUrl.takeIf { it.isNotBlank() })
+    return manifest.copy(
+        selectedAudioUrl = audioUrl,
+        selectedVideoUrl = videoUrl,
+        streams = manifest.streams.map { stream -> stream.copy(selected = stream.url in promotedUrls) }
+    )
+}
+
+private fun bestAlternative(
+    manifest: ResolvedPlaybackManifest,
+    kinds: Set<PlaybackStreamKind>,
+    current: PlaybackStreamDescriptor?,
+    nowMs: Long,
+    isBlocked: (String) -> Boolean
+): PlaybackStreamDescriptor? {
+    val targetHeight = current?.height ?: 0
+    return manifest.streams
+        .asSequence()
+        .filter { it.kind in kinds }
+        .filter { it.url.isNotBlank() && it.url != current?.url && !isBlocked(it.url) }
+        .filter { it.isFresh(nowMs, refreshAheadMs = 0L) }
+        .sortedWith(
+            compareBy<PlaybackStreamDescriptor> { candidate ->
+                if (targetHeight > 0) {
+                    // Stay as close as possible to what the user was already watching.
+                    kotlin.math.abs(candidate.height - targetHeight)
+                } else {
+                    0
+                }
+            }.thenByDescending { it.averageBitrate.coerceAtLeast(it.bitrate) }
+        )
+        .firstOrNull()
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackCandidateRecovery.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackCandidateRecovery.kt
@@ -4,16 +4,8 @@ import com.luc4n3x.levyra.domain.PlaybackStreamDescriptor
 import com.luc4n3x.levyra.domain.PlaybackStreamKind
 import com.luc4n3x.levyra.domain.ResolvedPlaybackManifest
 
-/**
- * Number of streams of one manifest that may be burned by candidate promotion before the resolver
- * has to go back to a fresh player response. It bounds the promotion ladder without extra state.
- */
 internal const val MAX_PROMOTED_PLAYBACK_CANDIDATES = 3
 
-/**
- * A failure that describes one media candidate rather than the client, the security state or the
- * resolver. Rotating clients or regenerating tokens for these only multiplies traffic.
- */
 internal fun isCandidateLevelPlaybackFailure(kind: PlaybackFailureKind): Boolean = when (kind) {
     PlaybackFailureKind.NotFound,
     PlaybackFailureKind.ServerError,
@@ -21,11 +13,6 @@ internal fun isCandidateLevelPlaybackFailure(kind: PlaybackFailureKind): Boolean
     else -> false
 }
 
-/**
- * Re-selects the manifest around the streams that are still usable, keeping the same resolved
- * player response. Returns null when no equivalent candidate survives, so the caller falls back to
- * its normal recovery ladder.
- */
 internal fun promoteAlternatePlaybackCandidate(
     manifest: ResolvedPlaybackManifest,
     isVideoMode: Boolean,
@@ -87,7 +74,6 @@ private fun bestAlternative(
         .sortedWith(
             compareBy<PlaybackStreamDescriptor> { candidate ->
                 if (targetHeight > 0) {
-                    // Stay as close as possible to what the user was already watching.
                     kotlin.math.abs(candidate.height - targetHeight)
                 } else {
                     0

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResilienceEngine.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResilienceEngine.kt
@@ -244,7 +244,7 @@ internal class PlaybackResilienceEngine(context: Context) {
 
     private fun sanitize(value: String): String {
         return value
-            .replace(Regex("""https?://[^\s]+"""), "<redacted-url>")
+            .replace(Regex("""[a-zA-Z][a-zA-Z0-9+.-]*://[^\s]+"""), "<redacted-url>")
             .replace(Regex("""(?i)(authorization|cookie|visitor|token|signature)=[^&\s]+""")) { match ->
                 "${match.groupValues[1]}=<redacted>"
             }

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -291,6 +291,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         private const val MAX_STREAM_CACHE_ENTRIES = 128
         private const val MAX_FAILED_PLAYBACK_URLS = 256
         private const val MAX_STRATEGY_ORIGINS = 256
+        private const val MAX_SABR_CANDIDATES = 2
         private val youtubeVideoIdRegex = Regex(YOUTUBE_VIDEO_ID_PATTERN)
         private val youtubeVideoUrlRegex = Regex("(?:v=|/shorts/|/embed/|/live/|youtu\\.be/)($YOUTUBE_VIDEO_ID_PATTERN)")
         private val youtubeSearchResultVideoIdRegex = Regex("""\\?["]videoId\\?["]\s*:\s*\\?["]($YOUTUBE_VIDEO_ID_PATTERN)\\?["]""")
@@ -556,25 +557,22 @@ class PlaybackResolver private constructor(private val context: Context) {
         )
         invalidate(track, isVideoMode, isOfflineExport)
         resilienceEngine.recordPlayerFailure(track.id, isVideoMode, reason)
+        val failureKind = classifyPlaybackFailureReason(reason)
         if (!isOfflineExport) {
             strategyOriginFor(track, isVideoMode)?.let { origin ->
                 strategyHealth.recordRuntimeFailure(
                     mode = origin.mode,
                     strategy = origin.strategy,
-                    kind = classifyPlaybackFailureReason(reason)
+                    kind = failureKind
                 )
             }
         }
         val now = System.currentTimeMillis()
         val lower = reason.lowercase()
-        val failureKind = classifyPlaybackFailureReason(reason)
-        val recovery = playbackRecoveryPlanFor(failureKind)
+        val recovery = resilienceEngine.recoveryPlan(reason)
         listOf(track.streamUrl, track.videoStreamUrl)
             .filter { it.isNotBlank() }
             .forEach { quarantinePlaybackUrl(it, now + recovery.quarantineMs, now) }
-        if (!isOfflineExport && isCandidateLevelPlaybackFailure(failureKind)) {
-            promoteAlternateCandidate(track, isVideoMode, audioQuality)
-        }
         if (recovery.rotateClient) {
             profileFromSource(track.source)?.let { profile ->
                 recordClientFailure(profile, null, PlaybackBlockedException(reason))
@@ -598,6 +596,9 @@ class PlaybackResolver private constructor(private val context: Context) {
         }
         if (recovery.rotateCodec && !isOfflineExport) {
             videoSelector.reportPlaybackFailure(track.videoStreamUrl.ifBlank { track.streamUrl }, lower)
+        }
+        if (!isOfflineExport && isCandidateLevelPlaybackFailure(failureKind)) {
+            promoteAlternateCandidate(track, isVideoMode, audioQuality)
         }
         val sourceMatchQuarantineMs = when {
             lower.contains("403") || lower.contains("410") || lower.contains("expired") || lower.contains("scadut") || lower.contains("signature") -> 0L
@@ -2519,6 +2520,12 @@ class PlaybackResolver private constructor(private val context: Context) {
             val audioConfig = root.optJSONObject("playerConfig")?.optJSONObject("audioConfig")
             val loudnessDb = audioConfig?.finiteFloat("loudnessDb")
             val perceptualLoudnessDb = audioConfig?.finiteFloat("perceptualLoudnessDb")
+            val sabrDelivery = if (preferMp4Audio) {
+                null
+            } else {
+                sabrDeliveryContext(root, streamingData, profile)
+            }
+            val sabrCandidates = if (sabrDelivery == null) emptyList() else sabrFormatCandidates(adaptiveFormats)
 
             val audioCandidates = buildList {
                 for (i in 0 until adaptiveFormats.length()) {
@@ -2622,6 +2629,8 @@ class PlaybackResolver private constructor(private val context: Context) {
                 val duration = details?.optString("lengthSeconds")?.toLongOrNull()?.times(1000L) ?: 0L
                 val thumbnail = details?.optJSONObject("thumbnail")?.optJSONArray("thumbnails")?.bestThumbnail().orEmpty()
                 val videoSubtitleTracks = videoSubtitleTracks(root)
+                val sabrVideoStreams = sabrVideoDescriptors(sabrDelivery, sabrCandidates, duration, audioQuality)
+                val sabrAudioStreams = sabrAudioDescriptors(sabrDelivery, sabrCandidates, duration, audioQuality)
                 return@responseUse when {
                     selection?.candidate?.muxed == true -> {
                         val manifest = buildManifest(
@@ -2655,7 +2664,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                             streams = listOf(
                                 innerTubeAudioDescriptor(bestAudioFormat, bestAudioUrl, true),
                                 videoDescriptor(selection.candidate, true)
-                            ),
+                            ) + sabrAudioStreams + sabrVideoStreams,
                             loudness = PlaybackLoudness(loudnessDb, perceptualLoudnessDb)
                         )
                         DirectStream(
@@ -2692,34 +2701,182 @@ class PlaybackResolver private constructor(private val context: Context) {
                             videoSubtitleTracks = videoSubtitleTracks
                         )
                     }
+                    sabrVideoStreams.isNotEmpty() && sabrAudioStreams.isNotEmpty() -> {
+                        val sabrAudio = sabrAudioStreams.first()
+                        val sabrVideo = sabrVideoStreams.first()
+                        val manifest = buildManifest(
+                            sourceVideoId = sourceVideoId,
+                            provider = "YouTube SABR ${profile.label}",
+                            durationMs = duration,
+                            selectedAudioUrl = sabrAudio.url,
+                            selectedVideoUrl = sabrVideo.url,
+                            streams = sabrAudioStreams + sabrVideoStreams,
+                            loudness = PlaybackLoudness(loudnessDb, perceptualLoudnessDb)
+                        )
+                        DirectStream(
+                            url = sabrAudio.url,
+                            videoUrl = sabrVideo.url,
+                            durationMs = duration,
+                            thumbnailUrl = thumbnail,
+                            source = "YouTube SABR ${profile.label}",
+                            manifest = manifest,
+                            loudnessDb = loudnessDb,
+                            perceptualLoudnessDb = perceptualLoudnessDb,
+                            videoSubtitleTracks = videoSubtitleTracks
+                        )
+                    }
                     else -> throw YoutubePlayerRequestException(null, "Nessuno stream video compatibile disponibile")
                 }
             }
 
-            if (bestAudioUrl.isBlank()) throw YoutubePlayerRequestException(null, "URL streaming assente")
             val details = root.optJSONObject("videoDetails")
             val duration = details?.optString("lengthSeconds")?.toLongOrNull()?.times(1000L) ?: 0L
+            val sabrAudioStreams = sabrAudioDescriptors(sabrDelivery, sabrCandidates, duration, audioQuality)
+            if (bestAudioUrl.isBlank() && sabrAudioStreams.isEmpty()) {
+                throw YoutubePlayerRequestException(null, "URL streaming assente")
+            }
             val thumbnail = details?.optJSONObject("thumbnail")?.optJSONArray("thumbnails")?.bestThumbnail().orEmpty()
+            val directAudioStreams = if (bestAudioUrl.isBlank()) {
+                emptyList()
+            } else {
+                listOf(innerTubeAudioDescriptor(bestAudioFormat, bestAudioUrl, true))
+            }
+            val selectedAudioUrl = bestAudioUrl.ifBlank { sabrAudioStreams.first().url }
+            val sabrSelected = selectedAudioUrl != bestAudioUrl
             val manifest = buildManifest(
                 sourceVideoId = sourceVideoId,
-                provider = "YouTube ${profile.label}",
+                provider = if (sabrSelected) "YouTube SABR ${profile.label}" else "YouTube ${profile.label}",
                 durationMs = duration,
-                selectedAudioUrl = bestAudioUrl,
+                selectedAudioUrl = selectedAudioUrl,
                 selectedVideoUrl = "",
-                streams = listOf(innerTubeAudioDescriptor(bestAudioFormat, bestAudioUrl, true)),
+                streams = directAudioStreams + sabrAudioStreams,
                 loudness = PlaybackLoudness(loudnessDb, perceptualLoudnessDb)
             )
             DirectStream(
-                url = bestAudioUrl,
+                url = selectedAudioUrl,
                 videoUrl = "",
                 durationMs = duration,
                 thumbnailUrl = thumbnail,
-                source = "YouTube ${profile.label}${bestAudioLabel.takeIf { it.isNotBlank() }?.let { " · $it" }.orEmpty()}",
+                source = if (sabrSelected) {
+                    "YouTube SABR ${profile.label}"
+                } else {
+                    "YouTube ${profile.label}${bestAudioLabel.takeIf { it.isNotBlank() }?.let { " · $it" }.orEmpty()}"
+                },
                 manifest = manifest,
                 loudnessDb = loudnessDb,
                 perceptualLoudnessDb = perceptualLoudnessDb
             )
         }
+    }
+
+    private fun prefersHighestAudioBitrate(audioQuality: String): Boolean =
+        !normalizeAudioQuality(audioQuality).equals("Low", ignoreCase = true)
+
+    private fun sabrDeliveryContext(
+        root: JSONObject,
+        streamingData: JSONObject,
+        profile: ClientProfile
+    ): SabrDeliveryContext? {
+        val endpoint = streamingData.optString("serverAbrStreamingUrl").takeIf { it.isNotBlank() } ?: return null
+        val rawConfig = root.optJSONObject("playerConfig")
+            ?.optJSONObject("mediaCommonConfig")
+            ?.optJSONObject("mediaUstreamerRequestConfig")
+            ?.optString("videoPlaybackUstreamerConfig")
+            .orEmpty()
+        val config = decodeSabrUstreamerConfig(rawConfig) ?: return null
+        val clientName = profile.clientHeaderName.toIntOrNull() ?: return null
+        return SabrDeliveryContext(
+            endpointUrl = endpoint,
+            ustreamerConfig = config,
+            clientName = clientName,
+            clientVersion = profile.clientVersion,
+            userAgent = playerUserAgent(profile),
+            expiresAtMs = expiresAtFor(endpoint)
+        )
+    }
+
+    private fun sabrFormatCandidates(adaptiveFormats: JSONArray): List<SabrFormatCandidate> = buildList {
+        for (index in 0 until adaptiveFormats.length()) {
+            val format = adaptiveFormats.optJSONObject(index) ?: continue
+            val mime = format.optString("mimeType")
+            if (mime.isBlank()) continue
+            add(
+                SabrFormatCandidate(
+                    itag = format.optInt("itag", 0),
+                    lastModified = format.optString("lastModified").toLongOrNull() ?: 0L,
+                    mimeType = mime,
+                    contentLength = format.optString("contentLength").toLongOrNull() ?: 0L,
+                    bitrate = format.optInt("bitrate", 0),
+                    averageBitrate = format.optInt("averageBitrate", 0),
+                    sampleRate = format.optString("audioSampleRate").toIntOrNull() ?: 0,
+                    width = format.optInt("width", 0),
+                    height = format.optInt("height", 0),
+                    fps = format.optInt("fps", 0),
+                    qualityLabel = format.optString("qualityLabel")
+                )
+            )
+        }
+    }
+
+    private fun sabrAudioDescriptors(
+        delivery: SabrDeliveryContext?,
+        candidates: List<SabrFormatCandidate>,
+        durationMs: Long,
+        audioQuality: String
+    ): List<PlaybackStreamDescriptor> {
+        if (delivery == null) return emptyList()
+        return orderSabrAudioCandidates(
+            candidates,
+            preferHighestBitrate = prefersHighestAudioBitrate(audioQuality)
+        )
+            .asSequence()
+            .mapNotNull { candidate ->
+                buildSabrStreamDescriptor(
+                    endpointUrl = delivery.endpointUrl,
+                    ustreamerConfig = delivery.ustreamerConfig,
+                    candidate = candidate,
+                    companionAudio = null,
+                    durationMs = durationMs,
+                    clientName = delivery.clientName,
+                    clientVersion = delivery.clientVersion,
+                    userAgent = delivery.userAgent,
+                    expiresAtMs = delivery.expiresAtMs
+                )
+            }
+            .filterNot { isPlaybackUrlBlocked(it.url) }
+            .take(MAX_SABR_CANDIDATES)
+            .toList()
+    }
+
+    private fun sabrVideoDescriptors(
+        delivery: SabrDeliveryContext?,
+        candidates: List<SabrFormatCandidate>,
+        durationMs: Long,
+        audioQuality: String
+    ): List<PlaybackStreamDescriptor> {
+        if (delivery == null) return emptyList()
+        val companionAudio = orderSabrAudioCandidates(
+            candidates,
+            preferHighestBitrate = prefersHighestAudioBitrate(audioQuality)
+        ).firstOrNull() ?: return emptyList()
+        return orderSabrVideoCandidates(candidates, videoSelector.targetHeight())
+            .asSequence()
+            .mapNotNull { candidate ->
+                buildSabrStreamDescriptor(
+                    endpointUrl = delivery.endpointUrl,
+                    ustreamerConfig = delivery.ustreamerConfig,
+                    candidate = candidate,
+                    companionAudio = companionAudio,
+                    durationMs = durationMs,
+                    clientName = delivery.clientName,
+                    clientVersion = delivery.clientVersion,
+                    userAgent = delivery.userAgent,
+                    expiresAtMs = delivery.expiresAtMs
+                )
+            }
+            .filterNot { isPlaybackUrlBlocked(it.url) }
+            .take(MAX_SABR_CANDIDATES)
+            .toList()
     }
 
     private fun selectAudioStream(
@@ -3496,6 +3653,15 @@ private data class DirectStream(
     val loudnessDb: Float? = null,
     val perceptualLoudnessDb: Float? = null,
     val videoSubtitleTracks: List<com.luc4n3x.levyra.domain.VideoSubtitleTrack> = emptyList()
+)
+
+private class SabrDeliveryContext(
+    val endpointUrl: String,
+    val ustreamerConfig: ByteArray,
+    val clientName: Int,
+    val clientVersion: String,
+    val userAgent: String,
+    val expiresAtMs: Long
 )
 
 private data class PlaybackStrategyOrigin(

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -497,8 +497,10 @@ class PlaybackResolver private constructor(private val context: Context) {
                 (isVideoMode || isPlayableAudioUrl(track.streamUrl)) &&
                 (!isVideoMode || track.hasVideoPlaybackPayload()) &&
                 streamStillFresh(track.streamUrl)
-            RuntimeHooks.cache(if (valid) RuntimeSignal.CACHE_HIT else RuntimeSignal.CACHE_MISS)
-            return track.takeIf { valid }
+            if (valid) {
+                RuntimeHooks.cache(RuntimeSignal.CACHE_HIT)
+                return track
+            }
         }
         val key = cacheKey(track, isVideoMode, audioQuality)
         val hit = streamCache[key] ?: run {
@@ -565,10 +567,14 @@ class PlaybackResolver private constructor(private val context: Context) {
         }
         val now = System.currentTimeMillis()
         val lower = reason.lowercase()
-        val recovery = resilienceEngine.recoveryPlan(reason)
+        val failureKind = classifyPlaybackFailureReason(reason)
+        val recovery = playbackRecoveryPlanFor(failureKind)
         listOf(track.streamUrl, track.videoStreamUrl)
             .filter { it.isNotBlank() }
             .forEach { quarantinePlaybackUrl(it, now + recovery.quarantineMs, now) }
+        if (!isOfflineExport && isCandidateLevelPlaybackFailure(failureKind)) {
+            promoteAlternateCandidate(track, isVideoMode, audioQuality)
+        }
         if (recovery.rotateClient) {
             profileFromSource(track.source)?.let { profile ->
                 recordClientFailure(profile, null, PlaybackBlockedException(reason))
@@ -611,6 +617,31 @@ class PlaybackResolver private constructor(private val context: Context) {
                 Timber.w(error, "persistent source match failure update failed")
             }
         }
+    }
+
+    private fun promoteAlternateCandidate(track: Track, isVideoMode: Boolean, audioQuality: String?) {
+        val manifest = track.playbackManifest ?: return
+        val burned = manifest.streams.count { isPlaybackUrlBlocked(it.url) }
+        if (burned > MAX_PROMOTED_PLAYBACK_CANDIDATES) return
+        val promoted = promoteAlternatePlaybackCandidate(
+            manifest = manifest,
+            isVideoMode = isVideoMode,
+            isBlocked = ::isPlaybackUrlBlocked
+        ) ?: return
+        val promotedTrack = track.applyManifest(promoted, track.videoUrl, track.source)
+        if (isVideoMode && !promotedTrack.hasVideoPlaybackPayload()) return
+        store(
+            requestedTrack = track,
+            resolvedTrack = promotedTrack,
+            isVideoMode = isVideoMode,
+            audioQuality = audioQuality?.let(::normalizeAudioQuality) ?: selectedAudioQuality,
+            expectedGeneration = resolverGeneration.get()
+        )
+        Timber.i(
+            "playback candidate promoted mode=%s burned=%d",
+            if (isVideoMode) "video" else "audio",
+            burned
+        )
     }
 
     private fun rememberStrategyOrigin(

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -538,7 +538,8 @@ class PlaybackResolver private constructor(private val context: Context) {
         isVideoMode: Boolean,
         reason: String,
         isOfflineExport: Boolean = false,
-        audioQuality: String? = null
+        audioQuality: String? = null,
+        failedUrl: String? = null
     ) {
         if (isLocalPlaybackTrack(track)) {
             resilienceEngine.recordPlayerFailure(track.id, isVideoMode, reason)
@@ -571,7 +572,18 @@ class PlaybackResolver private constructor(private val context: Context) {
         val now = System.currentTimeMillis()
         val lower = reason.lowercase()
         val recovery = resilienceEngine.recoveryPlan(reason)
-        listOf(track.streamUrl, track.videoStreamUrl)
+        val attributedUrl = failedUrl?.takeIf { it.isNotBlank() }
+            ?: if (isVideoMode) {
+                track.videoStreamUrl.ifBlank { track.streamUrl }
+            } else {
+                track.streamUrl
+            }.takeIf { it.isNotBlank() }
+        val quarantineTargets = if (isCandidateLevelPlaybackFailure(failureKind)) {
+            listOfNotNull(attributedUrl)
+        } else {
+            listOf(track.streamUrl, track.videoStreamUrl)
+        }
+        quarantineTargets
             .filter { it.isNotBlank() }
             .forEach { quarantinePlaybackUrl(it, now + recovery.quarantineMs, now) }
         if (recovery.rotateClient) {
@@ -598,7 +610,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         if (recovery.rotateCodec && !isOfflineExport) {
             videoSelector.reportPlaybackFailure(track.videoStreamUrl.ifBlank { track.streamUrl }, lower)
         }
-        if (!isOfflineExport && isCandidateLevelPlaybackFailure(failureKind)) {
+        if (!isOfflineExport && attributedUrl != null && isCandidateLevelPlaybackFailure(failureKind)) {
             promoteAlternateCandidate(track, isVideoMode, audioQuality)
         }
         val sourceMatchQuarantineMs = when {

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -15,6 +15,7 @@ import com.luc4n3x.levyra.domain.ResolvedPlaybackManifest
 import com.luc4n3x.levyra.domain.LevyraPersonalOrbit
 import com.luc4n3x.levyra.domain.Track
 import com.luc4n3x.levyra.domain.hasVideoPlaybackPayload
+import com.luc4n3x.levyra.player.sabr.SabrStreamSpec
 import com.luc4n3x.levyra.runtime.RuntimeHooks
 import com.luc4n3x.levyra.runtime.RuntimeSignal
 import kotlinx.coroutines.CancellationException
@@ -623,7 +624,7 @@ class PlaybackResolver private constructor(private val context: Context) {
     private fun promoteAlternateCandidate(track: Track, isVideoMode: Boolean, audioQuality: String?) {
         val manifest = track.playbackManifest ?: return
         val burned = manifest.streams.count { isPlaybackUrlBlocked(it.url) }
-        if (burned > MAX_PROMOTED_PLAYBACK_CANDIDATES) return
+        if (burned >= MAX_PROMOTED_PLAYBACK_CANDIDATES) return
         val promoted = promoteAlternatePlaybackCandidate(
             manifest = manifest,
             isVideoMode = isVideoMode,
@@ -2320,6 +2321,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         trustAttestedGoogleVideo: Boolean = true
     ): Boolean {
         if (url.isBlank() || !streamStillFresh(url) || !isDirectAudioUrl(url)) return false
+        if (SabrStreamSpec.isSabrUri(url)) return SabrStreamSpec.parse(url) != null
         if (trustAttestedGoogleVideo && isTrustedGoogleVideoUrl(url) && url.containsQueryParameter("pot")) return true
         val request = Request.Builder()
             .url(url)

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSabrDelivery.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSabrDelivery.kt
@@ -1,0 +1,134 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.domain.PlaybackDeliveryMethod
+import com.luc4n3x.levyra.domain.PlaybackStreamDescriptor
+import com.luc4n3x.levyra.domain.PlaybackStreamKind
+import com.luc4n3x.levyra.player.sabr.SabrEndpoint
+import com.luc4n3x.levyra.player.sabr.SabrFormatId
+import com.luc4n3x.levyra.player.sabr.SabrStreamSpec
+import java.util.Base64
+
+/** One adaptive format as the player response describes it, reduced to what SABR delivery needs. */
+internal data class SabrFormatCandidate(
+    val itag: Int,
+    val lastModified: Long,
+    val mimeType: String,
+    val contentLength: Long,
+    val bitrate: Int = 0,
+    val averageBitrate: Int = 0,
+    val sampleRate: Int = 0,
+    val width: Int = 0,
+    val height: Int = 0,
+    val fps: Int = 0,
+    val qualityLabel: String = ""
+) {
+    val isAudio: Boolean get() = mimeType.startsWith("audio/", ignoreCase = true)
+    val isVideo: Boolean get() = mimeType.startsWith("video/", ignoreCase = true)
+
+    fun formatId(): SabrFormatId = SabrFormatId(itag, lastModified)
+
+    fun isUsable(): Boolean =
+        itag > 0 && lastModified > 0L && contentLength > 0L && (isAudio || isVideo)
+}
+
+/**
+ * Builds the descriptor for one SABR-delivered format.
+ *
+ * The descriptive query on the returned URL is not sent anywhere: it mirrors the shape of a direct
+ * Googlevideo URL so the resolver's existing freshness, MIME and playability checks read a SABR
+ * stream exactly the way they read a progressive one.
+ */
+internal fun buildSabrStreamDescriptor(
+    endpointUrl: String,
+    ustreamerConfig: ByteArray,
+    candidate: SabrFormatCandidate,
+    companionAudio: SabrFormatCandidate?,
+    durationMs: Long,
+    clientName: Int,
+    clientVersion: String,
+    userAgent: String,
+    expiresAtMs: Long
+): PlaybackStreamDescriptor? {
+    if (!SabrEndpoint.isAllowed(endpointUrl)) return null
+    if (ustreamerConfig.isEmpty() || durationMs <= 0L || !candidate.isUsable()) return null
+    if (companionAudio != null && (!companionAudio.isUsable() || !companionAudio.isAudio)) return null
+    if (candidate.isVideo && companionAudio == null) return null
+
+    val spec = SabrStreamSpec(
+        endpointUrl = endpointUrl,
+        ustreamerConfig = ustreamerConfig,
+        format = candidate.formatId(),
+        companionAudioFormat = companionAudio?.formatId(),
+        contentLength = candidate.contentLength,
+        durationMs = durationMs,
+        videoTrack = candidate.isVideo,
+        clientName = clientName,
+        clientVersion = clientVersion,
+        userAgent = userAgent
+    )
+    val mimeType = candidate.mimeType.substringBefore(';').trim()
+    val url = buildString {
+        append(spec.toUri())
+        append("?itag=").append(candidate.itag)
+        append("&mime=").append(mimeType.replace("/", "%2F"))
+        expiresAtMs.takeIf { it > 0L }?.let { append("&expire=").append(it / 1000L) }
+    }
+    return PlaybackStreamDescriptor(
+        url = url,
+        kind = if (candidate.isVideo) PlaybackStreamKind.VIDEO else PlaybackStreamKind.AUDIO,
+        deliveryMethod = PlaybackDeliveryMethod.SABR,
+        container = mimeType.substringAfter('/', ""),
+        mimeType = mimeType,
+        codec = candidate.mimeType.substringAfter("codecs=", "").trim('"', ' '),
+        bitrate = candidate.bitrate,
+        averageBitrate = candidate.averageBitrate,
+        sampleRate = candidate.sampleRate,
+        width = candidate.width,
+        height = candidate.height,
+        fps = candidate.fps,
+        itag = candidate.itag,
+        qualityLabel = candidate.qualityLabel,
+        expiresAtMs = expiresAtMs,
+        selected = false
+    )
+}
+
+/**
+ * SABR audio candidates ordered the way Levyra would pick a direct audio stream, so the fallback
+ * inherits the user's quality preference instead of introducing a second selector.
+ */
+internal fun orderSabrAudioCandidates(
+    candidates: List<SabrFormatCandidate>,
+    preferHighestBitrate: Boolean
+): List<SabrFormatCandidate> {
+    val usable = candidates.filter { it.isUsable() && it.isAudio }
+    val byBitrate = compareBy<SabrFormatCandidate> { it.averageBitrate.coerceAtLeast(it.bitrate) }
+    return usable.sortedWith(if (preferHighestBitrate) byBitrate.reversed() else byBitrate)
+}
+
+/**
+ * SABR video candidates capped at [maxHeight] so server-driven delivery can never hand the device a
+ * resolution Levyra already decided it should not decode.
+ */
+internal fun orderSabrVideoCandidates(
+    candidates: List<SabrFormatCandidate>,
+    maxHeight: Int
+): List<SabrFormatCandidate> = candidates
+    .filter { it.isUsable() && it.isVideo && (maxHeight <= 0 || it.height <= maxHeight) }
+    .sortedWith(
+        compareByDescending<SabrFormatCandidate> { it.height }
+            .thenByDescending { it.averageBitrate.coerceAtLeast(it.bitrate) }
+    )
+
+/** The player response encodes the ustreamer config as URL-safe base64 with optional padding. */
+internal fun decodeSabrUstreamerConfig(value: String): ByteArray? {
+    val trimmed = value.trim()
+    if (trimmed.isEmpty() || trimmed.length > MAX_USTREAMER_CONFIG_CHARS) return null
+    val normalized = trimmed.replace('-', '+').replace('_', '/').trimEnd('=')
+    val padding = (4 - normalized.length % 4) % 4
+    return runCatching {
+        Base64.getDecoder().decode(normalized + "=".repeat(padding))
+    }.getOrNull()?.takeIf { it.isNotEmpty() }
+}
+
+private const val MAX_USTREAMER_CONFIG_CHARS = 16 * 1024

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSabrDelivery.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSabrDelivery.kt
@@ -8,7 +8,6 @@ import com.luc4n3x.levyra.player.sabr.SabrFormatId
 import com.luc4n3x.levyra.player.sabr.SabrStreamSpec
 import java.util.Base64
 
-/** One adaptive format as the player response describes it, reduced to what SABR delivery needs. */
 internal data class SabrFormatCandidate(
     val itag: Int,
     val lastModified: Long,
@@ -31,13 +30,6 @@ internal data class SabrFormatCandidate(
         itag > 0 && lastModified > 0L && contentLength > 0L && (isAudio || isVideo)
 }
 
-/**
- * Builds the descriptor for one SABR-delivered format.
- *
- * The descriptive query on the returned URL is not sent anywhere: it mirrors the shape of a direct
- * Googlevideo URL so the resolver's existing freshness, MIME and playability checks read a SABR
- * stream exactly the way they read a progressive one.
- */
 internal fun buildSabrStreamDescriptor(
     endpointUrl: String,
     ustreamerConfig: ByteArray,
@@ -93,10 +85,6 @@ internal fun buildSabrStreamDescriptor(
     )
 }
 
-/**
- * SABR audio candidates ordered the way Levyra would pick a direct audio stream, so the fallback
- * inherits the user's quality preference instead of introducing a second selector.
- */
 internal fun orderSabrAudioCandidates(
     candidates: List<SabrFormatCandidate>,
     preferHighestBitrate: Boolean
@@ -106,10 +94,6 @@ internal fun orderSabrAudioCandidates(
     return usable.sortedWith(if (preferHighestBitrate) byBitrate.reversed() else byBitrate)
 }
 
-/**
- * SABR video candidates capped at [maxHeight] so server-driven delivery can never hand the device a
- * resolution Levyra already decided it should not decode.
- */
 internal fun orderSabrVideoCandidates(
     candidates: List<SabrFormatCandidate>,
     maxHeight: Int
@@ -120,7 +104,6 @@ internal fun orderSabrVideoCandidates(
             .thenByDescending { it.averageBitrate.coerceAtLeast(it.bitrate) }
     )
 
-/** The player response encodes the ustreamer config as URL-safe base64 with optional padding. */
 internal fun decodeSabrUstreamerConfig(value: String): ByteArray? {
     val trimmed = value.trim()
     if (trimmed.isEmpty() || trimmed.length > MAX_USTREAMER_CONFIG_CHARS) return null

--- a/app/src/main/java/com/luc4n3x/levyra/domain/PlaybackManifest.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/PlaybackManifest.kt
@@ -42,7 +42,6 @@ data class PlaybackStreamDescriptor(
 
     fun isMp4Audio(): Boolean {
         if (kind != PlaybackStreamKind.AUDIO) return false
-        // SABR is a session transport, not a downloadable file, whatever its media type says.
         if (deliveryMethod == PlaybackDeliveryMethod.HLS || deliveryMethod == PlaybackDeliveryMethod.SABR) {
             return false
         }

--- a/app/src/main/java/com/luc4n3x/levyra/domain/PlaybackManifest.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/PlaybackManifest.kt
@@ -11,6 +11,7 @@ enum class PlaybackDeliveryMethod {
     PROGRESSIVE,
     HLS,
     DASH,
+    SABR,
     UNKNOWN
 }
 
@@ -40,7 +41,11 @@ data class PlaybackStreamDescriptor(
     }
 
     fun isMp4Audio(): Boolean {
-        if (kind != PlaybackStreamKind.AUDIO || deliveryMethod == PlaybackDeliveryMethod.HLS) return false
+        if (kind != PlaybackStreamKind.AUDIO) return false
+        // SABR is a session transport, not a downloadable file, whatever its media type says.
+        if (deliveryMethod == PlaybackDeliveryMethod.HLS || deliveryMethod == PlaybackDeliveryMethod.SABR) {
+            return false
+        }
         val normalizedContainer = container.trim().lowercase()
         val normalizedMimeType = mimeType.substringBefore(';').trim().lowercase()
         val normalizedUrl = url.lowercase()

--- a/app/src/main/java/com/luc4n3x/levyra/player/GooglevideoMediaNetwork.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/GooglevideoMediaNetwork.kt
@@ -1,0 +1,84 @@
+package com.luc4n3x.levyra.player
+
+/**
+ * Googlevideo media hosts are shaped `rr<n>---<media-network>.googlevideo.com` and the signed
+ * `mn` query parameter lists the media networks that serve the same signed resource. Rewriting only
+ * the media-network label keeps path, query and signature intact, so an unreachable edge can be
+ * retried on an equivalent one without a fresh player response.
+ */
+internal object GooglevideoMediaNetwork {
+    const val MAX_ALTERNATE_CANDIDATES = 3
+
+    private const val HTTPS_PREFIX = "https://"
+    private const val GOOGLEVIDEO_SUFFIX = ".googlevideo.com"
+    private const val MEDIA_NETWORK_SEPARATOR = "---"
+    private val hostPrefixPattern = Regex("^[a-z0-9-]{1,32}$")
+    private val mediaNetworkPattern = Regex("^[a-z0-9-]{1,48}$")
+    private val endpointFailureStatuses = setOf(404, 500, 502, 503, 504)
+
+    /**
+     * A missing status is a transport failure that never reached the edge. Everything else must be
+     * an endpoint-level answer: security answers such as 403 or 401 describe the URL, not the edge,
+     * and retrying them elsewhere would hide the signal the security recovery path depends on.
+     */
+    fun isEndpointFailure(responseCode: Int?): Boolean =
+        responseCode == null || responseCode in endpointFailureStatuses
+
+    fun isGooglevideoHost(host: String): Boolean {
+        val normalized = host.lowercase().trimEnd('.')
+        return normalized.endsWith(GOOGLEVIDEO_SUFFIX) && normalized.length > GOOGLEVIDEO_SUFFIX.length
+    }
+
+    /**
+     * Ordered alternate absolute URLs for [url], never including [url] itself. Empty when the URL is
+     * not an eligible Googlevideo media URL or exposes no other usable media network.
+     */
+    fun alternateUrls(url: String, limit: Int = MAX_ALTERNATE_CANDIDATES): List<String> {
+        if (limit <= 0 || !url.startsWith(HTTPS_PREFIX, ignoreCase = true)) return emptyList()
+        val authorityEnd = url.indexOfAnyOrEnd(HTTPS_PREFIX.length, '/', '?', '#')
+        val authority = url.substring(HTTPS_PREFIX.length, authorityEnd)
+        if (authority.isEmpty() || authority.contains('@') || authority.contains(':')) return emptyList()
+
+        val host = authority.lowercase().trimEnd('.')
+        if (!isGooglevideoHost(host)) return emptyList()
+        val label = host.removeSuffix(GOOGLEVIDEO_SUFFIX)
+        val separator = label.indexOf(MEDIA_NETWORK_SEPARATOR)
+        if (separator <= 0) return emptyList()
+        val prefix = label.substring(0, separator)
+        val current = label.substring(separator + MEDIA_NETWORK_SEPARATOR.length)
+        if (!hostPrefixPattern.matches(prefix) || !mediaNetworkPattern.matches(current)) return emptyList()
+
+        val declared = queryParameter(url, authorityEnd, "mn") ?: return emptyList()
+        val suffix = url.substring(authorityEnd)
+        return declared.split(',')
+            .asSequence()
+            .map { it.trim().lowercase() }
+            .filter { it.isNotEmpty() && it != current && mediaNetworkPattern.matches(it) }
+            .distinct()
+            .take(limit)
+            .map { network -> "$HTTPS_PREFIX$prefix$MEDIA_NETWORK_SEPARATOR$network$GOOGLEVIDEO_SUFFIX$suffix" }
+            .toList()
+    }
+
+    private fun queryParameter(url: String, authorityEnd: Int, name: String): String? {
+        val queryStart = url.indexOf('?', authorityEnd)
+        if (queryStart < 0) return null
+        val fragmentStart = url.indexOf('#', queryStart).takeIf { it >= 0 } ?: url.length
+        val query = url.substring(queryStart + 1, fragmentStart)
+        for (pair in query.split('&')) {
+            val separator = pair.indexOf('=')
+            if (separator <= 0) continue
+            if (pair.regionMatches(0, name, 0, separator, ignoreCase = false) && separator == name.length) {
+                return pair.substring(separator + 1).takeIf { it.isNotBlank() }
+            }
+        }
+        return null
+    }
+
+    private fun String.indexOfAnyOrEnd(from: Int, vararg characters: Char): Int {
+        for (index in from until length) {
+            if (this[index] in characters) return index
+        }
+        return length
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/player/GooglevideoMediaNetwork.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/GooglevideoMediaNetwork.kt
@@ -1,11 +1,5 @@
 package com.luc4n3x.levyra.player
 
-/**
- * Googlevideo media hosts are shaped `rr<n>---<media-network>.googlevideo.com` and the signed
- * `mn` query parameter lists the media networks that serve the same signed resource. Rewriting only
- * the media-network label keeps path, query and signature intact, so an unreachable edge can be
- * retried on an equivalent one without a fresh player response.
- */
 internal object GooglevideoMediaNetwork {
     const val MAX_ALTERNATE_CANDIDATES = 3
 
@@ -16,11 +10,6 @@ internal object GooglevideoMediaNetwork {
     private val mediaNetworkPattern = Regex("^[a-z0-9-]{1,48}$")
     private val endpointFailureStatuses = setOf(404, 500, 502, 503, 504)
 
-    /**
-     * A missing status is a transport failure that never reached the edge. Everything else must be
-     * an endpoint-level answer: security answers such as 403 or 401 describe the URL, not the edge,
-     * and retrying them elsewhere would hide the signal the security recovery path depends on.
-     */
     fun isEndpointFailure(responseCode: Int?): Boolean =
         responseCode == null || responseCode in endpointFailureStatuses
 
@@ -29,10 +18,6 @@ internal object GooglevideoMediaNetwork {
         return normalized.endsWith(GOOGLEVIDEO_SUFFIX) && normalized.length > GOOGLEVIDEO_SUFFIX.length
     }
 
-    /**
-     * Ordered alternate absolute URLs for [url], never including [url] itself. Empty when the URL is
-     * not an eligible Googlevideo media URL or exposes no other usable media network.
-     */
     fun alternateUrls(url: String, limit: Int = MAX_ALTERNATE_CANDIDATES): List<String> {
         if (limit <= 0 || !url.startsWith(HTTPS_PREFIX, ignoreCase = true)) return emptyList()
         val authorityEnd = url.indexOfAnyOrEnd(HTTPS_PREFIX.length, '/', '?', '#')

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraYoutubeDataSource.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraYoutubeDataSource.kt
@@ -7,6 +7,7 @@ import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DataSpec
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.TransferListener
+import androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException
 import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper
 import timber.log.Timber
 import java.io.IOException
@@ -17,6 +18,7 @@ class LevyraYoutubeDataSource private constructor(
     private val delegate: DataSource
 ) : DataSource {
     private var openedSpec: DataSpec? = null
+    private var activeUri: Uri? = null
     private var bytesReadSinceOpen = 0L
     private var readRetries = 0
 
@@ -38,6 +40,7 @@ class LevyraYoutubeDataSource private constructor(
 
     override fun open(dataSpec: DataSpec): Long {
         openedSpec = dataSpec
+        activeUri = dataSpec.uri
         bytesReadSinceOpen = 0L
         readRetries = 0
         return openDelegate(dataSpec)
@@ -46,8 +49,17 @@ class LevyraYoutubeDataSource private constructor(
     private fun openDelegate(dataSpec: DataSpec): Long {
         val originalUrl = dataSpec.uri.toString()
         if (!isYoutubeMediaUrl(dataSpec.uri)) return delegate.open(dataSpec)
-        val adaptedUri = appendRequestNumber(dataSpec.uri)
         val headers = requestHeaders(originalUrl)
+        try {
+            return openWithHeaders(dataSpec, headers)
+        } catch (error: IOException) {
+            if (!isMediaNetworkFailure(error)) throw error
+            return openOnAlternateMediaNetwork(dataSpec, headers, error)
+        }
+    }
+
+    private fun openWithHeaders(dataSpec: DataSpec, headers: Map<String, String>): Long {
+        val adaptedUri = appendRequestNumber(dataSpec.uri)
         val httpDelegate = delegate as? HttpDataSource
         if (httpDelegate != null) {
             httpDelegate.clearAllRequestProperties()
@@ -57,6 +69,35 @@ class LevyraYoutubeDataSource private constructor(
             .withUri(adaptedUri)
             .withAdditionalHeaders(headers.filterKeys { !it.equals("User-Agent", true) })
         return delegate.open(adaptedSpec)
+    }
+
+    private fun openOnAlternateMediaNetwork(
+        dataSpec: DataSpec,
+        headers: Map<String, String>,
+        failure: IOException
+    ): Long {
+        val alternates = GooglevideoMediaNetwork.alternateUrls(dataSpec.uri.toString())
+        for (candidate in alternates) {
+            runCatching { delegate.close() }
+            val candidateUri = Uri.parse(candidate)
+            try {
+                val opened = openWithHeaders(dataSpec.withUri(candidateUri), headers)
+                activeUri = candidateUri
+                Timber.i("googlevideo media network failover applied")
+                return opened
+            } catch (retryFailure: IOException) {
+                if (!isMediaNetworkFailure(retryFailure)) throw retryFailure
+            }
+        }
+        throw failure
+    }
+
+    private fun isMediaNetworkFailure(error: IOException): Boolean {
+        val responseCode = generateSequence(error as Throwable) { it.cause }
+            .filterIsInstance<InvalidResponseCodeException>()
+            .firstOrNull()
+            ?.responseCode
+        return GooglevideoMediaNetwork.isEndpointFailure(responseCode)
     }
 
     override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
@@ -83,6 +124,7 @@ class LevyraYoutubeDataSource private constructor(
         if (remaining == 0L) return false
         readRetries++
         val resumeSpec = original.buildUpon()
+            .setUri(activeUri ?: original.uri)
             .setPosition(original.position + bytesReadSinceOpen)
             .setLength(remaining)
             .build()
@@ -102,6 +144,7 @@ class LevyraYoutubeDataSource private constructor(
 
     override fun close() {
         openedSpec = null
+        activeUri = null
         bytesReadSinceOpen = 0L
         readRetries = 0
         delegate.close()

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraYoutubeDataSource.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraYoutubeDataSource.kt
@@ -76,9 +76,9 @@ class LevyraYoutubeDataSource private constructor(
         headers: Map<String, String>,
         failure: IOException
     ): Long {
+        runCatching { delegate.close() }
         val alternates = GooglevideoMediaNetwork.alternateUrls(dataSpec.uri.toString())
         for (candidate in alternates) {
-            runCatching { delegate.close() }
             val candidateUri = Uri.parse(candidate)
             try {
                 val opened = openWithHeaders(dataSpec.withUri(candidateUri), headers)
@@ -86,6 +86,7 @@ class LevyraYoutubeDataSource private constructor(
                 Timber.i("googlevideo media network failover applied")
                 return opened
             } catch (retryFailure: IOException) {
+                runCatching { delegate.close() }
                 if (!isMediaNetworkFailure(retryFailure)) throw retryFailure
             }
         }

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -76,6 +76,8 @@ import com.luc4n3x.levyra.feature.cast.LocalPlaybackSnapshot
 import com.luc4n3x.levyra.player.queue.PersistentQueueEngine
 import com.luc4n3x.levyra.player.queue.PlaybackQueueSnapshot
 import com.luc4n3x.levyra.player.queue.playbackQueueIdentity
+import com.luc4n3x.levyra.player.sabr.SabrDataSource
+import com.luc4n3x.levyra.player.sabr.SabrStreamSpec
 import com.luc4n3x.levyra.runtime.RuntimeHooks
 import com.luc4n3x.levyra.runtime.RuntimeSignal
 import com.luc4n3x.levyra.widget.LevyraWidgetBridge
@@ -370,7 +372,8 @@ class PlaybackService : MediaLibraryService() {
         val mergingFactory = LevyraMediaSourceFactory(
             defaultFactory,
             cacheDataSourceFactory,
-            localDataSourceFactory
+            localDataSourceFactory,
+            SabrDataSource.Factory(baseHttpFactory)
         ).apply {
             setLoadErrorHandlingPolicy(LevyraPlaybackLoadErrorHandlingPolicy)
         }
@@ -2295,7 +2298,8 @@ private object LevyraPlaybackLoadErrorHandlingPolicy : LoadErrorHandlingPolicy {
 private class LevyraMediaSourceFactory(
     private val delegate: DefaultMediaSourceFactory,
     private val dataSourceFactory: DataSource.Factory,
-    private val localDataSourceFactory: DataSource.Factory
+    private val localDataSourceFactory: DataSource.Factory,
+    private val sabrDataSourceFactory: DataSource.Factory
 ) : MediaSource.Factory {
     private var loadErrorHandlingPolicy: LoadErrorHandlingPolicy = LevyraPlaybackLoadErrorHandlingPolicy
 
@@ -2360,6 +2364,13 @@ private class LevyraMediaSourceFactory(
     private fun mediaSourceFor(mediaItem: MediaItem): MediaSource {
         val localUri = mediaItem.localConfiguration?.uri
         val scheme = localUri?.scheme.orEmpty().lowercase()
+        if (SabrStreamSpec.isSabrUri(localUri?.toString().orEmpty())) {
+            // SABR responses are session-scoped, so they never reach the shared media cache.
+            val sabrItem = mediaItem.buildUpon().setCustomCacheKey(null).build()
+            return ProgressiveMediaSource.Factory(sabrDataSourceFactory)
+                .setLoadErrorHandlingPolicy(loadErrorHandlingPolicy)
+                .createMediaSource(sabrItem)
+        }
         if (scheme == "content" || scheme == "file") {
             val localItem = mediaItem.buildUpon().setCustomCacheKey(null).build()
             return ProgressiveMediaSource.Factory(localDataSourceFactory)

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackService.kt
@@ -1821,7 +1821,6 @@ class PlaybackService : MediaLibraryService() {
             .apply()
     }
 
-
     private data class ServiceRecoveryPlan(
         val localPlayback: Boolean,
         val delaysMs: LongArray,
@@ -2365,7 +2364,6 @@ private class LevyraMediaSourceFactory(
         val localUri = mediaItem.localConfiguration?.uri
         val scheme = localUri?.scheme.orEmpty().lowercase()
         if (SabrStreamSpec.isSabrUri(localUri?.toString().orEmpty())) {
-            // SABR responses are session-scoped, so they never reach the shared media cache.
             val sabrItem = mediaItem.buildUpon().setCustomCacheKey(null).build()
             return ProgressiveMediaSource.Factory(sabrDataSourceFactory)
                 .setLoadErrorHandlingPolicy(loadErrorHandlingPolicy)

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackWarmup.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackWarmup.kt
@@ -24,17 +24,23 @@ internal data class VideoWarmupPlan(
     val probeUrl: String
 )
 
+/**
+ * A SABR stream is served by its own session transport, so warming it through the plain HTTP stack
+ * would only issue a request that cannot succeed.
+ */
+internal fun isWarmableMediaUrl(url: String): Boolean = url.startsWith("https://", ignoreCase = true)
+
 internal fun videoWarmupPlan(track: Track): VideoWarmupPlan {
     val splitVideo = track.videoStreamUrl.trim()
     return if (splitVideo.isNotBlank()) {
         VideoWarmupPlan(
-            cachePrimaryAsAudio = track.streamUrl.isNotBlank(),
-            probeUrl = splitVideo
+            cachePrimaryAsAudio = isWarmableMediaUrl(track.streamUrl.trim()),
+            probeUrl = splitVideo.takeIf(::isWarmableMediaUrl).orEmpty()
         )
     } else {
         VideoWarmupPlan(
             cachePrimaryAsAudio = false,
-            probeUrl = track.streamUrl.trim()
+            probeUrl = track.streamUrl.trim().takeIf(::isWarmableMediaUrl).orEmpty()
         )
     }
 }
@@ -45,7 +51,7 @@ class PlaybackWarmup(context: Context) {
     private val primeLocks = ConcurrentHashMap<String, Mutex>()
 
     suspend fun prime(track: Track, bytes: Long = DEFAULT_PRIME_BYTES): Boolean = primeUrl(
-        url = track.streamUrl,
+        url = track.streamUrl.takeIf(::isWarmableMediaUrl).orEmpty(),
         cacheKey = LevyraPlaybackCacheKey.stream(track),
         bytes = bytes
     )

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackWarmup.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackWarmup.kt
@@ -24,10 +24,6 @@ internal data class VideoWarmupPlan(
     val probeUrl: String
 )
 
-/**
- * A SABR stream is served by its own session transport, so warming it through the plain HTTP stack
- * would only issue a request that cannot succeed.
- */
 internal fun isWarmableMediaUrl(url: String): Boolean = url.startsWith("https://", ignoreCase = true)
 
 internal fun videoWarmupPlan(track: Track): VideoWarmupPlan {

--- a/app/src/main/java/com/luc4n3x/levyra/player/sabr/ProtoCodec.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/sabr/ProtoCodec.kt
@@ -1,0 +1,140 @@
+package com.luc4n3x.levyra.player.sabr
+
+import java.io.ByteArrayOutputStream
+
+internal const val PROTO_WIRE_VARINT = 0
+internal const val PROTO_WIRE_FIXED64 = 1
+internal const val PROTO_WIRE_LENGTH_DELIMITED = 2
+internal const val PROTO_WIRE_FIXED32 = 5
+
+/**
+ * Just enough protocol-buffer encoding for the SABR request bodies Levyra sends. A full runtime
+ * would add hundreds of generated classes to the APK for the handful of fields this path uses.
+ */
+internal class ProtoWriter {
+    private val output = ByteArrayOutputStream(256)
+
+    /**
+     * Zero values are written explicitly. The SABR server treats an omitted buffered-range start or
+     * track-type bitfield differently from an explicit zero, and dropping them makes a video session
+     * receive the audio bytes the audio session already owns.
+     */
+    fun varint(field: Int, value: Long): ProtoWriter {
+        tag(field, PROTO_WIRE_VARINT)
+        writeVarint(value)
+        return this
+    }
+
+    fun bytes(field: Int, value: ByteArray): ProtoWriter {
+        tag(field, PROTO_WIRE_LENGTH_DELIMITED)
+        writeVarint(value.size.toLong())
+        output.write(value)
+        return this
+    }
+
+    fun string(field: Int, value: String): ProtoWriter = bytes(field, value.toByteArray(Charsets.UTF_8))
+
+    fun message(field: Int, value: ProtoWriter): ProtoWriter = bytes(field, value.toByteArray())
+
+    fun toByteArray(): ByteArray = output.toByteArray()
+
+    private fun tag(field: Int, wireType: Int) {
+        writeVarint(((field.toLong() shl 3) or wireType.toLong()))
+    }
+
+    private fun writeVarint(value: Long) {
+        var remaining = value
+        while (true) {
+            val chunk = (remaining and 0x7FL).toInt()
+            remaining = remaining ushr 7
+            if (remaining == 0L) {
+                output.write(chunk)
+                return
+            }
+            output.write(chunk or 0x80)
+        }
+    }
+}
+
+/** Forward-only reader over a single protocol-buffer message held in memory. */
+internal class ProtoReader(
+    private val data: ByteArray,
+    private var position: Int,
+    private val limit: Int
+) {
+    var field: Int = 0
+        private set
+    var wireType: Int = 0
+        private set
+
+    fun next(): Boolean {
+        if (position >= limit) return false
+        val key = readVarint()
+        field = (key ushr 3).toInt()
+        wireType = (key and 7L).toInt()
+        if (field <= 0) throw SabrProtocolException("invalid protobuf field number")
+        return true
+    }
+
+    fun readVarintValue(): Long {
+        requireWireType(wireType == PROTO_WIRE_VARINT)
+        return readVarint()
+    }
+
+    fun readBytesValue(): ByteArray {
+        val length = readLengthDelimitedLength()
+        val value = data.copyOfRange(position, position + length)
+        position += length
+        return value
+    }
+
+    fun readStringValue(): String {
+        val length = readLengthDelimitedLength()
+        val value = String(data, position, length, Charsets.UTF_8)
+        position += length
+        return value
+    }
+
+    fun skipValue() {
+        when (wireType) {
+            PROTO_WIRE_VARINT -> readVarint()
+            PROTO_WIRE_FIXED64 -> advance(8)
+            PROTO_WIRE_LENGTH_DELIMITED -> advance(readLengthDelimitedLength())
+            PROTO_WIRE_FIXED32 -> advance(4)
+            else -> throw SabrProtocolException("unsupported protobuf wire type $wireType")
+        }
+    }
+
+    private fun readLengthDelimitedLength(): Int {
+        requireWireType(wireType == PROTO_WIRE_LENGTH_DELIMITED)
+        val length = readVarint()
+        if (length < 0L || length > (limit - position).toLong()) {
+            throw SabrProtocolException("protobuf length out of bounds")
+        }
+        return length.toInt()
+    }
+
+    private fun advance(count: Int) {
+        if (count < 0 || position + count > limit) throw SabrProtocolException("protobuf value out of bounds")
+        position += count
+    }
+
+    private fun readVarint(): Long {
+        var result = 0L
+        var shift = 0
+        while (shift <= 63) {
+            if (position >= limit) throw SabrProtocolException("truncated protobuf varint")
+            val current = data[position++].toInt() and 0xFF
+            result = result or ((current and 0x7F).toLong() shl shift)
+            if (current and 0x80 == 0) return result
+            shift += 7
+        }
+        throw SabrProtocolException("protobuf varint too long")
+    }
+
+    private fun requireWireType(condition: Boolean) {
+        if (!condition) throw SabrProtocolException("unexpected protobuf wire type $wireType for field $field")
+    }
+}
+
+internal class SabrProtocolException(message: String) : java.io.IOException(message)

--- a/app/src/main/java/com/luc4n3x/levyra/player/sabr/ProtoCodec.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/sabr/ProtoCodec.kt
@@ -7,18 +7,9 @@ internal const val PROTO_WIRE_FIXED64 = 1
 internal const val PROTO_WIRE_LENGTH_DELIMITED = 2
 internal const val PROTO_WIRE_FIXED32 = 5
 
-/**
- * Just enough protocol-buffer encoding for the SABR request bodies Levyra sends. A full runtime
- * would add hundreds of generated classes to the APK for the handful of fields this path uses.
- */
 internal class ProtoWriter {
     private val output = ByteArrayOutputStream(256)
 
-    /**
-     * Zero values are written explicitly. The SABR server treats an omitted buffered-range start or
-     * track-type bitfield differently from an explicit zero, and dropping them makes a video session
-     * receive the audio bytes the audio session already owns.
-     */
     fun varint(field: Int, value: Long): ProtoWriter {
         tag(field, PROTO_WIRE_VARINT)
         writeVarint(value)
@@ -56,7 +47,6 @@ internal class ProtoWriter {
     }
 }
 
-/** Forward-only reader over a single protocol-buffer message held in memory. */
 internal class ProtoReader(
     private val data: ByteArray,
     private var position: Int,

--- a/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrDataSource.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrDataSource.kt
@@ -9,6 +9,7 @@ import androidx.media3.datasource.DataSpec
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException
 import com.luc4n3x.levyra.player.GooglevideoMediaNetwork
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import timber.log.Timber
 import java.io.IOException
 import java.io.InputStream
@@ -33,6 +34,7 @@ internal class SabrDataSource(
     private var endpointUrl: String = ""
     private var redirectsUsed = 0
     private var endpointFailoversUsed = 0
+    private var requestNumber = 0L
     private var position = 0L
     private var bytesRemaining = 0L
     private var opened = false
@@ -54,6 +56,7 @@ internal class SabrDataSource(
         endpointUrl = parsed.endpointUrl
         redirectsUsed = 0
         endpointFailoversUsed = 0
+        requestNumber = 0L
         unproductiveRequests = 0
         producedReadableBytes = false
         position = dataSpec.position
@@ -95,6 +98,7 @@ internal class SabrDataSource(
         spec = null
         uri = null
         endpointUrl = ""
+        requestNumber = 0L
         position = 0L
         bytesRemaining = 0L
         if (wasOpen) transferEnded()
@@ -223,7 +227,7 @@ internal class SabrDataSource(
             clientVersion = current.clientVersion
         )
         val request = DataSpec.Builder()
-            .setUri(endpoint)
+            .setUri(sabrRequestEndpoint(endpoint, requestNumber))
             .setHttpMethod(DataSpec.HTTP_METHOD_POST)
             .setHttpBody(body)
             .setHttpRequestHeaders(
@@ -236,8 +240,9 @@ internal class SabrDataSource(
             )
             .build()
         val source = httpDataSourceFactory.createDataSource()
-        source.open(request)
         httpDataSource = source
+        requestNumber++
+        source.open(request)
         umpReader = UmpReader(HttpDataSourceInputStream(source))
         assembler?.reset()
         producedReadableBytes = false
@@ -313,3 +318,9 @@ internal class SabrDataSource(
         const val MAX_SUPPRESSED_SEGMENT_INDEX = 1_000_000L
     }
 }
+
+internal fun sabrRequestEndpoint(endpoint: String, requestNumber: Long): String = endpoint.toHttpUrl()
+    .newBuilder()
+    .setQueryParameter("rn", requestNumber.toString())
+    .build()
+    .toString()

--- a/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrDataSource.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrDataSource.kt
@@ -1,0 +1,328 @@
+package com.luc4n3x.levyra.player.sabr
+
+import android.net.Uri
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.BaseDataSource
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.HttpDataSource
+import androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException
+import com.luc4n3x.levyra.player.GooglevideoMediaNetwork
+import timber.log.Timber
+import java.io.IOException
+import java.io.InputStream
+
+/**
+ * Reads one YouTube SABR format as if it were the progressive resource for the same format.
+ *
+ * SABR delivers media as UMP parts whose headers carry the absolute byte offset of every chunk, and
+ * those offsets describe exactly the byte stream the direct URL would serve. Presenting that as a
+ * plain seekable stream keeps Media3's extractor, seek map, end-of-stream handling, renderers and
+ * Levyra's own player recovery unchanged: only the transport is different.
+ *
+ * Responses are parsed incrementally and never accumulated, so memory stays bounded by one UMP part.
+ */
+@UnstableApi
+internal class SabrDataSource(
+    private val httpDataSourceFactory: HttpDataSource.Factory,
+    private val maxRedirects: Int = MAX_REDIRECTS,
+    private val maxAlternateEndpoints: Int = GooglevideoMediaNetwork.MAX_ALTERNATE_CANDIDATES
+) : BaseDataSource(true) {
+
+    class Factory(
+        private val httpDataSourceFactory: HttpDataSource.Factory
+    ) : DataSource.Factory {
+        override fun createDataSource(): DataSource = SabrDataSource(httpDataSourceFactory)
+    }
+
+    private var assembler: SabrSegmentAssembler? = null
+
+    private var uri: Uri? = null
+    private var spec: SabrStreamSpec? = null
+    private var endpointUrl: String = ""
+    private var redirectsUsed = 0
+    private var endpointFailoversUsed = 0
+    private var position = 0L
+    private var bytesRemaining = 0L
+    private var opened = false
+
+    private var httpDataSource: HttpDataSource? = null
+    private var umpReader: UmpReader? = null
+    private var unproductiveRequests = 0
+    private var pendingOffset = 0
+    private var pendingRemaining = 0
+
+    override fun open(dataSpec: DataSpec): Long {
+        val parsed = SabrStreamSpec.parse(dataSpec.uri.toString())
+            ?: throw SabrProtocolException("unsupported SABR stream descriptor")
+        transferInitializing(dataSpec)
+        spec = parsed
+        assembler = SabrSegmentAssembler(parsed.format.itag)
+        uri = dataSpec.uri
+        endpointUrl = parsed.endpointUrl
+        redirectsUsed = 0
+        endpointFailoversUsed = 0
+        unproductiveRequests = 0
+        position = dataSpec.position
+        val available = (parsed.contentLength - position).coerceAtLeast(0L)
+        bytesRemaining = if (dataSpec.length == C.LENGTH_UNSET.toLong()) {
+            available
+        } else {
+            minOf(dataSpec.length, available)
+        }
+        opened = true
+        transferStarted(dataSpec)
+        return bytesRemaining
+    }
+
+    override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+        if (length == 0) return 0
+        if (bytesRemaining <= 0L) return C.RESULT_END_OF_INPUT
+        while (pendingRemaining <= 0) {
+            if (!advance()) return C.RESULT_END_OF_INPUT
+        }
+        val payload = umpReader?.partPayload ?: return C.RESULT_END_OF_INPUT
+        val count = minOf(length.toLong(), pendingRemaining.toLong(), bytesRemaining).toInt()
+        System.arraycopy(payload, pendingOffset, buffer, offset, count)
+        pendingOffset += count
+        pendingRemaining -= count
+        position += count
+        bytesRemaining -= count
+        bytesTransferred(count)
+        return count
+    }
+
+    override fun getUri(): Uri? = uri
+
+    override fun close() {
+        val wasOpen = opened
+        opened = false
+        closeResponse()
+        assembler = null
+        spec = null
+        uri = null
+        endpointUrl = ""
+        position = 0L
+        bytesRemaining = 0L
+        if (wasOpen) transferEnded()
+    }
+
+    /** Fills the pending media window, returning false once the stream has no more bytes to give. */
+    private fun advance(): Boolean {
+        val current = spec ?: return false
+        while (true) {
+            if (bytesRemaining <= 0L || position >= current.contentLength) return false
+            val reader = umpReader ?: run {
+                openResponse(
+                    current,
+                    sabrPlayerTimeMsFor(
+                        contentLength = current.contentLength,
+                        durationMs = current.durationMs,
+                        position = position,
+                        unproductiveAttempts = unproductiveRequests
+                    )
+                )
+                umpReader
+            } ?: return false
+
+            val hasPart = try {
+                reader.next()
+            } catch (error: IOException) {
+                closeResponse()
+                throw error
+            }
+            if (!hasPart) {
+                closeResponse()
+                if (position >= current.contentLength) return false
+                if ((assembler?.deliveredBytes ?: 0L) <= 0L) {
+                    unproductiveRequests++
+                    if (unproductiveRequests > MAX_UNPRODUCTIVE_REQUESTS) {
+                        throw SabrProtocolException("SABR stopped delivering data before end of stream")
+                    }
+                } else {
+                    unproductiveRequests = 0
+                }
+                continue
+            }
+
+            when (reader.partType) {
+                SabrPart.MEDIA_HEADER -> onMediaHeader(reader)
+                SabrPart.MEDIA -> if (onMedia(reader)) return true
+                SabrPart.SABR_REDIRECT -> onRedirect(reader)
+                SabrPart.SABR_ERROR ->
+                    throw SabrProtocolException("SABR server reported a stream error")
+                SabrPart.RELOAD_PLAYER_RESPONSE ->
+                    throw SabrProtocolException("SABR requires a fresh player response")
+                else -> Unit
+            }
+        }
+    }
+
+    private fun onMediaHeader(reader: UmpReader) {
+        assembler?.onMediaHeader(SabrMessages.parseMediaHeader(reader.partPayload, reader.partLength))
+    }
+
+    /** Returns true when the part left readable bytes for the caller's current position. */
+    private fun onMedia(reader: UmpReader): Boolean {
+        val window = assembler?.onMedia(
+            headerId = SabrMessages.mediaHeaderId(reader.partPayload, reader.partLength),
+            payloadLength = reader.partLength - SabrSegmentAssembler.MEDIA_PAYLOAD_OFFSET,
+            position = position
+        ) ?: return false
+        pendingOffset = window.offset
+        pendingRemaining = window.length
+        return true
+    }
+
+    private fun onRedirect(reader: UmpReader) {
+        val target = SabrMessages.parseRedirectUrl(reader.partPayload, reader.partLength)
+        if (target == null || !SabrEndpoint.isAllowed(target)) {
+            throw SabrProtocolException("SABR redirect rejected")
+        }
+        if (redirectsUsed >= maxRedirects) {
+            throw SabrProtocolException("SABR redirect budget exhausted")
+        }
+        redirectsUsed++
+        endpointUrl = target
+        closeResponse()
+    }
+
+    private fun openResponse(current: SabrStreamSpec, playerTimeMs: Long) {
+        var failure: IOException? = null
+        for (candidate in endpointCandidates()) {
+            try {
+                startRequest(current, candidate, playerTimeMs)
+                if (candidate != endpointUrl) {
+                    endpointFailoversUsed++
+                    endpointUrl = candidate
+                    Timber.i("SABR endpoint failover applied")
+                }
+                return
+            } catch (error: IOException) {
+                closeResponse()
+                if (!isEndpointFailure(error)) throw error
+                failure = error
+            }
+        }
+        throw failure ?: SabrProtocolException("SABR endpoint unavailable")
+    }
+
+    private fun endpointCandidates(): List<String> {
+        val remaining = (maxAlternateEndpoints - endpointFailoversUsed).coerceAtLeast(0)
+        if (remaining == 0) return listOf(endpointUrl)
+        return listOf(endpointUrl) +
+            GooglevideoMediaNetwork.alternateUrls(endpointUrl, remaining).filter(SabrEndpoint::isAllowed)
+    }
+
+    private fun startRequest(current: SabrStreamSpec, endpoint: String, playerTimeMs: Long) {
+        val body = SabrMessages.playbackRequest(
+            ustreamerConfig = current.ustreamerConfig,
+            playerTimeMs = playerTimeMs,
+            enabledTrackTypes = if (current.videoTrack) {
+                SabrMessages.TRACK_TYPES_AUDIO_AND_VIDEO
+            } else {
+                SabrMessages.TRACK_TYPES_AUDIO_ONLY
+            },
+            preferredAudio = if (current.videoTrack) current.companionAudioFormat else current.format,
+            preferredVideo = current.format.takeIf { current.videoTrack },
+            initializedFormats = initializedFormats(current),
+            alreadyBuffered = suppressedCompanionRanges(current),
+            clientName = current.clientName,
+            clientVersion = current.clientVersion
+        )
+        val request = DataSpec.Builder()
+            .setUri(endpoint)
+            .setHttpMethod(DataSpec.HTTP_METHOD_POST)
+            .setHttpBody(body)
+            .setHttpRequestHeaders(
+                buildMap {
+                    put("Content-Type", "application/x-protobuf")
+                    put("Accept", "*/*")
+                    put("Accept-Encoding", "identity")
+                    current.userAgent.takeIf { it.isNotBlank() }?.let { put("User-Agent", it) }
+                }
+            )
+            .build()
+        val source = httpDataSourceFactory.createDataSource()
+        source.open(request)
+        httpDataSource = source
+        umpReader = UmpReader(HttpDataSourceInputStream(source))
+        assembler?.reset()
+        pendingOffset = 0
+        pendingRemaining = 0
+    }
+
+    /**
+     * Telling the server the paired audio format is already buffered is what keeps a video session
+     * from re-sending the audio bytes the audio session owns.
+     */
+    private fun suppressedCompanionRanges(current: SabrStreamSpec): List<SabrBufferedRange> {
+        val companionAudio = current.companionAudioFormat?.takeIf { current.videoTrack } ?: return emptyList()
+        return listOf(
+            SabrBufferedRange(
+                formatId = companionAudio,
+                startTimeMs = 0L,
+                durationMs = current.durationMs,
+                startSegmentIndex = 1L,
+                endSegmentIndex = MAX_SUPPRESSED_SEGMENT_INDEX
+            )
+        )
+    }
+
+    private fun initializedFormats(current: SabrStreamSpec): List<SabrFormatId> {
+        val companionAudio = current.companionAudioFormat?.takeIf { current.videoTrack }
+        // Asking for the init segment again only wastes bytes the extractor already parsed.
+        val skipInitSegment = position > 0L
+        return when {
+            companionAudio != null && skipInitSegment -> listOf(current.format, companionAudio)
+            companionAudio != null -> listOf(companionAudio)
+            skipInitSegment -> listOf(current.format)
+            else -> emptyList()
+        }
+    }
+
+    private fun isEndpointFailure(error: IOException): Boolean {
+        val responseCode = generateSequence(error as Throwable) { it.cause }
+            .filterIsInstance<InvalidResponseCodeException>()
+            .firstOrNull()
+            ?.responseCode
+        return GooglevideoMediaNetwork.isEndpointFailure(responseCode)
+    }
+
+    private fun closeResponse() {
+        umpReader = null
+        pendingOffset = 0
+        pendingRemaining = 0
+        val source = httpDataSource
+        httpDataSource = null
+        if (source != null) {
+            try {
+                source.close()
+            } catch (error: IOException) {
+                Timber.d(error, "SABR response close failed")
+            }
+        }
+    }
+
+    private class HttpDataSourceInputStream(private val source: HttpDataSource) : InputStream() {
+        private val single = ByteArray(1)
+
+        override fun read(): Int {
+            val count = read(single, 0, 1)
+            return if (count == -1) -1 else single[0].toInt() and 0xFF
+        }
+
+        override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+            if (length == 0) return 0
+            val count = source.read(buffer, offset, length)
+            return if (count == C.RESULT_END_OF_INPUT) -1 else count
+        }
+    }
+
+    private companion object {
+        const val MAX_REDIRECTS = 3
+        const val MAX_UNPRODUCTIVE_REQUESTS = 2
+        const val MAX_SUPPRESSED_SEGMENT_INDEX = 1_000_000L
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrDataSource.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrDataSource.kt
@@ -13,16 +13,6 @@ import timber.log.Timber
 import java.io.IOException
 import java.io.InputStream
 
-/**
- * Reads one YouTube SABR format as if it were the progressive resource for the same format.
- *
- * SABR delivers media as UMP parts whose headers carry the absolute byte offset of every chunk, and
- * those offsets describe exactly the byte stream the direct URL would serve. Presenting that as a
- * plain seekable stream keeps Media3's extractor, seek map, end-of-stream handling, renderers and
- * Levyra's own player recovery unchanged: only the transport is different.
- *
- * Responses are parsed incrementally and never accumulated, so memory stays bounded by one UMP part.
- */
 @UnstableApi
 internal class SabrDataSource(
     private val httpDataSourceFactory: HttpDataSource.Factory,
@@ -50,6 +40,7 @@ internal class SabrDataSource(
     private var httpDataSource: HttpDataSource? = null
     private var umpReader: UmpReader? = null
     private var unproductiveRequests = 0
+    private var producedReadableBytes = false
     private var pendingOffset = 0
     private var pendingRemaining = 0
 
@@ -64,6 +55,7 @@ internal class SabrDataSource(
         redirectsUsed = 0
         endpointFailoversUsed = 0
         unproductiveRequests = 0
+        producedReadableBytes = false
         position = dataSpec.position
         val available = (parsed.contentLength - position).coerceAtLeast(0L)
         bytesRemaining = if (dataSpec.length == C.LENGTH_UNSET.toLong()) {
@@ -108,7 +100,6 @@ internal class SabrDataSource(
         if (wasOpen) transferEnded()
     }
 
-    /** Fills the pending media window, returning false once the stream has no more bytes to give. */
     private fun advance(): Boolean {
         val current = spec ?: return false
         while (true) {
@@ -135,7 +126,7 @@ internal class SabrDataSource(
             if (!hasPart) {
                 closeResponse()
                 if (position >= current.contentLength) return false
-                if ((assembler?.deliveredBytes ?: 0L) <= 0L) {
+                if (!producedReadableBytes) {
                     unproductiveRequests++
                     if (unproductiveRequests > MAX_UNPRODUCTIVE_REQUESTS) {
                         throw SabrProtocolException("SABR stopped delivering data before end of stream")
@@ -163,7 +154,6 @@ internal class SabrDataSource(
         assembler?.onMediaHeader(SabrMessages.parseMediaHeader(reader.partPayload, reader.partLength))
     }
 
-    /** Returns true when the part left readable bytes for the caller's current position. */
     private fun onMedia(reader: UmpReader): Boolean {
         val window = assembler?.onMedia(
             headerId = SabrMessages.mediaHeaderId(reader.partPayload, reader.partLength),
@@ -172,6 +162,7 @@ internal class SabrDataSource(
         ) ?: return false
         pendingOffset = window.offset
         pendingRemaining = window.length
+        producedReadableBytes = true
         return true
     }
 
@@ -249,14 +240,11 @@ internal class SabrDataSource(
         httpDataSource = source
         umpReader = UmpReader(HttpDataSourceInputStream(source))
         assembler?.reset()
+        producedReadableBytes = false
         pendingOffset = 0
         pendingRemaining = 0
     }
 
-    /**
-     * Telling the server the paired audio format is already buffered is what keeps a video session
-     * from re-sending the audio bytes the audio session owns.
-     */
     private fun suppressedCompanionRanges(current: SabrStreamSpec): List<SabrBufferedRange> {
         val companionAudio = current.companionAudioFormat?.takeIf { current.videoTrack } ?: return emptyList()
         return listOf(
@@ -272,7 +260,6 @@ internal class SabrDataSource(
 
     private fun initializedFormats(current: SabrStreamSpec): List<SabrFormatId> {
         val companionAudio = current.companionAudioFormat?.takeIf { current.videoTrack }
-        // Asking for the init segment again only wastes bytes the extractor already parsed.
         val skipInitSegment = position > 0L
         return when {
             companionAudio != null && skipInitSegment -> listOf(current.format, companionAudio)

--- a/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrProtocol.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrProtocol.kt
@@ -6,7 +6,8 @@ internal object SabrPart {
     const val MEDIA_END = 22
     const val SABR_REDIRECT = 43
     const val SABR_ERROR = 44
-    const val RELOAD_PLAYER_RESPONSE = 45
+    const val SABR_SEEK = 45
+    const val RELOAD_PLAYER_RESPONSE = 46
 }
 
 internal data class SabrFormatId(val itag: Int, val lastModified: Long) {

--- a/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrProtocol.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrProtocol.kt
@@ -1,6 +1,5 @@
 package com.luc4n3x.levyra.player.sabr
 
-/** UMP part types Levyra acts on. Everything else is skipped without inspection. */
 internal object SabrPart {
     const val MEDIA_HEADER = 20
     const val MEDIA = 21
@@ -10,15 +9,10 @@ internal object SabrPart {
     const val RELOAD_PLAYER_RESPONSE = 45
 }
 
-/**
- * Identifies one media format inside a SABR session. lastModified is the discriminator YouTube uses
- * when the same itag is re-encoded, so it must travel with the itag everywhere.
- */
 internal data class SabrFormatId(val itag: Int, val lastModified: Long) {
     fun write(): ProtoWriter = ProtoWriter().varint(1, itag.toLong()).varint(2, lastModified)
 }
 
-/** The header that precedes every media payload, describing where it belongs in the byte stream. */
 internal data class SabrMediaHeader(
     val headerId: Int,
     val itag: Int,
@@ -75,11 +69,6 @@ internal object SabrMessages {
 
     private const val REDIRECT_FIELD_URL = 1
 
-    /**
-     * Builds one VideoPlaybackAbrRequest. [alreadyBuffered] lets a video session declare the paired
-     * audio format as fully buffered, which is how the server is told to stop sending audio bytes the
-     * audio session already owns.
-     */
     fun playbackRequest(
         ustreamerConfig: ByteArray,
         playerTimeMs: Long,
@@ -168,7 +157,6 @@ internal object SabrMessages {
         return null
     }
 
-    /** The first byte of a media part selects the header it continues. */
     fun mediaHeaderId(data: ByteArray, length: Int): Int {
         if (length <= 0) throw SabrProtocolException("empty SABR media part")
         return data[0].toInt() and 0xFF

--- a/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrProtocol.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrProtocol.kt
@@ -1,0 +1,176 @@
+package com.luc4n3x.levyra.player.sabr
+
+/** UMP part types Levyra acts on. Everything else is skipped without inspection. */
+internal object SabrPart {
+    const val MEDIA_HEADER = 20
+    const val MEDIA = 21
+    const val MEDIA_END = 22
+    const val SABR_REDIRECT = 43
+    const val SABR_ERROR = 44
+    const val RELOAD_PLAYER_RESPONSE = 45
+}
+
+/**
+ * Identifies one media format inside a SABR session. lastModified is the discriminator YouTube uses
+ * when the same itag is re-encoded, so it must travel with the itag everywhere.
+ */
+internal data class SabrFormatId(val itag: Int, val lastModified: Long) {
+    fun write(): ProtoWriter = ProtoWriter().varint(1, itag.toLong()).varint(2, lastModified)
+}
+
+/** The header that precedes every media payload, describing where it belongs in the byte stream. */
+internal data class SabrMediaHeader(
+    val headerId: Int,
+    val itag: Int,
+    val lastModified: Long,
+    val startDataRange: Long,
+    val contentLength: Long,
+    val sequenceNumber: Long,
+    val durationMs: Long,
+    val isInitSegment: Boolean
+)
+
+internal data class SabrBufferedRange(
+    val formatId: SabrFormatId,
+    val startTimeMs: Long,
+    val durationMs: Long,
+    val startSegmentIndex: Long,
+    val endSegmentIndex: Long
+) {
+    fun write(): ProtoWriter = ProtoWriter()
+        .message(1, formatId.write())
+        .varint(2, startTimeMs)
+        .varint(3, durationMs)
+        .varint(4, startSegmentIndex)
+        .varint(5, endSegmentIndex)
+}
+
+internal object SabrMessages {
+    const val TRACK_TYPES_AUDIO_AND_VIDEO = 0L
+    const val TRACK_TYPES_AUDIO_ONLY = 1L
+
+    private const val FIELD_CLIENT_ABR_STATE = 1
+    private const val FIELD_SELECTED_FORMAT_IDS = 2
+    private const val FIELD_BUFFERED_RANGES = 3
+    private const val FIELD_USTREAMER_CONFIG = 5
+    private const val FIELD_PREFERRED_AUDIO_FORMAT_IDS = 16
+    private const val FIELD_PREFERRED_VIDEO_FORMAT_IDS = 17
+    private const val FIELD_STREAMER_CONTEXT = 19
+
+    private const val ABR_FIELD_PLAYER_TIME_MS = 28
+    private const val ABR_FIELD_ENABLED_TRACK_TYPES = 40
+
+    private const val CONTEXT_FIELD_CLIENT_INFO = 1
+    private const val CLIENT_INFO_FIELD_NAME = 16
+    private const val CLIENT_INFO_FIELD_VERSION = 17
+
+    private const val MEDIA_HEADER_FIELD_ID = 1
+    private const val MEDIA_HEADER_FIELD_ITAG = 3
+    private const val MEDIA_HEADER_FIELD_LAST_MODIFIED = 4
+    private const val MEDIA_HEADER_FIELD_START_DATA_RANGE = 6
+    private const val MEDIA_HEADER_FIELD_IS_INIT_SEGMENT = 8
+    private const val MEDIA_HEADER_FIELD_SEQUENCE_NUMBER = 9
+    private const val MEDIA_HEADER_FIELD_DURATION_MS = 10
+    private const val MEDIA_HEADER_FIELD_CONTENT_LENGTH = 14
+
+    private const val REDIRECT_FIELD_URL = 1
+
+    /**
+     * Builds one VideoPlaybackAbrRequest. [alreadyBuffered] lets a video session declare the paired
+     * audio format as fully buffered, which is how the server is told to stop sending audio bytes the
+     * audio session already owns.
+     */
+    fun playbackRequest(
+        ustreamerConfig: ByteArray,
+        playerTimeMs: Long,
+        enabledTrackTypes: Long,
+        preferredAudio: SabrFormatId?,
+        preferredVideo: SabrFormatId?,
+        initializedFormats: List<SabrFormatId>,
+        alreadyBuffered: List<SabrBufferedRange>,
+        clientName: Int,
+        clientVersion: String
+    ): ByteArray {
+        val request = ProtoWriter()
+            .message(
+                FIELD_CLIENT_ABR_STATE,
+                ProtoWriter()
+                    .varint(ABR_FIELD_PLAYER_TIME_MS, playerTimeMs.coerceAtLeast(0L))
+                    .varint(ABR_FIELD_ENABLED_TRACK_TYPES, enabledTrackTypes)
+            )
+        initializedFormats.forEach { request.message(FIELD_SELECTED_FORMAT_IDS, it.write()) }
+        alreadyBuffered.forEach { request.message(FIELD_BUFFERED_RANGES, it.write()) }
+        request.bytes(FIELD_USTREAMER_CONFIG, ustreamerConfig)
+        preferredAudio?.let { request.message(FIELD_PREFERRED_AUDIO_FORMAT_IDS, it.write()) }
+        preferredVideo?.let { request.message(FIELD_PREFERRED_VIDEO_FORMAT_IDS, it.write()) }
+        request.message(
+            FIELD_STREAMER_CONTEXT,
+            ProtoWriter().message(
+                CONTEXT_FIELD_CLIENT_INFO,
+                ProtoWriter()
+                    .varint(CLIENT_INFO_FIELD_NAME, clientName.toLong())
+                    .string(CLIENT_INFO_FIELD_VERSION, clientVersion)
+            )
+        )
+        return request.toByteArray()
+    }
+
+    fun parseMediaHeader(data: ByteArray, length: Int): SabrMediaHeader {
+        var headerId = 0
+        var itag = 0
+        var lastModified = 0L
+        var startDataRange = 0L
+        var contentLength = 0L
+        var sequenceNumber = 0L
+        var durationMs = 0L
+        var isInitSegment = false
+        val reader = ProtoReader(data, 0, length)
+        while (reader.next()) {
+            if (reader.wireType != PROTO_WIRE_VARINT) {
+                reader.skipValue()
+                continue
+            }
+            when (reader.field) {
+                MEDIA_HEADER_FIELD_ID -> headerId = reader.readVarintValue().toInt()
+                MEDIA_HEADER_FIELD_ITAG -> itag = reader.readVarintValue().toInt()
+                MEDIA_HEADER_FIELD_LAST_MODIFIED -> lastModified = reader.readVarintValue()
+                MEDIA_HEADER_FIELD_START_DATA_RANGE -> startDataRange = reader.readVarintValue()
+                MEDIA_HEADER_FIELD_IS_INIT_SEGMENT -> isInitSegment = reader.readVarintValue() != 0L
+                MEDIA_HEADER_FIELD_SEQUENCE_NUMBER -> sequenceNumber = reader.readVarintValue()
+                MEDIA_HEADER_FIELD_DURATION_MS -> durationMs = reader.readVarintValue()
+                MEDIA_HEADER_FIELD_CONTENT_LENGTH -> contentLength = reader.readVarintValue()
+                else -> reader.skipValue()
+            }
+        }
+        if (headerId < 0 || startDataRange < 0L || contentLength < 0L) {
+            throw SabrProtocolException("SABR media header out of range")
+        }
+        return SabrMediaHeader(
+            headerId = headerId,
+            itag = itag,
+            lastModified = lastModified,
+            startDataRange = startDataRange,
+            contentLength = contentLength,
+            sequenceNumber = sequenceNumber,
+            durationMs = durationMs,
+            isInitSegment = isInitSegment
+        )
+    }
+
+    fun parseRedirectUrl(data: ByteArray, length: Int): String? {
+        val reader = ProtoReader(data, 0, length)
+        while (reader.next()) {
+            if (reader.field == REDIRECT_FIELD_URL && reader.wireType == PROTO_WIRE_LENGTH_DELIMITED) {
+                return reader.readStringValue().takeIf { it.isNotBlank() }
+            }
+            reader.skipValue()
+        }
+        return null
+    }
+
+    /** The first byte of a media part selects the header it continues. */
+    fun mediaHeaderId(data: ByteArray, length: Int): Int {
+        if (length <= 0) throw SabrProtocolException("empty SABR media part")
+        return data[0].toInt() and 0xFF
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrSegmentAssembler.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrSegmentAssembler.kt
@@ -25,6 +25,7 @@ internal class SabrSegmentAssembler(
         if (state.itag != targetItag) return null
         val chunkEnd = chunkStart + payloadLength
         if (chunkEnd <= position) return null
+        if (chunkStart > position) return null
         val skip = (position - chunkStart).coerceAtLeast(0L).toInt()
         val length = payloadLength - skip
         return if (length > 0) SabrMediaWindow(MEDIA_PAYLOAD_OFFSET + skip, length) else null

--- a/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrSegmentAssembler.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrSegmentAssembler.kt
@@ -1,27 +1,15 @@
 package com.luc4n3x.levyra.player.sabr
 
-/** The readable slice of one media payload, relative to the start of the UMP part. */
 internal data class SabrMediaWindow(val offset: Int, val length: Int)
 
-/**
- * Rebuilds one format's contiguous byte stream out of the interleaved media parts of a SABR
- * response.
- *
- * Media headers carry the absolute byte offset of the chunk that follows, so a response that starts
- * before the byte the player asked for is simply trimmed instead of restarting the request.
- */
 internal class SabrSegmentAssembler(
     private val targetItag: Int,
     private val maxTrackedHeaders: Int = MAX_TRACKED_HEADERS
 ) {
     private val headers = HashMap<Int, HeaderState>()
 
-    var deliveredBytes: Long = 0L
-        private set
-
     fun reset() {
         headers.clear()
-        deliveredBytes = 0L
     }
 
     fun onMediaHeader(header: SabrMediaHeader) {
@@ -29,17 +17,12 @@ internal class SabrSegmentAssembler(
         headers[header.headerId] = HeaderState(header.itag, header.startDataRange)
     }
 
-    /**
-     * Advances the byte cursor for [headerId] and returns the part of the payload that still lies at
-     * or after [position], or null when the chunk belongs to another format or is already consumed.
-     */
     fun onMedia(headerId: Int, payloadLength: Int, position: Long): SabrMediaWindow? {
         val state = headers[headerId] ?: return null
         if (payloadLength <= 0) return null
         val chunkStart = state.nextOffset
         state.nextOffset = chunkStart + payloadLength
         if (state.itag != targetItag) return null
-        deliveredBytes += payloadLength
         val chunkEnd = chunkStart + payloadLength
         if (chunkEnd <= position) return null
         val skip = (position - chunkStart).coerceAtLeast(0L).toInt()
@@ -55,11 +38,6 @@ internal class SabrSegmentAssembler(
     }
 }
 
-/**
- * Maps a byte position to the media time a SABR request should start from. The estimate is linear in
- * the format's own byte stream; [unproductiveAttempts] walks it backwards so a request that landed
- * past the wanted byte converges instead of repeating.
- */
 internal fun sabrPlayerTimeMsFor(
     contentLength: Long,
     durationMs: Long,

--- a/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrSegmentAssembler.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrSegmentAssembler.kt
@@ -1,0 +1,76 @@
+package com.luc4n3x.levyra.player.sabr
+
+/** The readable slice of one media payload, relative to the start of the UMP part. */
+internal data class SabrMediaWindow(val offset: Int, val length: Int)
+
+/**
+ * Rebuilds one format's contiguous byte stream out of the interleaved media parts of a SABR
+ * response.
+ *
+ * Media headers carry the absolute byte offset of the chunk that follows, so a response that starts
+ * before the byte the player asked for is simply trimmed instead of restarting the request.
+ */
+internal class SabrSegmentAssembler(
+    private val targetItag: Int,
+    private val maxTrackedHeaders: Int = MAX_TRACKED_HEADERS
+) {
+    private val headers = HashMap<Int, HeaderState>()
+
+    var deliveredBytes: Long = 0L
+        private set
+
+    fun reset() {
+        headers.clear()
+        deliveredBytes = 0L
+    }
+
+    fun onMediaHeader(header: SabrMediaHeader) {
+        if (headers.size >= maxTrackedHeaders) headers.clear()
+        headers[header.headerId] = HeaderState(header.itag, header.startDataRange)
+    }
+
+    /**
+     * Advances the byte cursor for [headerId] and returns the part of the payload that still lies at
+     * or after [position], or null when the chunk belongs to another format or is already consumed.
+     */
+    fun onMedia(headerId: Int, payloadLength: Int, position: Long): SabrMediaWindow? {
+        val state = headers[headerId] ?: return null
+        if (payloadLength <= 0) return null
+        val chunkStart = state.nextOffset
+        state.nextOffset = chunkStart + payloadLength
+        if (state.itag != targetItag) return null
+        deliveredBytes += payloadLength
+        val chunkEnd = chunkStart + payloadLength
+        if (chunkEnd <= position) return null
+        val skip = (position - chunkStart).coerceAtLeast(0L).toInt()
+        val length = payloadLength - skip
+        return if (length > 0) SabrMediaWindow(MEDIA_PAYLOAD_OFFSET + skip, length) else null
+    }
+
+    private class HeaderState(val itag: Int, var nextOffset: Long)
+
+    companion object {
+        const val MEDIA_PAYLOAD_OFFSET = 1
+        private const val MAX_TRACKED_HEADERS = 32
+    }
+}
+
+/**
+ * Maps a byte position to the media time a SABR request should start from. The estimate is linear in
+ * the format's own byte stream; [unproductiveAttempts] walks it backwards so a request that landed
+ * past the wanted byte converges instead of repeating.
+ */
+internal fun sabrPlayerTimeMsFor(
+    contentLength: Long,
+    durationMs: Long,
+    position: Long,
+    unproductiveAttempts: Int = 0,
+    backoffMs: Long = SABR_UNPRODUCTIVE_BACKOFF_MS
+): Long {
+    if (position <= 0L || contentLength <= 0L || durationMs <= 0L) return 0L
+    val estimate = durationMs * position.coerceAtMost(contentLength) / contentLength
+    val backoff = unproductiveAttempts.coerceAtLeast(0).toLong() * backoffMs
+    return (estimate - backoff).coerceIn(0L, (durationMs - 1L).coerceAtLeast(0L))
+}
+
+internal const val SABR_UNPRODUCTIVE_BACKOFF_MS = 10_000L

--- a/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrStreamSpec.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrStreamSpec.kt
@@ -1,0 +1,174 @@
+package com.luc4n3x.levyra.player.sabr
+
+import java.util.Base64
+
+/**
+ * Everything one SABR byte stream needs, carried inside the media URI so the stream travels through
+ * the normal MediaItem and MediaSource plumbing without a second configuration channel.
+ *
+ * A SABR stream is byte-identical to the progressive stream for the same format, so Media3 keeps its
+ * usual extractor, seek map and end-of-stream handling; only the transport changes.
+ */
+internal data class SabrStreamSpec(
+    val endpointUrl: String,
+    val ustreamerConfig: ByteArray,
+    val format: SabrFormatId,
+    val companionAudioFormat: SabrFormatId?,
+    val contentLength: Long,
+    val durationMs: Long,
+    val videoTrack: Boolean,
+    val clientName: Int,
+    val clientVersion: String,
+    val userAgent: String
+) {
+    fun toUri(): String = SCHEME_PREFIX + ENCODER.encodeToString(
+        buildString {
+            appendField(FIELD_ENDPOINT, endpointUrl)
+            appendField(FIELD_USTREAMER, ENCODER.encodeToString(ustreamerConfig))
+            appendField(FIELD_ITAG, format.itag.toString())
+            appendField(FIELD_LAST_MODIFIED, format.lastModified.toString())
+            companionAudioFormat?.let {
+                appendField(FIELD_AUDIO_ITAG, it.itag.toString())
+                appendField(FIELD_AUDIO_LAST_MODIFIED, it.lastModified.toString())
+            }
+            appendField(FIELD_CONTENT_LENGTH, contentLength.toString())
+            appendField(FIELD_DURATION_MS, durationMs.toString())
+            appendField(FIELD_VIDEO, if (videoTrack) "1" else "0")
+            appendField(FIELD_CLIENT_NAME, clientName.toString())
+            appendField(FIELD_CLIENT_VERSION, clientVersion)
+            appendField(FIELD_USER_AGENT, userAgent)
+        }.toByteArray(Charsets.UTF_8)
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SabrStreamSpec) return false
+        return endpointUrl == other.endpointUrl &&
+            ustreamerConfig.contentEquals(other.ustreamerConfig) &&
+            format == other.format &&
+            companionAudioFormat == other.companionAudioFormat &&
+            contentLength == other.contentLength &&
+            durationMs == other.durationMs &&
+            videoTrack == other.videoTrack &&
+            clientName == other.clientName &&
+            clientVersion == other.clientVersion &&
+            userAgent == other.userAgent
+    }
+
+    override fun hashCode(): Int {
+        var result = endpointUrl.hashCode()
+        result = 31 * result + ustreamerConfig.contentHashCode()
+        result = 31 * result + format.hashCode()
+        result = 31 * result + (companionAudioFormat?.hashCode() ?: 0)
+        result = 31 * result + contentLength.hashCode()
+        result = 31 * result + durationMs.hashCode()
+        result = 31 * result + videoTrack.hashCode()
+        result = 31 * result + clientName
+        result = 31 * result + clientVersion.hashCode()
+        result = 31 * result + userAgent.hashCode()
+        return result
+    }
+
+    companion object {
+        const val SCHEME_PREFIX = "levyra-sabr://s/"
+
+        private const val FIELD_ENDPOINT = "endpoint"
+        private const val FIELD_USTREAMER = "ustreamer"
+        private const val FIELD_ITAG = "itag"
+        private const val FIELD_LAST_MODIFIED = "lmt"
+        private const val FIELD_AUDIO_ITAG = "aitag"
+        private const val FIELD_AUDIO_LAST_MODIFIED = "almt"
+        private const val FIELD_CONTENT_LENGTH = "clen"
+        private const val FIELD_DURATION_MS = "dur"
+        private const val FIELD_VIDEO = "video"
+        private const val FIELD_CLIENT_NAME = "cname"
+        private const val FIELD_CLIENT_VERSION = "cver"
+        private const val FIELD_USER_AGENT = "cua"
+        private const val MAX_ENCODED_LENGTH = 32 * 1024
+
+        private val ENCODER: Base64.Encoder = Base64.getUrlEncoder().withoutPadding()
+        private val DECODER: Base64.Decoder = Base64.getUrlDecoder()
+
+        fun isSabrUri(uri: String): Boolean = uri.startsWith(SCHEME_PREFIX)
+
+        fun parse(uri: String): SabrStreamSpec? {
+            if (!isSabrUri(uri)) return null
+            val payload = uri.substring(SCHEME_PREFIX.length)
+            val encoded = payload.substringBefore('?').substringBefore('#')
+            if (encoded.isEmpty() || encoded.length > MAX_ENCODED_LENGTH) return null
+            val decoded = runCatching {
+                String(DECODER.decode(encoded), Charsets.UTF_8)
+            }.getOrNull() ?: return null
+
+            val fields = HashMap<String, String>()
+            decoded.lineSequence().forEach { line ->
+                val separator = line.indexOf('=')
+                if (separator > 0) fields[line.substring(0, separator)] = line.substring(separator + 1)
+            }
+
+            val endpoint = fields[FIELD_ENDPOINT].orEmpty()
+            if (!SabrEndpoint.isAllowed(endpoint)) return null
+            val ustreamer = runCatching {
+                DECODER.decode(fields[FIELD_USTREAMER].orEmpty())
+            }.getOrNull() ?: return null
+            if (ustreamer.isEmpty()) return null
+
+            val itag = fields[FIELD_ITAG]?.toIntOrNull() ?: return null
+            val lastModified = fields[FIELD_LAST_MODIFIED]?.toLongOrNull() ?: return null
+            val contentLength = fields[FIELD_CONTENT_LENGTH]?.toLongOrNull() ?: return null
+            val durationMs = fields[FIELD_DURATION_MS]?.toLongOrNull() ?: return null
+            if (itag <= 0 || contentLength <= 0L || durationMs <= 0L) return null
+
+            val audioItag = fields[FIELD_AUDIO_ITAG]?.toIntOrNull()
+            val audioLastModified = fields[FIELD_AUDIO_LAST_MODIFIED]?.toLongOrNull()
+            val companionAudio = if (audioItag != null && audioItag > 0 && audioLastModified != null) {
+                SabrFormatId(audioItag, audioLastModified)
+            } else {
+                null
+            }
+
+            return SabrStreamSpec(
+                endpointUrl = endpoint,
+                ustreamerConfig = ustreamer,
+                format = SabrFormatId(itag, lastModified),
+                companionAudioFormat = companionAudio,
+                contentLength = contentLength,
+                durationMs = durationMs,
+                videoTrack = fields[FIELD_VIDEO] == "1",
+                clientName = fields[FIELD_CLIENT_NAME]?.toIntOrNull() ?: 0,
+                clientVersion = fields[FIELD_CLIENT_VERSION].orEmpty(),
+                userAgent = fields[FIELD_USER_AGENT].orEmpty()
+            )
+        }
+
+        private fun StringBuilder.appendField(name: String, value: String) {
+            if (value.any { it == '\n' || it == '\r' }) return
+            if (isNotEmpty()) append('\n')
+            append(name).append('=').append(value)
+        }
+    }
+}
+
+/** Server-controlled SABR endpoints stay inside the Googlevideo media surface Levyra already trusts. */
+internal object SabrEndpoint {
+    private const val HTTPS_PREFIX = "https://"
+    private const val GOOGLEVIDEO_SUFFIX = ".googlevideo.com"
+    private const val MAX_URL_LENGTH = 8 * 1024
+
+    fun isAllowed(url: String): Boolean {
+        if (url.length <= HTTPS_PREFIX.length || url.length > MAX_URL_LENGTH) return false
+        if (!url.startsWith(HTTPS_PREFIX)) return false
+        var authorityEnd = url.length
+        for (index in HTTPS_PREFIX.length until url.length) {
+            val character = url[index]
+            if (character == '/' || character == '?' || character == '#') {
+                authorityEnd = index
+                break
+            }
+        }
+        val authority = url.substring(HTTPS_PREFIX.length, authorityEnd)
+        if (authority.isEmpty() || authority.contains('@') || authority.contains(':')) return false
+        val host = authority.lowercase().trimEnd('.')
+        return host.endsWith(GOOGLEVIDEO_SUFFIX) && host.length > GOOGLEVIDEO_SUFFIX.length
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrStreamSpec.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/sabr/SabrStreamSpec.kt
@@ -2,13 +2,6 @@ package com.luc4n3x.levyra.player.sabr
 
 import java.util.Base64
 
-/**
- * Everything one SABR byte stream needs, carried inside the media URI so the stream travels through
- * the normal MediaItem and MediaSource plumbing without a second configuration channel.
- *
- * A SABR stream is byte-identical to the progressive stream for the same format, so Media3 keeps its
- * usual extractor, seek map and end-of-stream handling; only the transport changes.
- */
 internal data class SabrStreamSpec(
     val endpointUrl: String,
     val ustreamerConfig: ByteArray,
@@ -149,7 +142,6 @@ internal data class SabrStreamSpec(
     }
 }
 
-/** Server-controlled SABR endpoints stay inside the Googlevideo media surface Levyra already trusts. */
 internal object SabrEndpoint {
     private const val HTTPS_PREFIX = "https://"
     private const val GOOGLEVIDEO_SUFFIX = ".googlevideo.com"

--- a/app/src/main/java/com/luc4n3x/levyra/player/sabr/UmpReader.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/sabr/UmpReader.kt
@@ -1,0 +1,142 @@
+package com.luc4n3x.levyra.player.sabr
+
+import java.io.EOFException
+import java.io.InputStream
+
+/**
+ * Incremental reader for the UMP framing SABR responses use: a flat sequence of
+ * `<part type><part size><payload>` where both headers use YouTube's own variable-length integer.
+ *
+ * The reader never materializes a whole response. It keeps one reusable payload buffer whose size is
+ * capped, so a hostile or corrupt length can neither allocate without bound nor stall playback.
+ */
+internal class UmpReader(
+    private val input: InputStream,
+    private val maxPartSize: Int = MAX_PART_SIZE
+) {
+    private val header = ByteArray(MAX_VARINT_BYTES)
+    private var payload = ByteArray(INITIAL_PAYLOAD_CAPACITY)
+
+    var partType: Int = -1
+        private set
+
+    var partLength: Int = 0
+        private set
+
+    /** Valid only for the part returned by the last successful [next] call. */
+    val partPayload: ByteArray
+        get() = payload
+
+    /**
+     * Reads the next part into [partPayload]. Returns false once the response ends cleanly on a part
+     * boundary; a response that ends mid-part is a truncated response and fails.
+     */
+    fun next(): Boolean {
+        val first = input.read()
+        if (first < 0) {
+            partType = -1
+            partLength = 0
+            return false
+        }
+        partType = readVarint(first)
+        val length = readVarint(readByte())
+        if (length < 0 || length > maxPartSize) {
+            throw SabrProtocolException("UMP part $partType declares $length bytes")
+        }
+        partLength = length
+        if (length > payload.size) {
+            payload = ByteArray(length)
+        }
+        readFully(payload, length)
+        return true
+    }
+
+    private fun readByte(): Int {
+        val value = input.read()
+        if (value < 0) throw EOFException("truncated UMP header")
+        return value
+    }
+
+    private fun readFully(target: ByteArray, length: Int) {
+        var read = 0
+        while (read < length) {
+            val count = input.read(target, read, length - read)
+            if (count < 0) throw EOFException("truncated UMP payload")
+            read += count
+        }
+    }
+
+    /**
+     * YouTube's variable-length integer: the leading byte selects the total size and contributes the
+     * low bits, the remaining bytes are little-endian high bits.
+     */
+    private fun readVarint(prefix: Int): Int {
+        val size = varintSize(prefix)
+        if (size == 1) return prefix
+        var index = 0
+        while (index < size - 1) {
+            header[index] = readByte().toByte()
+            index++
+        }
+        var rest = 0L
+        var shift = 0
+        for (byteIndex in 0 until size - 1) {
+            rest = rest or ((header[byteIndex].toLong() and 0xFFL) shl shift)
+            shift += 8
+        }
+        val value = if (size == MAX_VARINT_BYTES) {
+            rest
+        } else {
+            val maskBits = 8 - size
+            (rest shl maskBits) or (prefix and ((1 shl maskBits) - 1)).toLong()
+        }
+        if (value > Int.MAX_VALUE || value < 0L) throw SabrProtocolException("UMP varint out of range")
+        return value.toInt()
+    }
+
+    private fun varintSize(prefix: Int): Int = when {
+        prefix < 128 -> 1
+        prefix < 192 -> 2
+        prefix < 224 -> 3
+        prefix < 240 -> 4
+        else -> MAX_VARINT_BYTES
+    }
+
+    companion object {
+        const val MAX_PART_SIZE = 512 * 1024
+        private const val MAX_VARINT_BYTES = 5
+        private const val INITIAL_PAYLOAD_CAPACITY = 8 * 1024
+    }
+}
+
+internal fun umpVarint(value: Int): ByteArray {
+    require(value >= 0) { "UMP varint must be positive" }
+    return when {
+        value < 128 -> byteArrayOf(value.toByte())
+        value < (1 shl 14) -> byteArrayOf(
+            (0x80 or (value and 0x3F)).toByte(),
+            (value ushr 6).toByte()
+        )
+        value < (1 shl 21) -> byteArrayOf(
+            (0xC0 or (value and 0x1F)).toByte(),
+            ((value ushr 5) and 0xFF).toByte(),
+            ((value ushr 13) and 0xFF).toByte()
+        )
+        value < (1 shl 28) -> byteArrayOf(
+            (0xE0 or (value and 0x0F)).toByte(),
+            ((value ushr 4) and 0xFF).toByte(),
+            ((value ushr 12) and 0xFF).toByte(),
+            ((value ushr 20) and 0xFF).toByte()
+        )
+        else -> byteArrayOf(
+            0xF0.toByte(),
+            (value and 0xFF).toByte(),
+            ((value ushr 8) and 0xFF).toByte(),
+            ((value ushr 16) and 0xFF).toByte(),
+            ((value ushr 24) and 0xFF).toByte()
+        )
+    }
+}
+
+internal fun umpPart(type: Int, payload: ByteArray): ByteArray =
+    umpVarint(type) + umpVarint(payload.size) + payload

--- a/app/src/main/java/com/luc4n3x/levyra/player/sabr/UmpReader.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/sabr/UmpReader.kt
@@ -3,13 +3,6 @@ package com.luc4n3x.levyra.player.sabr
 import java.io.EOFException
 import java.io.InputStream
 
-/**
- * Incremental reader for the UMP framing SABR responses use: a flat sequence of
- * `<part type><part size><payload>` where both headers use YouTube's own variable-length integer.
- *
- * The reader never materializes a whole response. It keeps one reusable payload buffer whose size is
- * capped, so a hostile or corrupt length can neither allocate without bound nor stall playback.
- */
 internal class UmpReader(
     private val input: InputStream,
     private val maxPartSize: Int = MAX_PART_SIZE
@@ -23,14 +16,9 @@ internal class UmpReader(
     var partLength: Int = 0
         private set
 
-    /** Valid only for the part returned by the last successful [next] call. */
     val partPayload: ByteArray
         get() = payload
 
-    /**
-     * Reads the next part into [partPayload]. Returns false once the response ends cleanly on a part
-     * boundary; a response that ends mid-part is a truncated response and fails.
-     */
     fun next(): Boolean {
         val first = input.read()
         if (first < 0) {
@@ -66,10 +54,6 @@ internal class UmpReader(
         }
     }
 
-    /**
-     * YouTube's variable-length integer: the leading byte selects the total size and contributes the
-     * low bits, the remaining bytes are little-endian high bits.
-     */
     private fun readVarint(prefix: Int): Int {
         val size = varintSize(prefix)
         if (size == 1) return prefix

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackCandidateRecoveryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackCandidateRecoveryTest.kt
@@ -1,0 +1,205 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.domain.PlaybackDeliveryMethod
+import com.luc4n3x.levyra.domain.PlaybackStreamDescriptor
+import com.luc4n3x.levyra.domain.PlaybackStreamKind
+import com.luc4n3x.levyra.domain.ResolvedPlaybackManifest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaybackCandidateRecoveryTest {
+    private val now = 1_000_000L
+
+    @Test
+    fun onlyTransientCandidateStatusesAreTreatedAsCandidateFailures() {
+        listOf(
+            PlaybackFailureKind.NotFound,
+            PlaybackFailureKind.ServerError,
+            PlaybackFailureKind.Truncated
+        ).forEach { assertTrue(it.name, isCandidateLevelPlaybackFailure(it)) }
+
+        listOf(
+            PlaybackFailureKind.Forbidden,
+            PlaybackFailureKind.Signature,
+            PlaybackFailureKind.LoginRequired,
+            PlaybackFailureKind.ExpiredUrl,
+            PlaybackFailureKind.Decoder,
+            PlaybackFailureKind.UnsupportedFormat,
+            PlaybackFailureKind.Network,
+            PlaybackFailureKind.Timeout,
+            PlaybackFailureKind.RangeNotSatisfiable,
+            PlaybackFailureKind.Unknown
+        ).forEach { assertFalse(it.name, isCandidateLevelPlaybackFailure(it)) }
+    }
+
+    @Test
+    fun http503OnOneAudioUrlPromotesTheNextAudioCandidate() {
+        val manifest = audioManifest()
+
+        val promoted = promoteAlternatePlaybackCandidate(
+            manifest = manifest,
+            isVideoMode = false,
+            nowMs = now,
+            isBlocked = { it == "https://a/opus-high" }
+        )
+
+        assertEquals("https://a/aac", promoted?.selectedAudioUrl)
+        assertEquals("", promoted?.selectedVideoUrl)
+        assertEquals(
+            listOf("https://a/aac"),
+            promoted?.streams?.filter { it.selected }?.map { it.url }
+        )
+    }
+
+    @Test
+    fun promotionStopsWhenEveryEquivalentCandidateIsQuarantined() {
+        val manifest = audioManifest()
+
+        val promoted = promoteAlternatePlaybackCandidate(
+            manifest = manifest,
+            isVideoMode = false,
+            nowMs = now,
+            isBlocked = { true }
+        )
+
+        assertNull(promoted)
+    }
+
+    @Test
+    fun promotionIgnoresExpiredCandidates() {
+        val manifest = audioManifest(alternativeExpiresAtMs = now - 1L)
+
+        val promoted = promoteAlternatePlaybackCandidate(
+            manifest = manifest,
+            isVideoMode = false,
+            nowMs = now,
+            isBlocked = { it == "https://a/opus-high" }
+        )
+
+        assertNull(promoted)
+    }
+
+    @Test
+    fun healthySelectionIsNeverPromoted() {
+        assertNull(
+            promoteAlternatePlaybackCandidate(
+                manifest = audioManifest(),
+                isVideoMode = false,
+                nowMs = now,
+                isBlocked = { false }
+            )
+        )
+    }
+
+    @Test
+    fun videoFailurePromotesTheClosestHeightAndKeepsHealthyAudio() {
+        val manifest = videoManifest()
+
+        val promoted = promoteAlternatePlaybackCandidate(
+            manifest = manifest,
+            isVideoMode = true,
+            nowMs = now,
+            isBlocked = { it == "https://v/av1-1080" }
+        )
+
+        assertEquals("https://a/aac", promoted?.selectedAudioUrl)
+        assertEquals("https://v/vp9-1080", promoted?.selectedVideoUrl)
+        assertEquals(
+            setOf("https://a/aac", "https://v/vp9-1080"),
+            promoted?.streams?.filter { it.selected }?.map { it.url }?.toSet()
+        )
+    }
+
+    @Test
+    fun videoFailureFallsBackToALowerHeightWhenNoEqualHeightRemains() {
+        val manifest = videoManifest()
+
+        val promoted = promoteAlternatePlaybackCandidate(
+            manifest = manifest,
+            isVideoMode = true,
+            nowMs = now,
+            isBlocked = { it == "https://v/av1-1080" || it == "https://v/vp9-1080" }
+        )
+
+        assertEquals("https://v/avc-720", promoted?.selectedVideoUrl)
+    }
+
+    @Test
+    fun promotionNeverReturnsTheSameSelectionTwice() {
+        var blocked = setOf("https://a/opus-high")
+        val first = promoteAlternatePlaybackCandidate(
+            manifest = audioManifest(),
+            isVideoMode = false,
+            nowMs = now,
+            isBlocked = { it in blocked }
+        )
+        blocked = blocked + first!!.selectedAudioUrl
+        val second = promoteAlternatePlaybackCandidate(
+            manifest = first,
+            isVideoMode = false,
+            nowMs = now,
+            isBlocked = { it in blocked }
+        )
+
+        assertEquals("https://a/opus-low", second?.selectedAudioUrl)
+        assertTrue(first.selectedAudioUrl != second?.selectedAudioUrl)
+    }
+
+    private fun audioManifest(alternativeExpiresAtMs: Long = now + 600_000L) = ResolvedPlaybackManifest(
+        sourceVideoId = "abcdefghijk",
+        provider = "test",
+        resolvedAtMs = now,
+        expiresAtMs = now + 600_000L,
+        durationMs = 210_000L,
+        selectedAudioUrl = "https://a/opus-high",
+        selectedVideoUrl = "",
+        streams = listOf(
+            audio("https://a/opus-high", bitrate = 160_000, selected = true, expiresAtMs = now + 600_000L),
+            audio("https://a/aac", bitrate = 128_000, expiresAtMs = alternativeExpiresAtMs),
+            audio("https://a/opus-low", bitrate = 64_000, expiresAtMs = alternativeExpiresAtMs)
+        )
+    )
+
+    private fun videoManifest() = ResolvedPlaybackManifest(
+        sourceVideoId = "abcdefghijk",
+        provider = "test",
+        resolvedAtMs = now,
+        expiresAtMs = now + 600_000L,
+        durationMs = 210_000L,
+        selectedAudioUrl = "https://a/aac",
+        selectedVideoUrl = "https://v/av1-1080",
+        streams = listOf(
+            audio("https://a/aac", bitrate = 128_000, selected = true, expiresAtMs = now + 600_000L),
+            video("https://v/av1-1080", height = 1080, selected = true),
+            video("https://v/vp9-1080", height = 1080),
+            video("https://v/avc-720", height = 720)
+        )
+    )
+
+    private fun audio(
+        url: String,
+        bitrate: Int,
+        selected: Boolean = false,
+        expiresAtMs: Long
+    ) = PlaybackStreamDescriptor(
+        url = url,
+        kind = PlaybackStreamKind.AUDIO,
+        deliveryMethod = PlaybackDeliveryMethod.PROGRESSIVE,
+        averageBitrate = bitrate,
+        expiresAtMs = expiresAtMs,
+        selected = selected
+    )
+
+    private fun video(url: String, height: Int, selected: Boolean = false) = PlaybackStreamDescriptor(
+        url = url,
+        kind = PlaybackStreamKind.VIDEO,
+        deliveryMethod = PlaybackDeliveryMethod.PROGRESSIVE,
+        height = height,
+        averageBitrate = height * 1_000,
+        expiresAtMs = now + 600_000L,
+        selected = selected
+    )
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackSabrDeliveryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackSabrDeliveryTest.kt
@@ -1,0 +1,150 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.domain.PlaybackDeliveryMethod
+import com.luc4n3x.levyra.domain.PlaybackStreamKind
+import com.luc4n3x.levyra.player.sabr.SabrStreamSpec
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaybackSabrDeliveryTest {
+    private val endpoint = "https://rr5---sn-a.googlevideo.com/videoplayback?mn=sn-a,sn-b&expire=1788000000"
+    private val ustreamer = byteArrayOf(1, 2, 3, 4)
+    private val expiresAtMs = 1_788_000_000_000L
+
+    @Test
+    fun audioDescriptorCarriesEnoughForTheDataSourceAndForLevyraUrlChecks() {
+        val descriptor = descriptor(audio(itag = 140))
+
+        assertNotNull(descriptor)
+        assertEquals(PlaybackDeliveryMethod.SABR, descriptor!!.deliveryMethod)
+        assertEquals(PlaybackStreamKind.AUDIO, descriptor.kind)
+        assertEquals("audio/mp4", descriptor.mimeType)
+        assertEquals(140, descriptor.itag)
+        assertTrue(descriptor.url.contains("mime=audio%2Fmp4"))
+        assertTrue(descriptor.url.contains("expire=1788000000"))
+        assertTrue(SabrStreamSpec.isSabrUri(descriptor.url))
+
+        val spec = SabrStreamSpec.parse(descriptor.url)
+        assertNotNull(spec)
+        assertEquals(140, spec!!.format.itag)
+        assertEquals(9_397_248L, spec.contentLength)
+        assertEquals(213_090L, spec.durationMs)
+        assertNull(spec.companionAudioFormat)
+    }
+
+    @Test
+    fun videoDescriptorAlwaysCarriesThePairedAudioFormat() {
+        val withAudio = descriptor(video(itag = 133, height = 240), companionAudio = audio(itag = 140))
+        val withoutAudio = descriptor(video(itag = 133, height = 240), companionAudio = null)
+
+        assertNotNull(withAudio)
+        assertNull(withoutAudio)
+        val spec = SabrStreamSpec.parse(withAudio!!.url)
+        assertEquals(140, spec?.companionAudioFormat?.itag)
+        assertTrue(spec?.videoTrack == true)
+    }
+
+    @Test
+    fun descriptorsAreRefusedWhenTheDeliveryContextIsIncomplete() {
+        assertNull(descriptor(audio(itag = 140), endpointUrl = "https://evil.test/videoplayback"))
+        assertNull(descriptor(audio(itag = 140), ustreamerConfig = ByteArray(0)))
+        assertNull(descriptor(audio(itag = 140), durationMs = 0L))
+        assertNull(descriptor(audio(itag = 140, lastModified = 0L)))
+        assertNull(descriptor(audio(itag = 0)))
+        assertNull(descriptor(audio(itag = 140, contentLength = 0L)))
+        assertNull(descriptor(audio(itag = 140, mimeType = "text/html")))
+    }
+
+    @Test
+    fun audioOrderingFollowsTheRequestedQuality() {
+        val candidates = listOf(
+            audio(itag = 139, averageBitrate = 48_000),
+            audio(itag = 140, averageBitrate = 128_000),
+            video(itag = 133, height = 240)
+        )
+
+        assertEquals(
+            listOf(140, 139),
+            orderSabrAudioCandidates(candidates, preferHighestBitrate = true).map { it.itag }
+        )
+        assertEquals(
+            listOf(139, 140),
+            orderSabrAudioCandidates(candidates, preferHighestBitrate = false).map { it.itag }
+        )
+    }
+
+    @Test
+    fun videoOrderingNeverExceedsTheHeightTheDeviceWasAllowed() {
+        val candidates = listOf(
+            video(itag = 137, height = 1080),
+            video(itag = 136, height = 720),
+            video(itag = 133, height = 240),
+            audio(itag = 140)
+        )
+
+        assertEquals(
+            listOf(136, 133),
+            orderSabrVideoCandidates(candidates, maxHeight = 720).map { it.itag }
+        )
+        assertEquals(
+            listOf(137, 136, 133),
+            orderSabrVideoCandidates(candidates, maxHeight = 0).map { it.itag }
+        )
+        assertTrue(orderSabrVideoCandidates(candidates, maxHeight = 100).isEmpty())
+    }
+
+    @Test
+    fun ustreamerConfigAcceptsUrlSafeBase64WithOrWithoutPadding() {
+        assertEquals("hi", decodeSabrUstreamerConfig("aGk=")?.toString(Charsets.UTF_8))
+        assertEquals("hi", decodeSabrUstreamerConfig("aGk")?.toString(Charsets.UTF_8))
+        assertTrue(decodeSabrUstreamerConfig("Cs0JCowGCAAQgAUY6AIl-n6qPi0AAIA_")!!.isNotEmpty())
+        assertNull(decodeSabrUstreamerConfig(""))
+        assertNull(decodeSabrUstreamerConfig("   "))
+        assertNull(decodeSabrUstreamerConfig("!!!"))
+    }
+
+    private fun descriptor(
+        candidate: SabrFormatCandidate,
+        companionAudio: SabrFormatCandidate? = null,
+        endpointUrl: String = endpoint,
+        ustreamerConfig: ByteArray = ustreamer,
+        durationMs: Long = 213_090L
+    ) = buildSabrStreamDescriptor(
+        endpointUrl = endpointUrl,
+        ustreamerConfig = ustreamerConfig,
+        candidate = candidate,
+        companionAudio = companionAudio,
+        durationMs = durationMs,
+        clientName = 5,
+        clientVersion = "20.10.4",
+        userAgent = "com.google.ios.youtube/20.10.4",
+        expiresAtMs = expiresAtMs
+    )
+
+    private fun audio(
+        itag: Int,
+        lastModified: Long = 1_766_955_925_572_207L,
+        contentLength: Long = 9_397_248L,
+        averageBitrate: Int = 128_000,
+        mimeType: String = "audio/mp4; codecs=\"mp4a.40.2\""
+    ) = SabrFormatCandidate(
+        itag = itag,
+        lastModified = lastModified,
+        mimeType = mimeType,
+        contentLength = contentLength,
+        averageBitrate = averageBitrate
+    )
+
+    private fun video(itag: Int, height: Int) = SabrFormatCandidate(
+        itag = itag,
+        lastModified = 1_766_961_065_074_107L,
+        mimeType = "video/mp4; codecs=\"avc1.4d401f\"",
+        contentLength = 84_074L,
+        averageBitrate = height * 1_000,
+        height = height,
+        width = height * 16 / 9
+    )
+}

--- a/app/src/test/java/com/luc4n3x/levyra/player/GooglevideoMediaNetworkTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/GooglevideoMediaNetworkTest.kt
@@ -1,0 +1,110 @@
+package com.luc4n3x.levyra.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GooglevideoMediaNetworkTest {
+    @Test
+    fun rewritesOnlyTheMediaNetworkLabelForEachDeclaredAlternative() {
+        val url = "https://rr5---sn-hpa7knld.googlevideo.com/videoplayback" +
+            "?expire=1&itag=140&mn=sn-hpa7knld,sn-hpa7zns6&sig=abc"
+
+        val alternates = GooglevideoMediaNetwork.alternateUrls(url)
+
+        assertEquals(
+            listOf(
+                "https://rr5---sn-hpa7zns6.googlevideo.com/videoplayback" +
+                    "?expire=1&itag=140&mn=sn-hpa7knld,sn-hpa7zns6&sig=abc"
+            ),
+            alternates
+        )
+    }
+
+    @Test
+    fun preservesPathQueryAndFragmentWhileBoundingCandidates() {
+        val url = "https://rr2---sn-a.googlevideo.com/videoplayback/id/x?mn=sn-a,sn-b,sn-c,sn-d,sn-e#f"
+
+        val alternates = GooglevideoMediaNetwork.alternateUrls(url, limit = 2)
+
+        assertEquals(
+            listOf(
+                "https://rr2---sn-b.googlevideo.com/videoplayback/id/x?mn=sn-a,sn-b,sn-c,sn-d,sn-e#f",
+                "https://rr2---sn-c.googlevideo.com/videoplayback/id/x?mn=sn-a,sn-b,sn-c,sn-d,sn-e#f"
+            ),
+            alternates
+        )
+    }
+
+    @Test
+    fun deduplicatesAndSkipsTheCurrentMediaNetwork() {
+        val url = "https://rr1---sn-a.googlevideo.com/videoplayback?mn=sn-a,sn-b,sn-b,SN-A"
+
+        assertEquals(
+            listOf("https://rr1---sn-b.googlevideo.com/videoplayback?mn=sn-a,sn-b,sn-b,SN-A"),
+            GooglevideoMediaNetwork.alternateUrls(url)
+        )
+    }
+
+    @Test
+    fun rejectsMalformedOrHostileCandidates() {
+        val cases = listOf(
+            "https://rr1---sn-a.googlevideo.com/videoplayback?mn=sn-a",
+            "https://rr1---sn-a.googlevideo.com/videoplayback?mn=",
+            "https://rr1---sn-a.googlevideo.com/videoplayback",
+            "https://rr1---sn-a.googlevideo.com/videoplayback?mn=sn-a,evil.example.com",
+            "https://rr1---sn-a.googlevideo.com/videoplayback?mn=sn-a,sn-b/../x",
+            "https://rr1---sn-a.googlevideo.com/videoplayback?mn=sn-a,sn b",
+            "https://rr1---sn-a.googlevideo.com.evil.test/videoplayback?mn=sn-a,sn-b",
+            "https://user:pass@rr1---sn-a.googlevideo.com/videoplayback?mn=sn-a,sn-b",
+            "https://rr1---sn-a.googlevideo.com:8443/videoplayback?mn=sn-a,sn-b",
+            "http://rr1---sn-a.googlevideo.com/videoplayback?mn=sn-a,sn-b",
+            "https://googlevideo.com/videoplayback?mn=sn-a,sn-b",
+            "https://rr1.googlevideo.com/videoplayback?mn=sn-a,sn-b",
+            "https://---sn-a.googlevideo.com/videoplayback?mn=sn-a,sn-b",
+            "not a url"
+        )
+
+        cases.forEach { url ->
+            assertTrue(url, GooglevideoMediaNetwork.alternateUrls(url).isEmpty())
+        }
+    }
+
+    @Test
+    fun ignoresQueryParametersThatOnlyLookLikeTheMediaNetworkList() {
+        val url = "https://rr1---sn-a.googlevideo.com/videoplayback?mne=sn-a,sn-b&xmn=sn-c"
+
+        assertTrue(GooglevideoMediaNetwork.alternateUrls(url).isEmpty())
+    }
+
+    @Test
+    fun recognisesGooglevideoHostsOnly() {
+        assertTrue(GooglevideoMediaNetwork.isGooglevideoHost("rr1---sn-a.googlevideo.com"))
+        assertTrue(GooglevideoMediaNetwork.isGooglevideoHost("RR1---SN-A.GOOGLEVIDEO.COM."))
+        assertFalse(GooglevideoMediaNetwork.isGooglevideoHost("googlevideo.com"))
+        assertFalse(GooglevideoMediaNetwork.isGooglevideoHost("evil-googlevideo.com"))
+        assertFalse(GooglevideoMediaNetwork.isGooglevideoHost("googlevideo.com.evil.test"))
+    }
+
+    @Test
+    fun neverReturnsMoreThanTheBoundedCandidateCount() {
+        val networks = (0 until 12).joinToString(",") { "sn-$it" }
+        val url = "https://rr1---sn-a.googlevideo.com/videoplayback?mn=$networks"
+
+        assertEquals(
+            GooglevideoMediaNetwork.MAX_ALTERNATE_CANDIDATES,
+            GooglevideoMediaNetwork.alternateUrls(url).size
+        )
+    }
+
+    @Test
+    fun failsOverOnlyForEndpointLevelFailures() {
+        listOf(null, 404, 500, 502, 503, 504).forEach { status ->
+            assertTrue("$status", GooglevideoMediaNetwork.isEndpointFailure(status))
+        }
+        listOf(200, 206, 301, 401, 403, 410, 416, 429).forEach { status ->
+            assertFalse("$status", GooglevideoMediaNetwork.isEndpointFailure(status))
+        }
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/player/PlaybackWarmupPolicyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/PlaybackWarmupPolicyTest.kt
@@ -29,6 +29,20 @@ class PlaybackWarmupPolicyTest {
         assertEquals(track.streamUrl, plan.probeUrl)
     }
 
+    @Test
+    fun sabrStreamsAreNeverWarmedThroughThePlainHttpStack() {
+        val sabrUrl = "levyra-sabr://s/ZW5kcG9pbnQ?itag=140&mime=audio%2Fmp4"
+        val audioOnly = track(sabrUrl)
+        val splitVideo = track(sabrUrl).copy(videoStreamUrl = sabrUrl)
+
+        assertEquals("", videoWarmupPlan(audioOnly).probeUrl)
+        assertFalse(videoWarmupPlan(audioOnly).cachePrimaryAsAudio)
+        assertEquals("", videoWarmupPlan(splitVideo).probeUrl)
+        assertFalse(videoWarmupPlan(splitVideo).cachePrimaryAsAudio)
+        assertFalse(isWarmableMediaUrl(sabrUrl))
+        assertTrue(isWarmableMediaUrl("https://media.example/audio?itag=140"))
+    }
+
     private fun track(streamUrl: String): Track = Track(
         id = "video-id",
         title = "Title",

--- a/app/src/test/java/com/luc4n3x/levyra/player/sabr/SabrProtocolTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/sabr/SabrProtocolTest.kt
@@ -7,6 +7,20 @@ import org.junit.Test
 
 class SabrProtocolTest {
     @Test
+    fun seekAndReloadPartIdsMatchTheCurrentProtocol() {
+        assertEquals(45, SabrPart.SABR_SEEK)
+        assertEquals(46, SabrPart.RELOAD_PLAYER_RESPONSE)
+    }
+
+    @Test
+    fun requestNumberIsAddedAndReplacesAStaleValue() {
+        val endpoint = "https://rr5---sn-a.googlevideo.com/videoplayback?sabr=1"
+
+        assertEquals("$endpoint&rn=0", sabrRequestEndpoint(endpoint, 0L))
+        assertEquals("$endpoint&rn=1", sabrRequestEndpoint("$endpoint&rn=99", 1L))
+    }
+
+    @Test
     fun mediaHeaderCarriesTheAbsoluteByteOffsetOfTheChunk() {
         val encoded = ProtoWriter()
             .varint(1, 1L)

--- a/app/src/test/java/com/luc4n3x/levyra/player/sabr/SabrProtocolTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/sabr/SabrProtocolTest.kt
@@ -1,0 +1,278 @@
+package com.luc4n3x.levyra.player.sabr
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SabrProtocolTest {
+    @Test
+    fun mediaHeaderCarriesTheAbsoluteByteOffsetOfTheChunk() {
+        val encoded = ProtoWriter()
+            .varint(1, 1L)
+            .varint(3, 140L)
+            .varint(4, 1_766_955_925_572_207L)
+            .varint(6, 1_019L)
+            .varint(9, 1L)
+            .varint(10, 16_233L)
+            .varint(14, 162_083L)
+            .toByteArray()
+
+        val header = SabrMessages.parseMediaHeader(encoded, encoded.size)
+
+        assertEquals(1, header.headerId)
+        assertEquals(140, header.itag)
+        assertEquals(1_766_955_925_572_207L, header.lastModified)
+        assertEquals(1_019L, header.startDataRange)
+        assertEquals(162_083L, header.contentLength)
+        assertEquals(1L, header.sequenceNumber)
+        assertEquals(16_233L, header.durationMs)
+        assertTrue(!header.isInitSegment)
+    }
+
+    @Test
+    fun initSegmentHeadersAreRecognised() {
+        val encoded = ProtoWriter().varint(1, 0L).varint(3, 140L).varint(8, 1L).varint(14, 1_019L).toByteArray()
+
+        val header = SabrMessages.parseMediaHeader(encoded, encoded.size)
+
+        assertTrue(header.isInitSegment)
+        assertEquals(0L, header.startDataRange)
+    }
+
+    @Test
+    fun unknownHeaderFieldsAreSkippedInsteadOfFailing() {
+        val encoded = ProtoWriter()
+            .varint(3, 140L)
+            .string(13, "unexpected")
+            .varint(14, 42L)
+            .toByteArray()
+
+        val header = SabrMessages.parseMediaHeader(encoded, encoded.size)
+
+        assertEquals(140, header.itag)
+        assertEquals(42L, header.contentLength)
+    }
+
+    @Test
+    fun redirectUrlIsReadFromTheFirstField() {
+        val encoded = ProtoWriter()
+            .string(1, "https://rr4---sn-b.googlevideo.com/videoplayback?mn=sn-a,sn-b")
+            .varint(13, 116L)
+            .toByteArray()
+
+        assertEquals(
+            "https://rr4---sn-b.googlevideo.com/videoplayback?mn=sn-a,sn-b",
+            SabrMessages.parseRedirectUrl(encoded, encoded.size)
+        )
+    }
+
+    @Test
+    fun redirectWithoutAUrlIsRejected() {
+        val encoded = ProtoWriter().varint(13, 116L).toByteArray()
+
+        assertNull(SabrMessages.parseRedirectUrl(encoded, encoded.size))
+    }
+
+    @Test
+    fun audioRequestCarriesTheSelectedFormatAndNoVideoPreference() {
+        val body = SabrMessages.playbackRequest(
+            ustreamerConfig = byteArrayOf(1, 2, 3),
+            playerTimeMs = 60_000L,
+            enabledTrackTypes = SabrMessages.TRACK_TYPES_AUDIO_ONLY,
+            preferredAudio = SabrFormatId(140, 1_766_955_925_572_207L),
+            preferredVideo = null,
+            initializedFormats = listOf(SabrFormatId(140, 1_766_955_925_572_207L)),
+            alreadyBuffered = emptyList(),
+            clientName = 5,
+            clientVersion = "20.10.4"
+        )
+
+        val fields = topLevelFields(body)
+        assertTrue(fields.contains(1))
+        assertTrue(fields.contains(2))
+        assertTrue(fields.contains(5))
+        assertTrue(fields.contains(16))
+        assertTrue(!fields.contains(17))
+        assertTrue(fields.contains(19))
+    }
+
+    @Test
+    fun videoRequestDeclaresThePairedAudioAsAlreadyBuffered() {
+        val audio = SabrFormatId(140, 2L)
+        val body = SabrMessages.playbackRequest(
+            ustreamerConfig = byteArrayOf(9),
+            playerTimeMs = 0L,
+            enabledTrackTypes = SabrMessages.TRACK_TYPES_AUDIO_AND_VIDEO,
+            preferredAudio = audio,
+            preferredVideo = SabrFormatId(133, 3L),
+            initializedFormats = listOf(audio),
+            alreadyBuffered = listOf(SabrBufferedRange(audio, 0L, 213_090L, 1L, 1_000L)),
+            clientName = 5,
+            clientVersion = "20.10.4"
+        )
+
+        val fields = topLevelFields(body)
+        assertTrue(fields.contains(3))
+        assertTrue(fields.contains(16))
+        assertTrue(fields.contains(17))
+    }
+
+    @Test
+    fun playerTimeIsNeverNegative() {
+        val body = SabrMessages.playbackRequest(
+            ustreamerConfig = byteArrayOf(1),
+            playerTimeMs = -5_000L,
+            enabledTrackTypes = SabrMessages.TRACK_TYPES_AUDIO_ONLY,
+            preferredAudio = SabrFormatId(140, 1L),
+            preferredVideo = null,
+            initializedFormats = emptyList(),
+            alreadyBuffered = emptyList(),
+            clientName = 5,
+            clientVersion = "1"
+        )
+
+        val abrState = nestedMessage(body, 1)
+        val reader = ProtoReader(abrState, 0, abrState.size)
+        while (reader.next()) {
+            if (reader.field == 28) {
+                assertEquals(0L, reader.readVarintValue())
+                return
+            }
+            reader.skipValue()
+        }
+    }
+
+    @Test
+    fun protobufReaderSkipsEveryWireTypeItDoesNotUnderstand() {
+        val body = ProtoWriter()
+            .varint(1, 7L)
+            .string(2, "text")
+            .message(3, ProtoWriter().varint(1, 1L))
+            .toByteArray()
+
+        val reader = ProtoReader(body, 0, body.size)
+        var seen = 0
+        while (reader.next()) {
+            seen++
+            reader.skipValue()
+        }
+        assertEquals(3, seen)
+    }
+
+    @Test(expected = SabrProtocolException::class)
+    fun protobufLengthBeyondTheBufferIsRejected() {
+        val hostile = byteArrayOf(0x12, 0x7F, 0x01, 0x02)
+
+        val reader = ProtoReader(hostile, 0, hostile.size)
+        reader.next()
+        reader.readBytesValue()
+    }
+
+    @Test(expected = SabrProtocolException::class)
+    fun truncatedProtobufVarintIsRejected() {
+        val hostile = byteArrayOf(0x08, 0x80.toByte())
+
+        val reader = ProtoReader(hostile, 0, hostile.size)
+        reader.next()
+        reader.readVarintValue()
+    }
+
+    @Test(expected = SabrProtocolException::class)
+    fun emptyMediaPartIsRejected() {
+        SabrMessages.mediaHeaderId(ByteArray(0), 0)
+    }
+
+    @Test
+    fun requestBytesMatchThePayloadsTheServerAcceptedInProtocolValidation() {
+        val audioFormat = SabrFormatId(140, 1_766_955_925_572_207L)
+        val videoFormat = SabrFormatId(133, 1_766_961_065_074_107L)
+        val ustreamer = byteArrayOf(1, 2, 3)
+
+        val audio = SabrMessages.playbackRequest(
+            ustreamerConfig = ustreamer,
+            playerTimeMs = 0L,
+            enabledTrackTypes = SabrMessages.TRACK_TYPES_AUDIO_ONLY,
+            preferredAudio = audioFormat,
+            preferredVideo = null,
+            initializedFormats = listOf(audioFormat),
+            alreadyBuffered = emptyList(),
+            clientName = 5,
+            clientVersion = "20.10.4"
+        )
+        assertEquals(
+            "0a06e00100c00201120c088c0110ef949ce297e191032a03010203" +
+                "82010c088c0110ef949ce297e191039a010f0a0d8001058a010732302e31302e34",
+            audio.toHex()
+        )
+
+        val seek = SabrMessages.playbackRequest(
+            ustreamerConfig = ustreamer,
+            playerTimeMs = 60_000L,
+            enabledTrackTypes = SabrMessages.TRACK_TYPES_AUDIO_ONLY,
+            preferredAudio = audioFormat,
+            preferredVideo = null,
+            initializedFormats = emptyList(),
+            alreadyBuffered = emptyList(),
+            clientName = 5,
+            clientVersion = "20.10.4"
+        )
+        assertEquals(
+            "0a08e001e0d403c002012a03010203" +
+                "82010c088c0110ef949ce297e191039a010f0a0d8001058a010732302e31302e34",
+            seek.toHex()
+        )
+
+        val video = SabrMessages.playbackRequest(
+            ustreamerConfig = ustreamer,
+            playerTimeMs = 0L,
+            enabledTrackTypes = SabrMessages.TRACK_TYPES_AUDIO_AND_VIDEO,
+            preferredAudio = audioFormat,
+            preferredVideo = videoFormat,
+            initializedFormats = listOf(videoFormat, audioFormat),
+            alreadyBuffered = listOf(SabrBufferedRange(audioFormat, 0L, 213_090L, 1L, 1_000_000L)),
+            clientName = 5,
+            clientVersion = "20.10.4"
+        )
+        assertEquals(
+            "0a06e00100c00200120c08850110bbbbf6f4aae19103120c088c0110ef949ce297e19103" +
+                "1a1a0a0c088c0110ef949ce297e19103100018e2800d200128c0843d2a03010203" +
+                "82010c088c0110ef949ce297e191038a010c08850110bbbbf6f4aae19103" +
+                "9a010f0a0d8001058a010732302e31302e34",
+            video.toHex()
+        )
+    }
+
+    @Test
+    fun zeroValuedFieldsStayOnTheWire() {
+        val body = ProtoWriter().varint(1, 0L).varint(2, 5L).toByteArray()
+
+        assertEquals(setOf(1, 2), topLevelFields(body))
+    }
+
+    private fun ByteArray.toHex(): String = joinToString("") { byte ->
+        val value = byte.toInt() and 0xFF
+        "0123456789abcdef"[value ushr 4].toString() + "0123456789abcdef"[value and 0x0F]
+    }
+
+    private fun topLevelFields(body: ByteArray): Set<Int> {
+        val fields = LinkedHashSet<Int>()
+        val reader = ProtoReader(body, 0, body.size)
+        while (reader.next()) {
+            fields += reader.field
+            reader.skipValue()
+        }
+        return fields
+    }
+
+    private fun nestedMessage(body: ByteArray, field: Int): ByteArray {
+        val reader = ProtoReader(body, 0, body.size)
+        while (reader.next()) {
+            if (reader.field == field && reader.wireType == PROTO_WIRE_LENGTH_DELIMITED) {
+                return reader.readBytesValue()
+            }
+            reader.skipValue()
+        }
+        return ByteArray(0)
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/player/sabr/SabrSegmentAssemblerTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/sabr/SabrSegmentAssemblerTest.kt
@@ -13,7 +13,6 @@ class SabrSegmentAssemblerTest {
 
         assertEquals(SabrMediaWindow(1, 1_019), assembler.onMedia(0, 1_019, position = 0L))
         assertEquals(SabrMediaWindow(1, 162_083), assembler.onMedia(1, 162_083, position = 1_019L))
-        assertEquals(163_102L, assembler.deliveredBytes)
     }
 
     @Test
@@ -32,7 +31,6 @@ class SabrSegmentAssemblerTest {
         assembler.onMediaHeader(header(id = 0, itag = 140, start = 0L))
 
         assertNull(assembler.onMedia(0, 1_019, position = 5_000L))
-        assertEquals(1_019L, assembler.deliveredBytes)
     }
 
     @Test
@@ -43,7 +41,6 @@ class SabrSegmentAssemblerTest {
 
         assertNull(assembler.onMedia(0, 1_019, position = 0L))
         assertEquals(SabrMediaWindow(1, 1_228), assembler.onMedia(1, 1_228, position = 0L))
-        assertEquals(1_228L, assembler.deliveredBytes)
     }
 
     @Test
@@ -61,7 +58,6 @@ class SabrSegmentAssemblerTest {
         val assembler = SabrSegmentAssembler(targetItag = 140)
 
         assertNull(assembler.onMedia(7, 1_000, position = 0L))
-        assertEquals(0L, assembler.deliveredBytes)
     }
 
     @Test
@@ -80,8 +76,6 @@ class SabrSegmentAssemblerTest {
         assembler.onMedia(0, 1_019, position = 0L)
 
         assembler.reset()
-
-        assertEquals(0L, assembler.deliveredBytes)
         assertNull(assembler.onMedia(0, 1_019, position = 0L))
     }
 

--- a/app/src/test/java/com/luc4n3x/levyra/player/sabr/SabrSegmentAssemblerTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/sabr/SabrSegmentAssemblerTest.kt
@@ -1,0 +1,128 @@
+package com.luc4n3x.levyra.player.sabr
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SabrSegmentAssemblerTest {
+    @Test
+    fun deliversTheInitSegmentAndThenTheFirstMediaSegment() {
+        val assembler = SabrSegmentAssembler(targetItag = 140)
+        assembler.onMediaHeader(header(id = 0, itag = 140, start = 0L))
+        assembler.onMediaHeader(header(id = 1, itag = 140, start = 1_019L))
+
+        assertEquals(SabrMediaWindow(1, 1_019), assembler.onMedia(0, 1_019, position = 0L))
+        assertEquals(SabrMediaWindow(1, 162_083), assembler.onMedia(1, 162_083, position = 1_019L))
+        assertEquals(163_102L, assembler.deliveredBytes)
+    }
+
+    @Test
+    fun trimsAChunkThatStartsBeforeTheRequestedPosition() {
+        val assembler = SabrSegmentAssembler(targetItag = 140)
+        assembler.onMediaHeader(header(id = 0, itag = 140, start = 970_940L))
+
+        val window = assembler.onMedia(0, 161_619, position = 1_000_000L)
+
+        assertEquals(SabrMediaWindow(1 + 29_060, 161_619 - 29_060), window)
+    }
+
+    @Test
+    fun skipsChunksAlreadyBehindThePlayerPosition() {
+        val assembler = SabrSegmentAssembler(targetItag = 140)
+        assembler.onMediaHeader(header(id = 0, itag = 140, start = 0L))
+
+        assertNull(assembler.onMedia(0, 1_019, position = 5_000L))
+        assertEquals(1_019L, assembler.deliveredBytes)
+    }
+
+    @Test
+    fun ignoresChunksBelongingToAnotherFormat() {
+        val assembler = SabrSegmentAssembler(targetItag = 133)
+        assembler.onMediaHeader(header(id = 0, itag = 140, start = 0L))
+        assembler.onMediaHeader(header(id = 1, itag = 133, start = 0L))
+
+        assertNull(assembler.onMedia(0, 1_019, position = 0L))
+        assertEquals(SabrMediaWindow(1, 1_228), assembler.onMedia(1, 1_228, position = 0L))
+        assertEquals(1_228L, assembler.deliveredBytes)
+    }
+
+    @Test
+    fun consecutivePartsOfOneSegmentStayContiguous() {
+        val assembler = SabrSegmentAssembler(targetItag = 140)
+        assembler.onMediaHeader(header(id = 0, itag = 140, start = 0L))
+
+        assertEquals(SabrMediaWindow(1, 32_768), assembler.onMedia(0, 32_768, position = 0L))
+        assertEquals(SabrMediaWindow(1, 32_768), assembler.onMedia(0, 32_768, position = 32_768L))
+        assertEquals(SabrMediaWindow(101, 32_668), assembler.onMedia(0, 32_768, position = 65_636L))
+    }
+
+    @Test
+    fun mediaWithoutAKnownHeaderIsIgnored() {
+        val assembler = SabrSegmentAssembler(targetItag = 140)
+
+        assertNull(assembler.onMedia(7, 1_000, position = 0L))
+        assertEquals(0L, assembler.deliveredBytes)
+    }
+
+    @Test
+    fun emptyOrNegativePayloadsAreIgnored() {
+        val assembler = SabrSegmentAssembler(targetItag = 140)
+        assembler.onMediaHeader(header(id = 0, itag = 140, start = 0L))
+
+        assertNull(assembler.onMedia(0, 0, position = 0L))
+        assertNull(assembler.onMedia(0, -1, position = 0L))
+    }
+
+    @Test
+    fun resetClearsHeadersAndCountersBetweenRequests() {
+        val assembler = SabrSegmentAssembler(targetItag = 140)
+        assembler.onMediaHeader(header(id = 0, itag = 140, start = 0L))
+        assembler.onMedia(0, 1_019, position = 0L)
+
+        assembler.reset()
+
+        assertEquals(0L, assembler.deliveredBytes)
+        assertNull(assembler.onMedia(0, 1_019, position = 0L))
+    }
+
+    @Test
+    fun headerTrackingStaysBounded() {
+        val assembler = SabrSegmentAssembler(targetItag = 140, maxTrackedHeaders = 4)
+        repeat(64) { index -> assembler.onMediaHeader(header(id = index, itag = 140, start = 0L)) }
+
+        assertEquals(SabrMediaWindow(1, 10), assembler.onMedia(63, 10, position = 0L))
+    }
+
+    @Test
+    fun playerTimeTracksThePositionAndWalksBackWhenARequestOvershoots() {
+        val contentLength = 9_397_248L
+        val durationMs = 213_090L
+
+        assertEquals(0L, sabrPlayerTimeMsFor(contentLength, durationMs, position = 0L))
+        assertEquals(
+            durationMs / 2L,
+            sabrPlayerTimeMsFor(contentLength, durationMs, position = contentLength / 2L)
+        )
+        assertEquals(
+            durationMs - 1L,
+            sabrPlayerTimeMsFor(contentLength, durationMs, position = contentLength * 2L)
+        )
+        assertEquals(
+            0L,
+            sabrPlayerTimeMsFor(contentLength, durationMs, position = 1_000L, unproductiveAttempts = 3)
+        )
+        assertEquals(0L, sabrPlayerTimeMsFor(0L, durationMs, position = 10L))
+        assertEquals(0L, sabrPlayerTimeMsFor(contentLength, 0L, position = 10L))
+    }
+
+    private fun header(id: Int, itag: Int, start: Long) = SabrMediaHeader(
+        headerId = id,
+        itag = itag,
+        lastModified = 1L,
+        startDataRange = start,
+        contentLength = 0L,
+        sequenceNumber = 0L,
+        durationMs = 0L,
+        isInitSegment = false
+    )
+}

--- a/app/src/test/java/com/luc4n3x/levyra/player/sabr/SabrSegmentAssemblerTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/sabr/SabrSegmentAssemblerTest.kt
@@ -34,6 +34,14 @@ class SabrSegmentAssemblerTest {
     }
 
     @Test
+    fun rejectsAChunkThatStartsAfterTheRequestedPosition() {
+        val assembler = SabrSegmentAssembler(targetItag = 140)
+        assembler.onMediaHeader(header(id = 0, itag = 140, start = 1_200L))
+
+        assertNull(assembler.onMedia(0, 100, position = 1_000L))
+    }
+
+    @Test
     fun ignoresChunksBelongingToAnotherFormat() {
         val assembler = SabrSegmentAssembler(targetItag = 133)
         assembler.onMediaHeader(header(id = 0, itag = 140, start = 0L))

--- a/app/src/test/java/com/luc4n3x/levyra/player/sabr/SabrStreamSpecTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/sabr/SabrStreamSpecTest.kt
@@ -1,0 +1,97 @@
+package com.luc4n3x.levyra.player.sabr
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SabrStreamSpecTest {
+    private val endpoint = "https://rr5---sn-a.googlevideo.com/videoplayback?mn=sn-a,sn-b&sabr=1"
+
+    @Test
+    fun roundTripsThroughTheMediaUri() {
+        val spec = spec()
+
+        assertEquals(spec, SabrStreamSpec.parse(spec.toUri()))
+    }
+
+    @Test
+    fun toleratesTheDescriptiveQuerySuffixTheResolverAppends() {
+        val uri = spec().toUri() + "?itag=140&mime=audio%2Fmp4&expire=1788000000"
+
+        assertEquals(spec(), SabrStreamSpec.parse(uri))
+    }
+
+    @Test
+    fun rejectsEndpointsOutsideTheGooglevideoSurface() {
+        val hostile = listOf(
+            "http://rr5---sn-a.googlevideo.com/videoplayback",
+            "https://evil.test/videoplayback",
+            "https://rr5---sn-a.googlevideo.com.evil.test/videoplayback",
+            "https://user:pass@rr5---sn-a.googlevideo.com/videoplayback",
+            "https://rr5---sn-a.googlevideo.com:8443/videoplayback",
+            "https://127.0.0.1/videoplayback",
+            "https://localhost/videoplayback",
+            "https://googlevideo.com.evil.test/videoplayback",
+            ""
+        )
+
+        hostile.forEach { url ->
+            assertFalse(url, SabrEndpoint.isAllowed(url))
+            assertNull(url, SabrStreamSpec.parse(spec(endpointUrl = url).toUri()))
+        }
+    }
+
+    @Test
+    fun acceptsTheGooglevideoEndpointsSabrActuallyUses() {
+        assertTrue(SabrEndpoint.isAllowed(endpoint))
+        assertTrue(SabrEndpoint.isAllowed("https://rr2---sn-hpa7zns6.googlevideo.com/videoplayback"))
+    }
+
+    @Test
+    fun rejectsMalformedOrEmptyDescriptors() {
+        assertNull(SabrStreamSpec.parse("https://example.test/media.mp4"))
+        assertNull(SabrStreamSpec.parse(SabrStreamSpec.SCHEME_PREFIX))
+        assertNull(SabrStreamSpec.parse(SabrStreamSpec.SCHEME_PREFIX + "not base64"))
+        assertNull(SabrStreamSpec.parse(spec(contentLength = 0L).toUri()))
+        assertNull(SabrStreamSpec.parse(spec(durationMs = 0L).toUri()))
+        assertNull(SabrStreamSpec.parse(spec(itag = 0).toUri()))
+        assertNull(SabrStreamSpec.parse(spec(ustreamerConfig = ByteArray(0)).toUri()))
+    }
+
+    @Test
+    fun keepsTheCompanionAudioFormatOnlyWhenItIsPresent() {
+        assertNotNull(
+            SabrStreamSpec.parse(spec(companionAudio = SabrFormatId(140, 7L)).toUri())?.companionAudioFormat
+        )
+        assertNull(SabrStreamSpec.parse(spec().toUri())?.companionAudioFormat)
+    }
+
+    @Test
+    fun theUriIsRecognisableWithoutParsing() {
+        assertTrue(SabrStreamSpec.isSabrUri(spec().toUri()))
+        assertFalse(SabrStreamSpec.isSabrUri("https://rr5---sn-a.googlevideo.com/videoplayback"))
+    }
+
+    private fun spec(
+        endpointUrl: String = endpoint,
+        itag: Int = 140,
+        contentLength: Long = 9_397_248L,
+        durationMs: Long = 213_090L,
+        companionAudio: SabrFormatId? = null,
+        ustreamerConfig: ByteArray = byteArrayOf(10, 20, 30, 40)
+    ) = SabrStreamSpec(
+        endpointUrl = endpointUrl,
+        ustreamerConfig = ustreamerConfig,
+        format = SabrFormatId(itag, 1_766_955_925_572_207L),
+        companionAudioFormat = companionAudio,
+        contentLength = contentLength,
+        durationMs = durationMs,
+        videoTrack = false,
+        clientName = 5,
+        clientVersion = "20.10.4",
+        userAgent = "com.google.ios.youtube/20.10.4"
+    )
+}

--- a/app/src/test/java/com/luc4n3x/levyra/player/sabr/UmpReaderTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/sabr/UmpReaderTest.kt
@@ -1,0 +1,122 @@
+package com.luc4n3x.levyra.player.sabr
+
+import java.io.ByteArrayInputStream
+import java.io.EOFException
+import java.io.InputStream
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UmpReaderTest {
+    @Test
+    fun decodesTheFramingObservedOnLiveSabrResponses() {
+        // 0x33 0xa0 0x07 is the two-varint header of a 480 byte part observed on a real response.
+        val payload = ByteArray(480) { (it % 251).toByte() }
+        val response = byteArrayOf(0x33, 0xa0.toByte(), 0x07) + payload
+        val reader = UmpReader(ByteArrayInputStream(response))
+
+        assertTrue(reader.next())
+        assertEquals(51, reader.partType)
+        assertEquals(480, reader.partLength)
+        assertArrayEquals(payload, reader.partPayload.copyOf(reader.partLength))
+        assertFalse(reader.next())
+    }
+
+    @Test
+    fun varintRoundTripsAcrossEverySizeClass() {
+        val values = listOf(0, 1, 127, 128, 480, 16_383, 16_384, 2_097_151, 2_097_152, 268_435_455, 268_435_456, Int.MAX_VALUE)
+        values.forEach { value ->
+            val encoded = umpPart(value, ByteArray(0))
+            val reader = UmpReader(ByteArrayInputStream(encoded))
+            assertTrue("$value", reader.next())
+            assertEquals("$value", value, reader.partType)
+            assertEquals("$value", 0, reader.partLength)
+        }
+    }
+
+    @Test
+    fun readsSeveralPartsAndReusesOneBuffer() {
+        val first = ByteArray(1_000) { 1 }
+        val second = ByteArray(32_769) { 2 }
+        val response = umpPart(SabrPart.MEDIA_HEADER, first) + umpPart(SabrPart.MEDIA, second)
+        val reader = UmpReader(ByteArrayInputStream(response))
+
+        assertTrue(reader.next())
+        assertEquals(SabrPart.MEDIA_HEADER, reader.partType)
+        assertEquals(1_000, reader.partLength)
+        val firstBuffer = reader.partPayload
+
+        assertTrue(reader.next())
+        assertEquals(SabrPart.MEDIA, reader.partType)
+        assertEquals(32_769, reader.partLength)
+        assertEquals(2, reader.partPayload[0].toInt())
+        assertFalse(reader.next())
+        assertTrue(reader.partPayload.size >= firstBuffer.size)
+    }
+
+    @Test
+    fun reassemblesPartsSplitAcrossNetworkReads() {
+        val payload = ByteArray(5_000) { (it % 97).toByte() }
+        val response = umpPart(SabrPart.MEDIA, payload)
+        val reader = UmpReader(DripInputStream(response, chunk = 7))
+
+        assertTrue(reader.next())
+        assertEquals(SabrPart.MEDIA, reader.partType)
+        assertEquals(5_000, reader.partLength)
+        assertArrayEquals(payload, reader.partPayload.copyOf(reader.partLength))
+    }
+
+    @Test
+    fun unknownPartsAreReturnedAndCanBeSkippedByTheCaller() {
+        val response = umpPart(9_999, ByteArray(4)) + umpPart(SabrPart.MEDIA_END, byteArrayOf(0))
+        val reader = UmpReader(ByteArrayInputStream(response))
+
+        assertTrue(reader.next())
+        assertEquals(9_999, reader.partType)
+        assertTrue(reader.next())
+        assertEquals(SabrPart.MEDIA_END, reader.partType)
+        assertFalse(reader.next())
+    }
+
+    @Test(expected = SabrProtocolException::class)
+    fun oversizedPartsAreRejectedBeforeAllocating() {
+        val response = umpPart(SabrPart.MEDIA, ByteArray(0))
+        val oversized = umpVarint(SabrPart.MEDIA) + umpVarint(2_000_000) + ByteArray(16)
+        assertTrue(response.isNotEmpty())
+        UmpReader(ByteArrayInputStream(oversized), maxPartSize = 1_024).next()
+    }
+
+    @Test(expected = EOFException::class)
+    fun truncatedPayloadsFailInsteadOfReturningPartialMedia() {
+        val truncated = umpVarint(SabrPart.MEDIA) + umpVarint(64) + ByteArray(10)
+        UmpReader(ByteArrayInputStream(truncated)).next()
+    }
+
+    @Test(expected = EOFException::class)
+    fun truncatedHeadersFail() {
+        UmpReader(ByteArrayInputStream(byteArrayOf(0xa0.toByte()))).next()
+    }
+
+    @Test
+    fun emptyResponseEndsCleanly() {
+        val reader = UmpReader(ByteArrayInputStream(ByteArray(0)))
+        assertFalse(reader.next())
+        assertEquals(-1, reader.partType)
+    }
+
+    private class DripInputStream(private val data: ByteArray, private val chunk: Int) : InputStream() {
+        private var position = 0
+
+        override fun read(): Int = if (position >= data.size) -1 else data[position++].toInt() and 0xFF
+
+        override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+            if (position >= data.size) return -1
+            val count = minOf(chunk, length, data.size - position)
+            System.arraycopy(data, position, buffer, offset, count)
+            position += count
+            return count
+        }
+    }
+}

--- a/scripts/tests/test_youtube_canary.py
+++ b/scripts/tests/test_youtube_canary.py
@@ -216,6 +216,67 @@ class YoutubeCanaryTest(unittest.TestCase):
         self.assertEqual("repair", decision["decision"])
         self.assertTrue(any("SABR only" in item for item in decision["material_changes"]))
 
+    def test_a_matrix_where_every_probe_failed_is_not_evidence(self):
+        all_failed = canary._summarize_delivery(
+            [
+                {"client": "IOS", "delivery": canary.DELIVERY_TRANSPORT_FAILURE, "player": {}},
+                {"client": "WEB", "delivery": canary.DELIVERY_CLIENT_FAILURE, "player": {}},
+            ]
+        )
+        healthy_before = canary._summarize_delivery(
+            [
+                {"client": "IOS", "delivery": canary.DELIVERY_DIRECT_HEALTHY,
+                 "player": {"has_server_abr_streaming_url": True}},
+                {"client": "WEB", "delivery": canary.DELIVERY_CLIENT_FAILURE, "player": {}},
+            ]
+        )
+
+        self.assertFalse(canary._delivery_evidence_is_conclusive(all_failed))
+        self.assertFalse(canary._delivery_evidence_is_conclusive({}))
+        self.assertFalse(canary._delivery_evidence_is_conclusive(canary._summarize_delivery([])))
+        self.assertTrue(canary._delivery_evidence_is_conclusive(healthy_before))
+
+        baseline = {
+            "schema": canary.SCHEMA_VERSION,
+            "observation": {
+                "schema": canary.SCHEMA_VERSION,
+                "sentinels": [
+                    {
+                        "name": "s",
+                        "required": True,
+                        "ok": True,
+                        "observation": {
+                            "player": {"playability_status": "OK"},
+                            "delivery_summary": healthy_before,
+                        },
+                    }
+                ],
+            },
+        }
+        observation = {
+            "schema": canary.SCHEMA_VERSION,
+            "sentinels": [
+                {
+                    "name": "s",
+                    "required": True,
+                    "ok": True,
+                    "observation": {
+                        "player": {"playability_status": "OK"},
+                        "delivery_summary": all_failed,
+                    },
+                }
+            ],
+        }
+
+        decision = canary._classify(
+            baseline, observation, {"thresholds": {"required_sentinel_regressions_for_repair": 1}}
+        )
+        self.assertEqual("none", decision["decision"])
+
+    def test_canary_error_carries_the_http_status_for_classification(self):
+        self.assertIsNone(canary.CanaryError("invalid player JSON: boom").status)
+        self.assertEqual(403, canary.CanaryError("player endpoint HTTP 403", status=403).status)
+
     def test_media_host_policy_rejects_non_googlevideo(self):
         self.assertEqual("x.googlevideo.com", canary._safe_host("https://x.googlevideo.com/a", media=True))
         with self.assertRaises(canary.CanaryError):

--- a/scripts/tests/test_youtube_canary.py
+++ b/scripts/tests/test_youtube_canary.py
@@ -61,6 +61,161 @@ class YoutubeCanaryTest(unittest.TestCase):
         self.assertNotIn("secret", serialized)
         self.assertNotIn("videoplayback", serialized)
 
+    def test_summarize_player_response_records_sabr_metadata_without_urls(self):
+        player = {
+            "playabilityStatus": {"status": "OK"},
+            "playerConfig": {
+                "mediaCommonConfig": {
+                    "mediaUstreamerRequestConfig": {
+                        "videoPlaybackUseUmp": True,
+                        "videoPlaybackUstreamerConfig": "Q3M9Q29uZmln",
+                    }
+                }
+            },
+            "streamingData": {
+                "serverAbrStreamingUrl": (
+                    "https://rr5---sn-a.googlevideo.com/videoplayback?mn=sn-a,sn-b&sig=secret"
+                ),
+                "adaptiveFormats": [
+                    {
+                        "itag": 140,
+                        "mimeType": 'audio/mp4; codecs="mp4a.40.2"',
+                        "url": "https://rr5---sn-a.googlevideo.com/videoplayback?mn=sn-a,sn-b&n=abc",
+                    },
+                    {"itag": 137, "mimeType": 'video/mp4; codecs="avc1"', "height": 1080,
+                     "url": "https://rr5---sn-a.googlevideo.com/videoplayback?mn=sn-a,sn-b&n=abc"},
+                ],
+            },
+        }
+
+        summary = canary._summarize_player_response(player)
+        summary.pop("_probe_url")
+        serialized = json.dumps(summary)
+
+        self.assertTrue(summary["has_server_abr_streaming_url"])
+        self.assertTrue(summary["server_abr_host_is_googlevideo"])
+        self.assertEqual(2, summary["server_abr_media_networks"])
+        self.assertEqual(2, summary["direct_media_networks"])
+        self.assertTrue(summary["has_ustreamer_config"])
+        self.assertTrue(summary["video_playback_use_ump"])
+        self.assertNotIn("secret", serialized)
+        self.assertNotIn("googlevideo.com/videoplayback", serialized)
+
+    def test_delivery_classification_separates_sabr_security_and_client_failures(self):
+        healthy = {
+            "playability_status": "OK",
+            "has_streaming_data": True,
+            "direct_urls": 4,
+            "adaptive_audio_formats": 2,
+            "adaptive_video_formats": 2,
+        }
+        self.assertEqual(canary.DELIVERY_DIRECT_HEALTHY, canary._classify_delivery(healthy))
+        self.assertEqual(
+            canary.DELIVERY_DIRECT_DEGRADED,
+            canary._classify_delivery({**healthy, "adaptive_video_formats": 0}),
+        )
+        self.assertEqual(
+            canary.DELIVERY_SABR_ONLY,
+            canary._classify_delivery(
+                {
+                    "playability_status": "OK",
+                    "has_streaming_data": True,
+                    "direct_urls": 0,
+                    "cipher_urls": 0,
+                    "has_server_abr_streaming_url": True,
+                }
+            ),
+        )
+        self.assertEqual(
+            canary.DELIVERY_DIRECT_UNAVAILABLE,
+            canary._classify_delivery(
+                {"playability_status": "OK", "has_streaming_data": True, "direct_urls": 0}
+            ),
+        )
+        self.assertEqual(
+            canary.DELIVERY_SECURITY_FAILURE,
+            canary._classify_delivery(
+                {"playability_status": "LOGIN_REQUIRED", "playability_reason": "Please sign in"}
+            ),
+        )
+        self.assertEqual(
+            canary.DELIVERY_SECURITY_FAILURE,
+            canary._classify_delivery(
+                {
+                    "playability_status": "UNPLAYABLE",
+                    "playability_reason": "Sign in to confirm you are not a bot",
+                }
+            ),
+        )
+        self.assertEqual(
+            canary.DELIVERY_CLIENT_FAILURE,
+            canary._classify_delivery({"playability_status": "ERROR", "playability_reason": "nope"}),
+        )
+        self.assertEqual(
+            canary.DELIVERY_CLIENT_FAILURE,
+            canary._classify_delivery({"playability_status": "OK", "has_streaming_data": False}),
+        )
+
+    def test_client_matrix_matches_levyra_policy_and_excludes_android_vr(self):
+        names = [entry["name"] for entry in canary.LEVYRA_CLIENT_MATRIX]
+
+        self.assertEqual(sorted(names), sorted(set(names)))
+        self.assertNotIn("ANDROID_VR", names)
+        for expected in ("VISIONOS", "ANDROID_MUSIC", "ANDROID", "IOS", "WEB_REMIX", "WEB", "WEB_EMBEDDED_PLAYER"):
+            self.assertIn(expected, names)
+
+    def test_sabr_enforcement_is_material_only_when_direct_disappears_everywhere(self):
+        enforced = canary._summarize_delivery(
+            [
+                {"client": "IOS", "delivery": canary.DELIVERY_SABR_ONLY,
+                 "player": {"has_server_abr_streaming_url": True}},
+                {"client": "WEB", "delivery": canary.DELIVERY_CLIENT_FAILURE, "player": {}},
+            ]
+        )
+        mixed = canary._summarize_delivery(
+            [
+                {"client": "IOS", "delivery": canary.DELIVERY_DIRECT_HEALTHY,
+                 "player": {"has_server_abr_streaming_url": True}},
+                {"client": "WEB", "delivery": canary.DELIVERY_SABR_ONLY,
+                 "player": {"has_server_abr_streaming_url": True}},
+            ]
+        )
+
+        self.assertTrue(enforced["sabr_enforced"])
+        self.assertFalse(mixed["sabr_enforced"])
+
+        baseline = {
+            "schema": canary.SCHEMA_VERSION,
+            "observation": {
+                "schema": canary.SCHEMA_VERSION,
+                "sentinels": [
+                    {
+                        "name": "s",
+                        "required": True,
+                        "ok": True,
+                        "observation": {"player": {"playability_status": "OK"}, "delivery_summary": mixed},
+                    }
+                ],
+            },
+        }
+        observation = {
+            "schema": canary.SCHEMA_VERSION,
+            "sentinels": [
+                {
+                    "name": "s",
+                    "required": True,
+                    "ok": True,
+                    "observation": {"player": {"playability_status": "OK"}, "delivery_summary": enforced},
+                }
+            ],
+        }
+
+        decision = canary._classify(
+            baseline, observation, {"thresholds": {"required_sentinel_regressions_for_repair": 1}}
+        )
+        self.assertEqual("repair", decision["decision"])
+        self.assertTrue(any("SABR only" in item for item in decision["material_changes"]))
+
     def test_media_host_policy_rejects_non_googlevideo(self):
         self.assertEqual("x.googlevideo.com", canary._safe_host("https://x.googlevideo.com/a", media=True))
         with self.assertRaises(canary.CanaryError):

--- a/scripts/youtube_canary.py
+++ b/scripts/youtube_canary.py
@@ -111,7 +111,9 @@ EXACT_HTTPS_HOSTS = {
 
 
 class CanaryError(RuntimeError):
-    pass
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
 
 
 class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
@@ -372,7 +374,7 @@ def _player_api_request(
         max_bytes=PLAYER_JSON_MAX_BYTES,
     )
     if result.status < 200 or result.status >= 300:
-        raise CanaryError(f"player endpoint HTTP {result.status}")
+        raise CanaryError(f"player endpoint HTTP {result.status}", status=result.status)
     try:
         parsed = json.loads(result.body.decode("utf-8", errors="strict"))
     except (UnicodeDecodeError, json.JSONDecodeError) as error:
@@ -568,13 +570,18 @@ def _probe_client(
             user_agent=str(entry.get("user_agent") or USER_AGENT),
         )
     except CanaryError as error:
-        message = str(error)[:240]
-        transport = "HTTP" not in message
+        status = getattr(error, "status", None)
+        if status is None:
+            delivery = DELIVERY_TRANSPORT_FAILURE
+        elif status in (401, 403):
+            delivery = DELIVERY_SECURITY_FAILURE
+        else:
+            delivery = DELIVERY_CLIENT_FAILURE
         return {
             "client": name,
             "latency_ms": int((time.monotonic() - started) * 1000),
-            "delivery": DELIVERY_TRANSPORT_FAILURE if transport else DELIVERY_CLIENT_FAILURE,
-            "error": message,
+            "delivery": delivery,
+            "error": str(error)[:240],
         }
     summary = _summarize_player_response(player)
     summary.pop("_probe_url", "")
@@ -942,6 +949,19 @@ def _sentinel_access_blocked(sentinel: dict[str, Any]) -> bool:
     return any(marker in error for marker in blocked_markers)
 
 
+def _delivery_evidence_is_conclusive(delivery: dict[str, Any]) -> bool:
+    """A client matrix where every probe failed on our side says nothing about YouTube."""
+    if not delivery:
+        return False
+    probed = int(delivery.get("clients_probed") or 0)
+    if probed <= 0:
+        return False
+    failed = int(delivery.get("clients_transport_failure") or 0) + int(
+        delivery.get("clients_client_failure") or 0
+    )
+    return failed < probed
+
+
 def _classify(
     baseline: dict[str, Any],
     observation: dict[str, Any],
@@ -1052,7 +1072,7 @@ def _classify(
 
         old_delivery = old_obs.get("delivery_summary") if isinstance(old_obs.get("delivery_summary"), dict) else {}
         new_delivery = new_obs.get("delivery_summary") if isinstance(new_obs.get("delivery_summary"), dict) else {}
-        if new_delivery:
+        if not access_blocked and _delivery_evidence_is_conclusive(new_delivery):
             if int(new_delivery.get("clients_playable") or 0) == 0 and int(
                 old_delivery.get("clients_playable") or 0
             ) > 0:

--- a/scripts/youtube_canary.py
+++ b/scripts/youtube_canary.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 WATCH_MAX_BYTES = 5 * 1024 * 1024
 PLAYER_JS_MAX_BYTES = 10 * 1024 * 1024
 PLAYER_JSON_MAX_BYTES = 8 * 1024 * 1024
@@ -32,6 +32,71 @@ USER_AGENT = (
     "(KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36"
 )
 VIDEO_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
+
+# Mirrors the clients Levyra's playback compatibility policy actually uses. ANDROID_VR stays out
+# because the shipped policy disables it; the canary must not imply support Levyra does not ship.
+LEVYRA_CLIENT_MATRIX: tuple[dict[str, Any], ...] = (
+    {
+        "name": "VISIONOS",
+        "client": {
+            "clientName": "VISIONOS",
+            "clientVersion": "1.04",
+            "deviceMake": "Apple",
+            "deviceModel": "RealityDevice14,1",
+            "osName": "visionOS",
+            "osVersion": "1.0.3.21O566",
+        },
+        "user_agent": "com.google.ios.youtube/1.04 (RealityDevice14,1; U; CPU visionOS 1_0_3 like Mac OS X)",
+    },
+    {
+        "name": "ANDROID_MUSIC",
+        "client": {
+            "clientName": "ANDROID_MUSIC",
+            "clientVersion": "8.10.52",
+            "androidSdkVersion": 34,
+            "osName": "Android",
+            "osVersion": "15",
+        },
+        "user_agent": "com.google.android.apps.youtube.music/8.10.52 (Linux; U; Android 15) gzip",
+    },
+    {
+        "name": "ANDROID",
+        "client": {
+            "clientName": "ANDROID",
+            "clientVersion": "19.44.38",
+            "androidSdkVersion": 34,
+            "osName": "Android",
+            "osVersion": "15",
+        },
+        "user_agent": "com.google.android.youtube/19.44.38 (Linux; U; Android 15) gzip",
+    },
+    {
+        "name": "IOS",
+        "client": {
+            "clientName": "IOS",
+            "clientVersion": "20.10.4",
+            "deviceMake": "Apple",
+            "deviceModel": "iPhone16,2",
+            "osName": "iPhone",
+            "osVersion": "18.3.0.22D63",
+        },
+        "user_agent": "com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3 like Mac OS X)",
+    },
+    {"name": "WEB_REMIX", "client": {"clientName": "WEB_REMIX", "clientVersion": "1.20260804.16.00"}},
+    {"name": "WEB", "client": {"clientName": "WEB", "clientVersion": ""}},
+    {
+        "name": "WEB_EMBEDDED_PLAYER",
+        "client": {"clientName": "WEB_EMBEDDED_PLAYER", "clientVersion": "1.20260423.01.00"},
+    },
+)
+
+DELIVERY_DIRECT_HEALTHY = "direct_healthy"
+DELIVERY_DIRECT_DEGRADED = "direct_degraded"
+DELIVERY_DIRECT_UNAVAILABLE = "direct_unavailable"
+DELIVERY_SABR_ONLY = "sabr_only"
+DELIVERY_SECURITY_FAILURE = "security_failure"
+DELIVERY_CLIENT_FAILURE = "client_failure"
+DELIVERY_TRANSPORT_FAILURE = "transport_failure"
 KEYWORDS = ("youtube", "player", "cipher", "sabr", "innertube", "stream", "signature", "visionos", "reel")
 
 EXACT_HTTPS_HOSTS = {
@@ -265,19 +330,22 @@ def _player_api_request(
     visitor_data: str,
     hl: str,
     gl: str,
+    client: dict[str, Any] | None = None,
+    user_agent: str = USER_AGENT,
 ) -> dict[str, Any]:
     if not innertube_query_value or not client_version:
         raise CanaryError("watch page did not expose InnerTube API key/client version")
+    context_client: dict[str, Any] = dict(client or {"clientName": "WEB"})
+    context_client.update(
+        {
+            "clientVersion": client_version,
+            "hl": hl,
+            "gl": gl,
+            "utcOffsetMinutes": 0,
+        }
+    )
     body: dict[str, Any] = {
-        "context": {
-            "client": {
-                "clientName": "WEB",
-                "clientVersion": client_version,
-                "hl": hl,
-                "gl": gl,
-                "utcOffsetMinutes": 0,
-            }
-        },
+        "context": {"client": context_client},
         "videoId": video_id,
         "contentCheckOk": True,
         "racyCheckOk": True,
@@ -297,7 +365,7 @@ def _player_api_request(
             "Content-Type": "application/json",
             "Origin": "https://www.youtube.com",
             "Referer": f"https://www.youtube.com/watch?v={video_id}",
-            "User-Agent": USER_AGENT,
+            "User-Agent": user_agent,
             "X-YouTube-Client-Name": "1",
             "X-YouTube-Client-Version": client_version,
         },
@@ -382,11 +450,31 @@ def _summarize_player_response(player: dict[str, Any]) -> dict[str, Any]:
         elif mime_type.startswith("audio/"):
             adaptive_audio_count += 1
 
+    player_config = player.get("playerConfig")
+    media_common = player_config.get("mediaCommonConfig") if isinstance(player_config, dict) else None
+    ustreamer = media_common.get("mediaUstreamerRequestConfig") if isinstance(media_common, dict) else None
+    ustreamer_config = ""
+    use_ump = False
+    if isinstance(ustreamer, dict):
+        ustreamer_config = str(ustreamer.get("videoPlaybackUstreamerConfig") or "")
+        use_ump = bool(ustreamer.get("videoPlaybackUseUmp"))
+
+    sabr_url = str(streaming.get("serverAbrStreamingUrl") or "")
+    sabr_networks = _media_network_count(sabr_url)
+    direct_networks = _media_network_count(direct_probe_url)
+
     return {
         "playability_status": str(playability.get("status") or ""),
         "playability_reason": str(playability.get("reason") or "")[:240],
         "has_streaming_data": bool(streaming),
         "streaming_keys": sorted(str(key) for key in streaming.keys()),
+        "has_server_abr_streaming_url": bool(sabr_url),
+        "server_abr_host_is_googlevideo": _is_googlevideo(sabr_url),
+        "server_abr_media_networks": sabr_networks,
+        "has_ustreamer_config": bool(ustreamer_config),
+        "ustreamer_config_bytes": len(ustreamer_config),
+        "video_playback_use_ump": use_ump,
+        "direct_media_networks": direct_networks,
         "formats": len(formats),
         "adaptive_formats": len(adaptive),
         "total_formats": len(all_formats),
@@ -403,6 +491,126 @@ def _summarize_player_response(player: dict[str, Any]) -> dict[str, Any]:
         "top_level_keys": sorted(str(key) for key in player.keys()),
         "_probe_url": direct_probe_url,
     }
+
+
+def _is_googlevideo(url: str) -> bool:
+    if not url:
+        return False
+    try:
+        host = (urllib.parse.urlsplit(url).hostname or "").lower()
+    except ValueError:
+        return False
+    return host == "googlevideo.com" or host.endswith(".googlevideo.com")
+
+
+def _media_network_count(url: str) -> int:
+    """Number of equivalent Googlevideo media networks the signed URL advertises. Host names and
+    signed parameters are never recorded, only how many alternatives exist."""
+    if not url:
+        return 0
+    try:
+        query = urllib.parse.parse_qs(urllib.parse.urlsplit(url).query, keep_blank_values=False)
+    except ValueError:
+        return 0
+    declared = (query.get("mn") or [""])[0]
+    return len({item for item in declared.split(",") if item.strip()})
+
+
+def _classify_delivery(summary: dict[str, Any]) -> str:
+    """Where playback for one client currently stands. The canary is a sensor: it reports what the
+    protocol offers an unauthenticated prober, never what Levyra can reach with its own tokens."""
+    status = str(summary.get("playability_status") or "")
+    reason = str(summary.get("playability_reason") or "").lower()
+    if status in ("LOGIN_REQUIRED", "AGE_VERIFICATION_REQUIRED") or "bot" in reason or "sign in" in reason:
+        return DELIVERY_SECURITY_FAILURE
+    if status and status != "OK":
+        return DELIVERY_CLIENT_FAILURE
+    if not summary.get("has_streaming_data"):
+        return DELIVERY_CLIENT_FAILURE
+
+    direct = int(summary.get("direct_urls") or 0)
+    cipher = int(summary.get("cipher_urls") or 0)
+    adaptive_audio = int(summary.get("adaptive_audio_formats") or 0)
+    adaptive_video = int(summary.get("adaptive_video_formats") or 0)
+    sabr = bool(summary.get("has_server_abr_streaming_url"))
+
+    if direct == 0 and cipher == 0:
+        return DELIVERY_SABR_ONLY if sabr else DELIVERY_DIRECT_UNAVAILABLE
+    if adaptive_audio == 0 or adaptive_video == 0:
+        return DELIVERY_DIRECT_DEGRADED
+    return DELIVERY_DIRECT_HEALTHY
+
+
+def _probe_client(
+    entry: dict[str, Any],
+    *,
+    video_id: str,
+    innertube_query_value: str,
+    web_client_version: str,
+    visitor_data: str,
+    hl: str,
+    gl: str,
+) -> dict[str, Any]:
+    name = str(entry.get("name") or "")
+    client = dict(entry.get("client") or {})
+    if not client.get("clientVersion"):
+        client["clientVersion"] = web_client_version
+    started = time.monotonic()
+    try:
+        player = _player_api_request(
+            video_id=video_id,
+            innertube_query_value=innertube_query_value,
+            client_version=str(client.get("clientVersion") or ""),
+            visitor_data=visitor_data,
+            hl=hl,
+            gl=gl,
+            client=client,
+            user_agent=str(entry.get("user_agent") or USER_AGENT),
+        )
+    except CanaryError as error:
+        message = str(error)[:240]
+        transport = "HTTP" not in message
+        return {
+            "client": name,
+            "latency_ms": int((time.monotonic() - started) * 1000),
+            "delivery": DELIVERY_TRANSPORT_FAILURE if transport else DELIVERY_CLIENT_FAILURE,
+            "error": message,
+        }
+    summary = _summarize_player_response(player)
+    summary.pop("_probe_url", "")
+    summary.pop("top_level_keys", None)
+    summary.pop("streaming_keys", None)
+    return {
+        "client": name,
+        "latency_ms": int((time.monotonic() - started) * 1000),
+        "delivery": _classify_delivery(summary),
+        "player": summary,
+    }
+
+
+def _probe_client_matrix(
+    *,
+    video_id: str,
+    innertube_query_value: str,
+    web_client_version: str,
+    visitor_data: str,
+    hl: str,
+    gl: str,
+) -> list[dict[str, Any]]:
+    if not innertube_query_value:
+        return []
+    return [
+        _probe_client(
+            entry,
+            video_id=video_id,
+            innertube_query_value=innertube_query_value,
+            web_client_version=web_client_version,
+            visitor_data=visitor_data,
+            hl=hl,
+            gl=gl,
+        )
+        for entry in LEVYRA_CLIENT_MATRIX
+    ]
 
 
 def _probe_media_url(url: str) -> dict[str, Any]:
@@ -478,6 +686,7 @@ def _probe_sentinel(
         "attempts": [],
     }
 
+    matrix_inputs: dict[str, str] | None = None
     for attempt in range(1, max(1, attempts) + 1):
         attempt_result: dict[str, Any] = {"attempt": attempt}
         try:
@@ -515,11 +724,16 @@ def _probe_sentinel(
                 private_js = private_evidence_dir / f"player-{js_sha256[:16]}.js"
                 if not private_js.exists():
                     private_js.write_bytes(js_result.body)
+            matrix_inputs = {
+                "innertube_query_value": str(ytcfg.get("INNERTUBE_API_KEY") or ""),
+                "web_client_version": str(ytcfg.get("INNERTUBE_CLIENT_VERSION") or ""),
+                "visitor_data": str(ytcfg.get("VISITOR_DATA") or ""),
+            }
             player = _player_api_request(
                 video_id=video_id,
-                innertube_query_value=str(ytcfg.get("INNERTUBE_API_KEY") or ""),
-                client_version=str(ytcfg.get("INNERTUBE_CLIENT_VERSION") or ""),
-                visitor_data=str(ytcfg.get("VISITOR_DATA") or ""),
+                innertube_query_value=matrix_inputs["innertube_query_value"],
+                client_version=matrix_inputs["web_client_version"],
+                visitor_data=matrix_inputs["visitor_data"],
                 hl=hl,
                 gl=gl,
             )
@@ -565,9 +779,56 @@ def _probe_sentinel(
 
     successful = next((item for item in result["attempts"] if item.get("ok")), None)
     chosen = successful or result["attempts"][-1]
+    clients = (
+        _probe_client_matrix(
+            video_id=video_id,
+            hl=hl,
+            gl=gl,
+            **matrix_inputs,
+        )
+        if matrix_inputs
+        else []
+    )
+    chosen["clients"] = clients
+    chosen["delivery_summary"] = _summarize_delivery(clients)
     result["observation"] = chosen
     result["ok"] = bool(chosen.get("ok"))
     return result
+
+
+def _summarize_delivery(clients: list[dict[str, Any]]) -> dict[str, Any]:
+    deliveries = [str(item.get("delivery") or "") for item in clients]
+    direct_capable = [
+        item
+        for item in clients
+        if item.get("delivery") in (DELIVERY_DIRECT_HEALTHY, DELIVERY_DIRECT_DEGRADED)
+    ]
+    sabr_capable = [
+        item
+        for item in clients
+        if isinstance(item.get("player"), dict)
+        and item["player"].get("has_server_abr_streaming_url")
+    ]
+    playable = [
+        item
+        for item in clients
+        if item.get("delivery")
+        in (DELIVERY_DIRECT_HEALTHY, DELIVERY_DIRECT_DEGRADED, DELIVERY_SABR_ONLY)
+    ]
+    return {
+        "clients_probed": len(clients),
+        "clients_playable": len(playable),
+        "clients_direct_capable": len(direct_capable),
+        "clients_sabr_capable": len(sabr_capable),
+        "clients_sabr_only": deliveries.count(DELIVERY_SABR_ONLY),
+        "clients_security_failure": deliveries.count(DELIVERY_SECURITY_FAILURE),
+        "clients_client_failure": deliveries.count(DELIVERY_CLIENT_FAILURE),
+        "clients_transport_failure": deliveries.count(DELIVERY_TRANSPORT_FAILURE),
+        "sabr_enforced": bool(playable) and not direct_capable and bool(sabr_capable),
+        "by_client": {
+            str(item.get("client") or ""): str(item.get("delivery") or "") for item in clients
+        },
+    }
 
 
 def _fetch_upstream(repo: str, branch: str) -> dict[str, Any]:
@@ -789,6 +1050,34 @@ def _classify(
             )
             material_sentinels.add(name)
 
+        old_delivery = old_obs.get("delivery_summary") if isinstance(old_obs.get("delivery_summary"), dict) else {}
+        new_delivery = new_obs.get("delivery_summary") if isinstance(new_obs.get("delivery_summary"), dict) else {}
+        if new_delivery:
+            if int(new_delivery.get("clients_playable") or 0) == 0 and int(
+                old_delivery.get("clients_playable") or 0
+            ) > 0:
+                material.append(f"{name}: no probed client returns a playable delivery method")
+                material_sentinels.add(name)
+            elif not bool(old_delivery.get("sabr_enforced")) and bool(new_delivery.get("sabr_enforced")):
+                material.append(
+                    f"{name}: every playable client now exposes SABR only; direct delivery disappeared"
+                )
+                material_sentinels.add(name)
+            elif int(old_delivery.get("clients_direct_capable") or 0) > int(
+                new_delivery.get("clients_direct_capable") or 0
+            ):
+                info.append(
+                    f"{name}: clients with direct delivery "
+                    f"{old_delivery.get('clients_direct_capable')} -> "
+                    f"{new_delivery.get('clients_direct_capable')}"
+                )
+            old_by_client = old_delivery.get("by_client") or {}
+            new_by_client = new_delivery.get("by_client") or {}
+            for client_name, new_state in sorted(new_by_client.items()):
+                old_state = old_by_client.get(client_name)
+                if old_state and old_state != new_state:
+                    info.append(f"{name}: client {client_name} {old_state} -> {new_state}")
+
         old_media = old_obs.get("media_probe") if isinstance(old_obs.get("media_probe"), dict) else {}
         new_media = new_obs.get("media_probe") if isinstance(new_obs.get("media_probe"), dict) else {}
         if old_media.get("initial_ok") is True and new_media.get("initial_ok") is False:
@@ -889,6 +1178,32 @@ def _render_report(observation: dict[str, Any], decision: dict[str, Any]) -> str
                 r1="yes" if media.get("continuation_ok") else ("no" if media.get("attempted") else "n/a"),
             )
         )
+    lines += ["", "## Delivery method by client", ""]
+    lines.append("| Sentinel | Playable | Direct | SABR | SABR only | Security | Per client |")
+    lines.append("|---|---:|---:|---:|---:|---:|---|")
+    for sentinel in observation.get("sentinels") or []:
+        if not isinstance(sentinel, dict):
+            continue
+        chosen = sentinel.get("observation") if isinstance(sentinel.get("observation"), dict) else {}
+        delivery = chosen.get("delivery_summary") if isinstance(chosen.get("delivery_summary"), dict) else {}
+        if not delivery:
+            continue
+        per_client = ", ".join(
+            f"{key}={value}" for key, value in sorted((delivery.get("by_client") or {}).items())
+        )
+        lines.append(
+            "| {name} | {playable}/{probed} | {direct} | {sabr} | {only} | {security} | {per} |".format(
+                name=str(sentinel.get("name") or sentinel.get("video_id") or ""),
+                playable=int(delivery.get("clients_playable") or 0),
+                probed=int(delivery.get("clients_probed") or 0),
+                direct=int(delivery.get("clients_direct_capable") or 0),
+                sabr=int(delivery.get("clients_sabr_capable") or 0),
+                only=int(delivery.get("clients_sabr_only") or 0),
+                security=int(delivery.get("clients_security_failure") or 0),
+                per=per_client.replace("|", "/")[:220],
+            )
+        )
+
     lines += [
         "",
         "## Upstream radar",


### PR DESCRIPTION
## Summary

YouTube is moving more playback to server-driven delivery, where the player response carries a `serverAbrStreamingUrl` and no direct media URL that Levyra can use. This PR adds SABR as a real delivery method for VOD, and it fixes two recovery paths that were doing far more work than the failure deserved.

A 404 or a 5xx on one media URL describes that candidate, not the client, the security state or the resolver. Levyra was still going through a full re-resolution for those. It now promotes an equivalent stream out of the manifest it already holds. Separately, Googlevideo signs an `mn` list of media networks that serve the same resource, so an unreachable edge can be retried on a sibling without a new player response.

## What changed

- Added candidate-level recovery: a transient 404, 500, 502, 503 or 504 promotes another stream from the resolved manifest instead of rotating clients or refreshing security state. The cache lookup no longer stops at a quarantined URL, so the promoted stream is picked up without a network round trip. The promotion ladder is bounded by how many streams of the manifest are already quarantined.
- Added Googlevideo media-network failover in `LevyraYoutubeDataSource`. Only the media-network label of the host is rewritten, path, query and signature stay untouched, candidates are capped, and any host that is not a validated `*.googlevideo.com` is dropped. 403 and the other security answers are deliberately excluded so the existing security recovery still sees them.
- Added SABR delivery for VOD. It is implemented as a Media3 `DataSource` rather than a second player: every SABR media header carries the absolute byte offset of the chunk that follows, and those offsets describe the same byte stream the direct URL would serve, so Media3 keeps its extractor, seek map, end-of-stream handling and renderers.
- Added an incremental UMP reader with one reusable buffer and a hard part-size cap, plus a small protobuf writer and reader instead of a full runtime.
- The resolver now adds SABR streams to the manifest whenever the player response exposes them, selects SABR when no direct URL survives, and otherwise leaves them as alternatives that candidate recovery can promote to. Audio follows the user's quality preference and video is capped at the height `LevyraVideoStreamSelector` already allows.
- SABR sessions bypass the shared media cache, and offline export never uses them.
- Reworked the YouTube canary: it probes the client matrix Levyra actually ships, records the SABR fields (`serverAbrStreamingUrl`, ustreamer config, media-network counts, UMP flag), classifies a delivery method per client, and reports when every playable client has lost direct delivery.
- Suppressed the `MissingClass` lint error on the flavor-gated `MediaTransferReceiver` declarations, which was failing `lintRelease` on the F-Droid configuration before this branch.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor or maintenance
- [ ] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** Player / Streaming

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [x] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

Run locally:

- `./gradlew --no-daemon :app:testDebugUnitTest` (1549 tests, 0 failures)
- `./gradlew --no-daemon :app:assembleDebug` (upstream source set)
- `./gradlew --no-daemon -PlevyraFdroidBuild=true :app:assembleDebug`
- `./gradlew --no-daemon -PlevyraFdroidBuild=true :app:lintRelease`
- `./gradlew --no-daemon -PlevyraFdroidBuild=true :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.luc4n3x.levyra.player.sabr.SabrDataSourceTest` (12 tests)
- `python scripts/ai_quality_gate.py --profile fast`
- `python -m unittest discover -s scripts/tests -p test_youtube_canary.py` (21 tests)

The release variants of `lintRelease`, `testReleaseUnitTest` and `assembleRelease` need `YOUTUBE_INNERTUBE_API_KEY` and the signing inputs, which are not available on this machine. They ran against the F-Droid configuration instead, which builds from the public client identifier. CI covers the upstream release path.

The SABR request encoding is anchored to bytes the live server accepted: `SabrProtocolTest` asserts the exact payload for the audio, seek and video cases. That test caught a real defect, since omitting proto3 zero values makes the server ignore the buffered range that keeps a video session from re-sending audio.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Pixel 8 emulator, API 37, F-Droid debug build | Launch, Home, search "Bresh Da Dio", play | Resolved and played, MediaSession reported PLAYING with the position advancing |
| Pixel 8 emulator, API 37 | Pause, then resume | Paused at 48.6 s, resumed from 48.4 s |
| Pixel 8 emulator, API 37 | Memory during roughly five minutes of playback with track changes | Total PSS 328, 332, 329, 324, 315, 306 MB. No monotonic growth |
| Pixel 8 emulator, API 37 | `SabrDataSourceTest` against a scripted server | Full read, forward seek, backward seek, bounded range, end of stream, bounded retry, redirect, refused foreign redirect, media-network failover, 403 not retried, error frame, foreign-format media discarded |

## Risk and compatibility

- **Risk level:** Medium
- **Compatibility or migration notes:** `PlaybackDeliveryMethod` gains a `SABR` value and manifests may now contain `levyra-sabr://` stream URLs. Persisted manifests written by older builds keep decoding unchanged.
- **Known limitations:** SABR was exercised end to end against a scripted server and validated at the protocol level against the live endpoint, but it has not yet been observed serving a real playback session on a device, because direct delivery still wins on every video tested here. SABR live is not implemented; live playback keeps using DASH and HLS. SABR streams are not cast and are not downloadable.
- **Rollback plan:** Revert this PR

## Reviewer notes

- `SabrDataSource` is the piece that deserves the closest look: the byte-position to media-time mapping, the trimming of a segment that starts before the requested byte, and the bounded retry when a response delivers nothing for the requested format.
- `SabrStreamSpec` carries the SABR session inside the media URI so the stream travels through the normal MediaItem and MediaSource plumbing. The descriptive query on that URI mirrors a direct Googlevideo URL so the resolver's freshness, MIME and playability checks read a SABR stream the same way.
- `GooglevideoMediaNetwork.isEndpointFailure` is the single place that decides which failures may be retried on another edge. It is shared by the direct data source and by SABR.
- Warmup now skips non-HTTPS media URLs, otherwise it would open a doomed request against a SABR session URL.

## Release note

Playback can now fall back to YouTube's server-driven delivery when no direct stream is available, and a failing stream URL is retried on an equivalent one instead of restarting the whole resolution.

## Related issues

- Closes #
- Related to #

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims