### PR TITLE
chore: automate issue labels and status

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug report
 description: Report a reproducible problem in Levyra
-title: "[Bug] "
+labels:
+  - bug
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: Feature request
+description: Suggest an improvement or new feature for Levyra
+labels:
+  - feature request
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest an improvement for Levyra.
+
+        Please describe the problem or use case first, then explain the solution you would like to see.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched open and closed issues and did not find the same request.
+          required: true
+        - label: This request is related to Levyra itself rather than an unrelated upstream service.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What problem would this feature solve, or what would it make easier?
+      placeholder: Describe the situation and why the current behavior is limiting.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe what you would like Levyra to do.
+      placeholder: Explain the behavior or feature you would like to see.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Android
+        - Windows Desktop
+        - Android and Windows Desktop
+        - Shared infrastructure or extractor
+        - Not platform-specific
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Mention any workaround or alternative approach you have tried.
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Add screenshots, examples, links, mockups, or anything else that helps explain the idea.

--- a/.github/workflows/issue-labels.yml
+++ b/.github/workflows/issue-labels.yml
@@ -1,0 +1,88 @@
+name: Issue labels
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/ISSUE_TEMPLATE/**
+      - .github/workflows/issue-labels.yml
+  issues:
+    types:
+      - closed
+      - reopened
+
+permissions:
+  issues: write
+
+jobs:
+  labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure labels and update issue status
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const labels = [
+              {
+                name: 'bug',
+                color: 'd73a4a',
+                description: "Something isn't working",
+              },
+              {
+                name: 'feature request',
+                color: '1d76db',
+                description: 'A requested feature or improvement',
+              },
+              {
+                name: 'resolved',
+                color: '0e8a16',
+                description: 'Issue has been resolved',
+              },
+            ];
+
+            for (const label of labels) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ...label,
+                });
+              }
+            }
+
+            if (context.eventName !== 'issues') return;
+
+            const issueNumber = context.issue.number;
+            const action = context.payload.action;
+            const stateReason = context.payload.issue.state_reason;
+
+            if (action === 'closed' && stateReason === 'completed') {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['resolved'],
+              });
+            }
+
+            if (action === 'reopened') {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: 'resolved',
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            }


### PR DESCRIPTION
## Summary

- automatically apply the `bug` label to new bug reports
- add a dedicated feature request form with the `feature request` label
- remove the redundant `[Bug]` title prefix from future bug reports
- ensure the `bug`, `feature request`, and `resolved` labels exist
- automatically add `resolved` when an issue is closed as completed
- automatically remove `resolved` if the issue is reopened

## Scope

Only GitHub issue templates and issue-label automation are changed. No application code, build configuration, versioning, or release behavior is touched.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a structured feature request form with required details, platform selection, and optional context.
  * Added automatic issue labeling for bugs, feature requests, and resolved issues.

* **Improvements**
  * Bug reports are now labeled automatically without adding a title prefix.
  * Closed completed issues receive a “resolved” label, which is removed if reopened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->