### PR TITLE
Harden AI instruction bootstrap and reduce context overhead

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,89 +1,84 @@
 # Levyra Agent Configuration
 
-`.agents/` is Levyra's single tracked control center for coding agents.
+`.agents/` is Levyra's tracked control center for runtime-specific coding-agent
+configuration and the canonical skill tree. Root `AGENTS.md` is the compact
+cross-runtime contract.
 
-The repository keeps one canonical skill tree and one canonical set of
-runtime-specific configuration sources. Native `.claude/` and `.codex/`
-directories are generated locally when a runtime needs them and are ignored by
-Git.
-
-There is intentionally no tracked root `CLAUDE.md`.
+Claude Code is the deliberate exception to the otherwise generated native
+surfaces: tracked root `CLAUDE.md` is a tiny native bootstrap that imports
+`AGENTS.md`. This removes the clean-clone/startup dependency on a pre-existing
+`.claude/` projection. It must stay small and must not duplicate the contract.
 
 ## Configuration hierarchy
 
 ```text
-AGENTS.md                         repository-wide operating contract
-app/AGENTS.md                     Android rules
-desktop/AGENTS.md                 Windows Desktop rules
-.github/AGENTS.md                 CI and workflow rules
-docs/AGENTS.md                    documentation rules
+AGENTS.md                         compact cross-runtime contract
+CLAUDE.md                         tiny Claude-native @AGENTS.md bridge
+app/AGENTS.md                     Android scoped rules
+desktop/AGENTS.md                 Windows Desktop scoped rules
+.github/AGENTS.md                 CI/workflow scoped rules
+docs/AGENTS.md                    documentation scoped rules
 
 .agents/
-├── README.md                     this inventory and maintenance contract
+├── README.md                     this inventory
 ├── config/                       shared agent/plugin manifests
-├── rules/                        cross-runtime workspace rules
+├── rules/                        cross-runtime workspace bridges
 ├── skills/                       one canonical Levyra skill tree
-├── claude/                       canonical Claude Code config sources
-│   ├── CLAUDE.md
+├── claude/                       canonical Claude settings/hooks/agents/rules
+│   ├── CLAUDE.md                 Claude-specific runtime guidance
 │   ├── settings.json
 │   ├── agents/
 │   ├── hooks/
 │   └── rules/
-└── codex/                        canonical Codex project config sources
+└── codex/                        canonical Codex project config/hooks
     ├── config.toml
     └── hooks.json
-
-scripts/sync_agent_runtime.py     native runtime projection manager
 ```
 
-## Native runtime projection
+Generated `.claude/` and `.codex/` directories remain ignored by Git and are
+never sources of truth.
 
-Claude Code and Codex still receive the paths they expect. Levyra does not ask
-those tools to understand a custom unsupported runtime path.
+## Claude Code reliability
 
-`scripts/sync_agent_runtime.py` materializes:
+Claude Code natively reads root `CLAUDE.md`, which imports `AGENTS.md` at session
+startup. That bootstrap works before any repository setup script or generated
+runtime projection exists.
 
-```text
-.agents/claude/...  -> .claude/...
-.agents/skills/...  -> .claude/skills/...
-.agents/codex/...   -> .codex/...
-```
+When `.claude/settings.json` is available, `UserPromptSubmit` adds a second
+layer: it re-anchors a compact hard contract on every prompt and runs the shared
+skill router. Session/mutation/compaction/stop hooks add evidence and safety
+guards, but correctness must not depend on optional tooling being available.
 
-The generated `.claude/` and `.codex/` directories are ignored by Git. The
-synchronizer keeps a manifest of files it owns, removes only stale managed
-entries, and preserves unrelated machine-specific local files.
-
-The normal setup commands refresh both projections:
+The generated `.claude/` projection still supplies project settings, hooks,
+agents, rules, and the native skill view. Refresh it with:
 
 ```powershell
 .\scripts\setup-ai.ps1
 ```
 
+or:
+
 ```bash
 ./scripts/setup-ai.sh
 ```
 
-After the native runtime config is active, Claude Code and Codex refresh their
-projection again on startup/resume. The project jCodeMunch launcher also performs
-a best-effort Claude projection refresh as an additional clean-clone bootstrap.
+The projection manager is `scripts/sync_agent_runtime.py`.
 
 ## Automatic skill discovery
 
 `.agents/skills/` is the only tracked Levyra skill tree.
 
-- **Codex** discovers `.agents/skills/` directly.
-- **Claude Code** discovers the generated `.claude/skills/` projection, which is
-  copied directly from `.agents/skills/`.
+- **Codex** discovers `.agents/skills/` directly and keeps the existing
+  instruction-based Codex setup.
+- **Claude Code** receives the root contract natively and discovers the generated
+  `.claude/skills/` projection when runtime setup is active.
 - **Google Antigravity** uses `.agents/rules/levyra-workspace.md` and the same
   repository-native skills.
-- **ChatGPT Project** instructions route to the same skills through
-  `docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md`.
-- OpenClaw and compatible coding agents use the same canonical contracts where
-  supported.
+- **ChatGPT Project** routes through `docs/ai/CHATGPT_PROJECT_INSTRUCTIONS.md`.
+- OpenClaw and compatible runtimes use the same contracts where supported.
 
-This keeps automatic routing while preventing skill drift: edit a Levyra skill
-once under `.agents/skills/`; Codex uses it directly and Claude sees the synced
-native projection.
+Skill descriptions are routing metadata. Load `SKILL.md` bodies only when the
+active task matches them; never preload the whole tree.
 
 ## Canonical skill inventory
 
@@ -110,77 +105,36 @@ native projection.
 - `levyra-release-check`
 - `levyra-security-review`
 
-Skill descriptions are routing metadata; `SKILL.md` bodies are loaded only when
-the task requires them. Keep descriptions narrow enough to avoid unnecessary
-context expansion.
-
-## Cross-runtime routing
-
-The main automatic routes remain:
-
-- substantial implementation: `levyra-real-engineering`;
-- Compose/UI: `levyra-compose` and, when visual quality is central,
-  `levyra-design-taste`;
-- performance/memory/jank: `levyra-android-performance`;
-- R8/minification: `levyra-r8-proguard`;
-- Intent/component boundaries: `levyra-android-intent-security` plus
-  `levyra-security-review`;
-- CI/workflows: `levyra-ci-workflows`;
-- noisy command-output work: `levyra-context-efficiency`;
-- reviews: `levyra-pr-review`;
-- releases: `levyra-release-check`;
-- security-sensitive changes: `levyra-security-review`.
-
-Security work follows the **Codex Security** closed-loop workflow documented in
-`docs/ai/CODEX_SECURITY.md`: threat model, identification, validation,
-remediation, human review, and revalidation.
-
-## Codex
-
-Codex uses root `AGENTS.md` as its repository operating contract and discovers
-the canonical `.agents/skills/` tree directly. Levyra keeps the existing
-instruction-based Codex setup for optional tooling and plugins.
-
-Canonical project config and lifecycle hooks live under `.agents/codex/` and are
-projected to ignored `.codex/` native paths. Do not maintain a second tracked
-Codex config tree.
-
-## Claude Code
-
-Canonical Claude Code instructions, settings, subagents, hooks, and rules live
-under `.agents/claude/`. Claude's native `.claude/` projection is generated
-locally. `.claude/skills/` comes directly from the shared `.agents/skills/` tree;
-there is no tracked `.agents/claude/skills/` bridge.
-
-See `.agents/claude/README.md` for the detailed projection and bootstrap contract.
-
 ## Context efficiency
 
-Use `levyra-context-efficiency` when large command output would otherwise waste
-context. RTK/jCodeMunch are optimization layers only: correctness, exact failure
-evidence, security output, and validation results must remain complete when
-needed. Re-run raw commands whenever compressed output hides decisive evidence.
+`AGENTS.md` intentionally stays concise. Detailed multi-step procedure belongs in
+path-scoped instructions, `docs/ai/`, or a matching skill. Use
+`levyra-context-efficiency` when command output or repository exploration would
+otherwise flood the active context. RTK/jCodeMunch are optimization layers only;
+rerun raw when compact output hides decisive evidence.
 
 ## Security
 
 Use `levyra-security-review` for secrets, authentication, provider URLs,
 redirects, SSRF, permissions, privacy, workflow trust boundaries, dependency
-risk, update verification, or other security-sensitive changes. Never weaken
-security merely to make a test or provider response pass.
+risk, update verification, or other security-sensitive changes. The shared
+**Codex Security** lifecycle is documented in `docs/ai/CODEX_SECURITY.md`.
+Never weaken security merely to make a test or provider response pass.
 
 ## Maintenance contract
 
 When changing agent infrastructure:
 
-1. keep `.agents/skills/` as the only tracked Levyra skill tree;
-2. keep Claude-specific canonical configuration under `.agents/claude/`;
-3. keep Codex-specific canonical configuration under `.agents/codex/`;
-4. never commit root `CLAUDE.md`, `.claude/`, `.codex/`, or
-   `.agents/claude/skills/`;
-5. keep `scripts/sync_agent_runtime.py` idempotent and non-destructive to
-   unrelated local files;
-6. update runtime setup/hooks and validators together when a native path changes;
-7. run `python3 scripts/ai_quality_gate.py --profile fast` for focused agent
-   changes and the repository-required full gate before publication/merge;
-8. do not claim automatic discovery, a build, test, device check, or security
-   validation unless the current evidence proves it.
+1. keep `AGENTS.md` compact and root `CLAUDE.md` as a tiny import bridge;
+2. keep `.agents/skills/` as the only tracked Levyra skill tree;
+3. keep Claude-specific canonical runtime configuration under `.agents/claude/`;
+4. keep Codex-specific canonical configuration under `.agents/codex/`;
+5. never commit generated `.claude/`, `.codex/`, or
+   `.agents/claude/skills/` trees;
+6. keep runtime projection idempotent and non-destructive to unrelated local
+   files;
+7. update hooks, validators, and docs together when discovery behavior changes;
+8. run `python3 scripts/ai_quality_gate.py --profile fast` for focused agent
+   changes and the required full gate before publication/merge;
+9. never claim automatic discovery, builds, tests, device checks, or security
+   validation without direct evidence.

--- a/.agents/claude/CLAUDE.md
+++ b/.agents/claude/CLAUDE.md
@@ -1,135 +1,110 @@
-# Levyra Claude Code
+# Levyra Claude Code Runtime
 
-This is Claude's compact projection of the Levyra engineering contract. Root
-`AGENTS.md` remains the cross-runtime source of truth, but do not preload it or
-large `docs/ai/` playbooks wholesale on ordinary coding turns. Load the specific
-canonical document only when the active question requires details that are not
-already enforced by hooks or scoped rules.
+Root `CLAUDE.md` is Claude Code's native startup bridge and imports root
+`AGENTS.md`, the cross-runtime source of truth. This file adds only
+Claude-specific runtime behavior. Do not duplicate the full repository contract
+here and do not preload large `docs/ai/` playbooks wholesale.
 
