### PR TITLE
explore: build richer genre discovery

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/ui/ExploreDestinationScreens.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/ExploreDestinationScreens.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -35,6 +36,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -45,12 +47,14 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import coil3.compose.AsyncImage
 import com.luc4n3x.levyra.domain.AlbumHit
+import com.luc4n3x.levyra.domain.ExploreCatalog
 import com.luc4n3x.levyra.domain.ExploreZone
 import com.luc4n3x.levyra.domain.Track
 import com.luc4n3x.levyra.ui.i18n.LevyraStrings
@@ -86,6 +90,20 @@ internal fun ExploreCollectionDestinationScreen(
     onPlayTrack: (Track) -> Unit
 ) {
     BackHandler(onBack = onBack)
+    val zone = remember(title, strings.code) {
+        ExploreCatalog.getZones(strings).firstOrNull { candidate -> candidate.label == title }
+    }
+    val rotationBucket = remember(title) {
+        exploreGenreRotationBucket(System.currentTimeMillis())
+    }
+    val editorial = remember(tracks, zone?.id, rotationBucket) {
+        buildExploreGenreEditorial(
+            tracks = tracks,
+            zoneId = zone?.id.orEmpty().ifBlank { title },
+            rotationBucket = rotationBucket
+        )
+    }
+
     ExploreDestinationSurface(
         title = title,
         subtitle = subtitle,
@@ -97,6 +115,7 @@ internal fun ExploreCollectionDestinationScreen(
                     modifier = Modifier
                         .size(42.dp)
                         .background(LevyraCyan, CircleShape)
+                        .semantics { role = Role.Button }
                         .clickable(onClick = onPlayAll),
                     contentAlignment = Alignment.Center
                 ) {
@@ -141,16 +160,91 @@ internal fun ExploreCollectionDestinationScreen(
                     top = contentPadding.calculateTopPadding() + 10.dp,
                     bottom = 130.dp
                 ),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                verticalArrangement = Arrangement.spacedBy(18.dp)
             ) {
                 item(key = "explore-collection-hero") {
                     ExploreCollectionHero(
                         title = title,
                         subtitle = subtitle,
-                        leadTrack = tracks.first()
+                        leadTrack = tracks.first(),
+                        zone = zone
                     )
                 }
-                items(tracks, key = { track -> "explore-destination-track-${track.id}" }) { track ->
+
+                if (editorial.featured.isNotEmpty()) {
+                    item(key = "explore-genre-popular-header") {
+                        ExploreGenreSectionHeader(strings.popularTracks)
+                    }
+                    item(key = "explore-genre-popular") {
+                        LazyRow(
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            contentPadding = PaddingValues(end = 4.dp)
+                        ) {
+                            items(
+                                items = editorial.featured,
+                                key = { track -> "explore-featured-${track.id}" }
+                            ) { track ->
+                                ExploreGenreTrackCard(
+                                    track = track,
+                                    isCurrent = track.id == currentTrackId,
+                                    onClick = { onPlayTrack(track) }
+                                )
+                            }
+                        }
+                    }
+                }
+
+                if (editorial.artists.isNotEmpty()) {
+                    item(key = "explore-genre-artists-header") {
+                        ExploreGenreSectionHeader(strings.artists)
+                    }
+                    item(key = "explore-genre-artists") {
+                        LazyRow(
+                            horizontalArrangement = Arrangement.spacedBy(14.dp),
+                            contentPadding = PaddingValues(end = 4.dp)
+                        ) {
+                            items(
+                                items = editorial.artists,
+                                key = { artist -> "explore-artist-${artist.key}" }
+                            ) { artist ->
+                                ExploreGenreArtistCard(
+                                    artist = artist,
+                                    onClick = { onPlayTrack(artist.track) }
+                                )
+                            }
+                        }
+                    }
+                }
+
+                if (editorial.albums.isNotEmpty()) {
+                    item(key = "explore-genre-albums-header") {
+                        ExploreGenreSectionHeader(strings.albumsPlain)
+                    }
+                    item(key = "explore-genre-albums") {
+                        LazyRow(
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            contentPadding = PaddingValues(end = 4.dp)
+                        ) {
+                            items(
+                                items = editorial.albums,
+                                key = { album -> "explore-album-${album.key}" }
+                            ) { album ->
+                                ExploreGenreAlbumCard(
+                                    album = album,
+                                    onClick = { onPlayTrack(album.track) }
+                                )
+                            }
+                        }
+                    }
+                }
+
+                item(key = "explore-genre-songs-header") {
+                    ExploreGenreSectionHeader(strings.songsPlain)
+                }
+                items(
+                    items = editorial.essentials,
+                    key = { track -> "explore-destination-track-${track.id}" }
+                ) { track ->
                     ExploreDestinationTrackRow(
                         track = track,
                         isCurrent = track.id == currentTrackId,
@@ -164,20 +258,186 @@ internal fun ExploreCollectionDestinationScreen(
 }
 
 @Composable
+private fun ExploreGenreSectionHeader(title: String) {
+    Text(
+        text = title,
+        color = LevyraText,
+        fontSize = 20.sp,
+        lineHeight = LevyraTypeRhythm.lineHeight(20.sp),
+        fontWeight = FontWeight.Black,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis
+    )
+}
+
+@Composable
+private fun ExploreGenreTrackCard(
+    track: Track,
+    isCurrent: Boolean,
+    onClick: () -> Unit
+) {
+    val artwork = track.largeThumbnailUrl.ifBlank { track.thumbnailUrl }
+    Column(
+        modifier = Modifier
+            .width(148.dp)
+            .semantics { role = Role.Button }
+            .clickable(onClick = onClick),
+        verticalArrangement = Arrangement.spacedBy(7.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(148.dp)
+                .clip(RoundedCornerShape(16.dp))
+                .background(LevyraPanel)
+                .border(
+                    BorderStroke(
+                        1.dp,
+                        if (isCurrent) LevyraCyan.copy(alpha = 0.72f) else Color.White.copy(alpha = 0.09f)
+                    ),
+                    RoundedCornerShape(16.dp)
+                )
+        ) {
+            AsyncImage(
+                model = artwork,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize()
+            )
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(8.dp)
+                    .size(34.dp)
+                    .background(if (isCurrent) LevyraCyan else LevyraBlack.copy(alpha = 0.78f), CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.PlayArrow,
+                    contentDescription = null,
+                    tint = if (isCurrent) LevyraBlack else Color.White,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        }
+        Text(
+            text = track.title,
+            color = LevyraText,
+            fontSize = 13.5.sp,
+            lineHeight = LevyraTypeRhythm.lineHeight(13.5.sp),
+            fontWeight = FontWeight.Bold,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+        Text(
+            text = track.artist,
+            color = LevyraMuted,
+            fontSize = 11.5.sp,
+            lineHeight = LevyraTypeRhythm.lineHeight(11.5.sp),
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun ExploreGenreArtistCard(
+    artist: ExploreGenreArtistCard,
+    onClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .width(116.dp)
+            .semantics { role = Role.Button }
+            .clickable(onClick = onClick),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        AsyncImage(
+            model = artist.artworkUrl,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(112.dp)
+                .clip(CircleShape)
+                .background(LevyraPanel)
+                .border(BorderStroke(1.dp, Color.White.copy(alpha = 0.10f)), CircleShape)
+        )
+        Text(
+            text = artist.name,
+            color = LevyraText,
+            fontSize = 12.5.sp,
+            lineHeight = LevyraTypeRhythm.lineHeight(12.5.sp),
+            fontWeight = FontWeight.Bold,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+private fun ExploreGenreAlbumCard(
+    album: ExploreGenreAlbumCard,
+    onClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .width(140.dp)
+            .semantics { role = Role.Button }
+            .clickable(onClick = onClick),
+        verticalArrangement = Arrangement.spacedBy(7.dp)
+    ) {
+        AsyncImage(
+            model = album.artworkUrl,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(140.dp)
+                .clip(RoundedCornerShape(14.dp))
+                .background(LevyraPanel)
+                .border(BorderStroke(1.dp, Color.White.copy(alpha = 0.09f)), RoundedCornerShape(14.dp))
+        )
+        Text(
+            text = album.title,
+            color = LevyraText,
+            fontSize = 13.sp,
+            lineHeight = LevyraTypeRhythm.lineHeight(13.sp),
+            fontWeight = FontWeight.Bold,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+        if (album.artist.isNotBlank()) {
+            Text(
+                text = album.artist,
+                color = LevyraMuted,
+                fontSize = 11.5.sp,
+                lineHeight = LevyraTypeRhythm.lineHeight(11.5.sp),
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+@Composable
 private fun ExploreCollectionHero(
     title: String,
     subtitle: String?,
-    leadTrack: Track
+    leadTrack: Track,
+    zone: ExploreZone?
 ) {
-    val accentStart = Color(leadTrack.accentStart)
-    val accentEnd = Color(leadTrack.accentEnd)
+    val accentStart = Color(zone?.accentStart ?: leadTrack.accentStart)
+    val accentEnd = Color(zone?.accentEnd ?: leadTrack.accentEnd)
     val artwork = leadTrack.largeThumbnailUrl.ifBlank { leadTrack.thumbnailUrl }
     val shape = RoundedCornerShape(24.dp)
 
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(188.dp)
+            .height(214.dp)
             .clip(shape)
             .background(Brush.linearGradient(listOf(accentStart, accentEnd)))
             .border(BorderStroke(1.dp, Color.White.copy(alpha = 0.12f)), shape)
@@ -190,7 +450,7 @@ private fun ExploreCollectionHero(
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
                     .fillMaxHeight()
-                    .width(184.dp)
+                    .width(204.dp)
             )
         }
         Box(
@@ -199,9 +459,9 @@ private fun ExploreCollectionHero(
                 .background(
                     Brush.horizontalGradient(
                         listOf(
-                            accentStart.copy(alpha = 0.98f),
-                            accentStart.copy(alpha = 0.90f),
-                            accentEnd.copy(alpha = 0.28f),
+                            accentStart.copy(alpha = 0.99f),
+                            accentStart.copy(alpha = 0.92f),
+                            accentEnd.copy(alpha = 0.36f),
                             Color.Transparent
                         )
                     )
@@ -212,22 +472,29 @@ private fun ExploreCollectionHero(
                 .fillMaxSize()
                 .background(
                     Brush.verticalGradient(
-                        listOf(Color.Transparent, LevyraBlack.copy(alpha = 0.48f))
+                        listOf(Color.Transparent, LevyraBlack.copy(alpha = 0.58f))
                     )
                 )
         )
+        zone?.emoji?.takeIf(String::isNotBlank)?.let { emoji ->
+            Text(
+                text = emoji,
+                fontSize = 24.sp,
+                modifier = Modifier.align(Alignment.TopStart).padding(18.dp)
+            )
+        }
         Column(
             modifier = Modifier
                 .align(Alignment.BottomStart)
-                .fillMaxWidth(0.72f)
+                .fillMaxWidth(0.74f)
                 .padding(18.dp),
             verticalArrangement = Arrangement.spacedBy(6.dp)
         ) {
             Text(
                 text = title,
                 color = Color.White,
-                fontSize = 26.sp,
-                lineHeight = LevyraTypeRhythm.lineHeight(26.sp),
+                fontSize = 28.sp,
+                lineHeight = LevyraTypeRhythm.lineHeight(28.sp),
                 fontWeight = FontWeight.Black,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
@@ -235,7 +502,7 @@ private fun ExploreCollectionHero(
             subtitle?.takeIf(String::isNotBlank)?.let { detail ->
                 Text(
                     text = detail,
-                    color = Color.White.copy(alpha = 0.78f),
+                    color = Color.White.copy(alpha = 0.82f),
                     fontSize = 12.5.sp,
                     lineHeight = LevyraTypeRhythm.lineHeight(12.5.sp),
                     fontWeight = FontWeight.SemiBold,
@@ -379,7 +646,7 @@ internal fun ExploreMoodsDestinationScreen(
             contentPadding = PaddingValues(
                 start = 18.dp,
                 end = 18.dp,
-                top = contentPadding.calculateTopPadding() + 12.dp,
+                top = contentPadding.calculateTopPadding() + 14.dp,
                 bottom = 130.dp
             ),
             verticalArrangement = Arrangement.spacedBy(12.dp)
@@ -559,55 +826,54 @@ private fun ExploreDestinationMoodCard(
     val shape = RoundedCornerShape(18.dp)
     Box(
         modifier = modifier
-            .height(108.dp)
+            .height(116.dp)
             .clip(shape)
             .background(
                 Brush.linearGradient(
                     listOf(
                         start.copy(alpha = 0.98f),
-                        end.copy(alpha = 0.88f),
+                        end.copy(alpha = 0.92f),
                         LevyraPanel.copy(alpha = 0.94f)
                     )
                 )
             )
-            .border(BorderStroke(1.dp, Color.White.copy(alpha = 0.12f)), shape)
+            .border(BorderStroke(1.dp, Color.White.copy(alpha = 0.13f)), shape)
             .semantics { role = Role.Button }
             .clickable(onClick = onClick)
     ) {
-        Box(
+        Text(
+            text = zone.emoji,
+            color = Color.White.copy(alpha = 0.92f),
+            fontSize = 44.sp,
+            lineHeight = 48.sp,
             modifier = Modifier
-                .align(Alignment.CenterEnd)
-                .padding(10.dp)
-                .size(70.dp)
-                .background(Color.Black.copy(alpha = 0.18f), RoundedCornerShape(20.dp)),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(
-                text = zone.emoji,
-                fontSize = 34.sp,
-                lineHeight = 38.sp
-            )
-        }
+                .align(Alignment.TopEnd)
+                .padding(top = 12.dp, end = 14.dp)
+        )
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .background(
                     Brush.horizontalGradient(
-                        listOf(Color.Black.copy(alpha = 0.18f), Color.Transparent)
+                        listOf(
+                            Color.Black.copy(alpha = 0.20f),
+                            Color.Black.copy(alpha = 0.06f),
+                            Color.Transparent
+                        )
                     )
                 )
         )
         Text(
             text = zone.label,
             color = Color.White,
-            fontSize = 16.sp,
-            lineHeight = LevyraTypeRhythm.lineHeight(16.sp),
+            fontSize = 16.5.sp,
+            lineHeight = LevyraTypeRhythm.lineHeight(16.5.sp),
             fontWeight = FontWeight.Black,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier
                 .align(Alignment.BottomStart)
-                .fillMaxWidth(0.72f)
+                .fillMaxWidth(0.78f)
                 .padding(14.dp)
         )
     }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/ExploreDestinationScreens.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/ExploreDestinationScreens.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -52,6 +53,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel as composeViewModel
 import coil3.compose.AsyncImage
 import com.luc4n3x.levyra.domain.AlbumHit
 import com.luc4n3x.levyra.domain.ExploreCatalog
@@ -64,10 +67,12 @@ import com.luc4n3x.levyra.ui.theme.LevyraMuted
 import com.luc4n3x.levyra.ui.theme.LevyraPanel
 import com.luc4n3x.levyra.ui.theme.LevyraText
 import com.luc4n3x.levyra.ui.theme.LevyraTypeRhythm
+import com.luc4n3x.levyra.viewmodel.ExploreViewModel
 
 internal const val ExploreNewReleasesDestination = "explore-destination-new-releases"
 internal const val ExploreMoodsDestination = "explore-destination-moods"
 private const val ExploreMoodDestinationPrefix = "explore-destination-mood:"
+private const val ExploreViewModelKey = "levyra-explore"
 private val ExploreDestinationHeaderHeight = 66.dp
 
 internal fun exploreMoodDestination(zoneId: String): String = "$ExploreMoodDestinationPrefix$zoneId"
@@ -93,15 +98,36 @@ internal fun ExploreCollectionDestinationScreen(
     val zone = remember(title, strings.code) {
         ExploreCatalog.getZones(strings).firstOrNull { candidate -> candidate.label == title }
     }
+    val exploreViewModel: ExploreViewModel = composeViewModel(key = ExploreViewModelKey)
+    val exploreState by exploreViewModel.state.collectAsStateWithLifecycle()
+    val useSelectedZoneTracks = zone != null && exploreState.exploreZoneId == zone.id
+    val destinationTracks = if (useSelectedZoneTracks) exploreState.exploreTracks else tracks
+    val destinationLoading = if (useSelectedZoneTracks) exploreState.isExploreLoading else isLoading
     val rotationBucket = remember(title) {
         exploreGenreRotationBucket(System.currentTimeMillis())
     }
-    val editorial = remember(tracks, zone?.id, rotationBucket) {
+    val editorial = remember(destinationTracks, zone?.id, rotationBucket) {
         buildExploreGenreEditorial(
-            tracks = tracks,
+            tracks = destinationTracks,
             zoneId = zone?.id.orEmpty().ifBlank { title },
             rotationBucket = rotationBucket
         )
+    }
+    val playAll: () -> Unit = {
+        if (useSelectedZoneTracks) {
+            destinationTracks.firstOrNull()?.let { first ->
+                exploreViewModel.playFrom(destinationTracks, first)
+            }
+        } else {
+            onPlayAll()
+        }
+    }
+    val playTrack: (Track) -> Unit = { track ->
+        if (useSelectedZoneTracks) {
+            exploreViewModel.playFrom(destinationTracks, track)
+        } else {
+            onPlayTrack(track)
+        }
     }
 
     ExploreDestinationSurface(
@@ -109,14 +135,14 @@ internal fun ExploreCollectionDestinationScreen(
         subtitle = subtitle,
         strings = strings,
         onBack = onBack,
-        trailing = if (tracks.isNotEmpty()) {
+        trailing = if (destinationTracks.isNotEmpty()) {
             {
                 Box(
                     modifier = Modifier
                         .size(42.dp)
                         .background(LevyraCyan, CircleShape)
                         .semantics { role = Role.Button }
-                        .clickable(onClick = onPlayAll),
+                        .clickable(onClick = playAll),
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
@@ -132,14 +158,14 @@ internal fun ExploreCollectionDestinationScreen(
         }
     ) { contentPadding ->
         when {
-            isLoading && tracks.isEmpty() -> Box(
+            destinationLoading && destinationTracks.isEmpty() -> Box(
                 modifier = Modifier.fillMaxSize().padding(contentPadding),
                 contentAlignment = Alignment.Center
             ) {
                 CircularProgressIndicator(color = LevyraCyan, strokeWidth = 3.dp)
             }
 
-            tracks.isEmpty() -> Box(
+            destinationTracks.isEmpty() -> Box(
                 modifier = Modifier.fillMaxSize().padding(contentPadding).padding(horizontal = 28.dp),
                 contentAlignment = Alignment.Center
             ) {
@@ -166,7 +192,7 @@ internal fun ExploreCollectionDestinationScreen(
                     ExploreCollectionHero(
                         title = title,
                         subtitle = subtitle,
-                        leadTrack = tracks.first(),
+                        leadTrack = destinationTracks.first(),
                         zone = zone
                     )
                 }
@@ -187,7 +213,7 @@ internal fun ExploreCollectionDestinationScreen(
                                 ExploreGenreTrackCard(
                                     track = track,
                                     isCurrent = track.id == currentTrackId,
-                                    onClick = { onPlayTrack(track) }
+                                    onClick = { playTrack(track) }
                                 )
                             }
                         }
@@ -209,7 +235,7 @@ internal fun ExploreCollectionDestinationScreen(
                             ) { artist ->
                                 ExploreGenreArtistCard(
                                     artist = artist,
-                                    onClick = { onPlayTrack(artist.track) }
+                                    onClick = { playTrack(artist.track) }
                                 )
                             }
                         }
@@ -231,7 +257,7 @@ internal fun ExploreCollectionDestinationScreen(
                             ) { album ->
                                 ExploreGenreAlbumCard(
                                     album = album,
-                                    onClick = { onPlayTrack(album.track) }
+                                    onClick = { playTrack(album.track) }
                                 )
                             }
                         }
@@ -249,7 +275,7 @@ internal fun ExploreCollectionDestinationScreen(
                         track = track,
                         isCurrent = track.id == currentTrackId,
                         isPlaying = isPlaying && track.id == currentTrackId,
-                        onClick = { onPlayTrack(track) }
+                        onClick = { playTrack(track) }
                     )
                 }
             }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/ExploreGenreEditorial.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/ExploreGenreEditorial.kt
@@ -1,0 +1,102 @@
+package com.luc4n3x.levyra.ui
+
+import com.luc4n3x.levyra.domain.Track
+
+internal const val ExploreGenreRotationWindowMs = 3L * 24L * 60L * 60L * 1000L
+
+internal data class ExploreGenreArtistCard(
+    val key: String,
+    val name: String,
+    val artworkUrl: String,
+    val track: Track
+)
+
+internal data class ExploreGenreAlbumCard(
+    val key: String,
+    val title: String,
+    val artist: String,
+    val artworkUrl: String,
+    val track: Track
+)
+
+internal data class ExploreGenreEditorial(
+    val featured: List<Track>,
+    val artists: List<ExploreGenreArtistCard>,
+    val albums: List<ExploreGenreAlbumCard>,
+    val essentials: List<Track>
+)
+
+internal fun exploreGenreRotationBucket(nowMs: Long): Long =
+    if (nowMs <= 0L) 0L else nowMs / ExploreGenreRotationWindowMs
+
+internal fun buildExploreGenreEditorial(
+    tracks: List<Track>,
+    zoneId: String,
+    rotationBucket: Long
+): ExploreGenreEditorial {
+    val uniqueTracks = tracks.distinctBy { it.id }
+    if (uniqueTracks.isEmpty()) {
+        return ExploreGenreEditorial(
+            featured = emptyList(),
+            artists = emptyList(),
+            albums = emptyList(),
+            essentials = emptyList()
+        )
+    }
+
+    val seed = 31 * zoneId.hashCode() + rotationBucket.hashCode()
+    val visualTracks = uniqueTracks.filter { track -> artworkUrl(track).isNotBlank() }
+    val featured = rotateFromSeed(visualTracks, seed).take(8)
+    val rotated = rotateFromSeed(uniqueTracks, seed xor 0x5A17)
+
+    val artists = rotated.asSequence()
+        .mapNotNull { track ->
+            val name = track.artist.trim()
+            val artwork = artworkUrl(track)
+            if (name.isBlank() || artwork.isBlank()) return@mapNotNull null
+            val browseId = track.artistBrowseIds.firstOrNull().orEmpty().trim()
+            ExploreGenreArtistCard(
+                key = browseId.ifBlank { name.lowercase() },
+                name = name,
+                artworkUrl = artwork,
+                track = track
+            )
+        }
+        .distinctBy { it.key }
+        .take(10)
+        .toList()
+
+    val albums = rotated.asSequence()
+        .mapNotNull { track ->
+            val title = track.album.trim()
+            val artwork = artworkUrl(track)
+            if (title.isBlank() || artwork.isBlank()) return@mapNotNull null
+            ExploreGenreAlbumCard(
+                key = track.albumBrowseId.trim().ifBlank { "${track.artist.trim().lowercase()}|${title.lowercase()}" },
+                title = title,
+                artist = track.artist.trim(),
+                artworkUrl = artwork,
+                track = track
+            )
+        }
+        .distinctBy { it.key }
+        .take(10)
+        .toList()
+
+    return ExploreGenreEditorial(
+        featured = featured,
+        artists = artists,
+        albums = albums,
+        essentials = uniqueTracks.take(18)
+    )
+}
+
+private fun artworkUrl(track: Track): String =
+    track.largeThumbnailUrl.trim().ifBlank { track.thumbnailUrl.trim() }
+
+private fun <T> rotateFromSeed(items: List<T>, seed: Int): List<T> {
+    if (items.size < 2) return items
+    val offset = Math.floorMod(seed, items.size)
+    if (offset == 0) return items
+    return items.drop(offset) + items.take(offset)
+}

--- a/app/src/main/java/com/luc4n3x/levyra/ui/ExploreLayout.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/ExploreLayout.kt
@@ -66,16 +66,18 @@ internal fun buildExploreRows(
         isFreshLoading -> ExploreRow.FreshLoading
         else -> ExploreRow.FreshEmpty
     }
-    if (hasSamples) {
-        rows += ExploreRow.Header(ExploreAnchor.Samples)
-        rows += ExploreRow.Samples
-    }
+
     val distinctZones = zones.distinctBy { it.id }
     if (distinctZones.isNotEmpty()) {
         rows += ExploreRow.Header(ExploreAnchor.Moods)
         distinctZones.chunked(2).forEach { pair ->
             rows += ExploreRow.MoodPair(pair.first(), pair.getOrNull(1))
         }
+    }
+
+    if (hasSamples) {
+        rows += ExploreRow.Header(ExploreAnchor.Samples)
+        rows += ExploreRow.Samples
     }
     return rows
 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCard.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCard.kt
@@ -6,10 +6,11 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -89,11 +90,11 @@ private val ExploreMoodItalianRapArtists = listOf(
     "Kid Yugi"
 )
 
-internal fun exploreMoodPortraitArtist(
+internal fun exploreMoodPortraitCandidates(
     zoneId: String,
     languageCode: String,
     rotationBucket: Long
-): String? {
+): List<String> {
     val language = languageCode.trim().lowercase().substringBefore('-').substringBefore('_')
     val candidates = when {
         zoneId == "local-wave" -> ExploreMoodLocalWaveArtistPools[language]
@@ -101,11 +102,18 @@ internal fun exploreMoodPortraitArtist(
         zoneId == "rap-drill" && language == "it" -> ExploreMoodItalianRapArtists
         else -> ExploreMoodGlobalArtistPools[zoneId]
     }.orEmpty()
-    if (candidates.isEmpty()) return null
+    if (candidates.isEmpty()) return emptyList()
     val base = Math.floorMod(31 * zoneId.hashCode() + language.hashCode(), candidates.size)
     val rotation = Math.floorMod(rotationBucket, candidates.size.toLong()).toInt()
-    return candidates[(base + rotation) % candidates.size]
+    val offset = (base + rotation) % candidates.size
+    return candidates.drop(offset) + candidates.take(offset)
 }
+
+internal fun exploreMoodPortraitArtist(
+    zoneId: String,
+    languageCode: String,
+    rotationBucket: Long
+): String? = exploreMoodPortraitCandidates(zoneId, languageCode, rotationBucket).firstOrNull()
 
 @Composable
 internal fun RowScope.ExploreMoodCard(
@@ -118,56 +126,63 @@ internal fun RowScope.ExploreMoodCard(
     val context = LocalContext.current
     val artworkRepository = remember(context) { SpotifyArtistArtworkRepository.get(context) }
     val rotationBucket = remember(zone.id) { exploreGenreRotationBucket(System.currentTimeMillis()) }
-    val portraitArtist = remember(zone.id, strings.code, rotationBucket) {
-        exploreMoodPortraitArtist(zone.id, strings.code, rotationBucket)
+    val portraitCandidates = remember(zone.id, strings.code, rotationBucket) {
+        exploreMoodPortraitCandidates(zone.id, strings.code, rotationBucket)
     }
-    var portraitUrl by remember(portraitArtist) { mutableStateOf("") }
+    var portraitUrl by remember(portraitCandidates) { mutableStateOf("") }
 
-    LaunchedEffect(portraitArtist, artworkRepository) {
+    LaunchedEffect(portraitCandidates, artworkRepository) {
         portraitUrl = ""
-        val artist = portraitArtist ?: return@LaunchedEffect
-        portraitUrl = ExploreMoodPortraitLookupSemaphore.withPermit {
-            artworkRepository.resolveArtistPortrait(artist)
+        val lookupLimit = if (zone.id == "rap-drill") 3 else 2
+        for (artist in portraitCandidates.take(lookupLimit)) {
+            val resolved = ExploreMoodPortraitLookupSemaphore.withPermit {
+                artworkRepository.resolveArtistPortrait(artist)
+            }
+            if (resolved.isNotBlank()) {
+                portraitUrl = resolved
+                break
+            }
         }
     }
 
     val accentStart = Color(zone.accentStart)
     val accentEnd = Color(zone.accentEnd)
     val shape = RoundedCornerShape(18.dp)
-    val fallbackBrush = remember(accentStart, accentEnd) {
+    val backgroundBrush = remember(accentStart, accentEnd) {
         Brush.linearGradient(
             listOf(
-                accentStart.copy(alpha = 0.62f),
-                accentEnd.copy(alpha = 0.42f),
-                LevyraPanel
+                LevyraPanel,
+                accentStart.copy(alpha = 0.26f),
+                accentEnd.copy(alpha = 0.18f)
             )
         )
     }
-    val artworkScrim = remember(accentStart, accentEnd) {
+    val imageScrim = remember(accentStart) {
         Brush.horizontalGradient(
             colorStops = arrayOf(
-                0f to accentStart.copy(alpha = 0.96f),
-                0.42f to accentStart.copy(alpha = 0.78f),
-                0.70f to accentEnd.copy(alpha = 0.30f),
-                1f to Color.Black.copy(alpha = 0.12f)
+                0f to LevyraPanel,
+                0.34f to LevyraPanel.copy(alpha = 0.94f),
+                0.58f to accentStart.copy(alpha = 0.38f),
+                0.80f to Color.Transparent,
+                1f to Color.Transparent
             )
         )
     }
-    val lowerScrim = remember {
+    val bottomScrim = remember {
         Brush.verticalGradient(
             listOf(
                 Color.Transparent,
-                Color.Black.copy(alpha = 0.18f),
-                Color.Black.copy(alpha = 0.58f)
+                Color.Transparent,
+                Color.Black.copy(alpha = 0.36f)
             )
         )
     }
     val outlineBrush = remember(accentStart, accentEnd, isSelected) {
         Brush.linearGradient(
             listOf(
-                accentStart.copy(alpha = if (isSelected) 0.98f else 0.72f),
-                accentEnd.copy(alpha = if (isSelected) 0.82f else 0.42f),
-                Color.White.copy(alpha = if (isSelected) 0.22f else 0.10f)
+                accentStart.copy(alpha = if (isSelected) 0.96f else 0.54f),
+                accentEnd.copy(alpha = if (isSelected) 0.72f else 0.30f),
+                Color.White.copy(alpha = if (isSelected) 0.18f else 0.08f)
             )
         )
     }
@@ -175,9 +190,9 @@ internal fun RowScope.ExploreMoodCard(
     Box(
         modifier = Modifier
             .weight(1f)
-            .height(104.dp)
+            .height(108.dp)
             .clip(shape)
-            .background(fallbackBrush)
+            .background(backgroundBrush)
             .border(
                 BorderStroke(if (isSelected) 1.5.dp else 1.dp, outlineBrush),
                 shape
@@ -200,35 +215,39 @@ internal fun RowScope.ExploreMoodCard(
                 model = portraitUrl,
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
-                alignment = Alignment.CenterEnd,
-                modifier = Modifier.fillMaxSize()
+                alignment = Alignment.Center,
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .fillMaxHeight()
+                    .fillMaxWidth(0.72f)
             )
         } else {
             Text(
                 text = zone.emoji,
-                color = Color.White.copy(alpha = 0.38f),
-                fontSize = 44.sp,
+                color = Color.White.copy(alpha = 0.28f),
+                fontSize = 42.sp,
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
-                    .padding(end = 14.dp)
+                    .padding(end = 16.dp)
             )
         }
 
-        Box(modifier = Modifier.fillMaxSize().background(artworkScrim))
-        Box(modifier = Modifier.fillMaxSize().background(lowerScrim))
+        Box(modifier = Modifier.fillMaxSize().background(imageScrim))
+        Box(modifier = Modifier.fillMaxSize().background(bottomScrim))
 
         Column(
             modifier = Modifier
                 .align(Alignment.BottomStart)
-                .padding(start = 14.dp, end = 10.dp, bottom = 13.dp),
+                .fillMaxWidth(0.78f)
+                .padding(start = 14.dp, end = 8.dp, bottom = 13.dp),
             horizontalAlignment = Alignment.Start
         ) {
             Box(
                 modifier = Modifier
-                    .width(26.dp)
+                    .width(if (isSelected) 30.dp else 22.dp)
                     .height(3.dp)
                     .clip(RoundedCornerShape(50))
-                    .background(accentEnd.copy(alpha = 0.95f))
+                    .background(if (isSelected) Color.White else accentEnd.copy(alpha = 0.92f))
             )
             Text(
                 text = zone.label,
@@ -239,17 +258,6 @@ internal fun RowScope.ExploreMoodCard(
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.padding(top = 7.dp)
-            )
-        }
-
-        if (isSelected) {
-            Box(
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(10.dp)
-                    .size(7.dp)
-                    .clip(RoundedCornerShape(50))
-                    .background(Color.White.copy(alpha = 0.92f))
             )
         }
     }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCard.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCard.kt
@@ -47,7 +47,7 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 
 private val ExploreMoodPortraitLookupSemaphore = Semaphore(2)
-private const val ExploreRapFallbackPortraitUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Eminem_in_2021.jpg/500px-Eminem_in_2021.jpg"
+private const val ExploreRapFallbackPortraitUrl = "https://upload.wikimedia.org/wikipedia/commons/5/54/Eminem_in_2021.jpg"
 
 private val ExploreMoodGlobalArtistPools = mapOf(
     "nuove-uscite" to listOf("Billie Eilish", "The Weeknd", "Sabrina Carpenter", "Bruno Mars"),
@@ -168,14 +168,16 @@ internal fun RowScope.ExploreMoodCard(
     }
     val hardFallbackPortraitUrl = remember(zone.id) { exploreMoodHardFallbackPortraitUrl(zone.id) }
     var portraitCandidateIndex by remember(portraitCandidates) { mutableStateOf(0) }
-    var portraitUrl by remember(portraitCandidates) { mutableStateOf("") }
+    var portraitUrl by remember(portraitCandidates, hardFallbackPortraitUrl) {
+        mutableStateOf(hardFallbackPortraitUrl)
+    }
 
     LaunchedEffect(portraitCandidates, portraitCandidateIndex, portraitLookupLimit, artworkRepository) {
         if (portraitCandidateIndex >= portraitLookupLimit) {
             portraitUrl = hardFallbackPortraitUrl
             return@LaunchedEffect
         }
-        portraitUrl = ""
+        if (hardFallbackPortraitUrl.isBlank()) portraitUrl = ""
         val resolved = ExploreMoodPortraitLookupSemaphore.withPermit {
             artworkRepository.resolveArtistPortrait(portraitCandidates[portraitCandidateIndex])
         }
@@ -260,8 +262,10 @@ internal fun RowScope.ExploreMoodCard(
                 alignment = Alignment.Center,
                 onError = {
                     if (portraitUrl == activePortraitUrl) {
-                        portraitUrl = ""
-                        if (activePortraitUrl != hardFallbackPortraitUrl) {
+                        if (activePortraitUrl == hardFallbackPortraitUrl) {
+                            portraitUrl = ""
+                        } else {
+                            portraitUrl = hardFallbackPortraitUrl
                             portraitCandidateIndex = (portraitCandidateIndex + 1).coerceAtMost(portraitLookupLimit)
                         }
                     }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCard.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCard.kt
@@ -47,11 +47,12 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 
 private val ExploreMoodPortraitLookupSemaphore = Semaphore(2)
+private const val ExploreRapFallbackPortraitUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Eminem_in_2021.jpg/500px-Eminem_in_2021.jpg"
 
 private val ExploreMoodGlobalArtistPools = mapOf(
     "nuove-uscite" to listOf("Billie Eilish", "The Weeknd", "Sabrina Carpenter", "Bruno Mars"),
     "local-wave" to listOf("Dua Lipa", "The Weeknd", "Billie Eilish", "Bad Bunny"),
-    "rap-drill" to listOf("Central Cee", "Travis Scott", "21 Savage", "Don Toliver"),
+    "rap-drill" to listOf("Eminem", "50 Cent", "Central Cee", "Travis Scott", "21 Savage", "Don Toliver"),
     "elettronica" to listOf("Fred again..", "Peggy Gou", "Calvin Harris", "David Guetta"),
     "pop-global" to listOf("Dua Lipa", "Billie Eilish", "Sabrina Carpenter", "Ariana Grande"),
     "rnb-soul" to listOf("SZA", "The Weeknd", "Brent Faiyaz", "Tems"),
@@ -145,6 +146,9 @@ internal fun exploreMoodPortraitLookupLimit(zoneId: String, candidateCount: Int)
     return requested.coerceAtMost(candidateCount.coerceAtLeast(0))
 }
 
+internal fun exploreMoodHardFallbackPortraitUrl(zoneId: String): String =
+    if (zoneId == "rap-drill") ExploreRapFallbackPortraitUrl else ""
+
 @Composable
 internal fun RowScope.ExploreMoodCard(
     zone: ExploreZone,
@@ -162,12 +166,13 @@ internal fun RowScope.ExploreMoodCard(
     val portraitLookupLimit = remember(zone.id, portraitCandidates.size) {
         exploreMoodPortraitLookupLimit(zone.id, portraitCandidates.size)
     }
+    val hardFallbackPortraitUrl = remember(zone.id) { exploreMoodHardFallbackPortraitUrl(zone.id) }
     var portraitCandidateIndex by remember(portraitCandidates) { mutableStateOf(0) }
     var portraitUrl by remember(portraitCandidates) { mutableStateOf("") }
 
     LaunchedEffect(portraitCandidates, portraitCandidateIndex, portraitLookupLimit, artworkRepository) {
         if (portraitCandidateIndex >= portraitLookupLimit) {
-            portraitUrl = ""
+            portraitUrl = hardFallbackPortraitUrl
             return@LaunchedEffect
         }
         portraitUrl = ""
@@ -256,7 +261,9 @@ internal fun RowScope.ExploreMoodCard(
                 onError = {
                     if (portraitUrl == activePortraitUrl) {
                         portraitUrl = ""
-                        portraitCandidateIndex = (portraitCandidateIndex + 1).coerceAtMost(portraitLookupLimit)
+                        if (activePortraitUrl != hardFallbackPortraitUrl) {
+                            portraitCandidateIndex = (portraitCandidateIndex + 1).coerceAtMost(portraitLookupLimit)
+                        }
                     }
                 },
                 modifier = Modifier

--- a/app/src/main/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCard.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCard.kt
@@ -96,13 +96,38 @@ internal fun exploreMoodPortraitCandidates(
     rotationBucket: Long
 ): List<String> {
     val language = languageCode.trim().lowercase().substringBefore('-').substringBefore('_')
-    val candidates = when {
+    val primary = when {
         zoneId == "local-wave" -> ExploreMoodLocalWaveArtistPools[language]
             ?: ExploreMoodGlobalArtistPools[zoneId]
         zoneId == "rap-drill" && language == "it" -> ExploreMoodItalianRapArtists
         else -> ExploreMoodGlobalArtistPools[zoneId]
     }.orEmpty()
-    if (candidates.isEmpty()) return emptyList()
+    if (primary.isEmpty()) return emptyList()
+
+    val rotatedPrimary = rotateExploreMoodCandidates(
+        candidates = primary,
+        zoneId = zoneId,
+        language = language,
+        rotationBucket = rotationBucket
+    )
+    if (zoneId != "rap-drill" || language != "it") return rotatedPrimary
+
+    val globalFallback = ExploreMoodGlobalArtistPools[zoneId].orEmpty()
+    return buildList {
+        addAll(rotatedPrimary.take(3))
+        addAll(globalFallback.take(2))
+        addAll(rotatedPrimary.drop(3))
+        addAll(globalFallback.drop(2))
+    }.distinct()
+}
+
+private fun rotateExploreMoodCandidates(
+    candidates: List<String>,
+    zoneId: String,
+    language: String,
+    rotationBucket: Long
+): List<String> {
+    if (candidates.size < 2) return candidates
     val base = Math.floorMod(31 * zoneId.hashCode() + language.hashCode(), candidates.size)
     val rotation = Math.floorMod(rotationBucket, candidates.size.toLong()).toInt()
     val offset = (base + rotation) % candidates.size
@@ -133,7 +158,7 @@ internal fun RowScope.ExploreMoodCard(
 
     LaunchedEffect(portraitCandidates, artworkRepository) {
         portraitUrl = ""
-        val lookupLimit = if (zone.id == "rap-drill") 3 else 2
+        val lookupLimit = if (zone.id == "rap-drill") 5 else 2
         for (artist in portraitCandidates.take(lookupLimit)) {
             val resolved = ExploreMoodPortraitLookupSemaphore.withPermit {
                 artworkRepository.resolveArtistPortrait(artist)

--- a/app/src/main/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCard.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCard.kt
@@ -1,0 +1,256 @@
+package com.luc4n3x.levyra.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import com.luc4n3x.levyra.data.SpotifyArtistArtworkRepository
+import com.luc4n3x.levyra.domain.ExploreZone
+import com.luc4n3x.levyra.ui.components.LevyraPressScale
+import com.luc4n3x.levyra.ui.components.levyraPressable
+import com.luc4n3x.levyra.ui.i18n.LocalLevyraStrings
+import com.luc4n3x.levyra.ui.theme.LevyraPanel
+import com.luc4n3x.levyra.ui.theme.LevyraTypeRhythm
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+
+private val ExploreMoodPortraitLookupSemaphore = Semaphore(2)
+
+private val ExploreMoodGlobalArtistPools = mapOf(
+    "nuove-uscite" to listOf("Billie Eilish", "The Weeknd", "Sabrina Carpenter", "Bruno Mars"),
+    "local-wave" to listOf("Dua Lipa", "The Weeknd", "Billie Eilish", "Bad Bunny"),
+    "rap-drill" to listOf("Central Cee", "Travis Scott", "21 Savage", "Don Toliver"),
+    "elettronica" to listOf("Fred again..", "Peggy Gou", "Calvin Harris", "David Guetta"),
+    "pop-global" to listOf("Dua Lipa", "Billie Eilish", "Sabrina Carpenter", "Ariana Grande"),
+    "rnb-soul" to listOf("SZA", "The Weeknd", "Brent Faiyaz", "Tems"),
+    "rock-alt" to listOf("Måneskin", "Arctic Monkeys", "Paramore", "Linkin Park"),
+    "latino" to listOf("Bad Bunny", "KAROL G", "Rauw Alejandro", "Feid"),
+    "lofi-chill" to listOf("Joji", "Laufey", "beabadoobee", "keshi"),
+    "anime-jpop" to listOf("Ado", "YOASOBI", "LiSA", "Kenshi Yonezu")
+)
+
+private val ExploreMoodLocalWaveArtistPools = mapOf(
+    "it" to listOf("Annalisa", "Mahmood", "Elodie", "Lazza", "Geolier"),
+    "es" to listOf("Rosalía", "Quevedo", "Aitana", "Rels B"),
+    "fr" to listOf("Aya Nakamura", "GIMS", "Tiakola", "Angèle"),
+    "de" to listOf("Apache 207", "Nina Chuba", "AYLIVA", "Luciano"),
+    "pt" to listOf("Anitta", "Pedro Sampaio", "Luísa Sonza", "WIU"),
+    "ro" to listOf("INNA", "The Motans", "Irina Rimes", "Delia"),
+    "tr" to listOf("Ezhel", "Mabel Matiz", "Simge", "UZI"),
+    "ru" to listOf("JONY", "Zivert", "MACAN", "Miyagi & Andy Panda"),
+    "ar" to listOf("Wegz", "Marwan Pablo", "ElGrandeToto", "Saint Levant"),
+    "zh" to listOf("Jay Chou", "G.E.M.", "Lexie Liu", "Joker Xue"),
+    "ja" to listOf("YOASOBI", "Ado", "Fujii Kaze", "Kenshi Yonezu"),
+    "ko" to listOf("aespa", "IVE", "Stray Kids", "NewJeans"),
+    "hi" to listOf("Arijit Singh", "Diljit Dosanjh", "Badshah", "AP Dhillon"),
+    "id" to listOf("NIKI", "Rich Brian", "Pamungkas", "Mahalini"),
+    "vi" to listOf("Sơn Tùng M-TP", "tlinh", "HIEUTHUHAI", "Mỹ Anh"),
+    "th" to listOf("MILLI", "Jeff Satur", "Tilly Birds", "PP Krit"),
+    "fil" to listOf("BINI", "SB19", "Zack Tabudlo", "Lola Amour"),
+    "he" to listOf("Noa Kirel", "Omer Adam", "Eden Hason", "Tuna")
+)
+
+private val ExploreMoodItalianRapArtists = listOf(
+    "Sfera Ebbasta",
+    "Shiva",
+    "Geolier",
+    "Tony Boy",
+    "Kid Yugi"
+)
+
+internal fun exploreMoodPortraitArtist(
+    zoneId: String,
+    languageCode: String,
+    rotationBucket: Long
+): String? {
+    val language = languageCode.trim().lowercase().substringBefore('-').substringBefore('_')
+    val candidates = when {
+        zoneId == "local-wave" -> ExploreMoodLocalWaveArtistPools[language]
+            ?: ExploreMoodGlobalArtistPools[zoneId]
+        zoneId == "rap-drill" && language == "it" -> ExploreMoodItalianRapArtists
+        else -> ExploreMoodGlobalArtistPools[zoneId]
+    }.orEmpty()
+    if (candidates.isEmpty()) return null
+    val base = Math.floorMod(31 * zoneId.hashCode() + language.hashCode(), candidates.size)
+    val rotation = Math.floorMod(rotationBucket, candidates.size.toLong()).toInt()
+    return candidates[(base + rotation) % candidates.size]
+}
+
+@Composable
+internal fun RowScope.ExploreMoodCard(
+    zone: ExploreZone,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    onStartZoneMix: () -> Unit
+) {
+    val strings = LocalLevyraStrings.current
+    val context = LocalContext.current
+    val artworkRepository = remember(context) { SpotifyArtistArtworkRepository.get(context) }
+    val rotationBucket = remember(zone.id) { exploreGenreRotationBucket(System.currentTimeMillis()) }
+    val portraitArtist = remember(zone.id, strings.code, rotationBucket) {
+        exploreMoodPortraitArtist(zone.id, strings.code, rotationBucket)
+    }
+    var portraitUrl by remember(portraitArtist) { mutableStateOf("") }
+
+    LaunchedEffect(portraitArtist, artworkRepository) {
+        portraitUrl = ""
+        val artist = portraitArtist ?: return@LaunchedEffect
+        portraitUrl = ExploreMoodPortraitLookupSemaphore.withPermit {
+            artworkRepository.resolveArtistPortrait(artist)
+        }
+    }
+
+    val accentStart = Color(zone.accentStart)
+    val accentEnd = Color(zone.accentEnd)
+    val shape = RoundedCornerShape(18.dp)
+    val fallbackBrush = remember(accentStart, accentEnd) {
+        Brush.linearGradient(
+            listOf(
+                accentStart.copy(alpha = 0.62f),
+                accentEnd.copy(alpha = 0.42f),
+                LevyraPanel
+            )
+        )
+    }
+    val artworkScrim = remember(accentStart, accentEnd) {
+        Brush.horizontalGradient(
+            colorStops = arrayOf(
+                0f to accentStart.copy(alpha = 0.96f),
+                0.42f to accentStart.copy(alpha = 0.78f),
+                0.70f to accentEnd.copy(alpha = 0.30f),
+                1f to Color.Black.copy(alpha = 0.12f)
+            )
+        )
+    }
+    val lowerScrim = remember {
+        Brush.verticalGradient(
+            listOf(
+                Color.Transparent,
+                Color.Black.copy(alpha = 0.18f),
+                Color.Black.copy(alpha = 0.58f)
+            )
+        )
+    }
+    val outlineBrush = remember(accentStart, accentEnd, isSelected) {
+        Brush.linearGradient(
+            listOf(
+                accentStart.copy(alpha = if (isSelected) 0.98f else 0.72f),
+                accentEnd.copy(alpha = if (isSelected) 0.82f else 0.42f),
+                Color.White.copy(alpha = if (isSelected) 0.22f else 0.10f)
+            )
+        )
+    }
+
+    Box(
+        modifier = Modifier
+            .weight(1f)
+            .height(104.dp)
+            .clip(shape)
+            .background(fallbackBrush)
+            .border(
+                BorderStroke(if (isSelected) 1.5.dp else 1.dp, outlineBrush),
+                shape
+            )
+            .semantics(mergeDescendants = true) {
+                role = Role.Button
+                selected = isSelected
+            }
+            .levyraPressable(
+                onClick = onClick,
+                pressedScale = LevyraPressScale.Tile,
+                role = Role.Button,
+                onClickLabel = zone.label,
+                onLongClick = onStartZoneMix,
+                onLongClickLabel = strings.mixStartRadio
+            )
+    ) {
+        if (portraitUrl.isNotBlank()) {
+            AsyncImage(
+                model = portraitUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                alignment = Alignment.CenterEnd,
+                modifier = Modifier.fillMaxSize()
+            )
+        } else {
+            Text(
+                text = zone.emoji,
+                color = Color.White.copy(alpha = 0.38f),
+                fontSize = 44.sp,
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .padding(end = 14.dp)
+            )
+        }
+
+        Box(modifier = Modifier.fillMaxSize().background(artworkScrim))
+        Box(modifier = Modifier.fillMaxSize().background(lowerScrim))
+
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(start = 14.dp, end = 10.dp, bottom = 13.dp),
+            horizontalAlignment = Alignment.Start
+        ) {
+            Box(
+                modifier = Modifier
+                    .width(26.dp)
+                    .height(3.dp)
+                    .clip(RoundedCornerShape(50))
+                    .background(accentEnd.copy(alpha = 0.95f))
+            )
+            Text(
+                text = zone.label,
+                color = Color.White,
+                fontSize = 16.5.sp,
+                lineHeight = LevyraTypeRhythm.lineHeight(16.5.sp),
+                fontWeight = FontWeight.Black,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(top = 7.dp)
+            )
+        }
+
+        if (isSelected) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(10.dp)
+                    .size(7.dp)
+                    .clip(RoundedCornerShape(50))
+                    .background(Color.White.copy(alpha = 0.92f))
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCard.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCard.kt
@@ -140,6 +140,11 @@ internal fun exploreMoodPortraitArtist(
     rotationBucket: Long
 ): String? = exploreMoodPortraitCandidates(zoneId, languageCode, rotationBucket).firstOrNull()
 
+internal fun exploreMoodPortraitLookupLimit(zoneId: String, candidateCount: Int): Int {
+    val requested = if (zoneId == "rap-drill") 5 else 2
+    return requested.coerceAtMost(candidateCount.coerceAtLeast(0))
+}
+
 @Composable
 internal fun RowScope.ExploreMoodCard(
     zone: ExploreZone,
@@ -154,19 +159,25 @@ internal fun RowScope.ExploreMoodCard(
     val portraitCandidates = remember(zone.id, strings.code, rotationBucket) {
         exploreMoodPortraitCandidates(zone.id, strings.code, rotationBucket)
     }
+    val portraitLookupLimit = remember(zone.id, portraitCandidates.size) {
+        exploreMoodPortraitLookupLimit(zone.id, portraitCandidates.size)
+    }
+    var portraitCandidateIndex by remember(portraitCandidates) { mutableStateOf(0) }
     var portraitUrl by remember(portraitCandidates) { mutableStateOf("") }
 
-    LaunchedEffect(portraitCandidates, artworkRepository) {
+    LaunchedEffect(portraitCandidates, portraitCandidateIndex, portraitLookupLimit, artworkRepository) {
+        if (portraitCandidateIndex >= portraitLookupLimit) {
+            portraitUrl = ""
+            return@LaunchedEffect
+        }
         portraitUrl = ""
-        val lookupLimit = if (zone.id == "rap-drill") 5 else 2
-        for (artist in portraitCandidates.take(lookupLimit)) {
-            val resolved = ExploreMoodPortraitLookupSemaphore.withPermit {
-                artworkRepository.resolveArtistPortrait(artist)
-            }
-            if (resolved.isNotBlank()) {
-                portraitUrl = resolved
-                break
-            }
+        val resolved = ExploreMoodPortraitLookupSemaphore.withPermit {
+            artworkRepository.resolveArtistPortrait(portraitCandidates[portraitCandidateIndex])
+        }
+        if (resolved.isBlank()) {
+            portraitCandidateIndex += 1
+        } else {
+            portraitUrl = resolved
         }
     }
 
@@ -236,11 +247,18 @@ internal fun RowScope.ExploreMoodCard(
             )
     ) {
         if (portraitUrl.isNotBlank()) {
+            val activePortraitUrl = portraitUrl
             AsyncImage(
-                model = portraitUrl,
+                model = activePortraitUrl,
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 alignment = Alignment.Center,
+                onError = {
+                    if (portraitUrl == activePortraitUrl) {
+                        portraitUrl = ""
+                        portraitCandidateIndex = (portraitCandidateIndex + 1).coerceAtMost(portraitLookupLimit)
+                    }
+                },
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
                     .fillMaxHeight()

--- a/app/src/test/java/com/luc4n3x/levyra/ui/ExploreGenreEditorialTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/ExploreGenreEditorialTest.kt
@@ -46,7 +46,7 @@ class ExploreGenreEditorialTest {
 
     @Test
     fun laterRotationWindowsCanSurfaceDifferentArtists() {
-        val tracks = (1..8).map { index ->
+        val tracks = (1..14).map { index ->
             track(
                 id = index.toString(),
                 artist = "Artist $index",
@@ -59,8 +59,9 @@ class ExploreGenreEditorialTest {
         val first = buildExploreGenreEditorial(tracks, "rap-drill", 1L)
         val later = buildExploreGenreEditorial(tracks, "rap-drill", 2L)
 
-        assertNotEquals(first.artists.map { it.key }, later.artists.map { it.key })
-        assertEquals(first.artists.map { it.key }.toSet(), later.artists.map { it.key }.toSet())
+        assertEquals(10, first.artists.size)
+        assertEquals(10, later.artists.size)
+        assertNotEquals(first.artists.map { it.key }.toSet(), later.artists.map { it.key }.toSet())
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/ui/ExploreGenreEditorialTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/ExploreGenreEditorialTest.kt
@@ -1,0 +1,116 @@
+package com.luc4n3x.levyra.ui
+
+import com.luc4n3x.levyra.domain.Track
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExploreGenreEditorialTest {
+    @Test
+    fun editorialDeduplicatesTracksArtistsAndAlbums() {
+        val tracks = listOf(
+            track("1", "Artist A", "Album A", "artist-a", "album-a"),
+            track("1", "Artist A", "Album A", "artist-a", "album-a"),
+            track("2", "Artist A", "Album A", "artist-a", "album-a"),
+            track("3", "Artist B", "Album B", "artist-b", "album-b")
+        )
+
+        val editorial = buildExploreGenreEditorial(tracks, "rap-drill", 4L)
+
+        assertEquals(listOf("1", "2", "3"), editorial.essentials.map { it.id })
+        assertEquals(2, editorial.artists.size)
+        assertEquals(2, editorial.albums.size)
+        assertEquals(editorial.artists.map { it.key }.toSet().size, editorial.artists.size)
+        assertEquals(editorial.albums.map { it.key }.toSet().size, editorial.albums.size)
+    }
+
+    @Test
+    fun rotationIsStableWithinTheSameWindow() {
+        val tracks = (1..8).map { index ->
+            track(
+                id = index.toString(),
+                artist = "Artist $index",
+                album = "Album $index",
+                artistBrowseId = "artist-$index",
+                albumBrowseId = "album-$index"
+            )
+        }
+
+        val first = buildExploreGenreEditorial(tracks, "rap-drill", 12L)
+        val second = buildExploreGenreEditorial(tracks, "rap-drill", 12L)
+
+        assertEquals(first.featured.map { it.id }, second.featured.map { it.id })
+        assertEquals(first.artists.map { it.key }, second.artists.map { it.key })
+    }
+
+    @Test
+    fun laterRotationWindowsCanSurfaceDifferentArtists() {
+        val tracks = (1..8).map { index ->
+            track(
+                id = index.toString(),
+                artist = "Artist $index",
+                album = "Album $index",
+                artistBrowseId = "artist-$index",
+                albumBrowseId = "album-$index"
+            )
+        }
+
+        val first = buildExploreGenreEditorial(tracks, "rap-drill", 1L)
+        val later = buildExploreGenreEditorial(tracks, "rap-drill", 2L)
+
+        assertNotEquals(first.artists.map { it.key }, later.artists.map { it.key })
+        assertEquals(first.artists.map { it.key }.toSet(), later.artists.map { it.key }.toSet())
+    }
+
+    @Test
+    fun editorialOmitsBlankArtistAlbumAndArtworkCards() {
+        val tracks = listOf(
+            track("1", "", "Album A", "", "album-a"),
+            track("2", "Artist B", "", "artist-b", ""),
+            track("3", "Artist C", "Album C", "artist-c", "album-c", artwork = "")
+        )
+
+        val editorial = buildExploreGenreEditorial(tracks, "pop-global", 3L)
+
+        assertTrue(editorial.featured.size <= 2)
+        assertEquals(1, editorial.artists.size)
+        assertEquals(1, editorial.albums.size)
+    }
+
+    @Test
+    fun rotationBucketsChangeOnlyEveryThreeDays() {
+        assertEquals(0L, exploreGenreRotationBucket(0L))
+        assertEquals(0L, exploreGenreRotationBucket(ExploreGenreRotationWindowMs - 1L))
+        assertEquals(1L, exploreGenreRotationBucket(ExploreGenreRotationWindowMs))
+    }
+
+    private fun track(
+        id: String,
+        artist: String,
+        album: String,
+        artistBrowseId: String,
+        albumBrowseId: String,
+        artwork: String = "https://lh3.googleusercontent.com/$id=w544-h544"
+    ): Track = Track(
+        id = id,
+        title = "Track $id",
+        artist = artist,
+        album = album,
+        durationMs = 180_000L,
+        streamUrl = "",
+        videoUrl = "",
+        thumbnailUrl = artwork,
+        largeThumbnailUrl = artwork,
+        source = "test",
+        moodTags = emptySet(),
+        energy = 50,
+        vocal = 50,
+        replayScore = 50,
+        cacheScore = 0,
+        accentStart = 0xFF202020.toInt(),
+        accentEnd = 0xFF404040.toInt(),
+        albumBrowseId = albumBrowseId,
+        artistBrowseIds = listOfNotNull(artistBrowseId.takeIf(String::isNotBlank))
+    )
+}

--- a/app/src/test/java/com/luc4n3x/levyra/ui/ExploreLayoutTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/ExploreLayoutTest.kt
@@ -29,6 +29,23 @@ class ExploreLayoutTest {
     }
 
     @Test
+    fun genresStayAheadOfSamplesInTheMainDiscoveryFlow() {
+        val rows = buildExploreRows(
+            zones = zones(4),
+            isFreshLoading = false,
+            hasFreshTracks = true,
+            hasSamples = true
+        )
+
+        val moodsIndex = exploreAnchorIndex(rows, ExploreAnchor.Moods)
+        val samplesIndex = exploreAnchorIndex(rows, ExploreAnchor.Samples)
+
+        assertTrue(moodsIndex >= 0)
+        assertTrue(samplesIndex > moodsIndex)
+        assertTrue(rows.subList(moodsIndex + 1, samplesIndex).any { row -> row is ExploreRow.MoodPair })
+    }
+
+    @Test
     fun newReleasesShortcutTargetsAnExistingCatalogZone() {
         assertEquals(ExploreCatalog.NEW_RELEASES_ZONE_ID, ExploreShortcut.NewReleases.zoneId)
         assertNull(ExploreShortcut.Samples.zoneId)

--- a/app/src/test/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCardTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCardTest.kt
@@ -44,11 +44,13 @@ class ExploreMoodArtworkCardTest {
 
         repeat(5) { bucket ->
             val candidates = exploreMoodPortraitCandidates("rap-drill", "it-IT", bucket.toLong())
+            val lookupLimit = exploreMoodPortraitLookupLimit("rap-drill", candidates.size)
 
             assertEquals(9, candidates.size)
             assertEquals(candidates.size, candidates.toSet().size)
+            assertEquals(5, lookupLimit)
             assertTrue(candidates.take(3).all { artist -> artist in italianRapArtists })
-            assertTrue(candidates.drop(3).take(2).all { artist -> artist in globalFallback })
+            assertTrue(candidates.take(lookupLimit).drop(3).all { artist -> artist in globalFallback })
         }
     }
 
@@ -58,6 +60,13 @@ class ExploreMoodArtworkCardTest {
         val candidates = exploreMoodPortraitCandidates("rap-drill", "it", 4L)
 
         assertTrue(candidates.containsAll(italianRapArtists))
+    }
+
+    @Test
+    fun lookupLimitNeverExceedsAvailableCandidates() {
+        assertEquals(0, exploreMoodPortraitLookupLimit("rap-drill", 0))
+        assertEquals(1, exploreMoodPortraitLookupLimit("rap-drill", 1))
+        assertEquals(2, exploreMoodPortraitLookupLimit("pop-global", 8))
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCardTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCardTest.kt
@@ -38,22 +38,26 @@ class ExploreMoodArtworkCardTest {
     }
 
     @Test
-    fun fallbackCandidatesKeepEveryArtistExactlyOnce() {
-        val candidates = exploreMoodPortraitCandidates("rap-drill", "it", 4L)
-
-        assertEquals(candidates.size, candidates.toSet().size)
-        assertEquals(5, candidates.size)
-    }
-
-    @Test
-    fun italianRapUsesItalianArtistPool() {
+    fun italianRapTriesGlobalRapFallbackBeforeExhaustingLocalPool() {
         val italianRapArtists = setOf("Sfera Ebbasta", "Shiva", "Geolier", "Tony Boy", "Kid Yugi")
+        val globalFallback = setOf("Central Cee", "Travis Scott")
 
         repeat(5) { bucket ->
             val candidates = exploreMoodPortraitCandidates("rap-drill", "it-IT", bucket.toLong())
-            assertTrue(candidates.isNotEmpty())
-            assertTrue(candidates.all { artist -> artist in italianRapArtists })
+
+            assertEquals(9, candidates.size)
+            assertEquals(candidates.size, candidates.toSet().size)
+            assertTrue(candidates.take(3).all { artist -> artist in italianRapArtists })
+            assertTrue(candidates.drop(3).take(2).all { artist -> artist in globalFallback })
         }
+    }
+
+    @Test
+    fun italianRapKeepsAllItalianArtistsAvailableAfterFallbacks() {
+        val italianRapArtists = setOf("Sfera Ebbasta", "Shiva", "Geolier", "Tony Boy", "Kid Yugi")
+        val candidates = exploreMoodPortraitCandidates("rap-drill", "it", 4L)
+
+        assertTrue(candidates.containsAll(italianRapArtists))
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCardTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCardTest.kt
@@ -1,0 +1,62 @@
+package com.luc4n3x.levyra.ui
+
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExploreMoodArtworkCardTest {
+    @Test
+    fun supportedGenresAlwaysHavePortraitCandidates() {
+        val zoneIds = listOf(
+            "nuove-uscite",
+            "local-wave",
+            "rap-drill",
+            "elettronica",
+            "pop-global",
+            "rnb-soul",
+            "rock-alt",
+            "latino",
+            "lofi-chill",
+            "anime-jpop"
+        )
+
+        zoneIds.forEach { zoneId ->
+            assertNotNull(exploreMoodPortraitArtist(zoneId, "it", 0L))
+        }
+    }
+
+    @Test
+    fun portraitChoiceRotatesBetweenWindows() {
+        val first = exploreMoodPortraitArtist("pop-global", "it", 3L)
+        val next = exploreMoodPortraitArtist("pop-global", "it", 4L)
+
+        assertNotEquals(first, next)
+    }
+
+    @Test
+    fun italianRapUsesItalianArtistPool() {
+        val italianRapArtists = setOf("Sfera Ebbasta", "Shiva", "Geolier", "Tony Boy", "Kid Yugi")
+
+        repeat(5) { bucket ->
+            val artist = exploreMoodPortraitArtist("rap-drill", "it-IT", bucket.toLong())
+            assertTrue(artist in italianRapArtists)
+        }
+    }
+
+    @Test
+    fun localWaveUsesLocalizedArtistPoolWhenAvailable() {
+        val italianArtists = setOf("Annalisa", "Mahmood", "Elodie", "Lazza", "Geolier")
+
+        repeat(5) { bucket ->
+            val artist = exploreMoodPortraitArtist("local-wave", "it", bucket.toLong())
+            assertTrue(artist in italianArtists)
+        }
+    }
+
+    @Test
+    fun unknownGenreDoesNotTriggerPortraitLookup() {
+        assertNull(exploreMoodPortraitArtist("unknown-zone", "it", 0L))
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCardTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCardTest.kt
@@ -65,8 +65,9 @@ class ExploreMoodArtworkCardTest {
     fun rapHasIndependentHardArtworkFallback() {
         val fallback = exploreMoodHardFallbackPortraitUrl("rap-drill")
 
-        assertTrue(fallback.startsWith("https://"))
+        assertTrue(fallback.startsWith("https://upload.wikimedia.org/wikipedia/commons/"))
         assertTrue(fallback.contains("Eminem", ignoreCase = true))
+        assertTrue(!fallback.contains("/thumb/"))
         assertEquals("", exploreMoodHardFallbackPortraitUrl("pop-global"))
     }
 

--- a/app/src/test/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCardTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCardTest.kt
@@ -38,19 +38,18 @@ class ExploreMoodArtworkCardTest {
     }
 
     @Test
-    fun italianRapTriesGlobalRapFallbackBeforeExhaustingLocalPool() {
+    fun italianRapTriesEminemAnd50CentBeforeExhaustingLocalPool() {
         val italianRapArtists = setOf("Sfera Ebbasta", "Shiva", "Geolier", "Tony Boy", "Kid Yugi")
-        val globalFallback = setOf("Central Cee", "Travis Scott")
 
         repeat(5) { bucket ->
             val candidates = exploreMoodPortraitCandidates("rap-drill", "it-IT", bucket.toLong())
             val lookupLimit = exploreMoodPortraitLookupLimit("rap-drill", candidates.size)
 
-            assertEquals(9, candidates.size)
+            assertEquals(11, candidates.size)
             assertEquals(candidates.size, candidates.toSet().size)
             assertEquals(5, lookupLimit)
             assertTrue(candidates.take(3).all { artist -> artist in italianRapArtists })
-            assertTrue(candidates.take(lookupLimit).drop(3).all { artist -> artist in globalFallback })
+            assertEquals(listOf("Eminem", "50 Cent"), candidates.take(lookupLimit).drop(3))
         }
     }
 
@@ -60,6 +59,15 @@ class ExploreMoodArtworkCardTest {
         val candidates = exploreMoodPortraitCandidates("rap-drill", "it", 4L)
 
         assertTrue(candidates.containsAll(italianRapArtists))
+    }
+
+    @Test
+    fun rapHasIndependentHardArtworkFallback() {
+        val fallback = exploreMoodHardFallbackPortraitUrl("rap-drill")
+
+        assertTrue(fallback.startsWith("https://"))
+        assertTrue(fallback.contains("Eminem", ignoreCase = true))
+        assertEquals("", exploreMoodHardFallbackPortraitUrl("pop-global"))
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCardTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/ExploreMoodArtworkCardTest.kt
@@ -1,5 +1,6 @@
 package com.luc4n3x.levyra.ui
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -24,6 +25,7 @@ class ExploreMoodArtworkCardTest {
 
         zoneIds.forEach { zoneId ->
             assertNotNull(exploreMoodPortraitArtist(zoneId, "it", 0L))
+            assertTrue(exploreMoodPortraitCandidates(zoneId, "it", 0L).size >= 4)
         }
     }
 
@@ -36,12 +38,21 @@ class ExploreMoodArtworkCardTest {
     }
 
     @Test
+    fun fallbackCandidatesKeepEveryArtistExactlyOnce() {
+        val candidates = exploreMoodPortraitCandidates("rap-drill", "it", 4L)
+
+        assertEquals(candidates.size, candidates.toSet().size)
+        assertEquals(5, candidates.size)
+    }
+
+    @Test
     fun italianRapUsesItalianArtistPool() {
         val italianRapArtists = setOf("Sfera Ebbasta", "Shiva", "Geolier", "Tony Boy", "Kid Yugi")
 
         repeat(5) { bucket ->
-            val artist = exploreMoodPortraitArtist("rap-drill", "it-IT", bucket.toLong())
-            assertTrue(artist in italianRapArtists)
+            val candidates = exploreMoodPortraitCandidates("rap-drill", "it-IT", bucket.toLong())
+            assertTrue(candidates.isNotEmpty())
+            assertTrue(candidates.all { artist -> artist in italianRapArtists })
         }
     }
 
@@ -50,13 +61,15 @@ class ExploreMoodArtworkCardTest {
         val italianArtists = setOf("Annalisa", "Mahmood", "Elodie", "Lazza", "Geolier")
 
         repeat(5) { bucket ->
-            val artist = exploreMoodPortraitArtist("local-wave", "it", bucket.toLong())
-            assertTrue(artist in italianArtists)
+            val candidates = exploreMoodPortraitCandidates("local-wave", "it", bucket.toLong())
+            assertTrue(candidates.isNotEmpty())
+            assertTrue(candidates.all { artist -> artist in italianArtists })
         }
     }
 
     @Test
     fun unknownGenreDoesNotTriggerPortraitLookup() {
         assertNull(exploreMoodPortraitArtist("unknown-zone", "it", 0L))
+        assertTrue(exploreMoodPortraitCandidates("unknown-zone", "it", 0L).isEmpty())
     }
 }


### PR DESCRIPTION
## Summary

This PR turns genre destinations into richer discovery pages instead of a hero followed by one long track list. Each genre now presents a more editorial mix of featured tracks, artists, albums, and songs while keeping the existing Explore navigation, playback flow, and catalog ownership intact.

The main genre grid is artwork-led but deliberately restrained: portraits sit on the visual side of the card while Levyra keeps a darker text surface, zone accents, and a clean fallback. The main Explore flow is also easier to scan, with genres placed before the Samples section instead of mixing the two discovery modes together.

## What changed

- Added a small presentation model that derives bounded editorial shelves from the selected genre payload.
- Added a stable three-day rotation bucket so featured content and artist ordering can change occasionally without reshuffling during ordinary recomposition or every screen open.
- Reworked genre destinations into a larger category-led hero followed by horizontal featured-track, artist, and album shelves plus the existing playable song list.
- Bound genre destinations to the active `ExploreViewModel` payload when the destination zone matches the selected zone, so the page and playback queue use `exploreTracks` instead of the unrelated fresh-release feed.
- Reworked the two-column genre cards with a cleaner split between text and portrait artwork, lighter scrims, zone accents, stronger typography, and a gradient/emoji fallback.
- Added locale-aware portrait rotation for the local discovery card and an Italian artist pool for Rap & Drill, while the other genres use bounded curated pools.
- Rap & Drill now tries three rotated Italian artists, then Eminem and 50 Cent, before giving up on dynamic portrait resolution.
- Added an independent final Eminem artwork fallback for Rap & Drill so the card no longer depends entirely on the artist resolver.
- Portrait fallback advances both when portrait resolution returns no URL and when Coil fails to load a resolved URL.
- Reused Levyra's existing cached artist artwork resolver instead of adding another account flow, token owner, or artwork cache.
- Kept portrait resolution capped at two concurrent lookups so entering Explore does not fan out decorative artwork work at once.
- Moved the Samples section below Mood and genres in the main Explore flow, keeping every existing shortcut and destination while making music discovery read more clearly.
- Kept the existing tap navigation and long-press genre radio action unchanged.
- Reused existing localized headings for popular tracks, artists, albums, and songs, so this change does not add new user-facing copy.
- Added focused unit coverage for editorial deduplication, stable rotation, sparse metadata, portrait availability, retry bounds, the Rap & Drill hard fallback, locale-specific pools, and Explore section hierarchy.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [x] Refactor or maintenance
- [x] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** UI / Explore

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [x] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

The Android Gradle suite and repository quality-gate scripts were not run locally in this tool session because there is no usable repository checkout or Gradle execution path here. GitHub Actions is validating the published branch. Desktop validation is not required by the diff because no Desktop source is changed.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Android device/emulator | Open Explore and inspect artist-led genre cards, fallback state, scrolling, tap navigation, and long-press radio | Not run after the latest fix |
| Android device/emulator | Verify Rap & Drill tries Eminem / 50 Cent and then the independent Eminem artwork fallback instead of remaining empty | Not run after the latest fix |
| Android device/emulator | Open Rap & Drill and another genre and verify the destination shelves and playback queue use the selected genre payload | Not run after the latest fix |
| Android device/emulator | Verify Mood and genres appears before Samples and shortcut navigation still lands on the correct section | Not run in this session |
| Android device/emulator | Inspect compact-screen spacing, long labels, and image cropping in the genre grid | Not run after the latest fix |

## Risk and compatibility

- **Risk level:** Medium
- **Compatibility or migration notes:** None
- **Known limitations:** Artist portraits are decorative and resolved lazily. Rap & Drill has an independent final artwork URL after its bounded dynamic portrait attempts; if that URL also fails to render, the card still falls back to the Levyra gradient/emoji treatment. The first uncached Explore visit can perform portrait lookups, but concurrency remains capped at two and successful results reuse the existing persistent artwork cache.
- **Rollback plan:** Revert this PR

## Reviewer notes

- `ExploreGenreEditorial.kt` is presentation-only. It deduplicates the selected genre track payload and creates bounded featured, artist, album, and song projections without owning network or playback state.
- `ExploreMoodArtworkCard.kt` owns the artwork-led grid presentation and deterministic portrait candidate order. It reuses the existing artwork resolver, keeps the global concurrency cap at two, retries a bounded next candidate after either resolution failure or image-render failure, and gives Rap & Drill an independent final artwork fallback.
- The current-head code review found that a nonblank portrait URL could still fail inside Coil while suppressing the visual fallback. That path is handled by advancing the candidate index from `AsyncImage.onError`.
- The review also found that genre destinations were still rendering and playing `exploreFreshTracks` from the existing call site even after `selectExploreZone()` loaded the correct genre payload. The destination binds to the already-existing `ExploreViewModel` instance and uses `exploreTracks` only when its zone ID matches the active destination.
- `ExploreLayout.kt` only changes the main section order so genres are shown before Samples; anchors, shortcuts, keys, and feature availability are preserved.
- Rotation is deterministic within a three-day window, so content can feel less static without random order changes during recomposition.
- Fixed card dimensions, bounded retry counts, and bounded shelf sizes keep the additional discovery surface within the existing Coil and artwork-cache model.
- README was not changed because this is an Explore presentation change and the current documentation does not describe the old genre layout as a product contract.

## Release note

Explore genres now use cleaner artist-led cards with resilient portrait fallback and richer genre-specific discovery pages, with genres placed ahead of Samples for a more ordered Explore flow.

## Related issues

N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Explore screens now include editorial sections for featured tracks, artists, albums, and essential songs.
  - Genre collections support playback directly from Explore.
  - Mood cards now feature larger artwork, prominent emojis, gradients, and interactive mix actions.
  - Collection headers display richer visuals and optional emoji.

- **Improvements**
  - Explore content now presents Moods before Samples.
  - Editorial recommendations rotate over time for a fresh selection.
  - Artwork and artist imagery use improved fallback handling across genres and locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->