### PR TITLE
Verified player configs, listening-signal recommendations, and a real soundtrack hero

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/AppleArtistArtworkRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/AppleArtistArtworkRepository.kt
@@ -1,0 +1,172 @@
+package com.luc4n3x.levyra.data
+
+import android.content.Context
+import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
+import com.luc4n3x.levyra.domain.artistIdentityKey
+import com.luc4n3x.levyra.domain.artistIdentityMatches
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.Request
+import org.json.JSONObject
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+
+internal fun isAllowedAppleArtistArtworkUrl(rawUrl: String): Boolean {
+    val url = rawUrl.toHttpUrlOrNull() ?: return false
+    if (!url.isHttps) return false
+    val host = url.host.lowercase(Locale.ROOT)
+    return host == "mzstatic.com" || host.endsWith(".mzstatic.com")
+}
+
+internal fun isAllowedAppleArtistPageUrl(rawUrl: String): Boolean {
+    val url = rawUrl.toHttpUrlOrNull() ?: return false
+    if (!url.isHttps) return false
+    val host = url.host.lowercase(Locale.ROOT)
+    if (host != "music.apple.com") return false
+    return url.encodedPath.contains("/artist/", ignoreCase = true)
+}
+
+private val APPLE_ARTIST_IMAGE_PATTERN = Regex(
+    """https://is\d+-ssl\.mzstatic\.com/image/thumb/[A-Za-z0-9._/-]{10,180}\.(?:png|jpg|jpeg)"""
+)
+
+private val APPLE_ARTIST_SIZE_PATTERN = Regex("""\d{2,4}x\d{2,4}(?:cw|bb)""")
+
+private val APPLE_OPEN_GRAPH_IMAGE_PATTERN = Regex(
+    """<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']""",
+    RegexOption.IGNORE_CASE
+)
+
+private const val APPLE_ARTIST_IMAGE_MARKER = "AMCArtistImages"
+
+internal fun extractAppleArtistPortrait(html: String): String {
+    val candidates = APPLE_ARTIST_IMAGE_PATTERN.findAll(html)
+        .map(MatchResult::value)
+        .filter(::isAllowedAppleArtistArtworkUrl)
+        .toList()
+    if (candidates.isEmpty()) return ""
+    val openGraph = APPLE_OPEN_GRAPH_IMAGE_PATTERN.find(html)
+        ?.groupValues
+        ?.getOrNull(1)
+        ?.takeIf(::isAllowedAppleArtistArtworkUrl)
+    val portrait = openGraph
+        ?: candidates.firstOrNull { it.contains(APPLE_ARTIST_IMAGE_MARKER, ignoreCase = true) }
+        ?: return ""
+    return APPLE_ARTIST_SIZE_PATTERN.replace(portrait, "1200x1200bb")
+}
+
+internal class AppleArtistArtworkRepository private constructor(context: Context) {
+    private val client = LevyraHttpClientFactory.externalIntegrations()
+    private val preferences = context.applicationContext
+        .getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+    private val memoryCache = ConcurrentHashMap<String, String>()
+
+    suspend fun resolveArtistPortrait(artistName: String): String = withContext(Dispatchers.IO) {
+        val cleanName = artistName.trim()
+        val identity = artistIdentityKey(cleanName)
+        if (identity.isBlank()) return@withContext ""
+
+        val now = System.currentTimeMillis()
+        memoryCache[identity]?.let { return@withContext it }
+        readPersisted(identity, now)?.let { cached ->
+            memoryCache[identity] = cached
+            return@withContext cached
+        }
+
+        val resolved = runCatching {
+            val pageUrl = findArtistPageUrl(cleanName)
+            if (pageUrl.isBlank()) "" else portraitFromArtistPage(pageUrl)
+        }.getOrNull().orEmpty()
+
+        if (resolved.isNotBlank()) {
+            memoryCache[identity] = resolved
+            preferences.edit()
+                .putString("$identity.url", resolved)
+                .putLong("$identity.savedAt", now)
+                .apply()
+        }
+        resolved
+    }
+
+    private fun readPersisted(identity: String, now: Long): String? {
+        val url = preferences.getString("$identity.url", null).orEmpty()
+        val savedAt = preferences.getLong("$identity.savedAt", 0L)
+        if (url.isBlank() || now - savedAt !in 0 until ARTWORK_TTL_MS) return null
+        if (!isAllowedAppleArtistArtworkUrl(url)) return null
+        return url
+    }
+
+    private fun findArtistPageUrl(artistName: String): String {
+        val url = SEARCH_URL.toHttpUrl().newBuilder()
+            .addQueryParameter("term", artistName)
+            .addQueryParameter("entity", "musicArtist")
+            .addQueryParameter("limit", SEARCH_LIMIT.toString())
+            .build()
+        val request = Request.Builder()
+            .url(url)
+            .header("Accept", "application/json")
+            .header("User-Agent", USER_AGENT)
+            .build()
+        val body = client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return ""
+            val payload = response.body
+            if (payload.contentLength() > MAX_SEARCH_BYTES) return ""
+            val source = payload.source()
+            source.request(MAX_SEARCH_BYTES + 1L)
+            if (source.buffer.size > MAX_SEARCH_BYTES) return ""
+            source.buffer.readUtf8()
+        }
+        val results = JSONObject(body).optJSONArray("results") ?: return ""
+        for (index in 0 until results.length()) {
+            val entry = results.optJSONObject(index) ?: continue
+            val name = entry.optString("artistName").trim()
+            if (artistIdentityKey(name) != artistIdentityKey(artistName) &&
+                !artistIdentityMatches(name, artistName)
+            ) {
+                continue
+            }
+            val link = entry.optString("artistLinkUrl").trim()
+            if (isAllowedAppleArtistPageUrl(link)) return link
+        }
+        return ""
+    }
+
+    private fun portraitFromArtistPage(pageUrl: String): String {
+        val request = Request.Builder()
+            .url(pageUrl)
+            .header("Accept", "text/html")
+            .header("User-Agent", USER_AGENT)
+            .build()
+        return client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return ""
+            val payload = response.body
+            if (payload.contentLength() > MAX_PAGE_BYTES) return ""
+            val source = payload.source()
+            source.request(MAX_PAGE_BYTES + 1L)
+            if (source.buffer.size > MAX_PAGE_BYTES) return ""
+            extractAppleArtistPortrait(source.buffer.readUtf8())
+        }
+    }
+
+    companion object {
+        @Volatile
+        private var instance: AppleArtistArtworkRepository? = null
+
+        fun get(context: Context): AppleArtistArtworkRepository {
+            return instance ?: synchronized(this) {
+                instance ?: AppleArtistArtworkRepository(context.applicationContext).also { instance = it }
+            }
+        }
+
+        private const val PREFERENCES_NAME = "apple_artist_artwork"
+        private const val SEARCH_URL = "https://itunes.apple.com/search"
+        private const val USER_AGENT =
+            "Mozilla/5.0 (Linux; Android 16) AppleWebKit/537.36 Chrome/140.0.0.0 Mobile Safari/537.36"
+        private const val SEARCH_LIMIT = 5
+        private const val MAX_SEARCH_BYTES = 512_000L
+        private const val MAX_PAGE_BYTES = 4_000_000L
+        private const val ARTWORK_TTL_MS = 30L * 24L * 60L * 60L * 1000L
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/SpotifyArtistArtworkRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/SpotifyArtistArtworkRepository.kt
@@ -1,6 +1,7 @@
 package com.luc4n3x.levyra.data
 
 import android.content.Context
+import android.graphics.BitmapFactory
 import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
 import com.luc4n3x.levyra.domain.artistIdentityKey
 import com.luc4n3x.levyra.domain.artistIdentityMatches
@@ -20,6 +21,32 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentHashMap
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
+
+internal const val FLAT_ARTWORK_CHANNEL_SPREAD = 12
+
+internal fun isFlatArtworkSample(pixels: IntArray): Boolean {
+    if (pixels.isEmpty()) return false
+    var minRed = 255
+    var maxRed = 0
+    var minGreen = 255
+    var maxGreen = 0
+    var minBlue = 255
+    var maxBlue = 0
+    pixels.forEach { pixel ->
+        val red = (pixel shr 16) and 0xFF
+        val green = (pixel shr 8) and 0xFF
+        val blue = pixel and 0xFF
+        if (red < minRed) minRed = red
+        if (red > maxRed) maxRed = red
+        if (green < minGreen) minGreen = green
+        if (green > maxGreen) maxGreen = green
+        if (blue < minBlue) minBlue = blue
+        if (blue > maxBlue) maxBlue = blue
+    }
+    return (maxRed - minRed) <= FLAT_ARTWORK_CHANNEL_SPREAD &&
+        (maxGreen - minGreen) <= FLAT_ARTWORK_CHANNEL_SPREAD &&
+        (maxBlue - minBlue) <= FLAT_ARTWORK_CHANNEL_SPREAD
+}
 
 internal fun isAllowedSpotifyArtistArtworkUrl(rawUrl: String): Boolean {
     val url = rawUrl.toHttpUrlOrNull() ?: return false
@@ -64,17 +91,70 @@ internal class SpotifyArtistArtworkRepository private constructor(context: Conte
             return@withContext cached.url
         }
 
+        if (isPersistedFlat(identity, now)) return@withContext ""
+
         val resolved = runCatching {
             val bearer = anonymousAccessToken(now)
             searchArtistPortrait(cleanName, bearer)
         }.getOrNull().orEmpty()
 
-        if (resolved.isNotBlank()) {
-            val cached = CachedArtwork(resolved, now)
-            memoryCache[identity] = cached
-            persist(identity, cached)
+        if (resolved.isBlank()) return@withContext ""
+
+        if (isFlatPortrait(resolved) == true) {
+            persistFlat(identity, now)
+            return@withContext ""
         }
+
+        val cached = CachedArtwork(resolved, now)
+        memoryCache[identity] = cached
+        persist(identity, cached)
         resolved
+    }
+
+    private fun isFlatPortrait(url: String): Boolean? {
+        val request = Request.Builder()
+            .url(url)
+            .header("User-Agent", WEB_USER_AGENT)
+            .header("Accept", "image/*")
+            .build()
+        return runCatching {
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return null
+                val body = response.body
+                if (body.contentLength() > MAX_PORTRAIT_PROBE_BYTES) return null
+                val source = body.source()
+                source.request(MAX_PORTRAIT_PROBE_BYTES + 1L)
+                if (source.buffer.size > MAX_PORTRAIT_PROBE_BYTES) return null
+                val bytes = source.buffer.readByteArray()
+                if (bytes.isEmpty()) return null
+                val options = BitmapFactory.Options().apply { inSampleSize = PORTRAIT_PROBE_SAMPLE_SIZE }
+                val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options) ?: return null
+                try {
+                    val pixels = IntArray(bitmap.width * bitmap.height)
+                    if (pixels.isEmpty()) return null
+                    bitmap.getPixels(pixels, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)
+                    isFlatArtworkSample(pixels)
+                } finally {
+                    bitmap.recycle()
+                }
+            }
+        }.getOrNull()
+    }
+
+    private fun isPersistedFlat(identity: String, now: Long): Boolean {
+        if (!preferences.getBoolean("$identity.flat", false)) return false
+        val savedAt = preferences.getLong("$identity.flatSavedAt", 0L)
+        return now - savedAt in 0 until ARTWORK_TTL_MS
+    }
+
+    private fun persistFlat(identity: String, now: Long) {
+        memoryCache.remove(identity)
+        preferences.edit()
+            .putBoolean("$identity.flat", true)
+            .putLong("$identity.flatSavedAt", now)
+            .remove("$identity.url")
+            .remove("$identity.savedAt")
+            .apply()
     }
 
     private fun readPersisted(identity: String, now: Long): CachedArtwork? {
@@ -312,6 +392,8 @@ internal class SpotifyArtistArtworkRepository private constructor(context: Conte
             "Mozilla/5.0 (Linux; Android 16) AppleWebKit/537.36 Chrome/140.0.0.0 Mobile Safari/537.36"
         private const val SEARCH_LIMIT = 10
         private const val MAX_RESPONSE_CHARS = 1_000_000
+        private const val MAX_PORTRAIT_PROBE_BYTES = 2_000_000
+        private const val PORTRAIT_PROBE_SAMPLE_SIZE = 16
         private const val TOKEN_EXPIRY_SKEW_MS = 60_000L
         private const val DEFAULT_TOKEN_TTL_MS = 15L * 60L * 1000L
         private const val ARTWORK_TTL_MS = 7L * 24L * 60L * 60L * 1000L

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
@@ -430,6 +430,12 @@ private class YoutubeLocalDecoderEngine(
                 "Player config verification rejected for ${player.hash}: ${verification.reason}"
             )
         }
+        if (created.isDead) {
+            created.close()
+            throw YoutubeRendererFailureException(
+                "Player config verification left the runtime dead for ${player.hash}"
+            )
+        }
         runtime = created
         runtimeHash = player.hash
         runtimeConfigKey = player.configKey

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
@@ -143,6 +143,8 @@ class YoutubeLocalDecoder private constructor(
     }
 }
 