-The project lifecycle hooks keep `docs/ai/ALWAYS_ON_AGENT_GUARDS.md` active and
-inject applicable scoped `AGENTS.md`/current-file evidence around mutations.
-Path-scoped files under `.claude/rules/` load when relevant code is touched.
+The generated `.claude/` projection may load this file, hooks, rules, agents, and
+skills after `scripts/sync_agent_runtime.py` runs. The tracked root bridge means
+Claude still receives the essential Levyra contract even when that projection
+has not been created yet.
 
-## Core coding contract
+## Core Claude contract
 
-- Current repository evidence outranks memory, stale comments, previous agent
+- Current repository evidence outranks memory, stale comments, prior agent
   output, and old task status.
-- Inspect the current implementation and nearby tests before changing behavior.
-- Make the smallest coherent root-cause fix. Reuse existing owners, clients,
-  players, caches, stores, state models, and policies before adding structure.
-- Protect playback reliability, explicit song/audio versus native-video choice,
-  MediaSession/notification/Android Auto/queue synchronization, privacy, and
-  persisted user data before optional polish.
-- Preserve cancellation, lifecycle, concurrency, transient-failure, no-match,
-  persistence, and compatibility semantics.
-- Keep blocking network/database/disk/extraction/media work off UI threads.
-- Do not add explanatory source-code comments. Prefer clear names and structure;
-  preserve only required license/generated/lint/compatibility comments.
+- Root/scoped `AGENTS.md` instructions remain authoritative.
+- For production implementation or broad review, consult
+  `docs/ai/AI_ENGINEERING_GUARDRAILS.md` when its detailed decision procedure is
+  needed.
+- Apply `docs/ai/EVIDENCE_GATED_COMPLETION.md` to non-trivial completion.
 - `only this`, `solo questo`, and equivalents are hard scope boundaries.
+- Do not add explanatory source-code comments. Prefer clear names and structure.
 - Commit, push, PR, merge, tag, release, deployment, version changes, and
   repository settings remain owner-controlled.
 
-For a non-trivial production change or broad review, consult
-`docs/ai/AI_ENGINEERING_GUARDRAILS.md` only when its detailed decision procedure
-is needed. Apply `docs/ai/EVIDENCE_GATED_COMPLETION.md` at completion; the Stop
-hook enforces the critical evidence state mechanically.
-
 ## Immediate context budget
 
-Apply before broad reading on every real coding task:
+Before broad reading:
 
-1. identify the likely owner/module and the exact question the next read answers;
-2. search path, symbol, or call site first;
+1. identify the likely owner/module and exact question the next read answers;
+2. search path, symbol, filename, or call site first;
 3. read the smallest useful range, focused diff, or nearby test;
 4. expand only when a concrete unanswered question remains;
-5. do not reread unchanged evidence already present in the active context;
-6. load only the skills routed for this task, never the whole skill tree.
+5. do not reread unchanged evidence already in context;
+6. load only the skills routed for this task.
 
-For read-only discovery that would otherwise flood the main conversation, prefer
-Claude's built-in Explore agent. Use the custom implementation agent only when
-isolated implementation context is actually useful; tiny/local fixes stay in the
-main agent.
-
-For noisy builds, tests, lint, logs, broad searches, dependency listings, GitHub
-or CI output, invoke `levyra-context-efficiency`. Prefer RTK only when its
-filtered output is sufficient; rerun raw when exact stdout/stderr, stack traces,
-security/signing evidence, Perfetto/R8 evidence, or full diagnostics matter.
-Token savings never override correctness.
-
-## Subagent token discipline
-
-Custom subagents already receive this project context automatically. Never tell
-a subagent to reread `.claude/CLAUDE.md` merely as bootstrap.
-
-Delegate with one compact handoff containing only:
-
-- goal and verified/current evidence;
-- affected files or symbols;
-- invariants/constraints that matter to this task;
-- acceptance checks and any real blocker.
-
-Do not paste the parent conversation, broad repository summaries, whole files,
-or unrelated findings into a delegation message. Do not preload skill bodies in
-subagent frontmatter; let the subagent invoke the routed skill through `Skill`
-when it actually needs that procedure.
-
-Keep `model: inherit` and high reasoning for Levyra coding/review agents. Save
-tokens by reducing duplicate context and unused tools, not by lowering coding
-quality.
+Use `levyra-context-efficiency` for noisy builds, tests, lint, logs, broad
+searches, dependency listings, Git/GitHub/CI output, or other high-volume
+context. RTK is optional optimization; rerun raw when exact diagnostics,
+security/signing, Perfetto, or R8 evidence matters.
 
 ## Deterministic skill loading
 
-The `UserPromptSubmit` hook executes `scripts/agent_skill_router.py`. Every name
-under **Mandatory skill load** must be invoked before broad repository reading,
-editing, or shell work. The hook is the routing source of truth; do not maintain
-or scan a second full routing table in this always-loaded file.
+`UserPromptSubmit` runs the shared router. Every item reported under
+**Mandatory skill load** must be loaded before broad repository reading, editing,
+or shell work. The owner never needs to name a skill.
 
-Compatibility inventory for the core automatic routes:
+Compatibility inventory for automatic routes:
 `levyra-real-engineering`, `levyra-compose`, `levyra-design-taste`,
 `levyra-android-performance`, `levyra-r8-proguard`,
 `levyra-android-intent-security`, `levyra-ci-workflows`,
 `levyra-context-efficiency`, `levyra-pr-review`, `levyra-release-check`.
-The shared router may select additional focused Levyra skills and companions.
+The shared router may additionally select `levyra-player`, `levyra-extractor`,
+`levyra-database`, `levyra-desktop`, `levyra-security-review`,
+`levyra-project-manager`, `levyra-engineering`, `levyra-humanizer`, and other
+focused Levyra skills.
 
-## Delegation policy
+Do not scan or preload the whole skill tree. Invoke only the routed skill bodies.
 
-- Do not spawn `levyra-android-developer` for a trivial, already-local one-file
-  fix that the main agent can safely implement with focused validation.
-- Use `levyra-android-developer` for substantial Android implementation/debugging
-  where isolated code-reading/editing context keeps the main conversation clean.
-- Use `levyra-reviewer` after meaningful or risky changes, before merge-quality
-  handoff, or when an independent read-only pass can find regressions. Do not
-  spawn it ceremonially for a tiny edit with direct focused evidence.
-- Use built-in Explore for broad read-only repository discovery whenever its
-  lower startup context is sufficient.
+## Subagent token discipline
 
-## Claude context hygiene
+Subagents already receive project context. Delegate with only the goal, current
+verified evidence, affected files/symbols, task-specific invariants, acceptance
+checks, and real blockers. Do not paste the parent transcript, entire files,
+broad repository summaries, or unused skill bodies into subagent prompts.
 
-Use `/clear` at safe task boundaries, not mid-debugging. If the next owner
-request is unrelated and the prior task is complete/checkpointed, prefer a fresh
-context when the stop audit recommends it. Use `/compact` when the same task
-still needs summarized history. Never claim a hook executed a slash command.
+Use built-in Explore for broad read-only discovery when appropriate. Use custom
+implementation/review agents only when isolated context materially improves the
+work; do not spawn them ceremonially for tiny edits.
 
-## Review, validation, delivery
+## Hooks and resilience
 
-For code-bearing work, run focused validation after the latest material edit,
-inspect the actual final diff, and run `git diff --check`. Invoke `/code-review`
-when available for meaningful changes; otherwise use the installed review stage
-through `levyra-real-engineering`. Fix actionable findings and review the final
-corrected diff again when the fix materially changes it.
+Claude lifecycle hooks are a second enforcement layer, not the only source of
+instructions:
 
-Use the repository quality gate when applicable:
+- `SessionStart` refreshes optional runtime projection/tooling and re-anchors
+  active state;
+- `UserPromptSubmit` injects the compact Levyra hard-contract reminder and
+  deterministic skill routing on every user turn;
+- mutation hooks enforce scoped-instruction/current-file freshness where
+  supported;
+- compaction hooks re-anchor open task state;
+- the Stop audit checks evidence before completion.
+
+If optional RTK, jCodeMunch, memory, or projection setup fails, continue with
+native tools and report the limitation once. Never weaken safety or validation
+to make optional tooling work.
+
+## Review, validation, and PRs
+
+After the latest material code edit, run focused validation, inspect the actual
+final diff, and run `git diff --check`. For meaningful changes invoke
+`/code-review` when available; otherwise use the repository review stage. Fix
+valid findings and review the corrected diff again when needed.
+
+Use:
 
 ```bash
 python3 scripts/ai_quality_gate.py --profile fast
 python3 scripts/ai_quality_gate.py --profile full
 ```
 
-Run `fast` before commit and `full` before push/PR publication. Missing or
-blocked checks are not passes. Report exactly what ran and what remains
-unverified.
+`fast` is required before commit and `full` before push/PR publication when those
+actions are authorized. Missing prerequisites remain blocked, not passed.
 
-When opening or updating a pull request, keep the complete
-`.github/pull_request_template.md` structure, fill it with verified evidence,
-leave unperformed checks unmarked, and invoke `levyra-humanizer` as the final
-prose pass without changing any claim.
+When opening or updating a pull request, preserve the complete
+`.github/pull_request_template.md`, keep every validation claim truthful, leave
+unperformed checks unmarked, and apply `levyra-humanizer` as the final prose
+pass without changing facts.

--- a/.agents/claude/README.md
+++ b/.agents/claude/README.md
@@ -1,17 +1,22 @@
 # Levyra Claude Code Configuration
 
-Levyra keeps the tracked Claude Code source under `.agents/claude/` and the shared
-project skills under `.agents/skills/`.
+Levyra keeps Claude-specific tracked runtime sources under `.agents/claude/` and
+shared project skills under `.agents/skills/`.
 
-The native `.claude/` directory is a generated local runtime projection. It is
-ignored by Git and must never become a second source of truth.
+A tiny tracked root `CLAUDE.md` is intentionally present because Claude Code
+natively reads `CLAUDE.md`, not `AGENTS.md`. The root bridge imports `AGENTS.md`
+so the essential Levyra contract is available immediately in a fresh clone,
+before any generated `.claude/` projection exists.
 
 ## Canonical structure
 
 ```text
+CLAUDE.md                      native startup bridge -> @AGENTS.md
+AGENTS.md                      compact cross-runtime contract
+
 .agents/
 ├── claude/
-│   ├── CLAUDE.md
+│   ├── CLAUDE.md              Claude-specific runtime guidance
 │   ├── README.md
 │   ├── settings.json
 │   ├── agents/
@@ -21,12 +26,12 @@ ignored by Git and must never become a second source of truth.
     └── */SKILL.md
 ```
 
