### PR TITLE
chore: improve project-local RTK handling for ADB diagnostics

### DIFF
--- a/.agents/claude/rules/context-efficiency.md
+++ b/.agents/claude/rules/context-efficiency.md
@@ -18,4 +18,11 @@ RTK filters remain in `.rtk/filters.toml`. Use RTK only when filtered output is
 sufficient. Rerun the exact command raw for exact failures, stack traces,
 security/signing evidence, Perfetto/R8 evidence, or ambiguous results.
 
+For Android device diagnostics, prefer bounded textual output before compression:
+use `rtk adb logcat -d -t 400` or `rtk adb -s <serial> logcat -d -t 400` for
+routine logcat inspection, and `rtk summary adb shell dumpsys <service>` for a
+large textual adb command without a dedicated filter. Keep tiny deterministic adb
+queries raw. Never route binary capture/transfer such as `adb exec-out screencap
+-p`, redirected screenshots, or exact device evidence through a text filter.
+
 Token savings never override correctness, validation, or publication controls.

--- a/.agents/skills/levyra-context-efficiency/SKILL.md
+++ b/.agents/skills/levyra-context-efficiency/SKILL.md
@@ -71,10 +71,42 @@ rtk grep <pattern> <path>
 rtk find <pattern> <path>
 rtk log <file>
 rtk summary <command>
+rtk adb logcat -d -t 400
+rtk adb -s <serial> logcat -d -t 400
+rtk summary adb shell dumpsys <service>
 ```
 
 Never treat compact or empty output as proof of success. Verify exit status and
 the authoritative success/failure marker.
+
+## Android and ADB output
+
+Treat ADB by output shape instead of trying to maximize RTK adoption percentage.
+A tiny raw device query costs less context than an unnecessary wrapper, while an
+unbounded logcat or dumpsys can flood a session.
+
+For routine textual diagnostics:
+
+- prefer a bounded source command first, especially `adb logcat -d -t 400`;
+- invoke the project filter explicitly as `rtk adb logcat -d -t 400` or
+  `rtk adb -s <serial> logcat -d -t 400`;
+- use `rtk summary adb shell dumpsys <service>` for large textual ADB output that
+  has no dedicated project filter;
+- narrow dumpsys to the relevant service/package before summarizing whenever
+  possible;
+- rerun the exact raw ADB command when the compact form can hide the deciding
+  failure, lifecycle, package, permission, performance, or device evidence.
+
+Keep raw when compression provides no useful win or could corrupt the payload:
+
+- `adb devices` and one-line `getprop`, `pm path`, readiness, input, or control
+  checks;
+- `adb exec-out screencap -p`, redirected screenshots, binary stdout, file
+  transfers, and other payload-producing commands;
+- exact reproduction output that must be preserved byte-for-byte.
+
+Do not chase `rtk discover` adoption by wrapping tiny ADB commands. The goal is
+less model context without weakening Android diagnostics.
 
 ## Repository discovery ladder
 
@@ -223,6 +255,7 @@ Use:
 rtk gain
 rtk gain --daily
 rtk gain --history
+rtk gain --graph
 rtk discover --all --since 7
 rtk session
 ```

--- a/.rtk/filters.toml
+++ b/.rtk/filters.toml
@@ -55,15 +55,20 @@ on_empty = "CodeRabbit review completed without textual findings"
 
 
 [filters.levyra-adb-logcat]
-description = "Limit Android logcat output while keeping recent diagnostics"
-match_command = "^adb\\s+logcat\\b"
+description = "Keep recent Android logcat diagnostics while dropping banner noise"
+match_command = "^adb(?:\\.exe)?(?:\\s+-s\\s+\\S+)?\\s+logcat\\b"
 strip_ansi = true
 strip_lines_matching = [
   "^--------- beginning of (main|system|crash)$",
 ]
 truncate_lines_at = 400
-max_lines = 240
+tail_lines = 240
 on_empty = "adb logcat produced no matching lines"
+
+[[tests.levyra-adb-logcat]]
+name = "drops standard logcat buffer banners"
+input = "--------- beginning of main\n09-04 19:10:00.000  1234  1234 I Levyra: ready\n"
+expected = "09-04 19:10:00.000  1234  1234 I Levyra: ready"
 
 
 [filters.levyra-agent-tests]

