### PR TITLE
Update the extractor stack, add per-capability client policy, propagate client identity, and split the canary checks

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicy.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicy.kt
@@ -36,12 +36,30 @@ internal enum class PlaybackVideoStrategy {
     REEL
 }
 
+internal enum class PlaybackClientCapability(val jsonKey: String) {
+    PLAYER("player"),
+    STREAMING("streaming"),
+    BROWSE("browse"),
+    METADATA("metadata");
+
+    companion object {
+        fun fromJsonKey(value: String): PlaybackClientCapability? {
+            val normalized = value.trim().lowercase()
+            return entries.firstOrNull { it.jsonKey == normalized }
+        }
+    }
+}
+
 internal data class PlaybackClientOverride(
     val enabled: Boolean? = null,
     val priority: Int? = null,
     val requiresPoToken: Boolean? = null,
-    val clientVersion: String? = null
-)
+    val clientVersion: String? = null,
+    val capabilities: Map<PlaybackClientCapability, Boolean> = emptyMap()
+) {
+    fun isCapabilityEnabled(capability: PlaybackClientCapability): Boolean =
+        capabilities[capability] ?: enabled ?: true
+}
 
 internal data class PlaybackCompatibilityPolicy(
     val schema: Int,
@@ -92,6 +110,13 @@ internal data class PlaybackCompatibilityPolicy(
             override.priority?.let { value.put("priority", it) }
             override.requiresPoToken?.let { value.put("requiresPoToken", it) }
             override.clientVersion?.let { value.put("clientVersion", it) }
+            if (override.capabilities.isNotEmpty()) {
+                val capabilities = JSONObject()
+                PlaybackClientCapability.entries
+                    .mapNotNull { capability -> override.capabilities[capability]?.let { capability to it } }
+                    .forEach { (capability, allowed) -> capabilities.put(capability.jsonKey, allowed) }
+                value.put("capabilities", capabilities)
+            }
             clients.put(name, value)
         }
         return JSONObject()
@@ -161,7 +186,11 @@ internal object PlaybackCompatibilityPolicyParser {
             } else {
                 base.clientOverrides
             }
-            require(knownClients.any { clientOverrides[it]?.enabled != false })
+            require(
+                knownClients.any {
+                    clientOverrides[it]?.isCapabilityEnabled(PlaybackClientCapability.PLAYER) ?: true
+                }
+            )
 
             val expiresAt = if (root.has("expiresAt")) {
                 requiredLong(root, "expiresAt").also {
@@ -228,12 +257,31 @@ internal object PlaybackCompatibilityPolicyParser {
             val clientVersion = optionalString(value, "clientVersion")?.also {
                 require(clientVersionPattern.matches(it))
             }
+            val capabilities = parseCapabilities(value)
             output[name] = PlaybackClientOverride(
                 enabled = enabled,
                 priority = priority,
                 requiresPoToken = requiresPoToken,
-                clientVersion = clientVersion
+                clientVersion = clientVersion,
+                capabilities = capabilities
             )
+        }
+        return output
+    }
+
+    private fun parseCapabilities(client: JSONObject): Map<PlaybackClientCapability, Boolean> {
+        if (!client.has("capabilities") || client.isNull("capabilities")) return emptyMap()
+        val raw = client.get("capabilities")
+        require(raw is JSONObject)
+        require(raw.length() <= PlaybackClientCapability.entries.size)
+        val output = LinkedHashMap<PlaybackClientCapability, Boolean>()
+        val names = raw.keys()
+        while (names.hasNext()) {
+            val key = names.next()
+            val capability = PlaybackClientCapability.fromJsonKey(key) ?: continue
+            val allowed = raw.get(key)
+            require(allowed is Boolean)
+            output[capability] = allowed
         }
         return output
     }
@@ -249,7 +297,8 @@ internal object PlaybackCompatibilityPolicyParser {
                 enabled = override.enabled ?: previous?.enabled,
                 priority = override.priority ?: previous?.priority,
                 requiresPoToken = override.requiresPoToken ?: previous?.requiresPoToken,
-                clientVersion = override.clientVersion ?: previous?.clientVersion
+                clientVersion = override.clientVersion ?: previous?.clientVersion,
+                capabilities = previous?.capabilities.orEmpty() + override.capabilities
             )
         }
         return output
@@ -295,6 +344,22 @@ internal object PlaybackCompatibilityPolicyParser {
         require(raw is String && raw.isNotBlank())
         return raw
     }
+}
+
+internal fun PlaybackCompatibilityPolicy.isClientCapabilityEnabled(
+    clientName: String,
+    capability: PlaybackClientCapability
+): Boolean = clientOverrides[clientName]?.isCapabilityEnabled(capability) ?: true
+
+internal object PlaybackClientCapabilities {
+    private val active = AtomicReference(PlaybackCompatibilityPolicy.bundled())
+
+    fun publish(policy: PlaybackCompatibilityPolicy) {
+        active.set(policy)
+    }
+
+    fun isEnabled(clientName: String, capability: PlaybackClientCapability): Boolean =
+        active.get().isClientCapabilityEnabled(clientName, capability)
 }
 
 internal fun PlaybackCompatibilityPolicy.isExpired(nowMs: Long = System.currentTimeMillis()): Boolean {
@@ -364,8 +429,11 @@ internal class PlaybackCompatibilityPolicyStore(
     }
 
     private fun syncExtractorClientPolicy() {
-        val androidVrEnabled = current().clientOverrides["ANDROID_VR"]?.enabled ?: true
-        YoutubeStreamExtractor.setAndroidVrPlayerClientEnabled(androidVrEnabled)
+        val policy = current()
+        PlaybackClientCapabilities.publish(policy)
+        YoutubeStreamExtractor.setAndroidVrPlayerClientEnabled(
+            policy.isClientCapabilityEnabled("ANDROID_VR", PlaybackClientCapability.PLAYER)
+        )
     }
 
     private suspend fun refreshLocked(reason: String): Boolean {

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicy.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicy.kt
@@ -187,8 +187,11 @@ internal object PlaybackCompatibilityPolicyParser {
                 base.clientOverrides
             }
             require(
-                knownClients.any {
-                    clientOverrides[it]?.isCapabilityEnabled(PlaybackClientCapability.PLAYER) ?: true
+                knownClients.any { client ->
+                    val override = clientOverrides[client]
+                    val player = override?.isCapabilityEnabled(PlaybackClientCapability.PLAYER) ?: true
+                    val streaming = override?.isCapabilityEnabled(PlaybackClientCapability.STREAMING) ?: true
+                    player && streaming
                 }
             )
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -669,7 +669,7 @@ class PlaybackResolver private constructor(private val context: Context) {
     ) {
         rememberClientIdentity(
             stream = stream,
-            clientName = "ANDROID",
+            clientName = ANDROID_REEL_CLIENT_NAME,
             clientHeaderName = "3",
             clientVersion = clientVersion,
             userAgent = userAgent,
@@ -677,14 +677,9 @@ class PlaybackResolver private constructor(private val context: Context) {
         )
     }
 
-    private fun streamingCapabilityAllows(profile: ClientProfile): Boolean {
-        val policy = playbackPolicyStore.current()
-        if (policy.isClientCapabilityEnabled(profile.clientName, PlaybackClientCapability.STREAMING)) return true
-        val anyStreamingClient = effectiveProfiles().any {
-            policy.isClientCapabilityEnabled(it.clientName, PlaybackClientCapability.STREAMING)
-        }
-        return !anyStreamingClient
-    }
+    private fun streamingCapabilityAllows(clientName: String): Boolean =
+        playbackPolicyStore.current()
+            .isClientCapabilityEnabled(clientName, PlaybackClientCapability.STREAMING)
 
     private fun rememberClientIdentity(
         stream: DirectStream,
@@ -1286,6 +1281,12 @@ class PlaybackResolver private constructor(private val context: Context) {
         track: Track,
         audioQuality: String
     ): Track {
+        if (!streamingCapabilityAllows(ANDROID_REEL_CLIENT_NAME)) {
+            throw YoutubePlayerRequestException(
+                null,
+                "Client $ANDROID_REEL_CLIENT_NAME non abilitato alla capability streaming"
+            )
+        }
         val sourceVideoId = PlaybackSourceIdentity.sourceVideoId(track)
             .takeIf(youtubeVideoIdRegex::matches)
             ?: throw YoutubePlayerRequestException(null, "Identità video YouTube assente o non valida")
@@ -1405,6 +1406,12 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     private suspend fun resolveVideoWithAndroidReel(track: Track): Track {
+        if (!streamingCapabilityAllows(ANDROID_REEL_CLIENT_NAME)) {
+            throw YoutubePlayerRequestException(
+                null,
+                "Client $ANDROID_REEL_CLIENT_NAME non abilitato alla capability streaming"
+            )
+        }
         val sourceVideoId = PlaybackSourceIdentity.sourceVideoId(track)
             .takeIf(youtubeVideoIdRegex::matches)
             ?: throw YoutubePlayerRequestException(null, "Identità video YouTube assente o non valida")
@@ -2455,7 +2462,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         preferMp4Audio: Boolean = false,
         audioQuality: String = selectedAudioQuality
     ): DirectStream {
-        if (!streamingCapabilityAllows(profile)) {
+        if (!streamingCapabilityAllows(profile.clientName)) {
             throw YoutubePlayerRequestException(
                 null,
                 "Client ${profile.clientName} non abilitato alla capability streaming"
@@ -3636,6 +3643,8 @@ private fun Throwable.playbackDiagnostic(): String {
 }
 
 class PlaybackBlockedException(message: String) : IllegalStateException(message)
+
+private const val ANDROID_REEL_CLIENT_NAME = "ANDROID"
 
 private val PROGRESSIVE_STREAM_CLIENTS = setOf("VISIONOS", "ANDROID_VR")
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -7,6 +7,8 @@ import com.luc4n3x.levyra.BuildConfig
 import com.luc4n3x.levyra.data.security.GoogleApiKeyHeaders
 import com.luc4n3x.levyra.data.local.LevyraDatabase
 import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
+import com.luc4n3x.levyra.data.network.YoutubeStreamClientIdentity
+import com.luc4n3x.levyra.data.network.YoutubeStreamClientIdentityRegistry
 import com.luc4n3x.levyra.domain.LevyraContentLocales
 import com.luc4n3x.levyra.domain.PlaybackDeliveryMethod
 import com.luc4n3x.levyra.domain.PlaybackStreamDescriptor
@@ -382,8 +384,9 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     private fun applyExtractorClientPolicy() {
-        val overrides = playbackPolicyStore.current().clientOverrides
-        val androidVrEnabled = overrides["ANDROID_VR"]?.enabled ?: true
+        val policy = playbackPolicyStore.current()
+        PlaybackClientCapabilities.publish(policy)
+        val androidVrEnabled = policy.isClientCapabilityEnabled("ANDROID_VR", PlaybackClientCapability.PLAYER)
         YoutubeStreamExtractor.setAndroidVrPlayerClientEnabled(androidVrEnabled)
         Timber.i("Playback compatibility clients androidVrEnabled=%s", androidVrEnabled)
     }
@@ -412,6 +415,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 streamCache.clear()
                 prefs.edit().clear().apply()
                 strategyOriginByUrl.clear()
+                YoutubeStreamClientIdentityRegistry.clear()
             }
             sourceMatchStore.clearOnline()
         }
@@ -655,6 +659,59 @@ class PlaybackResolver private constructor(private val context: Context) {
             "playback candidate promoted mode=%s burned=%d",
             if (isVideoMode) "video" else "audio",
             burned
+        )
+    }
+
+    private fun rememberAndroidReelClientIdentity(
+        stream: DirectStream,
+        userAgent: String,
+        clientVersion: String
+    ) {
+        rememberClientIdentity(
+            stream = stream,
+            clientName = "ANDROID",
+            clientHeaderName = "3",
+            clientVersion = clientVersion,
+            userAgent = userAgent,
+            requiresPoToken = false
+        )
+    }
+
+    private fun streamingCapabilityAllows(profile: ClientProfile): Boolean {
+        val policy = playbackPolicyStore.current()
+        if (policy.isClientCapabilityEnabled(profile.clientName, PlaybackClientCapability.STREAMING)) return true
+        val anyStreamingClient = effectiveProfiles().any {
+            policy.isClientCapabilityEnabled(it.clientName, PlaybackClientCapability.STREAMING)
+        }
+        return !anyStreamingClient
+    }
+
+    private fun rememberClientIdentity(
+        stream: DirectStream,
+        clientName: String,
+        clientHeaderName: String,
+        clientVersion: String,
+        userAgent: String,
+        requiresPoToken: Boolean
+    ) {
+        val urls = buildList {
+            add(stream.url)
+            add(stream.videoUrl)
+            stream.manifest.streams
+                .filter { it.deliveryMethod != PlaybackDeliveryMethod.SABR }
+                .forEach { add(it.url) }
+        }.filter { it.isNotBlank() }
+        if (urls.isEmpty()) return
+        YoutubeStreamClientIdentityRegistry.register(
+            urls,
+            YoutubeStreamClientIdentity(
+                clientName = clientName,
+                clientHeaderName = clientHeaderName,
+                clientVersion = clientVersion,
+                userAgent = userAgent,
+                requiresPoToken = requiresPoToken,
+                videoId = stream.manifest.sourceVideoId
+            )
         )
     }
 
@@ -1332,16 +1389,16 @@ class PlaybackResolver private constructor(private val context: Context) {
                 selectedVideoUrl = "",
                 streams = listOf(innerTubeAudioDescriptor(format, url, true))
             )
-            return track.withDirectStream(
-                DirectStream(
-                    url = url,
-                    videoUrl = "",
-                    durationMs = duration,
-                    thumbnailUrl = thumbnail,
-                    source = "YouTube Android Reel Audio",
-                    manifest = manifest
-                )
+            val reelStream = DirectStream(
+                url = url,
+                videoUrl = "",
+                durationMs = duration,
+                thumbnailUrl = thumbnail,
+                source = "YouTube Android Reel Audio",
+                manifest = manifest
             )
+            rememberAndroidReelClientIdentity(reelStream, userAgent, reelClientVersion)
+            return track.withDirectStream(reelStream)
         }
 
         throw YoutubePlayerRequestException(null, "Android Reel non ha restituito uno stream solo audio riproducibile")
@@ -1448,17 +1505,17 @@ class PlaybackResolver private constructor(private val context: Context) {
             selectedVideoUrl = "",
             streams = listOf(videoDescriptor(selection.candidate, true))
         )
-        return track.withDirectStream(
-            DirectStream(
-                url = selection.candidate.url,
-                videoUrl = "",
-                durationMs = duration,
-                thumbnailUrl = thumbnail,
-                source = "YouTube Android Reel · ${selection.reason}",
-                manifest = manifest,
-                videoSubtitleTracks = videoSubtitleTracks(playerResponse)
-            )
+        val reelStream = DirectStream(
+            url = selection.candidate.url,
+            videoUrl = "",
+            durationMs = duration,
+            thumbnailUrl = thumbnail,
+            source = "YouTube Android Reel · ${selection.reason}",
+            manifest = manifest,
+            videoSubtitleTracks = videoSubtitleTracks(playerResponse)
         )
+        rememberAndroidReelClientIdentity(reelStream, userAgent, reelClientVersion)
+        return track.withDirectStream(reelStream)
     }
 
     private fun fetchAndroidReelVisitorData(
@@ -2028,7 +2085,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         val overrides = playbackPolicyStore.current().clientOverrides
         val effective = profiles.mapNotNull { base ->
             val override = overrides[base.clientName]
-            if (override?.enabled == false) return@mapNotNull null
+            if (override?.isCapabilityEnabled(PlaybackClientCapability.PLAYER) == false) return@mapNotNull null
             val version = override?.clientVersion ?: base.clientVersion
             base.copy(
                 clientVersion = version,
@@ -2398,6 +2455,12 @@ class PlaybackResolver private constructor(private val context: Context) {
         preferMp4Audio: Boolean = false,
         audioQuality: String = selectedAudioQuality
     ): DirectStream {
+        if (!streamingCapabilityAllows(profile)) {
+            throw YoutubePlayerRequestException(
+                null,
+                "Client ${profile.clientName} non abilitato alla capability streaming"
+            )
+        }
         val startedAt = System.nanoTime()
         val mode = if (isVideoMode) "video" else if (preferMp4Audio) "offline" else "audio"
         val diagnosticMode = if (isVideoMode) RuntimeSignal.MODE_VIDEO else RuntimeSignal.MODE_AUDIO
@@ -2414,6 +2477,14 @@ class PlaybackResolver private constructor(private val context: Context) {
                 RuntimeHooks.hot(RuntimeSignal.HOT_FALLBACK)
                 resolveWithInnerTubeOnce(track, profile, isVideoMode, preferMp4Audio, audioQuality)
             }
+            rememberClientIdentity(
+                stream = stream,
+                clientName = profile.clientName,
+                clientHeaderName = profile.clientHeaderName,
+                clientVersion = profile.clientVersion,
+                userAgent = playerUserAgent(profile),
+                requiresPoToken = profile.requiresPoToken
+            )
             playbackSecurity.resetFailureState()
             val latency = elapsedMs(startedAt)
             recordClientSuccess(profile, latency)

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicResilienceClient.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicResilienceClient.kt
@@ -383,7 +383,7 @@ internal class YoutubeMusicResilienceClient(
     private fun orderedProfiles(now: Long): List<YoutubeMusicClientProfile> {
         val permitted = profiles.filter {
             PlaybackClientCapabilities.isEnabled(it.clientName, PlaybackClientCapability.BROWSE)
-        }.ifEmpty { profiles }
+        }
         val available = permitted.filter { (health[it.id]?.blockedUntilMs ?: 0L) <= now }
         if (available.isEmpty()) return emptyList()
         return available.sortedWith(

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicResilienceClient.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeMusicResilienceClient.kt
@@ -381,7 +381,10 @@ internal class YoutubeMusicResilienceClient(
     }
 
     private fun orderedProfiles(now: Long): List<YoutubeMusicClientProfile> {
-        val available = profiles.filter { (health[it.id]?.blockedUntilMs ?: 0L) <= now }
+        val permitted = profiles.filter {
+            PlaybackClientCapabilities.isEnabled(it.clientName, PlaybackClientCapability.BROWSE)
+        }.ifEmpty { profiles }
+        val available = permitted.filter { (health[it.id]?.blockedUntilMs ?: 0L) <= now }
         if (available.isEmpty()) return emptyList()
         return available.sortedWith(
             compareByDescending<YoutubeMusicClientProfile> {

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeTranscriptLyricsProvider.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeTranscriptLyricsProvider.kt
@@ -46,6 +46,7 @@ class YoutubeTranscriptLyricsProvider(context: Context) {
     }
 
     private fun playerResponse(videoId: String): JSONObject? {
+        if (!PlaybackClientCapabilities.isEnabled("WEB", PlaybackClientCapability.METADATA)) return null
         val body = JSONObject()
             .put(
                 "context",

--- a/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeClientIdentityInterceptor.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeClientIdentityInterceptor.kt
@@ -33,6 +33,24 @@ internal object YoutubeClientIdentityInterceptor : Interceptor {
         CLIENT_VISIONOS
     )
 
+    internal data class MediaNavigation(val origin: String, val referer: String)
+
+    internal fun mediaNavigationFor(clientHeaderName: String, videoId: String): MediaNavigation? {
+        return when (clientHeaderName) {
+            CLIENT_WEB -> MediaNavigation("https://www.youtube.com", "https://www.youtube.com/")
+            CLIENT_WEB_REMIX -> MediaNavigation("https://music.youtube.com", "https://music.youtube.com/")
+            CLIENT_WEB_EMBEDDED -> MediaNavigation(
+                "https://www.youtube.com",
+                if (videoId.isBlank()) {
+                    "https://www.youtube.com/embed/"
+                } else {
+                    "https://www.youtube.com/embed/$videoId"
+                }
+            )
+            else -> null
+        }
+    }
+
     override fun intercept(chain: Interceptor.Chain): Response {
         return chain.proceed(normalize(chain.request()))
     }

--- a/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeStreamClientIdentity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeStreamClientIdentity.kt
@@ -63,6 +63,7 @@ internal object YoutubeStreamClientIdentityRegistry {
 
     private fun keysFor(url: String): List<String> {
         val keys = ArrayList<String>(2)
+        keys += "url" + '\u0000' + url.substringBefore('#')
         val parsed = url.toHttpUrlOrNull()
         if (parsed != null) {
             val mediaId = parsed.queryParameter("id").orEmpty()
@@ -71,7 +72,6 @@ internal object YoutubeStreamClientIdentityRegistry {
                 keys += "media" + '\u0000' + mediaId + '\u0000' + itag
             }
         }
-        keys += "url" + '\u0000' + url.substringBefore('#')
         return keys
     }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeStreamClientIdentity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeStreamClientIdentity.kt
@@ -1,0 +1,77 @@
+package com.luc4n3x.levyra.data.network
+
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+
+internal data class YoutubeStreamClientIdentity(
+    val clientName: String,
+    val clientHeaderName: String,
+    val clientVersion: String,
+    val userAgent: String,
+    val requiresPoToken: Boolean,
+    val videoId: String = ""
+) {
+    fun mediaRequestHeaders(): Map<String, String> {
+        val headers = linkedMapOf(
+            "User-Agent" to userAgent,
+            "Accept" to "*/*",
+            "Accept-Encoding" to "identity"
+        )
+        val navigation = YoutubeClientIdentityInterceptor.mediaNavigationFor(clientHeaderName, videoId)
+        if (navigation != null) {
+            headers["Origin"] = navigation.origin
+            headers["Referer"] = navigation.referer
+            headers["Sec-Fetch-Dest"] = "empty"
+            headers["Sec-Fetch-Mode"] = "cors"
+            headers["Sec-Fetch-Site"] = "cross-site"
+        }
+        return headers
+    }
+}
+
+internal object YoutubeStreamClientIdentityRegistry {
+    private const val MAX_ENTRIES = 256
+
+    private val entries = object : LinkedHashMap<String, YoutubeStreamClientIdentity>(64, 0.75f, true) {
+        override fun removeEldestEntry(
+            eldest: MutableMap.MutableEntry<String, YoutubeStreamClientIdentity>
+        ): Boolean = size > MAX_ENTRIES
+    }
+
+    fun register(urls: Collection<String>, identity: YoutubeStreamClientIdentity) {
+        val keys = urls.asSequence()
+            .filter { it.isNotBlank() }
+            .flatMap { keysFor(it).asSequence() }
+            .toList()
+        if (keys.isEmpty()) return
+        synchronized(entries) {
+            keys.forEach { entries[it] = identity }
+        }
+    }
+
+    fun find(url: String): YoutubeStreamClientIdentity? {
+        if (url.isBlank()) return null
+        val keys = keysFor(url)
+        synchronized(entries) {
+            keys.forEach { key -> entries[key]?.let { return it } }
+        }
+        return null
+    }
+
+    fun clear() {
+        synchronized(entries) { entries.clear() }
+    }
+
+    private fun keysFor(url: String): List<String> {
+        val keys = ArrayList<String>(2)
+        val parsed = url.toHttpUrlOrNull()
+        if (parsed != null) {
+            val mediaId = parsed.queryParameter("id").orEmpty()
+            val itag = parsed.queryParameter("itag").orEmpty()
+            if (mediaId.isNotBlank() && itag.isNotBlank()) {
+                keys += "media" + '\u0000' + mediaId + '\u0000' + itag
+            }
+        }
+        keys += "url" + '\u0000' + url.substringBefore('#')
+        return keys
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraYoutubeDataSource.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraYoutubeDataSource.kt
@@ -8,6 +8,7 @@ import androidx.media3.datasource.DataSpec
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.TransferListener
 import androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException
+import com.luc4n3x.levyra.data.network.YoutubeStreamClientIdentityRegistry
 import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper
 import timber.log.Timber
 import java.io.IOException
@@ -160,6 +161,7 @@ class LevyraYoutubeDataSource private constructor(
     }
 
     private fun requestHeaders(url: String): Map<String, String> {
+        YoutubeStreamClientIdentityRegistry.find(url)?.let { return it.mediaRequestHeaders() }
         val userAgent = when {
             runCatching { YoutubeParsingHelper.isIosStreamingUrl(url) }.getOrDefault(false) -> YoutubeParsingHelper.getIosUserAgent(null)
             runCatching { YoutubeParsingHelper.isAndroidStreamingUrl(url) }.getOrDefault(false) -> YoutubeParsingHelper.getAndroidUserAgent(null)

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicyTest.kt
@@ -367,4 +367,147 @@ class PlaybackCompatibilityPolicyTest {
         assertTrue(isAppVersionSupported(policy, appVersionCode = 15))
         assertTrue(isAppVersionSupported(policy, appVersionCode = 0))
     }
+
+    @Test
+    fun clientWithoutCapabilityBlockFallsBackToEnabledFlag() {
+        val disabled = PlaybackClientOverride(enabled = false)
+        val enabled = PlaybackClientOverride(enabled = true)
+        val unset = PlaybackClientOverride()
+
+        PlaybackClientCapability.entries.forEach { capability ->
+            assertFalse(disabled.isCapabilityEnabled(capability))
+            assertTrue(enabled.isCapabilityEnabled(capability))
+            assertTrue(unset.isCapabilityEnabled(capability))
+        }
+    }
+
+    @Test
+    fun perCapabilityOverrideNarrowsOnlyTheNamedCapabilities() {
+        val base = PlaybackCompatibilityPolicy.bundled()
+        val parsed = PlaybackCompatibilityPolicyParser.parse(
+            """
+            {
+              "schema": 1,
+              "revision": 2026090401,
+              "clients": {
+                "ANDROID_VR": {
+                  "enabled": false,
+                  "capabilities": { "browse": true, "metadata": true }
+                },
+                "VISIONOS": {
+                  "capabilities": { "streaming": false }
+                }
+              }
+            }
+            """.trimIndent(),
+            base
+        )
+
+        assertNotNull(parsed)
+        parsed!!
+        assertFalse(parsed.isClientCapabilityEnabled("ANDROID_VR", PlaybackClientCapability.PLAYER))
+        assertFalse(parsed.isClientCapabilityEnabled("ANDROID_VR", PlaybackClientCapability.STREAMING))
+        assertTrue(parsed.isClientCapabilityEnabled("ANDROID_VR", PlaybackClientCapability.BROWSE))
+        assertTrue(parsed.isClientCapabilityEnabled("ANDROID_VR", PlaybackClientCapability.METADATA))
+
+        assertTrue(parsed.isClientCapabilityEnabled("VISIONOS", PlaybackClientCapability.PLAYER))
+        assertFalse(parsed.isClientCapabilityEnabled("VISIONOS", PlaybackClientCapability.STREAMING))
+
+        assertTrue(parsed.isClientCapabilityEnabled("ANDROID", PlaybackClientCapability.PLAYER))
+        assertTrue(parsed.isClientCapabilityEnabled("IOS", PlaybackClientCapability.STREAMING))
+    }
+
+    @Test
+    fun capabilitiesSurviveSerializationRoundTrip() {
+        val base = PlaybackCompatibilityPolicy.bundled()
+        val policy = base.copy(
+            revision = base.revision + 1,
+            clientOverrides = mapOf(
+                "ANDROID_VR" to PlaybackClientOverride(
+                    enabled = false,
+                    capabilities = mapOf(
+                        PlaybackClientCapability.BROWSE to true,
+                        PlaybackClientCapability.METADATA to true
+                    )
+                )
+            )
+        )
+
+        val restored = PlaybackCompatibilityPolicyParser.parse(policy.toJson(), base)
+
+        assertNotNull(restored)
+        assertEquals(policy.clientOverrides, restored!!.clientOverrides)
+    }
+
+    @Test
+    fun malformedCapabilityBlockRejectsTheWholePayload() {
+        val base = PlaybackCompatibilityPolicy.bundled()
+
+        assertNull(
+            PlaybackCompatibilityPolicyParser.parse(
+                """
+                {
+                  "schema": 1,
+                  "revision": 2026090402,
+                  "clients": { "WEB": { "capabilities": { "player": "yes" } } }
+                }
+                """.trimIndent(),
+                base
+            )
+        )
+        assertNull(
+            PlaybackCompatibilityPolicyParser.parse(
+                """
+                {
+                  "schema": 1,
+                  "revision": 2026090403,
+                  "clients": { "WEB": { "capabilities": true } }
+                }
+                """.trimIndent(),
+                base
+            )
+        )
+    }
+
+    @Test
+    fun unknownCapabilityNameIsIgnoredWithoutLosingKnownOnes() {
+        val base = PlaybackCompatibilityPolicy.bundled()
+        val parsed = PlaybackCompatibilityPolicyParser.parse(
+            """
+            {
+              "schema": 1,
+              "revision": 2026090404,
+              "clients": { "WEB": { "capabilities": { "browse": false, "future": true } } }
+            }
+            """.trimIndent(),
+            base
+        )
+
+        assertNotNull(parsed)
+        assertFalse(parsed!!.isClientCapabilityEnabled("WEB", PlaybackClientCapability.BROWSE))
+        assertTrue(parsed.isClientCapabilityEnabled("WEB", PlaybackClientCapability.PLAYER))
+    }
+
+    @Test
+    fun policyRemovingEveryPlayerCapableClientIsRejected() {
+        val base = PlaybackCompatibilityPolicy.bundled()
+        val clients = base.clientOverrides.keys + setOf(
+            "VISIONOS",
+            "ANDROID_VR",
+            "ANDROID_MUSIC",
+            "ANDROID",
+            "IOS",
+            "WEB_REMIX",
+            "WEB",
+            "WEB_EMBEDDED_PLAYER"
+        )
+        val disabled = clients.joinToString(",") { """"$it": { "capabilities": { "player": false } }""" }
+
+        assertNull(
+            PlaybackCompatibilityPolicyParser.parse(
+                """{ "schema": 1, "revision": 2026090405, "clients": { $disabled } }""",
+                base
+            )
+        )
+    }
 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackCompatibilityPolicyTest.kt
@@ -510,4 +510,107 @@ class PlaybackCompatibilityPolicyTest {
             )
         )
     }
+
+    @Test
+    fun policyLeavingNoClientWithBothPlayerAndStreamingIsRejected() {
+        val base = PlaybackCompatibilityPolicy.bundled()
+        val clients = setOf(
+            "VISIONOS",
+            "ANDROID_VR",
+            "ANDROID_MUSIC",
+            "ANDROID",
+            "IOS",
+            "WEB_REMIX",
+            "WEB",
+            "WEB_EMBEDDED_PLAYER"
+        )
+        val splitCapabilities = clients.mapIndexed { index, client ->
+            val disabled = if (index % 2 == 0) "player" else "streaming"
+            """"$client": { "capabilities": { "$disabled": false } }"""
+        }.joinToString(",")
+
+        assertNull(
+            PlaybackCompatibilityPolicyParser.parse(
+                """{ "schema": 1, "revision": 2026090406, "clients": { $splitCapabilities } }""",
+                base
+            )
+        )
+    }
+
+    @Test
+    fun policyKeepingOneCompletePlaybackPathIsAccepted() {
+        val base = PlaybackCompatibilityPolicy.bundled()
+
+        val parsed = PlaybackCompatibilityPolicyParser.parse(
+            """
+            {
+              "schema": 1,
+              "revision": 2026090407,
+              "clients": {
+                "VISIONOS": { "capabilities": { "streaming": false } },
+                "WEB": { "capabilities": { "player": false } },
+                "IOS": { "capabilities": { "player": true, "streaming": true } }
+              }
+            }
+            """.trimIndent(),
+            base
+        )
+
+        assertNotNull(parsed)
+        assertTrue(parsed!!.isClientCapabilityEnabled("IOS", PlaybackClientCapability.PLAYER))
+        assertTrue(parsed.isClientCapabilityEnabled("IOS", PlaybackClientCapability.STREAMING))
+        assertFalse(parsed.isClientCapabilityEnabled("VISIONOS", PlaybackClientCapability.STREAMING))
+        assertFalse(parsed.isClientCapabilityEnabled("WEB", PlaybackClientCapability.PLAYER))
+    }
+
+    @Test
+    fun rejectedPolicyLeavesTheCallerOnItsPreviousKnownGoodPolicy() {
+        val base = PlaybackCompatibilityPolicy.bundled()
+
+        val rejected = PlaybackCompatibilityPolicyParser.parse(
+            """
+            {
+              "schema": 1,
+              "revision": 2026090408,
+              "clients": {
+                "VISIONOS": { "capabilities": { "streaming": false } },
+                "ANDROID_VR": { "capabilities": { "streaming": false } },
+                "ANDROID_MUSIC": { "capabilities": { "streaming": false } },
+                "ANDROID": { "capabilities": { "streaming": false } },
+                "IOS": { "capabilities": { "streaming": false } },
+                "WEB_REMIX": { "capabilities": { "streaming": false } },
+                "WEB": { "capabilities": { "streaming": false } },
+                "WEB_EMBEDDED_PLAYER": { "capabilities": { "streaming": false } }
+              }
+            }
+            """.trimIndent(),
+            base
+        )
+
+        assertNull(rejected)
+        assertTrue(base.isClientCapabilityEnabled("IOS", PlaybackClientCapability.STREAMING))
+    }
+
+    @Test
+    fun androidReelPathsSeeTheStreamingCapabilityOfTheAndroidClient() {
+        val base = PlaybackCompatibilityPolicy.bundled()
+
+        val parsed = PlaybackCompatibilityPolicyParser.parse(
+            """
+            {
+              "schema": 1,
+              "revision": 2026090409,
+              "clients": {
+                "ANDROID": { "capabilities": { "streaming": false } }
+              }
+            }
+            """.trimIndent(),
+            base
+        )
+
+        assertNotNull(parsed)
+        assertFalse(parsed!!.isClientCapabilityEnabled("ANDROID", PlaybackClientCapability.STREAMING))
+        assertTrue(parsed.isClientCapabilityEnabled("ANDROID", PlaybackClientCapability.PLAYER))
+        assertTrue(base.isClientCapabilityEnabled("ANDROID", PlaybackClientCapability.STREAMING))
+    }
 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicResilienceClientTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeMusicResilienceClientTest.kt
@@ -397,4 +397,59 @@ class YoutubeMusicResilienceClientTest {
 
     private fun validSuggestions(): String =
         """{"contents":[{"searchSuggestionsSectionRenderer":{"contents":[{"searchSuggestionRenderer":{"navigationEndpoint":{"searchEndpoint":{"query":"daft punk"}}}}]}}]}"""
+
+    @Test
+    fun browseStopsWhenThePolicyDisablesBrowseOnEveryClient() {
+        val disabled = PlaybackCompatibilityPolicy.bundled().copy(
+            clientOverrides = listOf(
+                "WEB_REMIX",
+                "ANDROID_MUSIC",
+                "ANDROID",
+                "IOS",
+                "WEB"
+            ).associateWith {
+                PlaybackClientOverride(
+                    capabilities = mapOf(PlaybackClientCapability.BROWSE to false)
+                )
+            }
+        )
+        PlaybackClientCapabilities.publish(disabled)
+        try {
+            val calls = AtomicInteger(0)
+            val client = client { _ ->
+                calls.incrementAndGet()
+                YoutubeMusicTransportResponse(200, validSearch(), 10L)
+            }
+
+            assertNull(client.search("test song", "it"))
+            assertEquals(0, calls.get())
+        } finally {
+            PlaybackClientCapabilities.publish(PlaybackCompatibilityPolicy.bundled())
+        }
+    }
+
+    @Test
+    fun browseKeepsTheClientsThePolicyStillPermits() {
+        val partial = PlaybackCompatibilityPolicy.bundled().copy(
+            clientOverrides = mapOf(
+                "WEB_REMIX" to PlaybackClientOverride(
+                    capabilities = mapOf(PlaybackClientCapability.BROWSE to false)
+                )
+            )
+        )
+        PlaybackClientCapabilities.publish(partial)
+        try {
+            val calls = mutableListOf<String>()
+            val client = client { request ->
+                calls += request.profile.id
+                YoutubeMusicTransportResponse(200, validSearch(), 10L)
+            }
+
+            assertNotNull(client.search("test song", "it"))
+            assertTrue(calls.isNotEmpty())
+            assertTrue(calls.none { it == "web-remix" })
+        } finally {
+            PlaybackClientCapabilities.publish(PlaybackCompatibilityPolicy.bundled())
+        }
+    }
 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/network/YoutubeStreamClientIdentityRegistryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/network/YoutubeStreamClientIdentityRegistryTest.kt
@@ -1,0 +1,142 @@
+package com.luc4n3x.levyra.data.network
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class YoutubeStreamClientIdentityRegistryTest {
+    private val visionOs = YoutubeStreamClientIdentity(
+        clientName = "VISIONOS",
+        clientHeaderName = "101",
+        clientVersion = "1.04",
+        userAgent = "com.google.visionos.youtube/1.04(RealityDevice17,1; U; CPU visionOS 26_6_0 like Mac OS X; US)",
+        requiresPoToken = false,
+        videoId = "dQw4w9WgXcQ"
+    )
+
+    private val web = YoutubeStreamClientIdentity(
+        clientName = "WEB",
+        clientHeaderName = "1",
+        clientVersion = "2.20260805.01.00",
+        userAgent = YoutubeClientIdentityInterceptor.PO_TOKEN_WEB_USER_AGENT,
+        requiresPoToken = true,
+        videoId = "dQw4w9WgXcQ"
+    )
+
+    @Before
+    fun setUp() = YoutubeStreamClientIdentityRegistry.clear()
+
+    @After
+    fun tearDown() = YoutubeStreamClientIdentityRegistry.clear()
+
+    @Test
+    fun resolvedClientIdentitySurvivesRequestNumberAndMediaNetworkFailover() {
+        val resolved = "https://rr3---sn-abc.googlevideo.com/videoplayback?id=o-media&itag=140&mime=audio%2Fmp4"
+        YoutubeStreamClientIdentityRegistry.register(listOf(resolved), visionOs)
+
+        val withRequestNumber = "$resolved&rn=7"
+        val onAlternateNetwork =
+            "https://rr9---sn-zyx.googlevideo.com/videoplayback?id=o-media&itag=140&mime=audio%2Fmp4&rn=7"
+
+        assertEquals(visionOs, YoutubeStreamClientIdentityRegistry.find(resolved))
+        assertEquals(visionOs, YoutubeStreamClientIdentityRegistry.find(withRequestNumber))
+        assertEquals(visionOs, YoutubeStreamClientIdentityRegistry.find(onAlternateNetwork))
+    }
+
+    @Test
+    fun distinctFormatsOfTheSameVideoKeepTheirOwnIdentity() {
+        val audio = "https://rr3---sn-abc.googlevideo.com/videoplayback?id=o-media&itag=140"
+        val video = "https://rr3---sn-abc.googlevideo.com/videoplayback?id=o-media&itag=137"
+        YoutubeStreamClientIdentityRegistry.register(listOf(audio), visionOs)
+        YoutubeStreamClientIdentityRegistry.register(listOf(video), web)
+
+        assertEquals(visionOs, YoutubeStreamClientIdentityRegistry.find(audio))
+        assertEquals(web, YoutubeStreamClientIdentityRegistry.find(video))
+    }
+
+    @Test
+    fun unknownUrlReturnsNoIdentitySoTheExistingFallbackStillApplies() {
+        assertNull(
+            YoutubeStreamClientIdentityRegistry.find(
+                "https://rr3---sn-abc.googlevideo.com/videoplayback?id=other&itag=251"
+            )
+        )
+        assertNull(YoutubeStreamClientIdentityRegistry.find(""))
+    }
+
+    @Test
+    fun urlWithoutMediaParametersIsStillMatchedExactly() {
+        val manifest = "https://manifest.googlevideo.com/api/manifest/dash/expire/1"
+        YoutubeStreamClientIdentityRegistry.register(listOf(manifest), visionOs)
+
+        assertEquals(visionOs, YoutubeStreamClientIdentityRegistry.find(manifest))
+        assertNull(YoutubeStreamClientIdentityRegistry.find("$manifest/other"))
+    }
+
+    @Test
+    fun nativeClientMediaHeadersCarryItsOwnUserAgentAndNoBrowserNavigation() {
+        val headers = visionOs.mediaRequestHeaders()
+
+        assertEquals(visionOs.userAgent, headers["User-Agent"])
+        assertNull(headers["Origin"])
+        assertNull(headers["Referer"])
+    }
+
+    @Test
+    fun webClientMediaHeadersCarryOriginAndReferer() {
+        val headers = web.mediaRequestHeaders()
+
+        assertEquals(YoutubeClientIdentityInterceptor.PO_TOKEN_WEB_USER_AGENT, headers["User-Agent"])
+        assertEquals("https://www.youtube.com", headers["Origin"])
+        assertEquals("https://www.youtube.com/", headers["Referer"])
+        assertEquals("cross-site", headers["Sec-Fetch-Site"])
+    }
+
+    @Test
+    fun musicWebClientMediaHeadersUseTheMusicOrigin() {
+        val remix = web.copy(clientName = "WEB_REMIX", clientHeaderName = "67")
+
+        val headers = remix.mediaRequestHeaders()
+
+        assertEquals("https://music.youtube.com", headers["Origin"])
+        assertEquals("https://music.youtube.com/", headers["Referer"])
+    }
+
+    @Test
+    fun embeddedWebClientRefererCarriesTheResolvedVideoId() {
+        val embedded = web.copy(clientName = "WEB_EMBEDDED_PLAYER", clientHeaderName = "56")
+
+        assertEquals(
+            "https://www.youtube.com/embed/dQw4w9WgXcQ",
+            embedded.mediaRequestHeaders()["Referer"]
+        )
+        assertEquals(
+            "https://www.youtube.com/embed/",
+            embedded.copy(videoId = "").mediaRequestHeaders()["Referer"]
+        )
+    }
+
+    @Test
+    fun registryEvictsOldestEntriesInsteadOfGrowingWithPlayback() {
+        repeat(400) { index ->
+            YoutubeStreamClientIdentityRegistry.register(
+                listOf("https://rr1---sn-abc.googlevideo.com/videoplayback?id=media$index&itag=140"),
+                visionOs
+            )
+        }
+
+        assertNull(
+            YoutubeStreamClientIdentityRegistry.find(
+                "https://rr1---sn-abc.googlevideo.com/videoplayback?id=media0&itag=140"
+            )
+        )
+        assertEquals(
+            visionOs,
+            YoutubeStreamClientIdentityRegistry.find(
+                "https://rr1---sn-abc.googlevideo.com/videoplayback?id=media399&itag=140"
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/network/YoutubeStreamClientIdentityRegistryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/network/YoutubeStreamClientIdentityRegistryTest.kt
@@ -139,4 +139,28 @@ class YoutubeStreamClientIdentityRegistryTest {
             )
         )
     }
+
+    @Test
+    fun exactUrlIdentityWinsOverTheMediaFallbackOfAnotherStream() {
+        val visionOsUrl =
+            "https://rr3---sn-abc.googlevideo.com/videoplayback?id=o-media&itag=140&pot=vision"
+        val webUrl =
+            "https://rr7---sn-xyz.googlevideo.com/videoplayback?id=o-media&itag=140&pot=web"
+        YoutubeStreamClientIdentityRegistry.register(listOf(visionOsUrl), visionOs)
+        YoutubeStreamClientIdentityRegistry.register(listOf(webUrl), web)
+
+        assertEquals(visionOs, YoutubeStreamClientIdentityRegistry.find(visionOsUrl))
+        assertEquals(web, YoutubeStreamClientIdentityRegistry.find(webUrl))
+    }
+
+    @Test
+    fun mediaFallbackStillAppliesToAnUrlThatWasNeverRegistered() {
+        val registered = "https://rr3---sn-abc.googlevideo.com/videoplayback?id=o-media&itag=251"
+        YoutubeStreamClientIdentityRegistry.register(listOf(registered), visionOs)
+
+        assertEquals(
+            visionOs,
+            YoutubeStreamClientIdentityRegistry.find("$registered&rn=4")
+        )
+    }
 }

--- a/docs/ai/YOUTUBE_PLAYBACK_RECOVERY_RUNBOOK.md
+++ b/docs/ai/YOUTUBE_PLAYBACK_RECOVERY_RUNBOOK.md
@@ -76,6 +76,12 @@ Relevant fields:
 - `videoStrategy`: ordered native-video strategies.
 - `androidReelClientVersion`: allowlisted client version string used by Android Reel requests.
 - `clients`: allowlisted per-client enable/priority/tier/PoToken/version overrides.
+- `clients.<CLIENT>.capabilities`: optional per-capability overrides (`player`, `streaming`,
+  `browse`, `metadata`). A capability that is not listed falls back to that client's `enabled`
+  flag, so a policy without this block behaves exactly as before. Use it to keep a client usable
+  for part of the pipeline while disabling another part, for example `ANDROID_VR` with
+  `player: false` but `browse: true`. Unknown capability names are ignored; a non-boolean
+  capability value rejects the whole payload. At least one client must keep `player` enabled.
 - `expiresAt`: optional absolute epoch milliseconds; `0` means no expiry.
 - `minSupportedAppVersion`: optional minimum Android version code; `0` means no lower bound.
 - `maxSupportedAppVersion`: optional maximum Android version code; `0` means no upper bound.
@@ -87,7 +93,7 @@ Never place credentials, cookies, arbitrary endpoints, arbitrary headers, JavaSc
 1. Start from the current `main` policy.
 2. Change only the strategy/client setting proven to be broken.
 3. Increment `revision`.
-4. Keep at least one viable playback path enabled.
+4. Keep at least one viable playback path enabled, including at least one client with the `player` and `streaming` capabilities.
 5. Commit the policy change to `main` only after JSON/schema review.
 6. Re-test song, native video, and a download on a real device.
 7. If the change makes things worse, publish a new higher revision restoring the previous known-good values. Do not lower the revision.

--- a/scripts/tests/test_youtube_canary.py
+++ b/scripts/tests/test_youtube_canary.py
@@ -471,5 +471,348 @@ class YoutubeCanaryTest(unittest.TestCase):
         }
 
 
+class CapabilityProbePatch:
+    def __init__(self, clients, html=""):
+        self.clients = clients
+        self.html = html
+
+    def __enter__(self):
+        self.inputs = canary._capability_matrix_inputs
+        self.matrix = canary._probe_client_matrix
+        self.client = canary._probe_client
+        html = self.html
+        clients = self.clients
+        canary._capability_matrix_inputs = lambda video_id, *, hl, gl: {
+            "innertube_query_value": "key",
+            "web_client_version": "1.0",
+            "visitor_data": "visitor",
+            "_watch_html": html,
+        }
+        canary._probe_client_matrix = lambda **kwargs: clients
+        canary._probe_client = lambda entry, **kwargs: {
+            "client": entry["name"],
+            "delivery": canary.DELIVERY_SECURITY_FAILURE,
+        }
+        return self
+
+    def __exit__(self, *args):
+        canary._capability_matrix_inputs = self.inputs
+        canary._probe_client_matrix = self.matrix
+        canary._probe_client = self.client
+        return False
+
+
+class YoutubeCanaryCapabilityCheckTest(unittest.TestCase):
+    def _client(self, name, delivery, sabr=False):
+        entry = {"client": name, "delivery": delivery, "latency_ms": 10}
+        if delivery != canary.DELIVERY_TRANSPORT_FAILURE:
+            entry["player"] = {"has_server_abr_streaming_url": sabr}
+        return entry
+
+    def _observation(self, checks):
+        return {
+            "schema": canary.SCHEMA_VERSION,
+            "sentinels": [],
+            "capability_checks": checks,
+            "upstreams": [],
+        }
+
+    def test_default_checks_cover_made_for_kids_and_potoken(self):
+        names = {str(item["name"]) for item in canary.DEFAULT_CAPABILITY_CHECKS}
+        self.assertEqual({canary.CAPABILITY_MADE_FOR_KIDS, canary.CAPABILITY_POTOKEN}, names)
+        for item in canary.DEFAULT_CAPABILITY_CHECKS:
+            self.assertTrue(canary.VIDEO_ID_RE.fullmatch(str(item["video_id"])))
+
+    def test_shipped_config_declares_both_capability_checks(self):
+        config_path = (
+            Path(__file__).resolve().parents[2]
+            / "third_party"
+            / "LevyraExtractor"
+            / "canary"
+            / "config.json"
+        )
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        checks = canary._configured_capability_checks(config)
+        self.assertEqual(
+            {canary.CAPABILITY_MADE_FOR_KIDS, canary.CAPABILITY_POTOKEN},
+            {str(item["name"]) for item in checks},
+        )
+
+    def test_client_matrix_po_token_flags_match_the_shipped_playback_profiles(self):
+        flags = {
+            str(entry["name"]): bool(entry.get("requires_po_token", False))
+            for entry in canary.LEVYRA_CLIENT_MATRIX
+        }
+        self.assertEqual(
+            {
+                "VISIONOS": False,
+                "ANDROID_MUSIC": False,
+                "ANDROID": False,
+                "IOS": False,
+                "WEB_REMIX": True,
+                "WEB": True,
+                "WEB_EMBEDDED_PLAYER": False,
+            },
+            flags,
+        )
+
+    def test_made_for_kids_failure_is_material_even_when_sentinels_stay_healthy(self):
+        baseline = {
+            "schema": canary.SCHEMA_VERSION,
+            "observation": self._observation(
+                [{"name": canary.CAPABILITY_MADE_FOR_KIDS, "status": canary.CAPABILITY_STATUS_PASS}]
+            ),
+        }
+        observation = self._observation(
+            [
+                {
+                    "name": canary.CAPABILITY_MADE_FOR_KIDS,
+                    "status": canary.CAPABILITY_STATUS_FAIL,
+                    "detail": "no probed client delivers the made-for-kids fixture",
+                }
+            ]
+        )
+
+        decision = canary._classify(baseline, observation, {})
+
+        self.assertEqual("repair", decision["decision"])
+        self.assertTrue(
+            any(
+                "MADE_FOR_KIDS capability check FAIL" in item
+                for item in decision["material_changes"]
+            ),
+            decision["material_changes"],
+        )
+
+    def test_potoken_failure_is_material_even_when_sentinels_stay_healthy(self):
+        baseline = {
+            "schema": canary.SCHEMA_VERSION,
+            "observation": self._observation(
+                [{"name": canary.CAPABILITY_POTOKEN, "status": canary.CAPABILITY_STATUS_PASS}]
+            ),
+        }
+        observation = self._observation(
+            [
+                {
+                    "name": canary.CAPABILITY_POTOKEN,
+                    "status": canary.CAPABILITY_STATUS_FAIL,
+                    "detail": "no PoToken-free client delivers",
+                }
+            ]
+        )
+
+        decision = canary._classify(baseline, observation, {})
+
+        self.assertEqual("repair", decision["decision"])
+        self.assertTrue(
+            any("POTOKEN capability check FAIL" in item for item in decision["material_changes"]),
+            decision["material_changes"],
+        )
+
+    def test_blocked_capability_check_never_triggers_a_repair(self):
+        baseline = {
+            "schema": canary.SCHEMA_VERSION,
+            "observation": self._observation(
+                [{"name": canary.CAPABILITY_POTOKEN, "status": canary.CAPABILITY_STATUS_PASS}]
+            ),
+        }
+        observation = self._observation(
+            [
+                {
+                    "name": canary.CAPABILITY_POTOKEN,
+                    "status": canary.CAPABILITY_STATUS_BLOCKED,
+                    "detail": "every client probe failed on our side",
+                }
+            ]
+        )
+
+        decision = canary._classify(baseline, observation, {})
+
+        self.assertEqual("none", decision["decision"])
+        self.assertTrue(
+            any(
+                "POTOKEN capability check BLOCKED" in item
+                for item in decision["informational_changes"]
+            ),
+            decision["informational_changes"],
+        )
+
+    def test_recovered_capability_check_does_not_open_a_repair(self):
+        baseline = {
+            "schema": canary.SCHEMA_VERSION,
+            "observation": self._observation(
+                [{"name": canary.CAPABILITY_MADE_FOR_KIDS, "status": canary.CAPABILITY_STATUS_FAIL}]
+            ),
+        }
+        observation = self._observation(
+            [{"name": canary.CAPABILITY_MADE_FOR_KIDS, "status": canary.CAPABILITY_STATUS_PASS}]
+        )
+
+        decision = canary._classify(baseline, observation, {})
+
+        self.assertEqual("none", decision["decision"])
+
+    def test_report_renders_distinguishable_capability_lines(self):
+        observation = self._observation(
+            [
+                {
+                    "name": canary.CAPABILITY_MADE_FOR_KIDS,
+                    "status": canary.CAPABILITY_STATUS_PASS,
+                    "detail": "3/7 clients deliver the made-for-kids fixture",
+                },
+                {
+                    "name": canary.CAPABILITY_POTOKEN,
+                    "status": canary.CAPABILITY_STATUS_FAIL,
+                    "detail": "no PoToken-free client delivers",
+                },
+            ]
+        )
+
+        report = canary._render_report(
+            observation,
+            {
+                "decision": "repair",
+                "severity": "major",
+                "material_changes": [],
+                "informational_changes": [],
+            },
+        )
+
+        self.assertIn("MADE_FOR_KIDS PASS", report)
+        self.assertIn("POTOKEN FAIL", report)
+
+    def test_made_for_kids_passes_when_any_client_delivers(self):
+        clients = [
+            self._client("VISIONOS", canary.DELIVERY_DIRECT_HEALTHY),
+            self._client("WEB", canary.DELIVERY_SECURITY_FAILURE),
+        ]
+        with CapabilityProbePatch(clients, html='"isMadeForKids":true'):
+            result = canary._probe_capability_check(
+                {
+                    "name": canary.CAPABILITY_MADE_FOR_KIDS,
+                    "kind": canary.CAPABILITY_KIND_MADE_FOR_KIDS,
+                    "video_id": "XqZsoesa55w",
+                },
+                hl="en",
+                gl="US",
+            )
+
+        self.assertEqual(canary.CAPABILITY_STATUS_PASS, result["status"])
+        self.assertEqual(["VISIONOS"], result["playable_clients"])
+        self.assertEqual({"isMadeForKids": True}, result["fixture_markers"])
+
+    def test_made_for_kids_fails_when_no_client_delivers(self):
+        clients = [
+            self._client("VISIONOS", canary.DELIVERY_DIRECT_UNAVAILABLE),
+            self._client("WEB", canary.DELIVERY_SECURITY_FAILURE),
+        ]
+        with CapabilityProbePatch(clients):
+            result = canary._probe_capability_check(
+                {
+                    "name": canary.CAPABILITY_MADE_FOR_KIDS,
+                    "kind": canary.CAPABILITY_KIND_MADE_FOR_KIDS,
+                    "video_id": "XqZsoesa55w",
+                },
+                hl="en",
+                gl="US",
+            )
+
+        self.assertEqual(canary.CAPABILITY_STATUS_FAIL, result["status"])
+
+    def test_potoken_passes_while_only_potoken_bound_clients_are_blocked(self):
+        clients = [
+            self._client("VISIONOS", canary.DELIVERY_DIRECT_HEALTHY),
+            self._client("WEB", canary.DELIVERY_SECURITY_FAILURE),
+            self._client("WEB_REMIX", canary.DELIVERY_SECURITY_FAILURE),
+        ]
+        with CapabilityProbePatch(clients):
+            result = canary._probe_capability_check(
+                {
+                    "name": canary.CAPABILITY_POTOKEN,
+                    "kind": canary.CAPABILITY_KIND_POTOKEN,
+                    "video_id": "BaW_jenozKc",
+                },
+                hl="en",
+                gl="US",
+            )
+
+        self.assertEqual(canary.CAPABILITY_STATUS_PASS, result["status"])
+        self.assertTrue(result["po_token_enforced"])
+        self.assertEqual(["VISIONOS"], result["po_token_free_playable"])
+
+    def test_potoken_fails_when_the_potoken_free_path_disappears(self):
+        clients = [
+            self._client("VISIONOS", canary.DELIVERY_SECURITY_FAILURE),
+            self._client("IOS", canary.DELIVERY_SECURITY_FAILURE),
+            self._client("WEB", canary.DELIVERY_DIRECT_HEALTHY),
+        ]
+        with CapabilityProbePatch(clients):
+            result = canary._probe_capability_check(
+                {
+                    "name": canary.CAPABILITY_POTOKEN,
+                    "kind": canary.CAPABILITY_KIND_POTOKEN,
+                    "video_id": "BaW_jenozKc",
+                },
+                hl="en",
+                gl="US",
+            )
+
+        self.assertEqual(canary.CAPABILITY_STATUS_FAIL, result["status"])
+        self.assertEqual([], result["po_token_free_playable"])
+
+    def test_capability_check_is_blocked_when_the_watch_page_is_unreachable(self):
+        def fail_inputs(video_id, *, hl, gl):
+            raise canary.CanaryError("watch page HTTP 429", status=429)
+
+        original = canary._capability_matrix_inputs
+        canary._capability_matrix_inputs = fail_inputs
+        try:
+            result = canary._probe_capability_check(
+                {
+                    "name": canary.CAPABILITY_POTOKEN,
+                    "kind": canary.CAPABILITY_KIND_POTOKEN,
+                    "video_id": "BaW_jenozKc",
+                },
+                hl="en",
+                gl="US",
+            )
+        finally:
+            canary._capability_matrix_inputs = original
+
+        self.assertEqual(canary.CAPABILITY_STATUS_BLOCKED, result["status"])
+        self.assertIn("429", result["detail"])
+
+    def test_capability_check_is_blocked_when_every_probe_failed_on_our_side(self):
+        clients = [
+            self._client("VISIONOS", canary.DELIVERY_TRANSPORT_FAILURE),
+            self._client("WEB", canary.DELIVERY_TRANSPORT_FAILURE),
+        ]
+        with CapabilityProbePatch(clients):
+            result = canary._probe_capability_check(
+                {
+                    "name": canary.CAPABILITY_MADE_FOR_KIDS,
+                    "kind": canary.CAPABILITY_KIND_MADE_FOR_KIDS,
+                    "video_id": "XqZsoesa55w",
+                },
+                hl="en",
+                gl="US",
+            )
+
+        self.assertEqual(canary.CAPABILITY_STATUS_BLOCKED, result["status"])
+
+    def test_invalid_configured_video_id_is_blocked_not_failed(self):
+        result = canary._probe_capability_check(
+            {
+                "name": canary.CAPABILITY_POTOKEN,
+                "kind": canary.CAPABILITY_KIND_POTOKEN,
+                "video_id": "nope",
+            },
+            hl="en",
+            gl="US",
+        )
+
+        self.assertEqual(canary.CAPABILITY_STATUS_BLOCKED, result["status"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/youtube_canary.py
+++ b/scripts/youtube_canary.py
@@ -47,6 +47,7 @@ LEVYRA_CLIENT_MATRIX: tuple[dict[str, Any], ...] = (
             "osVersion": "1.0.3.21O566",
         },
         "user_agent": "com.google.ios.youtube/1.04 (RealityDevice14,1; U; CPU visionOS 1_0_3 like Mac OS X)",
+        "requires_po_token": False,
     },
     {
         "name": "ANDROID_MUSIC",
@@ -58,6 +59,7 @@ LEVYRA_CLIENT_MATRIX: tuple[dict[str, Any], ...] = (
             "osVersion": "15",
         },
         "user_agent": "com.google.android.apps.youtube.music/8.10.52 (Linux; U; Android 15) gzip",
+        "requires_po_token": False,
     },
     {
         "name": "ANDROID",
@@ -69,6 +71,7 @@ LEVYRA_CLIENT_MATRIX: tuple[dict[str, Any], ...] = (
             "osVersion": "15",
         },
         "user_agent": "com.google.android.youtube/19.44.38 (Linux; U; Android 15) gzip",
+        "requires_po_token": False,
     },
     {
         "name": "IOS",
@@ -81,12 +84,18 @@ LEVYRA_CLIENT_MATRIX: tuple[dict[str, Any], ...] = (
             "osVersion": "18.3.0.22D63",
         },
         "user_agent": "com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3 like Mac OS X)",
+        "requires_po_token": False,
     },
-    {"name": "WEB_REMIX", "client": {"clientName": "WEB_REMIX", "clientVersion": "1.20260804.16.00"}},
-    {"name": "WEB", "client": {"clientName": "WEB", "clientVersion": ""}},
+    {
+        "name": "WEB_REMIX",
+        "client": {"clientName": "WEB_REMIX", "clientVersion": "1.20260804.16.00"},
+        "requires_po_token": True,
+    },
+    {"name": "WEB", "client": {"clientName": "WEB", "clientVersion": ""}, "requires_po_token": True},
     {
         "name": "WEB_EMBEDDED_PLAYER",
         "client": {"clientName": "WEB_EMBEDDED_PLAYER", "clientVersion": "1.20260423.01.00"},
+        "requires_po_token": False,
     },
 )
 
@@ -97,7 +106,32 @@ DELIVERY_SABR_ONLY = "sabr_only"
 DELIVERY_SECURITY_FAILURE = "security_failure"
 DELIVERY_CLIENT_FAILURE = "client_failure"
 DELIVERY_TRANSPORT_FAILURE = "transport_failure"
-KEYWORDS = ("youtube", "player", "cipher", "sabr", "innertube", "stream", "signature", "visionos", "reel")
+CAPABILITY_STATUS_PASS = "PASS"
+CAPABILITY_STATUS_FAIL = "FAIL"
+CAPABILITY_STATUS_BLOCKED = "BLOCKED"
+CAPABILITY_MADE_FOR_KIDS = "MADE_FOR_KIDS"
+CAPABILITY_POTOKEN = "POTOKEN"
+CAPABILITY_KIND_MADE_FOR_KIDS = "made_for_kids"
+CAPABILITY_KIND_POTOKEN = "potoken"
+
+# Fixed public fixtures. MADE_FOR_KIDS uses a long-standing children's video so the kids-specific
+# protocol branch is exercised even when ordinary playback is healthy; POTOKEN uses the same
+# youtube-dl reference video the sentinels use, probed once with and once without visitor data so
+# the PoToken-free fallback path is observed on its own.
+DEFAULT_CAPABILITY_CHECKS: tuple[dict[str, Any], ...] = (
+    {
+        "name": CAPABILITY_MADE_FOR_KIDS,
+        "kind": CAPABILITY_KIND_MADE_FOR_KIDS,
+        "video_id": "XqZsoesa55w",
+    },
+    {
+        "name": CAPABILITY_POTOKEN,
+        "kind": CAPABILITY_KIND_POTOKEN,
+        "video_id": "BaW_jenozKc",
+    },
+)
+
+KEYWORDS = ("youtube", "player", "cipher", "sabr", "innertube", "stream", "signature", "visionos", "reel", "kids", "potoken")
 
 EXACT_HTTPS_HOSTS = {
     "www.youtube.com",
@@ -838,6 +872,166 @@ def _summarize_delivery(clients: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _capability_matrix_inputs(video_id: str, *, hl: str, gl: str) -> dict[str, str]:
+    watch_url = "https://www.youtube.com/watch?" + urllib.parse.urlencode(
+        {"v": video_id, "hl": hl, "gl": gl, "bpctr": "9999999999", "has_verified": "1"}
+    )
+    watch = _bounded_request(
+        watch_url,
+        headers={"Accept": "text/html", "User-Agent": USER_AGENT},
+        max_bytes=WATCH_MAX_BYTES,
+    )
+    if watch.status < 200 or watch.status >= 300:
+        raise CanaryError(f"watch page HTTP {watch.status}", status=watch.status)
+    html = watch.body.decode("utf-8", errors="replace")
+    ytcfg = _extract_ytcfg(html)
+    return {
+        "innertube_query_value": str(ytcfg.get("INNERTUBE_API_KEY") or ""),
+        "web_client_version": str(ytcfg.get("INNERTUBE_CLIENT_VERSION") or ""),
+        "visitor_data": str(ytcfg.get("VISITOR_DATA") or ""),
+        "_watch_html": html,
+    }
+
+
+def _observed_kids_markers(html: str) -> dict[str, Any]:
+    """Record, never assert. A fixture that silently stops being made for kids must be visible in
+    the report instead of turning into a false regression."""
+    markers: dict[str, Any] = {}
+    for key in ("isMadeForKids", "isFamilySafe"):
+        match = re.search(rf'"{key}"\s*:\s*(true|false)', html)
+        if match:
+            markers[key] = match.group(1) == "true"
+    return markers
+
+
+def _playable_clients(clients: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        item
+        for item in clients
+        if item.get("delivery")
+        in (DELIVERY_DIRECT_HEALTHY, DELIVERY_DIRECT_DEGRADED, DELIVERY_SABR_ONLY)
+    ]
+
+
+def _probe_capability_check(
+    check: dict[str, Any], *, hl: str, gl: str
+) -> dict[str, Any]:
+    name = str(check.get("name") or "")
+    kind = str(check.get("kind") or "")
+    video_id = str(check.get("video_id") or "")
+    result: dict[str, Any] = {"name": name, "kind": kind, "video_id": video_id}
+    if not VIDEO_ID_RE.fullmatch(video_id):
+        result.update({"status": CAPABILITY_STATUS_BLOCKED, "detail": "invalid configured video id"})
+        return result
+
+    try:
+        inputs = _capability_matrix_inputs(video_id, hl=hl, gl=gl)
+    except CanaryError as error:
+        result.update({"status": CAPABILITY_STATUS_BLOCKED, "detail": str(error)[:240]})
+        return result
+
+    html = inputs.pop("_watch_html")
+    if not inputs["innertube_query_value"]:
+        result.update(
+            {"status": CAPABILITY_STATUS_BLOCKED, "detail": "watch page did not expose InnerTube inputs"}
+        )
+        return result
+
+    clients = _probe_client_matrix(video_id=video_id, hl=hl, gl=gl, **inputs)
+    delivery = _summarize_delivery(clients)
+    result["delivery_summary"] = delivery
+    if not _delivery_evidence_is_conclusive(delivery):
+        result.update(
+            {"status": CAPABILITY_STATUS_BLOCKED, "detail": "every client probe failed on our side"}
+        )
+        return result
+
+    if kind == CAPABILITY_KIND_MADE_FOR_KIDS:
+        result["fixture_markers"] = _observed_kids_markers(html)
+        playable = _playable_clients(clients)
+        result["playable_clients"] = sorted(str(item.get("client") or "") for item in playable)
+        if playable:
+            result.update(
+                {
+                    "status": CAPABILITY_STATUS_PASS,
+                    "detail": f"{len(playable)}/{len(clients)} clients deliver the made-for-kids fixture",
+                }
+            )
+        else:
+            result.update(
+                {
+                    "status": CAPABILITY_STATUS_FAIL,
+                    "detail": "no probed client delivers the made-for-kids fixture",
+                }
+            )
+        return result
+
+    if kind == CAPABILITY_KIND_POTOKEN:
+        po_token_free = [item for item in clients if not _matrix_requires_po_token(item)]
+        playable_free = _playable_clients(po_token_free)
+        po_token_bound = [item for item in clients if _matrix_requires_po_token(item)]
+        playable_bound = _playable_clients(po_token_bound)
+        anonymous = _probe_client(
+            {"name": "WEB_ANONYMOUS", "client": {"clientName": "WEB", "clientVersion": ""}},
+            video_id=video_id,
+            innertube_query_value=inputs["innertube_query_value"],
+            web_client_version=inputs["web_client_version"],
+            visitor_data="",
+            hl=hl,
+            gl=gl,
+        )
+        result["anonymous_web_delivery"] = str(anonymous.get("delivery") or "")
+        result["po_token_free_playable"] = sorted(
+            str(item.get("client") or "") for item in playable_free
+        )
+        result["po_token_enforced"] = bool(po_token_bound) and not playable_bound
+        if playable_free:
+            result.update(
+                {
+                    "status": CAPABILITY_STATUS_PASS,
+                    "detail": (
+                        f"{len(playable_free)}/{len(po_token_free)} PoToken-free clients still deliver"
+                    ),
+                }
+            )
+        else:
+            result.update(
+                {
+                    "status": CAPABILITY_STATUS_FAIL,
+                    "detail": "no PoToken-free client delivers; PoToken is now mandatory for playback",
+                }
+            )
+        return result
+
+    result.update({"status": CAPABILITY_STATUS_BLOCKED, "detail": f"unknown capability kind {kind!r}"})
+    return result
+
+
+def _matrix_requires_po_token(client_result: dict[str, Any]) -> bool:
+    name = str(client_result.get("client") or "")
+    for entry in LEVYRA_CLIENT_MATRIX:
+        if str(entry.get("name") or "") == name:
+            return bool(entry.get("requires_po_token", False))
+    return False
+
+
+def _configured_capability_checks(config: dict[str, Any]) -> tuple[dict[str, Any], ...]:
+    configured = config.get("capability_checks")
+    if not isinstance(configured, list) or not configured:
+        return DEFAULT_CAPABILITY_CHECKS
+    return tuple(item for item in configured if isinstance(item, dict))
+
+
+def _capability_map(observation: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    checks = observation.get("capability_checks")
+    if isinstance(checks, list):
+        for item in checks:
+            if isinstance(item, dict):
+                result[str(item.get("name") or "")] = item
+    return result
+
+
 def _fetch_upstream(repo: str, branch: str) -> dict[str, Any]:
     if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo):
         return {"repo": repo, "branch": branch, "error": "invalid repository name"}
@@ -908,11 +1102,16 @@ def _current_observation(config: dict[str, Any], private_evidence_dir: Path | No
                 upstreams.append(
                     _fetch_upstream(str(item.get("repo") or ""), str(item.get("branch") or "main"))
                 )
+    capability_checks = [
+        _probe_capability_check(item, hl=hl, gl=gl)
+        for item in _configured_capability_checks(config)
+    ]
     return {
         "schema": SCHEMA_VERSION,
         "observed_at_epoch": int(time.time()),
         "youtube": {"hl": hl, "gl": gl},
         "sentinels": observed,
+        "capability_checks": capability_checks,
         "upstreams": upstreams,
     }
 
@@ -1126,6 +1325,8 @@ def _classify(
         if disappeared:
             info.append(f"{name}: streaming keys disappeared: {', '.join(disappeared)}")
 
+    capability_material = _classify_capability_checks(accepted, observation, info)
+
     thresholds = config.get("thresholds") if isinstance(config.get("thresholds"), dict) else {}
     sentinel_threshold = int(thresholds.get("required_sentinel_regressions_for_repair") or 2)
     if material_sentinels and len(material_sentinels) < sentinel_threshold:
@@ -1141,6 +1342,8 @@ def _classify(
         material = [entry for entry in material if "Range probe regressed" not in entry]
         info.append(f"Range probe regression count {range_regressions} below repair threshold {range_threshold}")
 
+    material.extend(capability_material)
+
     decision = "repair" if material else "none"
     severity = "major" if material else "info"
     return {
@@ -1151,12 +1354,36 @@ def _classify(
     }
 
 
+def _classify_capability_checks(
+    accepted: dict[str, Any],
+    observation: dict[str, Any],
+    info: list[str],
+) -> list[str]:
+    """A capability regression is material even when ordinary sentinels stay healthy: Made for Kids
+    and the PoToken-free path can break while generic YouTube playback keeps working."""
+    before = _capability_map(accepted)
+    after = _capability_map(observation)
+    material: list[str] = []
+    for name, current in sorted(after.items()):
+        status = str(current.get("status") or "")
+        previous_status = str((before.get(name) or {}).get("status") or "")
+        detail = str(current.get("detail") or "")[:160]
+        if status == CAPABILITY_STATUS_FAIL and previous_status != CAPABILITY_STATUS_FAIL:
+            material.append(f"{name} capability check FAIL: {detail}")
+        elif status == CAPABILITY_STATUS_BLOCKED:
+            info.append(f"{name} capability check BLOCKED: {detail}")
+        elif previous_status and previous_status != status:
+            info.append(f"{name} capability check {previous_status} -> {status}")
+    return material
+
+
 def _sanitize_for_baseline(observation: dict[str, Any]) -> dict[str, Any]:
     safe = {
         "schema": SCHEMA_VERSION,
         "observed_at_epoch": observation.get("observed_at_epoch"),
         "youtube": observation.get("youtube"),
         "sentinels": observation.get("sentinels"),
+        "capability_checks": observation.get("capability_checks"),
         "upstreams": observation.get("upstreams"),
     }
     return json.loads(json.dumps(safe))
@@ -1198,6 +1425,21 @@ def _render_report(observation: dict[str, Any], decision: dict[str, Any]) -> str
                 r1="yes" if media.get("continuation_ok") else ("no" if media.get("attempted") else "n/a"),
             )
         )
+    lines += ["", "## Capability checks", ""]
+    capability_checks = observation.get("capability_checks") or []
+    if not capability_checks:
+        lines.append("- None")
+    for check in capability_checks:
+        if not isinstance(check, dict):
+            continue
+        lines.append(
+            "- `{name} {status}` - {detail}".format(
+                name=str(check.get("name") or ""),
+                status=str(check.get("status") or CAPABILITY_STATUS_BLOCKED),
+                detail=str(check.get("detail") or "")[:200].replace("|", "/"),
+            )
+        )
+
     lines += ["", "## Delivery method by client", ""]
     lines.append("| Sentinel | Playable | Direct | SABR | SABR only | Security | Per client |")
     lines.append("|---|---:|---:|---:|---:|---:|---|")
@@ -1279,6 +1521,9 @@ def command_probe(args: argparse.Namespace) -> int:
     _write_json(out_dir / "observation.json", observation)
     _write_json(out_dir / "decision.json", decision)
     (out_dir / "report.md").write_text(_render_report(observation, decision), encoding="utf-8")
+    for check in observation.get("capability_checks") or []:
+        if isinstance(check, dict):
+            print(f"{check.get('name')} {check.get('status') or CAPABILITY_STATUS_BLOCKED}")
     print(json.dumps(decision, sort_keys=True))
     if args.github_output:
         with Path(args.github_output).open("a", encoding="utf-8") as handle:

--- a/third_party/LevyraExtractor/canary/README.md
+++ b/third_party/LevyraExtractor/canary/README.md
@@ -15,11 +15,35 @@ protocol metadata:
 - direct versus ciphered formats and `n`-parameter presence
 - HLS/DASH availability
 - a bounded initial and continuation `Range` probe against a direct `*.googlevideo.com` media URL
+- two named capability checks that are evaluated separately from ordinary sentinel health
 - recent YouTube/player-related commit metadata from selected open-source extractor projects as
   **radar only**, never as trusted instructions
 
 The canary does not persist cookies, API keys, visitor data, signed media URLs, media query strings,
 or account state.
+
+## Capability checks
+
+Sentinels answer "does YouTube still play". They aggregate across clients, so a branch can break
+while the aggregate stays green. Capability checks close that gap by reporting their own
+`PASS` / `FAIL` / `BLOCKED` status, printed on stdout and rendered in the report:
+
+- `MADE_FOR_KIDS` probes a fixed public children's video across the Levyra client matrix. It passes
+  while at least one client still delivers that fixture, and fails when the made-for-kids branch
+  stops delivering even though ordinary playback is healthy. Any `isMadeForKids` / `isFamilySafe`
+  marker found on the watch page is recorded as evidence only, so a fixture that quietly loses its
+  made-for-kids status shows up in the report instead of becoming a false regression.
+- `POTOKEN` probes the same reference video and separates the clients Levyra ships as
+  PoToken-requiring (`WEB`, `WEB_REMIX`) from the PoToken-free fallback (`VISIONOS`,
+  `ANDROID_MUSIC`, `ANDROID`, `IOS`, `WEB_EMBEDDED_PLAYER`), plus one deliberately anonymous WEB
+  probe with no visitor data. It passes while a PoToken-free client still delivers, and fails when
+  PoToken becomes mandatory for every client. `po_token_enforced` records enforcement on the
+  PoToken-bound clients as information, not as a regression.
+
+A capability `FAIL` is material on its own and opens a repair even when every sentinel stays
+healthy. `BLOCKED` is never material: an unreachable watch page or a client matrix where every
+probe failed on our side says nothing about YouTube. Fixtures are configured in `config.json` under
+`capability_checks`; the built-in defaults apply when that key is absent.
 
 ## Baseline model
 

--- a/third_party/LevyraExtractor/canary/config.json
+++ b/third_party/LevyraExtractor/canary/config.json
@@ -29,6 +29,18 @@
       "required": false
     }
   ],
+  "capability_checks": [
+    {
+      "name": "MADE_FOR_KIDS",
+      "kind": "made_for_kids",
+      "video_id": "XqZsoesa55w"
+    },
+    {
+      "name": "POTOKEN",
+      "kind": "potoken",
+      "video_id": "BaW_jenozKc"
+    }
+  ],
   "upstreams": [
     {
       "repo": "TeamNewPipe/NewPipeExtractor",

--- a/third_party/LevyraExtractor/extractor/build.gradle
+++ b/third_party/LevyraExtractor/extractor/build.gradle
@@ -11,12 +11,12 @@ dependencies {
     implementation project(':timeago-parser')
 
     implementation "com.github.TeamNewPipe:nanojson:$nanojsonVersion"
-    implementation 'org.jsoup:jsoup:1.22.2'
+    implementation 'org.jsoup:jsoup:1.23.1'
     implementation "org.java-websocket:Java-WebSocket:1.6.0"
     implementation "com.github.spotbugs:spotbugs-annotations:$spotbugsVersion"
     implementation 'org.nibor.autolink:autolink:0.12.0'
-    implementation "com.google.protobuf:protobuf-java:4.35.1"
-    implementation "com.squareup.okhttp3:okhttp:5.4.0"
+    implementation "com.google.protobuf:protobuf-java:4.36.1"
+    implementation "com.squareup.okhttp3:okhttp:5.5.0"
     implementation "org.brotli:dec:0.1.2"
     implementation 'org.apache.commons:commons-lang3:3.20.0'
     implementation 'commons-codec:commons-codec:1.22.0'


### PR DESCRIPTION
## Summary

Four changes to the YouTube stack, kept independent of each other.

The LevyraExtractor dependencies move to recent versions that stay compatible with Levyra's architecture. OkHttp now matches the version the Android app already resolves, so the composite build stops pulling two different OkHttp 5.x releases.

The playback compatibility policy can now enable or disable a client per capability instead of only as a whole. A client that serves browse and metadata correctly no longer has to be turned off entirely because its player path broke.

The media DataSource used to guess the User-Agent from the stream URL, which meant a stream resolved with VisionOS or Android Reel was then downloaded under a different client's identity. The resolving client's identity is now carried through to the request.

The YouTube canary reports Made for Kids and the PoToken-free path as separate named checks, so either one can fail visibly while ordinary playback stays green.

## What changed

- LevyraExtractor: jsoup 1.22.2 to 1.23.1, protobuf-java 4.35.1 to 4.36.1, OkHttp 5.4.0 to 5.5.0. Levyra keeps `protobuf-java` on purpose and the artifact is not swapped for `protobuf-javalite`.
- `PlaybackClientOverride` gains an optional `capabilities` map over PLAYER, STREAMING, BROWSE and METADATA. Resolution is `capabilities[capability] ?: enabled ?: true`, so a policy without the new block behaves exactly as before.
- Capability gates wired to the existing owners: PLAYER on `effectiveProfiles()` and the extractor's Android VR player client, STREAMING on stream acceptance in `resolveWithInnerTube`, BROWSE on `YoutubeMusicResilienceClient.orderedProfiles`, METADATA on `YoutubeTranscriptLyricsProvider`.
- New `YoutubeStreamClientIdentityRegistry` records the client name, version, User-Agent and PoToken requirement of each resolved stream. `LevyraYoutubeDataSource` consults it before falling back to the existing URL inference.
- Origin and Referer selection moved into `YoutubeClientIdentityInterceptor.mediaNavigationFor` so the interceptor and the DataSource share one definition instead of two.
- Canary: `capability_checks` with `MADE_FOR_KIDS` and `POTOKEN`, reported as PASS, FAIL or BLOCKED on stdout and in the report. The client matrix gained the `requires_po_token` flag mirroring the shipped playback profiles.
- Documentation: the capability block in `docs/ai/YOUTUBE_PLAYBACK_RECOVERY_RUNBOOK.md`, the capability checks in `third_party/LevyraExtractor/canary/README.md`.

Applied after review:

- `keysFor` emits the exact URL key before the `(mediaId, itag)` fallback. Two resolutions of the same track by different clients share `mediaId` and `itag` but produce different signed URLs, so the fallback key was being overwritten and the first stream then served under the wrong identity.
- Both capability gates no longer open themselves when a policy disables every client. `orderedProfiles()` dropped its `ifEmpty` fallback and `streamingCapabilityAllows` no longer returns true once no client has STREAMING.
- The parser now accepts a payload only when at least one client keeps PLAYER and STREAMING together, so a policy that would leave no usable playback path is refused whole and the store stays on the cached last-known-good or bundled policy.
- The Android Reel audio and video paths check the STREAMING capability before issuing a request, so the ANDROID client behaves the same on the InnerTube and Reel paths.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor or maintenance
- [ ] UI or UX change
- [ ] Localization or accessibility
- [x] Build, CI, packaging, or release change
- [x] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android / Shared infrastructure
- **Area:** Player / Streaming / Build and release / Documentation

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [x] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

The Android box is left unchecked because the run was not exactly that command. `python scripts/ai_quality_gate.py --profile full` passed and covered `:app:lintRelease -PlevyraFdroidBuild=true`, `:app:assembleRelease -PlevyraFdroidBuild=true`, `:app:testDebugUnitTest` and `:extractor:test`. `:app:testReleaseUnitTest` was not run.

Desktop is not applicable: no file under `desktop/` is touched.

What actually ran:

| Check | Result |
|---|---|
| `scripts/ai_quality_gate.py --profile fast` | pass |
| `scripts/ai_quality_gate.py --profile full` | pass |
| `:extractor:test` | pass, 75 tests, 0 failures |
| `:app:testDebugUnitTest` | pass, 1681 tests, 0 failures |
| `:app:lintRelease` | pass |
| `:app:assembleRelease` (unsigned F-Droid) | pass |
| `scripts/tests/test_youtube_canary.py` | pass, 38 tests |
| `git diff --check` | clean |

New tests: 12 in `PlaybackCompatibilityPolicyTest`, 11 in the new `YoutubeStreamClientIdentityRegistryTest`, 2 in `YoutubeMusicResilienceClientTest`, 15 in `test_youtube_canary.py`.

The quality gate needs Python 3.11 or newer to parse `.rtk/filters.toml`. On a machine whose default `python` is 3.10 it stops at "Validate AI efficiency" with that message. Running it under 3.11+ passes. This is environmental and unrelated to the diff.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Emulator, Pixel 8 API 37 | App launch, home content | Pass, artwork and sections loaded |
| Emulator, Pixel 8 API 37 | Search "daft punk get lucky" | Pass, live YouTube Music results |
| Emulator, Pixel 8 API 37 | Open track and play (`4D7u5KF7SP8`) | Pass, PLAYING and position advanced to 33s |
| Emulator, Pixel 8 API 37 | Skip to next track (`Rgrt_8mXrK8`) | Pass, played to 0:52 of 4:08 |
| Emulator, Pixel 8 API 37 | Normal YouTube stream, song and video mode toggle | Pass, both modes still present |
| Emulator, Pixel 8 API 37 | Engagement metadata on the player | Pass, likes and comment count loaded |
| Emulator, Pixel 8 API 37 | Crash and ANR check | Pass, `logcat -b crash` empty, no FATAL, no ANR |
| Local host | `youtube_canary.py probe`, live | `MADE_FOR_KIDS PASS`, `POTOKEN BLOCKED` |

The live `POTOKEN BLOCKED` is the host, not the change. Every client probe failed on our side from this machine, the same reason the required sentinels failed here, and the check correctly reports BLOCKED rather than FAIL so a local network restriction cannot fabricate a regression. The emulator reached YouTube normally. CI remains the authoritative environment for the canary.

## Risk and compatibility

- **Risk level:** Medium
- **Compatibility or migration notes:** A policy payload without `capabilities` parses and behaves as it does today, and a persisted policy round trips through `toJson`. The canary `SCHEMA_VERSION` is unchanged, so a baseline without `capability_checks` still compares and keeps its sentinel history. `config/playback_policy.json` is not modified.
- **Known limitations:** The PoToken branch was not exercised live. It depends on when YouTube enforces PoToken on the selected client, which is not reproducible on demand from the emulator. Four deterministic tests cover the branch instead.
- **Rollback plan:** Revert this PR. The four commits are independent, so a single concern can also be reverted on its own.

## Reviewer notes

- `PlaybackResolver.resolveWithInnerTube`: the STREAMING gate runs before `recordAttempt` on purpose. Placed inside the health accounting block it would record a policy decision as a client failure and pollute the client score and quarantine.
- `PlaybackCompatibilityPolicyParser.parseCapabilities`: an unknown capability name is skipped so a newer server payload still parses, a non-boolean value rejects the whole payload. This mirrors how unknown clients and unknown enum strings are already handled.
- `PlaybackClientCapabilities` is a process-wide holder published from the same sync point that already drives `setAndroidVrPlayerClientEnabled`. Threading the policy store through `YoutubeMusicRepository` into the resilience client would have been a much wider change than the request.
- `YoutubeStreamClientIdentityRegistry` keys on the `(id, itag)` pair plus the exact URL. That is what keeps the identity attached after `rn=` is appended and after a `GooglevideoMediaNetwork` failover rewrites the host, both of which happen inside `LevyraYoutubeDataSource` after resolution.
- SABR already propagated its identity through `SabrDeliveryContext` and `SabrStreamSpec`. SABR descriptors are excluded from the registry and that path is untouched.
- Memory: the registry is bounded at 256 entries with LRU eviction and is cleared when the resolver generation advances, so it cannot grow with playback duration. A test covers the eviction.
- The canary's `requires_po_token` flags are pinned to the shipped playback profiles by a test, so the two lists cannot drift apart silently.

## Release note

None

## Related issues

- Closes #
- Related to #

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims

Every check passed on the previous head. The branch was force-pushed to drop trailing commit metadata, so CI is re-running on the current head. No version value was changed on either platform.
