### PR TITLE
Fix Claude runtime bootstrap and Windows jCodeMunch MCP

### DIFF
--- a/.agents/claude/settings.json
+++ b/.agents/claude/settings.json
@@ -58,11 +58,11 @@
       "Read(./**/*.keystore)",
       "Read(./**/.env)",
       "Read(./**/.env.*)",
-      "Write(./local.properties)",
-      "Write(./**/*.jks)",
-      "Write(./**/*.keystore)",
-      "Write(./**/.env)",
-      "Write(./**/.env.*)"
+      "Edit(./local.properties)",
+      "Edit(./**/*.jks)",
+      "Edit(./**/*.keystore)",
+      "Edit(./**/.env)",
+      "Edit(./**/.env.*)"
     ]
   },
   "hooks": {

--- a/scripts/agent_stop_audit.py
+++ b/scripts/agent_stop_audit.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 
 import json
 import sys
+from pathlib import Path
 from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from scripts import agent_checkpoint as checkpoint
 from scripts import agent_harness as harness

--- a/scripts/codex_jcodemunch.py
+++ b/scripts/codex_jcodemunch.py
@@ -120,6 +120,11 @@ def serve() -> int:
         print(f"Levyra jCodeMunch bootstrap failed: {exc}", file=sys.stderr)
         return 1
 
+    if os.name == "nt":
+        # os.execv does not quote argv on Windows, so a cache path containing a
+        # space is re-split by the child and parsed as a bogus subcommand.
+        return subprocess.run([str(binary)], check=False).returncode
+
     os.execv(str(binary), [str(binary)])
     return 0
 


### PR DESCRIPTION
## Summary

Three agent-runtime fixes that kept the Claude Code harness from working correctly on Windows. The Stop hook crashed on import, the sensitive-file deny list was written with rules the permission matcher does not apply to edits, and the jCodeMunch MCP server failed to launch whenever the install path contained a space. No Android or Desktop product code is touched.

## What changed

- `scripts/agent_stop_audit.py`: added the repository-root `sys.path` bootstrap before the `from scripts import ...` statements, matching the pattern already used by `scripts/agent_checkpoint.py`. The Stop hook previously died with `ModuleNotFoundError`.
- `.agents/claude/settings.json`: replaced the five sensitive-file `Write(...)` deny rules with `Edit(...)` equivalents, so `local.properties`, `*.jks`, `*.keystore`, `.env`, and `.env.*` are actually guarded against modification. The existing `Read(...)` protections are unchanged.
- `scripts/codex_jcodemunch.py`: on Windows, `serve()` now launches the pinned binary through `subprocess.run` instead of `os.execv`. `os.execv` does not quote argv on Windows, so a cache path under a user directory containing a space was re-split by the child process and parsed as a bogus subcommand. POSIX keeps the existing `os.execv` behavior.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor or maintenance
- [ ] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Shared infrastructure
- **Area:** Build and release (agent runtime tooling)

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [ ] Targeted tests were added or updated
- [x] Not applicable, with the reason explained below

The diff contains no Android or Desktop code, so the Gradle suites have no bearing on it and were deliberately not run locally. GitHub Actions owns full CI validation for this branch. The local Android SDK is also missing build-tools, which makes every `:app:` task fail at configuration time in this environment.

What did run locally:

- `python scripts/ai_quality_gate.py --profile full` — passed under Python 3.12: agent configuration, AI efficiency, Matt skills integration, claude-mem integration, F-Droid review contract, and 131 repository script tests (2 skipped). Worth noting for anyone reproducing this: under the machine default of Python 3.10 the `Validate AI efficiency` step fails with `Python 3.11 or newer is required to parse .rtk/filters.toml`. That is an interpreter-version limitation, not a defect in this diff.
- `git diff --check` — clean.
- `.agents/claude/settings.json` re-parsed as valid JSON; both edited scripts pass `py_compile`.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Windows 11, user path containing a space | Restart Claude Code and issue a real read-only jCodeMunch MCP call (`mcp__jcodemunch__menu`) | Server launched and returned results; 5 of 91 catalog actions listed |
| Windows 11 | Stop hook import path | No longer raises `ModuleNotFoundError` |

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** None. The Windows branch is guarded by `os.name == "nt"`, so POSIX behavior is byte-for-byte unchanged.
- **Known limitations:** On Windows the launcher is now a parent process waiting on a child rather than a process replacement, so the MCP server runs one level deeper in the process tree.
- **Rollback plan:** Revert this PR

## Reviewer notes

- `scripts/codex_jcodemunch.py` is the one behavioral change worth a close look. The Windows path returns the child's exit code so failures still propagate, and the `check=False` argument is intentional: the caller reports the code rather than raising.
- The `Edit(...)` versus `Write(...)` distinction in `.agents/claude/settings.json` is the substance of that file's change. Both rule sets look equivalent at a glance, but only `Edit(...)` is applied to edits by the permission matcher.

## Release note

None

## Related issues

- Closes #
- Related to #

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [ ] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows compatibility when launching the jCodeMunch service, including support for cache paths containing spaces.
  - Improved audit script reliability when run from outside the project directory.

- **Security**
  - Updated protected-file safeguards to prevent edits to local configuration, keystore, and environment files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->