-There is intentionally no tracked root `CLAUDE.md`, `.claude/`, or duplicate
-`.agents/claude/skills/` tree.
+The generated `.claude/` directory remains local and ignored. There is still no
+tracked duplicate `.agents/claude/skills/` tree.
 
 ## Native Claude projection
 
-Claude Code still receives the paths it expects locally:
+Runtime setup materializes the optional native surface:
 
 ```text
 .claude/
@@ -37,8 +42,10 @@ Claude Code still receives the paths it expects locally:
 └── skills/          <- .agents/skills/
 ```
 
-Run the normal repository setup once after a fresh clone or after pulling this
-migration:
+The projected `.claude/CLAUDE.md` contains Claude-specific runtime guidance only;
+root `CLAUDE.md` + imported `AGENTS.md` remain the reliable startup contract.
+
+Run setup after a fresh clone or after agent-infrastructure changes:
 
 ```powershell
 .\scripts\setup-ai.ps1
@@ -50,80 +57,62 @@ or:
 ./scripts/setup-ai.sh
 ```
 
-Both setup scripts invoke `scripts/sync_agent_runtime.py`, which materializes the
-ignored native Claude and Codex projections from `.agents/` without deleting
-unrelated local files. The projection is also refreshed on Claude
-`SessionStart`/resume after the native settings are active. The project-scoped
-jCodeMunch launcher performs a best-effort Claude projection refresh as an
-additional clean-clone bootstrap path.
+Both invoke `scripts/sync_agent_runtime.py`. SessionStart/resume refreshes the
+projection again once native project settings are active. The project
+jCodeMunch launcher also performs a best-effort refresh.
 
-To refresh or verify only Claude manually:
+Manual Claude-only refresh/check:
 
 ```bash
 python3 scripts/sync_agent_runtime.py --runtime claude --quiet
 python3 scripts/sync_agent_runtime.py --runtime claude --check
 ```
 
-On Windows, `python` or `py` can be used when `python3` is not available.
+## Automatic instruction and skill loading
 
-## Automatic skill loading
+The reliability chain is deliberately layered:
 
-`.agents/skills/` is the only tracked Levyra skill tree.
+1. root `CLAUDE.md` loads natively at startup and imports `AGENTS.md`;
+2. generated `.claude/CLAUDE.md` adds only Claude-specific runtime guidance;
+3. `UserPromptSubmit` re-anchors a compact hard contract on every prompt;
+4. the shared router selects only matching Levyra skills;
+5. path-scoped rules/instructions load when relevant files are touched.
 
-- Codex discovers `.agents/skills/` directly.
-- Claude Code discovers the generated `.claude/skills/` projection.
-- Every projected Claude skill comes directly from the same canonical
-  `.agents/skills/<skill>/SKILL.md` file.
-- `UserPromptSubmit` continues routing matching requests to the required Levyra
-  skills before editing.
-- `settings.json` keeps the project plugins and lifecycle hooks active.
+This avoids depending on Claude voluntarily searching for repository rules and
+also avoids stuffing every specialized procedure into startup context.
 
-This means adding or changing a Levyra skill requires editing it once under
-`.agents/skills/`. The next runtime sync updates Claude's native view; Codex uses
-the canonical file directly.
+`.agents/skills/` remains the only tracked Levyra skill tree. Claude discovers
+the generated `.claude/skills/` view; Codex reads the canonical tree directly.
 
 ## Settings and hooks
 
-The tracked settings file is `.agents/claude/settings.json`. Its generated
-`.claude/settings.json` counterpart is what Claude Code consumes locally.
+Tracked settings live at `.agents/claude/settings.json`; generated
+`.claude/settings.json` is what Claude Code consumes locally.
 
-The settings preserve the existing permission guardrails, project plugins,
-SessionStart environment/tooling checks, jCodeMunch bootstrap, prompt routing,
-always-on agent harness, checkpointing, comment guard, and completion audit.
+The settings preserve permission guardrails, project plugins, SessionStart
+environment checks, jCodeMunch bootstrap, prompt routing, always-on harness,
+checkpointing, comment guard, compaction re-anchoring, and completion audit.
 
-Canonical hook scripts stay under `.agents/claude/hooks/`. The generated
-settings call those canonical scripts directly, so hook logic is not duplicated
-inside `.claude/`.
+`UserPromptSubmit` must always inject the compact hard contract even if skill
+routing returns no specialized match. If Python is unavailable, the hook emits a
+minimal static fallback rather than silently providing no context.
 
-The hooks are fail-open for optional tooling and must never turn an unavailable
-optimizer or indexer into a blocked coding session. Validation evidence remains
-truthful: a setup probe is a precondition check, not proof that a build or test
-passed.
+Optional tooling is fail-open: unavailable RTK, jCodeMunch, or memory tooling
+must not block normal coding. Validation claims remain evidence-based.
 
 ## Personal local overrides
 
-Generated `.claude/` is ignored by Git. The runtime synchronizer only owns files
-listed in its `.levyra-runtime-manifest.json`; it does not delete unrelated
-machine-specific files. Local-only Claude configuration can therefore coexist
-with the generated project projection.
-
-## Usage
-
-After setup, start Claude Code normally from the repository. No custom skill path
-is required. Claude sees the normal `.claude` runtime surface while the GitHub
-repository remains organized under `.agents/`.
-
-If a new skill is added while Claude Code is already running, start a new session
-when necessary so Claude refreshes its discovered skill inventory.
+Generated `.claude/` is ignored by Git. The synchronizer owns only files listed
+in its runtime manifest and preserves unrelated machine-specific local files.
 
 ## Maintenance
 
-- edit canonical Claude configuration only under `.agents/claude/`;
+- keep root `CLAUDE.md` tiny and importing `@AGENTS.md`;
+- keep `AGENTS.md` concise enough for reliable startup adherence;
+- edit Claude runtime sources under `.agents/claude/`;
 - edit Levyra skills only under `.agents/skills/`;
-- never commit root `CLAUDE.md`, `.claude/`, `.codex/`, or
-  `.agents/claude/skills/`;
-- keep `scripts/sync_agent_runtime.py` idempotent and non-destructive to unknown
-  local files;
-- preserve Claude's native automatic discovery by keeping the generated
-  `.claude` projection compatible with the current runtime;
+- never commit generated `.claude/`, `.codex/`, or
+  `.agents/claude/skills/` trees;
+- keep `scripts/sync_agent_runtime.py` idempotent and non-destructive;
+- keep prompt-hook fallback behavior and validators in sync with discovery;
 - run the AI quality gate after structural agent changes.

--- a/.agents/claude/hooks/user-prompt-submit.sh
+++ b/.agents/claude/hooks/user-prompt-submit.sh
@@ -14,12 +14,47 @@ router="$root/scripts/agent_skill_router.py"
 validator_contract="Mandatory skill load | Root AGENTS.md remains canonical | EVIDENCE_GATED_COMPLETION.md | Levyra context budget | code-review | levyra-project-manager | levyra-desktop | levyra-engineering | levyra-openclaw-orchestrator | levyra-real-engineering | levyra-compose | levyra-design-taste | levyra-android-performance | levyra-r8-proguard | levyra-android-intent-security | levyra-ci-workflows | levyra-context-efficiency | levyra-pr-review | levyra-humanizer | levyra-release-check | levyra-security-review | threat model | trust boundary | supply.?chain"
 : "$validator_contract"
 
+payload="$(cat)"
+
 if command -v python3 >/dev/null 2>&1; then
-  exec python3 "$router"
+  py=(python3)
 elif command -v python >/dev/null 2>&1; then
-  exec python "$router"
+  py=(python)
 elif command -v py >/dev/null 2>&1; then
-  exec py -3 "$router"
+  py=(py -3)
+else
+  printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"Levyra hard contract: root CLAUDE.md imports AGENTS.md and both are mandatory. Work only inside requested scope; inspect current code before edits; make the smallest coherent change; do not perform unrelated refactors; publication actions require explicit owner authorization; keep validation claims truthful."}}'
+  exit 0
 fi
+
+prompt="$(printf '%s' "$payload" | "${py[@]}" -c 'import json,sys; data=json.load(sys.stdin); print(str(data.get("prompt") or ""))' 2>/dev/null || true)"
+route_context="$("${py[@]}" "$router" --prompt "$prompt" --plain 2>/dev/null || true)"
+
+"${py[@]}" - "$route_context" <<'PY'
+import json
+import sys
+
+core = """Levyra hard contract (re-anchored on every prompt):
+- Root CLAUDE.md natively imports AGENTS.md; root/scoped instructions and current repository evidence are mandatory and outrank memory.
+- Execute implementation requests directly within the requested scope. 'only this' / 'solo questo' is a hard boundary; no unrelated cleanup, refactors, dependency churn, or version changes.
+- Before behavior changes, inspect the current implementation and nearby tests; prefer the smallest coherent root-cause fix and existing owners/abstractions.
+- Load detailed docs and skill bodies only when the active task requires them; keep the Levyra context budget small.
+- After material edits, run focused validation, inspect the final diff, and keep PASS/BLOCKED/UNRUN claims truthful.
+- Commit, push, PR creation, merge, tag, release, deployment, external messages, repository settings, and version changes require explicit owner authorization for that action and scope.
+"""
+
+routed = sys.argv[1].strip()
+context = core if not routed else f"{core}\n{routed}"
+print(
+    json.dumps(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "UserPromptSubmit",
+                "additionalContext": context,
+            }
+        }
+    )
+)
+PY
 
 exit 0

--- a/.agents/claude/hooks/user-prompt-submit.sh
+++ b/.agents/claude/hooks/user-prompt-submit.sh
@@ -11,7 +11,7 @@ fi
 router="$root/scripts/agent_skill_router.py"
 
 # Compatibility contract for repository validators; routing logic stays canonical in agent_skill_router.py.
-validator_contract="Mandatory skill load | Root AGENTS.md remains canonical | EVIDENCE_GATED_COMPLETION.md | Levyra context budget | code-review | levyra-project-manager | levyra-desktop | levyra-engineering | levyra-openclaw-orchestrator | levyra-real-engineering | levyra-compose | levyra-design-taste | levyra-android-performance | levyra-r8-proguard | levyra-android-intent-security | levyra-ci-workflows | levyra-context-efficiency | levyra-pr-review | levyra-humanizer | levyra-release-check | levyra-security-review | threat model | trust boundary | supply.?chain"
+validator_contract="Mandatory skill load | Root AGENTS.md remains canonical | root CLAUDE.md natively imports AGENTS.md | EVIDENCE_GATED_COMPLETION.md | Levyra context budget | code-review | levyra-project-manager | levyra-desktop | levyra-engineering | levyra-openclaw-orchestrator | levyra-real-engineering | levyra-compose | levyra-design-taste | levyra-android-performance | levyra-r8-proguard | levyra-android-intent-security | levyra-ci-workflows | levyra-context-efficiency | levyra-pr-review | levyra-humanizer | levyra-release-check | levyra-security-review | threat model | trust boundary | supply.?chain"
 : "$validator_contract"
 
 payload="$(cat)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,563 +1,164 @@
 # Levyra Engineering Instructions
 
-## Purpose and hierarchy
-
-This file is the repository-wide operating contract for coding agents. Claude
-Code, Codex, ChatGPT when operating through a repository-capable runtime,
-Google Antigravity, OpenCode, OpenClaw, and compatible runtimes should read it
-from the Git root, then apply any nearer `AGENTS.md` for the files in scope.
+## Purpose
+This is Levyra's compact, always-loaded engineering contract. It is a router,
+not a handbook: keep permanent rules here and load detailed procedures only
+when the active task needs them.
 
 Instruction order:
-
 1. root `AGENTS.md`;
-2. nearer path-specific `AGENTS.md` files;
-3. approved requirements and active planning in `docs/project/SPEC.md`,
-   `docs/project/ROADMAP.md`, and `docs/project/TASKS.md`;
+2. the nearest path-specific `AGENTS.md` for files in scope;
+3. applicable approved planning in `docs/project/`;
 4. matching native skills under `.agents/skills/`;
-5. current architecture, implementation, tests, build files, and workflows;
-6. runtime-specific canonical configuration under `.agents/claude/` and
-   `.agents/codex/` when that runtime is in use.
+5. current implementation, tests, build files, workflows, and runtime evidence;
+6. runtime-specific canonical configuration under `.agents/claude/` or `.agents/codex/`.
 
-Current repository evidence always overrides remembered behavior, old
-discussions, stale comments, previous agent output, or stale task status.
-Surface conflicts between planning files and implementation before editing.
-
+Current repository evidence outranks memory, stale comments, previous agent
+output, and old task status. Surface real conflicts before editing.
 For every engineering task apply `docs/ai/ALWAYS_ON_AGENT_GUARDS.md`. For
-production-code implementation or broad review, also read
-`docs/ai/AI_ENGINEERING_GUARDRAILS.md` and apply its reuse-first, explicit
-assumption/tradeoff, simpler-alternative, goal-verification, surgical-edit,
-complexity-budget, and diff-quality rules.
+production-code implementation or broad review also apply
+`docs/ai/AI_ENGINEERING_GUARDRAILS.md`. Use
+`docs/ai/EVIDENCE_GATED_COMPLETION.md` for non-trivial completion evidence.
 
-## Repository map
-
-- `docs/README.md`: canonical documentation index.
-- `docs/project/SPEC.md`: durable product and engineering requirements.
-- `docs/project/ROADMAP.md`: ordered outcomes, risks, and phase exit criteria.
-- `docs/project/TASKS.md`: one active reviewable phase and its truthful
-  validation state.
-- `app/`: Android client; additional rules in `app/AGENTS.md`.
-- `desktop/`: independent Windows client; additional rules in
-  `desktop/AGENTS.md`.
-- `.github/`: CI and release automation; additional rules in
-  `.github/AGENTS.md`.
-- `docs/`: project documentation; additional rules in `docs/AGENTS.md`.
-- `docs/project/`: product specification, engineering roadmap, and active task
-  phase.
-- `docs/agents/`: repository-specific configuration consumed by external agent
-  skills, including issue-tracker and domain-document conventions.
-- `docs/ai/`: ChatGPT, Codex, Google Antigravity, Claude Code, and OpenClaw
-  collaboration guidance.
-- `.agents/rules/`: lightweight workspace rules that link to this canonical
-  contract.
-- `.agents/skills/`: the single canonical Levyra skill tree shared by supported
-  coding runtimes.
-- `.agents/claude/`: tracked Claude Code instructions, settings, agents, hooks,
-  and rules.
-- `.agents/codex/`: tracked Codex project configuration and lifecycle hooks.
-- `.claude/` and `.codex/`: ignored native runtime projections generated
-  locally from `.agents/`; never treat them as tracked sources of truth.
-
-## Agent runtime discovery
-
-- Root `AGENTS.md` is the canonical repository context for supported coding
-  agents.
-- Google Antigravity discovers workspace skills from
-  `.agents/skills/<skill-name>/SKILL.md` when a conversation starts.
-- Codex discovers the canonical `.agents/skills/` tree directly. Its projected
-  `.codex/` surface supplies project-specific configuration and lifecycle hooks
-  after the native projection is materialized.
-- Claude Code consumes the native `.claude/` surface. Levyra generates that
-  ignored projection from `.agents/claude/` and projects `.agents/skills/`
-  directly to `.claude/skills/`; `scripts/setup-ai.*` is the deterministic
-  bootstrap and the project jCodeMunch launcher provides an additional
-  best-effort clean-clone projection path.
-- When the Claude/Codex native hook surface is active, user prompts execute
-  `scripts/agent_skill_router.py` automatically. Other supported runtimes must
-  infer the same routes from the current task and canonical table below without
-  requiring the owner to name a skill; shell-capable runtimes may invoke the
-  shared router directly.
-- A native runtime may need a new session after its projection or skill inventory
-  first appears so the runtime can rebuild discovery. Do not represent a file
-  generated mid-session as proof that the already-running process loaded it.
-- `.agents/rules/levyra-workspace.md` links back to this file with a relative
-  `@../../AGENTS.md` reference instead of maintaining a duplicate contract.
-- Open the repository root as the workspace. Starting only from `app/`,
-  `desktop/`, or another nested folder may hide repository-level agent
-  configuration.
-- Start a new agent conversation after pulling instruction or skill changes so
-  the runtime can rebuild its workspace inventory.
-- See `docs/ai/ANTIGRAVITY.md` for Antigravity setup and verification.
-
-Runtime-specific discovery must not create separate sources of truth. This file,
-nearest scoped instructions, approved planning, matching skills, and current
-repository evidence remain the shared hierarchy.
-
-## Execution-first operating mode
-
-This policy is shared by every supported coding runtime. It is not a
-Claude-specific preference.
-
-- When the owner asks to `fix`, `update`, `address`, `implement`, `refactor`, or
-  otherwise change code, execute the requested work directly inside the
-  authorized scope. Do not turn an implementation request into an unsolicited
-  design discussion, tutorial, list of alternatives, or approval pause.
-- Do not ask routine confirmation questions when the requested outcome,
-  repository evidence, and existing architecture already determine the next
-  safe action.
-- Ask only when an indispensable input is missing, materially different
-  interpretations would produce meaningfully different results, or the next
-  action is destructive, irreversible, security-sensitive, or outside the
-  owner's existing authorization.
-- If the requested approach conflicts with current repository evidence,
-  security, data integrity, compatibility, product invariants, or deterministic
-  validation, surface the conflict briefly and choose the smallest safe
-  correction when it remains inside scope. Never silently execute a known-bad
-  approach merely to appear compliant.
-- For code-bearing work: inspect the current implementation and nearby tests, make the
-  smallest coherent change, run focused validation, fix regressions introduced
-  by the change, inspect the final diff, then report the result, files changed,
-  checks run, and any real blocker.
-- Treat `only this`, `solo questo`, and equivalent wording as a hard scope
-  boundary. Do not perform opportunistic refactors, unrelated cleanup,
-  dependency churn, version changes, or speculative architecture work.
-- Prefer execution over commentary. Explain decisions only when they materially
-  affect correctness, safety, compatibility, validation, or the owner's next
-  action.
-- Execution-first behavior never grants permission to commit, push, open or
-  merge a pull request, tag, publish, release, deploy, change repository
-  settings, bypass approvals, weaken sandboxing, or skip required validation.
-  Those actions keep their existing owner-controlled authorization rules.
+## Execution contract
+- When the owner asks to fix, update, implement, refactor, or otherwise change
+  code, execute the requested work directly inside the authorized scope.
+- `only this`, `solo questo`, and equivalents are hard scope boundaries.
+- Inspect the current implementation and nearby tests before changing behavior.
+- Fix the root cause with the smallest coherent change. Reuse existing owners,
+  clients, players, caches, stores, state models, dispatchers, and policies.
+- Do not perform opportunistic refactors, dependency churn, version changes,
+  renames, cleanup, or architecture work unrelated to the request.
+- Do not add explanatory source-code comments. Prefer clear names and structure;
+  preserve only legally or mechanically required comments and genuinely
+  non-obvious compatibility/safety contracts.
+- Ask only when an indispensable input is missing, materially different valid
+  interpretations would change the result, or an action is destructive,
+  irreversible, security-sensitive, or outside existing authorization.
+- Investigation verbs such as inspect, review, diagnose, and report do not
+  authorize implementation. Implementation verbs do not authorize publication.
 
 ## Always-on context budget
-
-Codex and every compatible runtime must apply this before broad repository
-reading on every non-trivial task:
-
-1. identify the likely owner/module and the exact question the next read must
-   answer;
+Before broad repository reading on every non-trivial task:
+1. identify the likely owner/module and the exact question the next read answers;
 2. search path, filename, symbol, or call site first;
 3. read the smallest useful range, focused diff, or nearby test;
 4. expand only when a concrete unanswered question remains;
 5. do not reread unchanged evidence already present in context;
 6. load only matching skills, never the whole skill tree.
 
-Use `levyra-context-efficiency` immediately when the task needs non-trivial
-repository exploration, useful cross-session continuity, or high-volume output.
-Tiny, already-local edits keep the same baseline without loading extra skill
-text.
+Use `levyra-context-efficiency` for noisy builds, tests, lint, logs, dependency
+reports, Git/GitHub output, broad searches, or non-trivial repository
+exploration. RTK is an optimization layer only; rerun raw whenever compressed
+output could hide decisive diagnostics, security, signing, Perfetto, or R8 evidence.
 
-Keep security, Perfetto, R8, signing, exact failures, and decisive diagnostics
-raw whenever compacting them could change the conclusion. Token savings never
-justify missing evidence.
+## Repository map
+- `app/`: Android client; apply `app/AGENTS.md`.
+- `desktop/`: Windows client; apply `desktop/AGENTS.md`.
+- `.github/`: CI/release automation; apply `.github/AGENTS.md`.
+- `docs/`: documentation; apply `docs/AGENTS.md`.
+- `docs/project/`: `SPEC.md`, `ROADMAP.md`, and the active `TASKS.md` phase.
+- `docs/ai/`: detailed cross-runtime engineering procedures.
+- `.agents/skills/`: the single canonical Levyra skill tree.
+- `.agents/claude/`: canonical Claude-specific settings, hooks, agents, and rules.
+- `.agents/codex/`: canonical Codex-specific configuration and hooks.
+- `.claude/` and `.codex/`: generated local runtime projections; never sources of truth.
 
-## Agent skills
+Claude Code has a tracked root `CLAUDE.md` whose sole purpose is reliable native
+startup discovery and import of this file. Do not duplicate this contract there.
 
-### Issue tracker
+## Automatic skill routing
+Select matching skills automatically from the task. The owner never needs to
+name a skill. Claude/Codex hooks use `scripts/agent_skill_router.py`; compatible
+runtimes should follow the same routing behavior. Several skills may apply.
 
-Levyra tracks issues and publishable engineering tickets in GitHub Issues for
-`LUC4N3X/Levyra-deepsound`. Reads may use the runtime's authenticated GitHub
-integration or `gh`; issue writes require explicit owner authorization. See
-`docs/agents/issue-tracker.md`.
+Core automatic routes:
+- substantial or ambiguous engineering -> `levyra-real-engineering`;
+- Android playback/Media3/queue -> `levyra-player`;
+- extraction/InnerTube/network fallback -> `levyra-extractor`;
+- Room/persistence/backup -> `levyra-database`;
+- Compose/state/navigation/accessibility -> `levyra-compose`;
+- visual redesign/polish -> `levyra-design-taste` plus the matching UI skill;
+- Android performance/memory/jank -> `levyra-android-performance`;
+- R8/Proguard/shrinking -> `levyra-r8-proguard` plus `levyra-release-check`;
+- Intent/deep-link/component security -> `levyra-android-intent-security` plus `levyra-security-review`;
+- Windows Desktop -> `levyra-desktop`;
+- CI/workflows/build tooling -> `levyra-ci-workflows`;
+- branch/commit/PR review -> `levyra-pr-review`;
+- PR creation or description -> `levyra-pr-review` plus `levyra-humanizer`;
+- release/pre-merge evidence -> `levyra-release-check`;
+- requirements/roadmap/task status -> `levyra-project-manager`;
+- genuine cross-domain orientation -> `levyra-engineering`;
+- OpenClaw coordination -> `levyra-openclaw-orchestrator`;
+- Android artifact decompilation -> `levyra-android-reverse-engineering` plus `levyra-security-review`;
+- secrets/privacy/trust boundaries -> `levyra-security-review`;
+- decorative Canvas/motion artwork -> `levyra-motion-artwork`.
 
-### Domain docs
-
-Levyra uses a single shared domain-language context. Read root `CONTEXT.md` and
-relevant `docs/adr/` entries when they exist; create either lazily only when a
-reusable term or durable architectural decision actually warrants it. See
-`docs/agents/domain.md`.
-
-## RTK agent bootstrap
-
-The repository owner gives standing authorization to supported shell-capable
-coding agents to bootstrap the pinned official `rtk-ai/rtk` command-output tool
-when working in this repository. The bootstrap is automatic and idempotent.
-
-At the start of the first non-trivial shell-capable task in a session, without
-asking the owner to run setup manually:
-
-1. on Windows PowerShell run `scripts/ensure-rtk.ps1 -Quiet`;
-2. on Bash, WSL, Linux, or macOS run `./scripts/ensure-rtk.sh --quiet`;
-3. let the ensure script verify raw `rtk --version` and `rtk gain` and install
-   only the pinned RTK revision through Cargo when those checks fail;
-4. if Cargo is unavailable, installation fails, or verification still fails,
-   report the blocked bootstrap once and continue with raw commands instead of
-   downloading an unverified executable, weakening sandboxing, or weakening
-   validation.
-
-The broader manual setup remains available through
-`scripts/setup-ai.ps1 -InstallRtk` or `./scripts/setup-ai.sh --install-rtk` for
-repair or explicit environment setup. Do not reinstall RTK repeatedly once the
-raw readiness checks pass.
-
-## Persistent agent memory bootstrap
-
-The repository owner also gives standing authorization to the pinned
-`thedotmack/claude-mem` integration defined in `docs/ai/CLAUDE_MEM.md` for
-Claude Code, Codex CLI, and Google Antigravity.
-
-Use it automatically only when prior-session context can materially reduce
-repeated investigation or restore continuity. When the runtime already exposes
-claude-mem memory tools, query them directly with progressive disclosure. When
-a local shell-capable supported runtime needs that context but the memory tools
-are absent, it may run one automatic pinned setup attempt through
-`scripts/setup-claude-mem.ps1` on Windows or `./scripts/setup-claude-mem.sh` on
-Bash/WSL/Linux/macOS, then retry the focused lookup.
-
-If setup, worker health, or MCP discovery fails, continue without memory. Never
-block implementation, review, tests, or answers waiting for memory; never enable
-cloud sync or experimental semantic injection implicitly; never store secrets,
-keystores, `.env`, cookies, tokens, signing material, private URLs, or
-`local.properties` as project memory. Current repository evidence always
-outranks stored observations.
-
-ChatGPT uses claude-mem only when a compatible MCP app is actually connected and
-the memory tools are available. Repository configuration alone must never be
-represented as a successful ChatGPT-to-local-worker connection.
-
-This standing authorization applies to the pinned `rtk-ai/rtk` bootstrap, the
-pinned claude-mem integration, the focused Matt Pocock skill bootstrap documented
-below, and task-required tools installed under
-`docs/ai/ALWAYS_ON_AGENT_GUARDS.md`. A shell-capable runtime may install a missing
-useful tool automatically when the active task genuinely requires it, using a
-trusted upstream and the narrowest practical user/project-local installation,
-then verifying the installed version. Broad package/system upgrades, unrelated
-plugins or daemons, telemetry, administrator/root elevation, unrestricted
-sandboxing, approval bypasses, commit, push, pull request, merge, tag, release,
-deployment, external messages, and repository settings still require their
-normal explicit authorization. Keep security, signing, checksum, secret, and
-exact reproduction evidence raw.
-
-## Matt Pocock skills bootstrap
-
-The repository owner authorizes the exact `mattpocock/skills` engineering
-integration defined by this repository:
-
-- Codex: `scripts/setup-ai.ps1` / `scripts/setup-ai.sh` may use the official
-  `skills` CLI through `npx` to install only the focused allowlist declared in
-  those scripts, globally for the Codex agent. Use `-SkipMattSkills` or
-  `--skip-matt-skills` to opt out on a machine.
-- Claude Code: `.agents/claude/settings.json`, projected locally to native
-  `.claude/settings.json`, enables `mattpocock-skills@claude-plugins-official`;
-  Claude's normal project trust and plugin installation controls remain intact.
-- ChatGPT and Antigravity: use the repository-native
-  `levyra-real-engineering` adapter whether or not an upstream package is
-  installed in the runtime.
-
-The one-time upstream repository configuration is represented by this
-`## Agent skills` block plus `docs/agents/issue-tracker.md` and
-`docs/agents/domain.md`. `triage` is intentionally not installed or configured.
-Do not rerun `setup-matt-pocock-skills` during ordinary work unless the owner
-wants to change the issue tracker or domain-doc layout.
-
-External skills are supplementary. `AGENTS.md`, approved planning, current
-architecture, focused `levyra-*` skills, tests, quality gates, and explicit
-owner publication controls always take precedence. See
-`docs/ai/MATT_POCOCK_SKILLS.md`.
+Do not preload skill bodies. Read the matching `.agents/skills/<name>/SKILL.md` only when routed.
 
 ## Product invariants
-
-- Protect playback reliability, responsiveness, privacy, user data, and
-  existing user choices before visual polish.
-- Android users explicitly choose song/audio mode or native-video mode. Never
-  remove, merge, hide, or silently override that choice.
-- Motion artwork is decorative, muted, and limited to song/audio mode. It must
-  never replace native video, produce audible output, or delay playback.
-- Static artwork is the immediate and permanent fallback.
-- Android audible playback, MediaSession, notification, Android Auto, queue,
-  and background service must remain synchronized.
-- Direct playback is the critical path. Artwork, lyrics, refresh, diagnostics,
-  prefetch, and enrichment must yield to it.
-- Preserve downloads, favorites, playlists, queues, lyrics, history, settings,
-  localization, onboarding, sessions, and backups unless explicitly changed.
-- Do not add account login, cookies, private tokens, scraping, telemetry, or
-  tracking unless explicitly requested.
-- Android and Desktop versions, packages, tags, artifacts, and releases remain
-  independent.
-
-## Native skill routing
-
-Select every matching skill automatically from the task before reading widely or
-editing. The owner never needs to name a skill. Claude Code and Codex use the
-shared prompt router when their native hook surface is active; other runtimes
-must apply this table directly. Prefer focused skills over the general
-coordinator and never preload the whole skill tree.
-
-| Task | Skill |
-| --- | --- |
-| Requirements, roadmap, active phase, acceptance criteria, task status, implementation handoff | `levyra-project-manager` |
-| OpenClaw delegation, coding-runtime coordination, evidence collection, safe publication handoff | `levyra-openclaw-orchestrator` |
-| Non-trivial feature, architectural change, unclear defect, or multi-step work needing clarification/spec/tickets/implementation/review separation | `levyra-real-engineering` |
-| Android playback, queue, Media3, MediaSession, notification, Android Auto, prefetch, audio/video mode | `levyra-player` |
-| InnerTube, extraction, stream resolution, runtime configuration, retry, cache, fallback | `levyra-extractor` |
-| Room, DAO, migration, schema, cache, store, backup, persistent personal data | `levyra-database` |
-| Android Compose UI, state, navigation, animation, lifecycle, accessibility, RTL, localization | `levyra-compose` |
-| Android jank, frame misses, latency, startup, Perfetto/System Trace, CPU/thread state, graphics, Binder/IPC, blocking, memory, I/O, power, or measured runtime-performance investigation | `levyra-android-performance` plus the affected domain skill |
-| APK/XAPK/AAB/DEX/JAR/AAR decompilation, jadx/smali, compiled Android API extraction, binary call-flow tracing, or Kotlin/R8 metadata recovery | `levyra-android-reverse-engineering` plus `levyra-security-review`; add `levyra-r8-proguard` when obfuscation/shrinker behavior is material |
-| R8, Proguard, minification, resource shrinking, keep/consumer rules, release-only shrinker crashes, mapping/missing classes, reflection/serialization/JNI shrinker issues, or measured APK-size work | `levyra-r8-proguard` plus `levyra-release-check`; add `levyra-ci-workflows` for build-tooling changes |
-| Android Intent, deep link, PendingIntent, exported activity/service/receiver/provider, nested Intent, `onNewIntent`, URI grant, FileProvider/ContentProvider, or caller/signature verification | `levyra-android-intent-security` plus `levyra-security-review` and the affected Android domain skill |
-| Visual redesign, UI polish, hierarchy, spacing, typography, color, shape, motion, screenshots/references, premium/modern/cohesive/anti-AI-slop requests | `levyra-design-taste` plus the matching Android/Desktop UI skill |
-| Decorative motion artwork | `levyra-motion-artwork` |
-| Windows Desktop, Compose Multiplatform, libvlc, downloads, mini player, deep links, updates, packaging | `levyra-desktop` |
-| Secrets, URLs, redirects, SSRF, MIME, permissions, privacy, update integrity, or other security-sensitive work | `levyra-security-review` |
-| GitHub Actions, CI, F-Droid, configuration sync, artifacts, build/release automation | `levyra-ci-workflows` |
-| Non-trivial repository exploration; builds, tests, lint, logs, broad searches, dependency reports, Git/GitHub, CI diagnostics, or other noisy context | `levyra-context-efficiency` |
-| Branch, commit, patch, or pull request review | `levyra-pr-review` |
-| Opening or updating a pull request, including its title or description | `levyra-pr-review` plus `levyra-humanizer` |
-| Pre-merge or pre-release validation, versions, signing, checksums, packaging | `levyra-release-check` |
-| Genuine cross-domain work or initial architecture orientation | `levyra-engineering` |
-
-Several skills may apply. A playback change that modifies stream resolution
-uses player and extractor skills; provider-controlled media normally also
-requires security review. A tracked multi-phase task additionally uses
-`levyra-project-manager`; non-trivial ambiguous/multi-step work additionally
-uses `levyra-real-engineering`; non-trivial repository exploration additionally
-uses `levyra-context-efficiency`; visual Android work uses `levyra-design-taste`
-plus `levyra-compose`; visual Desktop work uses `levyra-design-taste` plus
-`levyra-desktop`; Android runtime-performance work uses
-`levyra-android-performance` plus the affected domain skill; Android artifact
-reverse-engineering uses `levyra-android-reverse-engineering` plus security
-review and R8 guidance when obfuscation is material; R8/Proguard work uses
-`levyra-r8-proguard` plus release validation and build-tooling guidance when
-applicable; Android component-boundary security uses
-`levyra-android-intent-security` plus `levyra-security-review` and the affected
-domain skill; OpenClaw coordination additionally uses
-`levyra-openclaw-orchestrator`.
-
-## Planning documents
-
-Read only the planning material relevant to the task, but do not ignore an
-active phase:
-
-- `docs/project/SPEC.md` defines approved durable requirements and non-goals.
-- `docs/project/ROADMAP.md` orders outcomes, risks, and phase exit criteria; it
-  is not release authorization.
-- `docs/project/TASKS.md` records one active reviewable phase, validation
-  evidence, and owner checkpoints.
-- `docs/ARCHITECTURE.md` describes current implementation ownership and data
-  flow.
-- `docs/ai/WORKFLOW.md` defines the complete AI-assisted lifecycle.
-- `docs/ai/ALWAYS_ON_AGENT_GUARDS.md` defines non-optional execution, automatic
-  skill routing, checkpoint/retry discipline, narrow tool installation, and
-  context-hygiene rules shared by all coding runtimes.
-- `docs/ai/AI_ENGINEERING_GUARDRAILS.md` defines the anti-overengineering,
-  assumption/tradeoff, goal-verification, surgical-edit, and complexity rules
-  shared by all coding runtimes.
-- `docs/ai/CLAUDE_MEM.md` defines the optional persistent-memory integration,
-  privacy boundary, automatic-on-need bootstrap, and fail-open behavior.
-- `docs/ai/MATT_POCOCK_SKILLS.md` defines the real-engineering stage routing and
-  runtime-specific upstream skill installation.
-- `docs/ai/ANTIGRAVITY.md` defines Antigravity discovery, workspace, and
-  verification guidance.
-- `docs/ai/OPENCLAW.md` defines the recommended OpenClaw role and tool
-  boundaries.
-
-Do not mark task status from an agent report. Update it only from a direct
-command, CI result, review, device check, or owner decision.
-
-## Engineering rules
-
-- Preserve unidirectional data flow: user intent -> controller/ViewModel ->
-  repository/player operation -> immutable state -> UI.
-- Keep network, database, parsing, decoding, file, metadata, and blocking native
-  work off UI threads.
-- Reuse existing clients, stores, caches, scopes, dispatchers, queues, lifecycle
-  owners, extractors, players, and persistence.
-- Do not create a second source of truth for playback, queue, persistence,
-  localization, update state, release state, requirements, or active task
-  status.
-- Make ownership explicit for coroutines, players, callbacks, receivers,
-  surfaces, native handles, decoders, files, caches, and in-flight work.
-- One caller cancelling shared work must not cancel work still required by
-  another caller.
-- Use identity and generation checks when older asynchronous work can publish
-  after newer work.
-- Re-throw `CancellationException`; never cache or report cancellation as a
-  normal miss.
-- Distinguish conclusive no-match from timeout, transport, server, parsing,
-  verification, and stale-configuration failures.
-- Do not negative-cache inconclusive failures.
-- Bound retries, timeouts, concurrency, response sizes, cache/storage growth,
-  downloads, and prefetch.
-- Keep durable identity independent from mutable display text.
-- Treat user-provided screenshots and direct runtime observations as acceptance
-  evidence. Reconcile visible failures even when automated checks are green.
-- Match the requested action mode. `inspect`, `review`, `diagnose`, and `report`
-  authorize investigation and reporting, not implementation. `fix`, `update`,
-  `address`, and `implement` authorize the requested change and relevant
-  validation, but never imply publication, merge, release, deployment, or an
-  external message.
-- Do not add explanatory source-code comments. Prefer clear names, small
-  functions, and explicit structure. Preserve comments that are legally or
-  mechanically required, including license headers, generated/tool directives,
-  lint/suppression markers, and compatibility comments whose removal would
-  change or obscure a required contract.
+- Protect playback reliability, responsiveness, privacy, user data, and existing choices before optional polish.
+- Keep explicit song/audio mode and native-video mode distinct; never silently remove, merge, hide, or override the user's choice.
+- Motion artwork is decorative, muted, song/audio-only, and must never delay audible playback; static artwork remains the immediate fallback.
+- Keep audible playback, MediaSession, notification, Android Auto, queue, and background service synchronized.
+- Direct playback is the critical path; artwork, lyrics, diagnostics, prefetch, refresh, and enrichment must yield to it.
+- Preserve downloads, favorites, playlists, queues, lyrics, history, settings, localization, onboarding, sessions, and backups unless explicitly changed.
+- Do not add account login, cookies, private tokens, telemetry, or tracking unless explicitly requested.
+- Android and Desktop versions, packages, artifacts, tags, and releases remain independent.
 
 ## Work method
+Use `Plan -> Execute -> Verify` for non-trivial implementation:
+1. define exact outcome, action mode, scope, preserved behavior, and acceptance;
+2. route only matching skills and inspect the current control/data flow;
+3. identify root cause and the simplest existing-owner solution;
+4. make one minimal coherent change without unrelated churn;
+5. run the narrowest useful checks after the latest material edit;
+6. inspect the complete final diff and run `git diff --check`;
+7. report exactly what changed, what passed, what failed, and what is unverified.
 
-For non-trivial implementation use `Plan -> Execute -> Verify`: make the smallest
-evidence-based plan, implement one coherent slice, verify its success criterion,
-and only then expand. Do not insert a ceremonial approval pause unless the owner
-explicitly reserved one.
+Keep blocking network, database, disk, parsing, decoding, extraction, and native
+media work off UI threads. Preserve lifecycle, cancellation, shared-work,
+generation/identity, failure classification, retry, timeout, concurrency, and
+bounded-storage semantics. Do not negative-cache inconclusive failures.
 
-1. Define the exact requested outcome, action mode, and scope.
-2. At the start of a non-trivial shell-capable task, ensure the pinned RTK
-   bootstrap automatically; continue raw if it is unavailable.
-3. Route and load every matching native skill automatically from the task, then
-   apply the always-on context budget before broad reading; load
-   `levyra-context-efficiency` when exploration or cross-session continuity is
-   non-trivial.
-4. When prior-session context materially matters, use focused claude-mem
-   retrieval if available or the one-attempt owner-authorized bootstrap if it is
-   not; verify every remembered conclusion against the current repository.
-5. Read `docs/project/SPEC.md`, the relevant roadmap track, and the active
-   `docs/project/TASKS.md` phase when applicable.
-6. Identify behavior and compatibility that must remain unchanged.
-7. State material assumptions and unresolved tradeoffs; inspect the repository
-   first when evidence can resolve them.
-8. Identify a simpler existing-owner/reuse path before adding abstraction or
-   configurability.
-9. Inspect the complete current control/data flow and nearby tests.
-10. Identify the root cause before editing.
-11. Define the verification target for each non-trivial step.
-12. Make the smallest coherent change compatible with current architecture.
-13. Avoid unrelated cleanup, formatting churn, dependency upgrades, renames,
-    and broad refactors.
-14. Add or update regression tests for defects, migrations, matching, security
-    boundaries, lifecycle, and concurrency when applicable.
-15. Run focused checks first, then applicable broader checks.
-16. Inspect the complete final diff for unrelated edits, generated files,
-    secrets, binaries, conflict markers, and accidental version changes.
-17. Synchronize `docs/project/SPEC.md`, `docs/project/ROADMAP.md`,
-    `docs/project/TASKS.md`, architecture, and user documentation when the
-    approved requirement or architecture changes.
-18. Report exactly what changed, what ran, what passed, what failed, and what
-    remains unverified.
+## RTK agent bootstrap
+For shell-capable non-trivial tasks, the pinned `rtk-ai/rtk` bootstrap is
+owner-authorized. Verify `rtk --version` and `rtk gain`; use
+`scripts/ensure-rtk.ps1 -Quiet` on Windows or `./scripts/ensure-rtk.sh --quiet`
+elsewhere when needed. Manual repair remains available through
+`scripts/setup-ai.ps1 -InstallRtk` or `./scripts/setup-ai.sh --install-rtk`.
+If RTK is unavailable, continue raw rather than weakening validation or safety.
+See `docs/ai/RTK.md` for details.
 
-When the owner says "only this", modify only the named behavior or files unless
-an additional change is strictly required for correctness. State that dependency
-before expanding scope.
+Optional persistent memory and external skill integrations are defined in
+`docs/ai/CLAUDE_MEM.md` and `docs/ai/MATT_POCOCK_SKILLS.md`; use them only when
+relevant and never let optional tooling block implementation.
 
 ## Mandatory AI quality gate
