### PR TITLE
feat(android): refine player controls with tactile glass styling and responsive feedback

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -11910,17 +11910,22 @@ private fun PlayerModeSwitchIconTab(
         snap()
     }
     val background by animateColorAsState(
-        targetValue = if (selected) Color.White.copy(alpha = 0.22f) else Color.Transparent,
+        targetValue = if (selected) Color.White.copy(alpha = 0.20f) else Color.Transparent,
         animationSpec = tabSpec,
         label = "player-mode-tab-background"
     )
-    val borderTint by animateColorAsState(
-        targetValue = if (selected) Color.White.copy(alpha = 0.30f) else Color.Transparent,
+    val borderTopTint by animateColorAsState(
+        targetValue = if (selected) Color.White.copy(alpha = 0.38f) else Color.Transparent,
         animationSpec = tabSpec,
-        label = "player-mode-tab-border"
+        label = "player-mode-tab-border-top"
+    )
+    val borderBottomTint by animateColorAsState(
+        targetValue = if (selected) Color.White.copy(alpha = 0.12f) else Color.Transparent,
+        animationSpec = tabSpec,
+        label = "player-mode-tab-border-bottom"
     )
     val iconTint by animateColorAsState(
-        targetValue = if (selected) Color.White else Color.White.copy(alpha = 0.52f),
+        targetValue = if (selected) Color.White else Color.White.copy(alpha = 0.54f),
         animationSpec = tabSpec,
         label = "player-mode-tab-icon"
     )
@@ -11952,7 +11957,13 @@ private fun PlayerModeSwitchIconTab(
                             spotColor = Color.Black.copy(alpha = 0.45f)
                         )
                         .background(background, CircleShape)
-                        .border(BorderStroke(1.dp, borderTint), CircleShape)
+                        .border(
+                            BorderStroke(
+                                1.dp,
+                                Brush.verticalGradient(listOf(borderTopTint, borderBottomTint))
+                            ),
+                            CircleShape
+                        )
                 } else {
                     Modifier.background(background, CircleShape)
                 }
@@ -12072,7 +12083,18 @@ private fun PlayerQuickActionsBar(
                 .fillMaxWidth()
                 .height(if (compact) 44.dp else 48.dp)
                 .background(Color.White.copy(alpha = 0.05f), CircleShape)
-                .border(1.dp, Color.White.copy(alpha = 0.09f), CircleShape)
+                .border(
+                    BorderStroke(
+                        1.dp,
+                        Brush.verticalGradient(
+                            listOf(
+                                Color.White.copy(alpha = 0.14f),
+                                Color.White.copy(alpha = 0.04f)
+                            )
+                        )
+                    ),
+                    CircleShape
+                )
         )
         Row(
             modifier = Modifier
@@ -12194,14 +12216,19 @@ private fun PlayerQuickAction(
 ) {
     val animationsEnabled = LocalAnimationsEnabled.current
     val fill by animateColorAsState(
-        targetValue = if (active) tint.copy(alpha = 0.16f) else Color.Transparent,
+        targetValue = if (active) tint.copy(alpha = 0.14f) else Color.Transparent,
         animationSpec = if (animationsEnabled) LevyraPlayerDesign.standardTween(170) else snap(),
         label = "player-quick-fill"
     )
-    val border by animateColorAsState(
-        targetValue = if (active) tint.copy(alpha = 0.32f) else Color.Transparent,
+    val borderTop by animateColorAsState(
+        targetValue = if (active) tint.copy(alpha = 0.36f) else Color.Transparent,
         animationSpec = if (animationsEnabled) LevyraPlayerDesign.standardTween(170) else snap(),
-        label = "player-quick-border"
+        label = "player-quick-border-top"
+    )
+    val borderBottom by animateColorAsState(
+        targetValue = if (active) tint.copy(alpha = 0.12f) else Color.Transparent,
+        animationSpec = if (animationsEnabled) LevyraPlayerDesign.standardTween(170) else snap(),
+        label = "player-quick-border-bottom"
     )
     val shape = CircleShape
 
@@ -12227,7 +12254,13 @@ private fun PlayerQuickAction(
                     if (active) {
                         Modifier
                             .background(fill, shape)
-                            .border(LevyraPlayerDesign.Hairline, border, shape)
+                            .border(
+                                BorderStroke(
+                                    LevyraPlayerDesign.Hairline,
+                                    Brush.verticalGradient(listOf(borderTop, borderBottom))
+                                ),
+                                shape
+                            )
                     } else {
                         Modifier
                     }
@@ -13382,11 +13415,28 @@ private fun PlayerScreen(
 
         val metaBlock: @Composable (Track) -> Unit = { activeTrack ->
             val isFavorite = activeTrack.id in state.favoriteIds
-            val favoriteFill = if (isFavorite) Color(0xFFFF2D55).copy(alpha = 0.18f) else Color.White.copy(alpha = 0.06f)
-            val favoriteTint = if (isFavorite) Color(0xFFFF2D55) else Color.White.copy(alpha = 0.70f)
-            val favoriteBorder = if (isFavorite) Color(0xFFFF2D55).copy(alpha = 0.50f) else Color.White.copy(alpha = 0.12f)
+            val favoriteFill by animateColorAsState(
+                targetValue = if (isFavorite) Color(0xFFFF2D55).copy(alpha = 0.16f) else Color.White.copy(alpha = 0.05f),
+                animationSpec = if (state.animationsEnabled) LevyraPlayerDesign.standardTween(200) else snap(),
+                label = "player-favorite-fill"
+            )
+            val favoriteTint by animateColorAsState(
+                targetValue = if (isFavorite) Color(0xFFFF2D55) else Color.White.copy(alpha = 0.72f),
+                animationSpec = if (state.animationsEnabled) LevyraPlayerDesign.standardTween(200) else snap(),
+                label = "player-favorite-tint"
+            )
+            val favoriteBorderTop by animateColorAsState(
+                targetValue = if (isFavorite) Color(0xFFFF2D55).copy(alpha = 0.44f) else Color.White.copy(alpha = 0.14f),
+                animationSpec = if (state.animationsEnabled) LevyraPlayerDesign.standardTween(200) else snap(),
+                label = "player-favorite-border-top"
+            )
+            val favoriteBorderBottom by animateColorAsState(
+                targetValue = if (isFavorite) Color(0xFFFF2D55).copy(alpha = 0.18f) else Color.White.copy(alpha = 0.05f),
+                animationSpec = if (state.animationsEnabled) LevyraPlayerDesign.standardTween(200) else snap(),
+                label = "player-favorite-border-bottom"
+            )
             val favoriteScale by animateFloatAsState(
-                targetValue = if (isFavorite) 1.12f else 1f,
+                targetValue = if (isFavorite) 1.08f else 1f,
                 animationSpec = if (state.animationsEnabled) {
                     LevyraPlayerDesign.expressiveSpring()
                 } else {
@@ -13467,8 +13517,8 @@ private fun PlayerScreen(
                         iconSize = if (compactPlayer) 22.dp else 24.dp,
                         tint = favoriteTint,
                         fill = favoriteFill,
-                        borderTop = favoriteBorder,
-                        borderBottom = favoriteBorder,
+                        borderTop = favoriteBorderTop,
+                        borderBottom = favoriteBorderBottom,
                         modifier = Modifier
                             .graphicsLayer {
                                 scaleX = favoriteScale
@@ -13483,10 +13533,10 @@ private fun PlayerScreen(
                         contentDescription = strings.addToPlaylist,
                         size = heartButtonSize,
                         iconSize = if (compactPlayer) 22.dp else 24.dp,
-                        tint = Color.White.copy(alpha = 0.75f),
-                        fill = Color.White.copy(alpha = 0.06f),
-                        borderTop = Color.White.copy(alpha = 0.12f),
-                        borderBottom = Color.White.copy(alpha = 0.06f),
+                        tint = Color.White.copy(alpha = 0.78f),
+                        fill = Color.White.copy(alpha = 0.05f),
+                        borderTop = Color.White.copy(alpha = 0.14f),
+                        borderBottom = Color.White.copy(alpha = 0.05f),
                         onClick = { playlistTarget = activeTrack }
                     )
                 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
@@ -161,13 +161,16 @@ fun PlayerGlassIconButton(
     fill: Color = LevyraPlayerDesign.GlassFill,
     borderTop: Color = LevyraPlayerDesign.GlassBorderTop,
     borderBottom: Color = LevyraPlayerDesign.GlassBorderBottom,
-    gradientBorder: Boolean = true,
+    gradientBorder: Boolean = borderTop != LevyraPlayerDesign.GlassBorderTop ||
+        borderBottom != LevyraPlayerDesign.GlassBorderBottom,
     shape: Shape = CircleShape,
     enabled: Boolean = true
 ) {
     SpringIconButton(
         onClick = onClick,
         modifier = modifier.sizeIn(
+            // Dense player rows keep the full 48dp vertical target without reserving an
+            // invisible 48dp column around every 36–40dp circular control.
             minWidth = maxOf(size, DensePlayerHorizontalTouchTarget),
             minHeight = LevyraPlayerDesign.MinimumTouchTarget
         ),

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
@@ -161,8 +161,7 @@ fun PlayerGlassIconButton(
     fill: Color = LevyraPlayerDesign.GlassFill,
     borderTop: Color = LevyraPlayerDesign.GlassBorderTop,
     borderBottom: Color = LevyraPlayerDesign.GlassBorderBottom,
-    gradientBorder: Boolean = borderTop != LevyraPlayerDesign.GlassBorderTop ||
-        borderBottom != LevyraPlayerDesign.GlassBorderBottom,
+    gradientBorder: Boolean = false,
     shape: Shape = CircleShape,
     enabled: Boolean = true
 ) {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
@@ -127,7 +127,7 @@ fun Modifier.playerGlass(
     .border(
         BorderStroke(
             LevyraPlayerDesign.Hairline,
-            borderTop.playerMix(borderBottom, 0.5f)
+            Brush.verticalGradient(listOf(borderTop, borderBottom))
         ),
         shape
     )
@@ -150,8 +150,6 @@ fun PlayerGlassIconButton(
     SpringIconButton(
         onClick = onClick,
         modifier = modifier.sizeIn(
-            // Dense player rows keep the full 48dp vertical target without reserving an
-            // invisible 48dp column around every 36–40dp circular control.
             minWidth = maxOf(size, DensePlayerHorizontalTouchTarget),
             minHeight = LevyraPlayerDesign.MinimumTouchTarget
         ),
@@ -264,11 +262,11 @@ private fun PlayerSkipButton(
         Box(
             modifier = Modifier
                 .size(42.dp)
-                .background(Color.White.copy(alpha = 0.055f), shape)
-                .border(
-                    LevyraPlayerDesign.Hairline,
-                    Color.White.copy(alpha = 0.09f),
-                    shape
+                .playerGlass(
+                    shape = shape,
+                    fill = Color.White.copy(alpha = 0.055f),
+                    borderTop = Color.White.copy(alpha = 0.16f),
+                    borderBottom = Color.White.copy(alpha = 0.05f)
                 ),
             contentAlignment = Alignment.Center
         ) {
@@ -304,15 +302,25 @@ private fun PlayerModeToggleButton(
         animationSpec = if (animated) LevyraPlayerDesign.standardTween() else snap(),
         label = "player-toggle-indicator"
     )
+    val indicatorScale by animateFloatAsState(
+        targetValue = if (active) 1f else 0.4f,
+        animationSpec = if (animated) LevyraPlayerDesign.expressiveSpring() else snap(),
+        label = "player-toggle-indicator-scale"
+    )
     val surfaceColor by animateColorAsState(
-        targetValue = if (active) activeTint.copy(alpha = 0.15f) else Color.White.copy(alpha = 0.035f),
+        targetValue = if (active) activeTint.copy(alpha = 0.14f) else Color.White.copy(alpha = 0.04f),
         animationSpec = if (animated) LevyraPlayerDesign.standardTween(180) else snap(),
         label = "player-toggle-surface"
     )
-    val surfaceBorder by animateColorAsState(
-        targetValue = if (active) activeTint.copy(alpha = 0.26f) else Color.White.copy(alpha = 0.06f),
+    val borderTopColor by animateColorAsState(
+        targetValue = if (active) activeTint.copy(alpha = 0.38f) else Color.White.copy(alpha = 0.14f),
         animationSpec = if (animated) LevyraPlayerDesign.standardTween(180) else snap(),
-        label = "player-toggle-border"
+        label = "player-toggle-border-top"
+    )
+    val borderBottomColor by animateColorAsState(
+        targetValue = if (active) activeTint.copy(alpha = 0.16f) else Color.White.copy(alpha = 0.04f),
+        animationSpec = if (animated) LevyraPlayerDesign.standardTween(180) else snap(),
+        label = "player-toggle-border-bottom"
     )
 
     SpringIconButton(
@@ -323,17 +331,17 @@ private fun PlayerModeToggleButton(
                 minHeight = LevyraPlayerDesign.MinimumTouchTarget
             )
             .semantics { toggleableState = ToggleableState(active) },
-        pressedScale = 0.86f,
+        pressedScale = 0.88f,
         contentDescription = contentDescription
     ) {
         Box(
             modifier = Modifier
                 .size(LevyraPlayerDesign.ModeSlot)
-                .background(surfaceColor, LevyraPlayerDesign.ShapeSm)
-                .border(
-                    LevyraPlayerDesign.Hairline,
-                    surfaceBorder,
-                    LevyraPlayerDesign.ShapeSm
+                .playerGlass(
+                    shape = LevyraPlayerDesign.ShapeSm,
+                    fill = surfaceColor,
+                    borderTop = borderTopColor,
+                    borderBottom = borderBottomColor
                 ),
             contentAlignment = Alignment.Center
         ) {
@@ -347,7 +355,11 @@ private fun PlayerModeToggleButton(
                     .align(Alignment.BottomCenter)
                     .padding(bottom = LevyraPlayerDesign.SpaceXxs)
                     .size(LevyraPlayerDesign.ModeIndicator)
-                    .graphicsLayer { alpha = indicatorAlpha }
+                    .graphicsLayer {
+                        alpha = indicatorAlpha
+                        scaleX = indicatorScale
+                        scaleY = indicatorScale
+                    }
                     .background(activeTint, CircleShape)
             )
         }
@@ -364,14 +376,26 @@ private fun Modifier.playerPrimarySurface(
     shape: Shape
 ): Modifier = this
     .shadow(
-        elevation = 10.dp,
+        elevation = 8.dp,
         shape = shape,
         clip = false,
-        ambientColor = Color.Black.copy(alpha = 0.35f),
-        spotColor = Color.Black.copy(alpha = 0.60f)
+        ambientColor = Color.Black.copy(alpha = 0.30f),
+        spotColor = Color.Black.copy(alpha = 0.50f)
     )
     .background(
         Color.White,
+        shape
+    )
+    .border(
+        BorderStroke(
+            1.dp,
+            Brush.verticalGradient(
+                listOf(
+                    Color.White.copy(alpha = 0.90f),
+                    Color.White.copy(alpha = 0.40f)
+                )
+            )
+        ),
         shape
     )
 
@@ -410,11 +434,16 @@ private fun PlayerPrimaryButton(
     onClick: () -> Unit
 ) {
     val contentColor = LevyraPlayerDesign.PrimaryContent
-    val haloColor = accentColor.playerMix(Color.White, 0.16f)
+    val haloColor = accentColor.playerMix(Color.White, 0.20f)
     val haloAlpha by animateFloatAsState(
-        targetValue = if (isPlaying) 0.22f else 0.10f,
+        targetValue = if (isPlaying) 0.22f else 0.08f,
         animationSpec = if (animated) LevyraPlayerDesign.standardTween(260) else snap(),
         label = "player-primary-halo"
+    )
+    val haloRadiusFactor by animateFloatAsState(
+        targetValue = if (isPlaying) 0.82f else 0.65f,
+        animationSpec = if (animated) LevyraPlayerDesign.expressiveSpring() else snap(),
+        label = "player-primary-halo-radius"
     )
     val corner by animateDpAsState(
         targetValue = if (isPlaying) LevyraPlayerDesign.CornerMd else size * 0.5f,
@@ -431,12 +460,12 @@ private fun PlayerPrimaryButton(
             modifier = Modifier
                 .size(size)
                 .drawBehind {
-                    val radius = this.size.minDimension * 0.72f
+                    val radius = this.size.minDimension * haloRadiusFactor
                     drawCircle(
                         brush = Brush.radialGradient(
                             colors = listOf(
                                 haloColor.copy(alpha = haloAlpha),
-                                haloColor.copy(alpha = haloAlpha * 0.30f),
+                                haloColor.copy(alpha = haloAlpha * 0.28f),
                                 Color.Transparent
                             ),
                             center = center,

--- a/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/components/PlayerControls.kt
@@ -75,6 +75,12 @@ data class PlayerControlLabels(
 )
 
 private val DensePlayerHorizontalTouchTarget = 40.dp
+private val PlayerPrimaryBorderBrush = Brush.verticalGradient(
+    listOf(
+        Color.White.copy(alpha = 0.90f),
+        Color.White.copy(alpha = 0.40f)
+    )
+)
 
 private fun ioniconForPlayer(icon: ImageVector): ImageVector? {
     return when (icon.name.substringAfterLast('.')) {
@@ -121,15 +127,26 @@ fun Modifier.playerGlass(
     shape: Shape,
     fill: Color = LevyraPlayerDesign.GlassFill,
     borderTop: Color = LevyraPlayerDesign.GlassBorderTop,
-    borderBottom: Color = LevyraPlayerDesign.GlassBorderBottom
+    borderBottom: Color = LevyraPlayerDesign.GlassBorderBottom,
+    gradientBorder: Boolean = false
 ): Modifier = this
     .background(fill, shape)
-    .border(
-        BorderStroke(
-            LevyraPlayerDesign.Hairline,
-            Brush.verticalGradient(listOf(borderTop, borderBottom))
-        ),
-        shape
+    .then(
+        if (gradientBorder) {
+            Modifier.border(
+                BorderStroke(
+                    LevyraPlayerDesign.Hairline,
+                    Brush.verticalGradient(listOf(borderTop, borderBottom))
+                ),
+                shape
+            )
+        } else {
+            Modifier.border(
+                LevyraPlayerDesign.Hairline,
+                borderTop.playerMix(borderBottom, 0.5f),
+                shape
+            )
+        }
     )
 
 @Composable
@@ -144,6 +161,7 @@ fun PlayerGlassIconButton(
     fill: Color = LevyraPlayerDesign.GlassFill,
     borderTop: Color = LevyraPlayerDesign.GlassBorderTop,
     borderBottom: Color = LevyraPlayerDesign.GlassBorderBottom,
+    gradientBorder: Boolean = true,
     shape: Shape = CircleShape,
     enabled: Boolean = true
 ) {
@@ -160,7 +178,13 @@ fun PlayerGlassIconButton(
         Box(
             modifier = Modifier
                 .size(size)
-                .playerGlass(shape = shape, fill = fill, borderTop = borderTop, borderBottom = borderBottom),
+                .playerGlass(
+                    shape = shape,
+                    fill = fill,
+                    borderTop = borderTop,
+                    borderBottom = borderBottom,
+                    gradientBorder = gradientBorder
+                ),
             contentAlignment = Alignment.Center
         ) {
             PlayerIcon(
@@ -266,7 +290,8 @@ private fun PlayerSkipButton(
                     shape = shape,
                     fill = Color.White.copy(alpha = 0.055f),
                     borderTop = Color.White.copy(alpha = 0.16f),
-                    borderBottom = Color.White.copy(alpha = 0.05f)
+                    borderBottom = Color.White.copy(alpha = 0.05f),
+                    gradientBorder = true
                 ),
             contentAlignment = Alignment.Center
         ) {
@@ -341,7 +366,8 @@ private fun PlayerModeToggleButton(
                     shape = LevyraPlayerDesign.ShapeSm,
                     fill = surfaceColor,
                     borderTop = borderTopColor,
-                    borderBottom = borderBottomColor
+                    borderBottom = borderBottomColor,
+                    gradientBorder = true
                 ),
             contentAlignment = Alignment.Center
         ) {
@@ -387,15 +413,7 @@ private fun Modifier.playerPrimarySurface(
         shape
     )
     .border(
-        BorderStroke(
-            1.dp,
-            Brush.verticalGradient(
-                listOf(
-                    Color.White.copy(alpha = 0.90f),
-                    Color.White.copy(alpha = 0.40f)
-                )
-            )
-        ),
+        BorderStroke(1.dp, PlayerPrimaryBorderBrush),
         shape
     )
 


### PR DESCRIPTION
## Summary

Refine the Android Now Playing screen with tactile frosted-glass finishes, a subtle radial Play/Pause ambient glow, responsive spring feedback on transport toggles, and smoother metadata/quick-action transitions while preserving playback behavior and accessibility contracts.

## What changed

- Kept `Modifier.playerGlass` backward-compatible by default: the existing mixed-color border remains the standard path, while vertical gradient borders are opt-in for the controls that actually need the new treatment.
- Applied tactile frosted-glass depth to transport skip and mode toggle buttons (`PlayerSkipButton`, `PlayerModeToggleButton`).
- Refined `PlayerPrimaryButton` (Play/Pause) with a dynamic accent halo, a restrained specular border, and a reused static border brush instead of rebuilding that brush on recomposition.
- Added smooth color and spring feedback to the Favorite (Heart) action and matching custom border treatment to Favorite / Add to Playlist where custom border colors are supplied.
- Updated `PlayerQuickActionsBar` and `PlayerModeSwitchIconTab` with matching gradient borders and glass highlight states.
- Preserved minimum 48dp touch targets, existing semantics, state ownership, playback callbacks, and architecture.
- Kept `CastRouteButton` on the default non-gradient `playerGlass` path so this visual refinement does not silently change the Cast control surface.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor or maintenance
- [x] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** UI / Player / Design

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease` — current head CI pending
- [ ] Desktop: not required; Desktop is untouched
- [ ] Targeted tests were added or updated
- [x] No new targeted test was added because this PR changes rendering parameters only and does not introduce a new state or behavior contract

Previous branch validation before the final review fixes included `:app:testDebugUnitTest` and `git diff --check`. The current head is intentionally left dependent on the repository CI result rather than reusing older validation as proof for the final commit.

### Review / manual validation

| Validation | Result |
|---|---|
| Final static diff review | Passed; scope remains limited to the Android player UI |
| Touch target / semantics review | Passed statically; the existing minimum target and toggle semantics remain in place |
| Cast regression review | Passed statically; `CastRouteButton` keeps the default non-gradient `playerGlass` behavior |
| Device / emulator visual inspection on current head | Not run in this review environment |
| Measured 60/120fps performance | Not benchmarked; no FPS guarantee is claimed |

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** None; no state machine, playback ownership, database, network, or persistence changes.
- **Known limitation:** final visual polish on a running device/emulator is not verified by this review environment.
- **Rollback plan:** Revert this PR.

## Reviewer notes

- Gradient borders are deliberately scoped instead of changing every `playerGlass` caller globally.
- The Play/Pause specular border uses a reused static `Brush`; dynamic gradients remain only where their colors actually animate or vary by state.
- No blur pass, new dependency, or additional rendering subsystem was introduced.
- No performance claim is made without direct measurement.

## Release note

Refined the Android Now Playing screen with tactile glass controls, a smoother Play/Pause glow, and more responsive micro-interactions.

## Related issues

N/A

## Checklist

- [x] The PR is focused and contains no unrelated production changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green on the current head
- [x] Claims in this description match the evidence currently available


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined player controls with gradient borders, updated tints, fills, and transparency.
  * Improved visual feedback for mode indicators, toggle buttons, and primary playback controls.
  * Added smoother animated scaling and halo effects.
  * Adjusted favorite, playlist, quick-fill, and player control sizing for a more balanced appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->