+private const val MAX_TRACKED_CONFIG_IDENTITIES = 64
+
 private class YoutubeLocalDecoderEngine(
     private val context: Context,
     httpClient: OkHttpClient
@@ -160,6 +162,8 @@ private class YoutubeLocalDecoderEngine(
     private var runtimeConfigOrigin = YoutubePlayerConfigOrigin.VALIDATED
     private val lastSuccessfulDecodeAtMs = AtomicLong(0L)
     private val rendererRecovery = YoutubeRendererRecoveryPolicy()
+    private val verifiedConfigIdentities = ConcurrentHashMap.newKeySet<String>()
+    private val rejectedConfigIdentities = ConcurrentHashMap.newKeySet<String>()
 
     @Volatile
     private var lastSuccessfulDecodePlayerHash = ""
@@ -409,13 +413,71 @@ private class YoutubeLocalDecoderEngine(
         if (!rendererRecovery.shouldAttempt(recoveryIdentity, SystemClock.elapsedRealtime())) {
             throw YoutubeRendererBackoffException()
         }
+        if (config.identity in rejectedConfigIdentities) {
+            throw YoutubeAnalyzedConfigFailureException(
+                "Player config previously rejected by verification for ${player.hash}"
+            )
+        }
         val created = YoutubeCipherWebRuntime.create(context, player, config)
+        val verification = verifyConfig(created, config)
+        if (verification.provesConfigWrong) {
+            created.close()
+            rememberRejectedConfig(config.identity)
+            if (config.origin == YoutubePlayerConfigOrigin.ANALYZED) {
+                playerSource.rejectAnalyzedConfig(player.hash)
+            }
+            throw YoutubeAnalyzedConfigFailureException(
+                "Player config verification rejected for ${player.hash}: ${verification.reason}"
+            )
+        }
         runtime = created
         runtimeHash = player.hash
         runtimeConfigKey = player.configKey
         runtimeConfigEpoch = configStore.epoch
         runtimeConfigOrigin = config.origin
         return created
+    }
+
+    private fun rememberRejectedConfig(identity: String) {
+        if (rejectedConfigIdentities.size >= MAX_TRACKED_CONFIG_IDENTITIES) rejectedConfigIdentities.clear()
+        rejectedConfigIdentities += identity
+    }
+
+    private suspend fun verifyConfig(
+        runtime: YoutubeCipherWebRuntime,
+        config: YoutubePlayerCipherConfig
+    ): YoutubeConfigVerification {
+        if (verifiedConfigIdentities.size >= MAX_TRACKED_CONFIG_IDENTITIES) verifiedConfigIdentities.clear()
+        if (!verifiedConfigIdentities.add(config.identity)) {
+            return YoutubeConfigVerification(YoutubeConfigVerdict.ACCEPTED, "already verified")
+        }
+        val verification = try {
+            val signatureProbes = YoutubePlayerConfigVerifier.SIGNATURE_PROBES.map { input ->
+                YoutubeCipherProbe(input, runtime.decodeSignature(input))
+            }
+            val throttlingProbes = YoutubePlayerConfigVerifier.THROTTLING_PROBES.map { input ->
+                YoutubeCipherProbe(input, runtime.transformN(input))
+            }
+            YoutubePlayerConfigVerifier.verify(signatureProbes, throttlingProbes)
+        } catch (error: CancellationException) {
+            verifiedConfigIdentities.remove(config.identity)
+            throw error
+        } catch (error: Throwable) {
+            verifiedConfigIdentities.remove(config.identity)
+            Timber.w(error, "Player config verification inconclusive for %s", config.primaryHash)
+            return YoutubeConfigVerification(YoutubeConfigVerdict.INCONCLUSIVE, "probe execution failed")
+        }
+        if (verification.verdict != YoutubeConfigVerdict.ACCEPTED) {
+            verifiedConfigIdentities.remove(config.identity)
+        }
+        Timber.d(
+            "Player config verification %s origin=%s hash=%s reason=%s",
+            verification.verdict,
+            config.origin,
+            config.primaryHash,
+            verification.reason
+        )
+        return verification
     }
 
     private suspend fun invalidateRuntime() {
@@ -1055,17 +1117,55 @@ private class YoutubePlayerJsSource(
     }
 
     private suspend fun fetchPlayerHash(): String {
+        val samples = ArrayList<YoutubePlayerSample>(PLAYER_SAMPLE_SOURCES.size)
+        var primaryFailure: Throwable? = null
+        PLAYER_SAMPLE_SOURCES.forEach { source ->
+            try {
+                sampleHash(source)?.let { samples += YoutubePlayerSample(it, source.name) }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                if (source.required) primaryFailure = error
+                Timber.w(error, "Player hash sample failed source=%s", source.name)
+            }
+        }
+        val observation = YoutubePlayerSampleAggregator.aggregate(samples)
+            ?: throw ParsingException(
+                "Unable to extract YouTube player hash",
+                primaryFailure
+            )
+        if (observation.rotating) {
+            Timber.d(
+                "Rotating YouTube player detected dominant=%s alternates=%s",
+                observation.dominantHash,
+                observation.alternateHashes
+            )
+            observation.alternateHashes.forEach { alternate ->
+                runCatching { configStore.configFor(alternate, refreshUnknown = true) }
+                    .onFailure { Timber.w(it, "Alternate player config lookup failed for %s", alternate) }
+            }
+        }
+        return observation.dominantHash
+    }
+
+    private suspend fun sampleHash(source: PlayerSampleSource): String? {
         val request = Request.Builder()
-            .url(IFRAME_API_URL)
+            .url(source.url)
             .get()
             .header("User-Agent", USER_AGENT)
             .header("Accept", "*/*")
             .build()
-        val response = httpClient.awaitText(request, MAX_IFRAME_BYTES)
-        if (response.code !in 200..299) throw ParsingException("iframe_api HTTP ${response.code}")
+        val response = httpClient.awaitText(request, source.maxBytes)
+        if (response.code !in 200..299) throw ParsingException("${source.name} HTTP ${response.code}")
         return YoutubePlayerJsSupport.extractPlayerHash(response.body)
-            ?: throw ParsingException("Unable to extract YouTube player hash")
     }
+
+    private data class PlayerSampleSource(
+        val name: String,
+        val url: String,
+        val maxBytes: Int,
+        val required: Boolean
+    )
 
     private suspend fun downloadPlayerJs(hash: String): String {
         val failures = ArrayList<String>()
@@ -1093,9 +1193,15 @@ private class YoutubePlayerJsSource(
 
     companion object {
         private const val IFRAME_API_URL = "https://www.youtube.com/iframe_api"
+        private const val EMBED_SAMPLE_URL = "https://www.youtube.com/embed/"
+        private val PLAYER_SAMPLE_SOURCES = listOf(
+            PlayerSampleSource("iframe_api", IFRAME_API_URL, MAX_IFRAME_BYTES, required = true),
+            PlayerSampleSource("embed", EMBED_SAMPLE_URL, MAX_EMBED_BYTES, required = false)
+        )
         private const val USER_AGENT = "Mozilla/5.0 (Linux; Android 16) AppleWebKit/537.36 Chrome/150.0.0.0 Mobile Safari/537.36"
         private const val PLAYER_TTL_MS = 6L * 60L * 60L * 1000L
         private const val MAX_IFRAME_BYTES = 1_000_000
+        private const val MAX_EMBED_BYTES = 2_000_000
         private const val MAX_PLAYER_JS_BYTES = 6_000_000
         private const val MAX_CACHED_PLAYERS = 2
         private val PLAYER_LOCALES = listOf("en_GB", "en_US", "it_IT")

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerConfigVerification.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerConfigVerification.kt
@@ -1,0 +1,145 @@
+package com.luc4n3x.levyra.data
+
+internal enum class YoutubeConfigVerdict {
+    ACCEPTED,
+    REJECTED,
+    INCONCLUSIVE
+}
+
+internal data class YoutubeConfigVerification(
+    val verdict: YoutubeConfigVerdict,
+    val reason: String
+) {
+    val accepted: Boolean
+        get() = verdict == YoutubeConfigVerdict.ACCEPTED
+
+    val provesConfigWrong: Boolean
+        get() = verdict == YoutubeConfigVerdict.REJECTED
+}
+
+internal data class YoutubeCipherProbe(
+    val input: String,
+    val output: String
+)
+
+internal object YoutubePlayerConfigVerifier {
+
+    val SIGNATURE_PROBES: List<String> = listOf(
+        "AOq0QJ8wRgIhAK7VpLm2QcWnT4xYzB9dRfGhJkLmNpQrStUvWxYz0123456789AiEA" +
+            "4bC6dEfGhIjKlMnOpQrStUvWxYz9876543210ZyXwVuTsRqPoNmLkJiHgFeDcBaQw" +
+            "ErTyUiOpAsDfGhJkLzXcVbNm0192837465",
+        "AOq0QJ8wRQIgZ9yXwVuTsRqPoNmLkJiHgFeDcBa87654321ZyXwVuTsRqPoNmLkJiH" +
+            "gFeDcBaQwErTyUiOpAsDfGhJkLzXcVbNm5647382910AbCdEfGhIjKlMnOpQrStUv" +
+            "WxYz0123456789QwErTyUiOpAsDfGhJkL"
+    )
+
+    val THROTTLING_PROBES: List<String> = listOf(
+        "1PuFuHiVpM4tGJyMxq",
+        "9bTrXk2QwEr7YuIoPa"
+    )
+
+    private val signatureCharset = Regex("^[A-Za-z0-9_=.-]+$")
+    private val throttlingCharset = Regex("^[A-Za-z0-9_-]+$")
+
+    private const val MIN_THROTTLING_LENGTH = 4
+    private const val MAX_THROTTLING_LENGTH = 256
+
+    fun verify(
+        signatureProbes: List<YoutubeCipherProbe>,
+        throttlingProbes: List<YoutubeCipherProbe>
+    ): YoutubeConfigVerification {
+        if (signatureProbes.isEmpty() && throttlingProbes.isEmpty()) {
+            return YoutubeConfigVerification(YoutubeConfigVerdict.INCONCLUSIVE, "no probe evidence")
+        }
+
+        signatureProbes.forEach { probe ->
+            val failure = signatureFailure(probe)
+            if (failure != null) {
+                return YoutubeConfigVerification(YoutubeConfigVerdict.REJECTED, failure)
+            }
+        }
+        throttlingProbes.forEach { probe ->
+            val failure = throttlingFailure(probe)
+            if (failure != null) {
+                return YoutubeConfigVerification(YoutubeConfigVerdict.REJECTED, failure)
+            }
+        }
+
+        if (signatureProbes.size >= 2 && signatureProbes.map { it.output }.distinct().size == 1) {
+            return YoutubeConfigVerification(YoutubeConfigVerdict.REJECTED, "signature transform collapses distinct inputs")
+        }
+        if (throttlingProbes.size >= 2 && throttlingProbes.map { it.output }.distinct().size == 1) {
+            return YoutubeConfigVerification(YoutubeConfigVerdict.REJECTED, "n transform collapses distinct inputs")
+        }
+
+        if (signatureProbes.isEmpty() || throttlingProbes.isEmpty()) {
+            return YoutubeConfigVerification(YoutubeConfigVerdict.INCONCLUSIVE, "partial probe coverage")
+        }
+        return YoutubeConfigVerification(YoutubeConfigVerdict.ACCEPTED, "cipher probes consistent")
+    }
+
+    private fun signatureFailure(probe: YoutubeCipherProbe): String? {
+        val output = probe.output
+        if (output.isBlank()) return "empty signature output"
+        if (output == probe.input) return "signature output unchanged"
+        if (output.length > probe.input.length) return "signature output longer than input"
+        if (!signatureCharset.matches(output)) return "signature output charset invalid"
+        val inputCharacters = probe.input.toSet()
+        if (!output.all { it in inputCharacters }) return "signature output introduces foreign characters"
+        return null
+    }
+
+    private fun throttlingFailure(probe: YoutubeCipherProbe): String? {
+        val output = probe.output
+        if (output.isBlank()) return "empty n output"
+        if (output == probe.input) return "n output unchanged"
+        if (output.length < MIN_THROTTLING_LENGTH) return "n output too short (${output.length})"
+        if (output.length > MAX_THROTTLING_LENGTH) return "n output too long (${output.length})"
+        if (!throttlingCharset.matches(output)) return "n output charset invalid"
+        return null
+    }
+}
+
+internal data class YoutubePlayerSample(
+    val hash: String,
+    val source: String
+)
+
+internal data class YoutubePlayerObservation(
+    val dominantHash: String,
+    val alternateHashes: List<String>
+) {
+    val rotating: Boolean
+        get() = alternateHashes.isNotEmpty()
+
+    val allHashes: List<String>
+        get() = buildList {
+            add(dominantHash)
+            addAll(alternateHashes)
+        }
+}
+
+internal object YoutubePlayerSampleAggregator {
+
+    fun aggregate(samples: List<YoutubePlayerSample>): YoutubePlayerObservation? {
+        val valid = samples
+            .map { it.copy(hash = it.hash.trim().lowercase()) }
+            .filter { YoutubePlayerConfigParser.isValidHash(it.hash) }
+        if (valid.isEmpty()) return null
+
+        val order = LinkedHashMap<String, Int>()
+        valid.forEachIndexed { index, sample -> order.putIfAbsent(sample.hash, index) }
+        val counts = valid.groupingBy { it.hash }.eachCount()
+
+        val dominant = counts.entries
+            .sortedWith(
+                compareByDescending<Map.Entry<String, Int>> { it.value }
+                    .thenBy { order.getValue(it.key) }
+            )
+            .first()
+            .key
+
+        val alternates = order.keys.filterNot { it == dominant }
+        return YoutubePlayerObservation(dominant, alternates)
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/domain/ListeningSignals.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/ListeningSignals.kt
@@ -302,25 +302,32 @@ object ListeningSignalRanker {
     ): List<Track> {
         val runCap = artistRunLimit.coerceAtLeast(1)
         val selected = ArrayList<Track>(min(limit, scored.size))
-        val deferred = ArrayList<ScoredCandidate>()
-        val artistCounts = HashMap<String, Int>()
+        val pending = scored.toMutableList()
+        var previousArtistKey = ""
+        var consecutiveArtistCount = 0
 
-        scored.forEach { candidate ->
-            if (selected.size >= limit) return@forEach
-            val key = primaryArtistKey(candidate.track.artist)
-            val used = artistCounts.getOrDefault(key, 0)
-            val allowed = key.isBlank() || key in contextKeys || used < runCap
-            if (allowed) {
-                selected += candidate.track
-                artistCounts[key] = used + 1
-            } else {
-                deferred += candidate
+        while (selected.size < limit && pending.isNotEmpty()) {
+            val eligibleIndex = pending.indexOfFirst { candidate ->
+                val key = primaryArtistKey(candidate.track.artist)
+                key.isBlank() ||
+                    key in contextKeys ||
+                    key != previousArtistKey ||
+                    consecutiveArtistCount < runCap
             }
-        }
-
-        deferred.forEach { candidate ->
-            if (selected.size >= limit) return@forEach
+            val index = if (eligibleIndex >= 0) eligibleIndex else 0
+            val candidate = pending.removeAt(index)
             selected += candidate.track
+
+            val key = primaryArtistKey(candidate.track.artist)
+            if (key.isBlank()) {
+                previousArtistKey = ""
+                consecutiveArtistCount = 0
+            } else if (key == previousArtistKey) {
+                consecutiveArtistCount += 1
+            } else {
+                previousArtistKey = key
+                consecutiveArtistCount = 1
+            }
         }
         return selected
     }

--- a/app/src/main/java/com/luc4n3x/levyra/domain/ListeningSignals.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/ListeningSignals.kt
@@ -1,0 +1,344 @@
+package com.luc4n3x.levyra.domain
+
+import java.util.Locale
+import kotlin.math.max
+import kotlin.math.min
+
+data class ListeningSignalWeights(
+    val completion: Int = 40,
+    val repeat: Int = 26,
+    val favorite: Int = 34,
+    val playlist: Int = 22,
+    val followedArtist: Int = 30,
+    val artistAffinity: Int = 24,
+    val skipPenalty: Int = 46,
+    val artistSkipPenalty: Int = 28,
+    val recencyBonus: Int = 12
+) {
+    companion object {
+        val Default = ListeningSignalWeights()
+    }
+}
+
+data class TrackListeningSignal(
+    val key: String,
+    val plays: Int,
+    val countedPlays: Int,
+    val completionRatio: Double,
+    val skips: Int,
+    val earlySkips: Int,
+    val lastPlayedAt: Long
+) {
+    val skipRatio: Double
+        get() = if (plays <= 0) 0.0 else skips.toDouble() / plays.toDouble()
+}
+
+data class ArtistListeningSignal(
+    val key: String,
+    val plays: Int,
+    val countedPlays: Int,
+    val listenedMs: Long,
+    val completionRatio: Double,
+    val skips: Int,
+    val distinctTracks: Int
+) {
+    val skipRatio: Double
+        get() = if (plays <= 0) 0.0 else skips.toDouble() / plays.toDouble()
+}
+
+data class ListeningSignalProfile(
+    val tracks: Map<String, TrackListeningSignal> = emptyMap(),
+    val artists: Map<String, ArtistListeningSignal> = emptyMap(),
+    val favoriteKeys: Set<String> = emptySet(),
+    val playlistKeys: Set<String> = emptySet(),
+    val followedArtistKeys: Set<String> = emptySet(),
+    val referenceNowMs: Long = 0L,
+    val weights: ListeningSignalWeights = ListeningSignalWeights.Default
+) {
+    val hasSignal: Boolean
+        get() = tracks.isNotEmpty() || artists.isNotEmpty() ||
+            favoriteKeys.isNotEmpty() || playlistKeys.isNotEmpty() || followedArtistKeys.isNotEmpty()
+
+    fun trackScore(track: Track): Int {
+        val key = ListenIdentity.trackKey(track.id, track.title, track.artist)
+        val signal = tracks[key]
+        var score = 0
+        if (signal != null) {
+            score += (signal.completionRatio * weights.completion).toInt()
+            score += min(signal.countedPlays, REPEAT_CAP) * weights.repeat / REPEAT_CAP
+            score -= (signal.skipRatio * weights.skipPenalty).toInt()
+            if (signal.earlySkips >= STRONG_NEGATIVE_SKIPS && signal.countedPlays == 0) {
+                score -= weights.skipPenalty
+            }
+            score += recencyBonus(signal.lastPlayedAt)
+        }
+        if (key in favoriteKeys) score += weights.favorite
+        if (key in playlistKeys) score += weights.playlist
+        score += artistScore(track.artist)
+        return score
+    }
+
+    fun artistScore(artist: String): Int {
+        val names = ListeningSignalEngine.splitArtists(artist)
+        if (names.isEmpty()) return 0
+        return names.maxOf { name ->
+            val key = ListenIdentity.artistKey(name)
+            var score = 0
+            if (key in followedArtistKeys) score += weights.followedArtist
+            artists[key]?.let { signal ->
+                score += (signal.completionRatio * weights.artistAffinity).toInt()
+                score -= (signal.skipRatio * weights.artistSkipPenalty).toInt()
+            }
+            score
+        }
+    }
+
+    fun isSuppressed(track: Track): Boolean {
+        val key = ListenIdentity.trackKey(track.id, track.title, track.artist)
+        if (key in favoriteKeys || key in playlistKeys) return false
+        val signal = tracks[key] ?: return false
+        if (signal.countedPlays > 0) return false
+        return signal.earlySkips >= STRONG_NEGATIVE_SKIPS && signal.completionRatio <= SUPPRESSION_COMPLETION
+    }
+
+    fun isArtistSuppressed(artist: String): Boolean {
+        val names = ListeningSignalEngine.splitArtists(artist)
+        if (names.isEmpty()) return false
+        if (names.any { ListenIdentity.artistKey(it) in followedArtistKeys }) return false
+        return names.all { name ->
+            val signal = artists[ListenIdentity.artistKey(name)] ?: return false
+            signal.countedPlays == 0 &&
+                signal.plays >= STRONG_NEGATIVE_ARTIST_PLAYS &&
+                signal.skipRatio >= SUPPRESSION_ARTIST_SKIP_RATIO
+        }
+    }
+
+    private fun recencyBonus(lastPlayedAt: Long): Int {
+        if (lastPlayedAt <= 0L || referenceNowMs <= 0L) return 0
+        val age = referenceNowMs - lastPlayedAt
+        if (age < 0L) return 0
+        if (age >= RECENCY_WINDOW_MS) return 0
+        val remaining = (RECENCY_WINDOW_MS - age).toDouble() / RECENCY_WINDOW_MS.toDouble()
+        return (remaining * weights.recencyBonus).toInt()
+    }
+
+    internal companion object {
+        const val REPEAT_CAP = 6
+        const val STRONG_NEGATIVE_SKIPS = 3
+        const val STRONG_NEGATIVE_ARTIST_PLAYS = 4
+        const val SUPPRESSION_COMPLETION = 0.25
+        const val SUPPRESSION_ARTIST_SKIP_RATIO = 0.8
+        const val RECENCY_WINDOW_MS = 21L * 24L * 60L * 60L * 1000L
+    }
+}
+
+object ListeningSignalEngine {
+
+    const val EARLY_SKIP_RATIO = 0.2
+    const val SKIP_RATIO = 0.5
+
+    private val separatorPattern = Regex(
+        """\s*(?:feat\.?|featuring|ft\.?|&|,|;|\+|/|\bx\b|\bvs\.?\b)\s*""",
+        RegexOption.IGNORE_CASE
+    )
+
+    fun splitArtists(artist: String): List<String> = artist
+        .split(separatorPattern)
+        .map { it.trim() }
+        .filter { it.isNotBlank() }
+        .distinctBy { it.lowercase(Locale.ROOT) }
+
+    fun build(
+        events: List<ListenEvent>,
+        favorites: List<Track> = emptyList(),
+        playlistTracks: List<Track> = emptyList(),
+        followedArtists: List<String> = emptyList(),
+        nowMs: Long = System.currentTimeMillis(),
+        weights: ListeningSignalWeights = ListeningSignalWeights.Default
+    ): ListeningSignalProfile {
+        val trackAccumulators = LinkedHashMap<String, TrackAccumulator>()
+        val artistAccumulators = LinkedHashMap<String, ArtistAccumulator>()
+
+        events.forEach { event ->
+            val ratio = completionRatio(event)
+            val counted = ListenPlayPolicy.isCountedPlay(event)
+            val skipped = !event.completed && !counted && ratio <= SKIP_RATIO
+            val earlySkipped = !event.completed && !counted && ratio <= EARLY_SKIP_RATIO
+
+            val trackKey = ListenIdentity.trackKey(event)
+            val track = trackAccumulators.getOrPut(trackKey) { TrackAccumulator(trackKey) }
+            track.accept(ratio, counted, skipped, earlySkipped, event.startedAt)
+
+            splitArtists(event.artist).forEach { name ->
+                val artistKey = ListenIdentity.artistKey(name)
+                if (artistKey.isBlank()) return@forEach
+                val artist = artistAccumulators.getOrPut(artistKey) { ArtistAccumulator(artistKey) }
+                artist.accept(ratio, counted, skipped, event.listenedMs, trackKey)
+            }
+        }
+
+        return ListeningSignalProfile(
+            tracks = trackAccumulators.mapValues { it.value.toSignal() },
+            artists = artistAccumulators.mapValues { it.value.toSignal() },
+            favoriteKeys = favorites.mapTo(LinkedHashSet()) { ListenIdentity.trackKey(it.id, it.title, it.artist) },
+            playlistKeys = playlistTracks.mapTo(LinkedHashSet()) { ListenIdentity.trackKey(it.id, it.title, it.artist) },
+            followedArtistKeys = followedArtists
+                .flatMap(::splitArtists)
+                .mapTo(LinkedHashSet(), ListenIdentity::artistKey)
+                .filterTo(LinkedHashSet(), String::isNotBlank),
+            referenceNowMs = nowMs,
+            weights = weights
+        )
+    }
+
+    fun completionRatio(event: ListenEvent): Double {
+        if (event.completed) return 1.0
+        if (event.trackDurationMs <= 0L) return if (event.listenedMs >= ListenPlayPolicy.COUNTED_PLAY_MS) 1.0 else 0.0
+        return min(1.0, max(0.0, event.listenedMs.toDouble() / event.trackDurationMs.toDouble()))
+    }
+
+    private class TrackAccumulator(val key: String) {
+        var plays = 0
+        var counted = 0
+        var skips = 0
+        var earlySkips = 0
+        var ratioTotal = 0.0
+        var lastPlayedAt = 0L
+
+        fun accept(ratio: Double, counted: Boolean, skipped: Boolean, earlySkipped: Boolean, startedAt: Long) {
+            plays += 1
+            ratioTotal += ratio
+            if (counted) this.counted += 1
+            if (skipped) skips += 1
+            if (earlySkipped) earlySkips += 1
+            if (startedAt > lastPlayedAt) lastPlayedAt = startedAt
+        }
+
+        fun toSignal(): TrackListeningSignal = TrackListeningSignal(
+            key = key,
+            plays = plays,
+            countedPlays = counted,
+            completionRatio = if (plays <= 0) 0.0 else ratioTotal / plays.toDouble(),
+            skips = skips,
+            earlySkips = earlySkips,
+            lastPlayedAt = lastPlayedAt
+        )
+    }
+
+    private class ArtistAccumulator(val key: String) {
+        var plays = 0
+        var counted = 0
+        var skips = 0
+        var listenedMs = 0L
+        var ratioTotal = 0.0
+        val trackKeys = LinkedHashSet<String>()
+
+        fun accept(ratio: Double, counted: Boolean, skipped: Boolean, listenedMs: Long, trackKey: String) {
+            plays += 1
+            ratioTotal += ratio
+            if (counted) this.counted += 1
+            if (skipped) skips += 1
+            this.listenedMs += max(0L, listenedMs)
+            trackKeys += trackKey
+        }
+
+        fun toSignal(): ArtistListeningSignal = ArtistListeningSignal(
+            key = key,
+            plays = plays,
+            countedPlays = counted,
+            listenedMs = listenedMs,
+            completionRatio = if (plays <= 0) 0.0 else ratioTotal / plays.toDouble(),
+            skips = skips,
+            distinctTracks = trackKeys.size
+        )
+    }
+}
+
+object ListeningSignalRanker {
+
+    const val DEFAULT_ARTIST_RUN_LIMIT = 2
+
+    fun rank(
+        candidates: List<Track>,
+        profile: ListeningSignalProfile,
+        limit: Int = candidates.size,
+        contextArtist: String = "",
+        artistRunLimit: Int = DEFAULT_ARTIST_RUN_LIMIT,
+        dropSuppressed: Boolean = true
+    ): List<Track> {
+        if (candidates.isEmpty()) return emptyList()
+        val max = limit.coerceAtLeast(1)
+        if (!profile.hasSignal) return candidates.take(max)
+
+        val contextKeys = ListeningSignalEngine.splitArtists(contextArtist)
+            .mapTo(LinkedHashSet(), ListenIdentity::artistKey)
+            .filterTo(LinkedHashSet(), String::isNotBlank)
+
+        val pool = if (!dropSuppressed) {
+            candidates
+        } else {
+            candidates.filterNot { candidate ->
+                if (matchesContext(candidate, contextKeys)) return@filterNot false
+                profile.isSuppressed(candidate) || profile.isArtistSuppressed(candidate.artist)
+            }.ifEmpty { candidates }
+        }
+
+        val scored = pool.mapIndexed { index, candidate ->
+            ScoredCandidate(
+                track = candidate,
+                score = profile.trackScore(candidate) + if (matchesContext(candidate, contextKeys)) CONTEXT_BONUS else 0,
+                originalIndex = index
+            )
+        }.sortedWith(compareByDescending<ScoredCandidate> { it.score }.thenBy { it.originalIndex })
+
+        return diversify(scored, max, artistRunLimit, contextKeys)
+    }
+
+    private fun diversify(
+        scored: List<ScoredCandidate>,
+        limit: Int,
+        artistRunLimit: Int,
+        contextKeys: Set<String>
+    ): List<Track> {
+        val runCap = artistRunLimit.coerceAtLeast(1)
+        val selected = ArrayList<Track>(min(limit, scored.size))
+        val deferred = ArrayList<ScoredCandidate>()
+        val artistCounts = HashMap<String, Int>()
+
+        scored.forEach { candidate ->
+            if (selected.size >= limit) return@forEach
+            val key = primaryArtistKey(candidate.track.artist)
+            val used = artistCounts.getOrDefault(key, 0)
+            val allowed = key.isBlank() || key in contextKeys || used < runCap
+            if (allowed) {
+                selected += candidate.track
+                artistCounts[key] = used + 1
+            } else {
+                deferred += candidate
+            }
+        }
+
+        deferred.forEach { candidate ->
+            if (selected.size >= limit) return@forEach
+            selected += candidate.track
+        }
+        return selected
+    }
+
+    private fun matchesContext(track: Track, contextKeys: Set<String>): Boolean {
+        if (contextKeys.isEmpty()) return false
+        return ListeningSignalEngine.splitArtists(track.artist)
+            .any { ListenIdentity.artistKey(it) in contextKeys }
+    }
+
+    private fun primaryArtistKey(artist: String): String =
+        ListeningSignalEngine.splitArtists(artist).firstOrNull()?.let(ListenIdentity::artistKey).orEmpty()
+
+    private data class ScoredCandidate(
+        val track: Track,
+        val score: Int,
+        val originalIndex: Int
+    )
+
+    private const val CONTEXT_BONUS = 240
+}

--- a/app/src/main/java/com/luc4n3x/levyra/feature/scrobbling/Scrobbling.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/scrobbling/Scrobbling.kt
@@ -17,6 +17,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONArray
 import org.json.JSONObject
+import timber.log.Timber
 
 data class ScrobbleListen(val track: Track, val startedAtMs: Long, val listenedMs: Long)
 
@@ -188,17 +189,49 @@ class ScrobblingCoordinator(private val providers: List<ScrobbleProvider>) {
 
     suspend fun nowPlaying(track: Track, startedAtMs: Long) {
         val listen = ScrobbleListen(track, startedAtMs, 0L)
-        providers.filter(ScrobbleProvider::isConfigured).forEach { it.nowPlaying(listen) }
+        configuredProviders().forEach { provider ->
+            isolate(provider) { provider.nowPlaying(listen) }
+        }
     }
 
     suspend fun scrobble(track: Track, startedAtMs: Long, listenedMs: Long) {
         val threshold = scrobbleThresholdMs(track.durationMs) ?: return
-        providers.filter(ScrobbleProvider::isConfigured).forEach { provider ->
+        if (listenedMs < threshold) return
+        configuredProviders().forEach { provider ->
             val key = "${provider.id}:${track.id}:${startedAtMs}"
-            if (listenedMs >= threshold && markSubmitted(key)) {
+            if (!markSubmitted(key)) return@forEach
+            val delivered = isolate(provider) {
                 provider.scrobble(ScrobbleListen(track, startedAtMs, listenedMs))
             }
+            if (!delivered) releaseSubmitted(key)
         }
+    }
+
+    private fun configuredProviders(): List<ScrobbleProvider> = providers.filter { provider ->
+        try {
+            provider.isConfigured()
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            Timber.w(error, "Scrobble provider %s configuration check failed", provider.id)
+            false
+        }
+    }
+
+    private suspend fun isolate(provider: ScrobbleProvider, block: suspend () -> Unit): Boolean {
+        return try {
+            block()
+            true
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            Timber.w(error, "Scrobble provider %s failed", provider.id)
+            false
+        }
+    }
+
+    private fun releaseSubmitted(key: String) {
+        synchronized(submitted) { submitted.remove(key) }
     }
 
     private fun markSubmitted(key: String): Boolean = synchronized(submitted) {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/HomeExperience.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/HomeExperience.kt
@@ -54,21 +54,21 @@ private fun Modifier.homeAtmosphereBackground(
 ): Modifier = drawWithCache {
     val width = size.width.coerceAtLeast(1f)
     val height = size.height.coerceAtLeast(1f)
-    val primaryCenter = Offset(width * 0.12f, -height * 0.02f)
-    val secondaryCenter = Offset(width * 0.98f, height * 0.16f)
-    val centreCenter = Offset(width * 0.52f, height * 0.26f)
-    val primaryRadius = width * 1.18f
-    val secondaryRadius = width * 0.86f
-    val centreRadius = width * 0.92f
-    val fadeTop = height * 0.25f
+    val primaryCenter = Offset(width * 0.12f, -height * 0.10f)
+    val secondaryCenter = Offset(width * 0.98f, height * 0.26f)
+    val centreCenter = Offset(width * 0.52f, height * 0.44f)
+    val primaryRadius = width * 1.34f
+    val secondaryRadius = width * 1.02f
+    val centreRadius = width * 1.16f
+    val fadeTop = height * 0.34f
 
     val base = homeBaseBrush(isLight)
     val primaryHalo = homeHaloBrush(
         color = primary,
         center = primaryCenter,
         radius = primaryRadius,
-        leadingAlpha = if (isLight) 0.18f else 0.30f,
-        trailingAlpha = if (isLight) 0.055f else 0.085f
+        leadingAlpha = if (isLight) 0.18f else 0.22f,
+        trailingAlpha = if (isLight) 0.055f else 0.075f
     )
     val secondaryHalo = homeHaloBrush(
         color = secondary,
@@ -113,9 +113,9 @@ private fun homeBaseBrush(isLight: Boolean): Brush = if (isLight) {
     Brush.verticalGradient(
         colorStops = arrayOf(
             0f to LevyraHomeDesign.CanvasMid,
-            0.24f to LevyraHomeDesign.CanvasDark,
-            0.52f to Color(0xFF030407),
-            1f to Color.Black
+            0.32f to LevyraHomeDesign.CanvasDark,
+            0.68f to Color(0xFF060810),
+            1f to Color(0xFF04060B)
         )
     )
 }
@@ -157,14 +157,14 @@ private fun homeLowerFadeBrush(isLight: Boolean, fadeTop: Float, height: Float):
     } else {
         listOf(
             Color.Transparent,
-            Color.Black.copy(alpha = 0.78f),
-            Color.Black
+            LevyraHomeDesign.CanvasDark.copy(alpha = 0.58f),
+            LevyraHomeDesign.CanvasDark.copy(alpha = 0.90f)
         )
     }
     return Brush.verticalGradient(
         colors = colors,
         startY = fadeTop,
-        endY = height * 0.62f
+        endY = height * 0.88f
     )
 }
 

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -357,6 +357,7 @@ import com.luc4n3x.levyra.data.HomeSectionLayoutPolicy
 import com.luc4n3x.levyra.data.HomeSectionPresentation
 import com.luc4n3x.levyra.data.LevyraArtworkCache
 import com.luc4n3x.levyra.data.LevyraArtworkStartupMetrics
+import com.luc4n3x.levyra.data.AppleArtistArtworkRepository
 import com.luc4n3x.levyra.data.SpotifyArtistArtworkRepository
 import com.luc4n3x.levyra.data.PlaybackSourceIdentity
 import com.luc4n3x.levyra.data.buildPersonalizedHomeAlbumShelf
@@ -6843,11 +6844,30 @@ private fun homeSoundtrackMatchesArtist(track: Track, artistName: String, browse
 }
 
 private fun homeSoundtrackTitle(strings: LevyraStrings): String = when (strings.code.lowercase(Locale.ROOT)) {
-    "it" -> "La mia colonna sonora"
+    "ar" -> "موسيقاي التصويرية"
+    "cs" -> "Můj soundtrack"
+    "da" -> "Mit soundtrack"
+    "de" -> "Mein Soundtrack"
+    "el" -> "Το σάουντρακ μου"
     "es" -> "Mi banda sonora"
     "fr" -> "Ma bande-son"
-    "de" -> "Mein Soundtrack"
+    "he" -> "הפסקול שלי"
+    "hi" -> "मेरा साउंडट्रैक"
+    "id" -> "Soundtrack saya"
+    "it" -> "La mia colonna sonora"
+    "ja" -> "私のサウンドトラック"
+    "ko" -> "나의 사운드트랙"
+    "nl" -> "Mijn soundtrack"
+    "pl" -> "Moja ścieżka dźwiękowa"
     "pt" -> "Minha trilha sonora"
+    "ro" -> "Coloana mea sonoră"
+    "ru" -> "Мой саундтрек"
+    "sv" -> "Mitt soundtrack"
+    "th" -> "ซาวด์แทร็กของฉัน"
+    "tr" -> "Film müziğim"
+    "uk" -> "Мій саундтрек"
+    "vi" -> "Nhạc phim của tôi"
+    "zh" -> "我的原声带"
     else -> "My soundtrack"
 }
 
@@ -6856,18 +6876,56 @@ private fun homeSoundtrackLead(strings: LevyraStrings, artists: List<String>): S
         .map(String::trim)
         .firstOrNull { it.isNotBlank() }
     return when (strings.code.lowercase(Locale.ROOT)) {
-        "it" -> artist?.let { "$it al centro. Levyra segue il filo dei tuoi ascolti." }
-            ?: "Levyra segue il filo dei tuoi ascolti e costruisce la radio intorno a te."
-        "es" -> artist?.let { "$it en el centro. Levyra sigue el hilo de lo que escuchas." }
-            ?: "Levyra sigue el hilo de lo que escuchas y construye la radio a tu alrededor."
-        "fr" -> artist?.let { "$it au centre. Levyra suit le fil de tes écoutes." }
-            ?: "Levyra suit le fil de tes écoutes et construit la radio autour de toi."
-        "de" -> artist?.let { "$it im Mittelpunkt. Levyra folgt dem roten Faden deiner Hörgewohnheiten." }
-            ?: "Levyra folgt deinen Hörgewohnheiten und baut die Radioauswahl um dich herum."
-        "pt" -> artist?.let { "$it no centro. Levyra segue o fio do que você ouve." }
-            ?: "Levyra segue o fio do que você ouve e monta a rádio ao seu redor."
-        else -> artist?.let { "$it at the center. Levyra follows the thread of your listening." }
-            ?: "Levyra follows the thread of your listening and builds the radio around you."
+        "ar" -> artist?.let { "يبدأ من $it وينمو مع كل استماع." }
+            ?: "راديو ينمو مع كل استماع."
+        "cs" -> artist?.let { "Začíná u $it a roste s každým poslechem." }
+            ?: "Rádio, které roste s každým poslechem."
+        "da" -> artist?.let { "Starter med $it og vokser, mens du lytter." }
+            ?: "En radio, der vokser med hver lytning."
+        "de" -> artist?.let { "Start mit $it, das Radio wächst mit dir." }
+            ?: "Ein Radio, das mit jedem Hören wächst."
+        "el" -> artist?.let { "Ξεκινά από $it και μεγαλώνει με κάθε ακρόαση." }
+            ?: "Ένα ραδιόφωνο που μεγαλώνει με κάθε ακρόαση."
+        "es" -> artist?.let { "Empieza con $it y la radio crece contigo." }
+            ?: "Una radio que crece con cada escucha."
+        "fr" -> artist?.let { "On part de $it et la radio grandit avec toi." }
+            ?: "Une radio qui grandit à chaque écoute."
+        "he" -> artist?.let { "מתחיל עם $it וגדל עם כל האזנה." }
+            ?: "רדיו שגדל עם כל האזנה."
+        "hi" -> artist?.let { "$it से शुरू, हर बार सुनने पर बढ़ता है।" }
+            ?: "हर बार सुनने पर बढ़ने वाला रेडियो।"
+        "id" -> artist?.let { "Mulai dari $it dan tumbuh saat kamu mendengarkan." }
+            ?: "Radio yang tumbuh setiap kali kamu mendengarkan."
+        "it" -> artist?.let { "Si parte da $it e la radio cresce a ogni ascolto." }
+            ?: "Una radio che cresce a ogni tuo ascolto."
+        "ja" -> artist?.let { "$it から始まり、聴くほどに広がります。" }
+            ?: "聴くほどに広がるラジオ。"
+        "ko" -> artist?.let { "$it 에서 시작해 들을수록 넓어져요." }
+            ?: "들을수록 넓어지는 라디오."
+        "nl" -> artist?.let { "Begint bij $it en groeit terwijl je luistert." }
+            ?: "Een radio die groeit bij elke luisterbeurt."
+        "pl" -> artist?.let { "Zaczyna od $it i rośnie z każdym odsłuchem." }
+            ?: "Radio, które rośnie z każdym odsłuchem."
+        "pt" -> artist?.let { "Começa com $it e a rádio cresce com você." }
+            ?: "Uma rádio que cresce a cada música."
+        "ro" -> artist?.let { "Începe cu $it și crește pe măsură ce asculți." }
+            ?: "Un radio care crește cu fiecare ascultare."
+        "ru" -> artist?.let { "Начинается с $it и растёт с каждым прослушиванием." }
+            ?: "Радио, которое растёт с каждым прослушиванием."
+        "sv" -> artist?.let { "Börjar med $it och växer när du lyssnar." }
+            ?: "En radio som växer för varje lyssning."
+        "th" -> artist?.let { "เริ่มจาก $it และเติบโตไปกับการฟังของคุณ" }
+            ?: "วิทยุที่เติบโตไปกับทุกการฟัง"
+        "tr" -> artist?.let { "$it ile başlar, dinledikçe büyür." }
+            ?: "Dinledikçe büyüyen bir radyo."
+        "uk" -> artist?.let { "Починається з $it і росте з кожним прослуховуванням." }
+            ?: "Радіо, що росте з кожним прослуховуванням."
+        "vi" -> artist?.let { "Bắt đầu từ $it và lớn dần theo cách bạn nghe." }
+            ?: "Một đài phát lớn dần theo mỗi lần bạn nghe."
+        "zh" -> artist?.let { "从 $it 开始，越听越懂你。" }
+            ?: "越听越懂你的电台。"
+        else -> artist?.let { "Starts with $it and grows as you listen." }
+            ?: "A radio that grows with every listen."
     }
 }
 
@@ -6890,15 +6948,23 @@ private fun HomeEditorialSpotlight(
     val spotifyArtistArtworkRepository = remember(context) {
         SpotifyArtistArtworkRepository.get(context)
     }
+    val appleArtistArtworkRepository = remember(context) {
+        AppleArtistArtworkRepository.get(context)
+    }
     var resolvedArtistArtworkUrl by remember(heroArtistName, artistArtworkUrl) {
         mutableStateOf(artistArtworkUrl)
     }
-    LaunchedEffect(heroArtistName, artistArtworkUrl, spotifyArtistArtworkRepository) {
+    LaunchedEffect(heroArtistName, artistArtworkUrl, spotifyArtistArtworkRepository, appleArtistArtworkRepository) {
         resolvedArtistArtworkUrl = artistArtworkUrl
         if (heroArtistName.isNotBlank()) {
             val spotifyPortrait = spotifyArtistArtworkRepository.resolveArtistPortrait(heroArtistName)
             if (spotifyPortrait.isNotBlank()) {
                 resolvedArtistArtworkUrl = highResolutionHomeArtistArtworkUrl(spotifyPortrait)
+            } else {
+                val applePortrait = appleArtistArtworkRepository.resolveArtistPortrait(heroArtistName)
+                if (applePortrait.isNotBlank()) {
+                    resolvedArtistArtworkUrl = highResolutionHomeArtistArtworkUrl(applePortrait)
+                }
             }
         }
     }
@@ -7008,18 +7074,20 @@ private fun HomeEditorialSpotlight(
         )
     }
 
+    val heroCanvas = LevyraHomeDesign.CanvasDark
     Box(
         modifier = Modifier
             .matchParentSize()
             .background(
                 Brush.verticalGradient(
                     colorStops = arrayOf(
-                        0f to Color.Black.copy(alpha = 0.30f),
-                        0.12f to Color.Black.copy(alpha = 0.10f),
-                        0.48f to Color.Transparent,
-                        0.67f to Color.Black.copy(alpha = 0.18f),
-                        0.82f to Color.Black.copy(alpha = 0.72f),
-                        1f to Color.Black
+                        0f to heroCanvas,
+                        0.07f to heroCanvas.copy(alpha = 0.62f),
+                        0.20f to heroCanvas.copy(alpha = 0.12f),
+                        0.46f to Color.Transparent,
+                        0.66f to heroCanvas.copy(alpha = 0.34f),
+                        0.83f to heroCanvas.copy(alpha = 0.86f),
+                        1f to heroCanvas
                     )
                 )
             )
@@ -7030,10 +7098,12 @@ private fun HomeEditorialSpotlight(
             .background(
                 Brush.horizontalGradient(
                     colorStops = arrayOf(
-                        0f to Color.Black.copy(alpha = 0.42f),
-                        0.38f to Color.Black.copy(alpha = 0.12f),
-                        0.76f to Color.Transparent,
-                        1f to Color.Black.copy(alpha = 0.06f)
+                        0f to heroCanvas,
+                        0.10f to heroCanvas.copy(alpha = 0.46f),
+                        0.34f to heroCanvas.copy(alpha = 0.10f),
+                        0.72f to Color.Transparent,
+                        0.93f to heroCanvas.copy(alpha = 0.42f),
+                        1f to heroCanvas
                     )
                 )
             )
@@ -7121,10 +7191,10 @@ private fun HomeEditorialSpotlight(
         Text(
             text = soundtrackLead,
             color = Color.White.copy(alpha = 0.96f),
-            fontSize = 18.5.sp,
-            lineHeight = 24.sp,
+            fontSize = 17.sp,
+            lineHeight = 23.sp,
             fontWeight = FontWeight.Medium,
-            maxLines = 2,
+            maxLines = 3,
             overflow = TextOverflow.Ellipsis
         )
     }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -7068,42 +7068,70 @@ private fun HomeEditorialSpotlight(
         StableRemoteArtwork(
             url = resolvedArtistArtworkUrl,
             contentDescription = soundtrackTitle,
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
+                .drawWithContent {
+                    drawContent()
+                    drawRect(
+                        brush = Brush.verticalGradient(
+                            colorStops = arrayOf(
+                                0f to Color.Transparent,
+                                0.14f to Color.Black.copy(alpha = 0.55f),
+                                0.30f to Color.Black,
+                                0.74f to Color.Black,
+                                0.90f to Color.Black.copy(alpha = 0.45f),
+                                1f to Color.Transparent
+                            )
+                        ),
+                        blendMode = BlendMode.DstIn
+                    )
+                    drawRect(
+                        brush = Brush.horizontalGradient(
+                            colorStops = arrayOf(
+                                0f to Color.Black.copy(alpha = 0.30f),
+                                0.09f to Color.Black.copy(alpha = 0.86f),
+                                0.20f to Color.Black,
+                                0.80f to Color.Black,
+                                0.93f to Color.Black.copy(alpha = 0.84f),
+                                1f to Color.Black.copy(alpha = 0.30f)
+                            )
+                        ),
+                        blendMode = BlendMode.DstIn
+                    )
+                },
             contentScale = ContentScale.Crop,
             highRes = true
         )
     }
 
-    val heroCanvas = LevyraHomeDesign.CanvasDark
     Box(
         modifier = Modifier
             .matchParentSize()
             .background(
                 Brush.verticalGradient(
                     colorStops = arrayOf(
-                        0f to heroCanvas,
-                        0.07f to heroCanvas.copy(alpha = 0.62f),
-                        0.20f to heroCanvas.copy(alpha = 0.12f),
-                        0.46f to Color.Transparent,
-                        0.66f to heroCanvas.copy(alpha = 0.34f),
-                        0.83f to heroCanvas.copy(alpha = 0.86f),
-                        1f to heroCanvas
+                        0f to Color.Transparent,
+                        0.44f to Color.Transparent,
+                        0.63f to Color.Black.copy(alpha = 0.24f),
+                        0.80f to Color.Black.copy(alpha = 0.58f),
+                        1f to Color.Black.copy(alpha = 0.76f)
                     )
                 )
             )
     )
     Box(
         modifier = Modifier
-            .matchParentSize()
+            .align(Alignment.BottomStart)
+            .fillMaxWidth()
+            .fillMaxHeight(0.52f)
             .background(
                 Brush.horizontalGradient(
                     colorStops = arrayOf(
-                        0f to heroCanvas,
-                        0.10f to heroCanvas.copy(alpha = 0.46f),
-                        0.34f to heroCanvas.copy(alpha = 0.10f),
-                        0.72f to Color.Transparent,
-                        0.93f to heroCanvas.copy(alpha = 0.42f),
-                        1f to heroCanvas
+                        0f to Color.Black.copy(alpha = 0.30f),
+                        0.44f to Color.Black.copy(alpha = 0.07f),
+                        0.78f to Color.Transparent,
+                        1f to Color.Transparent
                     )
                 )
             )

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -850,6 +850,8 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private var loopCurrentQueueOnCompletion: Boolean = false
     private var samplesPlaybackSession: SamplesPlaybackSession? = null
     private var deferredPlaybackStartSideEffectsKey: String? = null
+    @Volatile
+    private var listeningSignals: com.luc4n3x.levyra.domain.ListeningSignalProfile? = null
     private var listenSessionTrack: Track? = null
     private var listenSessionStartedAt = 0L
     private var listenSessionAccumulatedMs = 0L
@@ -7846,7 +7848,15 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         if (!current.radioEnabled) return
         if (!isSameRadioSeed(current.currentTrack, request.seed)) return
         if (current.generation != request.generation) return
-        queueEngine.appendRadioTracks(radioTracks)
+        val orderedRadioTracks = listeningSignals?.takeIf { it.hasSignal }?.let { signals ->
+            com.luc4n3x.levyra.domain.ListeningSignalRanker.rank(
+                candidates = radioTracks,
+                profile = signals,
+                limit = radioTracks.size,
+                contextArtist = request.seed.artist
+            )
+        } ?: radioTracks
+        queueEngine.appendRadioTracks(orderedRadioTracks)
         if (!playWhenReady) return
         withContext(Dispatchers.Main) {
             queueEngine.next(respectRepeatOne = false)?.let(::startResolve)
@@ -8663,11 +8673,25 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             val mostPlayed = listeningPulseStore.mostPlayedTracks()
             val pulse = listeningPulseEngine.build(events)
             lastListeningPulseRefreshMs = android.os.SystemClock.elapsedRealtime()
+            val signalSnapshot = _state.value
+            val signals = com.luc4n3x.levyra.domain.ListeningSignalEngine.build(
+                events = events,
+                favorites = signalSnapshot.favorites,
+                playlistTracks = signalSnapshot.playlists.flatMap { it.tracks },
+                followedArtists = signalSnapshot.followedArtists.map { it.name }
+            )
+            listeningSignals = signals
             _state.update { current ->
                 val updated = current.copy(
                     listeningPulse = pulse,
                     recentListens = recent,
-                    mostPlayedTracks = mostPlayed
+                    mostPlayedTracks = mostPlayed,
+                    personalOrbitTracks = com.luc4n3x.levyra.domain.ListeningSignalRanker.rank(
+                        candidates = current.personalOrbitTracks,
+                        profile = signals,
+                        limit = current.personalOrbitTracks.size,
+                        dropSuppressed = false
+                    )
                 )
                 val localAlbums = instantAlbumRecommendations(updated, HOME_ALBUM_RECOMMENDATION_LIMIT)
                 val rankedAlbums = rankAlbumRecommendations(

--- a/app/src/test/java/com/luc4n3x/levyra/data/ArtistPortraitFallbackTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/ArtistPortraitFallbackTest.kt
@@ -1,0 +1,99 @@
+package com.luc4n3x.levyra.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ArtistPortraitFallbackTest {
+
+    private fun solid(color: Int, count: Int = 256): IntArray = IntArray(count) { color }
+
+    @Test
+    fun `a solid colour portrait is detected as flat`() {
+        assertTrue(isFlatArtworkSample(solid(0xFFC33028.toInt())))
+    }
+
+    @Test
+    fun `an almost solid portrait within tolerance is still flat`() {
+        val pixels = IntArray(256) { index ->
+            val jitter = index % (FLAT_ARTWORK_CHANNEL_SPREAD + 1)
+            (0xFF shl 24) or ((0xC0 + jitter) shl 16) or (0x30 shl 8) or 0x28
+        }
+        assertTrue(isFlatArtworkSample(pixels))
+    }
+
+    @Test
+    fun `a real photograph with colour range is not flat`() {
+        val pixels = IntArray(256) { index ->
+            (0xFF shl 24) or ((index % 256) shl 16) or ((255 - index % 256) shl 8) or (index % 128)
+        }
+        assertFalse(isFlatArtworkSample(pixels))
+    }
+
+    @Test
+    fun `an empty sample is never reported as flat`() {
+        assertFalse(isFlatArtworkSample(IntArray(0)))
+    }
+
+    @Test
+    fun `apple artwork host allowlist accepts mzstatic over https only`() {
+        assertTrue(isAllowedAppleArtistArtworkUrl("https://is1-ssl.mzstatic.com/image/thumb/a/b/1200x1200bb.png"))
+        assertFalse(isAllowedAppleArtistArtworkUrl("http://is1-ssl.mzstatic.com/image/thumb/a/b/1200x1200bb.png"))
+        assertFalse(isAllowedAppleArtistArtworkUrl("https://evil.example.com/image.png"))
+        assertFalse(isAllowedAppleArtistArtworkUrl("https://mzstatic.com.evil.example/image.png"))
+    }
+
+    @Test
+    fun `apple artist page allowlist requires the artist path on music apple com`() {
+        assertTrue(isAllowedAppleArtistPageUrl("https://music.apple.com/it/artist/sfera-ebbasta/881651714"))
+        assertFalse(isAllowedAppleArtistPageUrl("https://music.apple.com/it/album/x/123"))
+        assertFalse(isAllowedAppleArtistPageUrl("https://evil.example.com/it/artist/x/1"))
+        assertFalse(isAllowedAppleArtistPageUrl("http://music.apple.com/it/artist/x/1"))
+    }
+
+    @Test
+    fun `apple portrait extraction upgrades the requested size`() {
+        val html = """<meta property="og:image" content="https://is1-ssl.mzstatic.com/image/thumb/AMCArtistImages221/v4/b5/0d/07/file_cropped.png/1200x630cw.png">"""
+        assertEquals(
+            "https://is1-ssl.mzstatic.com/image/thumb/AMCArtistImages221/v4/b5/0d/07/file_cropped.png/1200x1200bb.png",
+            extractAppleArtistPortrait(html)
+        )
+    }
+
+    @Test
+    fun `apple portrait extraction rejects a page without a usable image`() {
+        assertEquals("", extractAppleArtistPortrait("<html><body>no artwork here</body></html>"))
+        assertEquals("", extractAppleArtistPortrait("<img src=\"https://evil.example.com/a/1200x630cw.png\">"))
+    }
+
+    @Test
+    fun `apple portrait extraction prefers the open graph image over album covers`() {
+        val html = """
+            <img src="https://is5-ssl.mzstatic.com/image/thumb/Music116/v4/aa/bb/cc/album_cover.jpg/300x300bb.jpg">
+            <meta property="og:image" content="https://is1-ssl.mzstatic.com/image/thumb/AMCArtistImages221/v4/b5/0d/07/file_cropped.png/1200x630cw.png">
+        """.trimIndent()
+        assertEquals(
+            "https://is1-ssl.mzstatic.com/image/thumb/AMCArtistImages221/v4/b5/0d/07/file_cropped.png/1200x1200bb.png",
+            extractAppleArtistPortrait(html)
+        )
+    }
+
+    @Test
+    fun `apple portrait extraction falls back to an artist image when open graph is absent`() {
+        val html = """
+            <img src="https://is5-ssl.mzstatic.com/image/thumb/Music116/v4/aa/bb/cc/album_cover.jpg/300x300bb.jpg">
+            <img src="https://is1-ssl.mzstatic.com/image/thumb/AMCArtistImages112/v4/d1/e2/f3/artist.png/486x486bb.png">
+        """.trimIndent()
+        assertEquals(
+            "https://is1-ssl.mzstatic.com/image/thumb/AMCArtistImages112/v4/d1/e2/f3/artist.png/1200x1200bb.png",
+            extractAppleArtistPortrait(html)
+        )
+    }
+
+    @Test
+    fun `apple portrait extraction ignores a page with only album covers`() {
+        val html = """<img src="https://is5-ssl.mzstatic.com/image/thumb/Music116/v4/aa/bb/cc/album.jpg/300x300bb.jpg">"""
+        assertEquals("", extractAppleArtistPortrait(html))
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerConfigVerificationTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerConfigVerificationTest.kt
@@ -1,0 +1,165 @@
+package com.luc4n3x.levyra.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class YoutubePlayerConfigVerificationTest {
+
+    private val signatureInput = YoutubePlayerConfigVerifier.SIGNATURE_PROBES[0]
+    private val secondSignatureInput = YoutubePlayerConfigVerifier.SIGNATURE_PROBES[1]
+    private val throttlingInput = YoutubePlayerConfigVerifier.THROTTLING_PROBES[0]
+    private val secondThrottlingInput = YoutubePlayerConfigVerifier.THROTTLING_PROBES[1]
+
+    private fun shuffled(value: String): String = value.reversed()
+
+    private fun healthySignatures() = listOf(
+        YoutubeCipherProbe(signatureInput, shuffled(signatureInput)),
+        YoutubeCipherProbe(secondSignatureInput, shuffled(secondSignatureInput))
+    )
+
+    private fun healthyThrottling() = listOf(
+        YoutubeCipherProbe(throttlingInput, "Kd93nchTQ7Bm2Xz1Lp"),
+        YoutubeCipherProbe(secondThrottlingInput, "Ws81mzpQ4Rc6Yv0Nk")
+    )
+
+    @Test
+    fun `a working cipher is accepted`() {
+        val result = YoutubePlayerConfigVerifier.verify(healthySignatures(), healthyThrottling())
+        assertEquals(YoutubeConfigVerdict.ACCEPTED, result.verdict)
+        assertTrue(result.accepted)
+        assertFalse(result.provesConfigWrong)
+    }
+
+    @Test
+    fun `no probe evidence is inconclusive rather than a rejection`() {
+        val result = YoutubePlayerConfigVerifier.verify(emptyList(), emptyList())
+        assertEquals(YoutubeConfigVerdict.INCONCLUSIVE, result.verdict)
+        assertFalse(result.provesConfigWrong)
+    }
+
+    @Test
+    fun `partial probe coverage is inconclusive`() {
+        val result = YoutubePlayerConfigVerifier.verify(healthySignatures(), emptyList())
+        assertEquals(YoutubeConfigVerdict.INCONCLUSIVE, result.verdict)
+    }
+
+    @Test
+    fun `an empty signature output is rejected`() {
+        val probes = listOf(YoutubeCipherProbe(signatureInput, ""))
+        val result = YoutubePlayerConfigVerifier.verify(probes, healthyThrottling())
+        assertTrue(result.provesConfigWrong)
+    }
+
+    @Test
+    fun `an unchanged signature output is rejected`() {
+        val probes = listOf(YoutubeCipherProbe(signatureInput, signatureInput))
+        val result = YoutubePlayerConfigVerifier.verify(probes, healthyThrottling())
+        assertTrue(result.provesConfigWrong)
+    }
+
+    @Test
+    fun `a spliced signature output stays acceptable`() {
+        val spliced = listOf(
+            YoutubeCipherProbe(signatureInput, shuffled(signatureInput).drop(20)),
+            YoutubeCipherProbe(secondSignatureInput, shuffled(secondSignatureInput).drop(18))
+        )
+        val result = YoutubePlayerConfigVerifier.verify(spliced, healthyThrottling())
+        assertEquals(YoutubeConfigVerdict.ACCEPTED, result.verdict)
+    }
+
+    @Test
+    fun `a signature output longer than the input is rejected`() {
+        val probes = listOf(YoutubeCipherProbe(signatureInput, signatureInput + "AB"))
+        val result = YoutubePlayerConfigVerifier.verify(probes, healthyThrottling())
+        assertTrue(result.provesConfigWrong)
+    }
+
+    @Test
+    fun `a signature output with foreign characters is rejected`() {
+        val corrupted = shuffled(signatureInput).dropLast(1) + "%"
+        val probes = listOf(YoutubeCipherProbe(signatureInput, corrupted))
+        val result = YoutubePlayerConfigVerifier.verify(probes, healthyThrottling())
+        assertTrue(result.provesConfigWrong)
+    }
+
+    @Test
+    fun `an unchanged n output is rejected`() {
+        val probes = listOf(YoutubeCipherProbe(throttlingInput, throttlingInput))
+        val result = YoutubePlayerConfigVerifier.verify(healthySignatures(), probes)
+        assertTrue(result.provesConfigWrong)
+    }
+
+    @Test
+    fun `a transform that collapses distinct inputs is rejected`() {
+        val collapsed = listOf(
+            YoutubeCipherProbe(throttlingInput, "SameOutput1"),
+            YoutubeCipherProbe(secondThrottlingInput, "SameOutput1")
+        )
+        val result = YoutubePlayerConfigVerifier.verify(healthySignatures(), collapsed)
+        assertTrue(result.provesConfigWrong)
+    }
+
+    @Test
+    fun `aggregator returns null without any valid sample`() {
+        assertNull(YoutubePlayerSampleAggregator.aggregate(emptyList()))
+        assertNull(
+            YoutubePlayerSampleAggregator.aggregate(
+                listOf(YoutubePlayerSample("not-a-hash", "iframe_api"))
+            )
+        )
+    }
+
+    @Test
+    fun `a single agreed player is not reported as rotating`() {
+        val observation = YoutubePlayerSampleAggregator.aggregate(
+            listOf(
+                YoutubePlayerSample("0a1b2c3d", "iframe_api"),
+                YoutubePlayerSample("0a1b2c3d", "embed")
+            )
+        )
+        assertEquals("0a1b2c3d", observation?.dominantHash)
+        assertFalse(observation!!.rotating)
+    }
+
+    @Test
+    fun `disagreeing samples expose the alternate player`() {
+        val observation = YoutubePlayerSampleAggregator.aggregate(
+            listOf(
+                YoutubePlayerSample("0a1b2c3d", "iframe_api"),
+                YoutubePlayerSample("ffee9911", "embed")
+            )
+        )
+        assertTrue(observation!!.rotating)
+        assertEquals("0a1b2c3d", observation.dominantHash)
+        assertEquals(listOf("ffee9911"), observation.alternateHashes)
+        assertEquals(listOf("0a1b2c3d", "ffee9911"), observation.allHashes)
+    }
+
+    @Test
+    fun `the most frequently observed player wins over sample order`() {
+        val observation = YoutubePlayerSampleAggregator.aggregate(
+            listOf(
+                YoutubePlayerSample("0a1b2c3d", "iframe_api"),
+                YoutubePlayerSample("ffee9911", "embed"),
+                YoutubePlayerSample("ffee9911", "watch")
+            )
+        )
+        assertEquals("ffee9911", observation?.dominantHash)
+        assertEquals(listOf("0a1b2c3d"), observation?.alternateHashes)
+    }
+
+    @Test
+    fun `hashes are normalised before aggregation`() {
+        val observation = YoutubePlayerSampleAggregator.aggregate(
+            listOf(
+                YoutubePlayerSample(" 0A1B2C3D ", "iframe_api"),
+                YoutubePlayerSample("0a1b2c3d", "embed")
+            )
+        )
+        assertEquals("0a1b2c3d", observation?.dominantHash)
+        assertFalse(observation!!.rotating)
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/domain/ListeningSignalsTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/domain/ListeningSignalsTest.kt
@@ -162,6 +162,29 @@ class ListeningSignalsTest {
     }
 
     @Test
+    fun `deferred higher ranked artist becomes eligible after another artist`() {
+        val candidates = listOf(
+            track("a1", "Alpha"),
+            track("a2", "Alpha"),
+            track("a3", "Alpha"),
+            track("b1", "Beta"),
+            track("c1", "Charlie")
+        )
+        val profile = ListeningSignalEngine.build(
+            events = listOf(
+                event("a1", "Alpha", 200_000L, completed = true),
+                event("a2", "Alpha", 200_000L, completed = true),
+                event("a3", "Alpha", 200_000L, completed = true)
+            ),
+            nowMs = now
+        )
+
+        val ranked = ListeningSignalRanker.rank(candidates, profile, limit = 4, artistRunLimit = 2)
+
+        assertEquals(listOf("a1", "a2", "b1", "a3"), ranked.map { it.id })
+    }
+
+    @Test
     fun `context artist keeps the hero artist in front and exempt from the run limit`() {
         val candidates = listOf(
             track("b1", "Beta"),

--- a/app/src/test/java/com/luc4n3x/levyra/domain/ListeningSignalsTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/domain/ListeningSignalsTest.kt
@@ -1,0 +1,220 @@
+package com.luc4n3x.levyra.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ListeningSignalsTest {
+
+    private val now = 1_750_000_000_000L
+
+    private fun track(id: String, artist: String, title: String = "Title $id"): Track = Track(
+        id = id,
+        title = title,
+        artist = artist,
+        album = "Album",
+        durationMs = 200_000L,
+        streamUrl = "",
+        videoUrl = "",
+        thumbnailUrl = "",
+        largeThumbnailUrl = "",
+        source = "youtube",
+        moodTags = setOf("music"),
+        energy = 50,
+        vocal = 50,
+        replayScore = 50,
+        cacheScore = 50,
+        accentStart = 0,
+        accentEnd = 0
+    )
+
+    private fun event(
+        id: String,
+        artist: String,
+        listenedMs: Long,
+        completed: Boolean = false,
+        durationMs: Long = 200_000L,
+        startedAt: Long = now
+    ): ListenEvent = ListenEvent(
+        trackId = id,
+        title = "Title $id",
+        artist = artist,
+        listenedMs = listenedMs,
+        trackDurationMs = durationMs,
+        completed = completed,
+        startedAt = startedAt
+    )
+
+    @Test
+    fun `completion ratio uses listened over duration and saturates at one`() {
+        assertEquals(0.5, ListeningSignalEngine.completionRatio(event("a", "A", 100_000L)), 0.001)
+        assertEquals(1.0, ListeningSignalEngine.completionRatio(event("a", "A", 400_000L)), 0.001)
+        assertEquals(1.0, ListeningSignalEngine.completionRatio(event("a", "A", 1_000L, completed = true)), 0.001)
+    }
+
+    @Test
+    fun `unknown duration falls back to the counted play threshold`() {
+        val short = event("a", "A", 10_000L, durationMs = 0L)
+        val long = event("a", "A", 45_000L, durationMs = 0L)
+        assertEquals(0.0, ListeningSignalEngine.completionRatio(short), 0.001)
+        assertEquals(1.0, ListeningSignalEngine.completionRatio(long), 0.001)
+    }
+
+    @Test
+    fun `repeated early skips build a strong negative signal that suppresses the track`() {
+        val events = List(3) { index ->
+            event("skipme", "Noisy", 8_000L, startedAt = now - index * 1_000L)
+        }
+        val profile = ListeningSignalEngine.build(events, nowMs = now)
+        val signal = profile.tracks.getValue("skipme")
+
+        assertEquals(3, signal.plays)
+        assertEquals(0, signal.countedPlays)
+        assertEquals(3, signal.earlySkips)
+        assertTrue(profile.isSuppressed(track("skipme", "Noisy")))
+    }
+
+    @Test
+    fun `a favorited track is never suppressed`() {
+        val events = List(3) { event("skipme", "Noisy", 8_000L) }
+        val profile = ListeningSignalEngine.build(
+            events = events,
+            favorites = listOf(track("skipme", "Noisy")),
+            nowMs = now
+        )
+        assertFalse(profile.isSuppressed(track("skipme", "Noisy")))
+    }
+
+    @Test
+    fun `completed repeats outrank a barely played track`() {
+        val events = listOf(
+            event("loved", "Alpha", 200_000L, completed = true),
+            event("loved", "Alpha", 200_000L, completed = true),
+            event("meh", "Beta", 12_000L)
+        )
+        val profile = ListeningSignalEngine.build(events, nowMs = now)
+        assertTrue(profile.trackScore(track("loved", "Alpha")) > profile.trackScore(track("meh", "Beta")))
+    }
+
+    @Test
+    fun `followed artists and playlist presence raise the score`() {
+        val plain = ListeningSignalEngine.build(emptyList(), nowMs = now)
+        val boosted = ListeningSignalEngine.build(
+            events = emptyList(),
+            playlistTracks = listOf(track("t1", "Alpha")),
+            followedArtists = listOf("Alpha"),
+            nowMs = now
+        )
+        assertEquals(0, plain.trackScore(track("t1", "Alpha")))
+        assertTrue(boosted.trackScore(track("t1", "Alpha")) > 0)
+    }
+
+    @Test
+    fun `artist affinity is credited to every collaborator`() {
+        val events = listOf(event("duet", "Alpha feat. Beta", 200_000L, completed = true))
+        val profile = ListeningSignalEngine.build(events, nowMs = now)
+
+        assertTrue(profile.artists.containsKey("alpha"))
+        assertTrue(profile.artists.containsKey("beta"))
+        assertTrue(profile.artistScore("Beta") > 0)
+    }
+
+    @Test
+    fun `ranker keeps original order when there is no signal`() {
+        val candidates = listOf(track("a", "Alpha"), track("b", "Beta"))
+        val ranked = ListeningSignalRanker.rank(candidates, ListeningSignalProfile())
+        assertEquals(candidates, ranked)
+    }
+
+    @Test
+    fun `ranker drops suppressed candidates but never returns an empty list`() {
+        val events = List(3) { event("skipme", "Noisy", 8_000L) }
+        val profile = ListeningSignalEngine.build(events, nowMs = now)
+
+        val mixed = ListeningSignalRanker.rank(
+            listOf(track("skipme", "Noisy"), track("keep", "Alpha")),
+            profile
+        )
+        assertEquals(listOf(track("keep", "Alpha")), mixed)
+
+        val onlySuppressed = ListeningSignalRanker.rank(listOf(track("skipme", "Noisy")), profile)
+        assertEquals(1, onlySuppressed.size)
+    }
+
+    @Test
+    fun `ranker limits consecutive tracks from the same artist`() {
+        val candidates = listOf(
+            track("a1", "Alpha"),
+            track("a2", "Alpha"),
+            track("a3", "Alpha"),
+            track("b1", "Beta")
+        )
+        val profile = ListeningSignalEngine.build(
+            events = listOf(event("a1", "Alpha", 200_000L, completed = true)),
+            followedArtists = listOf("Alpha"),
+            nowMs = now
+        )
+        val ranked = ListeningSignalRanker.rank(candidates, profile, limit = 3, artistRunLimit = 2)
+
+        assertEquals(3, ranked.size)
+        assertEquals("Beta", ranked[2].artist)
+    }
+
+    @Test
+    fun `context artist keeps the hero artist in front and exempt from the run limit`() {
+        val candidates = listOf(
+            track("b1", "Beta"),
+            track("a1", "Alpha"),
+            track("a2", "Alpha"),
+            track("a3", "Alpha")
+        )
+        val profile = ListeningSignalEngine.build(
+            events = listOf(event("b1", "Beta", 200_000L, completed = true)),
+            followedArtists = listOf("Beta"),
+            nowMs = now
+        )
+        val ranked = ListeningSignalRanker.rank(
+            candidates = candidates,
+            profile = profile,
+            limit = 4,
+            contextArtist = "Alpha",
+            artistRunLimit = 2
+        )
+
+        assertEquals(listOf("Alpha", "Alpha", "Alpha", "Beta"), ranked.map { it.artist })
+    }
+
+    @Test
+    fun `reorder only mode keeps every candidate so repeated ranking cannot shrink a shelf`() {
+        val events = List(3) { event("skipme", "Noisy", 8_000L) }
+        val profile = ListeningSignalEngine.build(events, nowMs = now)
+        val shelf = listOf(track("skipme", "Noisy"), track("keep", "Alpha"))
+
+        var current = shelf
+        repeat(5) {
+            current = ListeningSignalRanker.rank(
+                candidates = current,
+                profile = profile,
+                limit = current.size,
+                dropSuppressed = false
+            )
+        }
+
+        assertEquals(shelf.size, current.size)
+        assertEquals(shelf.map { it.id }.toSet(), current.map { it.id }.toSet())
+        assertEquals("keep", current.first().id)
+    }
+
+    @Test
+    fun `context artist survives suppression of its own catalogue`() {
+        val events = List(3) { event("a1", "Alpha", 8_000L) }
+        val profile = ListeningSignalEngine.build(events, nowMs = now)
+        val ranked = ListeningSignalRanker.rank(
+            candidates = listOf(track("a1", "Alpha")),
+            profile = profile,
+            contextArtist = "Alpha"
+        )
+        assertEquals(1, ranked.size)
+    }
+}


### PR DESCRIPTION
## Summary

Three pieces of work land together here. The local YouTube decoder now proves a player cipher configuration actually works before it trusts it, so a broken upstream or locally derived config is caught before it can produce unplayable stream URLs. The personal recommendation surfaces read real listening history instead of treating every candidate as equal, so "La tua orbita" and the personal radio follow what you actually finish, repeat and skip. And the "my soundtrack" hero finally shows a real artist photograph and dissolves into the home background instead of sitting on it as a rectangle.

The hero fix started as a bug report about a solid red panel. Spotify serves a flat colour tile rather than a photograph for artists with no official portrait, which is exactly what it returns for Sfera Ebbasta: 6.6 KB of uniform red against 52-124 KB for every other artist in the same search. The image was loading correctly, it simply had no content, so Levyra now detects that case and falls back to Apple Music.

## What changed

- Added a verification gate in front of the local decoder. A cipher config is exercised against deterministic signature and n-parameter probes before it is used, with a three-valued verdict so only a proven failure rejects a config and an inconclusive probe never negative-caches. Rejected identities are remembered so a persistently wrong config cannot cause repeated WebView churn.
- Player detection aggregates multiple live samples instead of trusting a single iframe_api response, and surfaces the alternate hash when samples disagree, which is how a low-rate A/B or canary player becomes visible. ETag, TTL, checksum, cooldown and bundled-offline fallback behaviour are untouched.
- Derived listening signals from the existing listen_events history: completion ratio, repeats, skips and early skips, favourites, playlist presence, followed artists, per-artist affinity, and strong negative signals for repeatedly skipped tracks and artists.
- Applied those signals to the orbit shelf and the personal radio tail, with a per-artist run limit for diversity and a context artist so an artist-centred card keeps playback on that artist. The orbit shelf is reordered only, never filtered, so repeated ranking cannot shrink it.
- Isolated scrobble providers from each other so a failing provider can no longer abort delivery to the remaining ones, and released the de-duplication key when a submission did not go through.
- Detected flat placeholder artist portraits by decoding the candidate at a low sample size and measuring per-channel colour spread, then resolving from Apple Music instead. The Apple resolver goes through the public iTunes search API, follows only a validated music.apple.com artist page, and accepts only an mzstatic image, preferring the Open Graph portrait over album covers on the same page.
- Masked the hero portrait with an alpha gradient so it fades on all four edges into the ambient background, confined the side scrim to the text band, translated the hero title and lead into every language in the catalogue rather than six, and carried the ambient palette further down the page so it no longer collapses to black.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor or maintenance
- [x] UI or UX change
- [x] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** Player / Streaming / UI / Localization

## Validation

### Automated checks

- [x] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [x] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

`python3 scripts/ai_quality_gate.py --profile full` passed, covering release lint and the unsigned F-Droid release build. `:app:testDebugUnitTest` runs 1648 tests with no failures, and `:app:lintDebug` is clean. Desktop is untouched by this change.

New tests cover the cipher verification verdicts and sample aggregation, the listening signal engine and ranker including the reorder-only path that protects the shelf from shrinking, and the flat-portrait detection plus the Apple URL allowlists and portrait extraction.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Galaxy S25+ (SM-S936B), Android 16, debug build | Cold start, home render, playback from the hero card | Playback started, mini player advanced, MediaSession updated, no crash |
| Galaxy S25+ | Artist-centred hero playback | Radio stayed on the hero artist rather than drifting |
| Galaxy S25+ | Artist portrait resolution with the cache cleared | Spotify portrait recorded as flat, Apple portrait resolved and rendered |
| Galaxy S25+ | Home scrolled through the shelves | Ambient palette carries down the page, shelves stay readable |

The emulator was not usable during this work: the AVD booted but ADB never brought the device out of `offline`, so all manual testing was done on the physical device instead.

## Risk and compatibility

- **Risk level:** Medium
- **Compatibility or migration notes:** No schema change and no new dependencies. The Spotify artwork preferences gain a flat marker alongside the existing keys, and the Apple resolver uses its own new preferences file, so existing cached data stays valid.
- **Known limitations:** The hero title and lead remain in-composable strings rather than the shared catalogue, following the pattern already in that file; moving them into the catalogue would touch the required-key contract across every language file and belongs in its own change. The flat-portrait probe costs one extra image request per artist, cached for the normal artwork TTL.
- **Rollback plan:** Revert this PR

## Reviewer notes

- `YoutubeLocalDecoder.ensureRuntime` is the behavioural hinge: a rejected config now throws before the runtime is published, which routes into the existing refresh-and-retry path rather than a new one. The verifier deliberately avoids length heuristics, since a player that splices more characters than expected would otherwise be rejected while working correctly.
- `ListeningSignalRanker.rank` has a `dropSuppressed` flag. The radio tail drops suppressed candidates because it is ephemeral; the orbit shelf only reorders, because its result is written back into state and filtering there would shrink the shelf a little more on every refresh.
- The hero image uses `CompositingStrategy.Offscreen` to apply the alpha mask. It is a single static image rather than an animated surface, but it is worth a second opinion on the home critical path.
- `HomeExperience` changes touch only the dark-theme values; the light branches are untouched.

## Release note

The soundtrack card on Home now shows a real artist photograph and blends into the background, and your recommendations follow what you actually listen to.

## Related issues

- Closes #
- Related to #

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through levyra-humanizer without changing its claims


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Personalized radio recommendations now reflect listening history, favorites, playlists, followed artists, skips, and completion.
  - Artist artwork can fall back to Apple Music when Spotify artwork is unavailable.
  - Expanded localized soundtrack titles and radio descriptions across additional languages.

- **Bug Fixes**
  - Improved YouTube playback reliability when player configurations change.
  - Avoids unsuitable flat-color artist artwork.
  - Scrobbling continues for other services when one provider fails.

- **Style**
  - Refined Home screen gradients and hero artwork presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->