-
-Every coding runtime working on Levyra, including Codex, ChatGPT, Claude Code,
-Google Antigravity, OpenCode, and OpenClaw-delegated runtimes, must use the same
-repository gate:
-
+Use repository wrappers, never a system Gradle installation. Start with focused checks. Before commit run:
 ```bash
 python3 scripts/ai_quality_gate.py --profile fast
+```
+Before push or PR publication run:
+```bash
 python3 scripts/ai_quality_gate.py --profile full
 ```
+On Windows use the repository's `.bat` wrappers where applicable. Missing SDK,
+JDK, signing input, device/emulator, libvlc, WiX, network, or OS support is
+`BLOCKED`, never `PASS`. ChatGPT or another runtime without command execution
+must not claim these checks ran. CodeRabbit and other reviewers are
+supplementary evidence, not substitutes for deterministic validation.
 
-- Run `fast` before creating a commit.
-- Run `full` before push or pull-request publication. It selects Android,
-  Desktop, extractor, Bash, PowerShell, and repository checks from the complete
-  diff against the base branch.
-- ChatGPT or another runtime without command execution must include the exact
-  gate commands in its implementation handoff and must not claim validation;
-  the implementing runtime must run them.
-- `.github/workflows/pr-check.yml` runs the fast gate again before build jobs.
-- Missing tools, failed checks, unresolved findings, and skipped required
-  evidence are blocked, not passed.
-- CodeRabbit and other reviewers are supplementary. Convert every valid review
-  finding into a deterministic test or validator whenever practical.
-
-Do not bypass the gate with `--no-verify`, remove checks to obtain a green run,
-or treat an AI-authored review as independent proof. Publication authorization
-remains separate from validation.
-
-## Validation
-
-Use repository wrappers, never a system Gradle installation.
-
-Agent configuration checks from the repository root:
-
-```bash
-python3 scripts/validate_agent_config.py
-python3 scripts/validate_ai_efficiency.py
-python3 scripts/validate_matt_skills.py
-python3 scripts/validate_claude_mem.py
-```
-
-Android checks from the repository root:
-
-```bash
-./gradlew --no-daemon :app:testDebugUnitTest
-./gradlew --no-daemon :app:lintRelease
-./gradlew --no-daemon --no-configuration-cache assembleRelease
-git diff --check
-```
-
-Desktop checks from `desktop/`:
-
-```bash
-./gradlew check
-./gradlew assemble check
-```
-
-On Windows use `gradlew.bat`.
-
-Start with the narrowest relevant test. Missing SDKs, JDKs, signing inputs,
-libvlc, WiX, network, CI, emulator, device, or OS support are blocked checks,
-not passes. Never claim build, playback, device, Android Auto, notification,
-PiP, installer, update, protocol, media-key, native VLC, agent-configuration,
-review, or CI success without direct evidence.
-
-## Security and repository safety
-
-- Never commit or expose passwords, secrets, tokens, cookies, private URLs,
-  keystores, signing material, `.env`, or `local.properties`.
-- Never commit APKs, installers, ZIPs, build output, IDE state, native runtime
-  bundles, or temporary diagnostics unless explicitly required and accepted by
-  repository policy.
-- Validate provider-controlled URLs across scheme, host, port, user info,
-  DNS/IP destination, every redirect hop, MIME, timeout, filename/path, and
-  response-size bounds.
-- Treat Android Intent/deep-link/PendingIntent/component boundaries as untrusted
-  input paths and load `levyra-android-intent-security` plus
-  `levyra-security-review` before changing or auditing them.
-- Preserve least privilege in Android permissions, GitHub workflow permissions,
-  coding-agent tools, and OpenClaw agent allowlists.
-- Do not weaken transport, redirect, MIME, checksum, signature, host, component,
-  caller, or URI-grant validation to make one response pass.
-- Treat fork code, workflow inputs, downloaded artifacts, deep links, update
-  metadata, filenames, local IPC, and third-party skills as untrusted where
-  applicable.
-- Update credits and licenses when adding external code, assets, models,
-  libraries, native files, or design references.
-
-## Versions, releases, and external actions
-
-- Do not change Android or Desktop version values unless the task explicitly
-  requests that platform's release/version change.
-- Do not commit, push, open a pull request, merge, tag, publish, release, or
-  change repository settings without explicit authorization.
-- When publication is authorized, use a dedicated branch and draft pull request
-  by default. Push directly to `main` only when explicitly requested for the
-  exact scope.
-- When opening or updating a pull request, follow `.github/pull_request_template.md`
-  without dropping required sections. Fill every section truthfully, use `N/A`
-  where allowed, keep unperformed checks unmarked, and apply `levyra-humanizer`
-  as the final prose pass without changing facts or validation claims.
-- OpenClaw or any delegated coding runtime must not infer publication, merge,
-  tag, or release permission from an implementation request.
-- Keep PR descriptions and checklists truthful; leave manual/device checks
-  unmarked until actually performed.
+## Security and publication
+- Never expose or commit secrets, tokens, cookies, private URLs, keystores, signing material, `.env`, or `local.properties`.
+- Never weaken transport, redirect, MIME, checksum, signature, host, Android component, caller, or URI-grant validation just to make one case pass.
+- Do not commit generated APKs/installers/archives/build output unless explicitly required by repository policy and the task.
+- Commit, push, PR creation, merge, tag, release, deployment, version changes, external messages, and repository-setting changes require explicit owner authorization for the exact action and scope.
+- When PR publication is authorized, use a dedicated branch and draft PR by default, preserve `.github/pull_request_template.md`, keep checks truthful, and apply `levyra-humanizer` without changing facts.
 
 ## Delivery contract
-
-Report:
-
-- root cause or rationale;
-- exact files changed;
-- behavior preserved;
-- material assumptions/tradeoffs and simpler alternatives considered when
-  relevant;
-- tests and checks run with results;
-- skipped or blocked checks and why;
-- remaining risks and manual validation;
-- professional commit message when requested;
-- verified branch, commit, PR, merge, or release state when applicable.
-
-Never represent a plan as an applied patch or an unverified result as completed.
-Distinguish planned, edited, locally validated, committed, pushed, pull request
-opened, CI passed, reviewed, merged, and released.
+Keep these states distinct:
+`planned -> edited -> locally validated -> final diff reviewed -> committed -> pushed -> pull request opened -> CI passed -> independently reviewed -> merged -> released`
+Report rationale/root cause, exact files changed, behavior preserved, validation
+run, blocked/unrun checks, remaining risk, and verified publication state. Never
+represent a plan as an applied patch or an unverified result as complete.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# Levyra Claude Code
+
+@AGENTS.md
+
+Claude Code reads this file natively at project startup. The imported
+`AGENTS.md` is the cross-runtime Levyra contract and must be applied before
+repository work.
+
+Claude-specific settings, hooks, agents, and path rules live under
+`.agents/claude/` and may be projected locally to `.claude/`. Those runtime
+helpers strengthen this contract but are not required for this root bootstrap to
+work.
+
+Do not duplicate the imported engineering rules here. Keep this bridge short so
+startup context stays reliable and inexpensive.

--- a/scripts/tests/test_validate_agent_config.py
+++ b/scripts/tests/test_validate_agent_config.py
@@ -11,7 +11,7 @@ class TrackedRuntimePathsTest(unittest.TestCase):
     def test_git_os_error_is_reported(self) -> None:
         errors: list[str] = []
         with patch.object(validate_agent_config.subprocess, "run", side_effect=OSError("missing")):
-            self.assertEqual(validate_agent_config.tracked_root_runtime_paths(errors), [])
+            self.assertEqual(validate_agent_config.tracked_generated_runtime_paths(errors), [])
         self.assertIn("unable to inspect", errors[0])
 
     def test_git_timeout_is_reported(self) -> None:
@@ -21,14 +21,14 @@ class TrackedRuntimePathsTest(unittest.TestCase):
             "run",
             side_effect=subprocess.TimeoutExpired("git", 30),
         ):
-            self.assertEqual(validate_agent_config.tracked_root_runtime_paths(errors), [])
+            self.assertEqual(validate_agent_config.tracked_generated_runtime_paths(errors), [])
         self.assertIn("timed out", errors[0])
 
     def test_git_failure_is_reported(self) -> None:
         errors: list[str] = []
         result = Mock(returncode=128, stderr="fatal probe failure", stdout="")
         with patch.object(validate_agent_config.subprocess, "run", return_value=result):
-            self.assertEqual(validate_agent_config.tracked_root_runtime_paths(errors), [])
+            self.assertEqual(validate_agent_config.tracked_generated_runtime_paths(errors), [])
         self.assertIn("fatal probe failure", errors[0])
 
 

--- a/scripts/validate_agent_config.py
+++ b/scripts/validate_agent_config.py
@@ -14,6 +14,7 @@ CODEX_ROOT = ".agents/codex"
 
 REQUIRED_FILES = (
     "AGENTS.md",
+    "CLAUDE.md",
     "app/AGENTS.md",
     "desktop/AGENTS.md",
     ".github/AGENTS.md",
@@ -138,10 +139,10 @@ def reject_terms(
             errors.append(f"{relative_path}: contains {label}: {term}")
 
 
-def tracked_root_runtime_paths(errors: list[str]) -> list[str]:
+def tracked_generated_runtime_paths(errors: list[str]) -> list[str]:
     try:
         result = subprocess.run(
-            ["git", "ls-files", "--", "CLAUDE.md", ".claude", ".codex"],
+            ["git", "ls-files", "--", ".claude", ".codex"],
             cwd=ROOT,
             check=False,
             text=True,
@@ -172,12 +173,20 @@ def main() -> int:
         if (ROOT / relative_path).exists():
             errors.append(f"obsolete root planning file must be removed: {relative_path}")
 
-    tracked_adapters = tracked_root_runtime_paths(errors)
+    tracked_adapters = tracked_generated_runtime_paths(errors)
     if tracked_adapters:
         errors.append(
-            "root CLAUDE.md/.claude/.codex runtime surfaces must not be tracked; canonical sources belong under .agents: "
+            "generated .claude/.codex runtime surfaces must not be tracked; canonical sources belong under .agents: "
             + ", ".join(tracked_adapters)
         )
+
+    root_claude_path = ROOT / "CLAUDE.md"
+    if root_claude_path.is_file():
+        root_claude = root_claude_path.read_text(encoding="utf-8")
+        if "@AGENTS.md" not in root_claude:
+            errors.append("CLAUDE.md: missing native @AGENTS.md import")
+        if len(root_claude_path.read_bytes()) > 1200:
+            errors.append("CLAUDE.md: native startup bridge must stay at or below 1200 bytes")
 
     duplicate_claude_skills = ROOT / CLAUDE_ROOT / "skills"
     if duplicate_claude_skills.exists():
@@ -215,6 +224,8 @@ def main() -> int:
     codex_instructions_path = ROOT / "AGENTS.md"
     if codex_instructions_path.is_file():
         codex_instructions = codex_instructions_path.read_text(encoding="utf-8")
+        if len(codex_instructions.splitlines()) > 200:
+            errors.append("AGENTS.md: compact always-loaded contract must stay at or below 200 lines")
         require_skill_references(
             errors, "AGENTS.md", codex_instructions, AUTOMATIC_ROUTED_SKILLS, "Codex"
         )
@@ -428,9 +439,9 @@ def main() -> int:
         return 1
 
     print(
-        "Agent configuration validation passed: one tracked .agents runtime tree, "
+        "Agent configuration validation passed: compact root contract, native Claude bridge, one tracked .agents runtime tree, "
         f"{len(actual_skills)} canonical skills, {len(referenced_skills)} documented skill references, "
-        f"{len(AUTOMATIC_ROUTED_SKILLS)} automatic cross-runtime routes, and no tracked root Claude/Codex runtime surfaces."
+        f"{len(AUTOMATIC_ROUTED_SKILLS)} automatic cross-runtime routes, and no tracked generated Claude/Codex runtime surfaces."
     )
     return 0
 

--- a/scripts/validate_ai_efficiency.py
+++ b/scripts/validate_ai_efficiency.py
@@ -18,6 +18,7 @@ CLAUDE_ROOT = ".agents/claude"
 CODEX_ROOT = ".agents/codex"
 
 REQUIRED_FILES = (
+    "CLAUDE.md",
     ".rtk/filters.toml",
     ".agents/README.md",
     ".agents/rules/levyra-workspace.md",
@@ -48,7 +49,6 @@ REQUIRED_FILES = (
 )
 
 FORBIDDEN_PATHS = (
-    "CLAUDE.md",
     "codex-home/ollama.config.toml",
     "codex-home/llamacpp.config.toml",
     f"{CODEX_ROOT}/ollama.config.toml",
@@ -165,10 +165,14 @@ def main() -> int:
             fail(errors, f"missing required AI-efficiency file: {relative_path}")
     for relative_path in FORBIDDEN_PATHS:
         if (ROOT / relative_path).exists():
-            if relative_path == "CLAUDE.md":
-                fail(errors, "root CLAUDE.md must stay absent; canonical Claude instructions live under .agents/claude")
-            else:
-                fail(errors, f"local-model profile is outside the approved scope: {relative_path}")
+            fail(errors, f"local-model profile is outside the approved scope: {relative_path}")
+
+    require_terms(
+        errors,
+        "CLAUDE.md",
+        "native Claude startup bridge",
+        ("@AGENTS.md", "Claude Code reads this file natively", "Keep this bridge short"),
+    )
 
     skill_path = ROOT / ".agents/skills/levyra-context-efficiency/SKILL.md"
     if skill_path.is_file():
@@ -382,9 +386,9 @@ def main() -> int:
         return 1
 
     print(
-        "AI efficiency validation passed: canonical .agents runtime layout, "
+        "AI efficiency validation passed: native compact Claude bridge, canonical .agents runtime layout, "
         f"{len(EXPECTED_FILTERS)} project filters, {len(EXPECTED_PLUGINS)} verified plugin, "
-        "cross-runtime security routing, dependency-review preflight, and no root Claude bridge or local-model profiles."
+        "cross-runtime security routing, dependency-review preflight, and no local-model profiles."
     )
     return 0
 

--- a/scripts/validate_claude_bootstrap.py
+++ b/scripts/validate_claude_bootstrap.py
@@ -51,8 +51,22 @@ def reject_terms(relative_path: str, terms: tuple[str, ...], errors: list[str]) 
 def main() -> int:
     errors: list[str] = []
 
-    if (ROOT / "CLAUDE.md").exists():
-        errors.append("root CLAUDE.md must stay absent; canonical Claude sources live under .agents/claude")
+    root_claude = ROOT / "CLAUDE.md"
+    if not root_claude.is_file():
+        errors.append("root CLAUDE.md is required as Claude Code's native startup bridge")
+    else:
+        text = root_claude.read_text(encoding="utf-8")
+        if "@AGENTS.md" not in text:
+            errors.append("root CLAUDE.md must import @AGENTS.md")
+        if len(root_claude.read_bytes()) > 1200:
+            errors.append("root CLAUDE.md must stay at or below 1200 bytes")
+        if text.count("@AGENTS.md") != 1:
+            errors.append("root CLAUDE.md must contain exactly one @AGENTS.md import")
+
+    agents_path = ROOT / "AGENTS.md"
+    if agents_path.is_file() and len(agents_path.read_text(encoding="utf-8").splitlines()) > 200:
+        errors.append("AGENTS.md must stay at or below 200 lines for reliable Claude startup adherence")
+
     if (ROOT / CLAUDE_ROOT / "skills").exists():
         errors.append(".agents/claude/skills must stay absent; .agents/skills is the only tracked skill tree")
 
@@ -156,7 +170,21 @@ def main() -> int:
     )
     require_terms(
         f"{CLAUDE_ROOT}/hooks/user-prompt-submit.sh",
-        ("command -v python3", "command -v python", "command -v py", "Mandatory skill load", "Root AGENTS.md remains canonical", "EVIDENCE_GATED_COMPLETION.md", "levyra-project-manager", "levyra-desktop", "levyra-engineering", "levyra-openclaw-orchestrator"),
+        (
+            "command -v python3",
+            "command -v python",
+            "command -v py",
+            "Mandatory skill load",
+            "Root AGENTS.md remains canonical",
+            "EVIDENCE_GATED_COMPLETION.md",
+            "levyra-project-manager",
+            "levyra-desktop",
+            "levyra-engineering",
+            "levyra-openclaw-orchestrator",
+            "Levyra hard contract (re-anchored on every prompt)",
+            "root CLAUDE.md natively imports AGENTS.md",
+            "smallest coherent root-cause fix",
+        ),
         errors,
     )
     require_terms(
@@ -198,8 +226,9 @@ def main() -> int:
         return 1
 
     print(
-        "Claude bootstrap validation passed: canonical .agents/claude config, native projection contract, "
-        "shared skill projection contract, direct canonical hooks, evidence gates, jCodeMunch, and permission safety verified."
+        "Claude bootstrap validation passed: native root CLAUDE.md -> AGENTS.md startup chain, "
+        "canonical .agents/claude config, prompt re-anchoring, shared skill projection, evidence gates, "
+        "jCodeMunch, and permission safety verified."
     )
     return 0
 

--- a/scripts/validate_matt_skills.py
+++ b/scripts/validate_matt_skills.py
@@ -82,10 +82,17 @@ def main() -> int:
             if required not in canonical:
                 errors.append(f"canonical real-engineering contract is missing: {required}")
 
+    # Root AGENTS.md is intentionally a compact router. Detailed issue/domain and
+    # Matt Pocock procedures live in their canonical docs instead of being
+    # duplicated in always-loaded context.
     require(
         errors,
         "AGENTS.md",
-        ("## Agent skills", "### Issue tracker", "docs/agents/issue-tracker.md", "### Domain docs", "docs/agents/domain.md", "## Matt Pocock skills bootstrap", "levyra-real-engineering"),
+        (
+            "## Automatic skill routing",
+            "levyra-real-engineering",
+            "docs/ai/MATT_POCOCK_SKILLS.md",
+        ),
     )
     require(errors, "docs/agents/issue-tracker.md", ("LUC4N3X/Levyra-deepsound", "owner explicitly authorizes", "PRs as a request surface: no"))
     require(errors, "docs/agents/domain.md", ("CONTEXT.md", "docs/adr/", "created lazily"))
@@ -145,7 +152,7 @@ def main() -> int:
         return 1
 
     print(
-        "Matt skills integration validation passed: upstream setup substrate, one canonical .agents skill tree, "
+        "Matt skills integration validation passed: compact root router, upstream setup substrate, one canonical .agents skill tree, "
         "Claude skill projection, Codex bootstrap, ChatGPT routing, and Antigravity routing verified."
     )
     return 0


### PR DESCRIPTION
## Summary

Makes Levyra's coding-agent instructions load more reliably while reducing always-on context. Claude Code now has a tiny native root bootstrap that imports the shared repository contract, and the Claude prompt hook re-anchors the essential rules on every user turn instead of relying on the model to discover them voluntarily.

The shared `AGENTS.md` was also reduced from a handbook-sized file to a compact routing contract, leaving detailed procedures in the existing scoped docs and skills.

## What changed

- Added a tracked root `CLAUDE.md` that natively imports `@AGENTS.md`.
- Reduced `AGENTS.md` to a compact always-loaded contract under the enforced line budget.
- Slimmed Claude-specific instructions to runtime-only guidance instead of duplicating the full repository contract.
- Hardened `UserPromptSubmit` so every Claude prompt receives a compact hard-contract reminder plus task-matched skill routing, with a static fallback when Python is unavailable.
- Updated agent documentation to describe the layered startup chain.
- Updated validators so CI requires the root Claude bridge, enforces its size/import, and enforces the root `AGENTS.md` context budget.
- Aligned the Matt-skills validator and runtime-path unit tests with the compact-router architecture instead of forcing obsolete duplicated sections back into always-loaded context.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor or maintenance
- [ ] UI or UX change
- [ ] Localization or accessibility
- [x] Build, CI, packaging, or release change
- [x] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Shared infrastructure
- **Area:** Build and release / Documentation

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [x] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

GitHub Actions has passed the updated **AI Quality Gate**, including the repository agent validators and script-test suite, on the current head. Dependency Review also passed. The broader PR workflow is still running its normal build/test stages. No Android or Desktop production code is changed.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| GitHub diff review | Compared the branch against current `main` | 4 focused commits, 11 expected agent/docs/test files, no app/desktop production files |
| Claude bootstrap design | Checked against current Claude Code documentation | Root `CLAUDE.md` import + per-prompt `additionalContext` use supported native mechanisms |
| GitHub Actions | AI Quality Gate on current head | Passed |
| GitHub Actions | Dependency Review on current head | Passed |

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** Existing `.agents/claude/` runtime projection remains supported. The new root bridge removes the requirement that it already exist before Claude can receive the shared contract.
- **Known limitations:** The remaining broader PR workflow stages are still running.
- **Rollback plan:** Revert this PR

## Reviewer notes

- The most important behavior is the layered fallback: native root `CLAUDE.md` -> imported `AGENTS.md` -> per-prompt hard-contract re-anchor -> task-specific skill router.
- `AGENTS.md` is intentionally a router now. Detailed issue-tracker, domain-modeling, Matt-skills, security, and engineering procedures remain in their canonical docs/skills rather than being duplicated into startup context.
- Check the Claude prompt hook for stdin handling and the static fallback used when Python is unavailable.

## Release note

None

## Related issues

- N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [ ] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims
