### PR TITLE
feat: introduce Levyra Vault backup and restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,13 @@ Modern music streaming applications often treat music as temporary, disposable b
       </ul>
     </td>
     <td width="50%">
-      <h3>💾 <b>Offline Audio Vault & File Exports</b></h3>
+      <h3>💾 <b>Offline Audio & Levyra Vault</b></h3>
       <ul>
         <li><b>Tagged M4A Files:</b> Cover art, artist, album, and lyrics embedded directly in the file.</li>
         <li><b>Local-First Playback:</b> Existing offline files play instantly from <code>Music/Levyra</code>.</li>
-        <li><b>Resilient Storage:</b> HTTP Range resume, atomic verification, and portable JSON backups.</li>
+        <li><b>Levyra Vault:</b> Versioned <code>.levyra</code> backups protect settings, favorites, playlists, followed artists, history, and queue without an online account.</li>
+        <li><b>Verified Restore:</b> Manifest validation, SHA-256 checksums, compatibility preview, required-section checks, and rollback protection before local data is replaced.</li>
+        <li><b>Automatic Protection:</b> Manual, scheduled, and pre-update backups with 3/5/10 retention and optional Android SAF destinations; internal storage remains the safe fallback.</li>
       </ul>
     </td>
   </tr>
@@ -254,8 +256,8 @@ Immutable ViewModel state keeps the Compose UI, MediaSession, and Android Auto s
 **02 · Dual Stream Resolver**<br>
 InnerTube and LevyraExtractor coordinate automatic fallback, fidelity selection, and queue prefetch.
 
-**03 · Standard File Vault**<br>
-Offline tracks are exported as tagged M4A files in `Music/Levyra`, ready for external players and car systems.
+**03 · Portable Local Vault**<br>
+Tagged M4A files stay standard and reusable, while Levyra Vault protects local app state in validated, versioned <code>.levyra</code> archives with no account or Levyra cloud required.
 
 ---
 
@@ -396,7 +398,7 @@ We welcome community contributions, bug fixes, localization, and performance enh
         <a href="https://github.com/LUC4N3X"><img src="https://img.shields.io/badge/GitHub-@LUC4N3X-7F52FF?style=flat-square&logo=github&logoColor=white&labelColor=0d1117" alt="GitHub Profile" /></a>&nbsp;
         <img src="https://img.shields.io/badge/Kotlin-Multiplatform-7F52FF?style=flat-square&logo=kotlin&logoColor=white&labelColor=0d1117" alt="Kotlin Multiplatform" />&nbsp;
         <img src="https://img.shields.io/badge/Android-Media3%20%2F%20Compose-38BDF8?style=flat-square&logo=android&logoColor=white&labelColor=0d1117" alt="Android Media3" />&nbsp;
-        <img src="https://img.shields.io/badge/Desktop-libvlc%20Core-FF8800?style=flat-square&logo=vlcmediaplayer&logoColor=white&labelColor=0d1117" alt="libvlc Desktop" />
+        <img src="https://img.shields.io/badge/Desktop-libvlc%20Core-FF8800?style=flat-square&logo=vlcmediaplayer&logoColor=white&labelColor=0d1117" alt="libvlc Desktop" />&nbsp;
       </div>
     </td>
   </tr>

--- a/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
@@ -49,6 +49,7 @@ import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.luc4n3x.levyra.data.LevyraArtworkCache
+import com.luc4n3x.levyra.data.LevyraBackupManager
 import com.luc4n3x.levyra.domain.AppUpdateInfo
 import com.luc4n3x.levyra.domain.LevyraFontPreset
 import com.luc4n3x.levyra.feature.recognition.LevyraRecognitionCenter
@@ -336,6 +337,12 @@ class MainActivity : ComponentActivity() {
         lateinit var job: Job
         job = lifecycleScope.launch {
             try {
+                runCatching {
+                    val backupSettings = viewModel.state.value.backupSettings
+                    if (backupSettings.preUpdate) {
+                        LevyraBackupManager(applicationContext).exportAutomatic(backupSettings.retentionCount)
+                    }
+                }.onFailure { error -> Timber.w(error, "Pre-update backup failed") }
                 val prepared = updateInstaller.prepareLatestUpdate { versionName, downloaded, total ->
                     val nowMs = SystemClock.elapsedRealtime()
                     val speed = updateSpeedTracker.sample(downloaded, nowMs)

--- a/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/MainActivity.kt
@@ -178,7 +178,9 @@ class MainActivity : ComponentActivity() {
                     Box(modifier = Modifier.weight(1f)) {
                         LevyraApp(
                             viewModel = viewModel,
-                            isInPictureInPicture = pipMode.value
+                            isInPictureInPicture = pipMode.value,
+                            onRetryPreUpdateBackup = ::retryPreUpdateBackup,
+                            onContinueUpdateWithoutBackup = ::continueUpdateWithoutBackup
                         )
                     }
                     if (activityUiState.showSettings && !pipMode.value) {
@@ -327,7 +329,7 @@ class MainActivity : ComponentActivity() {
         super.onDestroy()
     }
 
-    private fun beginInAppUpdate() {
+    private fun beginInAppUpdate(skipBackup: Boolean = false) {
         if (!BuildConfig.UPSTREAM_UPDATES_ENABLED || updateJob?.isActive == true) return
         val fallbackVersion = viewModel.state.value.updateInfo?.latestVersionName.orEmpty()
         updateSpeedTracker.reset()
@@ -337,12 +339,21 @@ class MainActivity : ComponentActivity() {
         lateinit var job: Job
         job = lifecycleScope.launch {
             try {
-                runCatching {
+                if (!skipBackup) {
                     val backupSettings = viewModel.state.value.backupSettings
                     if (backupSettings.preUpdate) {
-                        LevyraBackupManager(applicationContext).exportAutomatic(backupSettings.retentionCount)
+                        try {
+                            LevyraBackupManager(applicationContext).exportAutomatic(backupSettings.retentionCount)
+                        } catch (cancelled: CancellationException) {
+                            throw cancelled
+                        } catch (error: Throwable) {
+                            Timber.w(error, "Pre-update backup failed")
+                            updatePhase.value = LevyraUpdatePhase.Idle
+                            viewModel.setPreUpdateBackupFailed(true)
+                            return@launch
+                        }
                     }
-                }.onFailure { error -> Timber.w(error, "Pre-update backup failed") }
+                }
                 val prepared = updateInstaller.prepareLatestUpdate { versionName, downloaded, total ->
                     val nowMs = SystemClock.elapsedRealtime()
                     val speed = updateSpeedTracker.sample(downloaded, nowMs)
@@ -372,6 +383,16 @@ class MainActivity : ComponentActivity() {
             }
         }
         updateJob = job
+    }
+
+    private fun retryPreUpdateBackup() {
+        viewModel.setPreUpdateBackupFailed(false)
+        beginInAppUpdate()
+    }
+
+    private fun continueUpdateWithoutBackup() {
+        viewModel.setPreUpdateBackupFailed(false)
+        beginInAppUpdate(skipBackup = true)
     }
 
     private fun cancelInAppUpdate() {

--- a/app/src/main/java/com/luc4n3x/levyra/data/AutomaticBackupDocumentsProvider.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/AutomaticBackupDocumentsProvider.kt
@@ -115,11 +115,6 @@ class AutomaticBackupDocumentsProvider : DocumentsProvider() {
         return runCatching { file.canonicalFile.parentFile == directory }.getOrDefault(false)
     }
 
-    private fun isAutomaticBackupName(name: String): Boolean =
-        name.startsWith(AUTOMATIC_BACKUP_PREFIX) &&
-            name.endsWith(".zip") &&
-            name.substring(AUTOMATIC_BACKUP_PREFIX.length, name.length - 4).all(Char::isDigit)
-
     private fun rootColumns(projection: Array<out String>?): Array<String> =
         projection?.map { it }?.toTypedArray() ?: DEFAULT_ROOT_PROJECTION
 
@@ -132,7 +127,6 @@ class AutomaticBackupDocumentsProvider : DocumentsProvider() {
         const val FILE_DOCUMENT_PREFIX = "automatic-backup:"
         const val BACKUP_MIME_TYPE = "application/zip"
         const val AUTOMATIC_BACKUP_DIRECTORY = "backups"
-        const val AUTOMATIC_BACKUP_PREFIX = "levyra-auto-backup-"
 
         val DEFAULT_ROOT_PROJECTION = arrayOf(
             Root.COLUMN_ROOT_ID,

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraBackupManager.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraBackupManager.kt
@@ -35,6 +35,7 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -76,7 +77,12 @@ class LevyraBackupManager(private val context: Context) {
                         .copy(message = "Backup salvato nella memoria interna")
                 }
             } else {
-                exportAutomaticToInternal(retentionCount)
+                val result = exportAutomaticToInternal(retentionCount)
+                if (treeUri != null) {
+                    result.copy(message = "Backup salvato nella memoria interna")
+                } else {
+                    result
+                }
             }
         }
     }
@@ -240,8 +246,13 @@ class LevyraBackupManager(private val context: Context) {
             try {
                 applySnapshot(target)
             } catch (restoreError: Throwable) {
-                runCatching { applySnapshot(rollback) }
-                    .onFailure { rollbackError -> restoreError.addSuppressed(rollbackError) }
+                withContext(NonCancellable) {
+                    try {
+                        applySnapshot(rollback)
+                    } catch (rollbackError: Throwable) {
+                        restoreError.addSuppressed(rollbackError)
+                    }
+                }
                 throw restoreError
             }
             LevyraBackupResult("Ripristino completato", "")

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraBackupManager.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraBackupManager.kt
@@ -1,7 +1,9 @@
 package com.luc4n3x.levyra.data
 
 import android.content.Context
+import android.content.Intent
 import android.net.Uri
+import android.provider.DocumentsContract
 import androidx.room.withTransaction
 import com.luc4n3x.levyra.BuildConfig
 import com.luc4n3x.levyra.data.local.LEVYRA_DATABASE_VERSION
@@ -40,15 +42,16 @@ import org.json.JSONArray
 import org.json.JSONObject
 import timber.log.Timber
 
+internal val LevyraVaultOperationMutex: Mutex = Mutex()
+
 class LevyraBackupManager(private val context: Context) {
     private val appContext = context.applicationContext
     private val database = LevyraDatabase.get(appContext)
     private val preferences = LevyraPreferences(appContext)
     private val followedArtistsStore = FollowedArtistsStore(appContext)
-    private val operationMutex = Mutex()
 
     suspend fun exportTo(uri: Uri): LevyraBackupResult = withContext(Dispatchers.IO) {
-        operationMutex.withLock {
+        LevyraVaultOperationMutex.withLock {
             val output = appContext.contentResolver.openOutputStream(uri, "w")
                 ?: throw IOException("Impossibile aprire il file di backup")
             val result = output.use { writeArchive(it) }
@@ -58,36 +61,111 @@ class LevyraBackupManager(private val context: Context) {
     }
 
     suspend fun exportAutomatic(retentionCount: Int): LevyraBackupResult = withContext(Dispatchers.IO) {
-        operationMutex.withLock {
-            val directory = File(appContext.filesDir, AUTOMATIC_BACKUP_DIRECTORY)
-            if ((!directory.exists() && !directory.mkdirs()) || !directory.isDirectory) {
-                throw IOException("Impossibile creare la cartella dei backup automatici")
+        LevyraVaultOperationMutex.withLock {
+            val treeUri = preferences.backupTreeUri()
+                .takeIf { it.isNotBlank() }
+                ?.let { runCatching { Uri.parse(it) }.getOrNull() }
+            if (treeUri != null && hasPersistedTreeAccess(treeUri)) {
+                runCatching { exportAutomaticToTree(treeUri, retentionCount) }
+                    .getOrElse { error ->
+                        Timber.w(error, "SAF backup location unavailable, falling back to internal storage")
+                        exportAutomaticToInternal(retentionCount)
+                            .copy(message = "Backup salvato nella memoria interna")
+                    }
+            } else {
+                exportAutomaticToInternal(retentionCount)
             }
-            val canonicalDirectory = directory.canonicalFile
-            val timestamp = System.currentTimeMillis()
-            val target = File(canonicalDirectory, "$AUTOMATIC_BACKUP_PREFIX$timestamp$VAULT_EXTENSION")
-            val temporary = File(canonicalDirectory, ".$AUTOMATIC_BACKUP_PREFIX$timestamp.tmp")
-            checkBackupChild(canonicalDirectory, target)
-            checkBackupChild(canonicalDirectory, temporary)
-            val result = try {
-                val archiveResult = temporary.outputStream().buffered().use { writeArchive(it) }
-                if (!temporary.renameTo(target)) throw IOException("Impossibile finalizzare il backup automatico")
-                archiveResult
-            } finally {
-                if (temporary.exists()) temporary.delete()
-            }
-            runCatching {
-                pruneAutomaticBackups(canonicalDirectory, retentionCount.coerceIn(1, MAX_AUTOMATIC_BACKUPS))
-            }.onFailure { error ->
-                Timber.w(error, "Automatic backup retention cleanup failed")
-            }
-            preferences.setLastBackupAt(System.currentTimeMillis())
-            result
         }
     }
 
+    private suspend fun exportAutomaticToInternal(retentionCount: Int): LevyraBackupResult {
+        val directory = File(appContext.filesDir, AUTOMATIC_BACKUP_DIRECTORY)
+        if ((!directory.exists() && !directory.mkdirs()) || !directory.isDirectory) {
+            throw IOException("Impossibile creare la cartella dei backup automatici")
+        }
+        val canonicalDirectory = directory.canonicalFile
+        val timestamp = System.currentTimeMillis()
+        val target = File(canonicalDirectory, "$AUTOMATIC_BACKUP_PREFIX$timestamp$VAULT_EXTENSION")
+        val temporary = File(canonicalDirectory, ".$AUTOMATIC_BACKUP_PREFIX$timestamp.tmp")
+        checkBackupChild(canonicalDirectory, target)
+        checkBackupChild(canonicalDirectory, temporary)
+        val result = try {
+            val archiveResult = temporary.outputStream().buffered().use { writeArchive(it) }
+            if (!temporary.renameTo(target)) throw IOException("Impossibile finalizzare il backup automatico")
+            archiveResult
+        } finally {
+            if (temporary.exists()) temporary.delete()
+        }
+        runCatching {
+            pruneAutomaticBackups(canonicalDirectory, retentionCount.coerceIn(1, MAX_AUTOMATIC_BACKUPS))
+        }.onFailure { error ->
+            Timber.w(error, "Automatic backup retention cleanup failed")
+        }
+        preferences.setLastBackupAt(System.currentTimeMillis())
+        return result
+    }
+
+    private fun hasPersistedTreeAccess(treeUri: Uri): Boolean =
+        appContext.contentResolver.persistedUriPermissions.any {
+            it.uri == treeUri && it.isReadPermission && it.isWritePermission
+        }
+
+    private suspend fun exportAutomaticToTree(treeUri: Uri, retentionCount: Int): LevyraBackupResult {
+        val resolver = appContext.contentResolver
+        val name = "$AUTOMATIC_BACKUP_PREFIX${System.currentTimeMillis()}$VAULT_EXTENSION"
+        val documentUri = DocumentsContract.createDocument(resolver, treeUri, "application/zip", name)
+            ?: throw IOException("Impossibile creare il backup nella cartella selezionata")
+        val result = try {
+            resolver.openOutputStream(documentUri, "w")?.use { writeArchive(it) }
+                ?: throw IOException("Impossibile scrivere il backup nella cartella selezionata")
+        } catch (error: Throwable) {
+            runCatching { DocumentsContract.deleteDocument(resolver, documentUri) }
+            throw error
+        }
+        runCatching {
+            pruneSafBackups(treeUri, retentionCount.coerceIn(1, MAX_AUTOMATIC_BACKUPS))
+        }.onFailure { error ->
+            Timber.w(error, "SAF backup retention cleanup failed")
+        }
+        preferences.setLastBackupAt(System.currentTimeMillis())
+        return result
+    }
+
+    private fun pruneSafBackups(treeUri: Uri, retentionCount: Int) {
+        val resolver = appContext.contentResolver
+        val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(
+            treeUri,
+            DocumentsContract.getTreeDocumentId(treeUri)
+        )
+        val candidates = mutableListOf<Pair<String, String>>()
+        resolver.query(
+            childrenUri,
+            arrayOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID, DocumentsContract.Document.COLUMN_DISPLAY_NAME),
+            null,
+            null,
+            null
+        )?.use { cursor ->
+            val idColumn = cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DOCUMENT_ID)
+            val nameColumn = cursor.getColumnIndexOrThrow(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
+            while (cursor.moveToNext()) {
+                val displayName = cursor.getString(nameColumn)
+                if (isAutomaticBackupName(displayName)) {
+                    candidates.add(cursor.getString(idColumn) to displayName)
+                }
+            }
+        }
+        candidates
+            .sortedByDescending { it.second }
+            .drop(retentionCount)
+            .forEach { (documentId, _) ->
+                val documentUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, documentId)
+                runCatching { DocumentsContract.deleteDocument(resolver, documentUri) }
+                    .onFailure { error -> Timber.w(error, "Unable to delete SAF backup $documentId") }
+            }
+    }
+
     suspend fun inspect(uri: Uri): VaultPreview = withContext(Dispatchers.IO) {
-        operationMutex.withLock {
+        LevyraVaultOperationMutex.withLock {
             val input = appContext.contentResolver.openInputStream(uri)
                 ?: throw IOException("Impossibile leggere il backup")
             input.use { stream ->
@@ -103,16 +181,17 @@ class LevyraBackupManager(private val context: Context) {
                         if (entryCount > MAX_ZIP_ENTRIES) throw IOException("Backup non valido: troppe voci ZIP")
                         if (entry.isDirectory) throw IOException("Backup non valido: voce ZIP directory")
                         if (!vaultEntryAllowed(entry.name)) throw IOException("Backup non valido: voce ZIP inattesa ${entry.name}")
-                        if (entry.size > MAX_ENTRY_BYTES) throw IOException("Backup troppo grande")
-                        if (entry.size > 0L) {
-                            totalBytes += entry.size
-                            if (totalBytes > MAX_TOTAL_BYTES) throw IOException("Backup troppo grande")
-                        }
                         when {
                             entry.name == MANIFEST_ENTRY -> manifestBytes = readZipEntry(zip, MAX_ENTRY_BYTES)
                             entry.name == LEGACY_PAYLOAD_ENTRY -> hasLegacyPayload = true
                             else -> sectionNames.add(entry.name)
                         }
+                        totalBytes += if (entry.name == MANIFEST_ENTRY) {
+                            (manifestBytes?.size ?: 0).toLong()
+                        } else {
+                            countZipEntry(zip, MAX_ENTRY_BYTES)
+                        }
+                        if (totalBytes > MAX_TOTAL_BYTES) throw IOException("Backup troppo grande")
                         zip.closeEntry()
                     }
                     val manifest = manifestBytes?.let { bytes ->
@@ -140,7 +219,7 @@ class LevyraBackupManager(private val context: Context) {
     }
 
     suspend fun restoreFrom(uri: Uri): LevyraBackupResult = withContext(Dispatchers.IO) {
-        operationMutex.withLock {
+        LevyraVaultOperationMutex.withLock {
             val entries = readArchiveEntries(uri)
             val target = if (entries.containsKey(LEGACY_PAYLOAD_ENTRY)) {
                 legacySnapshot(entries)
@@ -288,6 +367,10 @@ class LevyraBackupManager(private val context: Context) {
         val databaseVersion = manifest.optInt("databaseVersion", 0)
         if (databaseVersion > LEVYRA_DATABASE_VERSION) {
             throw IOException("Backup creato da una versione più recente dell'app")
+        }
+        val missing = missingRequiredVaultSections(entries.keys)
+        if (missing.isNotEmpty()) {
+            throw IOException("Backup non valido: sezioni mancanti ${missing.sorted().joinToString(", ")}")
         }
         validateSectionChecksums(entries, manifest)
         val settingsBytes = entries[SETTINGS_ENTRY] ?: throw IOException("Dati impostazioni del backup mancanti")
@@ -709,6 +792,18 @@ class LevyraBackupManager(private val context: Context) {
         return buffer.toByteArray()
     }
 
+    private fun countZipEntry(zip: ZipInputStream, limit: Long): Long {
+        val chunk = ByteArray(DEFAULT_BUFFER_SIZE)
+        var total = 0L
+        while (true) {
+            val read = zip.read(chunk)
+            if (read < 0) break
+            total += read
+            if (total > limit) throw IOException("Backup troppo grande")
+        }
+        return total
+    }
+
     private fun sha256Hex(digest: ByteArray): String = digest.joinToString("") { "%02x".format(it) }
 
     private fun combinedChecksum(sections: Map<String, SectionInfo>): String {
@@ -792,7 +887,7 @@ class LevyraBackupManager(private val context: Context) {
         const val QUEUE_ENTRY = "data/queue.json"
         const val MAX_ZIP_ENTRIES = 16
         const val MAX_ENTRY_BYTES = 64L * 1024L * 1024L
-        const val MAX_TOTAL_BYTES = 192L * 1024L * 1024L
+        const val MAX_TOTAL_BYTES = 96L * 1024L * 1024L
         const val MAX_AUTOMATIC_BACKUPS = 12
         const val AUTOMATIC_BACKUP_DIRECTORY = "backups"
         const val AUTOMATIC_BACKUP_PREFIX = "levyra-auto-backup-"
@@ -827,6 +922,18 @@ internal fun vaultEntryAllowed(name: String): Boolean {
     if (name.isEmpty() || name.startsWith("/") || name.contains("..") || name.contains('\\')) return false
     return name in LevyraBackupManager.ALLOWED_VAULT_ENTRIES
 }
+
+internal val REQUIRED_VAULT_ENTRIES = setOf(
+    LevyraBackupManager.SETTINGS_ENTRY,
+    LevyraBackupManager.FAVORITES_ENTRY,
+    LevyraBackupManager.FOLLOWED_ARTISTS_ENTRY,
+    LevyraBackupManager.PLAYLISTS_ENTRY,
+    LevyraBackupManager.HISTORY_ENTRY,
+    LevyraBackupManager.QUEUE_ENTRY
+)
+
+internal fun missingRequiredVaultSections(entryNames: Collection<String>): Set<String> =
+    REQUIRED_VAULT_ENTRIES - entryNames
 
 internal fun isAutomaticBackupName(name: String): Boolean {
     if (!name.startsWith("levyra-auto-backup-")) return false

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraBackupManager.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraBackupManager.kt
@@ -64,14 +64,17 @@ class LevyraBackupManager(private val context: Context) {
         LevyraVaultOperationMutex.withLock {
             val treeUri = preferences.backupTreeUri()
                 .takeIf { it.isNotBlank() }
-                ?.let { runCatching { Uri.parse(it) }.getOrNull() }
+                ?.let { raw -> try { Uri.parse(raw) } catch (_: Throwable) { null } }
             if (treeUri != null && hasPersistedTreeAccess(treeUri)) {
-                runCatching { exportAutomaticToTree(treeUri, retentionCount) }
-                    .getOrElse { error ->
-                        Timber.w(error, "SAF backup location unavailable, falling back to internal storage")
-                        exportAutomaticToInternal(retentionCount)
-                            .copy(message = "Backup salvato nella memoria interna")
-                    }
+                try {
+                    exportAutomaticToTree(treeUri, retentionCount)
+                } catch (cancelled: kotlinx.coroutines.CancellationException) {
+                    throw cancelled
+                } catch (error: Throwable) {
+                    Timber.w(error, "SAF backup location unavailable, falling back to internal storage")
+                    exportAutomaticToInternal(retentionCount)
+                        .copy(message = "Backup salvato nella memoria interna")
+                }
             } else {
                 exportAutomaticToInternal(retentionCount)
             }
@@ -113,7 +116,11 @@ class LevyraBackupManager(private val context: Context) {
     private suspend fun exportAutomaticToTree(treeUri: Uri, retentionCount: Int): LevyraBackupResult {
         val resolver = appContext.contentResolver
         val name = "$AUTOMATIC_BACKUP_PREFIX${System.currentTimeMillis()}$VAULT_EXTENSION"
-        val documentUri = DocumentsContract.createDocument(resolver, treeUri, "application/zip", name)
+        val parentUri = DocumentsContract.buildDocumentUriUsingTree(
+            treeUri,
+            DocumentsContract.getTreeDocumentId(treeUri)
+        )
+        val documentUri = DocumentsContract.createDocument(resolver, parentUri, "application/zip", name)
             ?: throw IOException("Impossibile creare il backup nella cartella selezionata")
         val result = try {
             resolver.openOutputStream(documentUri, "w")?.use { writeArchive(it) }
@@ -175,12 +182,14 @@ class LevyraBackupManager(private val context: Context) {
                     var manifestBytes: ByteArray? = null
                     var hasLegacyPayload = false
                     val sectionNames = mutableListOf<String>()
+                    val seenEntries = mutableSetOf<String>()
                     while (true) {
                         val entry = zip.nextEntry ?: break
                         entryCount += 1
                         if (entryCount > MAX_ZIP_ENTRIES) throw IOException("Backup non valido: troppe voci ZIP")
                         if (entry.isDirectory) throw IOException("Backup non valido: voce ZIP directory")
                         if (!vaultEntryAllowed(entry.name)) throw IOException("Backup non valido: voce ZIP inattesa ${entry.name}")
+                        if (!seenEntries.add(entry.name)) throw IOException("Backup non valido: voce duplicata ${entry.name}")
                         when {
                             entry.name == MANIFEST_ENTRY -> manifestBytes = readZipEntry(zip, MAX_ENTRY_BYTES)
                             entry.name == LEGACY_PAYLOAD_ENTRY -> hasLegacyPayload = true
@@ -200,7 +209,8 @@ class LevyraBackupManager(private val context: Context) {
                     val vaultCompatible = manifest != null &&
                         manifest.optInt("formatVersion", 0) == FORMAT_VERSION &&
                         manifest.optString("platform", "").equals(PLATFORM, ignoreCase = true) &&
-                        manifest.optInt("databaseVersion", 0) <= LEVYRA_DATABASE_VERSION
+                        manifest.optInt("databaseVersion", 0) <= LEVYRA_DATABASE_VERSION &&
+                        vaultStructureCompatible(sectionNames)
                     val legacyCompatible = hasLegacyPayload &&
                         manifest?.optInt("schemaVersion", 0) == LEGACY_SCHEMA_VERSION
                     VaultPreview(
@@ -375,14 +385,15 @@ class LevyraBackupManager(private val context: Context) {
         validateSectionChecksums(entries, manifest)
         val settingsBytes = entries[SETTINGS_ENTRY] ?: throw IOException("Dati impostazioni del backup mancanti")
         val settingsJson = JSONObject(settingsBytes.toString(Charsets.UTF_8))
+        val queueJson = entries[QUEUE_ENTRY].toJsonObject()
         return VaultSnapshot(
             settings = parseSettings(settingsJson),
             favorites = entries[FAVORITES_ENTRY].toJsonArray().toTrackList(),
             followedArtists = parseFollowedArtists(entries[FOLLOWED_ARTISTS_ENTRY].toJsonArray()),
             playlists = parsePlaylists(entries[PLAYLISTS_ENTRY].toJsonArray()),
             history = parseHistory(entries[HISTORY_ENTRY].toJsonArray()),
-            queueItems = parseQueueItems(entries[QUEUE_ENTRY].toJsonObject()),
-            queueState = parseQueueState(entries[QUEUE_ENTRY].toJsonObject())
+            queueItems = parseQueueItems(queueJson),
+            queueState = parseQueueState(queueJson)
         )
     }
 
@@ -760,7 +771,7 @@ class LevyraBackupManager(private val context: Context) {
         return try {
             JSONArray(toString(Charsets.UTF_8))
         } catch (error: org.json.JSONException) {
-            throw IOException("Backup non valido: sezione JSON danneggiata")
+            throw IOException("Backup non valido: sezione JSON danneggiata", error)
         }
     }
 
@@ -769,7 +780,7 @@ class LevyraBackupManager(private val context: Context) {
         return try {
             JSONObject(toString(Charsets.UTF_8))
         } catch (error: org.json.JSONException) {
-            throw IOException("Backup non valido: sezione JSON danneggiata")
+            throw IOException("Backup non valido: sezione JSON danneggiata", error)
         }
     }
 
@@ -935,16 +946,16 @@ internal val REQUIRED_VAULT_ENTRIES = setOf(
 internal fun missingRequiredVaultSections(entryNames: Collection<String>): Set<String> =
     REQUIRED_VAULT_ENTRIES - entryNames
 
+internal fun vaultStructureCompatible(entryNames: Collection<String>): Boolean =
+    missingRequiredVaultSections(entryNames).isEmpty()
+
 internal fun isAutomaticBackupName(name: String): Boolean {
     if (!name.startsWith("levyra-auto-backup-")) return false
     val body = name.removePrefix("levyra-auto-backup-")
-    if (body.endsWith(".levyra")) {
-        return body.removeSuffix(".levyra").all(Char::isDigit)
-    }
-    if (body.endsWith(".zip")) {
-        return body.removeSuffix(".zip").all(Char::isDigit)
-    }
-    return false
+    val suffixes = listOf(".levyra.zip", ".levyra", ".zip")
+    val suffix = suffixes.firstOrNull { body.endsWith(it) } ?: return false
+    val timestamp = body.removeSuffix(suffix)
+    return timestamp.isNotEmpty() && timestamp.all(Char::isDigit)
 }
 
 internal fun levyraVaultFileName(timestamp: Long): String {

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraBackupManager.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraBackupManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import androidx.room.withTransaction
 import com.luc4n3x.levyra.BuildConfig
+import com.luc4n3x.levyra.data.local.LEVYRA_DATABASE_VERSION
 import com.luc4n3x.levyra.data.local.LevyraDatabase
 import com.luc4n3x.levyra.data.local.ListenEventEntity
 import com.luc4n3x.levyra.data.local.PlaybackQueueItemEntity
@@ -17,84 +18,241 @@ import com.luc4n3x.levyra.domain.LevyraAudioSettings
 import com.luc4n3x.levyra.domain.LevyraBackupFrequency
 import com.luc4n3x.levyra.domain.LevyraBackupSettings
 import com.luc4n3x.levyra.domain.LevyraDownloadSettings
-import com.luc4n3x.levyra.domain.LevyraInterfaceSettings
 import com.luc4n3x.levyra.domain.LevyraFontPreset
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import org.json.JSONArray
-import org.json.JSONObject
-import timber.log.Timber
+import com.luc4n3x.levyra.domain.LevyraInterfaceSettings
+import com.luc4n3x.levyra.domain.Track
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.IOException
 import java.io.OutputStream
+import java.io.OutputStreamWriter
 import java.nio.file.Files
+import java.security.DigestOutputStream
 import java.security.MessageDigest
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+import timber.log.Timber
 
 class LevyraBackupManager(private val context: Context) {
     private val appContext = context.applicationContext
     private val database = LevyraDatabase.get(appContext)
     private val preferences = LevyraPreferences(appContext)
     private val followedArtistsStore = FollowedArtistsStore(appContext)
+    private val operationMutex = Mutex()
 
     suspend fun exportTo(uri: Uri): LevyraBackupResult = withContext(Dispatchers.IO) {
-        val output = appContext.contentResolver.openOutputStream(uri, "w") ?: throw IOException("Impossibile aprire il file di backup")
-        val checksum = output.use { writeBackup(it) }
-        LevyraBackupResult("Backup completato", checksum)
+        operationMutex.withLock {
+            val output = appContext.contentResolver.openOutputStream(uri, "w")
+                ?: throw IOException("Impossibile aprire il file di backup")
+            val result = output.use { writeArchive(it) }
+            preferences.setLastBackupAt(System.currentTimeMillis())
+            result
+        }
     }
 
     suspend fun exportAutomatic(retentionCount: Int): LevyraBackupResult = withContext(Dispatchers.IO) {
-        val directory = File(appContext.filesDir, AUTOMATIC_BACKUP_DIRECTORY)
-        if ((!directory.exists() && !directory.mkdirs()) || !directory.isDirectory) {
-            throw IOException("Impossibile creare la cartella dei backup automatici")
+        operationMutex.withLock {
+            val directory = File(appContext.filesDir, AUTOMATIC_BACKUP_DIRECTORY)
+            if ((!directory.exists() && !directory.mkdirs()) || !directory.isDirectory) {
+                throw IOException("Impossibile creare la cartella dei backup automatici")
+            }
+            val canonicalDirectory = directory.canonicalFile
+            val timestamp = System.currentTimeMillis()
+            val target = File(canonicalDirectory, "$AUTOMATIC_BACKUP_PREFIX$timestamp$VAULT_EXTENSION")
+            val temporary = File(canonicalDirectory, ".$AUTOMATIC_BACKUP_PREFIX$timestamp.tmp")
+            checkBackupChild(canonicalDirectory, target)
+            checkBackupChild(canonicalDirectory, temporary)
+            val result = try {
+                val archiveResult = temporary.outputStream().buffered().use { writeArchive(it) }
+                if (!temporary.renameTo(target)) throw IOException("Impossibile finalizzare il backup automatico")
+                archiveResult
+            } finally {
+                if (temporary.exists()) temporary.delete()
+            }
+            runCatching {
+                pruneAutomaticBackups(canonicalDirectory, retentionCount.coerceIn(1, MAX_AUTOMATIC_BACKUPS))
+            }.onFailure { error ->
+                Timber.w(error, "Automatic backup retention cleanup failed")
+            }
+            preferences.setLastBackupAt(System.currentTimeMillis())
+            result
         }
-        val canonicalDirectory = directory.canonicalFile
-        val timestamp = System.currentTimeMillis()
-        val target = File(canonicalDirectory, "$AUTOMATIC_BACKUP_PREFIX$timestamp.zip")
-        val temporary = File(canonicalDirectory, ".$AUTOMATIC_BACKUP_PREFIX$timestamp.tmp")
-        checkBackupChild(canonicalDirectory, target)
-        checkBackupChild(canonicalDirectory, temporary)
-        val checksum = try {
-            temporary.outputStream().buffered().use { writeBackup(it) }
-            if (!temporary.renameTo(target)) throw IOException("Impossibile finalizzare il backup automatico")
-            checksumOf(target)
-        } finally {
-            if (temporary.exists()) temporary.delete()
-        }
-        runCatching {
-            pruneAutomaticBackups(canonicalDirectory, retentionCount.coerceIn(1, MAX_AUTOMATIC_BACKUPS))
-        }.onFailure { error ->
-            Timber.w(error, "Automatic backup retention cleanup failed")
-        }
-        LevyraBackupResult(target.name, checksum)
     }
 
-    private suspend fun writeBackup(output: OutputStream): String {
-        val payload = createPayload().toString().toByteArray(Charsets.UTF_8)
-        val checksum = sha256(payload)
-        val manifest = JSONObject()
-            .put("schemaVersion", SCHEMA_VERSION)
-            .put("appVersion", BuildConfig.VERSION_NAME)
-            .put("createdAt", System.currentTimeMillis())
-            .put("payloadSha256", checksum)
-            .toString()
-            .toByteArray(Charsets.UTF_8)
-        ZipOutputStream(output.buffered()).use { zip ->
-            zip.putNextEntry(ZipEntry(MANIFEST_ENTRY))
-            zip.write(manifest)
-            zip.closeEntry()
-            zip.putNextEntry(ZipEntry(PAYLOAD_ENTRY))
-            zip.write(payload)
-            zip.closeEntry()
+    suspend fun inspect(uri: Uri): VaultPreview = withContext(Dispatchers.IO) {
+        operationMutex.withLock {
+            val input = appContext.contentResolver.openInputStream(uri)
+                ?: throw IOException("Impossibile leggere il backup")
+            input.use { stream ->
+                ZipInputStream(stream.buffered()).use { zip ->
+                    var totalBytes = 0L
+                    var entryCount = 0
+                    var manifestBytes: ByteArray? = null
+                    var hasLegacyPayload = false
+                    val sectionNames = mutableListOf<String>()
+                    while (true) {
+                        val entry = zip.nextEntry ?: break
+                        entryCount += 1
+                        if (entryCount > MAX_ZIP_ENTRIES) throw IOException("Backup non valido: troppe voci ZIP")
+                        if (entry.isDirectory) throw IOException("Backup non valido: voce ZIP directory")
+                        if (!vaultEntryAllowed(entry.name)) throw IOException("Backup non valido: voce ZIP inattesa ${entry.name}")
+                        if (entry.size > MAX_ENTRY_BYTES) throw IOException("Backup troppo grande")
+                        if (entry.size > 0L) {
+                            totalBytes += entry.size
+                            if (totalBytes > MAX_TOTAL_BYTES) throw IOException("Backup troppo grande")
+                        }
+                        when {
+                            entry.name == MANIFEST_ENTRY -> manifestBytes = readZipEntry(zip, MAX_ENTRY_BYTES)
+                            entry.name == LEGACY_PAYLOAD_ENTRY -> hasLegacyPayload = true
+                            else -> sectionNames.add(entry.name)
+                        }
+                        zip.closeEntry()
+                    }
+                    val manifest = manifestBytes?.let { bytes ->
+                        runCatching { JSONObject(bytes.toString(Charsets.UTF_8)) }.getOrNull()
+                    }
+                    val vaultCompatible = manifest != null &&
+                        manifest.optInt("formatVersion", 0) == FORMAT_VERSION &&
+                        manifest.optString("platform", "").equals(PLATFORM, ignoreCase = true) &&
+                        manifest.optInt("databaseVersion", 0) <= LEVYRA_DATABASE_VERSION
+                    val legacyCompatible = hasLegacyPayload &&
+                        manifest?.optInt("schemaVersion", 0) == LEGACY_SCHEMA_VERSION
+                    VaultPreview(
+                        createdAt = manifest?.optLong("createdAt", 0L) ?: 0L,
+                        appVersion = manifest?.optString("appVersion", "").orEmpty(),
+                        databaseVersion = manifest?.optInt("databaseVersion", 0) ?: 0,
+                        formatVersion = manifest?.optInt("formatVersion", 0) ?: 0,
+                        platform = manifest?.optString("platform", "").orEmpty(),
+                        sizeBytes = totalBytes,
+                        sections = if (legacyCompatible) listOf(LEGACY_PAYLOAD_ENTRY) else sectionNames,
+                        compatible = vaultCompatible || legacyCompatible
+                    )
+                }
+            }
         }
-        return checksum
     }
 
     suspend fun restoreFrom(uri: Uri): LevyraBackupResult = withContext(Dispatchers.IO) {
-        val input = appContext.contentResolver.openInputStream(uri) ?: throw IOException("Impossibile leggere il backup")
+        operationMutex.withLock {
+            val entries = readArchiveEntries(uri)
+            val target = if (entries.containsKey(LEGACY_PAYLOAD_ENTRY)) {
+                legacySnapshot(entries)
+            } else {
+                vaultSnapshot(entries)
+            }
+            val rollback = currentSnapshot()
+            try {
+                applySnapshot(target)
+            } catch (restoreError: Throwable) {
+                runCatching { applySnapshot(rollback) }
+                    .onFailure { rollbackError -> restoreError.addSuppressed(rollbackError) }
+                throw restoreError
+            }
+            LevyraBackupResult("Ripristino completato", "")
+        }
+    }
+
+    private suspend fun writeArchive(output: OutputStream): LevyraBackupResult {
+        val sections = linkedMapOf<String, SectionInfo>()
+        ZipOutputStream(output.buffered()).use { zip ->
+            sections[FAVORITES_ENTRY] = writeJsonSection(zip, FAVORITES_ENTRY) { writer ->
+                val favorites = database.favoriteTracksDao().all().map { it.toTrack() }
+                writeJsonArray(writer, favorites) { TrackJson.toJson(it).toString() }
+            }
+            sections[FOLLOWED_ARTISTS_ENTRY] = writeJsonSection(zip, FOLLOWED_ARTISTS_ENTRY) { writer ->
+                writeJsonArray(writer, followedArtistsStore.load()) { followedArtistToJson(it).toString() }
+            }
+            sections[PLAYLISTS_ENTRY] = writeJsonSection(zip, PLAYLISTS_ENTRY) { writer ->
+                val playlists = database.playlistDao().allPlaylists()
+                writer.write("[")
+                playlists.forEachIndexed { index, playlist ->
+                    if (index > 0) writer.write(",")
+                    val tracks = database.playlistDao().tracksOf(playlist.id)
+                    val json = JSONObject()
+                        .put("id", playlist.id)
+                        .put("name", playlist.name)
+                        .put("coverUrl", playlist.coverUrl)
+                        .put("createdAt", playlist.createdAt)
+                        .put("updatedAt", playlist.updatedAt)
+                        .put("tracks", JSONArray().apply { tracks.forEach { put(TrackJson.toJson(it.toTrack())) } })
+                        .toString()
+                    writer.write(json)
+                }
+                writer.write("]")
+            }
+            sections[HISTORY_ENTRY] = writeJsonSection(zip, HISTORY_ENTRY) { writer ->
+                writeJsonArray(writer, database.listenEventsDao().all()) { listenEventToJson(it).toString() }
+            }
+            sections[SETTINGS_ENTRY] = writeJsonSection(zip, SETTINGS_ENTRY) { writer ->
+                writer.write(settingsToJson(preferences.snapshot()).toString())
+            }
+            sections[QUEUE_ENTRY] = writeJsonSection(zip, QUEUE_ENTRY) { writer ->
+                val queueItems = database.playbackQueueDao().items()
+                val queueState = database.playbackQueueDao().state()
+                writer.write("{\"items\":")
+                writeJsonArray(writer, queueItems) {
+                    JSONObject().put("position", it.position).put("payload", it.payload).put("identity", it.identity).toString()
+                }
+                writer.write(",\"state\":")
+                writer.write(queueState?.let(::queueStateToJson)?.toString() ?: "null")
+                writer.write("}")
+            }
+            val manifest = JSONObject()
+                .put("formatVersion", FORMAT_VERSION)
+                .put("appVersion", BuildConfig.VERSION_NAME)
+                .put("platform", PLATFORM)
+                .put("databaseVersion", LEVYRA_DATABASE_VERSION)
+                .put("createdAt", System.currentTimeMillis())
+                .put("sections", JSONObject().apply {
+                    sections.forEach { (name, info) ->
+                        put(name, JSONObject().put("sha256", info.sha256).put("bytes", info.bytes))
+                    }
+                })
+            sections[MANIFEST_ENTRY] = writeJsonSection(zip, MANIFEST_ENTRY) { writer ->
+                writer.write(manifest.toString())
+            }
+        }
+        return writeArchiveResult(combinedChecksum(sections))
+    }
+
+    private fun writeArchiveResult(checksum: String): LevyraBackupResult =
+        LevyraBackupResult("Backup completato", checksum)
+
+    private suspend fun writeJsonSection(
+        zip: ZipOutputStream,
+        name: String,
+        write: suspend (OutputStreamWriter) -> Unit
+    ): SectionInfo {
+        zip.putNextEntry(ZipEntry(name))
+        val digest = MessageDigest.getInstance("SHA-256")
+        val counter = ByteCounterOutputStream(zip)
+        val digestStream = DigestOutputStream(counter, digest)
+        val writer = OutputStreamWriter(digestStream, Charsets.UTF_8)
+        write(writer)
+        writer.flush()
+        zip.closeEntry()
+        return SectionInfo(sha256Hex(digest.digest()), counter.count)
+    }
+
+    private fun <T> writeJsonArray(writer: OutputStreamWriter, items: List<T>, encode: (T) -> String) {
+        writer.write("[")
+        items.forEachIndexed { index, item ->
+            if (index > 0) writer.write(",")
+            writer.write(encode(item))
+        }
+        writer.write("]")
+    }
+
+    private fun readArchiveEntries(uri: Uri): Map<String, ByteArray> {
+        val input = appContext.contentResolver.openInputStream(uri)
+            ?: throw IOException("Impossibile leggere il backup")
         val entries = mutableMapOf<String, ByteArray>()
         input.use { stream ->
             ZipInputStream(stream.buffered()).use { zip ->
@@ -104,101 +262,206 @@ class LevyraBackupManager(private val context: Context) {
                     val entry = zip.nextEntry ?: break
                     entryCount += 1
                     if (entryCount > MAX_ZIP_ENTRIES) throw IOException("Backup non valido: troppe voci ZIP")
-                    if (!entry.isDirectory) {
-                        if (entry.name !in REQUIRED_ENTRIES) throw IOException("Backup non valido: voce ZIP inattesa ${entry.name}")
-                        if (entries.containsKey(entry.name)) throw IOException("Backup non valido: voce duplicata ${entry.name}")
-                        if (entry.size > MAX_ENTRY_BYTES) throw IOException("Backup troppo grande")
-                        val bytes = readZipEntry(zip, MAX_ENTRY_BYTES)
-                        totalBytes += bytes.size
-                        if (totalBytes > MAX_TOTAL_BYTES) throw IOException("Backup troppo grande")
-                        entries[entry.name] = bytes
-                    }
+                    if (entry.isDirectory) throw IOException("Backup non valido: voce ZIP directory")
+                    if (!vaultEntryAllowed(entry.name)) throw IOException("Backup non valido: voce ZIP inattesa ${entry.name}")
+                    if (entries.containsKey(entry.name)) throw IOException("Backup non valido: voce duplicata ${entry.name}")
+                    if (entry.size > MAX_ENTRY_BYTES) throw IOException("Backup troppo grande")
+                    val bytes = readZipEntry(zip, MAX_ENTRY_BYTES)
+                    totalBytes += bytes.size
+                    if (totalBytes > MAX_TOTAL_BYTES) throw IOException("Backup troppo grande")
+                    entries[entry.name] = bytes
                     zip.closeEntry()
                 }
             }
         }
+        return entries
+    }
+
+    private suspend fun vaultSnapshot(entries: Map<String, ByteArray>): VaultSnapshot {
         val manifestBytes = entries[MANIFEST_ENTRY] ?: throw IOException("Manifest del backup mancante")
-        val payloadBytes = entries[PAYLOAD_ENTRY] ?: throw IOException("Dati del backup mancanti")
+        val manifest = JSONObject(manifestBytes.toString(Charsets.UTF_8))
+        val format = manifest.optInt("formatVersion", 0)
+        if (format != FORMAT_VERSION) throw IOException("Versione Vault non supportata: $format")
+        if (!manifest.optString("platform", "").equals(PLATFORM, ignoreCase = true)) {
+            throw IOException("Backup creato per un'altra piattaforma")
+        }
+        val databaseVersion = manifest.optInt("databaseVersion", 0)
+        if (databaseVersion > LEVYRA_DATABASE_VERSION) {
+            throw IOException("Backup creato da una versione più recente dell'app")
+        }
+        validateSectionChecksums(entries, manifest)
+        val settingsBytes = entries[SETTINGS_ENTRY] ?: throw IOException("Dati impostazioni del backup mancanti")
+        val settingsJson = JSONObject(settingsBytes.toString(Charsets.UTF_8))
+        return VaultSnapshot(
+            settings = parseSettings(settingsJson),
+            favorites = entries[FAVORITES_ENTRY].toJsonArray().toTrackList(),
+            followedArtists = parseFollowedArtists(entries[FOLLOWED_ARTISTS_ENTRY].toJsonArray()),
+            playlists = parsePlaylists(entries[PLAYLISTS_ENTRY].toJsonArray()),
+            history = parseHistory(entries[HISTORY_ENTRY].toJsonArray()),
+            queueItems = parseQueueItems(entries[QUEUE_ENTRY].toJsonObject()),
+            queueState = parseQueueState(entries[QUEUE_ENTRY].toJsonObject())
+        )
+    }
+
+    private suspend fun legacySnapshot(entries: Map<String, ByteArray>): VaultSnapshot {
+        val manifestBytes = entries[MANIFEST_ENTRY] ?: throw IOException("Manifest del backup mancante")
+        val payloadBytes = entries[LEGACY_PAYLOAD_ENTRY] ?: throw IOException("Dati del backup mancanti")
         val manifest = JSONObject(manifestBytes.toString(Charsets.UTF_8))
         val schema = manifest.optInt("schemaVersion", 0)
-        if (schema !in 1..SCHEMA_VERSION) throw IOException("Versione backup non supportata: $schema")
+        if (schema != LEGACY_SCHEMA_VERSION) throw IOException("Versione backup non supportata: $schema")
         val expected = manifest.optString("payloadSha256")
-        val actual = sha256(payloadBytes)
-        if (expected.isBlank() || !expected.equals(actual, true)) throw IOException("Backup danneggiato: checksum non valido")
-        restorePayload(JSONObject(payloadBytes.toString(Charsets.UTF_8)))
-        LevyraBackupResult("Ripristino completato", actual)
-    }
-
-    private suspend fun createPayload(): JSONObject {
-        val snapshot = preferences.snapshot()
-        val favorites = database.favoriteTracksDao().all().map { it.toTrack() }
-        val playlists = database.playlistDao().allPlaylists()
-        val history = database.listenEventsDao().all()
-        val queueItems = database.playbackQueueDao().items()
-        val queueState = database.playbackQueueDao().state()
-        val root = JSONObject()
-        root.put("settings", settingsToJson(snapshot))
-        root.put("favorites", JSONArray().apply { favorites.forEach { put(TrackJson.toJson(it)) } })
-        root.put("followedArtists", followedArtistsToJson(followedArtistsStore.load()))
-        root.put("playlists", JSONArray().apply {
-            playlists.forEach { playlist ->
-                val tracks = database.playlistDao().tracksOf(playlist.id)
-                put(
-                    JSONObject()
-                        .put("id", playlist.id)
-                        .put("name", playlist.name)
-                        .put("coverUrl", playlist.coverUrl)
-                        .put("createdAt", playlist.createdAt)
-                        .put("updatedAt", playlist.updatedAt)
-                        .put("tracks", JSONArray().apply { tracks.forEach { put(TrackJson.toJson(it.toTrack())) } })
-                )
-            }
-        })
-        root.put("history", JSONArray().apply { history.forEach { put(listenEventToJson(it)) } })
-        root.put("queue", JSONObject()
-            .put("items", JSONArray().apply {
-                queueItems.forEach { put(JSONObject().put("position", it.position).put("payload", it.payload).put("identity", it.identity)) }
-            })
-            .put("state", queueState?.let(::queueStateToJson) ?: JSONObject.NULL)
+        val actual = sha256Hex(MessageDigest.getInstance("SHA-256").digest(payloadBytes))
+        if (expected.isBlank() || !expected.equals(actual, ignoreCase = true)) {
+            throw IOException("Backup danneggiato: checksum non valido")
+        }
+        val root = JSONObject(payloadBytes.toString(Charsets.UTF_8))
+        val queue = root.optJSONObject("queue")
+        return VaultSnapshot(
+            settings = parseSettings(root.optJSONObject("settings") ?: JSONObject()),
+            favorites = root.optJSONArray("favorites").toTrackList(),
+            followedArtists = parseFollowedArtists(root.optJSONArray("followedArtists")),
+            playlists = parsePlaylists(root.optJSONArray("playlists") ?: JSONArray()),
+            history = parseHistory(root.optJSONArray("history")),
+            queueItems = parseQueueItems(queue),
+            queueState = parseQueueState(queue)
         )
-        return root
     }
 
-    private suspend fun restorePayload(root: JSONObject) {
-        val target = parseRestorePayload(root)
-        val rollback = parseRestorePayload(createPayload())
-        try {
-            applyRestorePayload(target)
-        } catch (restoreError: Throwable) {
-            runCatching { applyRestorePayload(rollback) }
-                .onFailure { rollbackError -> restoreError.addSuppressed(rollbackError) }
-            throw restoreError
+    private fun validateSectionChecksums(entries: Map<String, ByteArray>, manifest: JSONObject) {
+        val sections = manifest.optJSONObject("sections") ?: throw IOException("Backup non valido: sezioni mancanti")
+        for ((name, bytes) in entries) {
+            if (name == MANIFEST_ENTRY) continue
+            val section = sections.optJSONObject(name) ?: throw IOException("Backup non valido: sezione sconosciuta $name")
+            val expected = section.optString("sha256")
+            val declaredBytes = section.optLong("bytes", -1L)
+            if (declaredBytes >= 0L && declaredBytes != bytes.size.toLong()) {
+                throw IOException("Backup non valido: dimensione errata per $name")
+            }
+            val actual = sha256Hex(MessageDigest.getInstance("SHA-256").digest(bytes))
+            if (expected.isBlank() || !expected.equals(actual, ignoreCase = true)) {
+                throw IOException("Backup danneggiato: checksum non valido per $name")
+            }
         }
     }
 
-    private fun parseRestorePayload(root: JSONObject): RestorePayload {
-        val settingsJson = root.optJSONObject("settings") ?: JSONObject()
-        return RestorePayload(
-            settings = parseSettings(settingsJson),
-            favoriteTracks = root.optJSONArray("favorites").toTrackList(),
-            followedArtists = parseFollowedArtists(root.optJSONArray("followedArtists")),
-            playlists = root.optJSONArray("playlists") ?: JSONArray(),
-            history = parseHistory(root.optJSONArray("history")),
-            queue = root.optJSONObject("queue")
+    private suspend fun currentSnapshot(): VaultSnapshot {
+        val snapshot = preferences.snapshot()
+        val playlists = database.playlistDao().allPlaylists().map { playlist ->
+            PlaylistBackup(
+                id = playlist.id,
+                name = playlist.name,
+                coverUrl = playlist.coverUrl,
+                createdAt = playlist.createdAt,
+                updatedAt = playlist.updatedAt,
+                tracks = database.playlistDao().tracksOf(playlist.id).map { it.toTrack() }
+            )
+        }
+        return VaultSnapshot(
+            settings = snapshot,
+            favorites = database.favoriteTracksDao().all().map { it.toTrack() },
+            followedArtists = followedArtistsStore.load(),
+            playlists = playlists,
+            history = database.listenEventsDao().all(),
+            queueItems = database.playbackQueueDao().items(),
+            queueState = database.playbackQueueDao().state()
         )
     }
 
-    private suspend fun applyRestorePayload(payload: RestorePayload) {
+    private suspend fun applySnapshot(payload: VaultSnapshot) {
         preferences.restoreSnapshot(payload.settings)
         followedArtistsStore.saveDurable(payload.followedArtists)
         val now = System.currentTimeMillis()
         database.withTransaction {
-            database.favoriteTracksDao().replaceAll(payload.favoriteTracks.mapIndexed { index, track -> track.toFavoriteTrackEntity(now - index) })
+            database.favoriteTracksDao().replaceAll(payload.favorites.mapIndexed { index, track -> track.toFavoriteTrackEntity(now - index) })
             restorePlaylists(payload.playlists)
             database.listenEventsDao().replaceAll(payload.history)
-            restoreQueue(payload.queue)
+            restoreQueue(payload.queueItems, payload.queueState)
         }
         AutomaticBackupScheduler.schedule(appContext, payload.settings.backupSettings)
+    }
+
+    private suspend fun restorePlaylists(playlists: List<PlaylistBackup>) {
+        val dao = database.playlistDao()
+        dao.clearAll()
+        playlists.forEach { playlist ->
+            if (playlist.id.isBlank()) return@forEach
+            dao.upsertPlaylist(
+                PlaylistEntity(
+                    playlist.id,
+                    playlist.name.ifBlank { "Playlist" },
+                    playlist.coverUrl,
+                    playlist.createdAt,
+                    playlist.updatedAt
+                )
+            )
+            if (playlist.tracks.isNotEmpty()) {
+                dao.insertTracks(
+                    playlist.tracks.mapIndexed { position, track ->
+                        track.toPlaylistTrackEntity(playlist.id, position, playlist.createdAt + position)
+                    }
+                )
+            }
+        }
+    }
+
+    private suspend fun restoreQueue(items: List<PlaybackQueueItemEntity>, state: PlaybackQueueStateEntity?) {
+        val dao = database.playbackQueueDao()
+        if (state == null) {
+            dao.clear()
+        } else {
+            dao.replace(items, state)
+        }
+    }
+
+    private fun parseQueueItems(json: JSONObject?): List<PlaybackQueueItemEntity> {
+        if (json == null) return emptyList()
+        val itemsArray = json.optJSONArray("items") ?: return emptyList()
+        return buildList {
+            for (index in 0 until itemsArray.length()) {
+                val item = itemsArray.optJSONObject(index) ?: continue
+                add(PlaybackQueueItemEntity(item.optInt("position"), item.optString("payload"), item.optString("identity")))
+            }
+        }
+    }
+
+    private fun parseQueueState(json: JSONObject?): PlaybackQueueStateEntity? {
+        if (json == null) return null
+        val stateJson = json.optJSONObject("state") ?: return null
+        return PlaybackQueueStateEntity(
+            currentIndex = stateJson.optInt("currentIndex", -1),
+            positionMs = stateJson.optLong("positionMs"),
+            shuffleEnabled = stateJson.optBoolean("shuffleEnabled"),
+            shuffleOrder = stateJson.optString("shuffleOrder"),
+            shuffleCursor = stateJson.optInt("shuffleCursor", -1),
+            history = stateJson.optString("history"),
+            repeatMode = stateJson.optString("repeatMode", "Off"),
+            radioEnabled = stateJson.optBoolean("radioEnabled", true),
+            generation = stateJson.optLong("generation"),
+            updatedAt = stateJson.optLong("updatedAt")
+        )
+    }
+
+    private fun parsePlaylists(array: JSONArray?): List<PlaylistBackup> {
+        if (array == null) return emptyList()
+        return buildList {
+            for (index in 0 until array.length()) {
+                val json = array.optJSONObject(index) ?: continue
+                val id = json.optString("id").trim()
+                if (id.isBlank()) continue
+                val createdAt = json.optLong("createdAt", System.currentTimeMillis())
+                val updatedAt = json.optLong("updatedAt", createdAt)
+                add(
+                    PlaylistBackup(
+                        id = id,
+                        name = json.optString("name", "Playlist"),
+                        coverUrl = json.optString("coverUrl"),
+                        createdAt = createdAt,
+                        updatedAt = updatedAt,
+                        tracks = json.optJSONArray("tracks").toTrackList()
+                    )
+                )
+            }
+        }
     }
 
     private fun settingsToJson(snapshot: LevyraPreferencesSnapshot): JSONObject {
@@ -253,42 +516,6 @@ class LevyraBackupManager(private val context: Context) {
             backupSettings = parseBackupSettings(json.optJSONObject("backupSettings")),
             jamDisplayName = json.optString("jamDisplayName")
         )
-    }
-
-    private suspend fun restorePlaylists(array: JSONArray) {
-        val dao = database.playlistDao()
-        dao.clearAll()
-        for (index in 0 until array.length()) {
-            val json = array.optJSONObject(index) ?: continue
-            val id = json.optString("id").trim()
-            if (id.isBlank()) continue
-            val createdAt = json.optLong("createdAt", System.currentTimeMillis())
-            val updatedAt = json.optLong("updatedAt", createdAt)
-            dao.upsertPlaylist(PlaylistEntity(id, json.optString("name", "Playlist"), json.optString("coverUrl"), createdAt, updatedAt))
-            val tracks = json.optJSONArray("tracks").toTrackList()
-            if (tracks.isNotEmpty()) dao.insertTracks(tracks.mapIndexed { position, track -> track.toPlaylistTrackEntity(id, position, createdAt + position) })
-        }
-    }
-
-    private suspend fun restoreQueue(json: JSONObject?) {
-        val dao = database.playbackQueueDao()
-        if (json == null) {
-            dao.clear()
-            return
-        }
-        val itemsArray = json.optJSONArray("items") ?: JSONArray()
-        val items = buildList {
-            for (index in 0 until itemsArray.length()) {
-                val item = itemsArray.optJSONObject(index) ?: continue
-                add(PlaybackQueueItemEntity(item.optInt("position"), item.optString("payload"), item.optString("identity")))
-            }
-        }
-        val stateJson = json.optJSONObject("state")
-        if (stateJson == null) {
-            dao.clear()
-        } else {
-            dao.replace(items, parseQueueState(stateJson))
-        }
     }
 
     private fun audioSettingsToJson(value: LevyraAudioSettings): JSONObject =
@@ -352,6 +579,7 @@ class LevyraBackupManager(private val context: Context) {
         .put("frequency", value.frequency.name)
         .put("retentionCount", value.retentionCount)
         .put("chargingOnly", value.chargingOnly)
+        .put("preUpdate", value.preUpdate)
 
     private fun parseBackupSettings(json: JSONObject?): LevyraBackupSettings {
         if (json == null) return LevyraBackupSettings()
@@ -359,13 +587,16 @@ class LevyraBackupManager(private val context: Context) {
             enabled = json.optBoolean("enabled"),
             frequency = LevyraBackupFrequency.from(json.optString("frequency")),
             retentionCount = json.optInt("retentionCount", 5),
-            chargingOnly = json.optBoolean("chargingOnly", true)
+            chargingOnly = json.optBoolean("chargingOnly", true),
+            preUpdate = json.optBoolean("preUpdate", true)
         ).normalized()
     }
 
-    private fun followedArtistsToJson(values: List<FollowedArtist>): JSONArray = JSONArray().apply {
-        values.forEach { put(JSONObject().put("browseId", it.browseId).put("name", it.name).put("thumbnailUrl", it.thumbnailUrl).put("followedAt", it.followedAt)) }
-    }
+    private fun followedArtistToJson(value: FollowedArtist): JSONObject = JSONObject()
+        .put("browseId", value.browseId)
+        .put("name", value.name)
+        .put("thumbnailUrl", value.thumbnailUrl)
+        .put("followedAt", value.followedAt)
 
     private fun parseFollowedArtists(array: JSONArray?): List<FollowedArtist> {
         if (array == null) return emptyList()
@@ -401,7 +632,23 @@ class LevyraBackupManager(private val context: Context) {
                 val json = array.optJSONObject(index) ?: continue
                 val trackId = json.optString("trackId")
                 if (trackId.isBlank()) continue
-                add(ListenEventEntity(trackId = trackId, title = json.optString("title"), artist = json.optString("artist"), album = json.optString("album"), durationMs = json.optLong("durationMs"), videoUrl = json.optString("videoUrl"), thumbnailUrl = json.optString("thumbnailUrl"), largeThumbnailUrl = json.optString("largeThumbnailUrl"), source = json.optString("source"), artistBrowseIds = json.optString("artistBrowseIds"), listenedMs = json.optLong("listenedMs"), completed = json.optBoolean("completed"), startedAt = json.optLong("startedAt")))
+                add(
+                    ListenEventEntity(
+                        trackId = trackId,
+                        title = json.optString("title"),
+                        artist = json.optString("artist"),
+                        album = json.optString("album"),
+                        durationMs = json.optLong("durationMs"),
+                        videoUrl = json.optString("videoUrl"),
+                        thumbnailUrl = json.optString("thumbnailUrl"),
+                        largeThumbnailUrl = json.optString("largeThumbnailUrl"),
+                        source = json.optString("source"),
+                        artistBrowseIds = json.optString("artistBrowseIds"),
+                        listenedMs = json.optLong("listenedMs"),
+                        completed = json.optBoolean("completed"),
+                        startedAt = json.optLong("startedAt")
+                    )
+                )
             }
         }
     }
@@ -418,23 +665,28 @@ class LevyraBackupManager(private val context: Context) {
         .put("generation", value.generation)
         .put("updatedAt", value.updatedAt)
 
-    private fun parseQueueState(json: JSONObject): PlaybackQueueStateEntity = PlaybackQueueStateEntity(
-        currentIndex = json.optInt("currentIndex", -1),
-        positionMs = json.optLong("positionMs"),
-        shuffleEnabled = json.optBoolean("shuffleEnabled"),
-        shuffleOrder = json.optString("shuffleOrder"),
-        shuffleCursor = json.optInt("shuffleCursor", -1),
-        history = json.optString("history"),
-        repeatMode = json.optString("repeatMode", "Off"),
-        radioEnabled = json.optBoolean("radioEnabled", true),
-        generation = json.optLong("generation"),
-        updatedAt = json.optLong("updatedAt")
-    )
-
-    private fun JSONArray?.toTrackList(): List<com.luc4n3x.levyra.domain.Track> {
+    private fun JSONArray?.toTrackList(): List<Track> {
         if (this == null) return emptyList()
         return buildList {
             for (index in 0 until length()) optJSONObject(index)?.let(TrackJson::fromJson)?.let(::add)
+        }
+    }
+
+    private fun ByteArray?.toJsonArray(): JSONArray? {
+        if (this == null) return null
+        return try {
+            JSONArray(toString(Charsets.UTF_8))
+        } catch (error: org.json.JSONException) {
+            throw IOException("Backup non valido: sezione JSON danneggiata")
+        }
+    }
+
+    private fun ByteArray?.toJsonObject(): JSONObject? {
+        if (this == null) return null
+        return try {
+            JSONObject(toString(Charsets.UTF_8))
+        } catch (error: org.json.JSONException) {
+            throw IOException("Backup non valido: sezione JSON danneggiata")
         }
     }
 
@@ -457,23 +709,20 @@ class LevyraBackupManager(private val context: Context) {
         return buffer.toByteArray()
     }
 
-    private fun sha256(bytes: ByteArray): String = MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+    private fun sha256Hex(digest: ByteArray): String = digest.joinToString("") { "%02x".format(it) }
 
-    private fun checksumOf(file: File): String = file.inputStream().buffered().use { input ->
+    private fun combinedChecksum(sections: Map<String, SectionInfo>): String {
         val digest = MessageDigest.getInstance("SHA-256")
-        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-        while (true) {
-            val count = input.read(buffer)
-            if (count < 0) break
-            digest.update(buffer, 0, count)
+        sections.toSortedMap().forEach { (name, info) ->
+            digest.update(name.toByteArray(Charsets.UTF_8))
+            digest.update(info.sha256.toByteArray(Charsets.UTF_8))
         }
-        digest.digest().joinToString("") { "%02x".format(it) }
+        return sha256Hex(digest.digest())
     }
 
     private fun pruneAutomaticBackups(directory: File, retentionCount: Int) {
         val candidates = directory.listFiles().orEmpty().filter { file ->
-            file.name.startsWith(AUTOMATIC_BACKUP_PREFIX) &&
-                file.name.endsWith(".zip") &&
+            isAutomaticBackupName(file.name) &&
                 file.canonicalFile.parentFile == directory &&
                 Files.isRegularFile(file.toPath()) &&
                 !Files.isSymbolicLink(file.toPath())
@@ -489,28 +738,117 @@ class LevyraBackupManager(private val context: Context) {
         if (file.canonicalFile.parentFile != directory.canonicalFile) throw IOException("Percorso backup non valido")
     }
 
-    private data class RestorePayload(
-        val settings: LevyraPreferencesSnapshot,
-        val favoriteTracks: List<com.luc4n3x.levyra.domain.Track>,
-        val followedArtists: List<FollowedArtist>,
-        val playlists: JSONArray,
-        val history: List<ListenEventEntity>,
-        val queue: JSONObject?
+    private data class SectionInfo(val sha256: String, val bytes: Long)
+
+    private data class PlaylistBackup(
+        val id: String,
+        val name: String,
+        val coverUrl: String,
+        val createdAt: Long,
+        val updatedAt: Long,
+        val tracks: List<Track>
     )
 
-    private companion object {
-        const val SCHEMA_VERSION = 1
+    private data class VaultSnapshot(
+        val settings: LevyraPreferencesSnapshot,
+        val favorites: List<Track>,
+        val followedArtists: List<FollowedArtist>,
+        val playlists: List<PlaylistBackup>,
+        val history: List<ListenEventEntity>,
+        val queueItems: List<PlaybackQueueItemEntity>,
+        val queueState: PlaybackQueueStateEntity?
+    )
+
+    private class ByteCounterOutputStream(private val delegate: OutputStream) : OutputStream() {
+        var count: Long = 0L
+            private set
+
+        override fun write(value: Int) {
+            delegate.write(value)
+            count++
+        }
+
+        override fun write(buffer: ByteArray, offset: Int, length: Int) {
+            delegate.write(buffer, offset, length)
+            count += length
+        }
+
+        override fun flush() = delegate.flush()
+
+        override fun close() = delegate.close()
+    }
+
+    internal companion object {
+        const val FORMAT_VERSION = 1
+        const val PLATFORM = "android"
+        const val LEGACY_SCHEMA_VERSION = 1
         const val MANIFEST_ENTRY = "manifest.json"
-        const val PAYLOAD_ENTRY = "payload.json"
-        const val MAX_ZIP_ENTRIES = 32
+        const val LEGACY_PAYLOAD_ENTRY = "payload.json"
+        const val SETTINGS_ENTRY = "data/settings.json"
+        const val FAVORITES_ENTRY = "data/favorites.json"
+        const val FOLLOWED_ARTISTS_ENTRY = "data/followed_artists.json"
+        const val PLAYLISTS_ENTRY = "data/playlists.json"
+        const val HISTORY_ENTRY = "data/history.json"
+        const val QUEUE_ENTRY = "data/queue.json"
+        const val MAX_ZIP_ENTRIES = 16
         const val MAX_ENTRY_BYTES = 64L * 1024L * 1024L
-        const val MAX_TOTAL_BYTES = 65L * 1024L * 1024L
+        const val MAX_TOTAL_BYTES = 192L * 1024L * 1024L
         const val MAX_AUTOMATIC_BACKUPS = 12
         const val AUTOMATIC_BACKUP_DIRECTORY = "backups"
         const val AUTOMATIC_BACKUP_PREFIX = "levyra-auto-backup-"
-        val REQUIRED_ENTRIES = setOf(MANIFEST_ENTRY, PAYLOAD_ENTRY)
+        const val VAULT_EXTENSION = ".levyra"
+        val ALLOWED_VAULT_ENTRIES = setOf(
+            MANIFEST_ENTRY,
+            SETTINGS_ENTRY,
+            FAVORITES_ENTRY,
+            FOLLOWED_ARTISTS_ENTRY,
+            PLAYLISTS_ENTRY,
+            HISTORY_ENTRY,
+            QUEUE_ENTRY,
+            LEGACY_PAYLOAD_ENTRY
+        )
     }
 }
+
+data class LevyraBackupResult(val message: String, val checksum: String)
+
+data class VaultPreview(
+    val createdAt: Long,
+    val appVersion: String,
+    val databaseVersion: Int,
+    val formatVersion: Int,
+    val platform: String,
+    val sizeBytes: Long,
+    val sections: List<String>,
+    val compatible: Boolean
+)
+
+internal fun vaultEntryAllowed(name: String): Boolean {
+    if (name.isEmpty() || name.startsWith("/") || name.contains("..") || name.contains('\\')) return false
+    return name in LevyraBackupManager.ALLOWED_VAULT_ENTRIES
+}
+
+internal fun isAutomaticBackupName(name: String): Boolean {
+    if (!name.startsWith("levyra-auto-backup-")) return false
+    val body = name.removePrefix("levyra-auto-backup-")
+    if (body.endsWith(".levyra")) {
+        return body.removeSuffix(".levyra").all(Char::isDigit)
+    }
+    if (body.endsWith(".zip")) {
+        return body.removeSuffix(".zip").all(Char::isDigit)
+    }
+    return false
+}
+
+internal fun levyraVaultFileName(timestamp: Long): String {
+    val date = java.text.SimpleDateFormat("yyyy-MM-dd_HHmm", java.util.Locale.US).format(java.util.Date(timestamp))
+    return "Levyra_${date}.levyra"
+}
+
+internal fun automaticBackupFilesToDelete(fileNames: List<String>, retentionCount: Int): List<String> = fileNames
+    .filter(::isAutomaticBackupName)
+    .sortedDescending()
+    .drop(retentionCount.coerceIn(1, 12))
 
 internal fun backupAudioSettingsToJson(value: LevyraAudioSettings): JSONObject = JSONObject()
     .put("equalizerEnabled", value.equalizerEnabled)
@@ -559,10 +897,3 @@ internal fun backupAudioSettingsFromJson(json: JSONObject?): LevyraAudioSettings
         customPresets = customPresets
     ).normalized()
 }
-
-internal fun automaticBackupFilesToDelete(fileNames: List<String>, retentionCount: Int): List<String> = fileNames
-    .filter { it.startsWith("levyra-auto-backup-") && it.endsWith(".zip") }
-    .sortedDescending()
-    .drop(retentionCount.coerceIn(1, 12))
-
-data class LevyraBackupResult(val message: String, val checksum: String)

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
@@ -806,7 +806,6 @@ class LevyraPreferences(context: Context) {
         val KEY_BACKUP_CHARGING_ONLY = booleanPreferencesKey("automatic_backup_charging_only")
         val KEY_BACKUP_PRE_UPDATE = booleanPreferencesKey("automatic_backup_pre_update")
         val KEY_VAULT_LAST_BACKUP = longPreferencesKey("vault_last_backup_at")
-        // Device-specific SAF destination: never serialized into the Vault or restored.
         val KEY_VAULT_BACKUP_TREE_URI = stringPreferencesKey("vault_backup_tree_uri")
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
@@ -317,6 +317,10 @@ class LevyraPreferences(context: Context) {
         write { it[KEY_VAULT_BACKUP_TREE_URI] = value }
     }
 
+    fun vaultRuntimeState(): Pair<Long, String> = read(0L to "") {
+        (it[KEY_VAULT_LAST_BACKUP] ?: 0L) to it[KEY_VAULT_BACKUP_TREE_URI].orEmpty()
+    }
+
     fun jamDisplayName(): String = read("") { it[KEY_JAM_DISPLAY_NAME].orEmpty() }
 
     fun setJamDisplayName(value: String) {
@@ -798,6 +802,7 @@ class LevyraPreferences(context: Context) {
         val KEY_BACKUP_CHARGING_ONLY = booleanPreferencesKey("automatic_backup_charging_only")
         val KEY_BACKUP_PRE_UPDATE = booleanPreferencesKey("automatic_backup_pre_update")
         val KEY_VAULT_LAST_BACKUP = longPreferencesKey("vault_last_backup_at")
+        // Device-specific SAF destination: never serialized into the Vault or restored.
         val KEY_VAULT_BACKUP_TREE_URI = stringPreferencesKey("vault_backup_tree_uri")
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
@@ -153,6 +153,7 @@ class LevyraPreferences(context: Context) {
             mutable[KEY_BACKUP_FREQUENCY] = normalizedBackup.frequency.name
             mutable[KEY_BACKUP_RETENTION] = normalizedBackup.retentionCount
             mutable[KEY_BACKUP_CHARGING_ONLY] = normalizedBackup.chargingOnly
+            mutable[KEY_BACKUP_PRE_UPDATE] = normalizedBackup.preUpdate
             mutable[KEY_RECENT_SEARCHES] = recentSearchesJson
             mutable[personalOrbitTracksKey(normalizedLanguage)] = personalOrbitJson
             if (snapshot.lastTrack == null) {
@@ -300,7 +301,14 @@ class LevyraPreferences(context: Context) {
             it[KEY_BACKUP_FREQUENCY] = normalized.frequency.name
             it[KEY_BACKUP_RETENTION] = normalized.retentionCount
             it[KEY_BACKUP_CHARGING_ONLY] = normalized.chargingOnly
+            it[KEY_BACKUP_PRE_UPDATE] = normalized.preUpdate
         }
+    }
+
+    fun lastBackupAt(): Long = read(0L) { it[KEY_VAULT_LAST_BACKUP] ?: 0L }
+
+    fun setLastBackupAt(value: Long) {
+        write { it[KEY_VAULT_LAST_BACKUP] = value.coerceAtLeast(0L) }
     }
 
     fun jamDisplayName(): String = read("") { it[KEY_JAM_DISPLAY_NAME].orEmpty() }
@@ -583,7 +591,8 @@ class LevyraPreferences(context: Context) {
         enabled = preferences[KEY_BACKUP_ENABLED] ?: false,
         frequency = LevyraBackupFrequency.from(preferences[KEY_BACKUP_FREQUENCY].orEmpty()),
         retentionCount = preferences[KEY_BACKUP_RETENTION] ?: 5,
-        chargingOnly = preferences[KEY_BACKUP_CHARGING_ONLY] ?: true
+        chargingOnly = preferences[KEY_BACKUP_CHARGING_ONLY] ?: true,
+        preUpdate = preferences[KEY_BACKUP_PRE_UPDATE] ?: true
     ).normalized()
 
     private fun homeSectionsKey(languageCode: String): Preferences.Key<String> = stringPreferencesKey("home_sections_v2_${LevyraLanguageCatalog.normalize(languageCode)}")
@@ -781,6 +790,8 @@ class LevyraPreferences(context: Context) {
         val KEY_BACKUP_FREQUENCY = stringPreferencesKey("automatic_backup_frequency")
         val KEY_BACKUP_RETENTION = intPreferencesKey("automatic_backup_retention")
         val KEY_BACKUP_CHARGING_ONLY = booleanPreferencesKey("automatic_backup_charging_only")
+        val KEY_BACKUP_PRE_UPDATE = booleanPreferencesKey("automatic_backup_pre_update")
+        val KEY_VAULT_LAST_BACKUP = longPreferencesKey("vault_last_backup_at")
     }
 }
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
@@ -311,6 +311,12 @@ class LevyraPreferences(context: Context) {
         write { it[KEY_VAULT_LAST_BACKUP] = value.coerceAtLeast(0L) }
     }
 
+    fun backupTreeUri(): String = read("") { it[KEY_VAULT_BACKUP_TREE_URI].orEmpty() }
+
+    fun setBackupTreeUri(value: String) {
+        write { it[KEY_VAULT_BACKUP_TREE_URI] = value }
+    }
+
     fun jamDisplayName(): String = read("") { it[KEY_JAM_DISPLAY_NAME].orEmpty() }
 
     fun setJamDisplayName(value: String) {
@@ -792,6 +798,7 @@ class LevyraPreferences(context: Context) {
         val KEY_BACKUP_CHARGING_ONLY = booleanPreferencesKey("automatic_backup_charging_only")
         val KEY_BACKUP_PRE_UPDATE = booleanPreferencesKey("automatic_backup_pre_update")
         val KEY_VAULT_LAST_BACKUP = longPreferencesKey("vault_last_backup_at")
+        val KEY_VAULT_BACKUP_TREE_URI = stringPreferencesKey("vault_backup_tree_uri")
     }
 }
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
@@ -317,6 +317,10 @@ class LevyraPreferences(context: Context) {
         write { it[KEY_VAULT_BACKUP_TREE_URI] = value }
     }
 
+    suspend fun persistBackupTreeUri(value: String) {
+        dataStore.edit { it[KEY_VAULT_BACKUP_TREE_URI] = value }
+    }
+
     fun vaultRuntimeState(): Pair<Long, String> = read(0L to "") {
         (it[KEY_VAULT_LAST_BACKUP] ?: 0L) to it[KEY_VAULT_BACKUP_TREE_URI].orEmpty()
     }

--- a/app/src/main/java/com/luc4n3x/levyra/data/local/LevyraDatabase.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/local/LevyraDatabase.kt
@@ -7,6 +7,8 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
+const val LEVYRA_DATABASE_VERSION = 18
+
 @Database(
     entities = [
         FavoriteTrackEntity::class,
@@ -27,7 +29,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         RecognitionHistoryEntity::class,
         FollowedArtistEntity::class
     ],
-    version = 18,
+    version = LEVYRA_DATABASE_VERSION,
     exportSchema = true
 )
 abstract class LevyraDatabase : RoomDatabase() {

--- a/app/src/main/java/com/luc4n3x/levyra/domain/LevyraExperienceSettings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/LevyraExperienceSettings.kt
@@ -126,10 +126,13 @@ data class LevyraBackupSettings(
     val enabled: Boolean = false,
     val frequency: LevyraBackupFrequency = LevyraBackupFrequency.Weekly,
     val retentionCount: Int = 5,
-    val chargingOnly: Boolean = true
+    val chargingOnly: Boolean = true,
+    val preUpdate: Boolean = true
 ) {
     fun normalized(): LevyraBackupSettings = copy(retentionCount = retentionCount.coerceIn(1, 12))
 }
+
+enum class LevyraVaultStatus { Idle, Running, Completed, Error }
 
 internal fun LevyraDownloadSettings.shouldSkipExistingDownload(
     trackId: String,

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -40,6 +40,7 @@ import com.luc4n3x.levyra.update.AppUpdateContract
 import android.net.Uri
 import android.os.PowerManager
 import android.os.SystemClock
+import android.provider.DocumentsContract
 import android.widget.Toast
 import android.speech.RecognizerIntent
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -376,6 +377,9 @@ import com.luc4n3x.levyra.domain.LevyraDownloadPreset
 import com.luc4n3x.levyra.domain.LevyraDownloadSettings
 import com.luc4n3x.levyra.domain.LevyraBackupFrequency
 import com.luc4n3x.levyra.domain.LevyraBackupSettings
+import com.luc4n3x.levyra.domain.LevyraVaultStatus
+import com.luc4n3x.levyra.data.levyraVaultFileName
+import com.luc4n3x.levyra.data.VaultPreview
 import com.luc4n3x.levyra.domain.LevyraFontPreset
 import com.luc4n3x.levyra.domain.OfflineDownloadTask
 import com.luc4n3x.levyra.domain.LevyraAudioPresets
@@ -1140,7 +1144,24 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
         uri?.let(viewModel::createBackup)
     }
     val restoreBackupLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
-        uri?.let(viewModel::restoreBackup)
+        uri?.let(viewModel::previewRestore)
+    }
+    val manageBackupsLauncher = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            result.data?.data?.let(viewModel::previewRestore)
+        }
+    }
+    val openManageBackups = {
+        val rootUri = DocumentsContract.buildRootUri(
+            "${toastContext.packageName}.automatic-backups",
+            "levyra-automatic-backups"
+        )
+        manageBackupsLauncher.launch(
+            Intent(Intent.ACTION_OPEN_DOCUMENT)
+                .addCategory(Intent.CATEGORY_OPENABLE)
+                .setType("application/zip")
+                .putExtra(DocumentsContract.EXTRA_INITIAL_URI, rootUri)
+        )
     }
     val accent = if (state.dynamicColor) state.currentTrack ?: state.tracks.firstOrNull() else null
     val overlayEnter = if (state.animationsEnabled) fadeIn(animationSpec = tween(180, easing = LinearOutSlowInEasing)) else EnterTransition.None
@@ -1624,6 +1645,8 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
                     interfaceSettings = state.interfaceSettings,
                     downloadSettings = state.downloadSettings,
                     backupSettings = state.backupSettings,
+                    vaultStatus = state.vaultStatus,
+                    lastBackupAtMs = state.lastBackupAtMs,
                     downloadQueue = state.downloadQueue,
                     playbackDiagnostics = state.playbackDiagnostics,
                     lastFmConfigured = state.lastFmConfigured,
@@ -1672,8 +1695,10 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
                             }
                         }
                     },
-                    onCreateBackup = { createBackupLauncher.launch("levyra-backup-${System.currentTimeMillis()}.zip") },
+                    onCreateBackup = { createBackupLauncher.launch(levyraVaultFileName(System.currentTimeMillis())) },
                     onRestoreBackup = { restoreBackupLauncher.launch(arrayOf("application/zip", "application/octet-stream")) },
+                    onBackupNow = viewModel::backupNow,
+                    onManageBackups = { openManageBackups() },
                     onPauseDownload = viewModel::pauseDownload,
                     onResumeDownload = viewModel::resumeDownload,
                     onCancelDownload = viewModel::cancelDownload,
@@ -1695,6 +1720,14 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
                     onClearAudD = viewModel::clearAudDToken,
                     onRedoQuestionnaire = viewModel::restartOnboarding,
                     onClose = viewModel::closeSettings
+                )
+            }
+
+            state.backupPreview?.let { preview ->
+                VaultRestorePreviewDialog(
+                    preview = preview,
+                    onConfirm = viewModel::confirmRestore,
+                    onDismiss = viewModel::dismissRestorePreview
                 )
             }
 
@@ -2271,6 +2304,81 @@ private fun LanguageRestartDialog(onRestart: () -> Unit, onLater: () -> Unit) {
         confirmButton = { TextButton(onClick = onRestart) { Text(strings.restartNow, color = LevyraCyan, fontWeight = FontWeight.Black) } },
         dismissButton = { TextButton(onClick = onLater) { Text(strings.later, color = LevyraMuted, fontWeight = FontWeight.Bold) } }
     )
+}
+
+@Composable
+private fun VaultRestorePreviewDialog(
+    preview: VaultPreview,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val strings = LocalLevyraStrings.current
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Color(0xFF11131C),
+        title = { Text(strings.restorePreviewTitle, color = LevyraText, fontWeight = FontWeight.Black) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                Text(
+                    text = if (preview.compatible) strings.restorePreviewCompatible else strings.restorePreviewIncompatible,
+                    color = if (preview.compatible) LevyraCyan else Color(0xFFFF6B6B),
+                    fontWeight = FontWeight.Bold
+                )
+                if (preview.createdAt > 0L) {
+                    Text(
+                        text = "${strings.restorePreviewCreated}: ${formatVaultTimestamp(preview.createdAt, strings.code)}",
+                        color = LevyraMuted,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+                if (preview.appVersion.isNotBlank()) {
+                    Text(
+                        text = "${strings.restorePreviewVersion}: ${preview.appVersion}",
+                        color = LevyraMuted,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+                Text(
+                    text = "${strings.restorePreviewSize}: ${formatVaultBytes(preview.sizeBytes)}",
+                    color = LevyraMuted,
+                    fontWeight = FontWeight.SemiBold
+                )
+                if (preview.sections.isNotEmpty()) {
+                    Text(
+                        text = "${strings.restorePreviewContents}: ${preview.sections.joinToString(", ") { it.removePrefix("data/").removeSuffix(".json") }}",
+                        color = LevyraMuted,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+                Text(
+                    text = strings.restoreConfirmBody,
+                    color = LevyraMuted,
+                    fontWeight = FontWeight.SemiBold,
+                    lineHeight = 20.sp
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm, enabled = preview.compatible) {
+                Text(strings.restoreConfirm, color = if (preview.compatible) LevyraCyan else LevyraMuted, fontWeight = FontWeight.Black)
+            }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text(strings.cancel, color = LevyraMuted, fontWeight = FontWeight.Bold) } }
+    )
+}
+
+private fun formatVaultTimestamp(timestampMs: Long, languageCode: String): String {
+    val locale = Locale.forLanguageTag(languageCode.replace('_', '-'))
+    return java.text.DateFormat.getDateTimeInstance(java.text.DateFormat.MEDIUM, java.text.DateFormat.SHORT, locale)
+        .format(java.util.Date(timestampMs))
+}
+
+private fun formatVaultBytes(bytes: Long): String {
+    if (bytes < 1024L) return "$bytes B"
+    val kilobytes = bytes / 1024.0
+    if (kilobytes < 1024.0) return "%.1f KB".format(Locale.US, kilobytes)
+    val megabytes = kilobytes / 1024.0
+    return "%.1f MB".format(Locale.US, megabytes)
 }
 
 private fun restartLevyra(activity: Activity?) {
@@ -15112,6 +15220,8 @@ private fun SettingsOverlay(
     interfaceSettings: LevyraInterfaceSettings,
     downloadSettings: LevyraDownloadSettings,
     backupSettings: LevyraBackupSettings,
+    vaultStatus: LevyraVaultStatus,
+    lastBackupAtMs: Long,
     downloadQueue: List<OfflineDownloadTask>,
     playbackDiagnostics: String,
     lastFmConfigured: Boolean,
@@ -15140,6 +15250,8 @@ private fun SettingsOverlay(
     onDownloadUpdate: () -> Unit,
     onCreateBackup: () -> Unit,
     onRestoreBackup: () -> Unit,
+    onBackupNow: () -> Unit,
+    onManageBackups: () -> Unit,
     onPauseDownload: (String) -> Unit,
     onResumeDownload: (String) -> Unit,
     onCancelDownload: (String) -> Unit,
@@ -15184,7 +15296,7 @@ private fun SettingsOverlay(
             SettingsCategoryMeta("player", categoryTitle(strings.player), "${strings.advancedGestures} · ${strings.sponsorBlock} · ${strings.skipSilence}", Icons.Rounded.PlayArrow, LevyraPink),
             SettingsCategoryMeta("downloads", categoryTitle(strings.downloads), "${strings.wifiOnly} · ${strings.simultaneousDownloads}", Icons.Rounded.Download, LevyraBlue),
             SettingsCategoryMeta("lyrics", categoryTitle(strings.lyricsAnalysisSection), strings.lyricsAnalysisCompact, Icons.Rounded.Insights, LevyraOrange),
-            SettingsCategoryMeta("backup", categoryTitle(strings.backupRestoreSection), "${strings.createDataBackup} · ${strings.restoreBackup}", Icons.Rounded.History, LevyraCyan),
+            SettingsCategoryMeta("backup", strings.vaultTitle, "${strings.backupNow} · ${strings.restoreBackup}", Icons.Rounded.History, LevyraCyan),
             SettingsCategoryMeta("system", categoryTitle(strings.preferences), "${strings.batteryUnrestricted} · ${strings.language}", Icons.Rounded.Settings, LevyraViolet),
             SettingsCategoryMeta("app", categoryTitle(strings.app), "${strings.updates} · ${BuildConfig.VERSION_NAME}", Icons.Rounded.Info, LevyraPink)
             , SettingsCategoryMeta("integrations", categoryTitle(strings.integrations), "Last.fm · ListenBrainz · AudD", Icons.Rounded.Settings, LevyraCyan)
@@ -15207,8 +15319,8 @@ private fun SettingsOverlay(
                 SettingsSearchEntry(strings.wifiOnly, strings.wifiOnlySubtitle, strings.downloads, "downloads", categoryTitle(strings.downloads)),
                 SettingsSearchEntry(strings.simultaneousDownloads, strings.simultaneousDownloadsSubtitle, strings.downloads, "downloads", categoryTitle(strings.downloads)),
                 SettingsSearchEntry(strings.lyricsAnalysisSection, strings.lyricsAnalysisCompactSubtitle, strings.lyrics, "lyrics", categoryTitle(strings.lyricsAnalysisSection)),
-                SettingsSearchEntry(strings.createDataBackup, strings.createDataBackupSubtitle, "backup", "backup", categoryTitle(strings.backupRestoreSection)),
-                SettingsSearchEntry(strings.restoreBackup, strings.restoreBackupSubtitle, "backup", "backup", categoryTitle(strings.backupRestoreSection)),
+                SettingsSearchEntry(strings.createDataBackup, strings.createDataBackupSubtitle, "backup", "backup", strings.vaultTitle),
+                SettingsSearchEntry(strings.restoreBackup, strings.restoreBackupSubtitle, "backup", "backup", strings.vaultTitle),
                 SettingsSearchEntry(strings.batteryUnrestricted, strings.batteryUnrestrictedSubtitle, "battery", "system", categoryTitle(strings.preferences)),
                 SettingsSearchEntry(strings.language, strings.languageSubtitle, "locale", "system", categoryTitle(strings.preferences)),
                 SettingsSearchEntry(strings.updates, strings.checkNewVersions, "version", "app", categoryTitle(strings.app))
@@ -15760,6 +15872,24 @@ private fun SettingsOverlay(
                         }
                         "backup" -> {
                             item {
+                                SettingsInfoCard(
+                                    icon = Icons.Rounded.History,
+                                    title = strings.vaultTitle,
+                                    subtitle = strings.vaultSubtitle
+                                )
+                            }
+                            item {
+                                SettingsInfoCard(
+                                    icon = Icons.Rounded.Schedule,
+                                    title = strings.lastBackup,
+                                    subtitle = if (lastBackupAtMs > 0L) {
+                                        formatVaultTimestamp(lastBackupAtMs, strings.code)
+                                    } else {
+                                        strings.lastBackupNever
+                                    }
+                                )
+                            }
+                            item {
                                 SettingsToggle(
                                     icon = Icons.Rounded.History,
                                     title = strings.automaticBackup,
@@ -15790,7 +15920,7 @@ private fun SettingsOverlay(
                                         icon = Icons.Rounded.History,
                                         title = strings.backupRetention,
                                         subtitle = strings.automaticBackupSubtitle,
-                                        options = listOf(3, 5, 8, 12).map { count ->
+                                        options = listOf(3, 5, 10).map { count ->
                                             count.toString() to strings.backupRetentionLabel(count)
                                         },
                                         selected = backupSettings.retentionCount.toString(),
@@ -15810,6 +15940,30 @@ private fun SettingsOverlay(
                                         onCheckedChange = { onBackupSettings(backupSettings.copy(chargingOnly = it)) }
                                     )
                                 }
+                                item {
+                                    SettingsInfoCard(
+                                        icon = Icons.Rounded.Source,
+                                        title = strings.backupLocation,
+                                        subtitle = strings.backupLocationSubtitle
+                                    )
+                                }
+                            }
+                            item {
+                                SettingsToggle(
+                                    icon = Icons.Rounded.Refresh,
+                                    title = strings.backupBeforeUpdates,
+                                    subtitle = strings.backupBeforeUpdatesSubtitle,
+                                    checked = backupSettings.preUpdate,
+                                    onCheckedChange = { onBackupSettings(backupSettings.copy(preUpdate = it)) }
+                                )
+                            }
+                            item {
+                                SettingsButton(
+                                    icon = Icons.Rounded.Download,
+                                    title = if (vaultStatus == LevyraVaultStatus.Running) strings.vaultBusy else strings.backupNow,
+                                    subtitle = strings.backupNowSubtitle,
+                                    onClick = onBackupNow
+                                )
                             }
                             item {
                                 SettingsButton(
@@ -15825,6 +15979,14 @@ private fun SettingsOverlay(
                                     title = strings.restoreBackup,
                                     subtitle = strings.restoreBackupSubtitle,
                                     onClick = onRestoreBackup
+                                )
+                            }
+                            item {
+                                SettingsButton(
+                                    icon = Icons.Rounded.Source,
+                                    title = strings.manageBackups,
+                                    subtitle = strings.manageBackupsSubtitle,
+                                    onClick = onManageBackups
                                 )
                             }
                         }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -55,6 +55,7 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.draw.drawWithCache
@@ -1157,15 +1158,17 @@ fun LevyraApp(
         }
     }
     val openManageBackups = {
-        val rootUri = DocumentsContract.buildRootUri(
-            "${toastContext.packageName}.automatic-backups",
-            "levyra-automatic-backups"
-        )
+        val initialUri = state.backupLocationUri
+            ?.let { raw -> try { Uri.parse(raw) } catch (_: Throwable) { null } }
+            ?: DocumentsContract.buildRootUri(
+                "${toastContext.packageName}.automatic-backups",
+                "levyra-automatic-backups"
+            )
         manageBackupsLauncher.launch(
             Intent(Intent.ACTION_OPEN_DOCUMENT)
                 .addCategory(Intent.CATEGORY_OPENABLE)
                 .setType("application/zip")
-                .putExtra(DocumentsContract.EXTRA_INITIAL_URI, rootUri)
+                .putExtra(DocumentsContract.EXTRA_INITIAL_URI, initialUri)
         )
     }
     val backupLocationLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
@@ -16010,7 +16013,8 @@ private fun SettingsOverlay(
                                     icon = Icons.Rounded.Download,
                                     title = if (vaultStatus == LevyraVaultStatus.Running) strings.vaultBusy else strings.backupNow,
                                     subtitle = strings.backupNowSubtitle,
-                                    onClick = onBackupNow
+                                    onClick = onBackupNow,
+                                    enabled = vaultStatus != LevyraVaultStatus.Running
                                 )
                             }
                             item {
@@ -16609,17 +16613,19 @@ private fun SettingsToggle(icon: ImageVector, title: String, subtitle: String, c
 }
 
 @Composable
-private fun SettingsButton(icon: ImageVector, title: String, subtitle: String, onClick: () -> Unit) {
+private fun SettingsButton(icon: ImageVector, title: String, subtitle: String, enabled: Boolean = true, onClick: () -> Unit) {
     Surface(
         color = LevyraAdaptiveCard,
         border = BorderStroke(1.dp, LevyraAdaptiveHairline),
         shape = RoundedCornerShape(18.dp),
         modifier = Modifier
             .fillMaxWidth()
-            .pressable(onClick = onClick)
+            .pressable(enabled = enabled, onClick = onClick)
     ) {
         Row(
-            modifier = Modifier.padding(14.dp),
+            modifier = Modifier
+                .padding(14.dp)
+                .alpha(if (enabled) 1f else 0.45f),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -1112,7 +1112,12 @@ private fun Modifier.consumeOverlayTouches(): Modifier = pointerInput(Unit) {
 }
 
 @Composable
-fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false) {
+fun LevyraApp(
+    viewModel: LevyraViewModel,
+    isInPictureInPicture: Boolean = false,
+    onRetryPreUpdateBackup: () -> Unit = {},
+    onContinueUpdateWithoutBackup: () -> Unit = {}
+) {
     val screenViewModelFactory = remember(viewModel) { LevyraScreenViewModelFactory(viewModel) }
     val state by viewModel.state.collectAsStateWithLifecycle()
     val currentStrings = LevyraStrings.forCode(state.languageCode)
@@ -1162,6 +1167,9 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
                 .setType("application/zip")
                 .putExtra(DocumentsContract.EXTRA_INITIAL_URI, rootUri)
         )
+    }
+    val backupLocationLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
+        uri?.let(viewModel::setBackupLocation)
     }
     val accent = if (state.dynamicColor) state.currentTrack ?: state.tracks.firstOrNull() else null
     val overlayEnter = if (state.animationsEnabled) fadeIn(animationSpec = tween(180, easing = LinearOutSlowInEasing)) else EnterTransition.None
@@ -1647,6 +1655,7 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
                     backupSettings = state.backupSettings,
                     vaultStatus = state.vaultStatus,
                     lastBackupAtMs = state.lastBackupAtMs,
+                    backupLocationUri = state.backupLocationUri,
                     downloadQueue = state.downloadQueue,
                     playbackDiagnostics = state.playbackDiagnostics,
                     lastFmConfigured = state.lastFmConfigured,
@@ -1699,6 +1708,8 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
                     onRestoreBackup = { restoreBackupLauncher.launch(arrayOf("application/zip", "application/octet-stream")) },
                     onBackupNow = viewModel::backupNow,
                     onManageBackups = { openManageBackups() },
+                    onSelectBackupLocation = { backupLocationLauncher.launch(null) },
+                    onClearBackupLocation = viewModel::clearBackupLocation,
                     onPauseDownload = viewModel::pauseDownload,
                     onResumeDownload = viewModel::resumeDownload,
                     onCancelDownload = viewModel::cancelDownload,
@@ -1728,6 +1739,13 @@ fun LevyraApp(viewModel: LevyraViewModel, isInPictureInPicture: Boolean = false)
                     preview = preview,
                     onConfirm = viewModel::confirmRestore,
                     onDismiss = viewModel::dismissRestorePreview
+                )
+            }
+
+            if (state.preUpdateBackupFailed) {
+                PreUpdateBackupFailedDialog(
+                    onRetry = onRetryPreUpdateBackup,
+                    onContinue = onContinueUpdateWithoutBackup
                 )
             }
 
@@ -2364,6 +2382,22 @@ private fun VaultRestorePreviewDialog(
             }
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text(strings.cancel, color = LevyraMuted, fontWeight = FontWeight.Bold) } }
+    )
+}
+
+@Composable
+private fun PreUpdateBackupFailedDialog(
+    onRetry: () -> Unit,
+    onContinue: () -> Unit
+) {
+    val strings = LocalLevyraStrings.current
+    AlertDialog(
+        onDismissRequest = onContinue,
+        containerColor = Color(0xFF11131C),
+        title = { Text(strings.preUpdateBackupFailedTitle, color = LevyraText, fontWeight = FontWeight.Black) },
+        text = { Text(strings.preUpdateBackupFailedBody, color = LevyraMuted, fontWeight = FontWeight.SemiBold, lineHeight = 20.sp) },
+        confirmButton = { TextButton(onClick = onRetry) { Text(strings.preUpdateBackupRetry, color = LevyraCyan, fontWeight = FontWeight.Black) } },
+        dismissButton = { TextButton(onClick = onContinue) { Text(strings.preUpdateBackupContinue, color = LevyraMuted, fontWeight = FontWeight.Bold) } }
     )
 }
 
@@ -15222,6 +15256,7 @@ private fun SettingsOverlay(
     backupSettings: LevyraBackupSettings,
     vaultStatus: LevyraVaultStatus,
     lastBackupAtMs: Long,
+    backupLocationUri: String?,
     downloadQueue: List<OfflineDownloadTask>,
     playbackDiagnostics: String,
     lastFmConfigured: Boolean,
@@ -15252,6 +15287,8 @@ private fun SettingsOverlay(
     onRestoreBackup: () -> Unit,
     onBackupNow: () -> Unit,
     onManageBackups: () -> Unit,
+    onSelectBackupLocation: () -> Unit,
+    onClearBackupLocation: () -> Unit,
     onPauseDownload: (String) -> Unit,
     onResumeDownload: (String) -> Unit,
     onCancelDownload: (String) -> Unit,
@@ -15941,11 +15978,22 @@ private fun SettingsOverlay(
                                     )
                                 }
                                 item {
-                                    SettingsInfoCard(
+                                    SettingsButton(
                                         icon = Icons.Rounded.Source,
                                         title = strings.backupLocation,
-                                        subtitle = strings.backupLocationSubtitle
+                                        subtitle = if (backupLocationUri != null) strings.backupLocationSafSelected else strings.backupLocationSubtitle,
+                                        onClick = onSelectBackupLocation
                                     )
+                                }
+                                if (backupLocationUri != null) {
+                                    item {
+                                        SettingsButton(
+                                            icon = Icons.Rounded.History,
+                                            title = strings.backupLocationInternal,
+                                            subtitle = strings.backupLocationInternalSubtitle,
+                                            onClick = onClearBackupLocation
+                                        )
+                                    }
                                 }
                             }
                             item {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
@@ -548,9 +548,20 @@ class LevyraStrings private constructor(
     val lastBackupNever: String get() = if (code == "it") "Mai" else "Never"
     val backupLocation: String get() = if (code == "it") "Posizione backup" else "Backup location"
     val backupLocationSubtitle: String get() = if (code == "it") {
-        "I backup automatici restano nella memoria interna dell'app; usa Backup dati per salvare dove preferisci"
+        "Scegli dove salvare i backup automatici"
     } else {
-        "Automatic backups stay in app storage; use Create data backup to save anywhere"
+        "Choose where automatic backups are saved"
+    }
+    val backupLocationSafSelected: String get() = if (code == "it") {
+        "Cartella selezionata con il selettore di sistema"
+    } else {
+        "Folder selected with the system picker"
+    }
+    val backupLocationInternal: String get() = if (code == "it") "Usa memoria interna" else "Use internal storage"
+    val backupLocationInternalSubtitle: String get() = if (code == "it") {
+        "Torna alla cartella interna di Levyra"
+    } else {
+        "Go back to Levyra's internal folder"
     }
     val backupBeforeUpdates: String get() = if (code == "it") {
         "Backup prima degli aggiornamenti"
@@ -586,6 +597,18 @@ class LevyraStrings private constructor(
     } else {
         "Replaces favorites, playlists, history, queue and settings with the backup data."
     }
+    val preUpdateBackupFailedTitle: String get() = if (code == "it") {
+        "Backup prima dell'aggiornamento non riuscito"
+    } else {
+        "Backup before update failed"
+    }
+    val preUpdateBackupFailedBody: String get() = if (code == "it") {
+        "Il backup locale non è riuscito. Puoi riprovare o continuare con l'aggiornamento."
+    } else {
+        "The local backup failed. You can retry or continue with the update."
+    }
+    val preUpdateBackupRetry: String get() = if (code == "it") "Riprova" else "Retry"
+    val preUpdateBackupContinue: String get() = if (code == "it") "Aggiorna comunque" else "Update anyway"
     val restoreBackup: String get() = value("restoreBackup")
     val restoreBackupSubtitle: String get() = value("restoreBackupSubtitle")
     val playbackResilienceSection: String get() = value("playbackResilienceSection")

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
@@ -532,6 +532,60 @@ class LevyraStrings private constructor(
         else -> if (code == "it") "Ogni settimana" else "Weekly"
     }
     fun backupRetentionLabel(count: Int): String = if (code == "it") "$count copie" else "$count copies"
+    val vaultTitle: String get() = "Levyra Vault"
+    val vaultSubtitle: String get() = if (code == "it") {
+        "Proteggi playlist, preferiti, cronologia e impostazioni"
+    } else {
+        "Protect playlists, favorites, history and settings"
+    }
+    val backupNow: String get() = if (code == "it") "Backup ora" else "Back up now"
+    val backupNowSubtitle: String get() = if (code == "it") {
+        "Crea subito un backup locale"
+    } else {
+        "Create a local backup now"
+    }
+    val lastBackup: String get() = if (code == "it") "Ultimo backup" else "Last backup"
+    val lastBackupNever: String get() = if (code == "it") "Mai" else "Never"
+    val backupLocation: String get() = if (code == "it") "Posizione backup" else "Backup location"
+    val backupLocationSubtitle: String get() = if (code == "it") {
+        "I backup automatici restano nella memoria interna dell'app; usa Backup dati per salvare dove preferisci"
+    } else {
+        "Automatic backups stay in app storage; use Create data backup to save anywhere"
+    }
+    val backupBeforeUpdates: String get() = if (code == "it") {
+        "Backup prima degli aggiornamenti"
+    } else {
+        "Back up before updates"
+    }
+    val backupBeforeUpdatesSubtitle: String get() = if (code == "it") {
+        "Crea un backup locale prima di installare un aggiornamento"
+    } else {
+        "Create a local backup before installing an update"
+    }
+    val manageBackups: String get() = if (code == "it") "Gestisci backup" else "Manage backups"
+    val manageBackupsSubtitle: String get() = if (code == "it") {
+        "Apri la cartella dei backup automatici"
+    } else {
+        "Open the automatic backups folder"
+    }
+    val vaultBusy: String get() = if (code == "it") "Operazione Vault in corso..." else "Vault operation in progress..."
+    val restorePreviewTitle: String get() = if (code == "it") "Ripristina Levyra" else "Restore Levyra"
+    val restorePreviewCompatible: String get() = if (code == "it") "Backup compatibile" else "Compatible backup"
+    val restorePreviewIncompatible: String get() = if (code == "it") {
+        "Backup non compatibile con questa versione"
+    } else {
+        "Backup incompatible with this version"
+    }
+    val restorePreviewCreated: String get() = if (code == "it") "Creato" else "Created"
+    val restorePreviewVersion: String get() = if (code == "it") "Versione Levyra" else "Levyra version"
+    val restorePreviewSize: String get() = if (code == "it") "Dimensione" else "Size"
+    val restorePreviewContents: String get() = if (code == "it") "Contenuti" else "Contents"
+    val restoreConfirm: String get() = if (code == "it") "Ripristina" else "Restore"
+    val restoreConfirmBody: String get() = if (code == "it") {
+        "Sostituisce preferiti, playlist, cronologia, coda e impostazioni con i dati del backup."
+    } else {
+        "Replaces favorites, playlists, history, queue and settings with the backup data."
+    }
     val restoreBackup: String get() = value("restoreBackup")
     val restoreBackupSubtitle: String get() = value("restoreBackupSubtitle")
     val playbackResilienceSection: String get() = value("playbackResilienceSection")

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
@@ -1,6 +1,8 @@
 package com.luc4n3x.levyra.viewmodel
 
+import android.net.Uri
 import androidx.compose.runtime.Immutable
+import com.luc4n3x.levyra.data.VaultPreview
 import com.luc4n3x.levyra.domain.ArtistHit
 import com.luc4n3x.levyra.domain.ArtistProfile
 import com.luc4n3x.levyra.domain.AlbumHit
@@ -16,6 +18,7 @@ import com.luc4n3x.levyra.domain.LevyraAudioSettings
 import com.luc4n3x.levyra.domain.LevyraDownloadSettings
 import com.luc4n3x.levyra.domain.LevyraInterfaceSettings
 import com.luc4n3x.levyra.domain.LevyraBackupSettings
+import com.luc4n3x.levyra.domain.LevyraVaultStatus
 import com.luc4n3x.levyra.domain.LevyraIntelligenceSummary
 import com.luc4n3x.levyra.domain.BatchDownload
 import com.luc4n3x.levyra.domain.OfflineDownloadTask
@@ -207,6 +210,10 @@ data class LevyraUiState(
     val interfaceSettings: LevyraInterfaceSettings = LevyraInterfaceSettings(),
     val downloadSettings: LevyraDownloadSettings = LevyraDownloadSettings(),
     val backupSettings: LevyraBackupSettings = LevyraBackupSettings(),
+    val vaultStatus: LevyraVaultStatus = LevyraVaultStatus.Idle,
+    val backupPreview: VaultPreview? = null,
+    val pendingRestoreUri: Uri? = null,
+    val lastBackupAtMs: Long = 0L,
     val sharedMediaPreview: SharedMediaPreview? = null,
     val intelligenceSummary: LevyraIntelligenceSummary = LevyraIntelligenceSummary(),
     val backupMessage: String? = null,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
@@ -214,6 +214,8 @@ data class LevyraUiState(
     val backupPreview: VaultPreview? = null,
     val pendingRestoreUri: Uri? = null,
     val lastBackupAtMs: Long = 0L,
+    val backupLocationUri: String? = null,
+    val preUpdateBackupFailed: Boolean = false,
     val sharedMediaPreview: SharedMediaPreview? = null,
     val intelligenceSummary: LevyraIntelligenceSummary = LevyraIntelligenceSummary(),
     val backupMessage: String? = null,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -3712,29 +3712,32 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 val resolver = getApplication<Application>().contentResolver
+                val newUri = uri.toString()
+                val previous = preferences.backupTreeUri().takeIf { it.isNotBlank() }
                 resolver.takePersistableUriPermission(
                     uri,
                     Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
                 )
                 try {
-                    preferences.persistBackupTreeUri(uri.toString())
+                    preferences.persistBackupTreeUri(newUri)
                 } catch (persistError: Throwable) {
                     if (persistError is CancellationException) throw persistError
-                    runCatching {
-                        resolver.releasePersistableUriPermission(
-                            uri,
-                            Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-                        )
-                    }.onFailure { releaseError ->
-                        if (releaseError is CancellationException) throw releaseError
-                        Timber.w(releaseError, "Unable to release backup location permission after persistence failure")
+                    if (previous != newUri) {
+                        runCatching {
+                            resolver.releasePersistableUriPermission(
+                                uri,
+                                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                            )
+                        }.onFailure { releaseError ->
+                            if (releaseError is CancellationException) throw releaseError
+                            Timber.w(releaseError, "Unable to release backup location permission after persistence failure")
+                        }
                     }
                     _state.update { it.copy(backupMessage = "Posizione backup non disponibile") }
                     return@launch
                 }
-                val previous = preferences.backupTreeUri().takeIf { it.isNotBlank() }
-                _state.update { it.copy(backupLocationUri = uri.toString()) }
-                if (previous != null && previous != uri.toString()) {
+                _state.update { it.copy(backupLocationUri = newUri) }
+                if (previous != null && previous != newUri) {
                     runCatching {
                         resolver.releasePersistableUriPermission(
                             Uri.parse(previous),

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -678,6 +678,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private val listeningPulseEngine = ListeningPulseEngine()
     private val startupSmartProfile = smartMusicProfileStore.load()
     private val startupSettings = preferences.snapshot()
+    private val vaultRuntimeState = preferences.vaultRuntimeState()
     private val startupMoods = moodEngine.moodsForLanguage(startupSettings.languageCode)
     private val _integrationAuthorizationUrls = MutableSharedFlow<String>(extraBufferCapacity = 1)
     val integrationAuthorizationUrls = _integrationAuthorizationUrls.asSharedFlow()
@@ -697,8 +698,8 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             interfaceSettings = startupSettings.interfaceSettings,
             downloadSettings = startupSettings.downloadSettings,
             backupSettings = startupSettings.backupSettings,
-            lastBackupAtMs = preferences.lastBackupAt(),
-            backupLocationUri = preferences.backupTreeUri().takeIf { it.isNotBlank() },
+            lastBackupAtMs = vaultRuntimeState.first,
+            backupLocationUri = vaultRuntimeState.second.takeIf { it.isNotBlank() },
             playbackDiagnostics = resolver.playbackDiagnostics(),
             recognitionAvailable = LevyraRecognitionCenter.isAvailable
         )
@@ -3601,14 +3602,25 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         viewModelScope.launch {
             if (_state.value.vaultStatus == LevyraVaultStatus.Running) return@launch
             _state.update { it.copy(vaultStatus = LevyraVaultStatus.Running) }
-            val message = runCatching { backupManager.exportTo(uri).message }
-                .getOrElse { "Backup non riuscito: ${cleanUserError(it)}" }
-            _state.update {
-                it.copy(
-                    backupMessage = message,
-                    vaultStatus = if (message.startsWith("Backup non riuscito")) LevyraVaultStatus.Error else LevyraVaultStatus.Completed,
-                    lastBackupAtMs = if (message.startsWith("Backup non riuscito")) it.lastBackupAtMs else System.currentTimeMillis()
-                )
+            try {
+                val result = backupManager.exportTo(uri)
+                _state.update {
+                    it.copy(
+                        backupMessage = result.message,
+                        vaultStatus = LevyraVaultStatus.Completed,
+                        lastBackupAtMs = System.currentTimeMillis()
+                    )
+                }
+            } catch (cancelled: CancellationException) {
+                _state.update { it.copy(vaultStatus = LevyraVaultStatus.Idle) }
+                throw cancelled
+            } catch (error: Throwable) {
+                _state.update {
+                    it.copy(
+                        backupMessage = "Backup non riuscito: ${cleanUserError(error)}",
+                        vaultStatus = LevyraVaultStatus.Error
+                    )
+                }
             }
         }
     }
@@ -3617,27 +3629,39 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         viewModelScope.launch {
             if (_state.value.vaultStatus == LevyraVaultStatus.Running) return@launch
             _state.update { it.copy(vaultStatus = LevyraVaultStatus.Running) }
-            val message = runCatching {
-                backupManager.exportAutomatic(_state.value.backupSettings.retentionCount).message
-            }.getOrElse { "Backup non riuscito: ${cleanUserError(it)}" }
-            _state.update {
-                it.copy(
-                    backupMessage = message,
-                    vaultStatus = if (message.startsWith("Backup non riuscito")) LevyraVaultStatus.Error else LevyraVaultStatus.Completed,
-                    lastBackupAtMs = if (message.startsWith("Backup non riuscito")) it.lastBackupAtMs else System.currentTimeMillis()
-                )
+            try {
+                val result = backupManager.exportAutomatic(_state.value.backupSettings.retentionCount)
+                _state.update {
+                    it.copy(
+                        backupMessage = result.message,
+                        vaultStatus = LevyraVaultStatus.Completed,
+                        lastBackupAtMs = System.currentTimeMillis()
+                    )
+                }
+            } catch (cancelled: CancellationException) {
+                _state.update { it.copy(vaultStatus = LevyraVaultStatus.Idle) }
+                throw cancelled
+            } catch (error: Throwable) {
+                _state.update {
+                    it.copy(
+                        backupMessage = "Backup non riuscito: ${cleanUserError(error)}",
+                        vaultStatus = LevyraVaultStatus.Error
+                    )
+                }
             }
         }
     }
 
     fun previewRestore(uri: Uri) {
         viewModelScope.launch {
-            val preview = runCatching { backupManager.inspect(uri) }
-                .getOrElse { error ->
-                    _state.update { it.copy(backupMessage = "Backup non valido: ${cleanUserError(error)}") }
-                    return@launch
-                }
-            _state.update { it.copy(backupPreview = preview, pendingRestoreUri = uri) }
+            try {
+                val preview = backupManager.inspect(uri)
+                _state.update { it.copy(backupPreview = preview, pendingRestoreUri = uri) }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Throwable) {
+                _state.update { it.copy(backupMessage = "Backup non valido: ${cleanUserError(error)}") }
+            }
         }
     }
 
@@ -3657,16 +3681,25 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         viewModelScope.launch {
             if (_state.value.vaultStatus == LevyraVaultStatus.Running) return@launch
             _state.update { it.copy(vaultStatus = LevyraVaultStatus.Running, backupPreview = null, pendingRestoreUri = null) }
-            val message = runCatching {
-                backupManager.restoreFrom(uri)
+            try {
+                val result = backupManager.restoreFrom(uri)
                 refreshAfterRestore()
-                "Ripristino completato"
-            }.getOrElse { "Ripristino non riuscito: ${cleanUserError(it)}" }
-            _state.update {
-                it.copy(
-                    backupMessage = message,
-                    vaultStatus = if (message.startsWith("Ripristino non riuscito")) LevyraVaultStatus.Error else LevyraVaultStatus.Completed
-                )
+                _state.update {
+                    it.copy(
+                        backupMessage = result.message,
+                        vaultStatus = LevyraVaultStatus.Completed
+                    )
+                }
+            } catch (cancelled: CancellationException) {
+                _state.update { it.copy(vaultStatus = LevyraVaultStatus.Idle) }
+                throw cancelled
+            } catch (error: Throwable) {
+                _state.update {
+                    it.copy(
+                        backupMessage = "Ripristino non riuscito: ${cleanUserError(error)}",
+                        vaultStatus = LevyraVaultStatus.Error
+                    )
+                }
             }
         }
     }
@@ -3677,17 +3710,26 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     fun setBackupLocation(uri: Uri) {
         viewModelScope.launch(Dispatchers.IO) {
-            val resolver = getApplication<Application>().contentResolver
-            val granted = runCatching {
+            try {
+                val resolver = getApplication<Application>().contentResolver
                 resolver.takePersistableUriPermission(
                     uri,
                     Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
                 )
-            }.isSuccess
-            if (granted) {
+                val previous = preferences.backupTreeUri().takeIf { it.isNotBlank() }
                 preferences.setBackupTreeUri(uri.toString())
                 _state.update { it.copy(backupLocationUri = uri.toString()) }
-            } else {
+                if (previous != null && previous != uri.toString()) {
+                    runCatching {
+                        resolver.releasePersistableUriPermission(
+                            Uri.parse(previous),
+                            Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                        )
+                    }
+                }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Throwable) {
                 _state.update { it.copy(backupMessage = "Posizione backup non disponibile") }
             }
         }
@@ -3695,17 +3737,20 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     fun clearBackupLocation() {
         viewModelScope.launch(Dispatchers.IO) {
-            _state.value.backupLocationUri?.let { raw ->
-                runCatching {
-                    val resolver = getApplication<Application>().contentResolver
-                    resolver.releasePersistableUriPermission(
-                        Uri.parse(raw),
-                        Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-                    )
-                }
+            val raw = _state.value.backupLocationUri ?: return@launch
+            try {
+                val resolver = getApplication<Application>().contentResolver
+                resolver.releasePersistableUriPermission(
+                    Uri.parse(raw),
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                )
+                preferences.setBackupTreeUri("")
+                _state.update { it.copy(backupLocationUri = null) }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Throwable) {
+                Timber.w(error, "Unable to clear backup location")
             }
-            preferences.setBackupTreeUri("")
-            _state.update { it.copy(backupLocationUri = null) }
         }
     }
 

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -21,6 +21,7 @@ import com.luc4n3x.levyra.data.ReleaseRadarWorker
 import com.luc4n3x.levyra.data.LevyraArtworkCache
 import com.luc4n3x.levyra.data.LevyraBackupManager
 import com.luc4n3x.levyra.data.AutomaticBackupScheduler
+import com.luc4n3x.levyra.data.VaultPreview
 import com.luc4n3x.levyra.data.LevyraPreferences
 import com.luc4n3x.levyra.data.LevyraHomeSnapshotCache
 import com.luc4n3x.levyra.data.LevyraStartupCatalog
@@ -106,6 +107,7 @@ import com.luc4n3x.levyra.domain.LevyraAudioPreset
 import com.luc4n3x.levyra.domain.LevyraAudioSettings
 import com.luc4n3x.levyra.domain.AutoEqImporter
 import com.luc4n3x.levyra.domain.LevyraBackupSettings
+import com.luc4n3x.levyra.domain.LevyraVaultStatus
 import com.luc4n3x.levyra.domain.LevyraDownloadSettings
 import com.luc4n3x.levyra.domain.shouldSkipExistingDownload
 import com.luc4n3x.levyra.domain.LevyraInterfaceSettings
@@ -694,6 +696,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             interfaceSettings = startupSettings.interfaceSettings,
             downloadSettings = startupSettings.downloadSettings,
             backupSettings = startupSettings.backupSettings,
+            lastBackupAtMs = preferences.lastBackupAt(),
             playbackDiagnostics = resolver.playbackDiagnostics(),
             recognitionAvailable = LevyraRecognitionCenter.isAvailable
         )
@@ -3594,20 +3597,75 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     fun createBackup(uri: Uri) {
         viewModelScope.launch {
+            if (_state.value.vaultStatus == LevyraVaultStatus.Running) return@launch
+            _state.update { it.copy(vaultStatus = LevyraVaultStatus.Running) }
             val message = runCatching { backupManager.exportTo(uri).message }
                 .getOrElse { "Backup non riuscito: ${cleanUserError(it)}" }
-            _state.update { it.copy(backupMessage = message) }
+            _state.update {
+                it.copy(
+                    backupMessage = message,
+                    vaultStatus = if (message.startsWith("Backup non riuscito")) LevyraVaultStatus.Error else LevyraVaultStatus.Completed,
+                    lastBackupAtMs = if (message.startsWith("Backup non riuscito")) it.lastBackupAtMs else System.currentTimeMillis()
+                )
+            }
         }
     }
 
-    fun restoreBackup(uri: Uri) {
+    fun backupNow() {
         viewModelScope.launch {
+            if (_state.value.vaultStatus == LevyraVaultStatus.Running) return@launch
+            _state.update { it.copy(vaultStatus = LevyraVaultStatus.Running) }
+            val message = runCatching {
+                backupManager.exportAutomatic(_state.value.backupSettings.retentionCount).message
+            }.getOrElse { "Backup non riuscito: ${cleanUserError(it)}" }
+            _state.update {
+                it.copy(
+                    backupMessage = message,
+                    vaultStatus = if (message.startsWith("Backup non riuscito")) LevyraVaultStatus.Error else LevyraVaultStatus.Completed,
+                    lastBackupAtMs = if (message.startsWith("Backup non riuscito")) it.lastBackupAtMs else System.currentTimeMillis()
+                )
+            }
+        }
+    }
+
+    fun previewRestore(uri: Uri) {
+        viewModelScope.launch {
+            val preview = runCatching { backupManager.inspect(uri) }
+                .getOrElse { error ->
+                    _state.update { it.copy(backupMessage = "Backup non valido: ${cleanUserError(error)}") }
+                    return@launch
+                }
+            _state.update { it.copy(backupPreview = preview, pendingRestoreUri = uri) }
+        }
+    }
+
+    fun dismissRestorePreview() {
+        _state.update { it.copy(backupPreview = null, pendingRestoreUri = null) }
+    }
+
+    fun confirmRestore() {
+        val uri = _state.value.pendingRestoreUri ?: return
+        val preview = _state.value.backupPreview
+        if (preview != null && !preview.compatible) {
+            _state.update {
+                it.copy(backupMessage = "Backup non compatibile con questa versione di Levyra", backupPreview = null, pendingRestoreUri = null)
+            }
+            return
+        }
+        viewModelScope.launch {
+            if (_state.value.vaultStatus == LevyraVaultStatus.Running) return@launch
+            _state.update { it.copy(vaultStatus = LevyraVaultStatus.Running, backupPreview = null, pendingRestoreUri = null) }
             val message = runCatching {
                 backupManager.restoreFrom(uri)
                 refreshAfterRestore()
                 "Ripristino completato"
             }.getOrElse { "Ripristino non riuscito: ${cleanUserError(it)}" }
-            _state.update { it.copy(backupMessage = message) }
+            _state.update {
+                it.copy(
+                    backupMessage = message,
+                    vaultStatus = if (message.startsWith("Ripristino non riuscito")) LevyraVaultStatus.Error else LevyraVaultStatus.Completed
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -1,6 +1,7 @@
 package com.luc4n3x.levyra.viewmodel
 
 import android.content.Context
+import android.content.Intent
 import android.os.Build
 import android.os.SystemClock
 import android.app.Application
@@ -697,6 +698,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             downloadSettings = startupSettings.downloadSettings,
             backupSettings = startupSettings.backupSettings,
             lastBackupAtMs = preferences.lastBackupAt(),
+            backupLocationUri = preferences.backupTreeUri().takeIf { it.isNotBlank() },
             playbackDiagnostics = resolver.playbackDiagnostics(),
             recognitionAvailable = LevyraRecognitionCenter.isAvailable
         )
@@ -3671,6 +3673,44 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     fun clearBackupMessage() {
         _state.update { it.copy(backupMessage = null) }
+    }
+
+    fun setBackupLocation(uri: Uri) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val resolver = getApplication<Application>().contentResolver
+            val granted = runCatching {
+                resolver.takePersistableUriPermission(
+                    uri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                )
+            }.isSuccess
+            if (granted) {
+                preferences.setBackupTreeUri(uri.toString())
+                _state.update { it.copy(backupLocationUri = uri.toString()) }
+            } else {
+                _state.update { it.copy(backupMessage = "Posizione backup non disponibile") }
+            }
+        }
+    }
+
+    fun clearBackupLocation() {
+        viewModelScope.launch(Dispatchers.IO) {
+            _state.value.backupLocationUri?.let { raw ->
+                runCatching {
+                    val resolver = getApplication<Application>().contentResolver
+                    resolver.releasePersistableUriPermission(
+                        Uri.parse(raw),
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                    )
+                }
+            }
+            preferences.setBackupTreeUri("")
+            _state.update { it.copy(backupLocationUri = null) }
+        }
+    }
+
+    fun setPreUpdateBackupFailed(value: Boolean) {
+        _state.update { it.copy(preUpdateBackupFailed = value) }
     }
 
     fun refreshPlaybackDiagnostics(): String {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -3716,8 +3716,23 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                     uri,
                     Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
                 )
+                try {
+                    preferences.persistBackupTreeUri(uri.toString())
+                } catch (persistError: Throwable) {
+                    if (persistError is CancellationException) throw persistError
+                    runCatching {
+                        resolver.releasePersistableUriPermission(
+                            uri,
+                            Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                        )
+                    }.onFailure { releaseError ->
+                        if (releaseError is CancellationException) throw releaseError
+                        Timber.w(releaseError, "Unable to release backup location permission after persistence failure")
+                    }
+                    _state.update { it.copy(backupMessage = "Posizione backup non disponibile") }
+                    return@launch
+                }
                 val previous = preferences.backupTreeUri().takeIf { it.isNotBlank() }
-                preferences.setBackupTreeUri(uri.toString())
                 _state.update { it.copy(backupLocationUri = uri.toString()) }
                 if (previous != null && previous != uri.toString()) {
                     runCatching {
@@ -3725,6 +3740,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                             Uri.parse(previous),
                             Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
                         )
+                    }.onFailure { releaseError ->
+                        if (releaseError is CancellationException) throw releaseError
+                        Timber.w(releaseError, "Unable to release previous backup location permission")
                     }
                 }
             } catch (cancelled: CancellationException) {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -3740,10 +3740,15 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             val raw = _state.value.backupLocationUri ?: return@launch
             try {
                 val resolver = getApplication<Application>().contentResolver
-                resolver.releasePersistableUriPermission(
-                    Uri.parse(raw),
-                    Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-                )
+                try {
+                    resolver.releasePersistableUriPermission(
+                        Uri.parse(raw),
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                    )
+                } catch (releaseError: Throwable) {
+                    if (releaseError is CancellationException) throw releaseError
+                    Timber.w(releaseError, "Unable to release backup location permission")
+                }
                 preferences.setBackupTreeUri("")
                 _state.update { it.copy(backupLocationUri = null) }
             } catch (cancelled: CancellationException) {

--- a/app/src/test/java/com/luc4n3x/levyra/data/AutomaticBackupPolicyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/AutomaticBackupPolicyTest.kt
@@ -31,12 +31,28 @@ class AutomaticBackupPolicyTest {
     }
 
     @Test
-    fun automaticBackupNameMatchesLevyraAndLegacyZip() {
+    fun automaticBackupNameMatchesLevyraNormalizedAndLegacyZip() {
         assertTrue(isAutomaticBackupName("levyra-auto-backup-1700000000000.levyra"))
+        assertTrue(isAutomaticBackupName("levyra-auto-backup-1700000000000.levyra.zip"))
         assertTrue(isAutomaticBackupName("levyra-auto-backup-1700000000000.zip"))
+        assertFalse(isAutomaticBackupName("levyra-auto-backup-.levyra"))
+        assertFalse(isAutomaticBackupName("levyra-auto-backup-abc.levyra"))
         assertFalse(isAutomaticBackupName("levyra-auto-backup-1700000000000.txt"))
         assertFalse(isAutomaticBackupName("Levyra_2026-08-30_1255.levyra"))
         assertFalse(isAutomaticBackupName("../levyra-auto-backup-1.levyra"))
+    }
+
+    @Test
+    fun retentionCoversProviderNormalizedNames() {
+        val files = listOf(
+            "levyra-auto-backup-1700000000010.levyra.zip",
+            "levyra-auto-backup-1700000000020.levyra",
+            "levyra-auto-backup-1700000000030.zip",
+            "notes.txt",
+            "Levyra_2026-08-30_1255.levyra"
+        )
+        val deleted = automaticBackupFilesToDelete(files, retentionCount = 2)
+        assertEquals(listOf("levyra-auto-backup-1700000000010.levyra.zip"), deleted)
     }
 
     @Test
@@ -82,5 +98,20 @@ class AutomaticBackupPolicyTest {
             setOf("data/favorites.json", "data/queue.json"),
             missingRequiredVaultSections(complete - "data/favorites.json" - "data/queue.json")
         )
+    }
+
+    @Test
+    fun previewStructuralCompatibilityMatchesRequiredSections() {
+        val complete = setOf(
+            "data/settings.json",
+            "data/favorites.json",
+            "data/followed_artists.json",
+            "data/playlists.json",
+            "data/history.json",
+            "data/queue.json"
+        )
+        assertTrue(vaultStructureCompatible(complete))
+        assertFalse(vaultStructureCompatible(complete - "data/playlists.json"))
+        assertFalse(vaultStructureCompatible(complete - "data/favorites.json" - "data/queue.json"))
     }
 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/AutomaticBackupPolicyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/AutomaticBackupPolicyTest.kt
@@ -1,6 +1,8 @@
 package com.luc4n3x.levyra.data
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AutomaticBackupPolicyTest {
@@ -8,14 +10,58 @@ class AutomaticBackupPolicyTest {
     fun retentionKeepsNewestMatchingArchivesOnly() {
         val result = automaticBackupFilesToDelete(
             listOf(
-                "levyra-auto-backup-100.zip",
+                "levyra-auto-backup-100.levyra",
                 "notes.txt",
-                "levyra-auto-backup-300.zip",
-                "levyra-auto-backup-200.zip"
+                "levyra-auto-backup-300.levyra",
+                "levyra-auto-backup-200.zip",
+                "other-archive-500.levyra"
             ),
             retentionCount = 2
         )
 
-        assertEquals(listOf("levyra-auto-backup-100.zip"), result)
+        assertEquals(listOf("levyra-auto-backup-100.levyra"), result)
+    }
+
+    @Test
+    fun retentionAcceptsThreeFiveTen() {
+        val files = (1L..12L).map { "levyra-auto-backup-${1700000000000L + it}.levyra" }
+        assertEquals(3, files.size - automaticBackupFilesToDelete(files, 3).size)
+        assertEquals(5, files.size - automaticBackupFilesToDelete(files, 5).size)
+        assertEquals(10, files.size - automaticBackupFilesToDelete(files, 10).size)
+    }
+
+    @Test
+    fun automaticBackupNameMatchesLevyraAndLegacyZip() {
+        assertTrue(isAutomaticBackupName("levyra-auto-backup-1700000000000.levyra"))
+        assertTrue(isAutomaticBackupName("levyra-auto-backup-1700000000000.zip"))
+        assertFalse(isAutomaticBackupName("levyra-auto-backup-1700000000000.txt"))
+        assertFalse(isAutomaticBackupName("Levyra_2026-08-30_1255.levyra"))
+        assertFalse(isAutomaticBackupName("../levyra-auto-backup-1.levyra"))
+    }
+
+    @Test
+    fun vaultEntriesRejectTraversalAndUnknownNames() {
+        assertTrue(vaultEntryAllowed("manifest.json"))
+        assertTrue(vaultEntryAllowed("data/settings.json"))
+        assertTrue(vaultEntryAllowed("data/favorites.json"))
+        assertTrue(vaultEntryAllowed("data/followed_artists.json"))
+        assertTrue(vaultEntryAllowed("data/playlists.json"))
+        assertTrue(vaultEntryAllowed("data/history.json"))
+        assertTrue(vaultEntryAllowed("data/queue.json"))
+        assertTrue(vaultEntryAllowed("payload.json"))
+        assertFalse(vaultEntryAllowed("../manifest.json"))
+        assertFalse(vaultEntryAllowed("/etc/passwd"))
+        assertFalse(vaultEntryAllowed("data/../../secret.json"))
+        assertFalse(vaultEntryAllowed("..\\manifest.json"))
+        assertFalse(vaultEntryAllowed("data/evil.json"))
+        assertFalse(vaultEntryAllowed(""))
+    }
+
+    @Test
+    fun vaultFileNameUsesLevyraPrefixAndExtension() {
+        val name = levyraVaultFileName(0L)
+        assertTrue(name.startsWith("Levyra_"))
+        assertTrue(name.endsWith(".levyra"))
+        assertFalse(name.contains(" "))
     }
 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/AutomaticBackupPolicyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/AutomaticBackupPolicyTest.kt
@@ -64,4 +64,23 @@ class AutomaticBackupPolicyTest {
         assertTrue(name.endsWith(".levyra"))
         assertFalse(name.contains(" "))
     }
+
+    @Test
+    fun missingRequiredVaultSectionIsRejected() {
+        val complete = setOf(
+            "manifest.json",
+            "data/settings.json",
+            "data/favorites.json",
+            "data/followed_artists.json",
+            "data/playlists.json",
+            "data/history.json",
+            "data/queue.json"
+        )
+        assertEquals(emptySet<String>(), missingRequiredVaultSections(complete))
+        assertEquals(setOf("data/playlists.json"), missingRequiredVaultSections(complete - "data/playlists.json"))
+        assertEquals(
+            setOf("data/favorites.json", "data/queue.json"),
+            missingRequiredVaultSections(complete - "data/favorites.json" - "data/queue.json")
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Levyra Vault is the local-first backup and restore system for Levyra. Users can create, restore and manage backups without an online account; data never leaves the device unless the user picks a storage provider through the Android Storage Access Framework.

## What changed

- Introduced the versioned `.levyra` archive format: a ZIP with `manifest.json` (formatVersion, appVersion, platform, databaseVersion, per-section SHA-256 checksums and sizes) and separate `data/*.json` sections for settings, favorites, playlists, followed artists, history and queue.
- Reworked backup writing to stream each section into the ZIP with per-section SHA-256 digests and byte counting instead of building one large JSON payload in memory.
- Kept restore compatible with the previous `payload.json` backup format so existing backups remain restorable.
- Added restore inspection and confirmation: before restoring, the app shows backup date, Levyra version, size, sections and compatibility, and refuses incompatible archives.
- Added the Levyra Vault settings section: automatic backup, frequency, retention (3/5/10), charging only, backup location, back up before updates, back up now, create data backup, restore and manage backups.
- Backup location is selectable with `ACTION_OPEN_DOCUMENT_TREE` and persisted URI permissions. Automatic backups and retention run on the selected provider; internal storage stays the fallback when no location is set or the provider becomes unavailable. Changing folder acquires the new grant first and releases the old one only after success.
- Added a pre-update backup hook before in-app update downloads. If it fails, a dialog offers Retry or Update anyway instead of continuing silently; cancellation is never shown as a failure.
- Serialized all vault operations with one process-wide mutex and exposed Idle/Running/Completed/Error status in the UI so ViewModel, worker, pre-update backup and restore cannot overlap. Status is derived from operation results, not from user-facing message text.
- Strengthened archive validation: entry allowlist (ZIP Slip protection), entry count, per-entry and total size limits, required sections for formatVersion 1, and per-section checksum verification before any data is applied. A missing required section fails the restore without touching local data, and the preview marks the same structure incompatible.
- Restore preview size counts the actual entry bytes while streaming instead of trusting `ZipEntry.size`, so valid backups no longer show 0 B.
- Automatic backup retention recognizes provider-normalized names (`levyra-auto-backup-<ts>.levyra`, `.levyra.zip` and legacy `.zip`) and never deletes manual `Levyra_*.levyra` exports or unrelated files.
- Cancellation is rethrown across all suspend vault paths; a cancelled coroutine never starts a fallback backup or reports a fake failure.
- Reduced the total archive limit from 192 MB to 96 MB; preview counting streams through entries without loading them into memory.
- Vault runtime state (last backup time and the device-specific SAF destination) is loaded in a single DataStore read at startup; the SAF destination is never serialized into the Vault or restored across devices.

## Type of change

- [x] New feature
- [x] UI or UX change

## Scope

- **Platform:** Android
- **Area:** Library / System integration

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [x] Targeted tests were added or updated

Ran locally: `./gradlew --no-daemon :app:compileDebugKotlin`, `./gradlew --no-daemon :app:testDebugUnitTest` (1571 tests, 0 failures), the repository fast AI quality gate, and `git diff --check`. `lintRelease` and `assembleRelease` are covered by the PR Check CI workflow.


## Risk and compatibility

- **Risk level:** Medium
- **Compatibility or migration notes:** Restore accepts the previous `payload.json` format and the new `.levyra` format. Older automatic backups keep their `.zip` names and are still listed and pruned.
- **Known limitations:** Downloaded media are not included. The SAF destination requires provider support for `DocumentsContract` create/delete; when unavailable, Levyra falls back to internal storage and reports it. Device flows (SAF picker, restore dialog, pre-update dialog) are not validated on hardware because the local emulator is unstable.
- **Rollback plan:** Revert this PR

## Reviewer notes

- `LevyraBackupManager` is the core: streaming section writer, shared process-wide mutex, required-section validation, archive checksum verification, legacy restore path and SAF export/retention with the correct parent document URI.
- Restore applies structured data through DAOs inside a Room transaction with a rollback snapshot, so it never copies the Room database file and does not need WAL/SHM handling.
- Pre-update backup failure surfaces in `MainActivity` and renders the retry dialog in `LevyraApp`.
- `KEY_VAULT_BACKUP_TREE_URI` is device-specific and intentionally excluded from Vault serialization and restore.

## Release note

Backups, restores, retention and the backup location are now managed by Levyra Vault, with a verified local archive format, optional SAF destination and no online account.

## Related issues

N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims