### PR TITLE
privacy: harden SponsorBlock lookups and artwork quality

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraArtworkCache.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraArtworkCache.kt
@@ -81,7 +81,10 @@ internal fun isLikelyArtworkBytes(bytes: ByteArray): Boolean {
     return false
 }
 
-private val FullResolutionAppleArtworkSizePattern = Regex("/\\d+x\\d+bb(?=[.-])")
+private const val FULL_RESOLUTION_ARTWORK_SIZE = 1200
+private val FullResolutionAppleArtworkSizePattern = Regex("/(\\d+)x(\\d+)bb(?=[.-])")
+private val FullResolutionGoogleWidthHeightPattern = Regex("=w(\\d+)-h(\\d+)")
+private val FullResolutionGoogleSquarePattern = Regex("=s(\\d+)")
 
 internal fun fullResolutionArtworkUrl(url: String): String {
     val clean = url.trim()
@@ -91,17 +94,40 @@ internal fun fullResolutionArtworkUrl(url: String): String {
     return when {
         lower.contains("i.scdn.co/image/ab67616d00001e02") ->
             clean.replace("ab67616d00001e02", "ab67616d0000b273", ignoreCase = true)
-        lower.contains("mzstatic.com/") ->
-            clean.replace("{w}", "1200", ignoreCase = true)
-                .replace("{h}", "1200", ignoreCase = true)
-                .replace(FullResolutionAppleArtworkSizePattern, "/1200x1200bb")
+        lower.contains("mzstatic.com/") -> upgradeAppleArtworkUrl(clean)
         lower.contains("googleusercontent.com/") || lower.contains("ggpht.com/") ->
-            LevyraPersonalOrbit.upscaledArtworkUrl(clean)
+            if (googleArtworkAlreadyLargeEnough(clean)) clean else LevyraPersonalOrbit.upscaledArtworkUrl(clean)
         lower.contains("e-cdns-images.dzcdn.net/") ->
             clean.replace("/cover_medium/", "/cover_xl/", ignoreCase = true)
                 .replace("/cover_big/", "/cover_xl/", ignoreCase = true)
         else -> clean
     }
+}
+
+private fun upgradeAppleArtworkUrl(url: String): String {
+    val templated = url
+        .replace("{w}", FULL_RESOLUTION_ARTWORK_SIZE.toString(), ignoreCase = true)
+        .replace("{h}", FULL_RESOLUTION_ARTWORK_SIZE.toString(), ignoreCase = true)
+    if (templated != url) return templated
+
+    val match = FullResolutionAppleArtworkSizePattern.find(url) ?: return url
+    val width = match.groupValues[1].toIntOrNull() ?: return url
+    val height = match.groupValues[2].toIntOrNull() ?: return url
+    if (width >= FULL_RESOLUTION_ARTWORK_SIZE || height >= FULL_RESOLUTION_ARTWORK_SIZE) return url
+    return url.replaceRange(match.range, "/${FULL_RESOLUTION_ARTWORK_SIZE}x${FULL_RESOLUTION_ARTWORK_SIZE}bb")
+}
+
+private fun googleArtworkAlreadyLargeEnough(url: String): Boolean {
+    FullResolutionGoogleWidthHeightPattern.find(url)?.let { match ->
+        val width = match.groupValues[1].toIntOrNull() ?: return@let
+        val height = match.groupValues[2].toIntOrNull() ?: return@let
+        return width >= FULL_RESOLUTION_ARTWORK_SIZE || height >= FULL_RESOLUTION_ARTWORK_SIZE
+    }
+    FullResolutionGoogleSquarePattern.find(url)?.let { match ->
+        val size = match.groupValues[1].toIntOrNull() ?: return@let
+        return size >= FULL_RESOLUTION_ARTWORK_SIZE
+    }
+    return false
 }
 
 private class FullResolutionArtworkInterceptor : Interceptor {
@@ -281,6 +307,7 @@ object LevyraArtworkCache {
     private fun preloadRequest(context: Context, url: String): ImageRequest {
         return ImageRequest.Builder(context)
             .data(url)
+            .size(SMALL_SIZE)
             .memoryCachePolicy(CachePolicy.ENABLED)
             .diskCachePolicy(CachePolicy.ENABLED)
             .networkCachePolicy(CachePolicy.ENABLED)

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraArtworkCache.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraArtworkCache.kt
@@ -6,9 +6,11 @@ import android.content.pm.ApplicationInfo
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
 import coil3.disk.DiskCache
+import coil3.intercept.Interceptor
 import coil3.memory.MemoryCache
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
+import coil3.request.ImageResult
 import coil3.request.crossfade
 import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
 import com.luc4n3x.levyra.domain.LevyraPersonalOrbit
@@ -79,6 +81,41 @@ internal fun isLikelyArtworkBytes(bytes: ByteArray): Boolean {
     return false
 }
 
+private val FullResolutionAppleArtworkSizePattern = Regex("/\\d+x\\d+bb(?=[.-])")
+
+internal fun fullResolutionArtworkUrl(url: String): String {
+    val clean = url.trim()
+    if (!clean.startsWith("https://", ignoreCase = true)) return clean
+    if (clean.indexOf('?') >= 0) return clean
+    val lower = clean.lowercase()
+    return when {
+        lower.contains("i.scdn.co/image/ab67616d00001e02") ->
+            clean.replace("ab67616d00001e02", "ab67616d0000b273", ignoreCase = true)
+        lower.contains("mzstatic.com/") ->
+            clean.replace("{w}", "1200", ignoreCase = true)
+                .replace("{h}", "1200", ignoreCase = true)
+                .replace(FullResolutionAppleArtworkSizePattern, "/1200x1200bb")
+        lower.contains("googleusercontent.com/") || lower.contains("ggpht.com/") ->
+            LevyraPersonalOrbit.upscaledArtworkUrl(clean)
+        lower.contains("e-cdns-images.dzcdn.net/") ->
+            clean.replace("/cover_medium/", "/cover_xl/", ignoreCase = true)
+                .replace("/cover_big/", "/cover_xl/", ignoreCase = true)
+        else -> clean
+    }
+}
+
+private class FullResolutionArtworkInterceptor : Interceptor {
+    override suspend fun intercept(chain: Interceptor.Chain): ImageResult {
+        val source = chain.request.data as? String ?: return chain.proceed()
+        val upgraded = fullResolutionArtworkUrl(source)
+        if (upgraded == source) return chain.proceed()
+        val request = chain.request.newBuilder()
+            .data(upgraded)
+            .build()
+        return chain.withRequest(request).proceed()
+    }
+}
+
 object LevyraArtworkCache {
     private const val SMALL_SIZE = 192
     private const val LARGE_SIZE = 512
@@ -111,6 +148,9 @@ object LevyraArtworkCache {
                     memoryProfile.largeHeapEnabled
                 )
                 ImageLoader.Builder(appContext)
+                    .components {
+                        add(FullResolutionArtworkInterceptor())
+                    }
                     .memoryCache {
                         MemoryCache.Builder()
                             .maxSizeBytes(memoryCacheBytes)

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraArtworkCache.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraArtworkCache.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Request
 import okio.Path.Companion.toOkioPath
 import timber.log.Timber
@@ -90,19 +91,23 @@ internal fun fullResolutionArtworkUrl(url: String): String {
     val clean = url.trim()
     if (!clean.startsWith("https://", ignoreCase = true)) return clean
     if (clean.indexOf('?') >= 0) return clean
-    val lower = clean.lowercase()
+    val parsed = clean.toHttpUrlOrNull() ?: return clean
+    val host = parsed.host.lowercase()
     return when {
-        lower.contains("i.scdn.co/image/ab67616d00001e02") ->
+        host == "i.scdn.co" && parsed.encodedPath.contains("/image/ab67616d00001e02", ignoreCase = true) ->
             clean.replace("ab67616d00001e02", "ab67616d0000b273", ignoreCase = true)
-        lower.contains("mzstatic.com/") -> upgradeAppleArtworkUrl(clean)
-        lower.contains("googleusercontent.com/") || lower.contains("ggpht.com/") ->
+        isHostOrSubdomain(host, "mzstatic.com") -> upgradeAppleArtworkUrl(clean)
+        isHostOrSubdomain(host, "googleusercontent.com") || isHostOrSubdomain(host, "ggpht.com") ->
             if (googleArtworkAlreadyLargeEnough(clean)) clean else LevyraPersonalOrbit.upscaledArtworkUrl(clean)
-        lower.contains("e-cdns-images.dzcdn.net/") ->
+        host == "e-cdns-images.dzcdn.net" ->
             clean.replace("/cover_medium/", "/cover_xl/", ignoreCase = true)
                 .replace("/cover_big/", "/cover_xl/", ignoreCase = true)
         else -> clean
     }
 }
+
+private fun isHostOrSubdomain(host: String, domain: String): Boolean =
+    host == domain || host.endsWith(".$domain")
 
 private fun upgradeAppleArtworkUrl(url: String): String {
     val templated = url

--- a/app/src/main/java/com/luc4n3x/levyra/data/SponsorBlockRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/SponsorBlockRepository.kt
@@ -9,15 +9,12 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
 
-/**
- * SponsorBlock community segments (sponsor.ajay.app) so LEVYRA can auto-skip the
- * non-music parts of YouTube videos — sponsor reads, intros, outros, etc.
- */
 class SponsorBlockRepository internal constructor(
     private val fetcher: SponsorBlockHttpFetcher,
     private val clockMs: () -> Long
@@ -25,7 +22,6 @@ class SponsorBlockRepository internal constructor(
     constructor() : this(UrlConnectionSponsorBlockHttpFetcher(), System::currentTimeMillis)
 
     private val categories = listOf("sponsor", "selfpromo", "intro", "outro", "interaction", "music_offtopic", "preview")
-
     private val cache = object : java.util.LinkedHashMap<String, SponsorBlockCacheEntry>(128, 0.75f, true) {
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, SponsorBlockCacheEntry>?): Boolean {
             return size > SPONSORBLOCK_CACHE_LIMIT
@@ -38,7 +34,8 @@ class SponsorBlockRepository internal constructor(
 
         val catsJson = categories.joinToString(",", prefix = "[", postfix = "]") { "\"$it\"" }
         val cats = URLEncoder.encode(catsJson, "UTF-8")
-        val url = "https://sponsor.ajay.app/api/skipSegments?videoID=$videoId&categories=$cats"
+        val hashPrefix = sponsorBlockHashPrefix(videoId)
+        val url = "https://sponsor.ajay.app/api/skipSegments/$hashPrefix?categories=$cats"
 
         val response = try {
             fetcher.fetch(url)
@@ -59,19 +56,8 @@ class SponsorBlockRepository internal constructor(
             val input = response.body ?: return@withContext emptyList()
             val body = readUtf8Bounded(input, SPONSORBLOCK_MAX_RESPONSE_BYTES)
                 ?: return@withContext emptyList()
-            val array = runCatching { JSONArray(body) }.getOrNull() ?: return@withContext emptyList()
-            val parsed = buildList {
-                for (index in 0 until array.length()) {
-                    val item = array.optJSONObject(index) ?: continue
-                    val range = item.optJSONArray("segment") ?: continue
-                    if (range.length() < 2) continue
-                    val startMs = (range.optDouble(0, 0.0) * 1000).toLong()
-                    val endMs = (range.optDouble(1, 0.0) * 1000).toLong()
-                    if (endMs > startMs) {
-                        add(SponsorSegment(startMs, endMs, item.optString("category", "sponsor")))
-                    }
-                }
-            }.sortedBy { it.startMs }
+            val parsed = parseSponsorBlockSegments(body, videoId)
+                ?: return@withContext emptyList()
             publishSponsorBlockCacheResult(cache, videoId, parsed, clockMs())
         }
     }
@@ -86,6 +72,34 @@ internal data class SponsorBlockCacheEntry(
     val segments: List<SponsorSegment>,
     val expiresAtMs: Long
 )
+
+internal fun sponsorBlockHashPrefix(videoId: String): String =
+    MessageDigest.getInstance("SHA-256")
+        .digest(videoId.toByteArray(StandardCharsets.UTF_8))
+        .take(2)
+        .joinToString("") { "%02x".format(it) }
+
+internal fun parseSponsorBlockSegments(body: String, videoId: String): List<SponsorSegment>? {
+    val candidates = runCatching { JSONArray(body) }.getOrNull() ?: return null
+    for (candidateIndex in 0 until candidates.length()) {
+        val candidate = candidates.optJSONObject(candidateIndex) ?: continue
+        if (candidate.optString("videoID") != videoId) continue
+        val segments = candidate.optJSONArray("segments") ?: return emptyList()
+        return buildList {
+            for (index in 0 until segments.length()) {
+                val item = segments.optJSONObject(index) ?: continue
+                val range = item.optJSONArray("segment") ?: continue
+                if (range.length() < 2) continue
+                val startMs = (range.optDouble(0, 0.0) * 1000).toLong()
+                val endMs = (range.optDouble(1, 0.0) * 1000).toLong()
+                if (endMs > startMs) {
+                    add(SponsorSegment(startMs, endMs, item.optString("category", "sponsor")))
+                }
+            }
+        }.sortedBy { it.startMs }
+    }
+    return emptyList()
+}
 
 internal fun cachedSponsorBlockResult(
     cache: MutableMap<String, SponsorBlockCacheEntry>,

--- a/app/src/main/java/com/luc4n3x/levyra/data/SponsorBlockRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/SponsorBlockRepository.kt
@@ -77,7 +77,7 @@ internal fun sponsorBlockHashPrefix(videoId: String): String =
     MessageDigest.getInstance("SHA-256")
         .digest(videoId.toByteArray(StandardCharsets.UTF_8))
         .take(2)
-        .joinToString("") { "%02x".format(it) }
+        .joinToString("") { "%02x".format(it.toInt() and 0xff) }
 
 internal fun parseSponsorBlockSegments(body: String, videoId: String): List<SponsorSegment>? {
     val candidates = runCatching { JSONArray(body) }.getOrNull() ?: return null

--- a/app/src/main/java/com/luc4n3x/levyra/data/SponsorBlockRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/SponsorBlockRepository.kt
@@ -84,7 +84,7 @@ internal fun parseSponsorBlockSegments(body: String, videoId: String): List<Spon
     for (candidateIndex in 0 until candidates.length()) {
         val candidate = candidates.optJSONObject(candidateIndex) ?: continue
         if (candidate.optString("videoID") != videoId) continue
-        val segments = candidate.optJSONArray("segments") ?: return emptyList()
+        val segments = candidate.optJSONArray("segments") ?: return null
         return buildList {
             for (index in 0 until segments.length()) {
                 val item = segments.optJSONObject(index) ?: continue

--- a/app/src/main/java/com/luc4n3x/levyra/ui/PlayerArtworkPresentation.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/PlayerArtworkPresentation.kt
@@ -1,5 +1,6 @@
 package com.luc4n3x.levyra.ui
 
+import com.luc4n3x.levyra.data.fullResolutionArtworkUrl
 import com.luc4n3x.levyra.domain.LevyraPersonalOrbit
 import com.luc4n3x.levyra.domain.Track
 
@@ -12,24 +13,4 @@ internal fun preferredPlayerArtworkUrl(track: Track): String {
     return highResolutionPlayerArtworkUrl(albumArtwork ?: candidates.firstOrNull().orEmpty())
 }
 
-private val AppleArtworkSizePattern = Regex("/\\d+x\\d+bb(?=[.-])")
-
-internal fun highResolutionPlayerArtworkUrl(url: String): String {
-    val clean = url.trim()
-    if (!clean.startsWith("https://", ignoreCase = true)) return clean
-    val lower = clean.lowercase()
-    return when {
-        lower.contains("i.scdn.co/image/ab67616d00001e02") ->
-            clean.replace("ab67616d00001e02", "ab67616d0000b273", ignoreCase = true)
-        lower.contains("mzstatic.com/") ->
-            clean.replace("{w}", "1200", ignoreCase = true)
-                .replace("{h}", "1200", ignoreCase = true)
-                .replace(AppleArtworkSizePattern, "/1200x1200bb")
-        lower.contains("googleusercontent.com/") || lower.contains("ggpht.com/") ->
-            LevyraPersonalOrbit.upscaledArtworkUrl(clean)
-        lower.contains("e-cdns-images.dzcdn.net/") ->
-            clean.replace("/cover_medium/", "/cover_xl/", ignoreCase = true)
-                .replace("/cover_big/", "/cover_xl/", ignoreCase = true)
-        else -> clean
-    }
-}
+internal fun highResolutionPlayerArtworkUrl(url: String): String = fullResolutionArtworkUrl(url)

--- a/app/src/test/java/com/luc4n3x/levyra/data/SponsorBlockRepositoryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/SponsorBlockRepositoryTest.kt
@@ -65,6 +65,23 @@ class SponsorBlockRepositoryTest {
     }
 
     @Test
+    fun malformedMatchingCandidateIsNotNegativeCached() {
+        val fetcher = QueueSponsorBlockFetcher(
+            response(200, """[{"videoID":"video"}]"""),
+            response(200, """[{"videoID":"video","segments":[{"segment":[1.0,2.5],"category":"sponsor"}]}]""")
+        )
+        val repository = SponsorBlockRepository(fetcher) { 1_000L }
+
+        assertTrue(repositorySegments(repository, "video").isEmpty())
+        val refreshed = repositorySegments(repository, "video")
+
+        assertEquals(1, refreshed.size)
+        assertEquals(1_000L, refreshed.single().startMs)
+        assertEquals(2_500L, refreshed.single().endMs)
+        assertEquals(2, fetcher.calls)
+    }
+
+    @Test
     fun rateLimitAndServerFailuresAreNotCached() {
         val fetcher = QueueSponsorBlockFetcher(
             response(429),

--- a/app/src/test/java/com/luc4n3x/levyra/data/SponsorBlockRepositoryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/SponsorBlockRepositoryTest.kt
@@ -4,8 +4,9 @@ import com.luc4n3x.levyra.domain.SponsorSegment
 import java.io.ByteArrayInputStream
 import kotlinx.coroutines.CancellationException
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SponsorBlockRepositoryTest {
@@ -24,6 +25,43 @@ class SponsorBlockRepositoryTest {
         val bytes = body.toByteArray(Charsets.UTF_8)
 
         assertNull(readUtf8Bounded(ByteArrayInputStream(bytes), (bytes.size - 1).toLong()))
+    }
+
+    @Test
+    fun sponsorBlockHashPrefixMatchesOfficialKAnonymityExample() {
+        assertEquals("5f6b", sponsorBlockHashPrefix("dQw4w9WgXcQ"))
+    }
+
+    @Test
+    fun kAnonymousRequestDoesNotExposeVideoIdAndSelectsLocally() {
+        val videoId = "dQw4w9WgXcQ"
+        val fetcher = QueueSponsorBlockFetcher(
+            response(
+                200,
+                """[{"videoID":"other-video","segments":[{"segment":[9.0,10.0],"category":"intro"}]},{"videoID":"$videoId","segments":[{"segment":[1.0,2.5],"category":"sponsor"}]}]"""
+            )
+        )
+        val repository = SponsorBlockRepository(fetcher) { 1_000L }
+
+        val segments = repositorySegments(repository, videoId)
+
+        assertEquals(1, segments.size)
+        assertEquals(1_000L, segments.single().startMs)
+        assertEquals(2_500L, segments.single().endMs)
+        assertTrue(fetcher.urls.single().contains("/api/skipSegments/5f6b?"))
+        assertFalse(fetcher.urls.single().contains(videoId))
+    }
+
+    @Test
+    fun validPrefixResponseWithoutRequestedVideoIsNegativeCached() {
+        val fetcher = QueueSponsorBlockFetcher(
+            response(200, """[{"videoID":"different","segments":[]}]""")
+        )
+        val repository = SponsorBlockRepository(fetcher) { 1_000L }
+
+        assertTrue(repositorySegments(repository, "video").isEmpty())
+        assertTrue(repositorySegments(repository, "video").isEmpty())
+        assertEquals(1, fetcher.calls)
     }
 
     @Test
@@ -58,7 +96,7 @@ class SponsorBlockRepositoryTest {
         var now = 10_000L
         val fetcher = QueueSponsorBlockFetcher(
             response(404),
-            response(200, """[{"segment":[1.0,2.5],"category":"sponsor"}]""")
+            response(200, """[{"videoID":"video","segments":[{"segment":[1.0,2.5],"category":"sponsor"}]}]""")
         )
         val repository = SponsorBlockRepository(fetcher) { now }
 
@@ -128,11 +166,13 @@ class SponsorBlockRepositoryTest {
 
     private class QueueSponsorBlockFetcher(vararg responses: SponsorBlockHttpResponse) : SponsorBlockHttpFetcher {
         private val queue = responses.toMutableList()
+        val urls = mutableListOf<String>()
         var calls: Int = 0
             private set
 
         override fun fetch(url: String): SponsorBlockHttpResponse {
             calls += 1
+            urls += url
             return queue.removeAt(0)
         }
     }

--- a/app/src/test/java/com/luc4n3x/levyra/domain/ArtworkUrlUpgradeTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/domain/ArtworkUrlUpgradeTest.kt
@@ -78,6 +78,17 @@ class ArtworkUrlUpgradeTest {
     }
 
     @Test
+    fun fullResolutionPolicyNeverDownscalesBetterSources() {
+        val apple = "https://is1-ssl.mzstatic.com/image/thumb/Music/abc/1400x1400bb.jpg"
+        val googleWide = "https://lh3.googleusercontent.com/aAbBcC=w1600-h900-l90-rj"
+        val googleSquare = "https://yt3.ggpht.com/ytc/aAbBcC=s1600-c-k-c0x00ffffff-no-rj"
+
+        assertEquals(apple, fullResolutionArtworkUrl(apple))
+        assertEquals(googleWide, fullResolutionArtworkUrl(googleWide))
+        assertEquals(googleSquare, fullResolutionArtworkUrl(googleSquare))
+    }
+
+    @Test
     fun playerArtworkUsesTheSharedFullResolutionPolicy() {
         val url = "https://lh3.googleusercontent.com/aAbBcC=w640-h360"
         assertEquals(fullResolutionArtworkUrl(url), highResolutionPlayerArtworkUrl(url))

--- a/app/src/test/java/com/luc4n3x/levyra/domain/ArtworkUrlUpgradeTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/domain/ArtworkUrlUpgradeTest.kt
@@ -78,6 +78,19 @@ class ArtworkUrlUpgradeTest {
     }
 
     @Test
+    fun fullResolutionPolicyRejectsProviderLookingPathsOnOtherHosts() {
+        val spotify = "https://cdn.example/i.scdn.co/image/ab67616d00001e02abc"
+        val apple = "https://cdn.example/mzstatic.com/image/thumb/Music/abc/300x300bb.jpg"
+        val google = "https://cdn.example/googleusercontent.com/aAbBcC=w640-h360"
+        val deezer = "https://cdn.example/e-cdns-images.dzcdn.net/images/cover/example/cover_medium/image.jpg"
+
+        assertEquals(spotify, fullResolutionArtworkUrl(spotify))
+        assertEquals(apple, fullResolutionArtworkUrl(apple))
+        assertEquals(google, fullResolutionArtworkUrl(google))
+        assertEquals(deezer, fullResolutionArtworkUrl(deezer))
+    }
+
+    @Test
     fun fullResolutionPolicyNeverDownscalesBetterSources() {
         val apple = "https://is1-ssl.mzstatic.com/image/thumb/Music/abc/1400x1400bb.jpg"
         val googleWide = "https://lh3.googleusercontent.com/aAbBcC=w1600-h900-l90-rj"

--- a/app/src/test/java/com/luc4n3x/levyra/domain/ArtworkUrlUpgradeTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/domain/ArtworkUrlUpgradeTest.kt
@@ -1,5 +1,6 @@
 package com.luc4n3x.levyra.domain
 
+import com.luc4n3x.levyra.data.fullResolutionArtworkUrl
 import com.luc4n3x.levyra.ui.highResolutionPlayerArtworkUrl
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -41,6 +42,7 @@ class ArtworkUrlUpgradeTest {
     fun signedUrlsAreLeftExactlyAsTheyAre() {
         val signed = "https://lh3.googleusercontent.com/aAbBcC=w120-h120?sqp=-oaymwEdCJUDENAFSFXyq4qpAw&rs=AOn4CLA=x1"
         assertEquals(signed, LevyraPersonalOrbit.upscaledArtworkUrl(signed))
+        assertEquals(signed, fullResolutionArtworkUrl(signed))
         assertEquals(signed, highResolutionPlayerArtworkUrl(signed))
     }
 
@@ -48,6 +50,7 @@ class ArtworkUrlUpgradeTest {
     fun youtubeVideoFramesAreNotRewritten() {
         val url = "https://i.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg?sqp=-oaymwEcCNA&rs=AOn4CLA"
         assertEquals(url, LevyraPersonalOrbit.upscaledArtworkUrl(url))
+        assertEquals(url, fullResolutionArtworkUrl(url))
         assertEquals(url, highResolutionPlayerArtworkUrl(url))
     }
 
@@ -55,25 +58,32 @@ class ArtworkUrlUpgradeTest {
     fun urlsWithoutSizeTokenAreLeftUntouched() {
         val url = "https://lh3.googleusercontent.com/aAbBcC"
         assertEquals(url, LevyraPersonalOrbit.upscaledArtworkUrl(url))
+        assertEquals(url, fullResolutionArtworkUrl(url))
     }
 
     @Test
-    fun otherProvidersKeepTheirOwnUpgradeRules() {
+    fun fullResolutionPolicyUpgradesKnownArtworkProviders() {
         assertEquals(
             "https://i.scdn.co/image/ab67616d0000b273abc",
-            highResolutionPlayerArtworkUrl("https://i.scdn.co/image/ab67616d00001e02abc")
+            fullResolutionArtworkUrl("https://i.scdn.co/image/ab67616d00001e02abc")
         )
         assertEquals(
             "https://is1-ssl.mzstatic.com/image/thumb/Music/abc/1200x1200bb.jpg",
-            highResolutionPlayerArtworkUrl("https://is1-ssl.mzstatic.com/image/thumb/Music/abc/300x300bb.jpg")
+            fullResolutionArtworkUrl("https://is1-ssl.mzstatic.com/image/thumb/Music/abc/300x300bb.jpg")
+        )
+        assertEquals(
+            "https://e-cdns-images.dzcdn.net/images/cover/example/cover_xl/image.jpg",
+            fullResolutionArtworkUrl("https://e-cdns-images.dzcdn.net/images/cover/example/cover_medium/image.jpg")
         )
     }
 
     @Test
-    fun playerArtworkUsesTheSharedGoogleRule() {
+    fun playerArtworkUsesTheSharedFullResolutionPolicy() {
+        val url = "https://lh3.googleusercontent.com/aAbBcC=w640-h360"
+        assertEquals(fullResolutionArtworkUrl(url), highResolutionPlayerArtworkUrl(url))
         assertEquals(
             "https://lh3.googleusercontent.com/aAbBcC=w1200-h675",
-            highResolutionPlayerArtworkUrl("https://lh3.googleusercontent.com/aAbBcC=w640-h360")
+            highResolutionPlayerArtworkUrl(url)
         )
     }
 }


### PR DESCRIPTION
## Summary

This PR keeps the scope to two Android changes: SponsorBlock lookups no longer send the full YouTube video ID, and Coil now upgrades recognized artwork URLs to better source quality before decoding them for the UI.

The playback path, queue, download behavior, cache limits, and existing bounded memory policy are unchanged.

## What changed

- Switched SponsorBlock from the direct `videoID` endpoint to the recommended SHA-256 hash-prefix endpoint. Levyra sends only the first four hash characters, receives the matching candidate set, and selects the requested video locally.
- Kept SponsorBlock response-size limits, cancellation behavior, and valid positive/negative cache semantics intact. A malformed matching candidate is treated as a transient parse failure and is not negative-cached.
- Added a shared artwork URL policy for Spotify, Apple Music, Google/YouTube Music artwork hosts, and Deezer.
- Made the artwork policy monotonic: smaller known-provider sources are upgraded, while Apple or Google sources already at or above the 1200px quality target are never downscaled.
- Registered that policy once in Levyra's existing singleton Coil `ImageLoader`, so direct remote String image requests and existing artwork helpers use the same source-quality rule.
- Explicitly bound Home and priority preload decoding to the existing 192px small-artwork size. This preserves the warm cache behavior without allowing the global source upgrade to create oversized preload bitmap allocations.
- Kept the existing bounded memory/disk caches, persistent artwork bounds, and normal UI display-size decoding. Signed or queried URLs are left unchanged to avoid breaking provider signatures.
- Added focused regression coverage for k-anonymous SponsorBlock selection, malformed SponsorBlock candidates, provider artwork upgrades, signed URL preservation, and no-downscale behavior.
- README was reviewed but not changed because its existing SponsorBlock, privacy, and artwork descriptions remain accurate and do not document the old direct-ID lookup or a conflicting resolution policy.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Performance improvement
- [x] Refactor or maintenance
- [x] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** Player / Streaming / UI

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [x] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

The Android Gradle suite and repository quality-gate scripts were not executed locally in this tool session because there is no usable repository checkout/Gradle execution path here. GitHub Actions is running the repository checks against the current PR head. Desktop validation is not required by the diff because no Desktop or shared Desktop source is changed.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Physical Android device | Image-heavy browsing/player memory stability | Not run in this session |
| Physical Android device | SponsorBlock skip behavior against live videos | Not run in this session |

## Risk and compatibility

- **Risk level:** Medium
- **Compatibility or migration notes:** None
- **Known limitations:** Artwork source quality still depends on what each provider exposes. URLs carrying query parameters are intentionally not rewritten because they may be signed.
- **Rollback plan:** Revert this PR

## Reviewer notes

- `SponsorBlockRepository.kt` is the privacy-sensitive part: only the four-character SHA-256 prefix reaches the endpoint and candidate matching stays local.
- A matching SponsorBlock candidate without a valid `segments` array is not cached as an empty result, so a malformed/transient payload cannot suppress a later valid lookup.
- `LevyraArtworkCache.kt` owns the global Coil source-quality policy. Existing memory and disk cache bounds remain unchanged, and preloads explicitly decode at 192px to avoid reintroducing artwork memory pressure.
- The full-resolution policy upgrades known low-resolution provider URLs but leaves already-higher-resolution Apple and Google sources untouched.
- The player-specific high-resolution helper delegates to the shared policy instead of maintaining a second set of provider rules.

## Release note

SponsorBlock lookups now use a privacy-preserving hash prefix, while supported artwork providers use higher-quality source images without downscaling already-better artwork or inflating preload bitmap memory.

## Related issues

N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Artwork loading now automatically requests higher-resolution images from supported providers when available.
  * Player artwork uses the same full-resolution artwork handling for a more consistent viewing experience.

* **Bug Fixes**
  * SponsorBlock requests now use privacy-preserving video ID hash prefixes instead of sending complete video IDs.
  * SponsorBlock results are matched more reliably, including safer handling of invalid or unavailable responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->