### PR TITLE
ci: keep PR APK runtime config out of repository secrets

### DIFF
--- a/.github/workflows/apk-artifact-check.yml
+++ b/.github/workflows/apk-artifact-check.yml
@@ -21,7 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      YOUTUBE_INNERTUBE_API_KEY: ${{ secrets.YOUTUBE_INNERTUBE_API_KEY }}
       LEVYRA_KEYSTORE_FILE: app/levyra-release.jks
       LEVYRA_KEYSTORE_PASSWORD: ${{ secrets.LEVYRA_KEYSTORE_PASSWORD }}
       LEVYRA_KEY_ALIAS: ${{ secrets.LEVYRA_KEY_ALIAS }}
@@ -80,6 +79,24 @@ jobs:
             echo "SOURCE_REF=${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
           } >> "${GITHUB_ENV}"
 
+      - name: Resolve Public Runtime Config
+        shell: bash
+        run: |
+          set -euo pipefail
+          YOUTUBE_KEY="$(python3 - <<'PY'
+          import pathlib
+          import re
+
+          source = pathlib.Path('app/build.gradle.kts').read_text(encoding='utf-8')
+          match = re.search(r'val\s+publicYoutubeInnertubeApiKey\s*=\s*"([^"]+)"', source)
+          if match is None or not match.group(1).strip():
+              raise SystemExit('Public InnerTube client identifier is missing from app/build.gradle.kts')
+          print(match.group(1).strip())
+          PY
+          )"
+          test -n "${YOUTUBE_KEY}"
+          echo "YOUTUBE_INNERTUBE_API_KEY=${YOUTUBE_KEY}" >> "${GITHUB_ENV}"
+
       - name: Prepare Release Signing
         shell: bash
         env:
@@ -131,6 +148,7 @@ jobs:
             echo "versionCode=${VERSION_CODE}"
             echo "pullRequest=${PR_NUMBER}"
             echo "signingProfile=release-pr-diagnostics"
+            echo "runtimeConfig=public-innertube-client"
             echo "diagnosticsMarker=LEVYRA_PR_DIAGNOSTICS_V1"
             echo "commit=${GITHUB_SHA}"
             echo "branch=${SOURCE_REF}"


### PR DESCRIPTION
## Summary

PR diagnostics APKs should keep working like normal Levyra builds without compiling a private repository secret into the app. This changes the APK artifact workflow to reuse the public InnerTube client identifier already tracked by the Android build instead of reading `YOUTUBE_INNERTUBE_API_KEY` from GitHub Secrets.

Signing stays unchanged. The keystore secrets are still used only by the build job to sign the diagnostics APK and are not copied into the artifact.

## What changed

- Removed `secrets.YOUTUBE_INNERTUBE_API_KEY` from the PR APK job environment.
- Resolve the public InnerTube client identifier directly from the existing `publicYoutubeInnertubeApiKey` value in `app/build.gradle.kts`.
- Keep the existing signed PR diagnostics APK flow and record `runtimeConfig=public-innertube-client` in its build metadata.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor or maintenance
- [ ] UI or UX change
- [ ] Localization or accessibility
- [x] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Shared infrastructure
- **Area:** Build and release

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [ ] Targeted tests were added or updated
- [x] Not applicable, with the reason explained below

This is a focused workflow-only change. Local repository execution is unavailable in this ChatGPT environment, so the repository quality gate and APK build are left to PR CI and are not claimed as passed here.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| N/A | Workflow-only change | Not run locally |

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** None
- **Known limitations:** The diagnostics APK still depends on the existing signing secrets for its release-style signature.
- **Rollback plan:** Revert this PR

## Reviewer notes

- The public InnerTube identifier is already version-controlled in `app/build.gradle.kts` for the source-rebuild path. This workflow now reuses that same value instead of introducing another copy.
- The owner-only, same-repository PR condition and artifact naming remain unchanged.

## Release note

None

## Related issues

- Closes #
- Related to #

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated APK artifact verification to use the application’s publicly configured YouTube runtime settings.
  - Build information now identifies the runtime configuration used during artifact generation.
  - APK artifact checks continue to validate builds using the resolved configuration automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->