--- a/docs/ai/RTK.md
+++ b/docs/ai/RTK.md
@@ -232,6 +232,9 @@ rtk find <pattern> <path>
 rtk log <file>
 rtk test <command>
 rtk err <command>
+rtk adb logcat -d -t 400
+rtk adb -s <serial> logcat -d -t 400
+rtk summary adb shell dumpsys <service>
 ```
 
 Keep commands raw when exact evidence matters:
@@ -242,6 +245,7 @@ gradlew.bat --stacktrace <task>
 git diff --check
 sha256sum <artifact>
 certutil -hashfile <artifact> SHA256
+adb exec-out screencap -p > screenshot.png
 ```
 
 Security scans and decisive reproductions also remain raw.
@@ -252,6 +256,29 @@ Security scans and decisive reproductions also remain raw.
 CodeRabbit review output, bounded `adb logcat`, and setup-script runs. Gradle,
 Git, GitHub CLI, common tests, lint, Docker, searches, and standard logs continue
 to use RTK's built-in handlers.
+
+The logcat filter is intentionally narrow. Agents invoke it explicitly with
+`rtk adb logcat ...` or `rtk adb -s <serial> logcat ...`; short deterministic ADB
+queries stay raw, while large textual commands without a dedicated filter use
+`rtk summary`. Binary or redirected payloads such as `adb exec-out screencap -p`
+never go through a text filter.
+
+### Trusting project filters
+
+RTK custom filters are gated by an explicit local trust decision. A fresh clone
+or any content change to `.rtk/filters.toml` invalidates the previously trusted
+hash, so RTK skips the project filters until they are reviewed again.
+
+From the Levyra repository root run:
+
+```text
+rtk trust
+```
+
+Use `rtk trust --yes` only after reviewing the current `.rtk/filters.toml` and
+when a non-interactive trust action is deliberately intended. Do not add an
+automatic lifecycle hook that silently trusts future filter changes; the hash
+review is a security boundary, not setup noise.
 
 ## Measuring real savings
 
@@ -265,7 +292,8 @@ rtk session
 ```
 
 Do not add filters merely to inflate a percentage. Preserve enough information
-to diagnose failures correctly.
+to diagnose failures correctly. In particular, do not wrap tiny ADB commands
+only to improve the adoption metric.
 
 ## Failure recovery
 

--- a/scripts/validate_ai_efficiency.py
+++ b/scripts/validate_ai_efficiency.py
@@ -156,6 +156,30 @@ def validate_filters(errors: list[str]) -> None:
                     if matcher.search(command) is None:
                         fail(errors, f"levyra-agent-tests does not match documented command: {command}")
 
+    adb_logcat_filter = filters.get("levyra-adb-logcat")
+    if isinstance(adb_logcat_filter, dict):
+        pattern = adb_logcat_filter.get("match_command")
+        if isinstance(pattern, str):
+            try:
+                matcher = re.compile(pattern)
+            except re.error as exc:
+                fail(errors, f"levyra-adb-logcat match_command is invalid regex: {exc}")
+            else:
+                for command in (
+                    "adb logcat -d -t 400",
+                    "adb.exe logcat -d -t 400",
+                    "adb -s emulator-5554 logcat -d -t 400",
+                    "adb.exe -s R5CY735RFMV logcat -d -t 400",
+                ):
+                    if matcher.search(command) is None:
+                        fail(errors, f"levyra-adb-logcat does not match supported command: {command}")
+                if matcher.search("adb shell getprop sys.boot_completed") is not None:
+                    fail(errors, "levyra-adb-logcat must not capture unrelated adb shell commands")
+        if adb_logcat_filter.get("tail_lines") != 240:
+            fail(errors, "levyra-adb-logcat must keep the newest 240 lines with tail_lines = 240")
+        if "max_lines" in adb_logcat_filter:
+            fail(errors, "levyra-adb-logcat must not use max_lines because that keeps the oldest logcat lines")
+
 
 def main() -> int:
     errors: list[str] = []
@@ -189,6 +213,9 @@ def main() -> int:
             "danger-full-access",
             "scripts/setup-ai.ps1",
             "scripts/setup-ai.sh",
+            "rtk adb logcat -d -t 400",
+            "rtk summary adb shell dumpsys",
+            "adb exec-out screencap -p",
         ):
             if required_term not in skill:
                 fail(errors, f"context-efficiency skill is missing: {required_term}")
@@ -364,7 +391,13 @@ def main() -> int:
         errors,
         f"{CLAUDE_ROOT}/rules/context-efficiency.md",
         "Claude context-efficiency rule",
-        ("levyra-context-efficiency", ".rtk/filters.toml", "Rerun the exact command raw"),
+        (
+            "levyra-context-efficiency",
+            ".rtk/filters.toml",
+            "Rerun the exact command raw",
+            "rtk adb logcat -d -t 400",
+            "adb exec-out screencap",
+        ),
     )
     require_terms(
         errors,


### PR DESCRIPTION
## Summary

Tightens Levyra's project-local RTK setup for Android diagnostics so coding agents use compact output where it helps without hiding exact or binary evidence. The change stays inside the AI tooling layer and does not modify Android or Desktop product code.

## What changed

- Updated the project `adb logcat` filter to support `adb.exe` and device-scoped `adb -s <serial> logcat` calls.
- Switched logcat retention to the most recent 240 lines instead of the first 240 lines and added an inline filter test.
- Added explicit ADB routing to `levyra-context-efficiency`: bounded logcat goes through RTK, large textual `dumpsys` output may use `rtk summary`, and short exact-output commands stay raw.
- Kept `adb exec-out screencap -p`, binary transfers, exact reproductions, security evidence, and ambiguous diagnostics raw.
- Updated Claude's context-efficiency rule with the same ADB boundary.
- Strengthened `validate_ai_efficiency.py` so the expected logcat routing and raw binary boundary cannot disappear silently.
- Documented the project-filter trust step. Because RTK trust is content-hash based, a changed `.rtk/filters.toml` requires `rtk trust` after review.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [x] Refactor or maintenance
- [ ] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [x] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Shared infrastructure
- **Area:** Build and release / Documentation

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [ ] Targeted tests were added or updated
- [x] Not applicable, with the reason explained below

This patch changes only repository AI/RTK configuration, instructions, documentation, and its validator. Android and Desktop product builds were not run from the GitHub connector environment. The RTK filter includes a targeted inline regression case, but the local repository validators and full AI quality gate have not been executed in this environment. CI remains required evidence before merge.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| GitHub branch inspection | Reviewed the final branch diff against `main` | 5 files changed; no Android or Desktop product code changed |
| Local RTK installation, before this patch | `rtk verify` | Reported native Claude hook registered and 156/156 RTK tests passed |
| Local RTK usage, before this patch | `rtk gain` / `rtk discover` | Confirmed active RTK usage and identified repeated raw ADB commands as a remaining opportunity |

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** After pulling a revision that changes `.rtk/filters.toml`, review it and run `rtk trust` once so RTK can apply the project-local filters again.
- **Known limitations:** RTK should not replace raw diagnostics when compact output could hide the deciding evidence. Binary ADB output remains intentionally raw.
- **Rollback plan:** Revert this PR

## Reviewer notes

- Check `.rtk/filters.toml` first: the filter now uses `tail_lines = 240` and matches normal, `.exe`, and `-s <serial>` logcat forms.
- Check `.agents/skills/levyra-context-efficiency/SKILL.md` for the command-routing boundary. The intent is selective compression, not forcing every ADB invocation through RTK.
- `scripts/validate_ai_efficiency.py` now protects that boundary from future accidental regression.

## Release note

None

## Related issues

- Closes N/A
- Related to N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added recommended workflows for Android diagnostics, including bounded logcat collection and summarized `dumpsys` output.
  - Added support for device-specific and Windows Android Debug Bridge commands when collecting logcat data.
  - Added guidance for measuring RTK savings and handling binary captures without text processing.

- **Documentation**
  - Expanded guidance on trusting project filters and reviewing changes before approval.
  - Clarified when to keep small commands and screenshot captures unwrapped.
  - Added validation coverage for documented Android diagnostic commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->