### PR TITLE
feat(home): add authentic YouTube comment cards to Resonance shelf

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraHomeSnapshotCache.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraHomeSnapshotCache.kt
@@ -5,6 +5,7 @@ import com.luc4n3x.levyra.domain.ArtistHit
 import com.luc4n3x.levyra.domain.HomeSection
 import com.luc4n3x.levyra.domain.isArtistShelfNameEligible
 import com.luc4n3x.levyra.domain.LevyraLanguageCatalog
+import com.luc4n3x.levyra.domain.ResonanceCommentSnippet
 import com.luc4n3x.levyra.domain.Track
 import org.json.JSONArray
 import org.json.JSONObject
@@ -34,6 +35,11 @@ class LevyraHomeSnapshotCache(context: Context) {
             }
             val parsedPersonalOrbit = parseTracks(rootJson.optJSONArray("personalOrbit") ?: JSONArray())
             val parsedResonance = if (schema >= 12) parseTracks(rootJson.optJSONArray("resonanceTracks") ?: JSONArray()) else emptyList()
+            val parsedResonanceComments = if (schema >= 14) {
+                parseResonanceComments(rootJson.optJSONObject("resonanceComments"))
+            } else {
+                emptyMap()
+            }
             val homeSections = if (schema >= 7) parsedHomeSections else parsedHomeSections.map { section ->
                 section.copy(tracks = section.tracks.map { track -> track.copy(artistBrowseIds = emptyList()) })
             }
@@ -50,7 +56,8 @@ class LevyraHomeSnapshotCache(context: Context) {
                 personalOrbit = personalOrbit,
                 homeArtists = homeArtists,
                 resonanceTracks = parsedResonance,
-                resonanceUpdatedAt = if (schema >= 12) rootJson.optLong("resonanceUpdatedAt", 0L) else 0L
+                resonanceUpdatedAt = if (schema >= 12) rootJson.optLong("resonanceUpdatedAt", 0L) else 0L,
+                resonanceComments = parsedResonanceComments
             )
         }.onFailure { Timber.w(it, "Home snapshot restore failed") }.getOrNull()
     }
@@ -63,7 +70,8 @@ class LevyraHomeSnapshotCache(context: Context) {
         personalOrbit: List<Track>,
         homeArtists: List<ArtistHit>,
         resonanceTracks: List<Track>,
-        resonanceUpdatedAt: Long
+        resonanceUpdatedAt: Long,
+        resonanceComments: Map<String, ResonanceCommentSnippet> = emptyMap()
     ) {
         val normalized = LevyraLanguageCatalog.normalize(languageCode)
         val normalizedChartRegionId = chartRegionId.trim().lowercase()
@@ -80,6 +88,7 @@ class LevyraHomeSnapshotCache(context: Context) {
                 .put("homeArtists", artistsToJson(homeArtists.take(HOME_ARTIST_LIMIT)))
                 .put("resonanceTracks", tracksToJson(resonanceTracks.take(RESONANCE_TRACK_LIMIT)))
                 .put("resonanceUpdatedAt", resonanceUpdatedAt)
+                .put("resonanceComments", resonanceCommentsToJson(resonanceComments))
             val target = fileFor(normalized)
             val tmp = File(target.parentFile, "${target.name}.tmp")
             tmp.writeText(json.toString())
@@ -187,11 +196,50 @@ class LevyraHomeSnapshotCache(context: Context) {
 
     private fun snapshotKey(track: Track): String = track.id.ifBlank { track.videoUrl.ifBlank { "${track.artist}|${track.title}" } }.trim().lowercase()
 
+    private fun resonanceCommentsToJson(comments: Map<String, ResonanceCommentSnippet>): JSONObject {
+        val json = JSONObject()
+        comments.entries.take(RESONANCE_TRACK_LIMIT).forEach { (id, snippet) ->
+            if (id.isNotBlank() && (snippet.text.isNotBlank() || snippet.countText.isNotBlank())) {
+                val item = JSONObject()
+                    .put("videoId", snippet.videoId)
+                    .put("countText", snippet.countText)
+                    .put("author", snippet.author)
+                    .put("authorAvatarUrl", snippet.authorAvatarUrl)
+                    .put("text", snippet.text)
+                    .put("likeCountText", snippet.likeCountText)
+                    .put("disabled", snippet.disabled)
+                json.put(id, item)
+            }
+        }
+        return json
+    }
+
+    private fun parseResonanceComments(obj: JSONObject?): Map<String, ResonanceCommentSnippet> {
+        if (obj == null) return emptyMap()
+        val map = mutableMapOf<String, ResonanceCommentSnippet>()
+        val keys = obj.keys()
+        while (keys.hasNext()) {
+            val key = keys.next()
+            val item = obj.optJSONObject(key) ?: continue
+            val videoId = item.optString("videoId", key)
+            map[key] = ResonanceCommentSnippet(
+                videoId = videoId,
+                countText = item.optString("countText"),
+                author = item.optString("author"),
+                authorAvatarUrl = item.optString("authorAvatarUrl"),
+                text = item.optString("text"),
+                likeCountText = item.optString("likeCountText"),
+                disabled = item.optBoolean("disabled", false)
+            )
+        }
+        return map
+    }
+
     private companion object {
         const val HOME_ARTIST_LIMIT = 13
         const val RESONANCE_TRACK_LIMIT = 8
         const val MIN_SUPPORTED_SCHEMA = 5
-        const val SCHEMA = 13
+        const val SCHEMA = 14
         const val MAX_STALE_MS = 21L * 24L * 60L * 60L * 1000L
     }
 }
@@ -205,5 +253,6 @@ data class LevyraHomeSnapshot(
     val personalOrbit: List<Track>,
     val homeArtists: List<ArtistHit>,
     val resonanceTracks: List<Track>,
-    val resonanceUpdatedAt: Long
+    val resonanceUpdatedAt: Long,
+    val resonanceComments: Map<String, ResonanceCommentSnippet> = emptyMap()
 )

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraHomeSnapshotCache.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraHomeSnapshotCache.kt
@@ -7,6 +7,7 @@ import com.luc4n3x.levyra.domain.isArtistShelfNameEligible
 import com.luc4n3x.levyra.domain.LevyraLanguageCatalog
 import com.luc4n3x.levyra.domain.ResonanceCommentSnippet
 import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.domain.resonanceCommentsForTracks
 import org.json.JSONArray
 import org.json.JSONObject
 import timber.log.Timber
@@ -36,7 +37,10 @@ class LevyraHomeSnapshotCache(context: Context) {
             val parsedPersonalOrbit = parseTracks(rootJson.optJSONArray("personalOrbit") ?: JSONArray())
             val parsedResonance = if (schema >= 12) parseTracks(rootJson.optJSONArray("resonanceTracks") ?: JSONArray()) else emptyList()
             val parsedResonanceComments = if (schema >= 14) {
-                parseResonanceComments(rootJson.optJSONObject("resonanceComments"))
+                resonanceCommentsForTracks(
+                    parsedResonance,
+                    parseResonanceComments(rootJson.optJSONObject("resonanceComments"))
+                )
             } else {
                 emptyMap()
             }
@@ -88,7 +92,10 @@ class LevyraHomeSnapshotCache(context: Context) {
                 .put("homeArtists", artistsToJson(homeArtists.take(HOME_ARTIST_LIMIT)))
                 .put("resonanceTracks", tracksToJson(resonanceTracks.take(RESONANCE_TRACK_LIMIT)))
                 .put("resonanceUpdatedAt", resonanceUpdatedAt)
-                .put("resonanceComments", resonanceCommentsToJson(resonanceComments))
+                .put(
+                    "resonanceComments",
+                    resonanceCommentsToJson(resonanceTracks.take(RESONANCE_TRACK_LIMIT), resonanceComments)
+                )
             val target = fileFor(normalized)
             val tmp = File(target.parentFile, "${target.name}.tmp")
             tmp.writeText(json.toString())
@@ -196,24 +203,6 @@ class LevyraHomeSnapshotCache(context: Context) {
 
     private fun snapshotKey(track: Track): String = track.id.ifBlank { track.videoUrl.ifBlank { "${track.artist}|${track.title}" } }.trim().lowercase()
 
-    private fun resonanceCommentsToJson(comments: Map<String, ResonanceCommentSnippet>): JSONObject {
-        val json = JSONObject()
-        comments.entries.take(RESONANCE_TRACK_LIMIT).forEach { (id, snippet) ->
-            if (id.isNotBlank() && (snippet.text.isNotBlank() || snippet.countText.isNotBlank())) {
-                val item = JSONObject()
-                    .put("videoId", snippet.videoId)
-                    .put("countText", snippet.countText)
-                    .put("author", snippet.author)
-                    .put("authorAvatarUrl", snippet.authorAvatarUrl)
-                    .put("text", snippet.text)
-                    .put("likeCountText", snippet.likeCountText)
-                    .put("disabled", snippet.disabled)
-                json.put(id, item)
-            }
-        }
-        return json
-    }
-
     private fun parseResonanceComments(obj: JSONObject?): Map<String, ResonanceCommentSnippet> {
         if (obj == null) return emptyMap()
         val map = mutableMapOf<String, ResonanceCommentSnippet>()
@@ -229,7 +218,8 @@ class LevyraHomeSnapshotCache(context: Context) {
                 authorAvatarUrl = item.optString("authorAvatarUrl"),
                 text = item.optString("text"),
                 likeCountText = item.optString("likeCountText"),
-                disabled = item.optBoolean("disabled", false)
+                disabled = item.optBoolean("disabled", false),
+                updatedAtMs = item.optLong("updatedAtMs", 0L)
             )
         }
         return map
@@ -239,9 +229,34 @@ class LevyraHomeSnapshotCache(context: Context) {
         const val HOME_ARTIST_LIMIT = 13
         const val RESONANCE_TRACK_LIMIT = 8
         const val MIN_SUPPORTED_SCHEMA = 5
-        const val SCHEMA = 14
+        const val SCHEMA = 15
         const val MAX_STALE_MS = 21L * 24L * 60L * 60L * 1000L
     }
+}
+
+internal fun resonanceCommentsToJson(
+    tracks: List<Track>,
+    comments: Map<String, ResonanceCommentSnippet>
+): JSONObject {
+    val json = JSONObject()
+    resonanceCommentsForTracks(tracks, comments).forEach { (id, snippet) ->
+        if (
+            snippet.text.isNotBlank() || snippet.countText.isNotBlank() ||
+            snippet.disabled || snippet.updatedAtMs > 0L
+        ) {
+            val item = JSONObject()
+                .put("videoId", snippet.videoId)
+                .put("countText", snippet.countText)
+                .put("author", snippet.author)
+                .put("authorAvatarUrl", snippet.authorAvatarUrl)
+                .put("text", snippet.text)
+                .put("likeCountText", snippet.likeCountText)
+                .put("disabled", snippet.disabled)
+                .put("updatedAtMs", snippet.updatedAtMs)
+            json.put(id, item)
+        }
+    }
+    return json
 }
 
 data class LevyraHomeSnapshot(

--- a/app/src/main/java/com/luc4n3x/levyra/domain/ResonanceCommentSnippet.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/ResonanceCommentSnippet.kt
@@ -16,8 +16,24 @@ data class ResonanceCommentSnippet(
     val likeCountText: String = "",
     val isLoading: Boolean = false,
     val hasError: Boolean = false,
-    val disabled: Boolean = false
+    val disabled: Boolean = false,
+    val updatedAtMs: Long = 0L
 ) {
     val hasComment: Boolean
         get() = text.isNotBlank()
+}
+
+internal fun resonanceCommentsForTracks(
+    tracks: List<Track>,
+    comments: Map<String, ResonanceCommentSnippet>
+): Map<String, ResonanceCommentSnippet> = buildMap {
+    tracks.asSequence()
+        .map(Track::id)
+        .filter(String::isNotBlank)
+        .distinct()
+        .forEach { videoId ->
+            comments[videoId]
+                ?.takeIf { it.videoId == videoId }
+                ?.let { put(videoId, it) }
+        }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/domain/ResonanceCommentSnippet.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/ResonanceCommentSnippet.kt
@@ -1,0 +1,23 @@
+package com.luc4n3x.levyra.domain
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Real YouTube comment snippet displayed in the "Voci che risuonano" (most discussed tracks)
+ * home shelf. Holds authentic comment text, count, and author metadata without invented content.
+ */
+@Immutable
+data class ResonanceCommentSnippet(
+    val videoId: String,
+    val countText: String = "",
+    val author: String = "",
+    val authorAvatarUrl: String = "",
+    val text: String = "",
+    val likeCountText: String = "",
+    val isLoading: Boolean = false,
+    val hasError: Boolean = false,
+    val disabled: Boolean = false
+) {
+    val hasComment: Boolean
+        get() = text.isNotBlank()
+}

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -810,38 +810,45 @@ private fun ActiveTrackEqualizer(
 }
 @Composable
 private fun HomePlayAllButton(onClick: () -> Unit, size: Dp = 36.dp) {
+    val strings = LocalLevyraStrings.current
     Box(
         modifier = Modifier
-            .size(size)
-            .clip(CircleShape)
-            .background(
-                Brush.linearGradient(
-                    listOf(
-                        LevyraCyan.copy(alpha = 0.15f),
-                        LevyraViolet.copy(alpha = 0.11f)
-                    )
-                ),
-                CircleShape
-            )
-            .border(
-                1.dp,
-                Brush.linearGradient(
-                    listOf(
-                        LevyraCyan.copy(alpha = 0.45f),
-                        LevyraViolet.copy(alpha = 0.32f)
-                    )
-                ),
-                CircleShape
-            )
+            .size(LevyraPlayerDesign.MinimumTouchTarget)
             .pressable(onClick = onClick),
         contentAlignment = Alignment.Center
     ) {
-        Icon(
-            imageVector = Icons.Rounded.PlayArrow,
-            contentDescription = LocalLevyraStrings.current.play,
-            tint = LevyraCyan,
-            modifier = Modifier.size(size * 0.55f)
-        )
+        Box(
+            modifier = Modifier
+                .size(size)
+                .clip(CircleShape)
+                .background(
+                    Brush.linearGradient(
+                        listOf(
+                            LevyraCyan.copy(alpha = 0.15f),
+                            LevyraViolet.copy(alpha = 0.11f)
+                        )
+                    ),
+                    CircleShape
+                )
+                .border(
+                    1.dp,
+                    Brush.linearGradient(
+                        listOf(
+                            LevyraCyan.copy(alpha = 0.45f),
+                            LevyraViolet.copy(alpha = 0.32f)
+                        )
+                    ),
+                    CircleShape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.PlayArrow,
+                contentDescription = strings.playAll,
+                tint = LevyraCyan,
+                modifier = Modifier.size(size * 0.55f)
+            )
+        }
     }
 }
 
@@ -873,7 +880,6 @@ private fun HomeSectionHeader(
     title: String,
     subtitle: String? = null,
     onPlayAll: (() -> Unit)? = null,
-    titleMaxLines: Int = 1,
     modifier: Modifier = Modifier
 ) {
     val strings = LocalLevyraStrings.current
@@ -896,7 +902,7 @@ private fun HomeSectionHeader(
                 lineHeight = LevyraTypeRhythm.lineHeight(23.sp),
                 letterSpacing = (-0.65).sp,
                 fontWeight = FontWeight.Black,
-                maxLines = titleMaxLines,
+                maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
             if (displaySubtitle.isNotBlank()) {
@@ -7954,6 +7960,59 @@ private fun TrendingArtistLoadingItem() {
 }
 
 @Composable
+private fun ResonanceSectionHeader(
+    title: String,
+    subtitle: String,
+    onPlayAll: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(5.dp)
+    ) {
+        Text(
+            text = title,
+            color = LevyraText,
+            style = TextStyle(
+                fontSize = 23.sp,
+                fontWeight = FontWeight.Black,
+                letterSpacing = (-0.65).sp
+            ),
+            autoSize = TextAutoSize.StepBased(
+                minFontSize = 12.5.sp,
+                maxFontSize = 23.sp,
+                stepSize = 0.5.sp
+            ),
+            maxLines = 1,
+            softWrap = false,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = subtitle,
+                color = LevyraMuted,
+                style = TextStyle(fontSize = 12.5.sp, fontWeight = FontWeight.Medium),
+                autoSize = TextAutoSize.StepBased(
+                    minFontSize = 10.sp,
+                    maxFontSize = 12.5.sp,
+                    stepSize = 0.5.sp
+                ),
+                maxLines = 1,
+                softWrap = false,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f)
+            )
+            HomePlayAllButton(onClick = onPlayAll)
+        }
+    }
+}
+
+@Composable
 private fun ResonanceShelf(
     tracks: List<Track>,
     comments: Map<String, ResonanceCommentSnippet>,
@@ -7969,11 +8028,10 @@ private fun ResonanceShelf(
     if (displayTracks.isEmpty()) return
 
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        HomeSectionHeader(
+        ResonanceSectionHeader(
             title = strings.mostCommentedTracks,
             subtitle = strings.tapToOpenComments,
             onPlayAll = onPlayAll,
-            titleMaxLines = 2,
             modifier = Modifier.padding(horizontal = HomeHorizontalInset)
         )
         LazyRow(
@@ -8011,22 +8069,33 @@ private fun ResonanceCard(
     onOpenComments: () -> Unit
 ) {
     val strings = LocalLevyraStrings.current
-    val shape = RoundedCornerShape(24.dp)
+    val shape = RoundedCornerShape(20.dp)
+    val fontScale = LocalDensity.current.fontScale
+    val cardHeight = 196.dp + (90.dp * (fontScale - 1f).coerceAtLeast(0f))
     Column(
         modifier = Modifier
-            .width(336.dp)
+            .width(324.dp)
+            .height(cardHeight)
             .clip(shape)
             .background(
-                if (active) LevyraCyan.copy(alpha = if (LevyraIsLight) 0.08f else 0.10f)
-                else LevyraAdaptiveCard
+                Brush.verticalGradient(
+                    if (active) {
+                        listOf(
+                            LevyraCyan.copy(alpha = if (LevyraIsLight) 0.10f else 0.13f),
+                            LevyraViolet.copy(alpha = if (LevyraIsLight) 0.05f else 0.07f)
+                        )
+                    } else {
+                        listOf(LevyraAdaptiveCard, LevyraAdaptiveCardDeep)
+                    }
+                )
             )
             .border(
                 width = if (active) 1.dp else Dp.Hairline,
                 color = if (active) LevyraCyan.copy(alpha = 0.58f) else LevyraAdaptiveSoftHairline,
                 shape = shape
             )
-            .padding(14.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
         Row(
             modifier = Modifier
@@ -8037,9 +8106,9 @@ private fun ResonanceCard(
         ) {
             Box(
                 modifier = Modifier
-                    .size(58.dp)
-                    .clip(RoundedCornerShape(10.dp))
-                    .border(Dp.Hairline, LevyraAdaptiveSoftHairline, RoundedCornerShape(10.dp)),
+                    .size(56.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .border(Dp.Hairline, LevyraAdaptiveSoftHairline, RoundedCornerShape(12.dp)),
                 contentAlignment = Alignment.Center
             ) {
                 CoverImage(track = track, modifier = Modifier.fillMaxSize(), highRes = false)
@@ -8097,7 +8166,7 @@ private fun ResonanceCard(
                     if (active) LevyraCyan.copy(alpha = 0.40f) else LevyraText.copy(alpha = 0.10f)
                 ),
                 modifier = Modifier
-                    .size(34.dp)
+                    .size(36.dp)
                     .pressable(onClick = onPlay)
             ) {
                 Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
@@ -8112,7 +8181,7 @@ private fun ResonanceCard(
         }
 
         Surface(
-            shape = RoundedCornerShape(16.dp),
+            shape = RoundedCornerShape(14.dp),
             color = if (LevyraIsLight) Color.Black.copy(alpha = 0.06f) else LevyraAdaptiveCardDeep,
             border = BorderStroke(
                 Dp.Hairline,
@@ -8120,10 +8189,13 @@ private fun ResonanceCard(
             ),
             modifier = Modifier
                 .fillMaxWidth()
+                .weight(1f)
                 .pressable(onClick = onOpenComments)
         ) {
             Column(
-                modifier = Modifier.padding(horizontal = 12.dp, vertical = 11.dp),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 12.dp, vertical = 10.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 Row(

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -20,6 +20,7 @@ import com.luc4n3x.levyra.ui.artwork.livingArtworkColors
 import com.luc4n3x.levyra.ui.lyrics.LyricsShareCard
 import com.luc4n3x.levyra.ui.theme.LevyraPlayerDesign
 import com.luc4n3x.levyra.ui.theme.LevyraHomeDesign
+import com.luc4n3x.levyra.domain.ResonanceCommentSnippet
 import androidx.compose.material.icons.rounded.ChevronRight
 
 import androidx.compose.animation.core.spring
@@ -6098,6 +6099,11 @@ private fun HomeScreen(
         ).take(LevyraPersonalOrbit.DISPLAY_LIMIT)
     }
     val resonanceTracks = homeDerivedState.resonanceTracks
+    LaunchedEffect(resonanceTracks) {
+        if (resonanceTracks.isNotEmpty()) {
+            viewModel.refreshHomeResonanceComments(resonanceTracks)
+        }
+    }
     val quickPicks = homeDerivedState.quickPicks
     val newReleases = homeDerivedState.newReleases
     val homeAlbums = remember(
@@ -6536,11 +6542,13 @@ private fun HomeScreen(
                     HomeSectionLead(compactHome) {
                         ResonanceShelf(
                             tracks = resonanceTracks,
+                            comments = state.homeResonanceComments,
                             currentId = state.currentTrack?.id,
                             isPlaying = state.isPlaying,
                             isResolving = state.isResolving,
                             onPlay = { track -> viewModel.playFrom(resonanceTracks, track) },
-                            onPlayAll = { viewModel.playAll(resonanceTracks) }
+                            onPlayAll = { viewModel.playAll(resonanceTracks) },
+                            onOpenComments = { track -> viewModel.openYoutubeCommentsFor(track) }
                         )
                     }
                 }
@@ -7932,15 +7940,18 @@ private fun TrendingArtistLoadingItem() {
 @Composable
 private fun ResonanceShelf(
     tracks: List<Track>,
+    comments: Map<String, ResonanceCommentSnippet>,
     currentId: String?,
     isPlaying: Boolean,
     isResolving: Boolean,
     onPlay: (Track) -> Unit,
-    onPlayAll: () -> Unit
+    onPlayAll: () -> Unit,
+    onOpenComments: (Track) -> Unit
 ) {
     val strings = LocalLevyraStrings.current
-    val columns = remember(tracks) { tracks.take(8).chunked(2) }
-    if (columns.isEmpty()) return
+    val displayTracks = remember(tracks) { tracks.take(10) }
+    if (displayTracks.isEmpty()) return
+
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         HomeSectionHeader(
             title = strings.voicesTitle,
@@ -7950,98 +7961,255 @@ private fun ResonanceShelf(
         )
         LazyRow(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
             contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
         ) {
-            itemsIndexed(
-                items = columns,
-                key = { index, chunk -> "res-column-$index-${chunk.joinToString("-") { it.id }}" },
-                contentType = { _, _ -> "home-resonance-column" }
-            ) { _, chunk ->
-                Column(
-                    modifier = Modifier.width(310.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+            items(
+                items = displayTracks,
+                key = { track -> "res-card-${track.id}" },
+                contentType = { "home-resonance-card" }
+            ) { track ->
+                ResonanceCard(
+                    track = track,
+                    snippet = comments[track.id],
+                    active = track.id == currentId,
+                    isPlaying = isPlaying,
+                    isResolving = isResolving,
+                    onPlay = { onPlay(track) },
+                    onOpenComments = { onOpenComments(track) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ResonanceCard(
+    track: Track,
+    snippet: ResonanceCommentSnippet?,
+    active: Boolean,
+    isPlaying: Boolean,
+    isResolving: Boolean,
+    onPlay: () -> Unit,
+    onOpenComments: () -> Unit
+) {
+    val strings = LocalLevyraStrings.current
+    val shape = RoundedCornerShape(20.dp)
+    Column(
+        modifier = Modifier
+            .width(314.dp)
+            .clip(shape)
+            .background(
+                if (active) LevyraCyan.copy(alpha = if (LevyraIsLight) 0.08f else 0.10f)
+                else LevyraAdaptiveCard
+            )
+            .border(
+                width = if (active) 1.2.dp else Dp.Hairline,
+                color = if (active) LevyraCyan.copy(alpha = 0.75f) else LevyraAdaptiveSoftHairline,
+                shape = shape
+            )
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .pressable(onClick = onPlay),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(11.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(54.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .border(Dp.Hairline, LevyraAdaptiveSoftHairline, RoundedCornerShape(12.dp)),
+                contentAlignment = Alignment.Center
+            ) {
+                CoverImage(track = track, modifier = Modifier.fillMaxSize(), highRes = false)
+                if (active) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color.Black.copy(alpha = 0.32f)),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        if (isResolving) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(17.dp),
+                                strokeWidth = 2.dp,
+                                color = LevyraCyan
+                            )
+                        } else {
+                            ActiveTrackEqualizer(
+                                color = LevyraCyan,
+                                isPlaying = isPlaying,
+                                width = 16.dp,
+                                height = 11.dp
+                            )
+                        }
+                    }
+                }
+            }
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                Text(
+                    text = track.title,
+                    color = if (active) LevyraCyan else LevyraText,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 14.5.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = track.artist,
+                    color = LevyraMuted,
+                    fontSize = 12.5.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+
+            Surface(
+                shape = CircleShape,
+                color = if (active) LevyraCyan.copy(alpha = 0.18f) else LevyraText.copy(alpha = 0.07f),
+                border = BorderStroke(
+                    1.dp,
+                    if (active) LevyraCyan.copy(alpha = 0.40f) else LevyraText.copy(alpha = 0.10f)
+                ),
+                modifier = Modifier
+                    .size(34.dp)
+                    .pressable(onClick = onPlay)
+            ) {
+                Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                    Icon(
+                        imageVector = if (active && isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+                        contentDescription = null,
+                        tint = if (active) LevyraCyan else LevyraText.copy(alpha = 0.85f),
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+            }
+        }
+
+        Surface(
+            shape = RoundedCornerShape(14.dp),
+            color = if (LevyraIsLight) Color.Black.copy(alpha = 0.04f) else Color.White.copy(alpha = 0.05f),
+            border = BorderStroke(
+                Dp.Hairline,
+                if (active) LevyraCyan.copy(alpha = 0.28f) else LevyraAdaptiveSoftHairline.copy(alpha = 0.50f)
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .pressable(onClick = onOpenComments)
+        ) {
+            Column(
+                modifier = Modifier.padding(horizontal = 11.dp, vertical = 9.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
                 ) {
-                    chunk.forEach { track ->
-                        val active = track.id == currentId
-                        val shape = RoundedCornerShape(13.dp)
+                    Icon(
+                        imageVector = Icons.Rounded.ChatBubbleOutline,
+                        contentDescription = null,
+                        tint = LevyraCyan,
+                        modifier = Modifier.size(13.dp)
+                    )
+                    val count = snippet?.countText?.takeIf { it.isNotBlank() }
+                    Text(
+                        text = if (count != null) "$count ${strings.commentsLabel.lowercase(Locale.ROOT)}" else strings.commentsLabel,
+                        color = LevyraCyan,
+                        fontSize = 11.5.sp,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                    Icon(
+                        imageVector = Icons.Rounded.ChevronRight,
+                        contentDescription = strings.tapToOpenComments,
+                        tint = LevyraMuted.copy(alpha = 0.60f),
+                        modifier = Modifier.size(15.dp)
+                    )
+                }
+
+                when {
+                    snippet?.isLoading == true -> {
+                        ResonanceCommentShimmer()
+                    }
+                    snippet?.disabled == true -> {
+                        Text(
+                            text = strings.commentsDisabled,
+                            color = LevyraMuted.copy(alpha = 0.70f),
+                            fontSize = 11.5.sp,
+                            maxLines = 1
+                        )
+                    }
+                    snippet != null && snippet.hasComment -> {
                         Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(68.dp)
-                                .clip(shape)
-                                .background(
-                                    if (active) LevyraCyan.copy(alpha = if (LevyraIsLight) 0.10f else 0.11f)
-                                    else LevyraAdaptiveCard
-                                )
-                                .border(
-                                    if (active) 1.2.dp else Dp.Hairline,
-                                    if (active) LevyraCyan.copy(alpha = 0.72f) else LevyraAdaptiveSoftHairline,
-                                    shape
-                                )
-                                .pressable(onClick = { onPlay(track) }),
-                            verticalAlignment = Alignment.CenterVertically
+                            verticalAlignment = Alignment.Top,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
-                            Box(
+                            YoutubeCommentAvatar(
+                                url = snippet.authorAvatarUrl,
+                                author = snippet.author,
                                 modifier = Modifier
-                                    .size(68.dp)
-                                    .clip(RoundedCornerShape(topStart = 13.dp, bottomStart = 13.dp)),
-                                contentAlignment = Alignment.Center
+                                    .padding(top = 1.dp)
+                                    .size(20.dp)
+                            )
+                            Column(
+                                modifier = Modifier.weight(1f),
+                                verticalArrangement = Arrangement.spacedBy(2.dp)
                             ) {
-                                CoverImage(track = track, modifier = Modifier.fillMaxSize(), highRes = false)
-                                if (active) {
-                                    Box(
-                                        modifier = Modifier
-                                            .matchParentSize()
-                                            .background(Color.Black.copy(alpha = 0.30f)),
-                                        contentAlignment = Alignment.Center
-                                    ) {
-                                        if (isResolving) {
-                                            CircularProgressIndicator(
-                                                modifier = Modifier.size(17.dp),
-                                                strokeWidth = 2.dp,
-                                                color = LevyraCyan
-                                            )
-                                        } else {
-                                            ActiveTrackEqualizer(
-                                                color = LevyraCyan,
-                                                isPlaying = isPlaying,
-                                                width = 16.dp,
-                                                height = 11.dp
-                                            )
-                                        }
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                                ) {
+                                    Text(
+                                        text = snippet.author,
+                                        color = LevyraText.copy(alpha = 0.90f),
+                                        fontSize = 11.sp,
+                                        fontWeight = FontWeight.Bold,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        modifier = Modifier.weight(1f, fill = false)
+                                    )
+                                    if (snippet.likeCountText.isNotBlank()) {
+                                        Text(
+                                            text = "• \uD83D\uDC4D ${snippet.likeCountText}",
+                                            color = LevyraMuted,
+                                            fontSize = 10.sp,
+                                            maxLines = 1
+                                        )
                                     }
                                 }
-                            }
-                            Column(
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .padding(horizontal = 11.dp),
-                                verticalArrangement = Arrangement.spacedBy(3.dp)
-                            ) {
                                 Text(
-                                    text = track.title,
-                                    color = if (active) LevyraCyan else LevyraText,
-                                    fontWeight = FontWeight.Bold,
-                                    fontSize = 14.sp,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis
-                                )
-                                Text(
-                                    text = track.artist,
-                                    color = LevyraMuted,
-                                    fontSize = 12.sp,
-                                    maxLines = 1,
+                                    text = snippet.text,
+                                    color = LevyraMuted.copy(alpha = 0.95f),
+                                    fontSize = 11.5.sp,
+                                    lineHeight = 15.sp,
+                                    maxLines = 2,
                                     overflow = TextOverflow.Ellipsis
                                 )
                             }
-                            Icon(
-                                imageVector = if (active && isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
-                                contentDescription = null,
-                                tint = if (active) LevyraCyan else LevyraText.copy(alpha = 0.78f),
-                                modifier = Modifier
-                                    .padding(end = 12.dp)
-                                    .size(20.dp)
+                        }
+                    }
+                    else -> {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            Text(
+                                text = strings.tapToOpenComments,
+                                color = LevyraMuted.copy(alpha = 0.85f),
+                                fontSize = 11.5.sp,
+                                fontWeight = FontWeight.Medium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
                             )
                         }
                     }
@@ -8052,170 +8220,37 @@ private fun ResonanceShelf(
 }
 
 @Composable
-private fun ResonanceCard(
-    track: Track,
-    index: Int,
-    active: Boolean,
-    playing: Boolean,
-    resolving: Boolean,
-    onClick: () -> Unit
-) {
-    val accentStart = Color(track.accentStart)
-    val accentEnd = Color(track.accentEnd)
-    val score = (track.replayScore + track.vocal + track.cacheScore / 2 + index * 7).coerceAtLeast(24)
-    val comments = 520 + (score * 31) % 4200
-    val engagement = minOf(99, score % 100)
-    val pulseWidth = ((score % 72) + 24) / 100f
-    val shape = RoundedCornerShape(18.dp)
-    Surface(
-        color = if (LevyraIsLight) Color.White.copy(alpha = 0.92f) else Color(0xFF101114),
-        border = BorderStroke(
-            width = if (active) 1.5.dp else Dp.Hairline,
-            color = if (active) LevyraCyan.copy(alpha = 0.80f) else LevyraAdaptiveSoftHairline
-        ),
-        shape = shape,
-        modifier = Modifier
-            .width(282.dp)
-            .height(112.dp)
-            .pressable(onClick = onClick)
+private fun ResonanceCommentShimmer() {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.fillMaxWidth()
     ) {
-        Row(
+        Box(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                .size(20.dp)
+                .clip(CircleShape)
+                .background(LevyraAdaptiveTrack.copy(alpha = 0.35f))
+        )
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
             Box(
                 modifier = Modifier
-                    .size(88.dp)
-                    .clip(RoundedCornerShape(14.dp))
-                    .border(Dp.Hairline, LevyraAdaptiveSoftHairline, RoundedCornerShape(14.dp))
-            ) {
-                CoverImage(
-                    track = track,
-                    modifier = Modifier.fillMaxSize(),
-                    highRes = false
-                )
-                when {
-                    resolving -> {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .background(Color.Black.copy(alpha = 0.38f)),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            CircularProgressIndicator(
-                                modifier = Modifier.size(20.dp),
-                                strokeWidth = 2.dp,
-                                color = LevyraCyan
-                            )
-                        }
-                    }
-                    active -> {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .background(Color.Black.copy(alpha = 0.30f)),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            ActiveTrackEqualizer(
-                                color = LevyraCyan,
-                                isPlaying = playing,
-                                width = 20.dp,
-                                height = 16.dp
-                            )
-                        }
-                    }
-                }
-            }
-
-            Column(
+                    .fillMaxWidth(0.45f)
+                    .height(8.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(LevyraAdaptiveTrack.copy(alpha = 0.35f))
+            )
+            Box(
                 modifier = Modifier
-                    .weight(1f)
-                    .fillMaxHeight(),
-                verticalArrangement = Arrangement.SpaceBetween
-            ) {
-                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                    Text(
-                        text = track.title,
-                        color = LevyraText,
-                        fontSize = 15.sp,
-                        lineHeight = LevyraTypeRhythm.lineHeight(15.sp),
-                        fontWeight = FontWeight.ExtraBold,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    Text(
-                        text = track.artist,
-                        color = LevyraMuted,
-                        fontSize = 12.sp,
-                        lineHeight = LevyraTypeRhythm.lineHeight(12.sp),
-                        fontWeight = FontWeight.Medium,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
-
-                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(4.dp)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Rounded.LocalFireDepartment,
-                                contentDescription = null,
-                                tint = LevyraOrange,
-                                modifier = Modifier.size(13.dp)
-                            )
-                            Text(
-                                text = "$engagement%",
-                                color = LevyraText,
-                                fontSize = 12.5.sp,
-                                fontWeight = FontWeight.Bold
-                            )
-                        }
-                        Text(
-                            text = formatCompactNumber(comments),
-                            color = LevyraMuted,
-                            fontSize = 12.5.sp,
-                            fontWeight = FontWeight.Bold
-                        )
-                    }
-
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(2.dp)
-                            .clip(CircleShape)
-                            .background(LevyraAdaptiveTrack)
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth(pulseWidth.coerceIn(0.1f, 1f))
-                                .height(2.dp)
-                                .clip(CircleShape)
-                                .background(Brush.horizontalGradient(listOf(accentStart, accentEnd)))
-                        )
-                    }
-                }
-            }
+                    .fillMaxWidth(0.85f)
+                    .height(8.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(LevyraAdaptiveTrack.copy(alpha = 0.22f))
+            )
         }
-    }
-}
-
-private fun formatCompactNumber(value: Int): String {
-    return if (value >= 1000) {
-        val major = value / 1000
-        val minor = (value % 1000) / 100
-        if (minor == 0) "$major K" else "$major,$minor K"
-    } else {
-        value.toString()
     }
 }
 

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -7954,8 +7954,7 @@ private fun ResonanceShelf(
 
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         HomeSectionHeader(
-            title = strings.voicesTitle,
-            subtitle = strings.voicesSubtitle,
+            title = strings.mostCommentedTracks,
             onPlayAll = onPlayAll,
             modifier = Modifier.padding(horizontal = HomeHorizontalInset)
         )
@@ -7994,10 +7993,10 @@ private fun ResonanceCard(
     onOpenComments: () -> Unit
 ) {
     val strings = LocalLevyraStrings.current
-    val shape = RoundedCornerShape(20.dp)
+    val shape = RoundedCornerShape(22.dp)
     Column(
         modifier = Modifier
-            .width(314.dp)
+            .width(328.dp)
             .clip(shape)
             .background(
                 if (active) LevyraCyan.copy(alpha = if (LevyraIsLight) 0.08f else 0.10f)
@@ -8008,8 +8007,8 @@ private fun ResonanceCard(
                 color = if (active) LevyraCyan.copy(alpha = 0.75f) else LevyraAdaptiveSoftHairline,
                 shape = shape
             )
-            .padding(12.dp),
-        verticalArrangement = Arrangement.spacedBy(10.dp)
+            .padding(14.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         Row(
             modifier = Modifier
@@ -8020,9 +8019,9 @@ private fun ResonanceCard(
         ) {
             Box(
                 modifier = Modifier
-                    .size(54.dp)
-                    .clip(RoundedCornerShape(12.dp))
-                    .border(Dp.Hairline, LevyraAdaptiveSoftHairline, RoundedCornerShape(12.dp)),
+                    .size(58.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .border(Dp.Hairline, LevyraAdaptiveSoftHairline, RoundedCornerShape(10.dp)),
                 contentAlignment = Alignment.Center
             ) {
                 CoverImage(track = track, modifier = Modifier.fillMaxSize(), highRes = false)
@@ -8059,14 +8058,14 @@ private fun ResonanceCard(
                     text = track.title,
                     color = if (active) LevyraCyan else LevyraText,
                     fontWeight = FontWeight.Bold,
-                    fontSize = 14.5.sp,
+                    fontSize = 16.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
                 Text(
                     text = track.artist,
                     color = LevyraMuted,
-                    fontSize = 12.5.sp,
+                    fontSize = 13.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
@@ -8095,8 +8094,8 @@ private fun ResonanceCard(
         }
 
         Surface(
-            shape = RoundedCornerShape(14.dp),
-            color = if (LevyraIsLight) Color.Black.copy(alpha = 0.04f) else Color.White.copy(alpha = 0.05f),
+            shape = RoundedCornerShape(16.dp),
+            color = if (LevyraIsLight) Color.Black.copy(alpha = 0.055f) else Color.White.copy(alpha = 0.075f),
             border = BorderStroke(
                 Dp.Hairline,
                 if (active) LevyraCyan.copy(alpha = 0.28f) else LevyraAdaptiveSoftHairline.copy(alpha = 0.50f)
@@ -8106,8 +8105,8 @@ private fun ResonanceCard(
                 .pressable(onClick = onOpenComments)
         ) {
             Column(
-                modifier = Modifier.padding(horizontal = 11.dp, vertical = 9.dp),
-                verticalArrangement = Arrangement.spacedBy(6.dp)
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 11.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -8122,12 +8121,20 @@ private fun ResonanceCard(
                     )
                     val count = snippet?.countText?.takeIf { it.isNotBlank() }
                     Text(
-                        text = if (count != null) "$count ${strings.commentsLabel.lowercase(Locale.ROOT)}" else strings.commentsLabel,
-                        color = LevyraCyan,
-                        fontSize = 11.5.sp,
+                        text = strings.commentsLabel,
+                        color = LevyraText,
+                        fontSize = 13.sp,
                         fontWeight = FontWeight.Bold,
                         maxLines = 1
                     )
+                    if (count != null) {
+                        Text(
+                            text = count,
+                            color = LevyraMuted,
+                            fontSize = 12.sp,
+                            maxLines = 1
+                        )
+                    }
                     Spacer(modifier = Modifier.weight(1f))
                     Icon(
                         imageVector = Icons.Rounded.ChevronRight,

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -873,6 +873,7 @@ private fun HomeSectionHeader(
     title: String,
     subtitle: String? = null,
     onPlayAll: (() -> Unit)? = null,
+    titleMaxLines: Int = 1,
     modifier: Modifier = Modifier
 ) {
     val strings = LocalLevyraStrings.current
@@ -895,7 +896,7 @@ private fun HomeSectionHeader(
                 lineHeight = LevyraTypeRhythm.lineHeight(23.sp),
                 letterSpacing = (-0.65).sp,
                 fontWeight = FontWeight.Black,
-                maxLines = 1,
+                maxLines = titleMaxLines,
                 overflow = TextOverflow.Ellipsis
             )
             if (displaySubtitle.isNotBlank()) {
@@ -1310,7 +1311,7 @@ fun LevyraApp(
             viewModel.clearBackupMessage()
         }
     }
-    BackHandler(enabled = showLanguageRestartDialog || state.showRecognition || state.showJam || state.showYourSound || state.sharedMediaPreview != null || showDownloadsFolder || state.openPlaylist != null || state.showAlbum || state.showArtist || state.showQueue || state.showLyrics || state.showSettings || state.showAudioQualityPanel || state.selectedTab != LevyraTab.Home) {
+    BackHandler(enabled = showLanguageRestartDialog || state.youtubeEngagement.comments.visible || state.showRecognition || state.showJam || state.showYourSound || state.sharedMediaPreview != null || showDownloadsFolder || state.openPlaylist != null || state.showAlbum || state.showArtist || state.showQueue || state.showLyrics || state.showSettings || state.showAudioQualityPanel || state.selectedTab != LevyraTab.Home) {
         if (showLanguageRestartDialog) {
             showLanguageRestartDialog = false
         } else if (state.showRecognition) {
@@ -1616,6 +1617,21 @@ fun LevyraApp(
                         )
                     )
                 }
+            }
+
+            if (state.youtubeEngagement.comments.visible) {
+                PlayerYoutubeCommentsSheet(
+                    comments = state.youtubeEngagement.comments,
+                    primary = yourSoundAccent,
+                    secondary = LevyraViolet,
+                    strings = currentStrings,
+                    onDismiss = viewModel::closeYoutubeComments,
+                    onRetry = viewModel::retryYoutubeComments,
+                    onLoadMore = viewModel::loadMoreYoutubeComments,
+                    onRetryLoadMore = viewModel::retryYoutubeCommentsPage,
+                    onToggleReplies = viewModel::toggleYoutubeCommentReplies,
+                    onLoadMoreReplies = viewModel::loadMoreYoutubeCommentReplies
+                )
             }
 
             val morphTrack = state.currentTrack
@@ -6099,8 +6115,8 @@ private fun HomeScreen(
         ).take(LevyraPersonalOrbit.DISPLAY_LIMIT)
     }
     val resonanceTracks = homeDerivedState.resonanceTracks
-    LaunchedEffect(resonanceTracks) {
-        if (resonanceTracks.isNotEmpty()) {
+    LaunchedEffect(resonanceTracks, state.interfaceSettings.showResonance) {
+        if (resonanceTracks.isNotEmpty() && state.interfaceSettings.showResonance) {
             viewModel.refreshHomeResonanceComments(resonanceTracks)
         }
     }
@@ -7955,7 +7971,9 @@ private fun ResonanceShelf(
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         HomeSectionHeader(
             title = strings.mostCommentedTracks,
+            subtitle = strings.tapToOpenComments,
             onPlayAll = onPlayAll,
+            titleMaxLines = 2,
             modifier = Modifier.padding(horizontal = HomeHorizontalInset)
         )
         LazyRow(
@@ -7993,18 +8011,18 @@ private fun ResonanceCard(
     onOpenComments: () -> Unit
 ) {
     val strings = LocalLevyraStrings.current
-    val shape = RoundedCornerShape(22.dp)
+    val shape = RoundedCornerShape(24.dp)
     Column(
         modifier = Modifier
-            .width(328.dp)
+            .width(336.dp)
             .clip(shape)
             .background(
                 if (active) LevyraCyan.copy(alpha = if (LevyraIsLight) 0.08f else 0.10f)
                 else LevyraAdaptiveCard
             )
             .border(
-                width = if (active) 1.2.dp else Dp.Hairline,
-                color = if (active) LevyraCyan.copy(alpha = 0.75f) else LevyraAdaptiveSoftHairline,
+                width = if (active) 1.dp else Dp.Hairline,
+                color = if (active) LevyraCyan.copy(alpha = 0.58f) else LevyraAdaptiveSoftHairline,
                 shape = shape
             )
             .padding(14.dp),
@@ -8095,10 +8113,10 @@ private fun ResonanceCard(
 
         Surface(
             shape = RoundedCornerShape(16.dp),
-            color = if (LevyraIsLight) Color.Black.copy(alpha = 0.055f) else Color.White.copy(alpha = 0.075f),
+            color = if (LevyraIsLight) Color.Black.copy(alpha = 0.06f) else LevyraAdaptiveCardDeep,
             border = BorderStroke(
                 Dp.Hairline,
-                if (active) LevyraCyan.copy(alpha = 0.28f) else LevyraAdaptiveSoftHairline.copy(alpha = 0.50f)
+                if (active) LevyraCyan.copy(alpha = 0.22f) else LevyraAdaptiveSoftHairline.copy(alpha = 0.24f)
             ),
             modifier = Modifier
                 .fillMaxWidth()
@@ -8119,7 +8137,9 @@ private fun ResonanceCard(
                         tint = LevyraCyan,
                         modifier = Modifier.size(13.dp)
                     )
-                    val count = snippet?.countText?.takeIf { it.isNotBlank() }
+                    val count = snippet?.countText
+                        ?.let(::youtubeCommentCountBadge)
+                        ?.takeIf { it.isNotBlank() }
                     Text(
                         text = strings.commentsLabel,
                         color = LevyraText,
@@ -8166,7 +8186,7 @@ private fun ResonanceCard(
                                 author = snippet.author,
                                 modifier = Modifier
                                     .padding(top = 1.dp)
-                                    .size(20.dp)
+                                    .size(28.dp)
                             )
                             Column(
                                 modifier = Modifier.weight(1f),
@@ -8179,17 +8199,23 @@ private fun ResonanceCard(
                                     Text(
                                         text = snippet.author,
                                         color = LevyraText.copy(alpha = 0.90f),
-                                        fontSize = 11.sp,
+                                        fontSize = 12.sp,
                                         fontWeight = FontWeight.Bold,
                                         maxLines = 1,
                                         overflow = TextOverflow.Ellipsis,
                                         modifier = Modifier.weight(1f, fill = false)
                                     )
                                     if (snippet.likeCountText.isNotBlank()) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.ThumbUp,
+                                            contentDescription = null,
+                                            tint = LevyraMuted,
+                                            modifier = Modifier.size(11.dp)
+                                        )
                                         Text(
-                                            text = "• \uD83D\uDC4D ${snippet.likeCountText}",
+                                            text = snippet.likeCountText,
                                             color = LevyraMuted,
-                                            fontSize = 10.sp,
+                                            fontSize = 10.5.sp,
                                             maxLines = 1
                                         )
                                     }
@@ -8197,8 +8223,8 @@ private fun ResonanceCard(
                                 Text(
                                     text = snippet.text,
                                     color = LevyraMuted.copy(alpha = 0.95f),
-                                    fontSize = 11.5.sp,
-                                    lineHeight = 15.sp,
+                                    fontSize = 12.5.sp,
+                                    lineHeight = 17.sp,
                                     maxLines = 2,
                                     overflow = TextOverflow.Ellipsis
                                 )
@@ -13161,7 +13187,7 @@ private fun PlayerYoutubeEngagementRow(
     }
 }
 
-private fun youtubeCommentCountBadge(value: String): String {
+internal fun youtubeCommentCountBadge(value: String): String {
     val normalized = value.replace('\u00A0', ' ').trim()
     if (normalized.isBlank()) return ""
     return CommentCountBadgePattern
@@ -13577,10 +13603,6 @@ private fun PlayerScreen(
         animationSpec = if (state.animationsEnabled) LevyraPlayerDesign.smoothSpring() else snap(),
         label = "player-swipe-offset"
     )
-
-    BackHandler(enabled = state.youtubeEngagement.comments.visible) {
-        viewModel.closeYoutubeComments()
-    }
 
     LaunchedEffect(mediaSeekFeedbackEvent) {
         if (mediaSeekFeedbackEvent > 0) {
@@ -14316,20 +14338,6 @@ private fun PlayerScreen(
             )
         }
 
-        if (state.youtubeEngagement.comments.visible) {
-            PlayerYoutubeCommentsSheet(
-                comments = state.youtubeEngagement.comments,
-                primary = primary,
-                secondary = secondary,
-                strings = strings,
-                onDismiss = viewModel::closeYoutubeComments,
-                onRetry = viewModel::retryYoutubeComments,
-                onLoadMore = viewModel::loadMoreYoutubeComments,
-                onRetryLoadMore = viewModel::retryYoutubeCommentsPage,
-                onToggleReplies = viewModel::toggleYoutubeCommentReplies,
-                onLoadMoreReplies = viewModel::loadMoreYoutubeCommentReplies
-            )
-        }
     }
 }
 
@@ -14627,9 +14635,10 @@ private fun PlayerYoutubeCommentsSheet(
                             fontSize = 20.sp,
                             fontWeight = FontWeight.Black
                         )
-                        if (comments.countText.isNotBlank()) {
+                        val commentCount = youtubeCommentCountBadge(comments.countText)
+                        if (commentCount.isNotBlank()) {
                             Text(
-                                text = comments.countText,
+                                text = commentCount,
                                 color = Color.White.copy(alpha = 0.52f),
                                 fontSize = 11.sp,
                                 fontWeight = FontWeight.Medium,

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraResonanceStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraResonanceStrings.kt
@@ -1,0 +1,200 @@
+package com.luc4n3x.levyra.ui.i18n
+
+private val resonanceBundles: Map<String, Map<String, String>> = mapOf(
+    "en" to mapOf(
+        "commentsLabel" to "Comments",
+        "mostCommentedTracks" to "Most discussed tracks",
+        "tapToOpenComments" to "Tap to view comments",
+        "noCommentsAvailable" to "No comments yet",
+        "commentsDisabled" to "Comments disabled"
+    ),
+    "it" to mapOf(
+        "commentsLabel" to "Commenti",
+        "mostCommentedTracks" to "Tracce più commentate",
+        "tapToOpenComments" to "Tocca per vedere i commenti",
+        "noCommentsAvailable" to "Nessun commento ancora",
+        "commentsDisabled" to "Commenti disattivati"
+    ),
+    "es" to mapOf(
+        "commentsLabel" to "Comentarios",
+        "mostCommentedTracks" to "Pistas más comentadas",
+        "tapToOpenComments" to "Toca para ver los comentarios",
+        "noCommentsAvailable" to "Aún no hay comentarios",
+        "commentsDisabled" to "Comentarios desactivados"
+    ),
+    "fr" to mapOf(
+        "commentsLabel" to "Commentaires",
+        "mostCommentedTracks" to "Titres les plus commentés",
+        "tapToOpenComments" to "Appuyez pour voir les commentaires",
+        "noCommentsAvailable" to "Aucun commentaire pour l'instant",
+        "commentsDisabled" to "Commentaires désactivés"
+    ),
+    "de" to mapOf(
+        "commentsLabel" to "Kommentare",
+        "mostCommentedTracks" to "Meistdiskutierte Titel",
+        "tapToOpenComments" to "Tippen, um Kommentare zu sehen",
+        "noCommentsAvailable" to "Noch keine Kommentare",
+        "commentsDisabled" to "Kommentare deaktiviert"
+    ),
+    "pt" to mapOf(
+        "commentsLabel" to "Comentários",
+        "mostCommentedTracks" to "Faixas mais comentadas",
+        "tapToOpenComments" to "Toque para ver os comentários",
+        "noCommentsAvailable" to "Ainda sem comentários",
+        "commentsDisabled" to "Comentários desativados"
+    ),
+    "nl" to mapOf(
+        "commentsLabel" to "Reacties",
+        "mostCommentedTracks" to "Meest besproken nummers",
+        "tapToOpenComments" to "Tik om reacties te bekijken",
+        "noCommentsAvailable" to "Nog geen reacties",
+        "commentsDisabled" to "Reacties uitgeschakeld"
+    ),
+    "pl" to mapOf(
+        "commentsLabel" to "Komentarze",
+        "mostCommentedTracks" to "Najczęściej komentowane utwory",
+        "tapToOpenComments" to "Dotknij, aby zobaczyć komentarze",
+        "noCommentsAvailable" to "Brak komentarzy",
+        "commentsDisabled" to "Komentarze wyłączone"
+    ),
+    "ro" to mapOf(
+        "commentsLabel" to "Comentarii",
+        "mostCommentedTracks" to "Piese cele mai comentate",
+        "tapToOpenComments" to "Apasă pentru a vedea comentariile",
+        "noCommentsAvailable" to "Încă nu există comentarii",
+        "commentsDisabled" to "Comentarii dezactivate"
+    ),
+    "el" to mapOf(
+        "commentsLabel" to "Σχόλια",
+        "mostCommentedTracks" to "Κομμάτια με τα περισσότερα σχόλια",
+        "tapToOpenComments" to "Πατήστε για να δείτε τα σχόλια",
+        "noCommentsAvailable" to "Δεν υπάρχουν σχόλια ακόμα",
+        "commentsDisabled" to "Τα σχόλια είναι απενεργοποιημένα"
+    ),
+    "sv" to mapOf(
+        "commentsLabel" to "Kommentarer",
+        "mostCommentedTracks" to "Mest kommenterade spår",
+        "tapToOpenComments" to "Tryck för att se kommentarer",
+        "noCommentsAvailable" to "Inga kommentarer än",
+        "commentsDisabled" to "Kommentarer inaktiverade"
+    ),
+    "da" to mapOf(
+        "commentsLabel" to "Kommentarer",
+        "mostCommentedTracks" to "Mest kommenterede numre",
+        "tapToOpenComments" to "Tryk for at se kommentarer",
+        "noCommentsAvailable" to "Ingen kommentarer endnu",
+        "commentsDisabled" to "Kommentarer deaktiveret"
+    ),
+    "cs" to mapOf(
+        "commentsLabel" to "Komentáře",
+        "mostCommentedTracks" to "Nejdiskutovanější skladby",
+        "tapToOpenComments" to "Klepnutím zobrazíte komentáře",
+        "noCommentsAvailable" to "Zatím žádné komentáře",
+        "commentsDisabled" to "Komentáře jsou vypnuté"
+    ),
+    "uk" to mapOf(
+        "commentsLabel" to "Коментарі",
+        "mostCommentedTracks" to "Найбільш коментовані треки",
+        "tapToOpenComments" to "Торкніться, щоб переглянути коментарі",
+        "noCommentsAvailable" to "Коментарів поки немає",
+        "commentsDisabled" to "Коментарі вимкнено"
+    ),
+    "ru" to mapOf(
+        "commentsLabel" to "Комментарии",
+        "mostCommentedTracks" to "Самые обсуждаемые треки",
+        "tapToOpenComments" to "Нажмите, чтобы посмотреть комментарии",
+        "noCommentsAvailable" to "Комментариев пока нет",
+        "commentsDisabled" to "Комментарии отключены"
+    ),
+    "tr" to mapOf(
+        "commentsLabel" to "Yorumlar",
+        "mostCommentedTracks" to "En çok yorumlanan parçalar",
+        "tapToOpenComments" to "Yorumları görmek için dokunun",
+        "noCommentsAvailable" to "Henüz yorum yok",
+        "commentsDisabled" to "Yorumlar kapalı"
+    ),
+    "ar" to mapOf(
+        "commentsLabel" to "التعليقات",
+        "mostCommentedTracks" to "المقاطع الأكثر تعليقاً",
+        "tapToOpenComments" to "اضغط لعرض التعليقات",
+        "noCommentsAvailable" to "لا توجد تعليقات بعد",
+        "commentsDisabled" to "التعليقات متوقفة"
+    ),
+    "zh" to mapOf(
+        "commentsLabel" to "评论",
+        "mostCommentedTracks" to "最多讨论曲目",
+        "tapToOpenComments" to "点击查看评论"
+        ,"noCommentsAvailable" to "暂无评论",
+        "commentsDisabled" to "评论已关闭"
+    ),
+    "ja" to mapOf(
+        "commentsLabel" to "コメント",
+        "mostCommentedTracks" to "最もコメントされた曲",
+        "tapToOpenComments" to "タップしてコメントを表示",
+        "noCommentsAvailable" to "まだコメントはありません",
+        "commentsDisabled" to "コメントはオフです"
+    ),
+    "ko" to mapOf(
+        "commentsLabel" to "댓글",
+        "mostCommentedTracks" to "가장 많은 댓글이 달린 곡",
+        "tapToOpenComments" to "댓글을 보려면 탭하세요",
+        "noCommentsAvailable" to "아직 댓글이 없습니다",
+        "commentsDisabled" to "댓글이 사용 중지됨"
+    ),
+    "hi" to mapOf(
+        "commentsLabel" to "टिप्पणियाँ",
+        "mostCommentedTracks" to "सबसे अधिक टिप्पणी किए गए ट्रैक",
+        "tapToOpenComments" to "टिप्पणियाँ देखने के लिए टैप करें",
+        "noCommentsAvailable" to "अभी कोई टिप्पणी नहीं है",
+        "commentsDisabled" to "टिप्पणियाँ अक्षम हैं"
+    ),
+    "id" to mapOf(
+        "commentsLabel" to "Komentar",
+        "mostCommentedTracks" to "Trek paling banyak dikomentari",
+        "tapToOpenComments" to "Ketuk untuk melihat komentar",
+        "noCommentsAvailable" to "Belum ada komentar",
+        "commentsDisabled" to "Komentar dinonaktifkan"
+    ),
+    "vi" to mapOf(
+        "commentsLabel" to "Bình luận",
+        "mostCommentedTracks" to "Bài hát được bàn luận nhiều nhất",
+        "tapToOpenComments" to "Nhấn để xem bình luận",
+        "noCommentsAvailable" to "Chưa có bình luận nào",
+        "commentsDisabled" to "Bình luận đã tắt"
+    ),
+    "th" to mapOf(
+        "commentsLabel" to "ความคิดเห็น",
+        "mostCommentedTracks" to "เพลงที่มีความคิดเห็นมากที่สุด",
+        "tapToOpenComments" to "แตะเพื่อดูความคิดเห็น",
+        "noCommentsAvailable" to "ยังไม่มีความคิดเห็น",
+        "commentsDisabled" to "ปิดความคิดเห็นแล้ว"
+    ),
+    "fil" to mapOf(
+        "commentsLabel" to "Mga komento",
+        "mostCommentedTracks" to "Mga kantang may pinakamaraming komento",
+        "tapToOpenComments" to "I-tap para makita ang mga komento",
+        "noCommentsAvailable" to "Wala pang komento",
+        "commentsDisabled" to "Naka-off ang mga komento"
+    ),
+    "he" to mapOf(
+        "commentsLabel" to "תגובות",
+        "mostCommentedTracks" to "השירים עם הכי הרבה תגובות",
+        "tapToOpenComments" to "הקש לצפייה בתגובות",
+        "noCommentsAvailable" to "אין עדיין תגובות",
+        "commentsDisabled" to "התגובות מושבתות"
+    )
+)
+
+internal val resonanceKeys: Set<String> = setOf(
+    "commentsLabel",
+    "mostCommentedTracks",
+    "tapToOpenComments",
+    "noCommentsAvailable",
+    "commentsDisabled"
+)
+
+internal fun resonanceLocalizationCodes(): Set<String> = resonanceBundles.keys
+
+internal fun resonanceLocalizationEntries(code: String): Map<String, String> {
+    return resonanceBundles[code] ?: resonanceBundles.getValue("en")
+}

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
@@ -217,6 +217,12 @@ class LevyraStrings private constructor(
     val voicesSubtitle: String get() = value("voicesSubtitle")
     val totalComments: String get() = value("totalComments")
     val engagement: String get() = value("engagement")
+    val commentsLabel: String get() = value("commentsLabel")
+    val mostCommentedTracks: String get() = value("mostCommentedTracks")
+    val tapToOpenComments: String get() = value("tapToOpenComments")
+    val noCommentsAvailable: String get() = value("noCommentsAvailable")
+    val commentsDisabledLabel: String get() = value("commentsDisabled")
+    val commentsDisabled: String get() = value("commentsDisabled")
     val audioSectionQuality: String get() = value("audioSectionQuality")
     val audioSectionEqualizer: String get() = value("audioSectionEqualizer")
     val audioSectionSpatial: String get() = value("audioSectionSpatial")
@@ -1430,8 +1436,8 @@ class LevyraStrings private constructor(
         }
 
         private fun bundle(code: String, entries: Map<String, String>): LevyraStrings {
-            val resolvedEntries = entries + homeEditorialLocalizationEntries(code) + lyricsActionLocalizationEntries(code) + playerExperienceLocalizationEntries(code) + exploreLocalizationEntries(code) + canvasLocalizationEntries(code) + audioLocalizationEntries(code) + autoEqLocalizationEntries(code) + experienceLocalizationEntries(code) + insightLocalizationEntries(code) + systemActionLocalizationEntries(code) + integrationLocalizationEntries(code) + recognitionLocalizationEntries(code) + jamLocalizationEntries(code) + networkLocalizationEntries(code)
-            val allRequiredKeys = requiredKeys + "removeFromPlaylist" + motionArtworkKeys + canvasKeys + audioKeys + autoEqKeys + experienceKeys + insightKeys + systemActionKeys + integrationKeys + recognitionKeys + jamKeys + networkKeys
+            val resolvedEntries = entries + homeEditorialLocalizationEntries(code) + lyricsActionLocalizationEntries(code) + playerExperienceLocalizationEntries(code) + exploreLocalizationEntries(code) + canvasLocalizationEntries(code) + audioLocalizationEntries(code) + autoEqLocalizationEntries(code) + experienceLocalizationEntries(code) + insightLocalizationEntries(code) + systemActionLocalizationEntries(code) + integrationLocalizationEntries(code) + recognitionLocalizationEntries(code) + jamLocalizationEntries(code) + networkLocalizationEntries(code) + resonanceLocalizationEntries(code)
+            val allRequiredKeys = requiredKeys + "removeFromPlaylist" + motionArtworkKeys + canvasKeys + audioKeys + autoEqKeys + experienceKeys + insightKeys + systemActionKeys + integrationKeys + recognitionKeys + jamKeys + networkKeys + resonanceKeys
             require(resolvedEntries.keys == allRequiredKeys) {
                 "Invalid localization bundle $code: missing=${allRequiredKeys - resolvedEntries.keys}, extra=${resolvedEntries.keys - allRequiredKeys}"
             }

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -30,6 +30,7 @@ import com.luc4n3x.levyra.domain.Mood
 import com.luc4n3x.levyra.domain.OfflineDownloadTask
 import com.luc4n3x.levyra.domain.Playlist
 import com.luc4n3x.levyra.domain.ReleaseRadarEntry
+import com.luc4n3x.levyra.domain.ResonanceCommentSnippet
 import com.luc4n3x.levyra.domain.RepeatMode
 import com.luc4n3x.levyra.domain.SearchFilter
 import com.luc4n3x.levyra.domain.SearchResults
@@ -453,6 +454,7 @@ private fun LevyraUiState.withFrozenHomeContent(previous: LevyraUiState): Levyra
         homeAlbums = previous.homeAlbums,
         homeArtists = previous.homeArtists,
         homeResonanceTracks = previous.homeResonanceTracks,
+        homeResonanceComments = previous.homeResonanceComments,
         homeArtistsLoading = previous.homeArtistsLoading,
         homeAlbumsLoading = previous.homeAlbumsLoading,
         isLoadingHome = previous.isLoadingHome,
@@ -462,7 +464,7 @@ private fun LevyraUiState.withFrozenHomeContent(previous: LevyraUiState): Levyra
     )
 }
 
-private fun sameHomeRenderSnapshot(previous: HomeRenderSnapshot, current: HomeRenderSnapshot): Boolean {
+internal fun sameHomeRenderSnapshot(previous: HomeRenderSnapshot, current: HomeRenderSnapshot): Boolean {
     return homeProjection(previous.state) == homeProjection(current.state) && previous.derived == current.derived
 }
 
@@ -897,6 +899,7 @@ private data class HomeProjection(
     val homeAlbums: List<AlbumHit>,
     val homeArtists: List<ArtistHit>,
     val homeResonanceTracks: List<Track>,
+    val homeResonanceComments: Map<String, ResonanceCommentSnippet>,
     val homeArtistsLoading: Boolean,
     val homeAlbumsLoading: Boolean,
     val homeSections: List<HomeSection>,
@@ -934,6 +937,7 @@ private fun homeProjection(state: LevyraUiState): HomeProjection = HomeProjectio
     homeAlbums = state.homeAlbums,
     homeArtists = state.homeArtists,
     homeResonanceTracks = state.homeResonanceTracks,
+    homeResonanceComments = state.homeResonanceComments,
     homeArtistsLoading = state.homeArtistsLoading,
     homeAlbumsLoading = state.homeAlbumsLoading,
     homeSections = state.homeSections,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -174,6 +174,8 @@ class HomeViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::homeP
     fun openSearch() = root.selectTab(LevyraTab.Search)
     fun playAlbumRecommendations(albums: List<AlbumHit>) = root.playAlbumRecommendations(albums)
     fun refreshHomeArtists() = root.refreshHomeArtists()
+    fun refreshHomeResonanceComments(tracks: List<Track>) = root.refreshHomeResonanceComments(tracks)
+    fun openYoutubeCommentsFor(track: Track) = root.openYoutubeCommentsFor(track)
     fun playAll(tracks: List<Track>) = root.playAll(tracks)
     fun playFrom(list: List<Track>, track: Track, loopOnCompletion: Boolean = false) {
         val current = root.state.value
@@ -350,6 +352,7 @@ class LibraryViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::li
         )
     )
     fun openPlayerScreen() = root.openPlayerScreen()
+    fun openYoutubeCommentsFor(track: Track) = root.openYoutubeCommentsFor(track)
     fun openPlaylist(playlistId: String) = root.openPlaylist(playlistId)
     fun pauseDownload(taskKey: String) = root.pauseDownload(taskKey)
     fun playDownloaded(download: DownloadedTrack) = root.playDownloaded(download)
@@ -715,7 +718,12 @@ private fun buildQuickPicks(input: HomeDerivedInput): HomeSection? {
 }
 
 private fun buildHomeResonanceTracks(input: HomeDerivedInput): List<Track> {
+    val directCommentedSectionTracks = input.homeSections
+        .filter { isHomeResonanceSectionTitle(it.title, input.languageCode) || it.title.contains("comment", ignoreCase = true) }
+        .flatMap { it.tracks }
+    val directCommentedIds = directCommentedSectionTracks.map { it.id }.toSet()
     return buildList {
+        addAll(directCommentedSectionTracks)
         addAll(input.charts)
         input.homeSections.forEach { section -> addAll(section.tracks) }
         addAll(input.favorites)
@@ -726,8 +734,10 @@ private fun buildHomeResonanceTracks(input: HomeDerivedInput): List<Track> {
         .filter { it.id.length == 11 && isReliableHomeMusicCandidate(it) }
         .distinctBy { it.id }
         .sortedWith(
-            compareByDescending<Track> { it.replayScore + it.vocal + it.cacheScore / 2 }
-                .thenBy { it.title }
+            compareByDescending<Track> {
+                (if (directCommentedIds.contains(it.id)) 1000 else 0) +
+                    it.replayScore + it.vocal + it.cacheScore / 2
+            }.thenBy { it.title }
         )
         .take(8)
         .toList()
@@ -839,12 +849,18 @@ private fun isHomeSectionVisible(title: String, input: HomeDerivedInput): Boolea
 private fun isHomeResonanceSectionTitle(title: String, languageCode: String): Boolean {
     val normalized = title.trim().lowercase(Locale.ROOT)
     val localized = LevyraStrings.forCode(languageCode).voicesTitle.trim().lowercase(Locale.ROOT)
+    val localizedCommented = LevyraStrings.forCode(languageCode).mostCommentedTracks.trim().lowercase(Locale.ROOT)
     return normalized == localized ||
+        normalized == localizedCommented ||
         normalized.contains("voices that resonate") ||
         normalized.contains("voci che risuonano") ||
         normalized.contains("voces que resuenan") ||
         normalized.contains("voix qui résonnent") ||
-        normalized.contains("stimmen, die nachklingen")
+        normalized.contains("stimmen, die nachklingen") ||
+        normalized.contains("tracce più commentate") ||
+        normalized.contains("più commentate") ||
+        normalized.contains("most discussed") ||
+        normalized.contains("most commented")
 }
 
 private fun isLikelyHomePlaylistOrCompilation(track: Track): Boolean {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -721,7 +721,7 @@ private fun buildQuickPicks(input: HomeDerivedInput): HomeSection? {
 
 private fun buildHomeResonanceTracks(input: HomeDerivedInput): List<Track> {
     val directCommentedSectionTracks = input.homeSections
-        .filter { isHomeResonanceSectionTitle(it.title, input.languageCode) || it.title.contains("comment", ignoreCase = true) }
+        .filter { isHomeResonanceSectionTitle(it.title, input.languageCode) }
         .flatMap { it.tracks }
     val directCommentedIds = directCommentedSectionTracks.map { it.id }.toSet()
     return buildList {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
@@ -37,6 +37,7 @@ import com.luc4n3x.levyra.domain.SearchResults
 import com.luc4n3x.levyra.domain.SmartMusicProfile
 import com.luc4n3x.levyra.domain.Taste
 import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.domain.ResonanceCommentSnippet
 import com.luc4n3x.levyra.domain.YoutubeEngagementState
 import com.luc4n3x.levyra.data.LyricsRepository
 import com.luc4n3x.levyra.domain.LevyraNetworkSettings
@@ -110,6 +111,7 @@ data class LevyraUiState(
     val homeArtists: List<ArtistHit> = emptyList(),
     val homeResonanceTracks: List<Track> = emptyList(),
     val homeResonanceUpdatedAt: Long = 0L,
+    val homeResonanceComments: Map<String, ResonanceCommentSnippet> = emptyMap(),
     val homeArtistsLoading: Boolean = false,
     val homeAlbumsLoading: Boolean = false,
     val isLoadingHome: Boolean = false,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -1499,8 +1499,15 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     @Synchronized
     fun refreshHomeResonanceComments(tracks: List<Track> = _state.value.homeResonanceTracks) {
-        val requestIds = homeResonanceCommentVideoIds(tracks)
         val snapshot = _state.value
+        if (!snapshot.interfaceSettings.showResonance) {
+            homeResonanceCommentsJob?.cancel()
+            homeResonanceCommentsJob = null
+            homeResonanceCommentsRequestIds = emptyList()
+            homeResonanceCommentsGeneration.incrementAndGet()
+            return
+        }
+        val requestIds = homeResonanceCommentVideoIds(tracks)
         if (requestIds != homeResonanceCommentVideoIds(snapshot.homeResonanceTracks)) return
 
         val retainedComments = resonanceCommentsForTracks(tracks, snapshot.homeResonanceComments)
@@ -1604,6 +1611,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     private fun isHomeResonanceCommentsRequestCurrent(videoIds: List<String>, generation: Long): Boolean {
         return generation == homeResonanceCommentsGeneration.get() &&
+            _state.value.interfaceSettings.showResonance &&
             videoIds == homeResonanceCommentVideoIds(_state.value.homeResonanceTracks)
     }
 
@@ -3673,6 +3681,12 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         preferences.setInterfaceSettings(normalized)
         LevyraTypographyController.apply(normalized.fontPreset)
         _state.update { it.copy(interfaceSettings = normalized) }
+        if (previous.showResonance && !normalized.showResonance) {
+            homeResonanceCommentsJob?.cancel()
+            homeResonanceCommentsJob = null
+            homeResonanceCommentsRequestIds = emptyList()
+            homeResonanceCommentsGeneration.incrementAndGet()
+        }
         if (previous.canvasSource != normalized.canvasSource) {
             motionArtworkJob?.cancel()
             motionArtworkRequestKey = null

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -137,6 +137,7 @@ import com.luc4n3x.levyra.domain.Playlist
 import com.luc4n3x.levyra.domain.RepeatMode
 import com.luc4n3x.levyra.domain.Track
 import com.luc4n3x.levyra.domain.YoutubeMusicVideoType
+import com.luc4n3x.levyra.domain.ResonanceCommentSnippet
 import com.luc4n3x.levyra.domain.YoutubeComment
 import com.luc4n3x.levyra.domain.YoutubeCommentsState
 import com.luc4n3x.levyra.domain.YoutubeEngagementState
@@ -1075,6 +1076,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         }
         val startupResonanceTracks = instantSnapshot?.resonanceTracks.orEmpty()
         val startupResonanceUpdatedAt = instantSnapshot?.resonanceUpdatedAt ?: 0L
+        val startupResonanceComments = instantSnapshot?.resonanceComments.orEmpty()
         val rawCachedOrbitTracks = LevyraStartupCatalog.repairTracks(
             settings.personalOrbitTracks
                 .ifEmpty { instantSnapshot?.personalOrbit.orEmpty() }
@@ -1133,6 +1135,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 homeArtists = startupHomeArtists,
                 homeResonanceTracks = startupResonanceTracks,
                 homeResonanceUpdatedAt = startupResonanceUpdatedAt,
+                homeResonanceComments = startupResonanceComments,
                 homeArtistsLoading = startupHomeArtists.isEmpty(),
                 homeAlbumsLoading = startupAlbums.isEmpty(),
                 tracks = initialTracks,
@@ -1276,6 +1279,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         LevyraWidgetBridge.onNext = { next() }
         LevyraWidgetBridge.onPrevious = { previous() }
         updateWidget()
+        refreshHomeResonanceComments(startupResonanceTracks)
     }
 
     private fun observeDownloadBatches() {
@@ -1484,13 +1488,84 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             personalOrbit = snapshot.personalOrbitTracks,
             homeArtists = deferredHomeArtistsSnapshot.get() ?: snapshot.homeArtists,
             resonanceTracks = snapshot.homeResonanceTracks,
-            resonanceUpdatedAt = snapshot.homeResonanceUpdatedAt
+            resonanceUpdatedAt = snapshot.homeResonanceUpdatedAt,
+            resonanceComments = snapshot.homeResonanceComments
         )
+    }
+
+    private var homeResonanceCommentsJob: Job? = null
+
+    fun refreshHomeResonanceComments(tracks: List<Track> = _state.value.homeResonanceTracks) {
+        if (tracks.isEmpty()) return
+        val candidates = tracks.take(10).filter { it.id.length == 11 }
+        if (candidates.isEmpty()) return
+        if (homeResonanceCommentsJob?.isActive == true) return
+        homeResonanceCommentsJob = viewModelScope.launch(Dispatchers.IO) {
+            val currentComments = _state.value.homeResonanceComments
+            candidates.forEach { track ->
+                if (!isActive) return@launch
+                val cached = currentComments[track.id]
+                if (cached != null && (cached.text.isNotBlank() || cached.disabled)) return@forEach
+
+                _state.update { state ->
+                    val map = state.homeResonanceComments.toMutableMap()
+                    map[track.id] = (map[track.id] ?: ResonanceCommentSnippet(videoId = track.id)).copy(isLoading = true)
+                    state.copy(homeResonanceComments = map)
+                }
+
+                val result = try {
+                    youtubeCommentsRepository.initial(track.id, forceRefresh = false)
+                } catch (e: Exception) {
+                    YoutubeCommentsResult.Failed(e)
+                }
+
+                if (!isActive) return@launch
+                val snippet = when (result) {
+                    is YoutubeCommentsResult.Available -> {
+                        val top = result.page.items.firstOrNull()
+                        ResonanceCommentSnippet(
+                            videoId = track.id,
+                            countText = result.page.countText,
+                            author = top?.author.orEmpty(),
+                            authorAvatarUrl = top?.authorAvatarUrl.orEmpty(),
+                            text = top?.text.orEmpty(),
+                            likeCountText = top?.likeCountText.orEmpty(),
+                            isLoading = false,
+                            disabled = result.page.commentsDisabled
+                        )
+                    }
+                    YoutubeCommentsResult.Disabled -> {
+                        ResonanceCommentSnippet(
+                            videoId = track.id,
+                            disabled = true,
+                            isLoading = false
+                        )
+                    }
+                    is YoutubeCommentsResult.Failed -> {
+                        ResonanceCommentSnippet(
+                            videoId = track.id,
+                            hasError = true,
+                            isLoading = false
+                        )
+                    }
+                }
+
+                _state.update { state ->
+                    val map = state.homeResonanceComments.toMutableMap()
+                    map[track.id] = snippet
+                    state.copy(homeResonanceComments = map)
+                }
+            }
+            persistHomeSnapshot()
+        }
     }
 
     private fun refreshHomeResonanceIfStale() {
         val initial = _state.value
-        if (isHomeResonanceFresh(initial, System.currentTimeMillis())) return
+        if (isHomeResonanceFresh(initial, System.currentTimeMillis())) {
+            refreshHomeResonanceComments(initial.homeResonanceTracks)
+            return
+        }
         if (homeResonanceJob?.isActive == true) return
         val languageCode = initial.languageCode
         homeResonanceJob = viewModelScope.launch(Dispatchers.Default) {
@@ -1512,6 +1587,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 }
             }
             if (changed) persistHomeSnapshot()
+            refreshHomeResonanceComments(resolved)
         }
     }
 
@@ -7093,12 +7169,17 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     fun openYoutubeComments() {
         val track = _state.value.currentTrack ?: return
+        openYoutubeCommentsFor(track)
+    }
+
+    fun openYoutubeCommentsFor(track: Track) {
         val videoId = youtubeEngagementVideoId(track)
         if (videoId.isBlank()) return
         val generation = prepareYoutubeEngagement(videoId)
         _state.update { state ->
             state.copy(
                 youtubeEngagement = state.youtubeEngagement.copy(
+                    videoId = videoId,
                     comments = state.youtubeEngagement.comments.copy(
                         videoId = videoId,
                         visible = true

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -878,6 +878,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private val homeAlbumsRequestGeneration = AtomicLong(0L)
     private val chartsRequestGeneration = AtomicLong(0L)
     private val artistListStateGeneration = AtomicLong(0L)
+    private var homeResonanceCommentsJob: Job? = null
+    private var homeResonanceCommentsRequestIds: List<String> = emptyList()
+    private val homeResonanceCommentsGeneration = AtomicLong(0L)
     private val chartsByRegion = java.util.concurrent.ConcurrentHashMap<String, List<Track>>()
     private val chartsFreshAt = java.util.concurrent.ConcurrentHashMap<String, Long>()
 
@@ -1493,10 +1496,6 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             resonanceComments = snapshot.homeResonanceComments
         )
     }
-
-    private var homeResonanceCommentsJob: Job? = null
-    private var homeResonanceCommentsRequestIds: List<String> = emptyList()
-    private val homeResonanceCommentsGeneration = AtomicLong(0L)
 
     @Synchronized
     fun refreshHomeResonanceComments(tracks: List<Track> = _state.value.homeResonanceTracks) {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -141,6 +141,7 @@ import com.luc4n3x.levyra.domain.ResonanceCommentSnippet
 import com.luc4n3x.levyra.domain.YoutubeComment
 import com.luc4n3x.levyra.domain.YoutubeCommentsState
 import com.luc4n3x.levyra.domain.YoutubeEngagementState
+import com.luc4n3x.levyra.domain.resonanceCommentsForTracks
 import com.luc4n3x.levyra.domain.videoViewCountBonus
 import com.luc4n3x.levyra.feature.motion.MotionArtworkEngine
 import com.luc4n3x.levyra.feature.motion.MotionArtworkIdentityKey
@@ -1494,32 +1495,72 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     private var homeResonanceCommentsJob: Job? = null
+    private var homeResonanceCommentsRequestIds: List<String> = emptyList()
+    private val homeResonanceCommentsGeneration = AtomicLong(0L)
 
+    @Synchronized
     fun refreshHomeResonanceComments(tracks: List<Track> = _state.value.homeResonanceTracks) {
-        if (tracks.isEmpty()) return
-        val candidates = tracks.take(10).filter { it.id.length == 11 }
-        if (candidates.isEmpty()) return
-        if (homeResonanceCommentsJob?.isActive == true) return
-        homeResonanceCommentsJob = viewModelScope.launch(Dispatchers.IO) {
-            val currentComments = _state.value.homeResonanceComments
+        val requestIds = homeResonanceCommentVideoIds(tracks)
+        val snapshot = _state.value
+        if (requestIds != homeResonanceCommentVideoIds(snapshot.homeResonanceTracks)) return
+
+        val retainedComments = resonanceCommentsForTracks(tracks, snapshot.homeResonanceComments)
+        if (retainedComments != snapshot.homeResonanceComments) {
+            _state.update { state ->
+                if (requestIds != homeResonanceCommentVideoIds(state.homeResonanceTracks)) state else state.copy(
+                    homeResonanceComments = resonanceCommentsForTracks(
+                        state.homeResonanceTracks,
+                        state.homeResonanceComments
+                    )
+                )
+            }
+            persistHomeSnapshot()
+        }
+
+        if (homeResonanceCommentsJob?.isActive == true && homeResonanceCommentsRequestIds == requestIds) return
+        val generation = homeResonanceCommentsGeneration.incrementAndGet()
+        homeResonanceCommentsRequestIds = requestIds
+        val candidates = homeResonanceCommentsToRefresh(
+            tracks = tracks,
+            comments = retainedComments,
+            nowMs = System.currentTimeMillis(),
+            ttlMs = HOME_RESONANCE_COMMENTS_TTL_MS
+        )
+        if (candidates.isEmpty()) {
+            homeResonanceCommentsJob = null
+            return
+        }
+
+        homeResonanceCommentsJob = viewModelScope.replaceHomeResonanceCommentsJob(homeResonanceCommentsJob) {
             candidates.forEach { track ->
-                if (!isActive) return@launch
-                val cached = currentComments[track.id]
-                if (cached != null && (cached.text.isNotBlank() || cached.disabled)) return@forEach
+                if (!isActive || !isHomeResonanceCommentsRequestCurrent(requestIds, generation)) {
+                    return@replaceHomeResonanceCommentsJob
+                }
+                val cached = retainedComments[track.id]
 
                 _state.update { state ->
-                    val map = state.homeResonanceComments.toMutableMap()
-                    map[track.id] = (map[track.id] ?: ResonanceCommentSnippet(videoId = track.id)).copy(isLoading = true)
-                    state.copy(homeResonanceComments = map)
+                    if (generation != homeResonanceCommentsGeneration.get()) state else state.withHomeResonanceComment(
+                        requestIds,
+                        track.id
+                    ) { current ->
+                        (current ?: ResonanceCommentSnippet(videoId = track.id)).copy(
+                            isLoading = current?.hasComment != true && current?.disabled != true,
+                            hasError = false
+                        )
+                    }
                 }
 
                 val result = try {
                     youtubeCommentsRepository.initial(track.id, forceRefresh = false)
+                } catch (cancelled: CancellationException) {
+                    throw cancelled
                 } catch (e: Exception) {
                     YoutubeCommentsResult.Failed(e)
                 }
 
-                if (!isActive) return@launch
+                if (!isActive || !isHomeResonanceCommentsRequestCurrent(requestIds, generation)) {
+                    return@replaceHomeResonanceCommentsJob
+                }
                 val snippet = when (result) {
                     is YoutubeCommentsResult.Available -> {
                         val top = result.page.items.firstOrNull()
@@ -1531,19 +1572,20 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                             text = top?.text.orEmpty(),
                             likeCountText = top?.likeCountText.orEmpty(),
                             isLoading = false,
-                            disabled = result.page.commentsDisabled
+                            disabled = result.page.commentsDisabled,
+                            updatedAtMs = System.currentTimeMillis()
                         )
                     }
                     YoutubeCommentsResult.Disabled -> {
                         ResonanceCommentSnippet(
                             videoId = track.id,
                             disabled = true,
-                            isLoading = false
+                            isLoading = false,
+                            updatedAtMs = System.currentTimeMillis()
                         )
                     }
                     is YoutubeCommentsResult.Failed -> {
-                        ResonanceCommentSnippet(
-                            videoId = track.id,
+                        (cached ?: ResonanceCommentSnippet(videoId = track.id)).copy(
                             hasError = true,
                             isLoading = false
                         )
@@ -1551,13 +1593,19 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 }
 
                 _state.update { state ->
-                    val map = state.homeResonanceComments.toMutableMap()
-                    map[track.id] = snippet
-                    state.copy(homeResonanceComments = map)
+                    if (generation != homeResonanceCommentsGeneration.get()) state else state.withHomeResonanceComment(
+                        requestIds,
+                        track.id
+                    ) { snippet }
                 }
             }
-            persistHomeSnapshot()
+            if (isHomeResonanceCommentsRequestCurrent(requestIds, generation)) persistHomeSnapshot()
         }
+    }
+
+    private fun isHomeResonanceCommentsRequestCurrent(videoIds: List<String>, generation: Long): Boolean {
+        return generation == homeResonanceCommentsGeneration.get() &&
+            videoIds == homeResonanceCommentVideoIds(_state.value.homeResonanceTracks)
     }
 
     private fun refreshHomeResonanceIfStale() {
@@ -1582,7 +1630,11 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                     changed = current.homeResonanceTracks != resolved || current.homeResonanceUpdatedAt != updatedAt
                     current.copy(
                         homeResonanceTracks = resolved,
-                        homeResonanceUpdatedAt = updatedAt
+                        homeResonanceUpdatedAt = updatedAt,
+                        homeResonanceComments = resonanceCommentsForTracks(
+                            resolved,
+                            current.homeResonanceComments
+                        )
                     )
                 }
             }
@@ -4034,6 +4086,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 homeArtists = localizedCachedArtists,
                 homeResonanceTracks = localizedSnapshot?.resonanceTracks.orEmpty(),
                 homeResonanceUpdatedAt = localizedSnapshot?.resonanceUpdatedAt ?: 0L,
+                homeResonanceComments = localizedSnapshot?.resonanceComments.orEmpty(),
                 homeArtistsLoading = localizedCachedArtists.isEmpty() && refreshRemote,
                 homeAlbumsLoading = instantAlbums.isEmpty() && refreshRemote,
                 isLoadingHome = refreshRemote && homeSections.isEmpty() && allTracks.isEmpty(),
@@ -7047,6 +7100,15 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         return youtubeEngagementVideoId(current) == videoId
     }
 
+    private fun isYoutubeCommentsRequestCurrent(videoId: String, generation: Long): Boolean {
+        return isYoutubeCommentsRequestCurrent(
+            videoId = videoId,
+            generation = generation,
+            currentGeneration = youtubeEngagementGeneration.get(),
+            state = _state.value
+        )
+    }
+
     private fun refreshYoutubeDislikeEstimate(videoId: String, generation: Long) {
         val current = _state.value.youtubeEngagement
         if (current.videoId != videoId || current.dislikeEstimateLoading || current.dislikeEstimateAvailable) return
@@ -7128,40 +7190,14 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         }
         youtubeCommentsJob = viewModelScope.launch {
             val result = youtubeCommentsRepository.initial(videoId, forceRefresh = force)
-            if (!isActive || !isYoutubeEngagementRequestCurrent(videoId, generation)) return@launch
+            if (!isActive || !isYoutubeCommentsRequestCurrent(videoId, generation)) return@launch
             if (result !is YoutubeCommentsResult.Failed) youtubeCommentContinuationHistory.clear()
             _state.update { state ->
-                if (state.youtubeEngagement.videoId != videoId) return@update state
-                val visible = state.youtubeEngagement.comments.visible
-                val updatedComments = when (result) {
-                    is YoutubeCommentsResult.Available -> YoutubeCommentsState(
-                        videoId = videoId,
-                        visible = visible,
-                        loaded = true,
-                        loading = false,
-                        loadingMore = false,
-                        disabled = result.page.commentsDisabled,
-                        countText = result.page.countText,
-                        items = result.page.items.distinctBy(YoutubeComment::id),
-                        nextToken = result.page.nextToken,
-                        error = null
-                    )
-                    YoutubeCommentsResult.Disabled -> YoutubeCommentsState(
-                        videoId = videoId,
-                        visible = visible,
-                        loaded = true,
-                        loading = false,
-                        disabled = true
-                    )
-                    is YoutubeCommentsResult.Failed -> state.youtubeEngagement.comments.copy(
-                        videoId = videoId,
-                        loading = false,
-                        loaded = false,
-                        error = "unavailable"
-                    )
-                }
-                state.copy(
-                    youtubeEngagement = state.youtubeEngagement.copy(comments = updatedComments)
+                state.withYoutubeCommentsResultIfCurrent(
+                    videoId = videoId,
+                    generation = generation,
+                    currentGeneration = youtubeEngagementGeneration.get(),
+                    result = result
                 )
             }
         }
@@ -7244,9 +7280,15 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 continuationToken = token,
                 forceRefresh = forceRefresh
             )
-            if (!isActive || !isYoutubeEngagementRequestCurrent(videoId, generation)) return@launch
+            if (!isActive || !isYoutubeCommentsRequestCurrent(videoId, generation)) return@launch
             _state.update { state ->
-                if (state.youtubeEngagement.videoId != videoId) return@update state
+                if (!isYoutubeCommentsRequestCurrent(
+                        videoId,
+                        generation,
+                        youtubeEngagementGeneration.get(),
+                        state
+                    )
+                ) return@update state
                 val currentComments = state.youtubeEngagement.comments
                 val updated = when (result) {
                     is YoutubeCommentsResult.Available -> {
@@ -7317,7 +7359,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 continuationToken = token,
                 forceRefresh = comment.repliesError != null
             )
-            if (!isActive || !isYoutubeEngagementRequestCurrent(videoId, generation)) return@launch
+            if (!isActive || !isYoutubeCommentsRequestCurrent(videoId, generation)) return@launch
             when (result) {
                 is YoutubeCommentsResult.Available -> updateYoutubeComment(commentId) { current ->
                     val base = if (append) current.replies else emptyList()
@@ -8877,6 +8919,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         private const val HOME_STARTUP_STREAM_PREFETCH_COUNT = 2
         private const val HOME_STARTUP_METADATA_REFRESH_COUNT = 4
         private const val HOME_RESONANCE_REFRESH_INTERVAL_MS = 12L * 60L * 60L * 1000L
+        private const val HOME_RESONANCE_COMMENTS_TTL_MS = 5L * 60L * 1000L
         private const val HOME_ALBUM_RECOMMENDATION_LIMIT = 20
         private const val HOME_ALBUM_REMOTE_CANDIDATE_LIMIT = 32
         private const val HOME_ALBUM_REMOTE_CONCURRENCY = 4
@@ -8951,6 +8994,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         homeAlbumsJob?.cancel()
         homeArtistsJob?.cancel()
         homeResonanceJob?.cancel()
+        homeResonanceCommentsJob?.cancel()
         chartsJob?.cancel()
         chartPrefetchJob?.cancel()
         chartMemoryWarmJob?.cancel()
@@ -9240,6 +9284,93 @@ internal fun nextYoutubeCommentsToken(
     val candidate = candidateToken.trim()
     if (candidate.isBlank() || candidate == requested || candidate in successfulTokens) return ""
     return candidate
+}
+
+internal fun isYoutubeCommentsRequestCurrent(
+    videoId: String,
+    generation: Long,
+    currentGeneration: Long,
+    state: LevyraUiState
+): Boolean = generation == currentGeneration && state.youtubeEngagement.videoId == videoId
+
+internal fun LevyraUiState.withYoutubeCommentsResultIfCurrent(
+    videoId: String,
+    generation: Long,
+    currentGeneration: Long,
+    result: YoutubeCommentsResult
+): LevyraUiState {
+    if (!isYoutubeCommentsRequestCurrent(videoId, generation, currentGeneration, this)) return this
+    val visible = youtubeEngagement.comments.visible
+    val comments = when (result) {
+        is YoutubeCommentsResult.Available -> YoutubeCommentsState(
+            videoId = videoId,
+            visible = visible,
+            loaded = true,
+            loading = false,
+            loadingMore = false,
+            disabled = result.page.commentsDisabled,
+            countText = result.page.countText,
+            items = result.page.items.distinctBy(YoutubeComment::id),
+            nextToken = result.page.nextToken,
+            error = null
+        )
+        YoutubeCommentsResult.Disabled -> YoutubeCommentsState(
+            videoId = videoId,
+            visible = visible,
+            loaded = true,
+            loading = false,
+            disabled = true
+        )
+        is YoutubeCommentsResult.Failed -> youtubeEngagement.comments.copy(
+            videoId = videoId,
+            loading = false,
+            loaded = false,
+            error = "unavailable"
+        )
+    }
+    return copy(youtubeEngagement = youtubeEngagement.copy(comments = comments))
+}
+
+internal fun CoroutineScope.replaceHomeResonanceCommentsJob(
+    currentJob: Job?,
+    block: suspend CoroutineScope.() -> Unit
+): Job {
+    currentJob?.cancel()
+    return launch(Dispatchers.IO, block = block)
+}
+
+internal fun homeResonanceCommentVideoIds(tracks: List<Track>): List<String> = tracks.asSequence()
+    .map(Track::id)
+    .filter { it.length == 11 }
+    .distinct()
+    .toList()
+
+internal fun homeResonanceCommentsToRefresh(
+    tracks: List<Track>,
+    comments: Map<String, ResonanceCommentSnippet>,
+    nowMs: Long,
+    ttlMs: Long
+): List<Track> = tracks.asSequence()
+    .filter { it.id.length == 11 }
+    .distinctBy(Track::id)
+    .filter { track ->
+        val updatedAtMs = comments[track.id]?.updatedAtMs ?: 0L
+        val ageMs = nowMs - updatedAtMs
+        updatedAtMs <= 0L || ageMs < 0L || ageMs >= ttlMs
+    }
+    .toList()
+
+internal fun LevyraUiState.withHomeResonanceComment(
+    requestVideoIds: List<String>,
+    videoId: String,
+    transform: (ResonanceCommentSnippet?) -> ResonanceCommentSnippet
+): LevyraUiState {
+    if (requestVideoIds != homeResonanceCommentVideoIds(homeResonanceTracks) || videoId !in requestVideoIds) {
+        return this
+    }
+    val comments = LinkedHashMap(resonanceCommentsForTracks(homeResonanceTracks, homeResonanceComments))
+    comments[videoId] = transform(comments[videoId])
+    return copy(homeResonanceComments = resonanceCommentsForTracks(homeResonanceTracks, comments))
 }
 
 private fun isYoutubeBackedTrack(track: Track): Boolean {

--- a/app/src/test/java/com/luc4n3x/levyra/data/LevyraHomeSnapshotCacheTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/LevyraHomeSnapshotCacheTest.kt
@@ -1,0 +1,67 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.domain.ResonanceCommentSnippet
+import com.luc4n3x.levyra.domain.Track
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LevyraHomeSnapshotCacheTest {
+    @Test
+    fun resonanceSnapshotAfterCompleteReplacementContainsOnlyCurrentIds() {
+        val oldTrack = track("aaaaaaaaaaa")
+        val firstCurrent = track("bbbbbbbbbbb")
+        val disabledCurrent = track("ccccccccccc")
+        val comments = linkedMapOf(
+            oldTrack.id to ResonanceCommentSnippet(videoId = oldTrack.id, text = "Old"),
+            disabledCurrent.id to ResonanceCommentSnippet(
+                videoId = disabledCurrent.id,
+                disabled = true,
+                updatedAtMs = 20L
+            ),
+            firstCurrent.id to ResonanceCommentSnippet(
+                videoId = firstCurrent.id,
+                text = "Current",
+                updatedAtMs = 10L
+            )
+        )
+
+        val json = resonanceCommentsToJson(listOf(firstCurrent, disabledCurrent), comments)
+
+        assertEquals(setOf(firstCurrent.id, disabledCurrent.id), json.keys().asSequence().toSet())
+        assertEquals("Current", json.getJSONObject(firstCurrent.id).getString("text"))
+        assertTrue(json.getJSONObject(disabledCurrent.id).getBoolean("disabled"))
+    }
+
+    @Test
+    fun successfulEmptyCommentSnapshotKeepsFreshness() {
+        val track = track("bbbbbbbbbbb")
+
+        val json = resonanceCommentsToJson(
+            listOf(track),
+            mapOf(track.id to ResonanceCommentSnippet(videoId = track.id, updatedAtMs = 42L))
+        )
+
+        assertEquals(42L, json.getJSONObject(track.id).getLong("updatedAtMs"))
+    }
+
+    private fun track(id: String) = Track(
+        id = id,
+        title = "Title $id",
+        artist = "Artist",
+        album = "Album",
+        durationMs = 180_000L,
+        streamUrl = "",
+        videoUrl = "https://music.youtube.com/watch?v=$id",
+        thumbnailUrl = "",
+        largeThumbnailUrl = "",
+        source = "YouTube Music",
+        moodTags = emptySet(),
+        energy = 50,
+        vocal = 50,
+        replayScore = 50,
+        cacheScore = 50,
+        accentStart = 0,
+        accentEnd = 0
+    )
+}

--- a/app/src/test/java/com/luc4n3x/levyra/ui/ResonanceCommentsUiTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/ResonanceCommentsUiTest.kt
@@ -1,0 +1,17 @@
+package com.luc4n3x.levyra.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ResonanceCommentsUiTest {
+    @Test
+    fun `comment count keeps the number and removes provider language`() {
+        assertEquals("248", youtubeCommentCountBadge("248 Amazwana"))
+        assertEquals("1,2K", youtubeCommentCountBadge("1,2K comments"))
+    }
+
+    @Test
+    fun `blank comment count stays blank`() {
+        assertEquals("", youtubeCommentCountBadge("  "))
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/ui/i18n/LevyraStringsTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/i18n/LevyraStringsTest.kt
@@ -20,7 +20,12 @@ class LevyraStringsTest {
         assertEquals(catalogCodes, experienceLocalizationCodes())
         assertEquals(catalogCodes, insightLocalizationCodes())
         assertEquals(catalogCodes, integrationLocalizationCodes())
+        assertEquals(catalogCodes, resonanceLocalizationCodes())
         LevyraStrings.all().forEach { strings ->
+            assertTrue(strings.commentsLabel.isNotBlank())
+            assertTrue(strings.mostCommentedTracks.isNotBlank())
+            assertTrue(strings.tapToOpenComments.isNotBlank())
+            assertTrue(strings.noCommentsAvailable.isNotBlank())
             assertTrue(strings.introHeadline.isNotBlank())
             assertTrue(strings.introBody.isNotBlank())
             assertTrue(strings.introFeatureSound.isNotBlank())

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/HomeRenderSnapshotTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/HomeRenderSnapshotTest.kt
@@ -162,6 +162,23 @@ class HomeRenderSnapshotTest {
         assertEquals(false, idleSnapshot.derived.contentAvailability.hasCurrentTrack)
     }
 
+    @Test
+    fun prioritizesCommentedSectionTracksInResonanceShelf() {
+        val standardTrack = track("std11111111").copy(replayScore = 80)
+        val commentedTrack = track("cmt11111111").copy(replayScore = 20)
+        val state = LevyraUiState(
+            charts = listOf(standardTrack),
+            homeSections = listOf(
+                HomeSection("Tracce più commentate", listOf(commentedTrack))
+            ),
+            languageCode = "it"
+        )
+
+        val snapshot = buildHomeRenderSnapshot(state)
+
+        assertEquals("cmt11111111", snapshot.derived.resonanceTracks.firstOrNull()?.id)
+    }
+
     private fun track(id: String): Track {
         return Track(
             id = id,

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/HomeResonanceCommentsPolicyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/HomeResonanceCommentsPolicyTest.kt
@@ -1,0 +1,127 @@
+package com.luc4n3x.levyra.viewmodel
+
+import com.luc4n3x.levyra.domain.ResonanceCommentSnippet
+import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.domain.resonanceCommentsForTracks
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+class HomeResonanceCommentsPolicyTest {
+    @Test
+    fun replacingTracksLoadsLatestListAndRejectsOldPublication() {
+        val oldTrack = track("aaaaaaaaaaa")
+        val newTrack = track("bbbbbbbbbbb")
+        val oldComments = mapOf(
+            oldTrack.id to ResonanceCommentSnippet(videoId = oldTrack.id, text = "Old", updatedAtMs = 1L)
+        )
+        val replacedState = LevyraUiState(
+            homeResonanceTracks = listOf(newTrack),
+            homeResonanceComments = resonanceCommentsForTracks(listOf(newTrack), oldComments)
+        )
+
+        val stalePublication = replacedState.withHomeResonanceComment(listOf(oldTrack.id), oldTrack.id) {
+            ResonanceCommentSnippet(videoId = oldTrack.id, text = "Late old result")
+        }
+        val latestCandidates = homeResonanceCommentsToRefresh(
+            tracks = listOf(newTrack),
+            comments = replacedState.homeResonanceComments,
+            nowMs = 10_000L,
+            ttlMs = 1_000L
+        )
+        val latestPublication = replacedState.withHomeResonanceComment(listOf(newTrack.id), newTrack.id) {
+            ResonanceCommentSnippet(videoId = newTrack.id, text = "New result", updatedAtMs = 10_000L)
+        }
+
+        assertSame(replacedState, stalePublication)
+        assertEquals(listOf(newTrack), latestCandidates)
+        assertEquals(setOf(newTrack.id), latestPublication.homeResonanceComments.keys)
+        assertEquals("New result", latestPublication.homeResonanceComments[newTrack.id]?.text)
+    }
+
+    @Test
+    fun replacingTracksCancelsActiveRefreshAndLateOldResultCannotPublish() = runBlocking {
+        val oldTrack = track("aaaaaaaaaaa")
+        val newTrack = track("bbbbbbbbbbb")
+        val oldStarted = CompletableDeferred<Unit>()
+        val releaseOld = CompletableDeferred<Unit>()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        var state = LevyraUiState(homeResonanceTracks = listOf(oldTrack))
+
+        val oldJob = scope.replaceHomeResonanceCommentsJob(null) {
+            oldStarted.complete(Unit)
+            releaseOld.await()
+            state = state.withHomeResonanceComment(listOf(oldTrack.id), oldTrack.id) {
+                ResonanceCommentSnippet(videoId = oldTrack.id, text = "Late old result")
+            }
+        }
+        withTimeout(1_000L) { oldStarted.await() }
+        state = state.copy(homeResonanceTracks = listOf(newTrack), homeResonanceComments = emptyMap())
+        val newJob = scope.replaceHomeResonanceCommentsJob(oldJob) {
+            state = state.withHomeResonanceComment(listOf(newTrack.id), newTrack.id) {
+                ResonanceCommentSnippet(videoId = newTrack.id, text = "New result")
+            }
+        }
+
+        withTimeout(1_000L) { newJob.join() }
+        releaseOld.complete(Unit)
+        withTimeout(1_000L) { oldJob.join() }
+
+        assertEquals(setOf(newTrack.id), state.homeResonanceComments.keys)
+        assertEquals("New result", state.homeResonanceComments[newTrack.id]?.text)
+        scope.cancel()
+    }
+
+    @Test
+    fun staleCachedCommentRemainsVisibleAndIsSelectedForRefresh() {
+        val track = track("aaaaaaaaaaa")
+        val cached = ResonanceCommentSnippet(
+            videoId = track.id,
+            text = "Cached comment",
+            updatedAtMs = 1_000L
+        )
+        val retained = resonanceCommentsForTracks(listOf(track), mapOf(track.id to cached))
+
+        val candidates = homeResonanceCommentsToRefresh(
+            tracks = listOf(track),
+            comments = retained,
+            nowMs = 7_001L,
+            ttlMs = 6_000L
+        )
+        val refreshing = cached.copy(
+            isLoading = cached.hasComment.not() && cached.disabled.not(),
+            hasError = false
+        )
+
+        assertEquals("Cached comment", refreshing.text)
+        assertEquals(false, refreshing.isLoading)
+        assertEquals(listOf(track), candidates)
+    }
+
+    private fun track(id: String) = Track(
+        id = id,
+        title = "Title $id",
+        artist = "Artist",
+        album = "Album",
+        durationMs = 180_000L,
+        streamUrl = "",
+        videoUrl = "https://music.youtube.com/watch?v=$id",
+        thumbnailUrl = "",
+        largeThumbnailUrl = "",
+        source = "YouTube Music",
+        moodTags = emptySet(),
+        energy = 50,
+        vocal = 50,
+        replayScore = 50,
+        cacheScore = 50,
+        accentStart = 0,
+        accentEnd = 0
+    )
+}

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/YoutubeEngagementIdentityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/YoutubeEngagementIdentityTest.kt
@@ -93,7 +93,7 @@ class YoutubeEngagementIdentityTest {
         assertEquals(true, loaded.youtubeEngagement.comments.loaded)
         assertEquals("Comment B", loaded.youtubeEngagement.comments.items.single().text)
         assertEquals("next-b", loaded.youtubeEngagement.comments.nextToken)
-        assertEquals(trackA.id, state.currentTrack?.id)
+        assertEquals(trackA.id, loaded.currentTrack?.id)
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/YoutubeEngagementIdentityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/YoutubeEngagementIdentityTest.kt
@@ -1,6 +1,11 @@
 package com.luc4n3x.levyra.viewmodel
 
 import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.domain.YoutubeCommentsState
+import com.luc4n3x.levyra.domain.YoutubeEngagementState
+import com.luc4n3x.levyra.domain.YoutubeComment
+import com.luc4n3x.levyra.data.YoutubeCommentsPage
+import com.luc4n3x.levyra.data.YoutubeCommentsResult
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -52,6 +57,43 @@ class YoutubeEngagementIdentityTest {
                 track(id = "abcdefghijk", source = "Local library")
             )
         )
+    }
+
+    @Test
+    fun currentTrackAAllowsCommentsRequestForOpenedTrackBToComplete() {
+        val trackA = track(id = "aaaaaaaaaaa")
+        val trackB = track(id = "bbbbbbbbbbb")
+        val state = LevyraUiState(
+            currentTrack = trackA,
+            youtubeEngagement = YoutubeEngagementState(
+                videoId = trackB.id,
+                comments = YoutubeCommentsState(
+                    videoId = trackB.id,
+                    visible = true,
+                    loading = true
+                )
+            )
+        )
+
+        val loaded = state.withYoutubeCommentsResultIfCurrent(
+            videoId = trackB.id,
+            generation = 7L,
+            currentGeneration = 7L,
+            result = YoutubeCommentsResult.Available(
+                YoutubeCommentsPage(
+                    videoId = trackB.id,
+                    countText = "1",
+                    commentsDisabled = false,
+                    items = listOf(YoutubeComment(id = "comment-b", author = "Author", text = "Comment B")),
+                    nextToken = "next-b"
+                )
+            )
+        )
+
+        assertEquals(true, loaded.youtubeEngagement.comments.loaded)
+        assertEquals("Comment B", loaded.youtubeEngagement.comments.items.single().text)
+        assertEquals("next-b", loaded.youtubeEngagement.comments.nextToken)
+        assertEquals(trackA.id, state.currentTrack?.id)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Redesigns the "Voci che risuonano" shelf on the home screen into authentic YouTube Music inspired discussion cards. Each card highlights the track metadata alongside an inset preview bubble featuring real YouTube comments, author avatars, and comment counts, without generating placeholder or fake feedback. Tapping the preview bubble opens the full comments sheet.

## What changed

- Replaced the stacked 2-row layout in `ResonanceShelf` with single-row horizontal cards (314 dp width) pairing track playback controls with an inset comment bubble.
- Implemented background comment fetching via `youtubeCommentsRepository.initial()` for resonance candidate tracks, caching responses in `LevyraHomeSnapshotCache` (schema 14) so comments persist across sessions.
- Added `openYoutubeCommentsFor(track)` in `HomeViewModel` and `LevyraViewModel` so tapping the comment bubble directly presents `PlayerYoutubeCommentsSheet`.
- Created `ResonanceCommentSnippet` domain model and integrated sleek shimmer and empty state indicators for pending or disabled comments.
- Added complete localization for comment labels and empty states across all 26 supported languages in `LevyraResonanceStrings.kt`.
- Updated `HomeRenderSnapshotTest` and `LevyraStringsTest` to validate resonance track prioritization and localized bundle completeness.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor or maintenance
- [x] UI or UX change
- [x] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** UI / Streaming / Localization / Library

## Validation

### Automated checks

- [x] Targeted tests were added or updated: `LevyraStringsTest` and `HomeRenderSnapshotTest` passed via `./gradlew testDebugUnitTest`.
- [x] Fast quality gate passed via `py -3.12 scripts/ai_quality_gate.py --profile fast` (131 repository tests, configuration, efficiency, skills, and F-Droid checks).
- [ ] Full release gate: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease` (left to CI/pre-release gate).

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Local build / Gradle | Run unit tests across all 26 language bundles | Passed cleanly with zero missing keys |
| Local build / Gradle | Validate home snapshot resonance prioritization | Passed; commented section tracks properly prioritized |

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** Home snapshot schema bumped to 14 to store `resonanceComments`. Cache gracefully falls back to empty map if reading an older snapshot.
- **Known limitations:** None
- **Rollback plan:** Revert this PR

## Reviewer notes

- All comment content is authentic from YouTube; when comments are disabled or failing to load, honest placeholders and error states are shown instead of hardcoded strings.
- Tapping the top track section starts audio playback; tapping the lower bubble opens the full comment bottom sheet.

## Release note

Added authentic YouTube comment preview cards to the Resonant Voices shelf on Home.

## Related issues

- N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [x] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Home resonance tracks now display real YouTube comment snippets, including loading, unavailable, and disabled states.
  - Added actions to refresh comments and open a track’s YouTube comments.
  - Comment data is saved and restored between sessions.
  - Resonance tracks prioritize localized “most commented” sections where available.
  - Added comment-related translations across supported languages.

- **Bug Fixes**
  - Improved handling of refreshed track lists and outdated comment results.
  - Cached comments remain visible while updated data is retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->