### PR TITLE
Add Levyra Ambient, Rediscover, artist exclusions, playlist tags and hidden playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Play counts, listening time, streaks, playlists, and listening insights are comp
   <h3>🎧 <b>Everything in the signal path. Nothing in the way.</b></h3>
   <p><sub>Playback, discovery, lyrics, offline ownership, recognition, local sync, privacy, and resilient networking — engineered as one native audio system.</sub></p>
   <p>
-    <code>10 CORE SYSTEMS</code> &nbsp;·&nbsp;
+    <code>12 CORE SYSTEMS</code> &nbsp;·&nbsp;
     <code>ANDROID + WINDOWS</code> &nbsp;·&nbsp;
     <code>LOCAL-FIRST</code> &nbsp;·&nbsp;
     <code>ZERO TRACKING</code>
@@ -259,6 +259,31 @@ Play counts, listening time, streaks, playlists, and listening insights are comp
         <li><b>Scrobbling:</b> Last.fm and ListenBrainz integration with bounded deduplication.</li>
         <li><b>Searchable Settings:</b> Instant search across settings, titles, and keywords in 26 languages.</li>
         <li><b>Video Subtitles:</b> Selectable multi-language subtitles during native-video playback.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr valign="top">
+    <td width="50%">
+      <h3>🌙 <b>Levyra Ambient</b></h3>
+      <p><b>A quiet screen for a loud song.</b><br><sub>An OLED-friendly now-playing surface driven by the existing PlaybackService session — never a second player.</sub></p>
+      <ul>
+        <li><b>Same Session:</b> Attaches to the running MediaSession, so entering and leaving Ambient never interrupts audio.</li>
+        <li><b>Artwork or Canvas:</b> Shows Levyra Canvas when available, with static artwork as the immediate fallback.</li>
+        <li><b>Synced Lyric Line:</b> The current line follows playback, alongside title, artist, and a minimal progress cue.</li>
+        <li><b>Burn-in Care:</b> Reduced brightness, auto dimming, periodic pixel shifting, and a minimal layout once idle.</li>
+        <li><b>Proximity Blackout:</b> Optional blackout while the sensor is covered, for pocket and nightstand use.</li>
+        <li><b>Tile & Screensaver:</b> A Quick Settings tile plus a native Android <code>DreamService</code> for docked playback.</li>
+      </ul>
+    </td>
+    <td width="50%">
+      <h3>🗂️ <b>Library Organization</b></h3>
+      <p><b>Shape the library around how you actually listen.</b><br><sub>Tags, visibility, and recommendation control — all local, all reversible, all included in Levyra Vault backups.</sub></p>
+      <ul>
+        <li><b>Playlist Tags:</b> Create, rename, and remove tags such as Rap, Gym, Relax, or Auto, and assign several to one playlist.</li>
+        <li><b>Tag Filtering:</b> Filter the Library by one or more tags without leaving the playlist view.</li>
+        <li><b>Hidden Playlists:</b> Hide a playlist from the Library without deleting it, then restore it from a dedicated filter. No track or metadata is lost.</li>
+        <li><b>Artist Exclusions:</b> Keep an artist out of the personalized Home, Your Orbit, radio, autoplay, and mixes while still being able to search and open them.</li>
+        <li><b>Rediscover:</b> A Home shelf for favorites you have not played in a long time, built only from listening history already on the device.</li>
       </ul>
     </td>
   </tr>

--- a/app/schemas/com.luc4n3x.levyra.data.local.LevyraDatabase/18.json
+++ b/app/schemas/com.luc4n3x.levyra.data.local.LevyraDatabase/18.json
@@ -1807,7 +1807,7 @@
                                       },
                                       {
                                           "tableName":  "followed_artists",
-                                          "createSql":  "CREATE TABLE IF NOT EXISTS ${TABLE_NAME} (\u0007rtistKey TEXT NOT NULL, \browseId TEXT NOT NULL, \name TEXT NOT NULL, \thumbnailUrl TEXT NOT NULL, \followedAt INTEGER NOT NULL, PRIMARY KEY(\u0007rtistKey))",
+                                          "createSql":  "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`artistKey` TEXT NOT NULL, `browseId` TEXT NOT NULL, `name` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `followedAt` INTEGER NOT NULL, PRIMARY KEY(`artistKey`))",
                                           "fields":  [
                                                          {
                                                              "fieldPath":  "artistKey",

--- a/app/schemas/com.luc4n3x.levyra.data.local.LevyraDatabase/19.json
+++ b/app/schemas/com.luc4n3x.levyra.data.local.LevyraDatabase/19.json
@@ -1,0 +1,1979 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 19,
+    "identityHash": "703eb213ae18774d85ade9fcd3eaf7a4",
+    "entities": [
+      {
+        "tableName": "favorite_tracks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `durationMs` INTEGER NOT NULL, `streamUrl` TEXT NOT NULL, `videoUrl` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `largeThumbnailUrl` TEXT NOT NULL, `source` TEXT NOT NULL, `moodTags` TEXT NOT NULL, `energy` INTEGER NOT NULL, `vocal` INTEGER NOT NULL, `replayScore` INTEGER NOT NULL, `cacheScore` INTEGER NOT NULL, `accentStart` INTEGER NOT NULL, `accentEnd` INTEGER NOT NULL, `youtubeLoudnessDb` REAL, `youtubePerceptualLoudnessDb` REAL, `isrc` TEXT NOT NULL, `upc` TEXT NOT NULL, `releaseDate` TEXT NOT NULL, `year` TEXT NOT NULL, `trackNumber` INTEGER NOT NULL, `discNumber` INTEGER NOT NULL, `explicit` INTEGER NOT NULL, `albumBrowseId` TEXT NOT NULL, `artistBrowseIds` TEXT NOT NULL, `counterpartVideoId` TEXT NOT NULL, `videoType` TEXT NOT NULL, `metadataProvider` TEXT NOT NULL, `metadataConfidence` INTEGER NOT NULL, `canonicalAlbumUrl` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "streamUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoUrl",
+            "columnName": "videoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "largeThumbnailUrl",
+            "columnName": "largeThumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "moodTags",
+            "columnName": "moodTags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "energy",
+            "columnName": "energy",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vocal",
+            "columnName": "vocal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "replayScore",
+            "columnName": "replayScore",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheScore",
+            "columnName": "cacheScore",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accentStart",
+            "columnName": "accentStart",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accentEnd",
+            "columnName": "accentEnd",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "youtubeLoudnessDb",
+            "columnName": "youtubeLoudnessDb",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "youtubePerceptualLoudnessDb",
+            "columnName": "youtubePerceptualLoudnessDb",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "isrc",
+            "columnName": "isrc",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "upc",
+            "columnName": "upc",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseDate",
+            "columnName": "releaseDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackNumber",
+            "columnName": "trackNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "discNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumBrowseId",
+            "columnName": "albumBrowseId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistBrowseIds",
+            "columnName": "artistBrowseIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterpartVideoId",
+            "columnName": "counterpartVideoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoType",
+            "columnName": "videoType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataProvider",
+            "columnName": "metadataProvider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataConfidence",
+            "columnName": "metadataConfidence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canonicalAlbumUrl",
+            "columnName": "canonicalAlbumUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "downloaded_tracks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trackId` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `durationMs` INTEGER NOT NULL, `fileName` TEXT NOT NULL, `uri` TEXT NOT NULL, `mimeType` TEXT NOT NULL, `embeddedMetadata` INTEGER NOT NULL, `downloadPreset` TEXT NOT NULL, `downloadQuality` TEXT NOT NULL, `savedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "trackId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddedMetadata",
+            "columnName": "embeddedMetadata",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadPreset",
+            "columnName": "downloadPreset",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadQuality",
+            "columnName": "downloadQuality",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloaded_tracks_trackId",
+            "unique": false,
+            "columnNames": [
+              "trackId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_tracks_trackId` ON `${TABLE_NAME}` (`trackId`)"
+          },
+          {
+            "name": "index_downloaded_tracks_savedAt",
+            "unique": false,
+            "columnNames": [
+              "savedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_tracks_savedAt` ON `${TABLE_NAME}` (`savedAt`)"
+          },
+          {
+            "name": "index_downloaded_tracks_trackId_downloadPreset_downloadQuality",
+            "unique": false,
+            "columnNames": [
+              "trackId",
+              "downloadPreset",
+              "downloadQuality"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_tracks_trackId_downloadPreset_downloadQuality` ON `${TABLE_NAME}` (`trackId`, `downloadPreset`, `downloadQuality`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `hidden` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playlist_tracks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `trackId` TEXT NOT NULL, `position` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `durationMs` INTEGER NOT NULL, `videoUrl` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `largeThumbnailUrl` TEXT NOT NULL, `source` TEXT NOT NULL, `accentStart` INTEGER NOT NULL, `accentEnd` INTEGER NOT NULL, `youtubeLoudnessDb` REAL, `youtubePerceptualLoudnessDb` REAL, `isrc` TEXT NOT NULL, `upc` TEXT NOT NULL, `releaseDate` TEXT NOT NULL, `year` TEXT NOT NULL, `trackNumber` INTEGER NOT NULL, `discNumber` INTEGER NOT NULL, `explicit` INTEGER NOT NULL, `albumBrowseId` TEXT NOT NULL, `artistBrowseIds` TEXT NOT NULL, `counterpartVideoId` TEXT NOT NULL, `videoType` TEXT NOT NULL, `metadataProvider` TEXT NOT NULL, `metadataConfidence` INTEGER NOT NULL, `canonicalAlbumUrl` TEXT NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`playlistId`, `trackId`), FOREIGN KEY(`playlistId`) REFERENCES `playlists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "trackId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoUrl",
+            "columnName": "videoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "largeThumbnailUrl",
+            "columnName": "largeThumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accentStart",
+            "columnName": "accentStart",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accentEnd",
+            "columnName": "accentEnd",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "youtubeLoudnessDb",
+            "columnName": "youtubeLoudnessDb",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "youtubePerceptualLoudnessDb",
+            "columnName": "youtubePerceptualLoudnessDb",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "isrc",
+            "columnName": "isrc",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "upc",
+            "columnName": "upc",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseDate",
+            "columnName": "releaseDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackNumber",
+            "columnName": "trackNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "discNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumBrowseId",
+            "columnName": "albumBrowseId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistBrowseIds",
+            "columnName": "artistBrowseIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterpartVideoId",
+            "columnName": "counterpartVideoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoType",
+            "columnName": "videoType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataProvider",
+            "columnName": "metadataProvider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataConfidence",
+            "columnName": "metadataConfidence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canonicalAlbumUrl",
+            "columnName": "canonicalAlbumUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId",
+            "trackId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_tracks_playlistId",
+            "unique": false,
+            "columnNames": [
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_tracks_playlistId` ON `${TABLE_NAME}` (`playlistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "listen_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trackId` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `durationMs` INTEGER NOT NULL, `videoUrl` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `largeThumbnailUrl` TEXT NOT NULL, `source` TEXT NOT NULL, `listenedMs` INTEGER NOT NULL, `completed` INTEGER NOT NULL, `startedAt` INTEGER NOT NULL, `artistBrowseIds` TEXT NOT NULL DEFAULT '')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "trackId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoUrl",
+            "columnName": "videoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "largeThumbnailUrl",
+            "columnName": "largeThumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listenedMs",
+            "columnName": "listenedMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistBrowseIds",
+            "columnName": "artistBrowseIds",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_listen_events_startedAt",
+            "unique": false,
+            "columnNames": [
+              "startedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listen_events_startedAt` ON `${TABLE_NAME}` (`startedAt`)"
+          },
+          {
+            "name": "index_listen_events_trackId",
+            "unique": false,
+            "columnNames": [
+              "trackId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_listen_events_trackId` ON `${TABLE_NAME}` (`trackId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_queue_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`position` INTEGER NOT NULL, `payload` TEXT NOT NULL, `identity` TEXT NOT NULL, PRIMARY KEY(`position`))",
+        "fields": [
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identity",
+            "columnName": "identity",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "position"
+          ]
+        }
+      },
+      {
+        "tableName": "playback_queue_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`singletonId` INTEGER NOT NULL, `currentIndex` INTEGER NOT NULL, `positionMs` INTEGER NOT NULL, `shuffleEnabled` INTEGER NOT NULL, `shuffleOrder` TEXT NOT NULL, `shuffleCursor` INTEGER NOT NULL, `history` TEXT NOT NULL, `repeatMode` TEXT NOT NULL, `radioEnabled` INTEGER NOT NULL, `generation` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`singletonId`))",
+        "fields": [
+          {
+            "fieldPath": "singletonId",
+            "columnName": "singletonId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentIndex",
+            "columnName": "currentIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "positionMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shuffleEnabled",
+            "columnName": "shuffleEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shuffleOrder",
+            "columnName": "shuffleOrder",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shuffleCursor",
+            "columnName": "shuffleCursor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "history",
+            "columnName": "history",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repeatMode",
+            "columnName": "repeatMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "radioEnabled",
+            "columnName": "radioEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generation",
+            "columnName": "generation",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "singletonId"
+          ]
+        }
+      },
+      {
+        "tableName": "offline_download_tasks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`taskKey` TEXT NOT NULL, `trackId` TEXT NOT NULL, `payload` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `state` TEXT NOT NULL, `progress` INTEGER NOT NULL, `workId` TEXT NOT NULL, `error` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `batchKey` TEXT NOT NULL, `batchTitle` TEXT NOT NULL, `batchKind` TEXT NOT NULL, `batchArtworkUrl` TEXT NOT NULL, `batchPosition` INTEGER NOT NULL, PRIMARY KEY(`taskKey`))",
+        "fields": [
+          {
+            "fieldPath": "taskKey",
+            "columnName": "taskKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "trackId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workId",
+            "columnName": "workId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "batchKey",
+            "columnName": "batchKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "batchTitle",
+            "columnName": "batchTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "batchKind",
+            "columnName": "batchKind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "batchArtworkUrl",
+            "columnName": "batchArtworkUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "batchPosition",
+            "columnName": "batchPosition",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "taskKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_offline_download_tasks_batchKey",
+            "unique": false,
+            "columnNames": [
+              "batchKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_download_tasks_batchKey` ON `${TABLE_NAME}` (`batchKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "lyrics_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `titleKey` TEXT NOT NULL, `artistKey` TEXT NOT NULL, `durationBucket` INTEGER NOT NULL, `videoId` TEXT NOT NULL, `languageCode` TEXT NOT NULL, `translate` INTEGER NOT NULL, `synced` INTEGER NOT NULL, `provider` TEXT NOT NULL, `confidence` INTEGER NOT NULL, `payload` TEXT NOT NULL, `negative` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `expiresAt` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "titleKey",
+            "columnName": "titleKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistKey",
+            "columnName": "artistKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationBucket",
+            "columnName": "durationBucket",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "languageCode",
+            "columnName": "languageCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "translate",
+            "columnName": "translate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "synced",
+            "columnName": "synced",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "negative",
+            "columnName": "negative",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lyrics_cache_expiresAt",
+            "unique": false,
+            "columnNames": [
+              "expiresAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lyrics_cache_expiresAt` ON `${TABLE_NAME}` (`expiresAt`)"
+          },
+          {
+            "name": "index_lyrics_cache_lastAccessedAt",
+            "unique": false,
+            "columnNames": [
+              "lastAccessedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lyrics_cache_lastAccessedAt` ON `${TABLE_NAME}` (`lastAccessedAt`)"
+          },
+          {
+            "name": "index_lyrics_cache_titleKey_artistKey_durationBucket_languageCode_translate",
+            "unique": false,
+            "columnNames": [
+              "titleKey",
+              "artistKey",
+              "durationBucket",
+              "languageCode",
+              "translate"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lyrics_cache_titleKey_artistKey_durationBucket_languageCode_translate` ON `${TABLE_NAME}` (`titleKey`, `artistKey`, `durationBucket`, `languageCode`, `translate`)"
+          }
+        ]
+      },
+      {
+        "tableName": "lyrics_selections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`trackKey` TEXT NOT NULL, `candidateId` TEXT NOT NULL, `provider` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `durationSec` INTEGER NOT NULL, `payload` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`trackKey`))",
+        "fields": [
+          {
+            "fieldPath": "trackKey",
+            "columnName": "trackKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "candidateId",
+            "columnName": "candidateId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationSec",
+            "columnName": "durationSec",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payload",
+            "columnName": "payload",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "trackKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lyrics_selections_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lyrics_selections_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "motion_artwork",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identityKey` TEXT NOT NULL, `provider` TEXT, `url` TEXT, `mimeType` TEXT, `width` INTEGER, `height` INTEGER, `confidence` INTEGER NOT NULL, `expiresAt` INTEGER NOT NULL, `lastVerifiedAt` INTEGER NOT NULL, `configEpoch` INTEGER NOT NULL, `negative` INTEGER NOT NULL, PRIMARY KEY(`identityKey`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identityKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastVerifiedAt",
+            "columnName": "lastVerifiedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configEpoch",
+            "columnName": "configEpoch",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "negative",
+            "columnName": "negative",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identityKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_motion_artwork_expiresAt",
+            "unique": false,
+            "columnNames": [
+              "expiresAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_motion_artwork_expiresAt` ON `${TABLE_NAME}` (`expiresAt`)"
+          },
+          {
+            "name": "index_motion_artwork_lastVerifiedAt",
+            "unique": false,
+            "columnNames": [
+              "lastVerifiedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_motion_artwork_lastVerifiedAt` ON `${TABLE_NAME}` (`lastVerifiedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_source_matches",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`matchKey` TEXT NOT NULL, `canonicalKey` TEXT NOT NULL, `mode` TEXT NOT NULL, `audioQuality` TEXT NOT NULL, `sourceVideoId` TEXT NOT NULL, `sourceVideoUrl` TEXT NOT NULL, `provider` TEXT NOT NULL, `manifestJson` TEXT NOT NULL, `confidence` INTEGER NOT NULL, `successCount` INTEGER NOT NULL, `failureCount` INTEGER NOT NULL, `blockedUntil` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastValidatedAt` INTEGER NOT NULL, PRIMARY KEY(`matchKey`))",
+        "fields": [
+          {
+            "fieldPath": "matchKey",
+            "columnName": "matchKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canonicalKey",
+            "columnName": "canonicalKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mode",
+            "columnName": "mode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioQuality",
+            "columnName": "audioQuality",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceVideoId",
+            "columnName": "sourceVideoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceVideoUrl",
+            "columnName": "sourceVideoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "manifestJson",
+            "columnName": "manifestJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "successCount",
+            "columnName": "successCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failureCount",
+            "columnName": "failureCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "blockedUntil",
+            "columnName": "blockedUntil",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastValidatedAt",
+            "columnName": "lastValidatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "matchKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_source_matches_canonicalKey",
+            "unique": false,
+            "columnNames": [
+              "canonicalKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_source_matches_canonicalKey` ON `${TABLE_NAME}` (`canonicalKey`)"
+          },
+          {
+            "name": "index_playback_source_matches_sourceVideoId",
+            "unique": false,
+            "columnNames": [
+              "sourceVideoId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_source_matches_sourceVideoId` ON `${TABLE_NAME}` (`sourceVideoId`)"
+          },
+          {
+            "name": "index_playback_source_matches_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_source_matches_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artist_lore",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `artistKey` TEXT NOT NULL, `browseId` TEXT NOT NULL, `languageCode` TEXT NOT NULL, `text` TEXT NOT NULL, `description` TEXT NOT NULL, `pageTitle` TEXT NOT NULL, `pageId` INTEGER NOT NULL, `entityId` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `originalImageUrl` TEXT NOT NULL, `sourceUrl` TEXT NOT NULL, `confidence` INTEGER NOT NULL, `negative` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `lastAccessedAt` INTEGER NOT NULL, `expiresAt` INTEGER NOT NULL, `staleUntil` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistKey",
+            "columnName": "artistKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browseId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "languageCode",
+            "columnName": "languageCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageTitle",
+            "columnName": "pageTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageId",
+            "columnName": "pageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entityId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalImageUrl",
+            "columnName": "originalImageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceUrl",
+            "columnName": "sourceUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "negative",
+            "columnName": "negative",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessedAt",
+            "columnName": "lastAccessedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "staleUntil",
+            "columnName": "staleUntil",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artist_lore_artistKey_languageCode",
+            "unique": false,
+            "columnNames": [
+              "artistKey",
+              "languageCode"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artist_lore_artistKey_languageCode` ON `${TABLE_NAME}` (`artistKey`, `languageCode`)"
+          },
+          {
+            "name": "index_artist_lore_browseId_languageCode",
+            "unique": false,
+            "columnNames": [
+              "browseId",
+              "languageCode"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artist_lore_browseId_languageCode` ON `${TABLE_NAME}` (`browseId`, `languageCode`)"
+          },
+          {
+            "name": "index_artist_lore_expiresAt",
+            "unique": false,
+            "columnNames": [
+              "expiresAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artist_lore_expiresAt` ON `${TABLE_NAME}` (`expiresAt`)"
+          },
+          {
+            "name": "index_artist_lore_lastAccessedAt",
+            "unique": false,
+            "columnNames": [
+              "lastAccessedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artist_lore_lastAccessedAt` ON `${TABLE_NAME}` (`lastAccessedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "listen_lifetime_tracks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`trackKey` TEXT NOT NULL, `trackId` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `listenedMs` INTEGER NOT NULL, `countedPlays` INTEGER NOT NULL, `completedCount` INTEGER NOT NULL, `eventCount` INTEGER NOT NULL, `firstPlayedAt` INTEGER NOT NULL, `lastPlayedAt` INTEGER NOT NULL, PRIMARY KEY(`trackKey`))",
+        "fields": [
+          {
+            "fieldPath": "trackKey",
+            "columnName": "trackKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "trackId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listenedMs",
+            "columnName": "listenedMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countedPlays",
+            "columnName": "countedPlays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedCount",
+            "columnName": "completedCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventCount",
+            "columnName": "eventCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "firstPlayedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "lastPlayedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "trackKey"
+          ]
+        }
+      },
+      {
+        "tableName": "listen_lifetime_artists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`artistKey` TEXT NOT NULL, `name` TEXT NOT NULL, `listenedMs` INTEGER NOT NULL, `countedPlays` INTEGER NOT NULL, `completedCount` INTEGER NOT NULL, `eventCount` INTEGER NOT NULL, `firstPlayedAt` INTEGER NOT NULL, `lastPlayedAt` INTEGER NOT NULL, PRIMARY KEY(`artistKey`))",
+        "fields": [
+          {
+            "fieldPath": "artistKey",
+            "columnName": "artistKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "listenedMs",
+            "columnName": "listenedMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countedPlays",
+            "columnName": "countedPlays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedCount",
+            "columnName": "completedCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventCount",
+            "columnName": "eventCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "firstPlayedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "lastPlayedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "artistKey"
+          ]
+        }
+      },
+      {
+        "tableName": "recognition_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `recognizedAt` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `artworkUrl` TEXT NOT NULL, `provider` TEXT NOT NULL, `providerTrackId` TEXT NOT NULL, `isrc` TEXT NOT NULL, `youtubeVideoId` TEXT NOT NULL, `year` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recognizedAt",
+            "columnName": "recognizedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artworkUrl",
+            "columnName": "artworkUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "providerTrackId",
+            "columnName": "providerTrackId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isrc",
+            "columnName": "isrc",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "youtubeVideoId",
+            "columnName": "youtubeVideoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recognition_history_recognizedAt",
+            "unique": false,
+            "columnNames": [
+              "recognizedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recognition_history_recognizedAt` ON `${TABLE_NAME}` (`recognizedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "followed_artists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`artistKey` TEXT NOT NULL, `browseId` TEXT NOT NULL, `name` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `followedAt` INTEGER NOT NULL, PRIMARY KEY(`artistKey`))",
+        "fields": [
+          {
+            "fieldPath": "artistKey",
+            "columnName": "artistKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browseId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "followedAt",
+            "columnName": "followedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "artistKey"
+          ]
+        }
+      },
+      {
+        "tableName": "playlist_tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `normalizedName` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedName",
+            "columnName": "normalizedName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_tags_normalizedName",
+            "unique": true,
+            "columnNames": [
+              "normalizedName"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_playlist_tags_normalizedName` ON `${TABLE_NAME}` (`normalizedName`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_tag_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `tagId` TEXT NOT NULL, `assignedAt` INTEGER NOT NULL, PRIMARY KEY(`playlistId`, `tagId`), FOREIGN KEY(`playlistId`) REFERENCES `playlists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`tagId`) REFERENCES `playlist_tags`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tagId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assignedAt",
+            "columnName": "assignedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId",
+            "tagId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_tag_links_playlistId",
+            "unique": false,
+            "columnNames": [
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_tag_links_playlistId` ON `${TABLE_NAME}` (`playlistId`)"
+          },
+          {
+            "name": "index_playlist_tag_links_tagId",
+            "unique": false,
+            "columnNames": [
+              "tagId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_tag_links_tagId` ON `${TABLE_NAME}` (`tagId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "playlist_tags",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "tagId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "excluded_artists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`artistKey` TEXT NOT NULL, `browseId` TEXT NOT NULL, `name` TEXT NOT NULL, `excludedAt` INTEGER NOT NULL, PRIMARY KEY(`artistKey`))",
+        "fields": [
+          {
+            "fieldPath": "artistKey",
+            "columnName": "artistKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browseId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludedAt",
+            "columnName": "excludedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "artistKey"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '703eb213ae18774d85ade9fcd3eaf7a4')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/luc4n3x/levyra/data/local/LevyraDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/luc4n3x/levyra/data/local/LevyraDatabaseMigrationTest.kt
@@ -123,6 +123,61 @@ class LevyraDatabaseMigrationTest {
         migrated.close()
     }
 
+    @Test
+    fun migrate18To19KeepsUserDataAndAddsOrganizationTables() {
+        helper.createDatabase(TEST_DB, 18).use { db ->
+            db.execSQL(
+                "INSERT INTO playlists (id, name, coverUrl, createdAt, updatedAt) " +
+                    "VALUES ('p4', 'Gym mix', 'cover', 400, 400)"
+            )
+            db.execSQL(
+                "INSERT INTO playlist_tracks " +
+                    "(playlistId, trackId, position, title, artist, album, durationMs, videoUrl, " +
+                    "thumbnailUrl, largeThumbnailUrl, source, accentStart, accentEnd, " +
+                    "youtubeLoudnessDb, youtubePerceptualLoudnessDb, isrc, upc, releaseDate, year, " +
+                    "trackNumber, discNumber, explicit, albumBrowseId, artistBrowseIds, " +
+                    "counterpartVideoId, videoType, metadataProvider, metadataConfidence, " +
+                    "canonicalAlbumUrl, addedAt) " +
+                    "VALUES ('p4', 't4', 0, 'Kept track', 'Artist', 'Album', 200000, '', '', '', " +
+                    "'yt', 0, 0, NULL, NULL, '', '', '', '', 0, 0, 0, '', '', '', '', '', 0, '', 400)"
+            )
+            db.execSQL(
+                "INSERT INTO followed_artists (artistKey, browseId, name, thumbnailUrl, followedAt) " +
+                    "VALUES ('UC1', 'UC1', 'Artist', '', 400)"
+            )
+        }
+
+        val migrated = helper.runMigrationsAndValidate(TEST_DB, 19, true, *LevyraDatabase.MIGRATIONS)
+
+        migrated.query("SELECT name, coverUrl, hidden FROM playlists WHERE id = 'p4'").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("Gym mix", cursor.getString(0))
+            assertEquals("cover", cursor.getString(1))
+            assertEquals(0, cursor.getInt(2))
+        }
+        migrated.query("SELECT title FROM playlist_tracks WHERE playlistId = 'p4'").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("Kept track", cursor.getString(0))
+        }
+        migrated.query("SELECT name FROM followed_artists WHERE artistKey = 'UC1'").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals("Artist", cursor.getString(0))
+        }
+        migrated.query("SELECT COUNT(*) FROM playlist_tags").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(0, cursor.getInt(0))
+        }
+        migrated.query("SELECT COUNT(*) FROM playlist_tag_links").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(0, cursor.getInt(0))
+        }
+        migrated.query("SELECT COUNT(*) FROM excluded_artists").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(0, cursor.getInt(0))
+        }
+        migrated.close()
+    }
+
     private companion object {
         const val TEST_DB = "levyra-migration-test.db"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -205,6 +205,28 @@
             android:theme="@style/Theme.Levyra.Transparent" />
 
         <service
+            android:name=".feature.ambient.LevyraAmbientDreamService"
+            android:exported="true"
+            android:label="@string/ambient_dream_label"
+            android:permission="android.permission.BIND_DREAM_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.dreams.DreamService" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".feature.ambient.LevyraAmbientTileService"
+            android:exported="true"
+            android:icon="@drawable/ic_qs_ambient"
+            android:label="@string/tile_ambient"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
+
+        <service
             android:name=".feature.recognition.MusicRecognitionTileService"
             android:exported="true"
             android:icon="@drawable/ic_qs_recognize"

--- a/app/src/main/java/com/luc4n3x/levyra/LevyraLaunchActions.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/LevyraLaunchActions.kt
@@ -23,6 +23,7 @@ object LevyraLaunchActions {
     const val SHORTCUT_SEARCH = "search"
     const val SHORTCUT_LIBRARY = "library"
     const val SHORTCUT_RECOGNITION = "recognition"
+    const val SHORTCUT_AMBIENT = "ambient"
 
     private val knownShortcuts = setOf(
         SHORTCUT_FAVORITES,
@@ -31,7 +32,8 @@ object LevyraLaunchActions {
         SHORTCUT_LYRICS,
         SHORTCUT_SEARCH,
         SHORTCUT_LIBRARY,
-        SHORTCUT_RECOGNITION
+        SHORTCUT_RECOGNITION,
+        SHORTCUT_AMBIENT
     )
 
     val pendingShortcut = mutableStateOf<String?>(null)

--- a/app/src/main/java/com/luc4n3x/levyra/data/ExcludedArtistsStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/ExcludedArtistsStore.kt
@@ -1,0 +1,96 @@
+package com.luc4n3x.levyra.data
+
+import android.content.Context
+import com.luc4n3x.levyra.data.local.ExcludedArtistEntity
+import com.luc4n3x.levyra.data.local.LevyraDatabase
+import com.luc4n3x.levyra.domain.ExcludedArtist
+import com.luc4n3x.levyra.domain.excludedArtistKeyOf
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+class ExcludedArtistsStore(context: Context) {
+    private val dao = LevyraDatabase.get(context.applicationContext).excludedArtistsDao()
+
+    suspend fun load(): List<ExcludedArtist> = withContext(Dispatchers.IO) {
+        try {
+            dao.all().map { it.toDomain() }
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            Timber.w(error, "Excluded artists load failed")
+            emptyList()
+        }
+    }
+
+    suspend fun exclude(browseId: String, name: String, excludedAt: Long = System.currentTimeMillis()) {
+        val cleanName = name.trim()
+        val key = excludedArtistKeyOf(browseId, cleanName)
+        if (key.isBlank() || key == "name:") return
+        withContext(Dispatchers.IO) {
+            mutationMutex.withLock {
+                try {
+                    dao.upsert(
+                        ExcludedArtistEntity(
+                            artistKey = key,
+                            browseId = browseId.trim(),
+                            name = cleanName,
+                            excludedAt = excludedAt
+                        )
+                    )
+                } catch (cancelled: CancellationException) {
+                    throw cancelled
+                } catch (error: Exception) {
+                    Timber.w(error, "Artist exclusion write failed")
+                }
+            }
+        }
+    }
+
+    suspend fun include(browseId: String, name: String) {
+        val key = excludedArtistKeyOf(browseId, name)
+        if (key.isBlank()) return
+        withContext(Dispatchers.IO) {
+            mutationMutex.withLock {
+                try {
+                    dao.delete(key)
+                } catch (cancelled: CancellationException) {
+                    throw cancelled
+                } catch (error: Exception) {
+                    Timber.w(error, "Artist exclusion removal failed")
+                }
+            }
+        }
+    }
+
+    suspend fun replaceAll(artists: List<ExcludedArtist>) = withContext(Dispatchers.IO) {
+        mutationMutex.withLock {
+            val rows = artists
+                .map(ExcludedArtist::toEntity)
+                .filter { it.artistKey.isNotBlank() && it.artistKey != "name:" }
+                .distinctBy { it.artistKey }
+            dao.clear()
+            if (rows.isNotEmpty()) dao.upsertAll(rows)
+        }
+    }
+
+    private companion object {
+        val mutationMutex = Mutex()
+    }
+}
+
+private fun ExcludedArtistEntity.toDomain() = ExcludedArtist(
+    browseId = browseId,
+    name = name,
+    excludedAt = excludedAt
+)
+
+private fun ExcludedArtist.toEntity() = ExcludedArtistEntity(
+    artistKey = key,
+    browseId = browseId.trim(),
+    name = name.trim(),
+    excludedAt = excludedAt
+)

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraBackupManager.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraBackupManager.kt
@@ -15,7 +15,14 @@ import com.luc4n3x.levyra.data.local.PlaylistEntity
 import com.luc4n3x.levyra.data.local.toFavoriteTrackEntity
 import com.luc4n3x.levyra.data.local.toPlaylistTrackEntity
 import com.luc4n3x.levyra.data.local.toTrack
+import com.luc4n3x.levyra.data.local.PlaylistTagEntity
+import com.luc4n3x.levyra.data.local.PlaylistTagLinkEntity
+import com.luc4n3x.levyra.domain.ExcludedArtist
 import com.luc4n3x.levyra.domain.FollowedArtist
+import com.luc4n3x.levyra.domain.PLAYLIST_TAG_MAX_PER_PLAYLIST
+import com.luc4n3x.levyra.domain.PlaylistTag
+import com.luc4n3x.levyra.domain.isExcludableArtist
+import com.luc4n3x.levyra.domain.normalizePlaylistTagName
 import com.luc4n3x.levyra.domain.LevyraAudioSettings
 import com.luc4n3x.levyra.domain.LevyraBackupFrequency
 import com.luc4n3x.levyra.domain.LevyraBackupSettings
@@ -50,6 +57,8 @@ class LevyraBackupManager(private val context: Context) {
     private val database = LevyraDatabase.get(appContext)
     private val preferences = LevyraPreferences(appContext)
     private val followedArtistsStore = FollowedArtistsStore(appContext)
+    private val excludedArtistsStore = ExcludedArtistsStore(appContext)
+    private val tagsDao get() = database.playlistTagsDao()
 
     suspend fun exportTo(uri: Uri): LevyraBackupResult = withContext(Dispatchers.IO) {
         LevyraVaultOperationMutex.withLock {
@@ -281,11 +290,16 @@ class LevyraBackupManager(private val context: Context) {
                         .put("coverUrl", playlist.coverUrl)
                         .put("createdAt", playlist.createdAt)
                         .put("updatedAt", playlist.updatedAt)
+                        .put("hidden", playlist.hidden)
+                        .put("tagIds", JSONArray(tagsDao.tagIdsOf(playlist.id)))
                         .put("tracks", JSONArray().apply { tracks.forEach { put(TrackJson.toJson(it.toTrack())) } })
                         .toString()
                     writer.write(json)
                 }
                 writer.write("]")
+            }
+            sections[ORGANIZATION_ENTRY] = writeJsonSection(zip, ORGANIZATION_ENTRY) { writer ->
+                writer.write(organizationToJson(tagsDao.allTags(), excludedArtistsStore.load()).toString())
             }
             sections[HISTORY_ENTRY] = writeJsonSection(zip, HISTORY_ENTRY) { writer ->
                 writeJsonArray(writer, database.listenEventsDao().all()) { listenEventToJson(it).toString() }
@@ -401,6 +415,8 @@ class LevyraBackupManager(private val context: Context) {
             settings = parseSettings(settingsJson),
             favorites = entries[FAVORITES_ENTRY].toJsonArray().toTrackList(),
             followedArtists = parseFollowedArtists(entries[FOLLOWED_ARTISTS_ENTRY].toJsonArray()),
+            excludedArtists = parseExcludedArtists(entries[ORGANIZATION_ENTRY].toJsonObject()),
+            playlistTags = parsePlaylistTags(entries[ORGANIZATION_ENTRY].toJsonObject()),
             playlists = parsePlaylists(entries[PLAYLISTS_ENTRY].toJsonArray()),
             history = parseHistory(entries[HISTORY_ENTRY].toJsonArray()),
             queueItems = parseQueueItems(queueJson),
@@ -425,6 +441,8 @@ class LevyraBackupManager(private val context: Context) {
             settings = parseSettings(root.optJSONObject("settings") ?: JSONObject()),
             favorites = root.optJSONArray("favorites").toTrackList(),
             followedArtists = parseFollowedArtists(root.optJSONArray("followedArtists")),
+            excludedArtists = emptyList(),
+            playlistTags = emptyList(),
             playlists = parsePlaylists(root.optJSONArray("playlists") ?: JSONArray()),
             history = parseHistory(root.optJSONArray("history")),
             queueItems = parseQueueItems(queue),
@@ -458,6 +476,8 @@ class LevyraBackupManager(private val context: Context) {
                 coverUrl = playlist.coverUrl,
                 createdAt = playlist.createdAt,
                 updatedAt = playlist.updatedAt,
+                hidden = playlist.hidden,
+                tagIds = tagsDao.tagIdsOf(playlist.id),
                 tracks = database.playlistDao().tracksOf(playlist.id).map { it.toTrack() }
             )
         }
@@ -465,6 +485,8 @@ class LevyraBackupManager(private val context: Context) {
             settings = snapshot,
             favorites = database.favoriteTracksDao().all().map { it.toTrack() },
             followedArtists = followedArtistsStore.load(),
+            excludedArtists = excludedArtistsStore.load(),
+            playlistTags = tagsDao.allTags().map(::toPlaylistTag),
             playlists = playlists,
             history = database.listenEventsDao().all(),
             queueItems = database.playbackQueueDao().items(),
@@ -475,10 +497,12 @@ class LevyraBackupManager(private val context: Context) {
     private suspend fun applySnapshot(payload: VaultSnapshot) {
         preferences.restoreSnapshot(payload.settings)
         followedArtistsStore.saveDurable(payload.followedArtists)
+        excludedArtistsStore.replaceAll(payload.excludedArtists)
         val now = System.currentTimeMillis()
         database.withTransaction {
             database.favoriteTracksDao().replaceAll(payload.favorites.mapIndexed { index, track -> track.toFavoriteTrackEntity(now - index) })
             restorePlaylists(payload.playlists)
+            restorePlaylistTags(payload.playlistTags, payload.playlists)
             database.listenEventsDao().replaceAll(payload.history)
             restoreQueue(payload.queueItems, payload.queueState)
         }
@@ -496,7 +520,8 @@ class LevyraBackupManager(private val context: Context) {
                     playlist.name.ifBlank { "Playlist" },
                     playlist.coverUrl,
                     playlist.createdAt,
-                    playlist.updatedAt
+                    playlist.updatedAt,
+                    playlist.hidden
                 )
             )
             if (playlist.tracks.isNotEmpty()) {
@@ -505,6 +530,113 @@ class LevyraBackupManager(private val context: Context) {
                         track.toPlaylistTrackEntity(playlist.id, position, playlist.createdAt + position)
                     }
                 )
+            }
+        }
+    }
+
+    private suspend fun restorePlaylistTags(tags: List<PlaylistTag>, playlists: List<PlaylistBackup>) {
+        val now = System.currentTimeMillis()
+        val tagRows = tags
+            .filter { it.id.isNotBlank() && it.normalizedName.isNotBlank() }
+            .distinctBy { it.normalizedName }
+            .map {
+                PlaylistTagEntity(
+                    id = it.id,
+                    name = it.name.ifBlank { it.normalizedName },
+                    normalizedName = it.normalizedName,
+                    createdAt = if (it.createdAt > 0L) it.createdAt else now
+                )
+            }
+        val knownTagIds = tagRows.mapTo(hashSetOf()) { it.id }
+        val linkRows = playlists.flatMap { playlist ->
+            playlist.tagIds.distinct()
+                .filter { it in knownTagIds }
+                .take(PLAYLIST_TAG_MAX_PER_PLAYLIST)
+                .map { PlaylistTagLinkEntity(playlistId = playlist.id, tagId = it, assignedAt = now) }
+        }
+        tagsDao.replaceAll(tagRows, linkRows)
+    }
+
+    private fun toPlaylistTag(entity: PlaylistTagEntity): PlaylistTag = PlaylistTag(
+        id = entity.id,
+        name = entity.name,
+        normalizedName = entity.normalizedName,
+        createdAt = entity.createdAt
+    )
+
+    private fun organizationToJson(
+        tags: List<PlaylistTagEntity>,
+        excluded: List<ExcludedArtist>
+    ): JSONObject = JSONObject()
+        .put(
+            "tags",
+            JSONArray().apply {
+                tags.forEach { tag ->
+                    put(
+                        JSONObject()
+                            .put("id", tag.id)
+                            .put("name", tag.name)
+                            .put("normalizedName", tag.normalizedName)
+                            .put("createdAt", tag.createdAt)
+                    )
+                }
+            }
+        )
+        .put(
+            "excludedArtists",
+            JSONArray().apply {
+                excluded.forEach { artist ->
+                    put(
+                        JSONObject()
+                            .put("browseId", artist.browseId)
+                            .put("name", artist.name)
+                            .put("excludedAt", artist.excludedAt)
+                    )
+                }
+            }
+        )
+
+    private fun parsePlaylistTags(json: JSONObject?): List<PlaylistTag> {
+        val array = json?.optJSONArray("tags") ?: return emptyList()
+        return buildList {
+            for (index in 0 until array.length()) {
+                val item = array.optJSONObject(index) ?: continue
+                val id = item.optString("id").trim()
+                val name = item.optString("name").trim()
+                val normalized = item.optString("normalizedName").trim()
+                    .ifBlank { normalizePlaylistTagName(name) }
+                if (id.isBlank() || normalized.isBlank()) continue
+                add(
+                    PlaylistTag(
+                        id = id,
+                        name = name.ifBlank { normalized },
+                        normalizedName = normalized,
+                        createdAt = item.optLong("createdAt", 0L)
+                    )
+                )
+            }
+        }
+    }
+
+    private fun parseExcludedArtists(json: JSONObject?): List<ExcludedArtist> {
+        val array = json?.optJSONArray("excludedArtists") ?: return emptyList()
+        return buildList {
+            for (index in 0 until array.length()) {
+                val item = array.optJSONObject(index) ?: continue
+                val name = item.optString("name").trim()
+                val browseId = item.optString("browseId").trim()
+                if (!isExcludableArtist(browseId, name)) continue
+                add(ExcludedArtist(browseId, name, item.optLong("excludedAt", 0L)))
+            }
+        }
+    }
+
+    private fun JSONArray?.toStringList(): List<String> {
+        if (this == null) return emptyList()
+        return buildList {
+            for (index in 0 until length()) {
+                val value = optString(index).trim()
+                if (value.isNotEmpty()) add(value)
             }
         }
     }
@@ -562,6 +694,8 @@ class LevyraBackupManager(private val context: Context) {
                         coverUrl = json.optString("coverUrl"),
                         createdAt = createdAt,
                         updatedAt = updatedAt,
+                        hidden = json.optBoolean("hidden", false),
+                        tagIds = json.optJSONArray("tagIds").toStringList(),
                         tracks = json.optJSONArray("tracks").toTrackList()
                     )
                 )
@@ -863,6 +997,8 @@ class LevyraBackupManager(private val context: Context) {
         val coverUrl: String,
         val createdAt: Long,
         val updatedAt: Long,
+        val hidden: Boolean,
+        val tagIds: List<String>,
         val tracks: List<Track>
     )
 
@@ -870,6 +1006,8 @@ class LevyraBackupManager(private val context: Context) {
         val settings: LevyraPreferencesSnapshot,
         val favorites: List<Track>,
         val followedArtists: List<FollowedArtist>,
+        val excludedArtists: List<ExcludedArtist>,
+        val playlistTags: List<PlaylistTag>,
         val playlists: List<PlaylistBackup>,
         val history: List<ListenEventEntity>,
         val queueItems: List<PlaybackQueueItemEntity>,
@@ -907,6 +1045,7 @@ class LevyraBackupManager(private val context: Context) {
         const val PLAYLISTS_ENTRY = "data/playlists.json"
         const val HISTORY_ENTRY = "data/history.json"
         const val QUEUE_ENTRY = "data/queue.json"
+        const val ORGANIZATION_ENTRY = "data/library_organization.json"
         const val MAX_ZIP_ENTRIES = 16
         const val MAX_ENTRY_BYTES = 64L * 1024L * 1024L
         const val MAX_TOTAL_BYTES = 96L * 1024L * 1024L

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraBackupManager.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraBackupManager.kt
@@ -1059,6 +1059,7 @@ class LevyraBackupManager(private val context: Context) {
             FAVORITES_ENTRY,
             FOLLOWED_ARTISTS_ENTRY,
             PLAYLISTS_ENTRY,
+            ORGANIZATION_ENTRY,
             HISTORY_ENTRY,
             QUEUE_ENTRY,
             LEGACY_PAYLOAD_ENTRY

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
@@ -26,6 +26,7 @@ import com.luc4n3x.levyra.domain.LevyraCanvasSource
 import com.luc4n3x.levyra.domain.LevyraDownloadFolderMode
 import com.luc4n3x.levyra.domain.LevyraDownloadPreset
 import com.luc4n3x.levyra.domain.LevyraDownloadSettings
+import com.luc4n3x.levyra.domain.LevyraAmbientSettings
 import com.luc4n3x.levyra.domain.LevyraInterfaceSettings
 import com.luc4n3x.levyra.domain.LevyraFontPreset
 import com.luc4n3x.levyra.domain.Track
@@ -270,6 +271,21 @@ class LevyraPreferences(context: Context) {
             it[KEY_UI_ENHANCE_VIDEO_METADATA] = normalized.enhanceVideoMetadata
             it[KEY_UI_PURE_BLACK] = normalized.pureBlack
             it[KEY_UI_HAPTIC_FEEDBACK] = normalized.hapticFeedback
+        }
+    }
+
+    fun ambientSettings(): LevyraAmbientSettings = read(LevyraAmbientSettings()) { ambientSettingsFrom(it) }
+
+    fun setAmbientSettings(value: LevyraAmbientSettings) {
+        val normalized = value.normalized()
+        write {
+            it[KEY_AMBIENT_BRIGHTNESS] = normalized.brightness
+            it[KEY_AMBIENT_AUTO_DIM] = normalized.autoDim
+            it[KEY_AMBIENT_AUTO_DIM_SECONDS] = normalized.autoDimAfterSeconds
+            it[KEY_AMBIENT_PIXEL_SHIFT] = normalized.pixelShift
+            it[KEY_AMBIENT_PROXIMITY_BLACKOUT] = normalized.proximityBlackout
+            it[KEY_AMBIENT_SHOW_LYRICS] = normalized.showLyrics
+            it[KEY_AMBIENT_SHOW_CANVAS] = normalized.showCanvas
         }
     }
 
@@ -587,6 +603,16 @@ class LevyraPreferences(context: Context) {
         hapticFeedback = preferences[KEY_UI_HAPTIC_FEEDBACK] ?: true
     ).normalized()
 
+    private fun ambientSettingsFrom(preferences: Preferences): LevyraAmbientSettings = LevyraAmbientSettings(
+        brightness = preferences[KEY_AMBIENT_BRIGHTNESS] ?: 0.35f,
+        autoDim = preferences[KEY_AMBIENT_AUTO_DIM] ?: true,
+        autoDimAfterSeconds = preferences[KEY_AMBIENT_AUTO_DIM_SECONDS] ?: 20,
+        pixelShift = preferences[KEY_AMBIENT_PIXEL_SHIFT] ?: true,
+        proximityBlackout = preferences[KEY_AMBIENT_PROXIMITY_BLACKOUT] ?: false,
+        showLyrics = preferences[KEY_AMBIENT_SHOW_LYRICS] ?: true,
+        showCanvas = preferences[KEY_AMBIENT_SHOW_CANVAS] ?: true
+    ).normalized()
+
     private fun downloadSettingsFrom(preferences: Preferences): LevyraDownloadSettings = LevyraDownloadSettings(
         wifiOnly = preferences[KEY_DOWNLOAD_WIFI_ONLY] ?: false,
         chargingOnly = preferences[KEY_DOWNLOAD_CHARGING_ONLY] ?: false,
@@ -789,6 +815,13 @@ class LevyraPreferences(context: Context) {
         val KEY_UI_CANVAS_QUALITY = stringPreferencesKey("ui_canvas_quality")
         val KEY_UI_CANVAS_SOURCE = stringPreferencesKey("ui_canvas_source")
         val KEY_UI_ENHANCE_VIDEO_METADATA = booleanPreferencesKey("ui_enhance_video_metadata")
+        val KEY_AMBIENT_BRIGHTNESS = floatPreferencesKey("ambient_brightness")
+        val KEY_AMBIENT_AUTO_DIM = booleanPreferencesKey("ambient_auto_dim")
+        val KEY_AMBIENT_AUTO_DIM_SECONDS = intPreferencesKey("ambient_auto_dim_seconds")
+        val KEY_AMBIENT_PIXEL_SHIFT = booleanPreferencesKey("ambient_pixel_shift")
+        val KEY_AMBIENT_PROXIMITY_BLACKOUT = booleanPreferencesKey("ambient_proximity_blackout")
+        val KEY_AMBIENT_SHOW_LYRICS = booleanPreferencesKey("ambient_show_lyrics")
+        val KEY_AMBIENT_SHOW_CANVAS = booleanPreferencesKey("ambient_show_canvas")
         val KEY_DOWNLOAD_WIFI_ONLY = booleanPreferencesKey("download_wifi_only")
         val KEY_DOWNLOAD_CHARGING_ONLY = booleanPreferencesKey("download_charging_only")
         val KEY_DOWNLOAD_RESUMABLE = booleanPreferencesKey("download_resumable")

--- a/app/src/main/java/com/luc4n3x/levyra/data/ListeningPulseStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/ListeningPulseStore.kt
@@ -180,6 +180,21 @@ class ListeningPulseStore(context: Context) {
         )
     }
 
+    suspend fun lastPlayedByKey(trackKeys: List<String>): Map<String, Long> = withContext(Dispatchers.IO) {
+        val keys = trackKeys.filter(String::isNotEmpty).distinct()
+        if (keys.isEmpty()) return@withContext emptyMap()
+        try {
+            keys.chunked(LAST_PLAYED_QUERY_CHUNK)
+                .flatMap { chunk -> lifetimeDao.lastPlayedFor(chunk) }
+                .associate { it.trackKey to it.lastPlayedAt }
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            Timber.w(error, "Last played lookup failed")
+            emptyMap()
+        }
+    }
+
     suspend fun lifetime(): LifetimeListening = withContext(Dispatchers.IO) {
         try {
             val totals = lifetimeDao.trackTotals()
@@ -318,6 +333,7 @@ class ListeningPulseStore(context: Context) {
         const val MAX_LOOPS = 6L
         const val LIFETIME_BACKFILL_VERSION = 1
         const val LIFETIME_TOP_LIMIT = 8
+        const val LAST_PLAYED_QUERY_CHUNK = 500
         const val BACKFILL_PAGE_SIZE = 400
         const val BACKFILL_MAX_EVENTS = 50_000
         val RETENTION_MS = TimeUnit.DAYS.toMillis(RETENTION_DAYS.toLong())

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaylistStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaylistStore.kt
@@ -1,25 +1,35 @@
 package com.luc4n3x.levyra.data
 
 import android.content.Context
+import androidx.room.withTransaction
 import com.luc4n3x.levyra.data.local.LevyraDatabase
 import com.luc4n3x.levyra.data.local.PlaylistEntity
+import com.luc4n3x.levyra.data.local.PlaylistTagEntity
+import com.luc4n3x.levyra.data.local.PlaylistTagLinkEntity
 import com.luc4n3x.levyra.data.local.toPlaylistTrackEntity
 import com.luc4n3x.levyra.data.local.toTrack
+import com.luc4n3x.levyra.domain.PLAYLIST_TAG_MAX_PER_PLAYLIST
 import com.luc4n3x.levyra.domain.Playlist
+import com.luc4n3x.levyra.domain.PlaylistTag
 import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.domain.normalizePlaylistTagName
+import com.luc4n3x.levyra.domain.sanitizePlaylistTagName
 import java.util.UUID
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 class PlaylistStore(context: Context) {
-    private val dao = LevyraDatabase.get(context.applicationContext).playlistDao()
+    private val database = LevyraDatabase.get(context.applicationContext)
+    private val dao = database.playlistDao()
+    private val tagsDao = database.playlistTagsDao()
 
     suspend fun loadAll(): List<Playlist> = withContext(Dispatchers.IO) {
         runCatching {
+            val tagsByPlaylist = tagAssignments()
             dao.allPlaylists().map { entity ->
                 val tracks = dao.tracksOf(entity.id).map { it.toTrack() }
-                entity.toPlaylist(tracks)
+                entity.toPlaylist(tracks, tagsByPlaylist[entity.id].orEmpty())
             }
         }.onFailure { Timber.w(it, "Playlist load failed") }.getOrDefault(emptyList())
     }
@@ -27,8 +37,116 @@ class PlaylistStore(context: Context) {
     suspend fun load(playlistId: String): Playlist? = withContext(Dispatchers.IO) {
         runCatching {
             val entity = dao.playlist(playlistId) ?: return@runCatching null
-            entity.toPlaylist(dao.tracksOf(playlistId).map { it.toTrack() })
+            val tags = tagAssignments()[playlistId].orEmpty()
+            entity.toPlaylist(dao.tracksOf(playlistId).map { it.toTrack() }, tags)
         }.onFailure { Timber.w(it, "Playlist load failed") }.getOrNull()
+    }
+
+    suspend fun setHidden(playlistId: String, hidden: Boolean) {
+        withContext(Dispatchers.IO) {
+            runCatching { dao.setHidden(playlistId, hidden, System.currentTimeMillis()) }
+                .onFailure { Timber.w(it, "Playlist visibility update failed") }
+        }
+    }
+
+    suspend fun allTags(): List<PlaylistTag> = withContext(Dispatchers.IO) {
+        runCatching { tagsDao.allTags().map { it.toDomain() } }
+            .onFailure { Timber.w(it, "Playlist tag load failed") }
+            .getOrDefault(emptyList())
+    }
+
+    suspend fun createTag(name: String): PlaylistTag? = withContext(Dispatchers.IO) {
+        val display = sanitizePlaylistTagName(name)
+        val normalized = normalizePlaylistTagName(name)
+        if (normalized.isEmpty()) return@withContext null
+        runCatching {
+            database.withTransaction {
+                val existing = tagsDao.tagByNormalizedName(normalized)
+                if (existing != null) {
+                    existing.toDomain()
+                } else {
+                    val tag = PlaylistTagEntity(
+                        id = UUID.randomUUID().toString(),
+                        name = display,
+                        normalizedName = normalized,
+                        createdAt = System.currentTimeMillis()
+                    )
+                    tagsDao.upsertTag(tag)
+                    tag.toDomain()
+                }
+            }
+        }.onFailure { Timber.w(it, "Playlist tag creation failed") }.getOrNull()
+    }
+
+    suspend fun renameTag(tagId: String, name: String): Boolean = withContext(Dispatchers.IO) {
+        val display = sanitizePlaylistTagName(name)
+        val normalized = normalizePlaylistTagName(name)
+        if (normalized.isEmpty()) return@withContext false
+        runCatching {
+            database.withTransaction {
+                val conflict = tagsDao.tagByNormalizedName(normalized)
+                if (conflict != null && conflict.id != tagId) {
+                    false
+                } else {
+                    tagsDao.renameTag(tagId, display, normalized)
+                    true
+                }
+            }
+        }.onFailure { Timber.w(it, "Playlist tag rename failed") }.getOrDefault(false)
+    }
+
+    suspend fun deleteTag(tagId: String) {
+        withContext(Dispatchers.IO) {
+            runCatching { tagsDao.deleteTag(tagId) }
+                .onFailure { Timber.w(it, "Playlist tag removal failed") }
+        }
+    }
+
+    suspend fun setPlaylistTags(playlistId: String, tagIds: List<String>) {
+        withContext(Dispatchers.IO) {
+            val now = System.currentTimeMillis()
+            val links = tagIds.distinct()
+                .take(PLAYLIST_TAG_MAX_PER_PLAYLIST)
+                .map { PlaylistTagLinkEntity(playlistId = playlistId, tagId = it, assignedAt = now) }
+            runCatching { tagsDao.replaceLinksOf(playlistId, links) }
+                .onFailure { Timber.w(it, "Playlist tag assignment failed") }
+        }
+    }
+
+    suspend fun replaceTagCatalog(tags: List<PlaylistTag>, assignments: Map<String, List<String>>) {
+        withContext(Dispatchers.IO) {
+            val now = System.currentTimeMillis()
+            val tagRows = tags
+                .filter { it.id.isNotBlank() && it.normalizedName.isNotBlank() }
+                .distinctBy { it.normalizedName }
+                .map {
+                    PlaylistTagEntity(
+                        id = it.id,
+                        name = it.name.ifBlank { it.normalizedName },
+                        normalizedName = it.normalizedName,
+                        createdAt = if (it.createdAt > 0L) it.createdAt else now
+                    )
+                }
+            val knownTagIds = tagRows.mapTo(hashSetOf()) { it.id }
+            val linkRows = assignments.flatMap { (playlistId, tagIds) ->
+                tagIds.distinct()
+                    .filter { it in knownTagIds }
+                    .take(PLAYLIST_TAG_MAX_PER_PLAYLIST)
+                    .map { PlaylistTagLinkEntity(playlistId = playlistId, tagId = it, assignedAt = now) }
+            }
+            runCatching { tagsDao.replaceAll(tagRows, linkRows) }
+                .onFailure { Timber.w(it, "Playlist tag restore failed") }
+        }
+    }
+
+    private suspend fun tagAssignments(): Map<String, List<PlaylistTag>> {
+        val tagsById = tagsDao.allTags().associate { it.id to it.toDomain() }
+        if (tagsById.isEmpty()) return emptyMap()
+        return tagsDao.allLinks()
+            .groupBy(PlaylistTagLinkEntity::playlistId)
+            .mapValues { (_, links) ->
+                links.mapNotNull { tagsById[it.tagId] }.sortedBy { it.normalizedName }
+            }
     }
 
     suspend fun create(name: String, firstTrack: Track? = null): Playlist = withContext(Dispatchers.IO) {
@@ -133,6 +251,15 @@ class PlaylistStore(context: Context) {
         }.onFailure { Timber.w(it, "Playlist metadata update failed") }
     }
 
-    private fun PlaylistEntity.toPlaylist(tracks: List<Track>): Playlist =
-        Playlist(id, name, coverUrl, tracks, createdAt, updatedAt)
+    private fun PlaylistEntity.toPlaylist(
+        tracks: List<Track>,
+        tags: List<PlaylistTag> = emptyList()
+    ): Playlist = Playlist(id, name, coverUrl, tracks, createdAt, updatedAt, tags, hidden)
 }
+
+private fun PlaylistTagEntity.toDomain() = PlaylistTag(
+    id = id,
+    name = name,
+    normalizedName = normalizedName,
+    createdAt = createdAt
+)

--- a/app/src/main/java/com/luc4n3x/levyra/data/local/ExcludedArtistEntity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/local/ExcludedArtistEntity.kt
@@ -1,0 +1,34 @@
+package com.luc4n3x.levyra.data.local
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.PrimaryKey
+import androidx.room.Query
+
+@Entity(tableName = "excluded_artists")
+data class ExcludedArtistEntity(
+    @PrimaryKey val artistKey: String,
+    val browseId: String,
+    val name: String,
+    val excludedAt: Long
+)
+
+@Dao
+interface ExcludedArtistsDao {
+    @Query("SELECT * FROM excluded_artists ORDER BY excludedAt DESC")
+    suspend fun all(): List<ExcludedArtistEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(row: ExcludedArtistEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertAll(rows: List<ExcludedArtistEntity>)
+
+    @Query("DELETE FROM excluded_artists WHERE artistKey = :artistKey")
+    suspend fun delete(artistKey: String)
+
+    @Query("DELETE FROM excluded_artists")
+    suspend fun clear()
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/local/LevyraDatabase.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/local/LevyraDatabase.kt
@@ -7,7 +7,7 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
-const val LEVYRA_DATABASE_VERSION = 18
+const val LEVYRA_DATABASE_VERSION = 19
 
 @Database(
     entities = [
@@ -27,7 +27,10 @@ const val LEVYRA_DATABASE_VERSION = 18
         ListenLifetimeTrackEntity::class,
         ListenLifetimeArtistEntity::class,
         RecognitionHistoryEntity::class,
-        FollowedArtistEntity::class
+        FollowedArtistEntity::class,
+        PlaylistTagEntity::class,
+        PlaylistTagLinkEntity::class,
+        ExcludedArtistEntity::class
     ],
     version = LEVYRA_DATABASE_VERSION,
     exportSchema = true
@@ -47,6 +50,8 @@ abstract class LevyraDatabase : RoomDatabase() {
     abstract fun listenLifetimeDao(): ListenLifetimeDao
     abstract fun recognitionHistoryDao(): RecognitionHistoryDao
     abstract fun followedArtistsDao(): FollowedArtistsDao
+    abstract fun playlistTagsDao(): PlaylistTagsDao
+    abstract fun excludedArtistsDao(): ExcludedArtistsDao
 
     companion object {
         @Volatile private var instance: LevyraDatabase? = null
@@ -544,6 +549,48 @@ abstract class LevyraDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_18_19 = object : Migration(18, 19) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                val playlistColumns = mutableSetOf<String>()
+                db.query("PRAGMA table_info(playlists)").use { cursor ->
+                    val nameIndex = cursor.getColumnIndex("name")
+                    while (cursor.moveToNext()) {
+                        if (nameIndex >= 0) playlistColumns += cursor.getString(nameIndex)
+                    }
+                }
+                if ("hidden" !in playlistColumns) {
+                    db.execSQL("ALTER TABLE playlists ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0")
+                }
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS playlist_tags (" +
+                        "id TEXT NOT NULL, name TEXT NOT NULL, normalizedName TEXT NOT NULL, " +
+                        "createdAt INTEGER NOT NULL, PRIMARY KEY(id))"
+                )
+                db.execSQL(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS index_playlist_tags_normalizedName " +
+                        "ON playlist_tags(normalizedName)"
+                )
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS playlist_tag_links (" +
+                        "playlistId TEXT NOT NULL, tagId TEXT NOT NULL, assignedAt INTEGER NOT NULL, " +
+                        "PRIMARY KEY(playlistId, tagId), " +
+                        "FOREIGN KEY(playlistId) REFERENCES playlists(id) ON UPDATE NO ACTION ON DELETE CASCADE, " +
+                        "FOREIGN KEY(tagId) REFERENCES playlist_tags(id) ON UPDATE NO ACTION ON DELETE CASCADE)"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS index_playlist_tag_links_playlistId ON playlist_tag_links(playlistId)"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS index_playlist_tag_links_tagId ON playlist_tag_links(tagId)"
+                )
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS excluded_artists (" +
+                        "artistKey TEXT NOT NULL, browseId TEXT NOT NULL, name TEXT NOT NULL, " +
+                        "excludedAt INTEGER NOT NULL, PRIMARY KEY(artistKey))"
+                )
+            }
+        }
+
         internal val MIGRATIONS: Array<Migration> = arrayOf(
             MIGRATION_1_2,
             MIGRATION_2_3,
@@ -561,7 +608,8 @@ abstract class LevyraDatabase : RoomDatabase() {
             MIGRATION_14_15,
             MIGRATION_15_16,
             MIGRATION_16_17,
-            MIGRATION_17_18
+            MIGRATION_17_18,
+            MIGRATION_18_19
         )
 
         fun get(context: Context): LevyraDatabase {

--- a/app/src/main/java/com/luc4n3x/levyra/data/local/ListenLifetimeDao.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/local/ListenLifetimeDao.kt
@@ -160,6 +160,12 @@ interface ListenLifetimeDao {
     suspend fun artistCount(): Int
 
     @Query(
+        "SELECT trackKey, lastPlayedAt FROM listen_lifetime_tracks " +
+            "WHERE trackKey IN (:trackKeys) AND lastPlayedAt > 0"
+    )
+    suspend fun lastPlayedFor(trackKeys: List<String>): List<ListenLifetimeLastPlayed>
+
+    @Query(
         "SELECT * FROM listen_lifetime_tracks ORDER BY listenedMs DESC, countedPlays DESC LIMIT :limit"
     )
     suspend fun topTracks(limit: Int): List<ListenLifetimeTrackEntity>

--- a/app/src/main/java/com/luc4n3x/levyra/data/local/ListenLifetimeEntity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/local/ListenLifetimeEntity.kt
@@ -29,6 +29,11 @@ data class ListenLifetimeArtistEntity(
     val lastPlayedAt: Long
 )
 
+data class ListenLifetimeLastPlayed(
+    val trackKey: String,
+    val lastPlayedAt: Long
+)
+
 data class ListenLifetimeTotals(
     val listenedMs: Long,
     val countedPlays: Int,

--- a/app/src/main/java/com/luc4n3x/levyra/data/local/PlaylistDao.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/local/PlaylistDao.kt
@@ -51,6 +51,9 @@ abstract class PlaylistDao {
     @Query("UPDATE playlists SET updatedAt = :updatedAt WHERE id = :playlistId")
     abstract suspend fun touch(playlistId: String, updatedAt: Long)
 
+    @Query("UPDATE playlists SET hidden = :hidden, updatedAt = :updatedAt WHERE id = :playlistId")
+    abstract suspend fun setHidden(playlistId: String, hidden: Boolean, updatedAt: Long)
+
     @Transaction
     open suspend fun createPlaylistWithTracks(
         playlist: PlaylistEntity,

--- a/app/src/main/java/com/luc4n3x/levyra/data/local/PlaylistEntity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/local/PlaylistEntity.kt
@@ -1,5 +1,6 @@
 package com.luc4n3x.levyra.data.local
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
@@ -12,7 +13,8 @@ data class PlaylistEntity(
     val name: String,
     val coverUrl: String,
     val createdAt: Long,
-    val updatedAt: Long
+    val updatedAt: Long,
+    @ColumnInfo(defaultValue = "0") val hidden: Boolean = false
 )
 
 @Entity(

--- a/app/src/main/java/com/luc4n3x/levyra/data/local/PlaylistTagEntity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/local/PlaylistTagEntity.kt
@@ -1,0 +1,97 @@
+package com.luc4n3x.levyra.data.local
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.Transaction
+
+@Entity(
+    tableName = "playlist_tags",
+    indices = [Index(value = ["normalizedName"], unique = true)]
+)
+data class PlaylistTagEntity(
+    @PrimaryKey val id: String,
+    val name: String,
+    val normalizedName: String,
+    val createdAt: Long
+)
+
+@Entity(
+    tableName = "playlist_tag_links",
+    primaryKeys = ["playlistId", "tagId"],
+    foreignKeys = [
+        ForeignKey(
+            entity = PlaylistEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["playlistId"],
+            onDelete = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = PlaylistTagEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["tagId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("playlistId"), Index("tagId")]
+)
+data class PlaylistTagLinkEntity(
+    val playlistId: String,
+    val tagId: String,
+    val assignedAt: Long
+)
+
+@Dao
+abstract class PlaylistTagsDao {
+
+    @Query("SELECT * FROM playlist_tags ORDER BY name COLLATE NOCASE ASC")
+    abstract suspend fun allTags(): List<PlaylistTagEntity>
+
+    @Query("SELECT * FROM playlist_tags WHERE normalizedName = :normalizedName LIMIT 1")
+    abstract suspend fun tagByNormalizedName(normalizedName: String): PlaylistTagEntity?
+
+    @Query("SELECT * FROM playlist_tag_links")
+    abstract suspend fun allLinks(): List<PlaylistTagLinkEntity>
+
+    @Query("SELECT tagId FROM playlist_tag_links WHERE playlistId = :playlistId")
+    abstract suspend fun tagIdsOf(playlistId: String): List<String>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun upsertTag(tag: PlaylistTagEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun upsertTags(tags: List<PlaylistTagEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun upsertLinks(links: List<PlaylistTagLinkEntity>)
+
+    @Query("DELETE FROM playlist_tags WHERE id = :tagId")
+    abstract suspend fun deleteTag(tagId: String)
+
+    @Query("DELETE FROM playlist_tag_links WHERE playlistId = :playlistId")
+    abstract suspend fun clearLinksOf(playlistId: String)
+
+    @Query("DELETE FROM playlist_tags")
+    abstract suspend fun clearTags()
+
+    @Query("UPDATE playlist_tags SET name = :name, normalizedName = :normalizedName WHERE id = :tagId")
+    abstract suspend fun renameTag(tagId: String, name: String, normalizedName: String)
+
+    @Transaction
+    open suspend fun replaceLinksOf(playlistId: String, links: List<PlaylistTagLinkEntity>) {
+        clearLinksOf(playlistId)
+        if (links.isNotEmpty()) upsertLinks(links)
+    }
+
+    @Transaction
+    open suspend fun replaceAll(tags: List<PlaylistTagEntity>, links: List<PlaylistTagLinkEntity>) {
+        clearTags()
+        if (tags.isNotEmpty()) upsertTags(tags)
+        if (links.isNotEmpty()) upsertLinks(links)
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/domain/ArtistExclusions.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/ArtistExclusions.kt
@@ -1,0 +1,118 @@
+package com.luc4n3x.levyra.domain
+
+private val EXCLUSION_ARTIST_SEPARATOR =
+    Regex("""(?i)\s+(?:feat(?:uring)?\.?|ft\.?|with|con|vs\.?|&|and|e|y|et|und)\s+|,\s*|;\s*|\s+[x×/]\s+""")
+
+data class ExcludedArtist(
+    val browseId: String,
+    val name: String,
+    val excludedAt: Long
+) {
+    val key: String
+        get() = excludedArtistKeyOf(browseId, name)
+}
+
+data class ArtistExclusions(
+    val browseIds: Set<String> = emptySet(),
+    val nameKeys: Set<String> = emptySet()
+) {
+    val isEmpty: Boolean get() = browseIds.isEmpty() && nameKeys.isEmpty()
+
+    fun excludesBrowseId(browseId: String): Boolean {
+        if (browseIds.isEmpty()) return false
+        val clean = browseId.trim()
+        return clean.isNotEmpty() && clean in browseIds
+    }
+
+    fun excludesArtistName(artist: String): Boolean {
+        if (nameKeys.isEmpty()) return false
+        val clean = artist.trim()
+        if (clean.isEmpty()) return false
+        if (artistIdentityKeys(clean).any(nameKeys::contains)) return true
+        return EXCLUSION_ARTIST_SEPARATOR.split(clean).any { segment ->
+            val part = segment.trim()
+            part.isNotEmpty() && artistIdentityKeys(part).any(nameKeys::contains)
+        }
+    }
+
+    fun excludesTrack(track: Track): Boolean {
+        if (isEmpty) return false
+        if (track.artistBrowseIds.any(::excludesBrowseId)) return true
+        return excludesArtistName(track.artist)
+    }
+
+    fun excludesArtistHit(artist: ArtistHit): Boolean {
+        if (isEmpty) return false
+        return excludesBrowseId(artist.browseId) || excludesArtistName(artist.name)
+    }
+
+    fun filterTracks(tracks: List<Track>): List<Track> {
+        if (isEmpty) return tracks
+        return keepSourceWhenUnchanged(tracks, tracks.filterNot(::excludesTrack))
+    }
+
+    fun filterArtistHits(artists: List<ArtistHit>): List<ArtistHit> {
+        if (isEmpty) return artists
+        return keepSourceWhenUnchanged(artists, artists.filterNot(::excludesArtistHit))
+    }
+
+    fun filterReleaseRadar(entries: List<ReleaseRadarEntry>): List<ReleaseRadarEntry> {
+        if (isEmpty) return entries
+        val kept = entries.filterNot { entry ->
+            excludesBrowseId(entry.artistBrowseId) || excludesArtistName(entry.artistName)
+        }
+        return keepSourceWhenUnchanged(entries, kept)
+    }
+
+    fun filterHomeSections(sections: List<HomeSection>): List<HomeSection> {
+        if (isEmpty) return sections
+        var changed = false
+        val kept = sections.mapNotNull { section ->
+            val keptTracks = filterTracks(section.tracks)
+            when {
+                keptTracks.size == section.tracks.size -> section
+                keptTracks.isEmpty() -> {
+                    changed = true
+                    null
+                }
+                else -> {
+                    changed = true
+                    section.copy(tracks = keptTracks)
+                }
+            }
+        }
+        return if (changed) kept else sections
+    }
+
+    fun filterAlbumHits(albums: List<AlbumHit>): List<AlbumHit> {
+        if (isEmpty) return albums
+        val kept = albums.filterNot { album ->
+            excludesBrowseId(album.artistBrowseId) || excludesArtistName(album.artist)
+        }
+        return keepSourceWhenUnchanged(albums, kept)
+    }
+
+    companion object {
+        val Empty = ArtistExclusions()
+
+        fun from(excluded: Collection<ExcludedArtist>): ArtistExclusions {
+            if (excluded.isEmpty()) return Empty
+            val browseIds = HashSet<String>(excluded.size)
+            val nameKeys = HashSet<String>(excluded.size * 2)
+            excluded.forEach { artist ->
+                artist.browseId.trim().takeIf(String::isNotEmpty)?.let(browseIds::add)
+                nameKeys += artistIdentityKeys(artist.name)
+            }
+            return ArtistExclusions(browseIds = browseIds, nameKeys = nameKeys)
+        }
+    }
+}
+
+private fun <T> keepSourceWhenUnchanged(source: List<T>, filtered: List<T>): List<T> =
+    if (filtered.size == source.size) source else filtered
+
+fun excludedArtistKeyOf(browseId: String, name: String): String =
+    browseId.trim().ifBlank { "name:${artistIdentityKey(name)}" }
+
+fun isExcludableArtist(browseId: String, name: String): Boolean =
+    browseId.trim().isNotEmpty() || artistIdentityKey(name).length >= 2

--- a/app/src/main/java/com/luc4n3x/levyra/domain/ForgottenFavorites.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/ForgottenFavorites.kt
@@ -1,0 +1,51 @@
+package com.luc4n3x.levyra.domain
+
+import java.util.concurrent.TimeUnit
+
+object ForgottenFavorites {
+    const val DEFAULT_THRESHOLD_DAYS = 30L
+    const val DISPLAY_LIMIT = 20
+
+    fun select(
+        favorites: List<Track>,
+        lastPlayedByKey: Map<String, Long>,
+        nowMs: Long = System.currentTimeMillis(),
+        thresholdDays: Long = DEFAULT_THRESHOLD_DAYS,
+        limit: Int = DISPLAY_LIMIT
+    ): List<Track> {
+        if (favorites.isEmpty() || lastPlayedByKey.isEmpty() || limit <= 0) return emptyList()
+        val cutoff = nowMs - TimeUnit.DAYS.toMillis(thresholdDays.coerceAtLeast(1L))
+        if (cutoff <= 0L) return emptyList()
+
+        val seen = HashSet<String>(favorites.size)
+        val candidates = ArrayList<Candidate>()
+        favorites.forEach { track ->
+            if (!isPlayableFavorite(track)) return@forEach
+            val key = ListenIdentity.trackKey(track.id, track.title, track.artist)
+            if (key.isEmpty() || !seen.add(key)) return@forEach
+            val lastPlayedAt = lastPlayedByKey[key] ?: return@forEach
+            if (lastPlayedAt !in 1..cutoff) return@forEach
+            candidates += Candidate(track, lastPlayedAt)
+        }
+        if (candidates.isEmpty()) return emptyList()
+
+        candidates.sortWith(
+            compareBy<Candidate> { it.lastPlayedAt }
+                .thenBy { it.track.title.lowercase() }
+        )
+        return candidates.take(limit).map { it.track }
+    }
+
+    fun listeningKeys(favorites: List<Track>): List<String> =
+        favorites.asSequence()
+            .filter(::isPlayableFavorite)
+            .map { ListenIdentity.trackKey(it.id, it.title, it.artist) }
+            .filter(String::isNotEmpty)
+            .distinct()
+            .toList()
+
+    private fun isPlayableFavorite(track: Track): Boolean =
+        track.title.isNotBlank() && (track.id.isNotBlank() || track.videoUrl.isNotBlank())
+
+    private data class Candidate(val track: Track, val lastPlayedAt: Long)
+}

--- a/app/src/main/java/com/luc4n3x/levyra/domain/LevyraAmbientSettings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/LevyraAmbientSettings.kt
@@ -1,0 +1,49 @@
+package com.luc4n3x.levyra.domain
+
+data class LevyraAmbientSettings(
+    val brightness: Float = 0.35f,
+    val autoDim: Boolean = true,
+    val autoDimAfterSeconds: Int = 20,
+    val pixelShift: Boolean = true,
+    val proximityBlackout: Boolean = false,
+    val showLyrics: Boolean = true,
+    val showCanvas: Boolean = true
+) {
+    fun normalized(): LevyraAmbientSettings = copy(
+        brightness = brightness.coerceIn(MIN_BRIGHTNESS, MAX_BRIGHTNESS),
+        autoDimAfterSeconds = autoDimAfterSeconds.coerceIn(MIN_AUTO_DIM_SECONDS, MAX_AUTO_DIM_SECONDS)
+    )
+
+    val autoDimAfterMs: Long
+        get() = autoDimAfterSeconds.coerceIn(MIN_AUTO_DIM_SECONDS, MAX_AUTO_DIM_SECONDS) * 1_000L
+
+    companion object {
+        const val MIN_BRIGHTNESS = 0.05f
+        const val MAX_BRIGHTNESS = 1f
+        const val MIN_AUTO_DIM_SECONDS = 5
+        const val MAX_AUTO_DIM_SECONDS = 120
+        const val DIMMED_CONTENT_ALPHA = 0.45f
+        const val PIXEL_SHIFT_RANGE_DP = 10f
+        const val PIXEL_SHIFT_INTERVAL_MS = 60_000L
+        const val CONTROLS_VISIBLE_MS = 6_000L
+    }
+}
+
+fun ambientPixelShiftOffset(
+    stepIndex: Int,
+    rangeDp: Float = LevyraAmbientSettings.PIXEL_SHIFT_RANGE_DP
+): Pair<Float, Float> {
+    if (rangeDp <= 0f) return 0f to 0f
+    val step = if (stepIndex < 0) 0 else stepIndex
+    val pattern = PIXEL_SHIFT_PATTERN[step % PIXEL_SHIFT_PATTERN.size]
+    return pattern.first * rangeDp to pattern.second * rangeDp
+}
+
+private val PIXEL_SHIFT_PATTERN = arrayOf(
+    0f to 0f,
+    1f to -0.6f,
+    0.4f to 1f,
+    -0.7f to 0.5f,
+    -1f to -0.4f,
+    0.2f to -1f
+)

--- a/app/src/main/java/com/luc4n3x/levyra/domain/Models.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/Models.kt
@@ -482,7 +482,9 @@ data class Playlist(
     val coverUrl: String,
     val tracks: List<Track>,
     val createdAt: Long,
-    val updatedAt: Long
+    val updatedAt: Long,
+    val tags: List<PlaylistTag> = emptyList(),
+    val hidden: Boolean = false
 ) {
     val size: Int get() = tracks.size
 }

--- a/app/src/main/java/com/luc4n3x/levyra/domain/PlaylistOrganization.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/PlaylistOrganization.kt
@@ -1,0 +1,57 @@
+package com.luc4n3x.levyra.domain
+
+import java.text.Normalizer
+import java.util.Locale
+
+private val TAG_COMBINING_MARKS = Regex("""\p{M}+""")
+private val TAG_WHITESPACE = Regex("""\s+""")
+
+const val PLAYLIST_TAG_MAX_LENGTH = 24
+const val PLAYLIST_TAG_MAX_PER_PLAYLIST = 8
+
+data class PlaylistTag(
+    val id: String,
+    val name: String,
+    val normalizedName: String,
+    val createdAt: Long
+)
+
+fun sanitizePlaylistTagName(value: String): String =
+    value.replace(TAG_WHITESPACE, " ").trim().take(PLAYLIST_TAG_MAX_LENGTH)
+
+fun normalizePlaylistTagName(value: String): String {
+    val sanitized = sanitizePlaylistTagName(value)
+    if (sanitized.isEmpty()) return ""
+    return Normalizer.normalize(sanitized, Normalizer.Form.NFKD)
+        .replace(TAG_COMBINING_MARKS, "")
+        .lowercase(Locale.ROOT)
+        .replace(TAG_WHITESPACE, " ")
+        .trim()
+}
+
+fun isValidPlaylistTagName(value: String): Boolean = normalizePlaylistTagName(value).isNotEmpty()
+
+fun List<Playlist>.visibleInLibrary(): List<Playlist> = filterNot { it.hidden }
+
+fun List<Playlist>.hiddenInLibrary(): List<Playlist> = filter { it.hidden }
+
+fun List<Playlist>.filterByTagIds(selectedTagIds: Set<String>): List<Playlist> {
+    if (selectedTagIds.isEmpty()) return this
+    return filter { playlist ->
+        val owned = playlist.tags.mapTo(hashSetOf()) { it.id }
+        selectedTagIds.all { it in owned }
+    }
+}
+
+fun playlistTagsInUse(playlists: List<Playlist>): List<PlaylistTag> =
+    playlists.asSequence()
+        .flatMap { it.tags.asSequence() }
+        .distinctBy { it.id }
+        .sortedBy { it.normalizedName }
+        .toList()
+
+fun mergePlaylistTagSelection(current: List<PlaylistTag>, tag: PlaylistTag): List<PlaylistTag> {
+    if (current.any { it.id == tag.id }) return current.filterNot { it.id == tag.id }
+    if (current.size >= PLAYLIST_TAG_MAX_PER_PLAYLIST) return current
+    return (current + tag).sortedBy { it.normalizedName }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/feature/ambient/AmbientSessionPresenter.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/ambient/AmbientSessionPresenter.kt
@@ -137,9 +137,12 @@ internal class AmbientSessionPresenter(
         val artist = metadata?.artist?.toString().orEmpty()
 
         if (mediaId != lyricsMediaId) {
-            lyricsMediaId = mediaId
+            lyricsMediaId = ""
             lyricLines = emptyList()
-            loadLyrics(mediaId, title, artist, durationMs)
+            if (title.isNotBlank()) {
+                lyricsMediaId = mediaId
+                loadLyrics(mediaId, title, artist, durationMs)
+            }
         }
 
         _state.value = _state.value.copy(

--- a/app/src/main/java/com/luc4n3x/levyra/feature/ambient/AmbientSessionPresenter.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/ambient/AmbientSessionPresenter.kt
@@ -1,0 +1,193 @@
+package com.luc4n3x.levyra.feature.ambient
+
+import android.content.ComponentName
+import android.content.Context
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Player
+import androidx.media3.session.MediaController
+import androidx.media3.session.SessionToken
+import com.luc4n3x.levyra.data.LevyraPreferences
+import com.luc4n3x.levyra.data.LyricsRepository
+import com.luc4n3x.levyra.domain.LyricLine
+import com.luc4n3x.levyra.player.PlaybackService
+import com.luc4n3x.levyra.ui.ambient.AmbientUiState
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+internal class AmbientSessionPresenter(
+    context: Context,
+    private val scope: CoroutineScope
+) {
+    private val appContext = context.applicationContext
+    private val preferences = LevyraPreferences(appContext)
+    private val lyricsRepository by lazy { LyricsRepository(appContext) }
+
+    private val _state = MutableStateFlow(AmbientUiState())
+    val state: StateFlow<AmbientUiState> = _state.asStateFlow()
+
+    private var controller: MediaController? = null
+    private var connectJob: Job? = null
+    private var tickJob: Job? = null
+    private var lyricsJob: Job? = null
+    private var lyricsMediaId: String = ""
+    private var lyricLines: List<LyricLine> = emptyList()
+
+    private val listener = object : Player.Listener {
+        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) = publish()
+
+        override fun onIsPlayingChanged(isPlaying: Boolean) {
+            publish()
+            restartTicker()
+        }
+
+        override fun onPlaybackStateChanged(playbackState: Int) = publish()
+
+        override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) = publish()
+    }
+
+    fun connect() {
+        if (controller != null || connectJob?.isActive == true) return
+        _state.value = _state.value.copy(settings = preferences.ambientSettings())
+        val token = SessionToken(appContext, ComponentName(appContext, PlaybackService::class.java))
+        val future = MediaController.Builder(appContext, token).buildAsync()
+        connectJob = scope.launch {
+            val connected = try {
+                withContext(Dispatchers.IO) { future.get(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS) }
+            } catch (cancelled: CancellationException) {
+                MediaController.releaseFuture(future)
+                throw cancelled
+            } catch (error: Exception) {
+                MediaController.releaseFuture(future)
+                Timber.w(error, "Ambient could not attach to the playback session")
+                null
+            }
+            if (connected == null) return@launch
+            if (!isActive) {
+                connected.release()
+                return@launch
+            }
+            controller = connected
+            connected.addListener(listener)
+            publish()
+            restartTicker()
+        }
+    }
+
+    fun release() {
+        connectJob?.cancel()
+        connectJob = null
+        tickJob?.cancel()
+        tickJob = null
+        lyricsJob?.cancel()
+        lyricsJob = null
+        lyricLines = emptyList()
+        lyricsMediaId = ""
+        controller?.removeListener(listener)
+        controller?.release()
+        controller = null
+    }
+
+    fun togglePlay() {
+        val active = controller ?: return
+        if (active.isPlaying) active.pause() else active.play()
+    }
+
+    fun next() {
+        controller?.takeIf { it.hasNextMediaItem() }?.seekToNextMediaItem()
+    }
+
+    fun previous() {
+        controller?.seekToPreviousMediaItem()
+    }
+
+    private fun restartTicker() {
+        tickJob?.cancel()
+        val active = controller ?: return
+        if (!active.isPlaying) return
+        tickJob = scope.launch {
+            while (isActive) {
+                delay(POSITION_TICK_MS)
+                publish()
+            }
+        }
+    }
+
+    private fun publish() {
+        val active = controller
+        val metadata = active?.mediaMetadata
+        val mediaId = active?.currentMediaItem?.mediaId.orEmpty()
+        val hasTrack = active != null && active.mediaItemCount > 0
+        val positionMs = active?.currentPosition?.coerceAtLeast(0L) ?: 0L
+        val durationMs = active?.duration?.takeIf { it > 0L } ?: 0L
+        val title = metadata?.title?.toString().orEmpty()
+        val artist = metadata?.artist?.toString().orEmpty()
+
+        if (mediaId != lyricsMediaId) {
+            lyricsMediaId = mediaId
+            lyricLines = emptyList()
+            loadLyrics(mediaId, title, artist, durationMs)
+        }
+
+        _state.value = _state.value.copy(
+            hasTrack = hasTrack,
+            title = title,
+            artist = artist,
+            artworkUrl = metadata?.artworkUri?.toString().orEmpty(),
+            isPlaying = active?.isPlaying == true,
+            positionMs = positionMs,
+            durationMs = durationMs,
+            lyricLine = currentLyricLine(positionMs)
+        )
+    }
+
+    private fun currentLyricLine(positionMs: Long): String {
+        if (lyricLines.isEmpty()) return ""
+        val line = lyricLines.lastOrNull { it.startMs <= positionMs } ?: return ""
+        if (line.endMs > 0L && positionMs > line.endMs + LYRIC_HOLD_MS) return ""
+        return line.text
+    }
+
+    private fun loadLyrics(mediaId: String, title: String, artist: String, durationMs: Long) {
+        lyricsJob?.cancel()
+        if (!_state.value.settings.showLyrics || title.isBlank()) return
+        lyricsJob = scope.launch {
+            val result = try {
+                withContext(Dispatchers.IO) {
+                    lyricsRepository.fetch(
+                        title = title,
+                        artist = artist,
+                        durationSec = TimeUnit.MILLISECONDS.toSeconds(durationMs.coerceAtLeast(0L)),
+                        videoId = mediaId,
+                        languageCode = preferences.languageCode()
+                    )
+                }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Exception) {
+                Timber.w(error, "Ambient lyrics lookup failed")
+                null
+            }
+            if (mediaId != lyricsMediaId) return@launch
+            lyricLines = result?.takeIf { it.synced }?.lines.orEmpty()
+            publish()
+        }
+    }
+
+    private companion object {
+        const val CONNECT_TIMEOUT_SECONDS = 5L
+        const val POSITION_TICK_MS = 1_000L
+        const val LYRIC_HOLD_MS = 4_000L
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/feature/ambient/AmbientSessionPresenter.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/ambient/AmbientSessionPresenter.kt
@@ -60,8 +60,10 @@ internal class AmbientSessionPresenter(
     fun connect() {
         if (controller != null || connectJob?.isActive == true) return
         _state.value = _state.value.copy(settings = preferences.ambientSettings())
-        val token = SessionToken(appContext, ComponentName(appContext, PlaybackService::class.java))
-        val future = MediaController.Builder(appContext, token).buildAsync()
+        val future = MediaController.Builder(
+            appContext,
+            SessionToken(appContext, ComponentName(appContext, PlaybackService::class.java))
+        ).buildAsync()
         connectJob = scope.launch {
             val connected = try {
                 withContext(Dispatchers.IO) { future.get(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS) }

--- a/app/src/main/java/com/luc4n3x/levyra/feature/ambient/LevyraAmbientDreamService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/ambient/LevyraAmbientDreamService.kt
@@ -1,0 +1,113 @@
+package com.luc4n3x.levyra.feature.ambient
+
+import android.os.Bundle
+import android.service.dreams.DreamService
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeViewModelStoreOwner
+import androidx.savedstate.SavedStateRegistry
+import androidx.savedstate.SavedStateRegistryController
+import androidx.savedstate.SavedStateRegistryOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import com.luc4n3x.levyra.data.LevyraPreferences
+import com.luc4n3x.levyra.ui.ambient.AmbientScreen
+import com.luc4n3x.levyra.ui.i18n.LevyraStrings
+import com.luc4n3x.levyra.ui.i18n.LocalLevyraStrings
+import com.luc4n3x.levyra.ui.theme.LevyraTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
+class LevyraAmbientDreamService :
+    DreamService(),
+    LifecycleOwner,
+    ViewModelStoreOwner,
+    SavedStateRegistryOwner {
+
+    private val lifecycleRegistry = LifecycleRegistry(this)
+    private val savedStateRegistryController = SavedStateRegistryController.create(this)
+    private val store = ViewModelStore()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var presenter: AmbientSessionPresenter? = null
+
+    override val lifecycle: Lifecycle get() = lifecycleRegistry
+    override val viewModelStore: ViewModelStore get() = store
+    override val savedStateRegistry: SavedStateRegistry
+        get() = savedStateRegistryController.savedStateRegistry
+
+    override fun onCreate() {
+        super.onCreate()
+        savedStateRegistryController.performAttach()
+        savedStateRegistryController.performRestore(Bundle())
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        isInteractive = true
+        isFullscreen = true
+        isScreenBright = false
+
+        val sessionPresenter = AmbientSessionPresenter(this, scope)
+        presenter = sessionPresenter
+        sessionPresenter.connect()
+
+        val strings = LevyraStrings.forCode(LevyraPreferences(this).snapshot().languageCode)
+        val composeView = ComposeView(this).apply {
+            setViewTreeLifecycleOwner(this@LevyraAmbientDreamService)
+            setViewTreeViewModelStoreOwner(this@LevyraAmbientDreamService)
+            setViewTreeSavedStateRegistryOwner(this@LevyraAmbientDreamService)
+            setContent {
+                val state by sessionPresenter.state.collectAsStateWithLifecycle()
+                LevyraTheme {
+                    CompositionLocalProvider(LocalLevyraStrings provides strings) {
+                        AmbientScreen(
+                            state = state,
+                            onTogglePlay = sessionPresenter::togglePlay,
+                            onNext = sessionPresenter::next,
+                            onPrevious = sessionPresenter::previous,
+                            onExit = null
+                        )
+                    }
+                }
+            }
+        }
+        setContentView(composeView)
+    }
+
+    override fun onDreamingStarted() {
+        super.onDreamingStarted()
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+    }
+
+    override fun onDreamingStopped() {
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        super.onDreamingStopped()
+    }
+
+    override fun onDetachedFromWindow() {
+        presenter?.release()
+        presenter = null
+        super.onDetachedFromWindow()
+    }
+
+    override fun onDestroy() {
+        if (lifecycleRegistry.currentState.isAtLeast(Lifecycle.State.CREATED)) {
+            lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        }
+        store.clear()
+        scope.cancel()
+        super.onDestroy()
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/feature/ambient/LevyraAmbientTileService.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/ambient/LevyraAmbientTileService.kt
@@ -1,0 +1,60 @@
+package com.luc4n3x.levyra.feature.ambient
+
+import android.app.PendingIntent
+import android.content.Intent
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import androidx.core.service.quicksettings.PendingIntentActivityWrapper
+import androidx.core.service.quicksettings.TileServiceCompat
+import com.luc4n3x.levyra.LevyraLaunchActions
+import com.luc4n3x.levyra.MainActivity
+import com.luc4n3x.levyra.data.LevyraPreferences
+import com.luc4n3x.levyra.ui.i18n.LevyraStrings
+
+class LevyraAmbientTileService : TileService() {
+
+    override fun onStartListening() {
+        super.onStartListening()
+        renderTile()
+    }
+
+    override fun onTileAdded() {
+        super.onTileAdded()
+        renderTile()
+    }
+
+    override fun onClick() {
+        super.onClick()
+        TileServiceCompat.startActivityAndCollapse(
+            this,
+            PendingIntentActivityWrapper(
+                this,
+                REQUEST_TILE_LAUNCH,
+                ambientIntent(),
+                PendingIntent.FLAG_UPDATE_CURRENT,
+                false
+            )
+        )
+    }
+
+    private fun ambientIntent(): Intent = Intent(this, MainActivity::class.java).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        putExtra(LevyraLaunchActions.EXTRA_SHORTCUT, LevyraLaunchActions.SHORTCUT_AMBIENT)
+    }
+
+    private fun renderTile() {
+        val tile = qsTile ?: return
+        val strings = LevyraStrings.forCode(LevyraPreferences(this).snapshot().languageCode)
+        tile.label = strings.ambientMode
+        tile.state = Tile.STATE_INACTIVE
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            tile.stateDescription = strings.ambientModeSubtitle
+        }
+        tile.updateTile()
+    }
+
+    private companion object {
+        const val REQUEST_TILE_LAUNCH = 5421
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -196,7 +196,10 @@ import androidx.compose.material.icons.rounded.Speed
 import androidx.compose.material.icons.rounded.Vibration
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.Mic
+import androidx.compose.material.icons.rounded.DoNotDisturbOn
+import androidx.compose.material.icons.rounded.Recommend
 import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.material.icons.rounded.Nightlight
 import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.icons.rounded.PersonAdd
 import androidx.compose.material.icons.rounded.Check
@@ -471,6 +474,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.luc4n3x.levyra.ui.theme.glassmorphism
 import com.luc4n3x.levyra.ui.i18n.LocalLevyraStrings
 import com.luc4n3x.levyra.ui.i18n.localizedAudioPresetLabel
+import com.luc4n3x.levyra.ui.ambient.LevyraAmbientOverlay
 import com.luc4n3x.levyra.ui.library.LevyraLibraryScreen
 import com.luc4n3x.levyra.ui.library.LevyraPlaylistDetailScreen
 import com.luc4n3x.levyra.ui.library.SavedAlbumBookmarkOverlay
@@ -491,6 +495,8 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
+import com.luc4n3x.levyra.domain.ExcludedArtist
+import com.luc4n3x.levyra.domain.LevyraAmbientSettings
 import com.luc4n3x.levyra.domain.LevyraInterfaceSettings
 import com.luc4n3x.levyra.ui.player.PlayerDragEvent
 import com.luc4n3x.levyra.ui.player.PlayerGestureZone
@@ -1258,6 +1264,7 @@ fun LevyraApp(
                 viewModel.selectTab(LevyraTab.Search)
                 viewModel.startMusicRecognition()
             }
+            LevyraLaunchActions.SHORTCUT_AMBIENT -> viewModel.openAmbient()
         }
         if (pendingShortcut != null) LevyraLaunchActions.pendingShortcut.value = null
     }
@@ -1694,6 +1701,8 @@ fun LevyraApp(
                     currentLanguageCode = state.languageCode,
                     themePreset = state.themePreset,
                     interfaceSettings = state.interfaceSettings,
+                    ambientSettings = state.ambientSettings,
+                    excludedArtists = state.excludedArtists,
                     downloadSettings = state.downloadSettings,
                     backupSettings = state.backupSettings,
                     vaultStatus = state.vaultStatus,
@@ -1718,6 +1727,12 @@ fun LevyraApp(
                     },
                     onThemePreset = viewModel::setThemePreset,
                     onInterfaceSettings = viewModel::setInterfaceSettings,
+                    onAmbientSettings = viewModel::updateAmbientSettings,
+                    onOpenAmbient = {
+                        viewModel.closeSettings()
+                        viewModel.openAmbient()
+                    },
+                    onIncludeArtist = viewModel::includeArtist,
                     onDownloadSettings = viewModel::setDownloadSettings,
                     onBackupSettings = viewModel::setBackupSettings,
                     onAnimations = viewModel::setAnimationsEnabled,
@@ -1883,6 +1898,7 @@ fun LevyraApp(
                     onPlay = viewModel::playArtistSong,
                     onPlayAll = { tracks -> viewModel.playAll(tracks) },
                     onToggleFollow = viewModel::toggleFollowArtist,
+                    onToggleExclude = { browseId, name -> viewModel.toggleExcludeArtist(browseId, name) },
                     onOpenArtist = viewModel::openArtistFromHit,
                     onOpenRelease = viewModel::openArtistRelease,
                     onClose = viewModel::closeArtist
@@ -1891,6 +1907,15 @@ fun LevyraApp(
 
             AnimatedVisibility(visible = state.openPlaylist != null, enter = overlayEnter, exit = overlayExit) {
                 LevyraPlaylistDetailScreen(viewModel = viewModel, state = state)
+            }
+
+            AnimatedVisibility(
+                visible = state.showAmbient,
+                modifier = Modifier.zIndex(50f),
+                enter = fadeIn(tween(320)),
+                exit = fadeOut(tween(240))
+            ) {
+                LevyraAmbientOverlay(state = state, viewModel = viewModel)
             }
 
             AnimatedVisibility(visible = showDownloadsFolder, enter = overlayEnter, exit = overlayExit) {
@@ -3299,6 +3324,7 @@ private fun ArtistOverlay(
     onPlay: (Track) -> Unit,
     onPlayAll: (List<Track>) -> Unit,
     onToggleFollow: () -> Unit,
+    onToggleExclude: (String, String) -> Unit,
     onOpenArtist: (ArtistHit) -> Unit,
     onOpenRelease: (ArtistRelease, String) -> Unit,
     onClose: () -> Unit
@@ -3308,6 +3334,9 @@ private fun ArtistOverlay(
         (profile.browseId.isNotBlank() && profile.browseId in state.followedArtistKeys) ||
             profile.name.trim().lowercase() in state.followedArtistKeys
         )
+    val isExcluded = profile != null && state.artistExclusions.let { exclusions ->
+        exclusions.excludesBrowseId(profile.browseId) || exclusions.excludesArtistName(profile.name)
+    }
     val accentStart = profile?.let { Color(it.accentStart) } ?: LevyraCyan
     val accentEnd = profile?.let { Color(it.accentEnd) } ?: LevyraViolet
     val strings = LocalLevyraStrings.current
@@ -3383,7 +3412,9 @@ private fun ArtistOverlay(
                                 onShuffle = artist.topSongs
                                     .takeIf { it.size > 1 }
                                     ?.let { songs -> { onPlayAll(songs.shuffled()) } },
-                                onToggleFollow = onToggleFollow
+                                onToggleFollow = onToggleFollow,
+                                isExcluded = isExcluded,
+                                onToggleExclude = { onToggleExclude(artist.browseId, artist.name) }
                             )
                             if (artist.hasBio) {
                                 ArtistBio(
@@ -3847,9 +3878,12 @@ private fun ArtistActionBar(
     isFollowed: Boolean,
     onPlay: (() -> Unit)?,
     onShuffle: (() -> Unit)?,
-    onToggleFollow: () -> Unit
+    onToggleFollow: () -> Unit,
+    isExcluded: Boolean,
+    onToggleExclude: () -> Unit
 ) {
     val strings = LocalLevyraStrings.current
+    var artistMenuExpanded by remember(profile.browseId, profile.name) { mutableStateOf(false) }
     val audience = remember(profile.monthlyListeners, profile.subscribers) {
         listOf(profile.monthlyListeners, profile.subscribers)
             .map(String::trim)
@@ -3880,6 +3914,40 @@ private fun ArtistActionBar(
         ) {
             ArtistFollowButton(isFollowed = isFollowed, onClick = onToggleFollow)
             Spacer(modifier = Modifier.weight(1f))
+            Box {
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(CircleShape)
+                        .pressable(onClick = { artistMenuExpanded = true }),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.MoreVert,
+                        contentDescription = strings.options,
+                        tint = Color.White.copy(alpha = 0.86f),
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+                DropdownMenu(
+                    expanded = artistMenuExpanded,
+                    onDismissRequest = { artistMenuExpanded = false }
+                ) {
+                    DropdownMenuItem(
+                        text = { Text(if (isExcluded) strings.includeArtist else strings.excludeArtist) },
+                        leadingIcon = {
+                            Icon(
+                                if (isExcluded) Icons.Rounded.Recommend else Icons.Rounded.DoNotDisturbOn,
+                                contentDescription = null
+                            )
+                        },
+                        onClick = {
+                            artistMenuExpanded = false
+                            onToggleExclude()
+                        }
+                    )
+                }
+            }
             if (onShuffle != null) {
                 Box(
                     modifier = Modifier
@@ -6128,6 +6196,7 @@ private fun HomeScreen(
     }
     val quickPicks = homeDerivedState.quickPicks
     val newReleases = homeDerivedState.newReleases
+    val forgottenFavorites = state.forgottenFavorites
     val homeAlbums = remember(
         state.homeAlbums,
         state.personalOrbitTracks,
@@ -6435,6 +6504,23 @@ private fun HomeScreen(
                             isResolving = state.isResolving,
                             onPlay = { track -> viewModel.playFrom(visiblePersonalTracks, track) },
                             onPlayAll = { viewModel.playAll(visiblePersonalTracks) },
+                            onTrackActions = onTrackActions
+                        )
+                    }
+                }
+            }
+
+            if (showDeferredHomeSections && forgottenFavorites.isNotEmpty()) {
+                item(key = "home-forgotten-favorites", contentType = HOME_DENSE_SHELF_CONTENT_TYPE) {
+                    HomeSectionLead(compactHome) {
+                        HomeQuickPicksShelf(
+                            title = strings.forgottenFavorites,
+                            tracks = forgottenFavorites,
+                            currentId = state.currentTrack?.id,
+                            isPlaying = state.isPlaying,
+                            isResolving = state.isResolving,
+                            onPlay = { track -> viewModel.playFrom(forgottenFavorites, track) },
+                            onPlayAll = { viewModel.playAll(forgottenFavorites) },
                             onTrackActions = onTrackActions
                         )
                     }
@@ -12889,7 +12975,8 @@ private fun PlayerQuickActionsBar(
                             compact = true,
                             onSpeed = viewModel::cycleSpeed,
                             onSleep = viewModel::openSleepTimer,
-                            onNormalization = viewModel::toggleAudioNormalization
+                            onNormalization = viewModel::toggleAudioNormalization,
+                            onAmbient = viewModel::openAmbient
                         )
                     }
                 }
@@ -13320,7 +13407,8 @@ private fun PlayerAdvancedControlsPanel(
                 compact = compact,
                 onSpeed = viewModel::cycleSpeed,
                 onSleep = viewModel::openSleepTimer,
-                onNormalization = viewModel::toggleAudioNormalization
+                onNormalization = viewModel::toggleAudioNormalization,
+                onAmbient = viewModel::openAmbient
             )
             PlayerInlineLyricsSection(
                 trackId = track.id,
@@ -15296,7 +15384,8 @@ private fun PlayerOptionsRow(
     compact: Boolean,
     onSpeed: () -> Unit,
     onSleep: () -> Unit,
-    onNormalization: () -> Unit
+    onNormalization: () -> Unit,
+    onAmbient: () -> Unit
 ) {
     Row(
         modifier = Modifier
@@ -15337,6 +15426,15 @@ private fun PlayerOptionsRow(
             modifier = Modifier.weight(1f),
             compact = compact,
             onClick = onSleep
+        )
+        OptionChip(
+            icon = Icons.Rounded.Nightlight,
+            label = LocalLevyraStrings.current.ambientMode,
+            active = false,
+            activeColor = secondaryColor,
+            modifier = Modifier.weight(1f),
+            compact = compact,
+            onClick = onAmbient
         )
     }
 }
@@ -16047,6 +16145,8 @@ private fun SettingsOverlay(
     currentLanguageCode: String,
     themePreset: String,
     interfaceSettings: LevyraInterfaceSettings,
+    ambientSettings: LevyraAmbientSettings,
+    excludedArtists: List<ExcludedArtist>,
     downloadSettings: LevyraDownloadSettings,
     backupSettings: LevyraBackupSettings,
     vaultStatus: LevyraVaultStatus,
@@ -16068,6 +16168,9 @@ private fun SettingsOverlay(
     onOpenJam: () -> Unit,
     onThemePreset: (String) -> Unit,
     onInterfaceSettings: (LevyraInterfaceSettings) -> Unit,
+    onAmbientSettings: (LevyraAmbientSettings) -> Unit,
+    onOpenAmbient: () -> Unit,
+    onIncludeArtist: (ExcludedArtist) -> Unit,
     onDownloadSettings: (LevyraDownloadSettings) -> Unit,
     onBackupSettings: (LevyraBackupSettings) -> Unit,
     onAnimations: (Boolean) -> Unit,
@@ -16527,6 +16630,97 @@ private fun SettingsOverlay(
                                         options = listOf("1.5" to "1.5×", "2.0" to "2×", "2.5" to "2.5×", "3.0" to "3×"),
                                         selected = String.format(Locale.US, "%.1f", interfaceSettings.longPressSpeed),
                                         onSelect = { value -> onInterfaceSettings(interfaceSettings.copy(longPressSpeed = value.toFloat())) }
+                                    )
+                                }
+                            }
+                            item { SettingsSectionLabel(strings.ambientSettingsTitle) }
+                            item {
+                                SettingsButton(
+                                    icon = Icons.Rounded.Nightlight,
+                                    title = strings.ambientOpen,
+                                    subtitle = strings.ambientModeSubtitle,
+                                    onClick = onOpenAmbient
+                                )
+                            }
+                            item {
+                                SettingsChoiceRow(
+                                    icon = Icons.Rounded.Nightlight,
+                                    title = strings.ambientBrightness,
+                                    subtitle = strings.ambientModeSubtitle,
+                                    options = listOf(
+                                        "0.10" to "10%",
+                                        "0.25" to "25%",
+                                        "0.35" to "35%",
+                                        "0.50" to "50%",
+                                        "0.75" to "75%"
+                                    ),
+                                    selected = String.format(Locale.US, "%.2f", ambientSettings.brightness),
+                                    onSelect = { value ->
+                                        onAmbientSettings(ambientSettings.copy(brightness = value.toFloat()))
+                                    }
+                                )
+                            }
+                            item {
+                                SettingsToggle(
+                                    icon = Icons.Rounded.Nightlight,
+                                    title = strings.ambientAutoDim,
+                                    subtitle = strings.ambientModeSubtitle,
+                                    checked = ambientSettings.autoDim,
+                                    onCheckedChange = { onAmbientSettings(ambientSettings.copy(autoDim = it)) }
+                                )
+                            }
+                            item {
+                                SettingsToggle(
+                                    icon = Icons.Rounded.Nightlight,
+                                    title = strings.ambientPixelShift,
+                                    subtitle = strings.ambientModeSubtitle,
+                                    checked = ambientSettings.pixelShift,
+                                    onCheckedChange = { onAmbientSettings(ambientSettings.copy(pixelShift = it)) }
+                                )
+                            }
+                            item {
+                                SettingsToggle(
+                                    icon = Icons.Rounded.Nightlight,
+                                    title = strings.ambientProximityBlackout,
+                                    subtitle = strings.ambientModeSubtitle,
+                                    checked = ambientSettings.proximityBlackout,
+                                    onCheckedChange = { onAmbientSettings(ambientSettings.copy(proximityBlackout = it)) }
+                                )
+                            }
+                            item {
+                                SettingsToggle(
+                                    icon = Icons.Rounded.Subtitles,
+                                    title = strings.ambientShowLyrics,
+                                    subtitle = strings.ambientModeSubtitle,
+                                    checked = ambientSettings.showLyrics,
+                                    onCheckedChange = { onAmbientSettings(ambientSettings.copy(showLyrics = it)) }
+                                )
+                            }
+                            item {
+                                SettingsToggle(
+                                    icon = Icons.Rounded.AutoAwesome,
+                                    title = strings.ambientShowCanvas,
+                                    subtitle = strings.ambientModeSubtitle,
+                                    checked = ambientSettings.showCanvas,
+                                    onCheckedChange = { onAmbientSettings(ambientSettings.copy(showCanvas = it)) }
+                                )
+                            }
+                            item { SettingsSectionLabel(strings.excludedArtists) }
+                            if (excludedArtists.isEmpty()) {
+                                item {
+                                    SettingsInfoCard(
+                                        icon = Icons.Rounded.DoNotDisturbOn,
+                                        title = strings.excludedArtists,
+                                        subtitle = strings.excludedArtistsEmpty
+                                    )
+                                }
+                            } else {
+                                items(excludedArtists, key = { "excluded-${it.key}" }) { artist ->
+                                    SettingsButton(
+                                        icon = Icons.Rounded.Recommend,
+                                        title = artist.name,
+                                        subtitle = strings.includeArtist,
+                                        onClick = { onIncludeArtist(artist) }
                                     )
                                 }
                             }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/ambient/AmbientHost.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/ambient/AmbientHost.kt
@@ -1,0 +1,98 @@
+package com.luc4n3x.levyra.ui.ambient
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.view.Window
+import android.view.WindowManager
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalView
+import com.luc4n3x.levyra.domain.LevyraAmbientSettings
+import com.luc4n3x.levyra.viewmodel.LevyraUiState
+import com.luc4n3x.levyra.viewmodel.LevyraViewModel
+
+@Composable
+internal fun LevyraAmbientOverlay(
+    state: LevyraUiState,
+    viewModel: LevyraViewModel,
+    modifier: Modifier = Modifier
+) {
+    val ambientState = remember(
+        state.currentTrack,
+        state.isPlaying,
+        state.positionMs,
+        state.durationMs,
+        state.activeLyric,
+        state.motionArtwork,
+        state.animationsEnabled,
+        state.motionArtworkEnabled,
+        state.interfaceSettings.canvasQuality,
+        state.ambientSettings
+    ) {
+        state.toAmbientUiState()
+    }
+
+    BackHandler(enabled = true) { viewModel.closeAmbient() }
+    AmbientWindowEffect(state.ambientSettings)
+
+    AmbientScreen(
+        state = ambientState,
+        onTogglePlay = viewModel::togglePlay,
+        onNext = viewModel::next,
+        onPrevious = viewModel::previous,
+        onExit = viewModel::closeAmbient,
+        modifier = modifier
+    )
+}
+
+internal fun LevyraUiState.toAmbientUiState(): AmbientUiState {
+    val track = currentTrack
+    return AmbientUiState(
+        hasTrack = track != null,
+        title = track?.title.orEmpty(),
+        artist = track?.artist.orEmpty(),
+        artworkUrl = track?.largeThumbnailUrl?.ifBlank { track.thumbnailUrl }.orEmpty(),
+        isPlaying = isPlaying,
+        positionMs = positionMs,
+        durationMs = durationMs,
+        lyricLine = activeLyric?.text.orEmpty(),
+        motionArtwork = motionArtwork,
+        animationsEnabled = animationsEnabled && motionArtworkEnabled,
+        canvasQuality = interfaceSettings.canvasQuality,
+        settings = ambientSettings
+    )
+}
+
+@Composable
+private fun AmbientWindowEffect(settings: LevyraAmbientSettings) {
+    val view = LocalView.current
+    val brightness = settings.normalized().brightness
+    DisposableEffect(view, brightness) {
+        val window = view.context.findActivity()?.window
+        if (window == null) {
+            onDispose { }
+        } else {
+            val previousBrightness = window.attributes.screenBrightness
+            window.applyScreenBrightness(brightness)
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            onDispose {
+                window.applyScreenBrightness(previousBrightness)
+                window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            }
+        }
+    }
+}
+
+private fun Window.applyScreenBrightness(value: Float) {
+    attributes = attributes.apply { screenBrightness = value }
+}
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}

--- a/app/src/main/java/com/luc4n3x/levyra/ui/ambient/AmbientHost.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/ambient/AmbientHost.kt
@@ -77,11 +77,15 @@ private fun AmbientWindowEffect(settings: LevyraAmbientSettings) {
             onDispose { }
         } else {
             val previousBrightness = window.attributes.screenBrightness
+            val keepScreenOnWasSet =
+                window.attributes.flags and WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON != 0
             window.applyScreenBrightness(brightness)
             window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
             onDispose {
                 window.applyScreenBrightness(previousBrightness)
-                window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                if (!keepScreenOnWasSet) {
+                    window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                }
             }
         }
     }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/ambient/AmbientScreen.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/ambient/AmbientScreen.kt
@@ -1,0 +1,382 @@
+package com.luc4n3x.levyra.ui.ambient
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.os.SystemClock
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.SkipNext
+import androidx.compose.material.icons.rounded.SkipPrevious
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import com.luc4n3x.levyra.domain.LevyraAmbientSettings
+import com.luc4n3x.levyra.domain.ambientPixelShiftOffset
+import com.luc4n3x.levyra.ui.MotionArtworkLayer
+import com.luc4n3x.levyra.ui.MotionArtworkPresentation
+import com.luc4n3x.levyra.ui.i18n.LocalLevyraStrings
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+
+@Composable
+internal fun AmbientScreen(
+    state: AmbientUiState,
+    onTogglePlay: () -> Unit,
+    onNext: () -> Unit,
+    onPrevious: () -> Unit,
+    onExit: (() -> Unit)?,
+    modifier: Modifier = Modifier
+) {
+    val strings = LocalLevyraStrings.current
+    val settings = state.settings
+    var lastInteractionAt by remember { mutableLongStateOf(SystemClock.elapsedRealtime()) }
+    var controlsVisible by remember { mutableStateOf(true) }
+    var dimmed by remember { mutableStateOf(false) }
+    var shiftStep by remember { mutableIntStateOf(0) }
+    val covered = rememberProximityCovered(settings.proximityBlackout)
+
+    LaunchedEffect(lastInteractionAt, settings.autoDim, settings.autoDimAfterSeconds) {
+        controlsVisible = true
+        dimmed = false
+        delay(LevyraAmbientSettings.CONTROLS_VISIBLE_MS)
+        controlsVisible = false
+        if (settings.autoDim) {
+            delay(settings.autoDimAfterMs)
+            dimmed = true
+        }
+    }
+
+    LaunchedEffect(settings.pixelShift) {
+        if (!settings.pixelShift) {
+            shiftStep = 0
+            return@LaunchedEffect
+        }
+        while (isActive) {
+            delay(LevyraAmbientSettings.PIXEL_SHIFT_INTERVAL_MS)
+            shiftStep++
+        }
+    }
+
+    val shift = remember(shiftStep, settings.pixelShift) {
+        if (settings.pixelShift) ambientPixelShiftOffset(shiftStep) else 0f to 0f
+    }
+    val shiftX by animateDpAsState(shift.first.dp, tween(2_000), label = "ambient-shift-x")
+    val shiftY by animateDpAsState(shift.second.dp, tween(2_000), label = "ambient-shift-y")
+    val contentAlpha by animateFloatAsState(
+        targetValue = if (dimmed) LevyraAmbientSettings.DIMMED_CONTENT_ALPHA else 1f,
+        animationSpec = tween(1_200),
+        label = "ambient-alpha"
+    )
+    val minimal = dimmed && !controlsVisible
+    val rootInteractionSource = remember { MutableInteractionSource() }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black)
+            .clickable(
+                interactionSource = rootInteractionSource,
+                indication = null
+            ) { lastInteractionAt = SystemClock.elapsedRealtime() }
+    ) {
+        if (covered) return@Box
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .systemBarsPadding()
+                .padding(horizontal = 32.dp, vertical = 24.dp)
+                .offset(x = shiftX, y = shiftY)
+                .alpha(contentAlpha),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            if (!state.hasTrack) {
+                Text(
+                    text = strings.ambientNothingPlaying,
+                    color = AmbientMuted,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium
+                )
+            } else {
+                AmbientArtwork(state = state, minimal = minimal)
+                Spacer(modifier = Modifier.height(if (minimal) 18.dp else 28.dp))
+                Text(
+                    text = state.title,
+                    color = AmbientText,
+                    fontSize = if (minimal) 18.sp else 22.sp,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Center,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (state.artist.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text(
+                        text = state.artist,
+                        color = AmbientMuted,
+                        fontSize = if (minimal) 13.sp else 15.sp,
+                        fontWeight = FontWeight.Medium,
+                        textAlign = TextAlign.Center,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                if (settings.showLyrics && state.lyricLine.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(20.dp))
+                    Text(
+                        text = state.lyricLine,
+                        color = AmbientLyric,
+                        fontSize = if (minimal) 15.sp else 18.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        textAlign = TextAlign.Center,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                AnimatedVisibility(
+                    visible = !minimal,
+                    enter = fadeIn(tween(400)),
+                    exit = fadeOut(tween(600))
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Spacer(modifier = Modifier.height(24.dp))
+                        AmbientProgress(positionMs = state.positionMs, durationMs = state.durationMs)
+                    }
+                }
+                AnimatedVisibility(
+                    visible = controlsVisible,
+                    enter = fadeIn(tween(220)),
+                    exit = fadeOut(tween(600))
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Spacer(modifier = Modifier.height(28.dp))
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(20.dp)
+                        ) {
+                            AmbientIconButton(
+                                icon = Icons.Rounded.SkipPrevious,
+                                contentDescription = strings.previous,
+                                size = 30.dp,
+                                onClick = {
+                                    lastInteractionAt = SystemClock.elapsedRealtime()
+                                    onPrevious()
+                                }
+                            )
+                            AmbientIconButton(
+                                icon = if (state.isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+                                contentDescription = if (state.isPlaying) strings.pause else strings.play,
+                                size = 42.dp,
+                                onClick = {
+                                    lastInteractionAt = SystemClock.elapsedRealtime()
+                                    onTogglePlay()
+                                }
+                            )
+                            AmbientIconButton(
+                                icon = Icons.Rounded.SkipNext,
+                                contentDescription = strings.next,
+                                size = 30.dp,
+                                onClick = {
+                                    lastInteractionAt = SystemClock.elapsedRealtime()
+                                    onNext()
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        if (onExit != null) {
+            AnimatedVisibility(
+                visible = controlsVisible,
+                enter = fadeIn(tween(220)),
+                exit = fadeOut(tween(600)),
+                modifier = Modifier.align(Alignment.TopEnd)
+            ) {
+                Box(modifier = Modifier.systemBarsPadding().padding(12.dp)) {
+                    AmbientIconButton(
+                        icon = Icons.Rounded.Close,
+                        contentDescription = strings.ambientExit,
+                        size = 24.dp,
+                        onClick = onExit
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AmbientArtwork(state: AmbientUiState, minimal: Boolean) {
+    val context = LocalContext.current
+    val fraction = if (minimal) 0.42f else 0.62f
+    Box(
+        modifier = Modifier
+            .fillMaxWidth(fraction)
+            .aspectRatio(1f)
+            .clip(RoundedCornerShape(18.dp))
+    ) {
+        MotionArtworkLayer(
+            artwork = state.motionArtwork.takeIf { state.settings.showCanvas },
+            enabled = state.animationsEnabled && state.settings.showCanvas,
+            isPlaying = state.isPlaying,
+            cornerRadius = 18.dp,
+            presentation = MotionArtworkPresentation.Card,
+            quality = state.canvasQuality,
+            modifier = Modifier.fillMaxSize()
+        ) {
+            if (state.artworkUrl.isNotBlank()) {
+                AsyncImage(
+                    model = ImageRequest.Builder(context).data(state.artworkUrl).crossfade(true).build(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            } else {
+                Box(modifier = Modifier.fillMaxSize().background(AmbientArtworkFallback))
+            }
+        }
+    }
+}
+
+@Composable
+private fun AmbientProgress(positionMs: Long, durationMs: Long) {
+    val progress = if (durationMs > 0L) {
+        (positionMs.toFloat() / durationMs.toFloat()).coerceIn(0f, 1f)
+    } else {
+        0f
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth(0.62f)
+            .height(2.dp)
+            .clip(RoundedCornerShape(1.dp))
+            .background(AmbientTrack)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(progress)
+                .height(2.dp)
+                .background(AmbientProgressColor)
+        )
+    }
+}
+
+@Composable
+private fun AmbientIconButton(
+    icon: ImageVector,
+    contentDescription: String,
+    size: Dp,
+    onClick: () -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    Box(
+        modifier = Modifier
+            .size(size + 22.dp)
+            .clip(RoundedCornerShape(50))
+            .clickable(interactionSource = interactionSource, indication = null, onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            tint = AmbientText,
+            modifier = Modifier.size(size)
+        )
+    }
+}
+
+@Composable
+private fun rememberProximityCovered(enabled: Boolean): Boolean {
+    val context = LocalContext.current
+    var covered by remember(enabled) { mutableStateOf(false) }
+    DisposableEffect(enabled, context) {
+        if (!enabled) {
+            covered = false
+            return@DisposableEffect onDispose { }
+        }
+        val manager = context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
+        val sensor = manager?.getDefaultSensor(Sensor.TYPE_PROXIMITY)
+        if (manager == null || sensor == null) {
+            covered = false
+            return@DisposableEffect onDispose { }
+        }
+        val listener = object : SensorEventListener {
+            override fun onSensorChanged(event: SensorEvent) {
+                val value = event.values.firstOrNull() ?: return
+                covered = value < sensor.maximumRange && value < PROXIMITY_NEAR_CM
+            }
+
+            override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
+        }
+        manager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_NORMAL)
+        onDispose {
+            manager.unregisterListener(listener)
+            covered = false
+        }
+    }
+    return covered
+}
+
+private const val PROXIMITY_NEAR_CM = 5f
+private val AmbientText = Color(0xFFE8E8EC)
+private val AmbientMuted = Color(0xFF8A8A93)
+private val AmbientLyric = Color(0xFFB9B9C4)
+private val AmbientTrack = Color(0xFF1E1E22)
+private val AmbientProgressColor = Color(0xFF6C6C78)
+private val AmbientArtworkFallback = Color(0xFF101014)

--- a/app/src/main/java/com/luc4n3x/levyra/ui/ambient/AmbientScreen.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/ambient/AmbientScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
@@ -139,7 +140,7 @@ internal fun AmbientScreen(
                 .fillMaxSize()
                 .systemBarsPadding()
                 .padding(horizontal = 32.dp, vertical = 24.dp)
-                .offset(x = shiftX, y = shiftY)
+                .offset { IntOffset(shiftX.roundToPx(), shiftY.roundToPx()) }
                 .alpha(contentAlpha),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center

--- a/app/src/main/java/com/luc4n3x/levyra/ui/ambient/AmbientUiState.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/ambient/AmbientUiState.kt
@@ -1,0 +1,22 @@
+package com.luc4n3x.levyra.ui.ambient
+
+import androidx.compose.runtime.Immutable
+import com.luc4n3x.levyra.domain.LevyraAmbientSettings
+import com.luc4n3x.levyra.domain.LevyraCanvasQuality
+import com.luc4n3x.levyra.feature.motion.MotionArtwork
+
+@Immutable
+internal data class AmbientUiState(
+    val hasTrack: Boolean = false,
+    val title: String = "",
+    val artist: String = "",
+    val artworkUrl: String = "",
+    val isPlaying: Boolean = false,
+    val positionMs: Long = 0L,
+    val durationMs: Long = 0L,
+    val lyricLine: String = "",
+    val motionArtwork: MotionArtwork? = null,
+    val animationsEnabled: Boolean = true,
+    val canvasQuality: LevyraCanvasQuality = LevyraCanvasQuality.Auto,
+    val settings: LevyraAmbientSettings = LevyraAmbientSettings()
+)

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraLibraryOrganizationStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraLibraryOrganizationStrings.kt
@@ -1,0 +1,373 @@
+package com.luc4n3x.levyra.ui.i18n
+
+private val organizationKeyList = listOf(
+    "ambientMode",
+    "ambientModeSubtitle",
+    "ambientOpen",
+    "ambientExit",
+    "ambientSettingsTitle",
+    "ambientBrightness",
+    "ambientAutoDim",
+    "ambientPixelShift",
+    "ambientProximityBlackout",
+    "ambientShowLyrics",
+    "ambientShowCanvas",
+    "ambientNothingPlaying",
+    "forgottenFavorites",
+    "forgottenFavoritesSubtitle",
+    "excludeArtist",
+    "includeArtist",
+    "excludedArtists",
+    "excludedArtistsEmpty",
+    "playlistTags",
+    "newPlaylistTag",
+    "playlistTagName",
+    "editPlaylistTags",
+    "filterByTag",
+    "playlistTagLimitReached",
+    "hidePlaylist",
+    "unhidePlaylist",
+    "hiddenPlaylists",
+    "hiddenPlaylistsEmpty"
+)
+
+internal val organizationKeys: Set<String> = organizationKeyList.toSet()
+
+private fun organization(vararg values: String): Map<String, String> {
+    require(values.size == organizationKeyList.size) {
+        "Expected ${organizationKeyList.size} organization strings, received ${values.size}"
+    }
+    return organizationKeyList.zip(values.asList()).toMap()
+}
+
+private val organizationBundles: Map<String, Map<String, String>> = mapOf(
+    "en" to organization(
+        "Ambient", "OLED-friendly screen for quiet listening", "Open Ambient", "Exit Ambient",
+        "Ambient screen", "Brightness", "Auto dimming", "Pixel shift", "Proximity blackout",
+        "Show lyrics", "Show Canvas", "Nothing is playing",
+        "Rediscover", "Favourites you have not played in a while",
+        "Do not recommend this artist", "Recommend again", "Excluded artists",
+        "No excluded artists yet.",
+        "Tags", "New tag", "Tag name", "Edit tags", "Filter by tag",
+        "You can assign up to 8 tags.",
+        "Hide from library", "Show in library", "Hidden playlists", "No hidden playlists."
+    ),
+    "it" to organization(
+        "Ambient", "Schermata OLED-friendly per l'ascolto tranquillo", "Apri Ambient", "Esci da Ambient",
+        "Schermata Ambient", "Luminosità", "Attenuazione automatica", "Spostamento pixel",
+        "Blackout di prossimità",
+        "Mostra i testi", "Mostra Canvas", "Nessun brano in riproduzione",
+        "Riscoprili", "Preferiti che non ascolti da un po'",
+        "Non consigliarmi questo artista", "Consiglia di nuovo", "Artisti esclusi",
+        "Nessun artista escluso.",
+        "Tag", "Nuovo tag", "Nome del tag", "Modifica tag", "Filtra per tag",
+        "Puoi assegnare fino a 8 tag.",
+        "Nascondi dalla libreria", "Mostra nella libreria", "Playlist nascoste",
+        "Nessuna playlist nascosta."
+    ),
+    "es" to organization(
+        "Ambient", "Pantalla apta para OLED para escuchar con calma", "Abrir Ambient", "Salir de Ambient",
+        "Pantalla Ambient", "Brillo", "Atenuación automática", "Desplazamiento de píxeles",
+        "Apagado por proximidad",
+        "Mostrar la letra", "Mostrar Canvas", "No hay nada en reproducción",
+        "Redescubre", "Favoritos que no escuchas desde hace tiempo",
+        "No recomendar este artista", "Volver a recomendar", "Artistas excluidos",
+        "Todavía no hay artistas excluidos.",
+        "Etiquetas", "Nueva etiqueta", "Nombre de la etiqueta", "Editar etiquetas",
+        "Filtrar por etiqueta",
+        "Puedes asignar hasta 8 etiquetas.",
+        "Ocultar de la biblioteca", "Mostrar en la biblioteca", "Listas ocultas",
+        "No hay listas ocultas."
+    ),
+    "fr" to organization(
+        "Ambient", "Écran adapté aux OLED pour une écoute calme", "Ouvrir Ambient", "Quitter Ambient",
+        "Écran Ambient", "Luminosité", "Atténuation automatique", "Décalage des pixels",
+        "Extinction de proximité",
+        "Afficher les paroles", "Afficher Canvas", "Aucune lecture en cours",
+        "Redécouvrir", "Des favoris que vous n'avez pas écoutés depuis un moment",
+        "Ne plus me recommander cet artiste", "Recommander à nouveau", "Artistes exclus",
+        "Aucun artiste exclu pour l'instant.",
+        "Tags", "Nouveau tag", "Nom du tag", "Modifier les tags", "Filtrer par tag",
+        "Vous pouvez attribuer jusqu'à 8 tags.",
+        "Masquer de la bibliothèque", "Afficher dans la bibliothèque", "Playlists masquées",
+        "Aucune playlist masquée."
+    ),
+    "de" to organization(
+        "Ambient", "OLED-freundlicher Bildschirm für ruhiges Hören", "Ambient öffnen", "Ambient verlassen",
+        "Ambient-Bildschirm", "Helligkeit", "Automatisches Abdunkeln", "Pixelverschiebung",
+        "Näherungs-Blackout",
+        "Songtext anzeigen", "Canvas anzeigen", "Es wird nichts abgespielt",
+        "Wiederentdecken", "Favoriten, die du länger nicht gehört hast",
+        "Diesen Künstler nicht empfehlen", "Wieder empfehlen", "Ausgeschlossene Künstler",
+        "Noch keine ausgeschlossenen Künstler.",
+        "Tags", "Neuer Tag", "Tag-Name", "Tags bearbeiten", "Nach Tag filtern",
+        "Du kannst bis zu 8 Tags vergeben.",
+        "Aus der Bibliothek ausblenden", "In der Bibliothek anzeigen", "Ausgeblendete Playlists",
+        "Keine ausgeblendeten Playlists."
+    ),
+    "pt" to organization(
+        "Ambient", "Ecrã amigo do OLED para ouvir com calma", "Abrir Ambient", "Sair do Ambient",
+        "Ecrã Ambient", "Brilho", "Escurecimento automático", "Deslocação de píxeis",
+        "Blackout de proximidade",
+        "Mostrar a letra", "Mostrar Canvas", "Nada em reprodução",
+        "Redescobrir", "Favoritos que não ouves há algum tempo",
+        "Não recomendar este artista", "Recomendar novamente", "Artistas excluídos",
+        "Ainda não há artistas excluídos.",
+        "Etiquetas", "Nova etiqueta", "Nome da etiqueta", "Editar etiquetas", "Filtrar por etiqueta",
+        "Podes atribuir até 8 etiquetas.",
+        "Ocultar da biblioteca", "Mostrar na biblioteca", "Playlists ocultas",
+        "Não há playlists ocultas."
+    ),
+    "nl" to organization(
+        "Ambient", "OLED-vriendelijk scherm om rustig te luisteren", "Ambient openen", "Ambient sluiten",
+        "Ambient-scherm", "Helderheid", "Automatisch dimmen", "Pixelverschuiving", "Nabijheidsblackout",
+        "Songtekst tonen", "Canvas tonen", "Er speelt niets",
+        "Herontdekken", "Favorieten die je al even niet hebt geluisterd",
+        "Deze artiest niet aanbevelen", "Weer aanbevelen", "Uitgesloten artiesten",
+        "Nog geen uitgesloten artiesten.",
+        "Tags", "Nieuwe tag", "Tagnaam", "Tags bewerken", "Filteren op tag",
+        "Je kunt maximaal 8 tags toewijzen.",
+        "Verbergen in bibliotheek", "Tonen in bibliotheek", "Verborgen afspeellijsten",
+        "Geen verborgen afspeellijsten."
+    ),
+    "pl" to organization(
+        "Ambient", "Ekran przyjazny OLED do spokojnego słuchania", "Otwórz Ambient", "Zamknij Ambient",
+        "Ekran Ambient", "Jasność", "Automatyczne przyciemnianie", "Przesuwanie pikseli",
+        "Wygaszanie zbliżeniowe",
+        "Pokaż tekst", "Pokaż Canvas", "Nic nie jest odtwarzane",
+        "Odkryj na nowo", "Ulubione, których dawno nie słuchasz",
+        "Nie polecaj mi tego wykonawcy", "Polecaj ponownie", "Wykluczeni wykonawcy",
+        "Brak wykluczonych wykonawców.",
+        "Tagi", "Nowy tag", "Nazwa tagu", "Edytuj tagi", "Filtruj według tagu",
+        "Możesz przypisać maksymalnie 8 tagów.",
+        "Ukryj w bibliotece", "Pokaż w bibliotece", "Ukryte playlisty", "Brak ukrytych playlist."
+    ),
+    "ro" to organization(
+        "Ambient", "Ecran prietenos cu OLED pentru ascultare liniștită", "Deschide Ambient",
+        "Ieși din Ambient",
+        "Ecran Ambient", "Luminozitate", "Estompare automată", "Deplasare pixeli",
+        "Stingere la proximitate",
+        "Afișează versurile", "Afișează Canvas", "Nu se redă nimic",
+        "Redescoperă", "Favorite pe care nu le-ai ascultat de mult",
+        "Nu îmi recomanda acest artist", "Recomandă din nou", "Artiști excluși",
+        "Niciun artist exclus.",
+        "Etichete", "Etichetă nouă", "Numele etichetei", "Editează etichetele",
+        "Filtrează după etichetă",
+        "Poți atribui până la 8 etichete.",
+        "Ascunde din bibliotecă", "Afișează în bibliotecă", "Playlisturi ascunse",
+        "Niciun playlist ascuns."
+    ),
+    "el" to organization(
+        "Ambient", "Οθόνη φιλική προς OLED για ήρεμη ακρόαση", "Άνοιγμα Ambient", "Έξοδος από Ambient",
+        "Οθόνη Ambient", "Φωτεινότητα", "Αυτόματη μείωση φωτεινότητας", "Μετατόπιση pixel",
+        "Σβήσιμο με εγγύτητα",
+        "Εμφάνιση στίχων", "Εμφάνιση Canvas", "Δεν αναπαράγεται τίποτα",
+        "Ανακαλύψτε ξανά", "Αγαπημένα που έχετε καιρό να ακούσετε",
+        "Να μην προτείνεται αυτός ο καλλιτέχνης", "Πρότεινε ξανά", "Εξαιρεμένοι καλλιτέχνες",
+        "Δεν υπάρχουν εξαιρεμένοι καλλιτέχνες.",
+        "Ετικέτες", "Νέα ετικέτα", "Όνομα ετικέτας", "Επεξεργασία ετικετών",
+        "Φιλτράρισμα κατά ετικέτα",
+        "Μπορείτε να αντιστοιχίσετε έως 8 ετικέτες.",
+        "Απόκρυψη από τη βιβλιοθήκη", "Εμφάνιση στη βιβλιοθήκη", "Κρυφές λίστες",
+        "Δεν υπάρχουν κρυφές λίστες."
+    ),
+    "sv" to organization(
+        "Ambient", "OLED-vänlig skärm för lugnt lyssnande", "Öppna Ambient", "Avsluta Ambient",
+        "Ambient-skärm", "Ljusstyrka", "Automatisk nedtoning", "Pixelförskjutning", "Närhetssläckning",
+        "Visa låttext", "Visa Canvas", "Inget spelas",
+        "Återupptäck", "Favoriter du inte lyssnat på på ett tag",
+        "Rekommendera inte den här artisten", "Rekommendera igen", "Uteslutna artister",
+        "Inga uteslutna artister ännu.",
+        "Taggar", "Ny tagg", "Taggnamn", "Redigera taggar", "Filtrera efter tagg",
+        "Du kan tilldela upp till 8 taggar.",
+        "Dölj i biblioteket", "Visa i biblioteket", "Dolda spellistor", "Inga dolda spellistor."
+    ),
+    "da" to organization(
+        "Ambient", "OLED-venlig skærm til rolig lytning", "Åbn Ambient", "Forlad Ambient",
+        "Ambient-skærm", "Lysstyrke", "Automatisk dæmpning", "Pixelforskydning", "Nærhedsslukning",
+        "Vis sangtekst", "Vis Canvas", "Der afspilles intet",
+        "Genopdag", "Favoritter du ikke har hørt i et stykke tid",
+        "Anbefal ikke denne kunstner", "Anbefal igen", "Udelukkede kunstnere",
+        "Ingen udelukkede kunstnere endnu.",
+        "Tags", "Nyt tag", "Tagnavn", "Rediger tags", "Filtrer efter tag",
+        "Du kan tildele op til 8 tags.",
+        "Skjul i biblioteket", "Vis i biblioteket", "Skjulte playlister", "Ingen skjulte playlister."
+    ),
+    "cs" to organization(
+        "Ambient", "Obrazovka šetrná k OLED pro klidný poslech", "Otevřít Ambient", "Ukončit Ambient",
+        "Obrazovka Ambient", "Jas", "Automatické ztlumení", "Posun pixelů", "Zhasnutí při přiblížení",
+        "Zobrazit text", "Zobrazit Canvas", "Nic se nepřehrává",
+        "Znovu objevit", "Oblíbené, které jste dlouho neposlouchali",
+        "Nedoporučovat tohoto interpreta", "Znovu doporučovat", "Vyloučení interpreti",
+        "Zatím žádní vyloučení interpreti.",
+        "Štítky", "Nový štítek", "Název štítku", "Upravit štítky", "Filtrovat podle štítku",
+        "Můžete přiřadit až 8 štítků.",
+        "Skrýt v knihovně", "Zobrazit v knihovně", "Skryté playlisty", "Žádné skryté playlisty."
+    ),
+    "uk" to organization(
+        "Ambient", "Екран, дружній до OLED, для спокійного прослуховування", "Відкрити Ambient",
+        "Вийти з Ambient",
+        "Екран Ambient", "Яскравість", "Автоматичне затемнення", "Зсув пікселів",
+        "Затемнення за наближенням",
+        "Показувати текст", "Показувати Canvas", "Нічого не відтворюється",
+        "Відкрийте знову", "Улюблене, яке ви давно не слухали",
+        "Не рекомендувати цього виконавця", "Рекомендувати знову", "Виключені виконавці",
+        "Виключених виконавців немає.",
+        "Теги", "Новий тег", "Назва тега", "Редагувати теги", "Фільтрувати за тегом",
+        "Можна призначити до 8 тегів.",
+        "Сховати з бібліотеки", "Показати в бібліотеці", "Приховані плейлисти",
+        "Прихованих плейлистів немає."
+    ),
+    "ru" to organization(
+        "Ambient", "Экран, щадящий OLED, для спокойного прослушивания", "Открыть Ambient",
+        "Выйти из Ambient",
+        "Экран Ambient", "Яркость", "Автоматическое затемнение", "Сдвиг пикселей",
+        "Затемнение по датчику",
+        "Показывать текст", "Показывать Canvas", "Ничего не воспроизводится",
+        "Открыть заново", "Избранное, которое вы давно не слушали",
+        "Не рекомендовать этого исполнителя", "Рекомендовать снова", "Исключённые исполнители",
+        "Исключённых исполнителей нет.",
+        "Теги", "Новый тег", "Название тега", "Изменить теги", "Фильтр по тегу",
+        "Можно назначить до 8 тегов.",
+        "Скрыть из библиотеки", "Показать в библиотеке", "Скрытые плейлисты",
+        "Скрытых плейлистов нет."
+    ),
+    "tr" to organization(
+        "Ambient", "Sakin dinleme için OLED dostu ekran", "Ambient'i aç", "Ambient'ten çık",
+        "Ambient ekranı", "Parlaklık", "Otomatik karartma", "Piksel kaydırma", "Yakınlıkta karartma",
+        "Şarkı sözlerini göster", "Canvas'ı göster", "Şu anda bir şey çalmıyor",
+        "Yeniden keşfet", "Bir süredir dinlemediğin favoriler",
+        "Bu sanatçıyı önerme", "Yeniden öner", "Hariç tutulan sanatçılar",
+        "Henüz hariç tutulan sanatçı yok.",
+        "Etiketler", "Yeni etiket", "Etiket adı", "Etiketleri düzenle", "Etikete göre filtrele",
+        "En fazla 8 etiket atayabilirsin.",
+        "Kitaplıktan gizle", "Kitaplıkta göster", "Gizli çalma listeleri",
+        "Gizli çalma listesi yok."
+    ),
+    "ar" to organization(
+        "Ambient", "شاشة ملائمة لشاشات OLED للاستماع الهادئ", "فتح Ambient", "الخروج من Ambient",
+        "شاشة Ambient", "السطوع", "تعتيم تلقائي", "إزاحة البكسل", "إطفاء عند الاقتراب",
+        "عرض الكلمات", "عرض Canvas", "لا يوجد تشغيل حاليًا",
+        "أعد الاكتشاف", "مفضلات لم تستمع إليها منذ فترة",
+        "لا توصِ بهذا الفنان", "أوصِ به مجددًا", "الفنانون المستبعدون",
+        "لا يوجد فنانون مستبعدون.",
+        "الوسوم", "وسم جديد", "اسم الوسم", "تعديل الوسوم", "تصفية حسب الوسم",
+        "يمكنك تعيين حتى 8 وسوم.",
+        "إخفاء من المكتبة", "إظهار في المكتبة", "قوائم التشغيل المخفية",
+        "لا توجد قوائم تشغيل مخفية."
+    ),
+    "zh" to organization(
+        "Ambient", "适合 OLED 的安静聆听界面", "打开 Ambient", "退出 Ambient",
+        "Ambient 界面", "亮度", "自动变暗", "像素偏移", "接近熄屏",
+        "显示歌词", "显示 Canvas", "当前没有播放内容",
+        "重新发现", "很久没听的收藏",
+        "不再推荐该艺人", "重新推荐", "已排除的艺人",
+        "暂无已排除的艺人。",
+        "标签", "新建标签", "标签名称", "编辑标签", "按标签筛选",
+        "最多可分配 8 个标签。",
+        "从音乐库隐藏", "在音乐库中显示", "隐藏的播放列表", "没有隐藏的播放列表。"
+    ),
+    "ja" to organization(
+        "Ambient", "静かに聴くためのOLEDにやさしい画面", "Ambientを開く", "Ambientを終了",
+        "Ambient画面", "明るさ", "自動減光", "ピクセルシフト", "近接ブラックアウト",
+        "歌詞を表示", "Canvasを表示", "再生中の曲はありません",
+        "再発見", "しばらく聴いていないお気に入り",
+        "このアーティストをおすすめしない", "再びおすすめする", "除外したアーティスト",
+        "除外したアーティストはありません。",
+        "タグ", "新しいタグ", "タグ名", "タグを編集", "タグで絞り込む",
+        "タグは8個まで設定できます。",
+        "ライブラリから隠す", "ライブラリに表示", "非表示のプレイリスト",
+        "非表示のプレイリストはありません。"
+    ),
+    "ko" to organization(
+        "Ambient", "조용한 감상을 위한 OLED 친화 화면", "Ambient 열기", "Ambient 종료",
+        "Ambient 화면", "밝기", "자동 어둡게", "픽셀 시프트", "근접 블랙아웃",
+        "가사 표시", "Canvas 표시", "재생 중인 곡이 없습니다",
+        "다시 발견하기", "한동안 듣지 않은 즐겨찾기",
+        "이 아티스트 추천하지 않기", "다시 추천하기", "제외한 아티스트",
+        "제외한 아티스트가 없습니다.",
+        "태그", "새 태그", "태그 이름", "태그 편집", "태그로 필터링",
+        "태그는 최대 8개까지 지정할 수 있습니다.",
+        "라이브러리에서 숨기기", "라이브러리에 표시", "숨긴 재생목록",
+        "숨긴 재생목록이 없습니다."
+    ),
+    "hi" to organization(
+        "Ambient", "शांत सुनने के लिए OLED-अनुकूल स्क्रीन", "Ambient खोलें", "Ambient से बाहर निकलें",
+        "Ambient स्क्रीन", "चमक", "स्वचालित मंद", "पिक्सेल शिफ्ट", "निकटता पर काली स्क्रीन",
+        "बोल दिखाएँ", "Canvas दिखाएँ", "अभी कुछ नहीं चल रहा",
+        "फिर से खोजें", "पसंदीदा जिन्हें आपने काफी समय से नहीं सुना",
+        "इस कलाकार की सिफारिश न करें", "फिर से सिफारिश करें", "बाहर रखे गए कलाकार",
+        "कोई बाहर रखा गया कलाकार नहीं।",
+        "टैग", "नया टैग", "टैग का नाम", "टैग संपादित करें", "टैग से फ़िल्टर करें",
+        "आप अधिकतम 8 टैग जोड़ सकते हैं।",
+        "लाइब्रेरी से छिपाएँ", "लाइब्रेरी में दिखाएँ", "छिपी हुई प्लेलिस्ट",
+        "कोई छिपी हुई प्लेलिस्ट नहीं।"
+    ),
+    "id" to organization(
+        "Ambient", "Layar ramah OLED untuk mendengarkan dengan tenang", "Buka Ambient",
+        "Keluar dari Ambient",
+        "Layar Ambient", "Kecerahan", "Peredupan otomatis", "Pergeseran piksel",
+        "Layar gelap saat dekat",
+        "Tampilkan lirik", "Tampilkan Canvas", "Tidak ada yang diputar",
+        "Temukan lagi", "Favorit yang sudah lama tidak kamu dengar",
+        "Jangan rekomendasikan artis ini", "Rekomendasikan lagi", "Artis yang dikecualikan",
+        "Belum ada artis yang dikecualikan.",
+        "Tag", "Tag baru", "Nama tag", "Edit tag", "Filter menurut tag",
+        "Kamu bisa menetapkan hingga 8 tag.",
+        "Sembunyikan dari pustaka", "Tampilkan di pustaka", "Playlist tersembunyi",
+        "Tidak ada playlist tersembunyi."
+    ),
+    "vi" to organization(
+        "Ambient", "Màn hình thân thiện với OLED để nghe nhạc thư giãn", "Mở Ambient", "Thoát Ambient",
+        "Màn hình Ambient", "Độ sáng", "Tự động giảm sáng", "Dịch chuyển điểm ảnh",
+        "Tắt màn hình khi che",
+        "Hiện lời bài hát", "Hiện Canvas", "Hiện không phát gì",
+        "Khám phá lại", "Những bài yêu thích bạn đã lâu không nghe",
+        "Không đề xuất nghệ sĩ này", "Đề xuất lại", "Nghệ sĩ đã loại trừ",
+        "Chưa có nghệ sĩ nào bị loại trừ.",
+        "Thẻ", "Thẻ mới", "Tên thẻ", "Sửa thẻ", "Lọc theo thẻ",
+        "Bạn có thể gán tối đa 8 thẻ.",
+        "Ẩn khỏi thư viện", "Hiện trong thư viện", "Danh sách phát đã ẩn",
+        "Không có danh sách phát nào bị ẩn."
+    ),
+    "th" to organization(
+        "Ambient", "หน้าจอที่เป็นมิตรกับ OLED สำหรับการฟังอย่างสงบ", "เปิด Ambient", "ออกจาก Ambient",
+        "หน้าจอ Ambient", "ความสว่าง", "หรี่แสงอัตโนมัติ", "การเลื่อนพิกเซล", "ดับจอเมื่อเข้าใกล้",
+        "แสดงเนื้อเพลง", "แสดง Canvas", "ยังไม่มีการเล่นเพลง",
+        "ค้นพบอีกครั้ง", "รายการโปรดที่คุณไม่ได้ฟังมานาน",
+        "ไม่ต้องแนะนำศิลปินนี้", "แนะนำอีกครั้ง", "ศิลปินที่ยกเว้น",
+        "ยังไม่มีศิลปินที่ยกเว้น",
+        "แท็ก", "แท็กใหม่", "ชื่อแท็ก", "แก้ไขแท็ก", "กรองตามแท็ก",
+        "คุณกำหนดได้สูงสุด 8 แท็ก",
+        "ซ่อนจากคลัง", "แสดงในคลัง", "เพลย์ลิสต์ที่ซ่อน", "ไม่มีเพลย์ลิสต์ที่ซ่อน"
+    ),
+    "fil" to organization(
+        "Ambient", "Screen na OLED-friendly para sa tahimik na pakikinig", "Buksan ang Ambient",
+        "Lumabas sa Ambient",
+        "Ambient screen", "Liwanag", "Awtomatikong pagdilim", "Pixel shift", "Blackout kapag malapit",
+        "Ipakita ang lyrics", "Ipakita ang Canvas", "Walang tumutugtog",
+        "Tuklasin muli", "Mga paborito na matagal mo nang hindi napapakinggan",
+        "Huwag imungkahi ang artist na ito", "Imungkahi muli", "Mga hindi isinasamang artist",
+        "Wala pang hindi isinasamang artist.",
+        "Mga tag", "Bagong tag", "Pangalan ng tag", "I-edit ang mga tag", "I-filter ayon sa tag",
+        "Hanggang 8 tag ang puwede mong itakda.",
+        "Itago sa library", "Ipakita sa library", "Mga nakatagong playlist",
+        "Walang nakatagong playlist."
+    ),
+    "he" to organization(
+        "Ambient", "מסך ידידותי ל-OLED להאזנה רגועה", "פתיחת Ambient", "יציאה מ-Ambient",
+        "מסך Ambient", "בהירות", "עמעום אוטומטי", "הסטת פיקסלים", "כיבוי בקרבה",
+        "הצגת מילים", "הצגת Canvas", "לא מתנגן כלום",
+        "לגלות מחדש", "מועדפים שלא האזנתם להם מזמן",
+        "אל תמליצו לי על האמן הזה", "להמליץ שוב", "אמנים שהוחרגו",
+        "אין אמנים שהוחרגו.",
+        "תגיות", "תגית חדשה", "שם התגית", "עריכת תגיות", "סינון לפי תגית",
+        "אפשר לשייך עד 8 תגיות.",
+        "הסתרה מהספרייה", "הצגה בספרייה", "פלייליסטים מוסתרים", "אין פלייליסטים מוסתרים."
+    )
+)
+
+internal fun organizationLocalizationEntries(code: String): Map<String, String> =
+    organizationBundles[code] ?: organizationBundles.getValue("en")
+
+internal fun organizationLocalizationCodes(): Set<String> = organizationBundles.keys

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
@@ -15,6 +15,34 @@ class LevyraStrings private constructor(
         return if (LevyraLanguageCatalog.isRtl(code) && clean.isNotBlank()) "\u2068$clean\u2069" else clean
     }
 
+    val ambientMode: String get() = value("ambientMode")
+    val ambientModeSubtitle: String get() = value("ambientModeSubtitle")
+    val ambientOpen: String get() = value("ambientOpen")
+    val ambientExit: String get() = value("ambientExit")
+    val ambientSettingsTitle: String get() = value("ambientSettingsTitle")
+    val ambientBrightness: String get() = value("ambientBrightness")
+    val ambientAutoDim: String get() = value("ambientAutoDim")
+    val ambientPixelShift: String get() = value("ambientPixelShift")
+    val ambientProximityBlackout: String get() = value("ambientProximityBlackout")
+    val ambientShowLyrics: String get() = value("ambientShowLyrics")
+    val ambientShowCanvas: String get() = value("ambientShowCanvas")
+    val ambientNothingPlaying: String get() = value("ambientNothingPlaying")
+    val forgottenFavorites: String get() = value("forgottenFavorites")
+    val forgottenFavoritesSubtitle: String get() = value("forgottenFavoritesSubtitle")
+    val excludeArtist: String get() = value("excludeArtist")
+    val includeArtist: String get() = value("includeArtist")
+    val excludedArtists: String get() = value("excludedArtists")
+    val excludedArtistsEmpty: String get() = value("excludedArtistsEmpty")
+    val playlistTags: String get() = value("playlistTags")
+    val newPlaylistTag: String get() = value("newPlaylistTag")
+    val playlistTagName: String get() = value("playlistTagName")
+    val editPlaylistTags: String get() = value("editPlaylistTags")
+    val filterByTag: String get() = value("filterByTag")
+    val playlistTagLimitReached: String get() = value("playlistTagLimitReached")
+    val hidePlaylist: String get() = value("hidePlaylist")
+    val unhidePlaylist: String get() = value("unhidePlaylist")
+    val hiddenPlaylists: String get() = value("hiddenPlaylists")
+    val hiddenPlaylistsEmpty: String get() = value("hiddenPlaylistsEmpty")
     val welcomeBadge: String get() = value("welcomeBadge")
     val levyraMix: String get() = value("levyraMix")
     val mixCreate: String get() = value("mixCreate")
@@ -1436,8 +1464,8 @@ class LevyraStrings private constructor(
         }
 
         private fun bundle(code: String, entries: Map<String, String>): LevyraStrings {
-            val resolvedEntries = entries + homeEditorialLocalizationEntries(code) + lyricsActionLocalizationEntries(code) + playerExperienceLocalizationEntries(code) + exploreLocalizationEntries(code) + canvasLocalizationEntries(code) + audioLocalizationEntries(code) + autoEqLocalizationEntries(code) + experienceLocalizationEntries(code) + insightLocalizationEntries(code) + systemActionLocalizationEntries(code) + integrationLocalizationEntries(code) + recognitionLocalizationEntries(code) + jamLocalizationEntries(code) + networkLocalizationEntries(code) + resonanceLocalizationEntries(code)
-            val allRequiredKeys = requiredKeys + "removeFromPlaylist" + motionArtworkKeys + canvasKeys + audioKeys + autoEqKeys + experienceKeys + insightKeys + systemActionKeys + integrationKeys + recognitionKeys + jamKeys + networkKeys + resonanceKeys
+            val resolvedEntries = entries + homeEditorialLocalizationEntries(code) + lyricsActionLocalizationEntries(code) + playerExperienceLocalizationEntries(code) + exploreLocalizationEntries(code) + canvasLocalizationEntries(code) + audioLocalizationEntries(code) + autoEqLocalizationEntries(code) + experienceLocalizationEntries(code) + insightLocalizationEntries(code) + systemActionLocalizationEntries(code) + integrationLocalizationEntries(code) + recognitionLocalizationEntries(code) + jamLocalizationEntries(code) + networkLocalizationEntries(code) + resonanceLocalizationEntries(code) + organizationLocalizationEntries(code)
+            val allRequiredKeys = requiredKeys + "removeFromPlaylist" + motionArtworkKeys + canvasKeys + audioKeys + autoEqKeys + experienceKeys + insightKeys + systemActionKeys + integrationKeys + recognitionKeys + jamKeys + networkKeys + resonanceKeys + organizationKeys
             require(resolvedEntries.keys == allRequiredKeys) {
                 "Invalid localization bundle $code: missing=${allRequiredKeys - resolvedEntries.keys}, extra=${resolvedEntries.keys - allRequiredKeys}"
             }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/library/LevyraLibraryScreen.kt
@@ -63,6 +63,9 @@ import com.luc4n3x.levyra.domain.offlineDownloadStageOf
 import com.luc4n3x.levyra.ui.components.LevyraConnectedPosition
 import com.luc4n3x.levyra.domain.DownloadedTrack
 import com.luc4n3x.levyra.domain.Playlist
+import com.luc4n3x.levyra.domain.filterByTagIds
+import com.luc4n3x.levyra.domain.hiddenInLibrary
+import com.luc4n3x.levyra.domain.visibleInLibrary
 import com.luc4n3x.levyra.domain.Track
 import com.luc4n3x.levyra.domain.visibleDownloadBatches
 import com.luc4n3x.levyra.ui.i18n.LocalLevyraStrings
@@ -119,6 +122,8 @@ internal fun LevyraLibraryScreen(
     var showImportPlaylist by remember { mutableStateOf(false) }
     var showImportPlaylistCard by rememberSaveable { mutableStateOf(true) }
     var openSmartCollectionName by rememberSaveable { mutableStateOf<String?>(null) }
+    var selectedTagIds by rememberSaveable { mutableStateOf(emptySet<String>()) }
+    var showHiddenPlaylists by rememberSaveable { mutableStateOf(false) }
     val listState = rememberLazyListState()
     val scrollPositions = remember { mutableStateMapOf<String, Pair<Int, Int>>() }
 
@@ -127,6 +132,10 @@ internal fun LevyraLibraryScreen(
         scrollPositions[category.name] = listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
         categoryName = next.name
         selectedKeys = emptySet()
+        if (next != LibraryCategory.Playlists) {
+            selectedTagIds = emptySet()
+            showHiddenPlaylists = false
+        }
     }
 
     LaunchedEffect(categoryName) {
@@ -134,8 +143,21 @@ internal fun LevyraLibraryScreen(
         runCatching { listState.scrollToItem(position.first, position.second) }
     }
 
-    val visiblePlaylists = remember(state.playlists, query, sort) {
-        filterLibraryPlaylists(state.playlists, query, sort)
+    val hiddenPlaylistCount = remember(state.playlists) { state.playlists.count { it.hidden } }
+    val knownTagIds = remember(state.playlistTags) { state.playlistTags.mapTo(hashSetOf()) { it.id } }
+    LaunchedEffect(knownTagIds) {
+        val pruned = selectedTagIds.filterTo(hashSetOf()) { it in knownTagIds }
+        if (pruned.size != selectedTagIds.size) selectedTagIds = pruned
+    }
+    LaunchedEffect(hiddenPlaylistCount) {
+        if (hiddenPlaylistCount == 0 && showHiddenPlaylists) showHiddenPlaylists = false
+    }
+    val scopedPlaylists = remember(state.playlists, showHiddenPlaylists, selectedTagIds) {
+        val scoped = if (showHiddenPlaylists) state.playlists.hiddenInLibrary() else state.playlists.visibleInLibrary()
+        scoped.filterByTagIds(selectedTagIds)
+    }
+    val visiblePlaylists = remember(scopedPlaylists, query, sort) {
+        filterLibraryPlaylists(scopedPlaylists, query, sort)
     }
     val visibleAlbums = remember(catalog.albums, query, sort) {
         filterLibraryAlbums(catalog.albums, query, sort)
@@ -203,7 +225,7 @@ internal fun LevyraLibraryScreen(
                     subtitle = when (category) {
                         LibraryCategory.Overview, LibraryCategory.Songs ->
                             strings.formatTrackCount(catalog.tracks.size)
-                        LibraryCategory.Playlists -> "${state.playlists.size} ${strings.playlistsPlain}"
+                        LibraryCategory.Playlists -> "${visiblePlaylists.size} ${strings.playlistsPlain}"
                         LibraryCategory.Albums -> "${catalog.albums.size} ${strings.albumsPlain}"
                         LibraryCategory.Artists -> "${catalog.artists.size} ${strings.artists}"
                         LibraryCategory.Offline ->
@@ -344,6 +366,20 @@ internal fun LevyraLibraryScreen(
                 }
 
                 LibraryCategory.Playlists -> {
+                    item(key = "playlist-filters") {
+                        LibraryPlaylistFilterRow(
+                            tags = state.playlistTags,
+                            selectedTagIds = selectedTagIds,
+                            hiddenVisible = showHiddenPlaylists,
+                            hiddenCount = hiddenPlaylistCount,
+                            onClearTags = { selectedTagIds = emptySet() },
+                            onToggleTag = { tagId -> selectedTagIds = selectedTagIds.toggle(tagId) },
+                            onToggleHidden = {
+                                showHiddenPlaylists = !showHiddenPlaylists
+                                selectedKeys = emptySet()
+                            }
+                        )
+                    }
                     item(key = "playlist-import-action") {
                         if (showImportPlaylistCard) {
                             LibraryImportPlaylistCard(
@@ -356,14 +392,21 @@ internal fun LevyraLibraryScreen(
                     }
                     if (visiblePlaylists.isEmpty()) {
                         item {
-                            if (query.isBlank()) {
-                                LibraryEmpty(
+                            when {
+                                query.isNotBlank() -> LibraryEmpty(Icons.Rounded.Search, strings.emptySearchPrompt)
+                                showHiddenPlaylists -> LibraryEmpty(
+                                    Icons.AutoMirrored.Rounded.QueueMusic,
+                                    strings.hiddenPlaylistsEmpty
+                                )
+                                selectedTagIds.isNotEmpty() -> LibraryEmpty(
+                                    Icons.AutoMirrored.Rounded.QueueMusic,
+                                    strings.filterByTag
+                                )
+                                else -> LibraryEmpty(
                                     Icons.AutoMirrored.Rounded.QueueMusic,
                                     strings.createFirstPlaylist,
                                     strings.createFirstPlaylistSubtitle
                                 )
-                            } else {
-                                LibraryEmpty(Icons.Rounded.Search, strings.emptySearchPrompt)
                             }
                         }
                     } else if (layout == LibraryLayout.List) {
@@ -773,6 +816,7 @@ internal fun LevyraPlaylistDetailScreen(
     var reorderMode by rememberSaveable(playlist.id) { mutableStateOf(false) }
     var orderedTracks by remember(playlist.id) { mutableStateOf(playlist.tracks) }
     var renameDialog by remember { mutableStateOf(false) }
+    var tagEditorOpen by remember(playlist.id) { mutableStateOf(false) }
     var tracksToRemove by remember(playlist.id) { mutableStateOf<List<Track>>(emptyList()) }
     var addTracksDialog by remember { mutableStateOf(false) }
 
@@ -844,6 +888,13 @@ internal fun LevyraPlaylistDetailScreen(
             }
 
             if (!reorderMode) {
+                item(key = "playlist-detail-organization") {
+                    PlaylistOrganizationBar(
+                        playlist = playlist,
+                        onEditTags = { tagEditorOpen = true },
+                        onToggleHidden = { viewModel.setPlaylistHidden(playlist.id, !playlist.hidden) }
+                    )
+                }
                 item(key = "playlist-detail-search") {
                     OutlinedTextField(
                         value = query,
@@ -941,6 +992,26 @@ internal fun LevyraPlaylistDetailScreen(
                     .padding(14.dp)
             )
         }
+    }
+
+    if (tagEditorOpen) {
+        val assignedTagIds = remember(playlist.tags) { playlist.tags.mapTo(hashSetOf()) { it.id } }
+        PlaylistTagEditorDialog(
+            assignedTagIds = assignedTagIds,
+            tags = state.playlistTags,
+            onDismiss = { tagEditorOpen = false },
+            onToggleTag = { tagId ->
+                val next = if (tagId in assignedTagIds) {
+                    playlist.tags.map { it.id }.filterNot { it == tagId }
+                } else {
+                    playlist.tags.map { it.id } + tagId
+                }
+                viewModel.setPlaylistTags(playlist.id, next)
+            },
+            onCreateTag = { name -> viewModel.createPlaylistTag(name, playlist.id) },
+            onRenameTag = { tagId, name -> viewModel.renamePlaylistTag(tagId, name) },
+            onDeleteTag = { tagId -> viewModel.deletePlaylistTag(tagId) }
+        )
     }
 
     if (renameDialog) {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/library/PlaylistOrganizationUi.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/library/PlaylistOrganizationUi.kt
@@ -1,0 +1,261 @@
+package com.luc4n3x.levyra.ui.library
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.Edit
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.Visibility
+import androidx.compose.material.icons.rounded.VisibilityOff
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.luc4n3x.levyra.domain.PLAYLIST_TAG_MAX_PER_PLAYLIST
+import com.luc4n3x.levyra.domain.Playlist
+import com.luc4n3x.levyra.domain.PlaylistTag
+import com.luc4n3x.levyra.domain.isValidPlaylistTagName
+import com.luc4n3x.levyra.ui.i18n.LocalLevyraStrings
+import com.luc4n3x.levyra.ui.theme.LevyraCyan
+import com.luc4n3x.levyra.ui.theme.LevyraMuted
+import com.luc4n3x.levyra.ui.theme.LevyraText
+
+@Composable
+internal fun LibraryPlaylistFilterRow(
+    tags: List<PlaylistTag>,
+    selectedTagIds: Set<String>,
+    hiddenVisible: Boolean,
+    hiddenCount: Int,
+    onClearTags: () -> Unit,
+    onToggleTag: (String) -> Unit,
+    onToggleHidden: () -> Unit
+) {
+    val strings = LocalLevyraStrings.current
+    if (tags.isEmpty() && hiddenCount == 0) return
+    Row(
+        modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        if (tags.isNotEmpty()) {
+            LibraryCategoryChip(
+                label = strings.all,
+                selected = selectedTagIds.isEmpty(),
+                onClick = onClearTags
+            )
+            tags.forEach { tag ->
+                LibraryCategoryChip(
+                    label = tag.name,
+                    selected = tag.id in selectedTagIds,
+                    onClick = { onToggleTag(tag.id) }
+                )
+            }
+        }
+        if (hiddenCount > 0) {
+            LibraryCategoryChip(
+                label = "${strings.hiddenPlaylists} · $hiddenCount",
+                selected = hiddenVisible,
+                onClick = onToggleHidden
+            )
+        }
+    }
+}
+
+@Composable
+internal fun PlaylistOrganizationBar(
+    playlist: Playlist,
+    onEditTags: () -> Unit,
+    onToggleHidden: () -> Unit
+) {
+    val strings = LocalLevyraStrings.current
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Row(
+            modifier = Modifier.weight(1f).horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            playlist.tags.forEach { tag ->
+                PlaylistTagChip(label = tag.name, onClick = onEditTags)
+            }
+            PlaylistTagChip(
+                label = if (playlist.tags.isEmpty()) strings.playlistTags else strings.editPlaylistTags,
+                onClick = onEditTags,
+                outlined = true
+            )
+        }
+        IconButton(onClick = onToggleHidden) {
+            Icon(
+                imageVector = if (playlist.hidden) Icons.Rounded.Visibility else Icons.Rounded.VisibilityOff,
+                contentDescription = if (playlist.hidden) strings.unhidePlaylist else strings.hidePlaylist,
+                tint = if (playlist.hidden) LevyraCyan else LevyraMuted
+            )
+        }
+    }
+}
+
+@Composable
+private fun PlaylistTagChip(label: String, onClick: () -> Unit, outlined: Boolean = false) {
+    Surface(
+        color = if (outlined) Color.Transparent else LevyraCyan.copy(alpha = 0.16f),
+        border = if (outlined) BorderStroke(1.dp, LevyraMuted.copy(alpha = 0.35f)) else null,
+        shape = RoundedCornerShape(14.dp),
+        onClick = onClick
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            color = if (outlined) LevyraMuted else LevyraText,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.SemiBold
+        )
+    }
+}
+
+@Composable
+internal fun PlaylistTagEditorDialog(
+    assignedTagIds: Set<String>,
+    tags: List<PlaylistTag>,
+    onDismiss: () -> Unit,
+    onToggleTag: (String) -> Unit,
+    onCreateTag: (String) -> Unit,
+    onRenameTag: (String, String) -> Unit,
+    onDeleteTag: (String) -> Unit
+) {
+    val strings = LocalLevyraStrings.current
+    var tagName by remember { mutableStateOf("") }
+    var renamingTagId by remember { mutableStateOf<String?>(null) }
+    val limitReached = assignedTagIds.size >= PLAYLIST_TAG_MAX_PER_PLAYLIST
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(strings.playlistTags) },
+        text = {
+            Column(
+                modifier = Modifier.heightIn(max = 420.dp).verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                if (limitReached) {
+                    Text(
+                        text = strings.playlistTagLimitReached,
+                        color = LevyraMuted,
+                        fontSize = 12.sp
+                    )
+                }
+                tags.forEach { tag ->
+                    val selected = tag.id in assignedTagIds
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        LibraryCategoryChip(
+                            label = tag.name,
+                            selected = selected,
+                            onClick = {
+                                if (selected || !limitReached) onToggleTag(tag.id)
+                            }
+                        )
+                        Row(
+                            modifier = Modifier.weight(1f),
+                            horizontalArrangement = Arrangement.End
+                        ) {
+                            IconButton(
+                                onClick = {
+                                    renamingTagId = tag.id
+                                    tagName = tag.name
+                                }
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.Edit,
+                                    contentDescription = strings.editPlaylistTags,
+                                    tint = if (renamingTagId == tag.id) LevyraCyan else LevyraMuted,
+                                    modifier = Modifier.size(18.dp)
+                                )
+                            }
+                            IconButton(
+                                onClick = {
+                                    if (renamingTagId == tag.id) {
+                                        renamingTagId = null
+                                        tagName = ""
+                                    }
+                                    onDeleteTag(tag.id)
+                                }
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.Delete,
+                                    contentDescription = strings.delete,
+                                    tint = LevyraMuted,
+                                    modifier = Modifier.size(18.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+                val editingTagId = renamingTagId
+                OutlinedTextField(
+                    value = tagName,
+                    onValueChange = { tagName = it },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                    placeholder = { Text(strings.playlistTagName) },
+                    trailingIcon = {
+                        IconButton(
+                            onClick = {
+                                if (!isValidPlaylistTagName(tagName)) return@IconButton
+                                if (editingTagId != null) {
+                                    onRenameTag(editingTagId, tagName)
+                                    renamingTagId = null
+                                } else {
+                                    onCreateTag(tagName)
+                                }
+                                tagName = ""
+                            },
+                            enabled = isValidPlaylistTagName(tagName) &&
+                                (editingTagId != null || !limitReached)
+                        ) {
+                            Icon(
+                                imageVector = if (editingTagId != null) Icons.Rounded.Check else Icons.Rounded.Add,
+                                contentDescription = if (editingTagId != null) {
+                                    strings.editPlaylistTags
+                                } else {
+                                    strings.newPlaylistTag
+                                }
+                            )
+                        }
+                    }
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(strings.done) }
+        }
+    )
+}

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -29,6 +29,7 @@ import com.luc4n3x.levyra.domain.LyricLine
 import com.luc4n3x.levyra.domain.Mood
 import com.luc4n3x.levyra.domain.OfflineDownloadTask
 import com.luc4n3x.levyra.domain.Playlist
+import com.luc4n3x.levyra.domain.PlaylistTag
 import com.luc4n3x.levyra.domain.ReleaseRadarEntry
 import com.luc4n3x.levyra.domain.ResonanceCommentSnippet
 import com.luc4n3x.levyra.domain.RepeatMode
@@ -363,6 +364,12 @@ class LibraryViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::li
     fun removeFromPlaylist(playlistId: String, trackId: String) = root.removeFromPlaylist(playlistId, trackId)
     fun removeTracksFromPlaylist(playlistId: String, tracks: List<Track>) = root.removeTracksFromPlaylist(playlistId, tracks)
     fun renamePlaylist(playlistId: String, name: String) = root.renamePlaylist(playlistId, name)
+    fun setPlaylistHidden(playlistId: String, hidden: Boolean) = root.setPlaylistHidden(playlistId, hidden)
+    fun createPlaylistTag(name: String, assignToPlaylistId: String? = null) =
+        root.createPlaylistTag(name, assignToPlaylistId)
+    fun renamePlaylistTag(tagId: String, name: String) = root.renamePlaylistTag(tagId, name)
+    fun deletePlaylistTag(tagId: String) = root.deletePlaylistTag(tagId)
+    fun setPlaylistTags(playlistId: String, tagIds: List<String>) = root.setPlaylistTags(playlistId, tagIds)
     fun reorderPlaylist(playlistId: String, tracks: List<Track>) = root.reorderPlaylist(playlistId, tracks)
     fun resumeDownload(taskKey: String) = root.resumeDownload(taskKey)
     fun toggleFavorite(track: Track) = root.toggleFavorite(track)
@@ -375,6 +382,7 @@ class PlayerViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::pla
     fun createPlaylist(name: String, firstTrack: Track? = null) = root.createPlaylist(name, firstTrack)
     fun cycleSpeed() = root.cycleSpeed()
     fun openSleepTimer() = root.openSleepTimer()
+    fun openAmbient() = root.openAmbient()
     fun exportCurrentTrack() = root.exportCurrentTrack()
     fun next() = root.next()
     fun openArtist(track: Track) = root.openArtist(track)
@@ -509,7 +517,7 @@ private data class HomeDerivedInput(
 )
 
 internal fun buildHomeRenderSnapshot(state: LevyraUiState): HomeRenderSnapshot {
-    val renderState = state.withDeduplicatedHomeAlbums()
+    val renderState = state.withoutExcludedArtists().withDeduplicatedHomeAlbums()
     return HomeRenderSnapshot(
         state = renderState,
         derived = buildHomeDerivedState(renderState.toHomeDerivedInput())
@@ -520,7 +528,7 @@ internal fun buildHomeRenderSnapshot(
     state: LevyraUiState,
     previous: HomeRenderSnapshot
 ): HomeRenderSnapshot {
-    val renderState = state.withDeduplicatedHomeAlbums()
+    val renderState = state.withoutExcludedArtists().withDeduplicatedHomeAlbums()
     val derived = if (sameHomeDerivedInputs(previous.state, renderState)) {
         previous.derived
     } else {
@@ -532,6 +540,41 @@ internal fun buildHomeRenderSnapshot(
 private fun LevyraUiState.withDeduplicatedHomeAlbums(): LevyraUiState {
     val distinctAlbums = deduplicateHomeAlbums(homeAlbums)
     return if (distinctAlbums.size == homeAlbums.size) this else copy(homeAlbums = distinctAlbums)
+}
+
+private fun LevyraUiState.withoutExcludedArtists(): LevyraUiState {
+    val exclusions = artistExclusions
+    if (exclusions.isEmpty) return this
+    val filteredSections = exclusions.filterHomeSections(homeSections)
+    val filteredAlbums = exclusions.filterAlbumHits(homeAlbums)
+    val filteredArtists = exclusions.filterArtistHits(homeArtists)
+    val filteredSimilar = exclusions.filterArtistHits(similarArtists)
+    val filteredOrbit = exclusions.filterTracks(personalOrbitTracks)
+    val filteredResonance = exclusions.filterTracks(homeResonanceTracks)
+    val filteredRadar = exclusions.filterReleaseRadar(releaseRadar)
+    val filteredTracks = exclusions.filterTracks(tracks)
+    val filteredForgotten = exclusions.filterTracks(forgottenFavorites)
+    val unchanged = filteredSections === homeSections &&
+        filteredAlbums === homeAlbums &&
+        filteredArtists === homeArtists &&
+        filteredSimilar === similarArtists &&
+        filteredOrbit === personalOrbitTracks &&
+        filteredResonance === homeResonanceTracks &&
+        filteredRadar === releaseRadar &&
+        filteredTracks === tracks &&
+        filteredForgotten === forgottenFavorites
+    if (unchanged) return this
+    return copy(
+        homeSections = filteredSections,
+        homeAlbums = filteredAlbums,
+        homeArtists = filteredArtists,
+        similarArtists = filteredSimilar,
+        personalOrbitTracks = filteredOrbit,
+        homeResonanceTracks = filteredResonance,
+        releaseRadar = filteredRadar,
+        tracks = filteredTracks,
+        forgottenFavorites = filteredForgotten
+    )
 }
 
 private fun sameHomeDerivedInputs(previous: LevyraUiState, current: LevyraUiState): Boolean {
@@ -896,6 +939,7 @@ private data class HomeProjection(
     val downloadingTrackIds: Set<String>,
     val favoriteIds: Set<String>,
     val favorites: List<Track>,
+    val forgottenFavorites: List<Track>,
     val homeAlbums: List<AlbumHit>,
     val homeArtists: List<ArtistHit>,
     val homeResonanceTracks: List<Track>,
@@ -934,6 +978,7 @@ private fun homeProjection(state: LevyraUiState): HomeProjection = HomeProjectio
     downloadingTrackIds = state.downloadingTrackIds,
     favoriteIds = state.favoriteIds,
     favorites = state.favorites,
+    forgottenFavorites = state.forgottenFavorites,
     homeAlbums = state.homeAlbums,
     homeArtists = state.homeArtists,
     homeResonanceTracks = state.homeResonanceTracks,
@@ -1084,6 +1129,7 @@ internal data class LibraryProjection(
     val listeningPulse: ListeningPulse,
     val openPlaylist: Playlist?,
     val playlists: List<Playlist>,
+    val playlistTags: List<PlaylistTag>,
     val recentListens: List<Track>
 )
 
@@ -1104,6 +1150,7 @@ internal fun libraryProjection(state: LevyraUiState): LibraryProjection = Librar
     listeningPulse = state.listeningPulse,
     openPlaylist = state.openPlaylist,
     playlists = state.playlists,
+    playlistTags = state.playlistTags,
     recentListens = state.recentListens
 )
 

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
@@ -3,8 +3,12 @@ package com.luc4n3x.levyra.viewmodel
 import android.net.Uri
 import androidx.compose.runtime.Immutable
 import com.luc4n3x.levyra.data.VaultPreview
+import com.luc4n3x.levyra.domain.ArtistExclusions
 import com.luc4n3x.levyra.domain.ArtistHit
 import com.luc4n3x.levyra.domain.ArtistProfile
+import com.luc4n3x.levyra.domain.ExcludedArtist
+import com.luc4n3x.levyra.domain.LevyraAmbientSettings
+import com.luc4n3x.levyra.domain.PlaylistTag
 import com.luc4n3x.levyra.domain.AlbumHit
 import com.luc4n3x.levyra.domain.AlbumDetail
 import com.luc4n3x.levyra.domain.CacheReport
@@ -124,7 +128,9 @@ data class LevyraUiState(
     val detailReturnTarget: DetailReturnTarget = DetailReturnTarget.None,
     val favorites: List<Track> = emptyList(),
     val favoriteIds: Set<String> = emptySet(),
+    val forgottenFavorites: List<Track> = emptyList(),
     val playlists: List<com.luc4n3x.levyra.domain.Playlist> = emptyList(),
+    val playlistTags: List<PlaylistTag> = emptyList(),
     val openPlaylist: com.luc4n3x.levyra.domain.Playlist? = null,
     val currentTrack: Track? = null,
     val motionArtwork: MotionArtwork? = null,
@@ -227,6 +233,10 @@ data class LevyraUiState(
     val mostPlayedTracks: List<Track> = emptyList(),
     val followedArtists: List<FollowedArtist> = emptyList(),
     val followedArtistKeys: Set<String> = emptySet(),
+    val excludedArtists: List<ExcludedArtist> = emptyList(),
+    val artistExclusions: ArtistExclusions = ArtistExclusions.Empty,
+    val showAmbient: Boolean = false,
+    val ambientSettings: LevyraAmbientSettings = LevyraAmbientSettings(),
     val releaseRadar: List<ReleaseRadarEntry> = emptyList(),
     val similarArtists: List<ArtistHit> = emptyList(),
     val mixFamiliarity: Float = LevyraMixDefaults.Familiarity,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -784,6 +784,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private var radarJob: Job? = null
     private var followedArtistsJob: Job? = null
     private var forgottenFavoritesJob: Job? = null
+    private var excludedArtistsGeneration = 0L
     private var followedArtistsGeneration = 0L
     private var radioJob: Job? = null
     private var sponsorSegments: List<SponsorSegment> = emptyList()
@@ -1980,8 +1981,10 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     private fun loadExcludedArtists() {
+        val loadGeneration = excludedArtistsGeneration
         viewModelScope.launch {
             val excluded = excludedArtistsStore.load()
+            if (loadGeneration != excludedArtistsGeneration) return@launch
             applyExcludedArtists(excluded)
         }
     }
@@ -2017,22 +2020,30 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 current.filterNot { it.key == key }
         }
         applyExcludedArtists(updated)
+        excludedArtistsGeneration++
+        val mutationGeneration = excludedArtistsGeneration
         viewModelScope.launch {
             if (alreadyExcluded) {
                 excludedArtistsStore.include(browseId, cleanName)
             } else {
                 excludedArtistsStore.exclude(browseId, cleanName)
             }
-            applyExcludedArtists(excludedArtistsStore.load())
+            val reloaded = excludedArtistsStore.load()
+            if (mutationGeneration != excludedArtistsGeneration) return@launch
+            applyExcludedArtists(reloaded)
         }
     }
 
     fun includeArtist(artist: ExcludedArtist) {
         val remaining = _state.value.excludedArtists.filterNot { it.key == artist.key }
         applyExcludedArtists(remaining)
+        excludedArtistsGeneration++
+        val mutationGeneration = excludedArtistsGeneration
         viewModelScope.launch {
             excludedArtistsStore.include(artist.browseId, artist.name)
-            applyExcludedArtists(excludedArtistsStore.load())
+            val reloaded = excludedArtistsStore.load()
+            if (mutationGeneration != excludedArtistsGeneration) return@launch
+            applyExcludedArtists(reloaded)
         }
     }
 
@@ -4164,6 +4175,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         if (snapshot.motionArtworkEnabled && restoredAnimationsEnabled) {
             _state.value.currentTrack?.let(::refreshMotionArtworkAround)
         }
+        refreshForgottenFavorites()
     }
 
     fun setLanguage(code: String) {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -95,7 +95,14 @@ import com.luc4n3x.levyra.ui.i18n.playlistImportFailureMessage
 import com.luc4n3x.levyra.ui.i18n.playlistImportStartedMessage
 import com.luc4n3x.levyra.ui.i18n.playlistImportSuccessMessage
 import com.luc4n3x.levyra.domain.ExploreZone
+import com.luc4n3x.levyra.domain.ArtistExclusions
+import com.luc4n3x.levyra.domain.ExcludedArtist
 import com.luc4n3x.levyra.domain.FollowedArtist
+import com.luc4n3x.levyra.domain.ForgottenFavorites
+import com.luc4n3x.levyra.domain.LevyraAmbientSettings
+import com.luc4n3x.levyra.domain.excludedArtistKeyOf
+import com.luc4n3x.levyra.domain.isExcludableArtist
+import com.luc4n3x.levyra.domain.isValidPlaylistTagName
 import com.luc4n3x.levyra.domain.ReleaseRadarEntry
 import com.luc4n3x.levyra.domain.SearchFilter
 import com.luc4n3x.levyra.domain.SearchResults
@@ -669,6 +676,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private val favoritesStore = FavoritesStore(application.applicationContext)
     private val favoriteMutationMutex = Mutex()
     private val followedArtistsStore = FollowedArtistsStore(application.applicationContext)
+    private val excludedArtistsStore = com.luc4n3x.levyra.data.ExcludedArtistsStore(application.applicationContext)
     private val playlistStore = com.luc4n3x.levyra.data.PlaylistStore(application.applicationContext)
     private val preferences = LevyraPreferences(application.applicationContext)
     private val audioSettingsPersistence = AudioSettingsPersistenceCoordinator(preferences::setAudioSettings)
@@ -775,6 +783,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private val deferredHomeArtistsSnapshot = AtomicReference<List<ArtistHit>?>(null)
     private var radarJob: Job? = null
     private var followedArtistsJob: Job? = null
+    private var forgottenFavoritesJob: Job? = null
     private var followedArtistsGeneration = 0L
     private var radioJob: Job? = null
     private var sponsorSegments: List<SponsorSegment> = emptyList()
@@ -1270,6 +1279,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         observeDownloadTasks()
         observeDownloadBatches()
         loadPlaylists()
+        loadExcludedArtists()
+        loadAmbientSettings()
+        refreshForgottenFavorites()
         viewModelScope.launch(Dispatchers.Default) { consumeOfficialMetadataQueue() }
         viewModelScope.launch(Dispatchers.IO) {
             listeningPulseStore.ensureLifetimeBackfill()
@@ -1962,7 +1974,154 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private fun loadPlaylists() {
         viewModelScope.launch {
             val lists = playlistStore.loadAll()
-            _state.update { it.copy(playlists = lists) }
+            val tags = playlistStore.allTags()
+            _state.update { it.copy(playlists = lists, playlistTags = tags) }
+        }
+    }
+
+    private fun loadExcludedArtists() {
+        viewModelScope.launch {
+            val excluded = excludedArtistsStore.load()
+            applyExcludedArtists(excluded)
+        }
+    }
+
+    private fun loadAmbientSettings() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val settings = preferences.ambientSettings()
+            withContext(Dispatchers.Main) {
+                _state.update { it.copy(ambientSettings = settings) }
+            }
+        }
+    }
+
+    private fun applyExcludedArtists(excluded: List<ExcludedArtist>) {
+        _state.update {
+            it.copy(
+                excludedArtists = excluded,
+                artistExclusions = ArtistExclusions.from(excluded)
+            )
+        }
+    }
+
+    fun toggleExcludeArtist(browseId: String, name: String) {
+        val cleanName = name.trim()
+        if (!isExcludableArtist(browseId, cleanName)) return
+        val key = excludedArtistKeyOf(browseId, cleanName)
+        val current = _state.value.excludedArtists
+        val alreadyExcluded = current.any { it.key == key }
+        val updated = if (alreadyExcluded) {
+            current.filterNot { it.key == key }
+        } else {
+            listOf(ExcludedArtist(browseId.trim(), cleanName, System.currentTimeMillis())) +
+                current.filterNot { it.key == key }
+        }
+        applyExcludedArtists(updated)
+        viewModelScope.launch {
+            if (alreadyExcluded) {
+                excludedArtistsStore.include(browseId, cleanName)
+            } else {
+                excludedArtistsStore.exclude(browseId, cleanName)
+            }
+            applyExcludedArtists(excludedArtistsStore.load())
+        }
+    }
+
+    fun includeArtist(artist: ExcludedArtist) {
+        val remaining = _state.value.excludedArtists.filterNot { it.key == artist.key }
+        applyExcludedArtists(remaining)
+        viewModelScope.launch {
+            excludedArtistsStore.include(artist.browseId, artist.name)
+            applyExcludedArtists(excludedArtistsStore.load())
+        }
+    }
+
+    fun setPlaylistHidden(playlistId: String, hidden: Boolean) {
+        if (playlistId.isBlank()) return
+        viewModelScope.launch {
+            playlistStore.setHidden(playlistId, hidden)
+            loadPlaylists()
+            refreshOpenPlaylist(playlistId)
+        }
+    }
+
+    fun createPlaylistTag(name: String, assignToPlaylistId: String? = null) {
+        if (!isValidPlaylistTagName(name)) return
+        viewModelScope.launch {
+            val tag = playlistStore.createTag(name) ?: return@launch
+            if (!assignToPlaylistId.isNullOrBlank()) {
+                val existing = playlistStore.load(assignToPlaylistId)?.tags?.map { it.id }.orEmpty()
+                if (tag.id !in existing) {
+                    playlistStore.setPlaylistTags(assignToPlaylistId, existing + tag.id)
+                }
+            }
+            loadPlaylists()
+            assignToPlaylistId?.let { refreshOpenPlaylist(it) }
+        }
+    }
+
+    fun renamePlaylistTag(tagId: String, name: String) {
+        if (tagId.isBlank() || !isValidPlaylistTagName(name)) return
+        viewModelScope.launch {
+            playlistStore.renameTag(tagId, name)
+            loadPlaylists()
+            _state.value.openPlaylist?.id?.let { refreshOpenPlaylist(it) }
+        }
+    }
+
+    fun deletePlaylistTag(tagId: String) {
+        if (tagId.isBlank()) return
+        viewModelScope.launch {
+            playlistStore.deleteTag(tagId)
+            loadPlaylists()
+            _state.value.openPlaylist?.id?.let { refreshOpenPlaylist(it) }
+        }
+    }
+
+    fun setPlaylistTags(playlistId: String, tagIds: List<String>) {
+        if (playlistId.isBlank()) return
+        viewModelScope.launch {
+            playlistStore.setPlaylistTags(playlistId, tagIds)
+            loadPlaylists()
+            refreshOpenPlaylist(playlistId)
+        }
+    }
+
+    fun openAmbient() {
+        if (_state.value.showAmbient) return
+        _state.update { it.copy(showAmbient = true) }
+    }
+
+    fun closeAmbient() {
+        if (!_state.value.showAmbient) return
+        _state.update { it.copy(showAmbient = false) }
+    }
+
+    fun updateAmbientSettings(settings: LevyraAmbientSettings) {
+        val normalized = settings.normalized()
+        _state.update { it.copy(ambientSettings = normalized) }
+        viewModelScope.launch(Dispatchers.IO) { preferences.setAmbientSettings(normalized) }
+    }
+
+    private fun refreshForgottenFavorites() {
+        forgottenFavoritesJob?.cancel()
+        val favorites = _state.value.favorites
+        if (favorites.isEmpty()) {
+            if (_state.value.forgottenFavorites.isNotEmpty()) {
+                _state.update { it.copy(forgottenFavorites = emptyList()) }
+            }
+            return
+        }
+        forgottenFavoritesJob = viewModelScope.launch(Dispatchers.Default) {
+            val keys = ForgottenFavorites.listeningKeys(favorites)
+            val lastPlayed = listeningPulseStore.lastPlayedByKey(keys)
+            val selected = ForgottenFavorites.select(favorites, lastPlayed)
+            withContext(Dispatchers.Main) {
+                if (_state.value.favorites !== favorites) return@withContext
+                if (_state.value.forgottenFavorites != selected) {
+                    _state.update { it.copy(forgottenFavorites = selected) }
+                }
+            }
         }
     }
 
@@ -3945,8 +4104,10 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         val snapshot = withContext(Dispatchers.IO) { preferences.snapshot() }
         val favorites = withContext(Dispatchers.IO) { favoritesStore.load() }
         val playlists = playlistStore.loadAll()
+        val playlistTags = playlistStore.allTags()
         val followed = followedArtistsStore.load()
         applyFollowedArtists(followed)
+        applyExcludedArtists(excludedArtistsStore.load())
         pendingSeekMs = snapshot.lastPositionMs.coerceAtLeast(0L)
         val restoredTrack = snapshot.lastTrack?.copy(streamUrl = "", videoStreamUrl = "")
         val restoredAnimationsEnabled = snapshot.animationsEnabled &&
@@ -3959,6 +4120,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 favorites = favorites,
                 favoriteIds = favorites.map { track -> track.id }.toSet(),
                 playlists = playlists,
+                playlistTags = playlistTags,
                 recentSearches = snapshot.recentSearches,
                 personalOrbitTracks = snapshot.personalOrbitTracks,
                 userName = snapshot.userName,
@@ -4540,6 +4702,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 }
                 updated to isFavorite
             }
+            refreshForgottenFavorites()
             LevyraArtworkCache.preloadPriority(
                 getApplication<Application>().applicationContext,
                 updated,
@@ -4563,6 +4726,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                     }
                 }
             }
+            refreshForgottenFavorites()
             LevyraArtworkCache.preloadPriority(
                 getApplication<Application>().applicationContext,
                 updated,
@@ -4579,6 +4743,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         if (updated.size == current.size) return
         _state.update { it.copy(favorites = updated, favoriteIds = updated.map { favorite -> favorite.id }.toSet()) }
         viewModelScope.launch(Dispatchers.IO) { favoritesStore.saveSuspending(updated) }
+        refreshForgottenFavorites()
         _state.update { it.copy(offlineExportMessage = "Rimossi dai preferiti: ${current.size - updated.size}") }
     }
 
@@ -7972,13 +8137,14 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         request: RadioTailRequest,
         playWhenReady: Boolean
     ) {
-        val radioTracks = try {
+        val fetchedRadioTracks = try {
             repository.radio(request.seed, _state.value.languageCode, 5)
         } catch (cancelled: CancellationException) {
             throw cancelled
         } catch (_: Exception) {
             emptyList()
         }
+        val radioTracks = _state.value.artistExclusions.filterTracks(fetchedRadioTracks)
         if (radioTracks.isEmpty()) return
         val current = queueEngine.state.value
         if (!current.radioEnabled) return
@@ -9058,7 +9224,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                     ?: snapshot.currentTrack
                     ?: snapshot.recentListens.firstOrNull()
                     ?: snapshot.mostPlayedTracks.firstOrNull()
-                val pool = collectMixPool(kind, seed, seedQuery, snapshot)
+                val pool = snapshot.artistExclusions.filterTracks(
+                    collectMixPool(kind, seed, seedQuery, snapshot)
+                )
                 if (pool.isEmpty()) {
                     _state.update { it.copy(mixLoading = false, mixMessage = MIX_UNAVAILABLE_MARKER) }
                     return@launch

--- a/app/src/main/res/drawable/ic_qs_ambient.xml
+++ b/app/src/main/res/drawable/ic_qs_ambient.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,3c-4.97,0 -9,4.03 -9,9s4.03,9 9,9c0.42,0 0.83,-0.03 1.24,-0.09 -2.8,-1.6 -4.69,-4.61 -4.69,-8.06s1.89,-6.46 4.69,-8.06C12.83,3.03 12.42,3 12,3z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,8 +29,8 @@
     <string name="notification_shuffle">Shuffle</string>
     <string name="notification_favorite">Favorite</string>
     <string name="tile_recognize_music">Recognize music</string>
-    <string name="tile_ambient">Ambient</string>
-    <string name="ambient_dream_label">Levyra Ambient</string>
+    <string name="tile_ambient" translatable="false">Ambient</string>
+    <string name="ambient_dream_label" translatable="false">Levyra Ambient</string>
     <string name="recognition_notification_channel" translatable="false">Music recognition</string>
     <string name="shortcut_search">Search</string>
     <string name="shortcut_library">Library</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,8 @@
     <string name="notification_shuffle">Shuffle</string>
     <string name="notification_favorite">Favorite</string>
     <string name="tile_recognize_music">Recognize music</string>
+    <string name="tile_ambient">Ambient</string>
+    <string name="ambient_dream_label">Levyra Ambient</string>
     <string name="recognition_notification_channel" translatable="false">Music recognition</string>
     <string name="shortcut_search">Search</string>
     <string name="shortcut_library">Library</string>

--- a/app/src/test/java/com/luc4n3x/levyra/data/AutomaticBackupPolicyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/AutomaticBackupPolicyTest.kt
@@ -64,6 +64,7 @@ class AutomaticBackupPolicyTest {
         assertTrue(vaultEntryAllowed("data/playlists.json"))
         assertTrue(vaultEntryAllowed("data/history.json"))
         assertTrue(vaultEntryAllowed("data/queue.json"))
+        assertTrue(vaultEntryAllowed("data/library_organization.json"))
         assertTrue(vaultEntryAllowed("payload.json"))
         assertFalse(vaultEntryAllowed("../manifest.json"))
         assertFalse(vaultEntryAllowed("/etc/passwd"))
@@ -71,6 +72,31 @@ class AutomaticBackupPolicyTest {
         assertFalse(vaultEntryAllowed("..\\manifest.json"))
         assertFalse(vaultEntryAllowed("data/evil.json"))
         assertFalse(vaultEntryAllowed(""))
+    }
+
+    @Test
+    fun everyWrittenVaultSectionIsAcceptedOnRead() {
+        val written = setOf(
+            LevyraBackupManager.MANIFEST_ENTRY,
+            LevyraBackupManager.SETTINGS_ENTRY,
+            LevyraBackupManager.FAVORITES_ENTRY,
+            LevyraBackupManager.FOLLOWED_ARTISTS_ENTRY,
+            LevyraBackupManager.PLAYLISTS_ENTRY,
+            LevyraBackupManager.ORGANIZATION_ENTRY,
+            LevyraBackupManager.HISTORY_ENTRY,
+            LevyraBackupManager.QUEUE_ENTRY
+        )
+        written.forEach { entry ->
+            assertTrue("$entry is written but rejected on read", vaultEntryAllowed(entry))
+        }
+        assertTrue(written.size <= LevyraBackupManager.MAX_ZIP_ENTRIES)
+    }
+
+    @Test
+    fun optionalVaultSectionsAreNotRequiredForRestore() {
+        val legacyEntries = REQUIRED_VAULT_ENTRIES + LevyraBackupManager.MANIFEST_ENTRY
+        assertTrue(vaultStructureCompatible(legacyEntries))
+        assertFalse(LevyraBackupManager.ORGANIZATION_ENTRY in REQUIRED_VAULT_ENTRIES)
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/domain/ArtistExclusionsTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/domain/ArtistExclusionsTest.kt
@@ -1,0 +1,135 @@
+package com.luc4n3x.levyra.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ArtistExclusionsTest {
+
+    @Test
+    fun emptyExclusionsKeepEverything() {
+        val tracks = listOf(track("a", "Some Artist"))
+
+        assertSame(tracks, ArtistExclusions.Empty.filterTracks(tracks))
+    }
+
+    @Test
+    fun matchesByBrowseId() {
+        val exclusions = ArtistExclusions.from(listOf(ExcludedArtist("UC123", "Renamed Artist", 0L)))
+        val tracks = listOf(
+            track("kept", "Other", browseIds = listOf("UC999")),
+            track("dropped", "Whatever", browseIds = listOf("UC123"))
+        )
+
+        assertEquals(listOf("kept"), exclusions.filterTracks(tracks).map { it.id })
+    }
+
+    @Test
+    fun matchesByNameIgnoringCaseAccentsAndLeadingArticle() {
+        val exclusions = ArtistExclusions.from(listOf(ExcludedArtist("", "The Weeknd", 0L)))
+
+        assertTrue(exclusions.excludesArtistName("weeknd"))
+        assertTrue(exclusions.excludesArtistName("THE WEEKND"))
+        assertFalse(exclusions.excludesArtistName("Weekend Warriors"))
+    }
+
+    @Test
+    fun matchesCollaborationSegments() {
+        val exclusions = ArtistExclusions.from(listOf(ExcludedArtist("", "Blocked", 0L)))
+
+        assertTrue(exclusions.excludesArtistName("Allowed feat. Blocked"))
+        assertTrue(exclusions.excludesArtistName("Allowed, Blocked"))
+        assertTrue(exclusions.excludesArtistName("Allowed & Blocked"))
+        assertFalse(exclusions.excludesArtistName("Allowed & Someone"))
+    }
+
+    @Test
+    fun keepsListIdentityWhenNothingIsRemoved() {
+        val exclusions = ArtistExclusions.from(listOf(ExcludedArtist("UC404", "Absent", 0L)))
+        val tracks = listOf(track("a", "Present"))
+
+        assertSame(tracks, exclusions.filterTracks(tracks))
+    }
+
+    @Test
+    fun dropsEmptiedHomeSectionsAndTrimsPartialOnes() {
+        val exclusions = ArtistExclusions.from(listOf(ExcludedArtist("", "Blocked", 0L)))
+        val sections = listOf(
+            HomeSection("only blocked", listOf(track("x", "Blocked"))),
+            HomeSection("mixed", listOf(track("y", "Blocked"), track("z", "Allowed"))),
+            HomeSection("clean", listOf(track("w", "Allowed")))
+        )
+
+        val result = exclusions.filterHomeSections(sections)
+
+        assertEquals(listOf("mixed", "clean"), result.map { it.title })
+        assertEquals(listOf("z"), result.first().tracks.map { it.id })
+    }
+
+    @Test
+    fun filtersArtistHitsAlbumsAndReleaseRadar() {
+        val exclusions = ArtistExclusions.from(listOf(ExcludedArtist("UC1", "Blocked", 0L)))
+
+        val artists = listOf(
+            ArtistHit("Blocked", "", "", 0, 0, "UC1"),
+            ArtistHit("Allowed", "", "", 0, 0, "UC2")
+        )
+        val albums = listOf(
+            AlbumHit("Album A", "Blocked", "2024", "", ""),
+            AlbumHit("Album B", "Allowed", "2024", "", "")
+        )
+        val radar = listOf(
+            ReleaseRadarEntry("Blocked", "UC1", release(), isFresh = true),
+            ReleaseRadarEntry("Allowed", "UC2", release(), isFresh = true)
+        )
+
+        assertEquals(listOf("Allowed"), exclusions.filterArtistHits(artists).map { it.name })
+        assertEquals(listOf("Album B"), exclusions.filterAlbumHits(albums).map { it.title })
+        assertEquals(listOf("Allowed"), exclusions.filterReleaseRadar(radar).map { it.artistName })
+    }
+
+    @Test
+    fun exclusionKeyPrefersBrowseIdAndFallsBackToIdentity() {
+        assertEquals("UC7", excludedArtistKeyOf("UC7", "Anything"))
+        assertEquals("name:some artist", excludedArtistKeyOf("", "  Sómé Artist  "))
+    }
+
+    @Test
+    fun onlyArtistsWithUsableIdentityCanBeExcluded() {
+        assertTrue(isExcludableArtist("UC7", ""))
+        assertTrue(isExcludableArtist("", "Ok"))
+        assertFalse(isExcludableArtist("", " "))
+        assertFalse(isExcludableArtist("", "!"))
+    }
+
+    private fun release() = ArtistRelease(
+        browseId = "MPRE1",
+        title = "Release",
+        subtitle = "2024",
+        thumbnailUrl = "",
+        year = "2024"
+    )
+
+    private fun track(id: String, artist: String, browseIds: List<String> = emptyList()) = Track(
+        id = id,
+        title = "Title $id",
+        artist = artist,
+        album = "Album",
+        durationMs = 1_000L,
+        streamUrl = "",
+        videoUrl = "",
+        thumbnailUrl = "",
+        largeThumbnailUrl = "",
+        source = "test",
+        moodTags = emptySet(),
+        energy = 0,
+        vocal = 0,
+        replayScore = 0,
+        cacheScore = 0,
+        accentStart = 0,
+        accentEnd = 0,
+        artistBrowseIds = browseIds
+    )
+}

--- a/app/src/test/java/com/luc4n3x/levyra/domain/ForgottenFavoritesTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/domain/ForgottenFavoritesTest.kt
@@ -1,0 +1,150 @@
+package com.luc4n3x.levyra.domain
+
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ForgottenFavoritesTest {
+
+    private val now = 1_700_000_000_000L
+
+    @Test
+    fun selectsOnlyFavoritesNotPlayedForAtLeastThreshold() {
+        val forgotten = track("forgotten")
+        val recent = track("recent")
+
+        val result = ForgottenFavorites.select(
+            favorites = listOf(recent, forgotten),
+            lastPlayedByKey = mapOf(
+                "forgotten" to now - days(90),
+                "recent" to now - days(3)
+            ),
+            nowMs = now
+        )
+
+        assertEquals(listOf("forgotten"), result.map { it.id })
+    }
+
+    @Test
+    fun excludesFavoritesWithoutAnyListeningRecord() {
+        val neverPlayed = track("never")
+
+        val result = ForgottenFavorites.select(
+            favorites = listOf(neverPlayed),
+            lastPlayedByKey = mapOf("other" to now - days(365)),
+            nowMs = now
+        )
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun ordersMostForgottenFirst() {
+        val oldest = track("oldest")
+        val middle = track("middle")
+        val newest = track("newest")
+
+        val result = ForgottenFavorites.select(
+            favorites = listOf(middle, newest, oldest),
+            lastPlayedByKey = mapOf(
+                "oldest" to now - days(400),
+                "middle" to now - days(120),
+                "newest" to now - days(31)
+            ),
+            nowMs = now
+        )
+
+        assertEquals(listOf("oldest", "middle", "newest"), result.map { it.id })
+    }
+
+    @Test
+    fun deduplicatesFavoritesSharingTheSameListeningIdentity() {
+        val first = track("dup")
+        val second = track("dup").copy(title = "Different display title")
+
+        val result = ForgottenFavorites.select(
+            favorites = listOf(first, second),
+            lastPlayedByKey = mapOf("dup" to now - days(60)),
+            nowMs = now
+        )
+
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun skipsUnplayableEntries() {
+        val blankTitle = track("blank").copy(title = "  ")
+        val noPlaybackTarget = Track(
+            id = "",
+            title = "Orphan",
+            artist = "Artist",
+            album = "Album",
+            durationMs = 0L,
+            streamUrl = "",
+            videoUrl = "",
+            thumbnailUrl = "",
+            largeThumbnailUrl = "",
+            source = "test",
+            moodTags = emptySet(),
+            energy = 0,
+            vocal = 0,
+            replayScore = 0,
+            cacheScore = 0,
+            accentStart = 0,
+            accentEnd = 0
+        )
+
+        val result = ForgottenFavorites.select(
+            favorites = listOf(blankTitle, noPlaybackTarget),
+            lastPlayedByKey = mapOf(
+                "blank" to now - days(90),
+                ListenIdentity.trackKey("", "Orphan", "Artist") to now - days(90)
+            ),
+            nowMs = now
+        )
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun respectsDisplayLimit() {
+        val favorites = (1..30).map { track("t$it") }
+        val lastPlayed = favorites.associate { it.id to now - days(60) }
+
+        val result = ForgottenFavorites.select(favorites, lastPlayed, nowMs = now, limit = 5)
+
+        assertEquals(5, result.size)
+    }
+
+    @Test
+    fun listeningKeysSkipInvalidFavorites() {
+        val keys = ForgottenFavorites.listeningKeys(
+            listOf(track("a"), track("a"), track("b").copy(title = " "))
+        )
+
+        assertEquals(listOf("a"), keys)
+    }
+
+    private fun days(value: Long): Long = TimeUnit.DAYS.toMillis(value)
+
+    private fun track(id: String) = Track(
+        id = id,
+        title = "Title $id",
+        artist = "Artist",
+        album = "Album",
+        durationMs = 180_000L,
+        streamUrl = "",
+        videoUrl = "https://example.invalid/$id",
+        thumbnailUrl = "",
+        largeThumbnailUrl = "",
+        source = "test",
+        moodTags = emptySet(),
+        energy = 0,
+        vocal = 0,
+        replayScore = 0,
+        cacheScore = 0,
+        accentStart = 0,
+        accentEnd = 0
+    )
+}

--- a/app/src/test/java/com/luc4n3x/levyra/domain/PlaylistOrganizationTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/domain/PlaylistOrganizationTest.kt
@@ -1,0 +1,111 @@
+package com.luc4n3x.levyra.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaylistOrganizationTest {
+
+    @Test
+    fun normalizationFoldsCaseAccentsAndWhitespace() {
+        assertEquals("relax", normalizePlaylistTagName("  Relax  "))
+        assertEquals("relax", normalizePlaylistTagName("RELAX"))
+        assertEquals("cafe", normalizePlaylistTagName("Café"))
+        assertEquals("gym time", normalizePlaylistTagName("Gym   Time"))
+        assertEquals("", normalizePlaylistTagName("   "))
+    }
+
+    @Test
+    fun sanitizationTrimsAndBoundsLength() {
+        val long = "a".repeat(PLAYLIST_TAG_MAX_LENGTH + 20)
+
+        assertEquals(PLAYLIST_TAG_MAX_LENGTH, sanitizePlaylistTagName(long).length)
+        assertEquals("Gym Time", sanitizePlaylistTagName(" Gym   Time "))
+    }
+
+    @Test
+    fun blankTagNamesAreRejected() {
+        assertFalse(isValidPlaylistTagName("   "))
+        assertTrue(isValidPlaylistTagName("Rap"))
+    }
+
+    @Test
+    fun visibilityHelpersSplitLibraryAndHiddenPlaylists() {
+        val visible = playlist("visible")
+        val hidden = playlist("hidden", hidden = true)
+        val playlists = listOf(visible, hidden)
+
+        assertEquals(listOf("visible"), playlists.visibleInLibrary().map { it.id })
+        assertEquals(listOf("hidden"), playlists.hiddenInLibrary().map { it.id })
+    }
+
+    @Test
+    fun emptyTagSelectionKeepsTheWholeList() {
+        val playlists = listOf(playlist("a"), playlist("b"))
+
+        assertSame(playlists, playlists.filterByTagIds(emptySet()))
+    }
+
+    @Test
+    fun tagFilterRequiresEverySelectedTag() {
+        val gym = tag("gym")
+        val rap = tag("rap")
+        val both = playlist("both", tags = listOf(gym, rap))
+        val onlyGym = playlist("onlyGym", tags = listOf(gym))
+
+        val result = listOf(both, onlyGym).filterByTagIds(setOf(gym.id, rap.id))
+
+        assertEquals(listOf("both"), result.map { it.id })
+    }
+
+    @Test
+    fun tagsInUseAreDeduplicatedAndOrdered() {
+        val gym = tag("gym")
+        val auto = tag("auto")
+        val playlists = listOf(
+            playlist("a", tags = listOf(gym)),
+            playlist("b", tags = listOf(gym, auto))
+        )
+
+        assertEquals(listOf("auto", "gym"), playlistTagsInUse(playlists).map { it.normalizedName })
+    }
+
+    @Test
+    fun selectionTogglesAndStopsAtTheLimit() {
+        val gym = tag("gym")
+
+        val added = mergePlaylistTagSelection(emptyList(), gym)
+        assertEquals(listOf(gym.id), added.map { it.id })
+
+        val removed = mergePlaylistTagSelection(added, gym)
+        assertTrue(removed.isEmpty())
+
+        val full = (1..PLAYLIST_TAG_MAX_PER_PLAYLIST).map { tag("tag$it") }
+        val overflow = mergePlaylistTagSelection(full, tag("extra"))
+        assertEquals(PLAYLIST_TAG_MAX_PER_PLAYLIST, overflow.size)
+    }
+
+    private fun tag(name: String) = PlaylistTag(
+        id = "id-$name",
+        name = name.replaceFirstChar(Char::uppercase),
+        normalizedName = normalizePlaylistTagName(name),
+        createdAt = 0L
+    )
+
+    private fun playlist(
+        id: String,
+        tags: List<PlaylistTag> = emptyList(),
+        hidden: Boolean = false
+    ) = Playlist(
+        id = id,
+        name = id,
+        coverUrl = "",
+        tracks = emptyList(),
+        createdAt = 0L,
+        updatedAt = 0L,
+        tags = tags,
+        hidden = hidden
+    )
+}


### PR DESCRIPTION
## Summary

Adds five listening and library features that were missing from Levyra: an OLED-friendly Ambient screen, a Home shelf for forgotten favorites, per-artist recommendation exclusions, playlist tags, and hidden playlists.

Ambient attaches to the running `PlaybackService` MediaSession instead of creating a second player, so opening and closing it never interrupts audio. The four library features are entirely local: they read listening history that already exists on the device and add no new tracking.

Along the way this fixes a pre-existing defect in the committed `app/schemas/.../18.json`: the `followed_artists` `createSql` had been stored with escaped control characters in place of backticks. `MigrationTestHelper` executes that SQL whenever it creates a version 18 database, so any migration test starting from 18 failed with `unrecognized token` before the repair.

## What changed

- **Room schema 18 to 19**, additive only: `playlists.hidden` (default `0`), new `playlist_tags`, `playlist_tag_links` and `excluded_artists` tables. No table is dropped or rewritten.
- **`app/schemas/.../18.json` repaired** so the exported `followed_artists` SQL is valid again.
- **Ambient**: `AmbientScreen` is one composable driven by two hosts, an in-app overlay reading the existing `LevyraViewModel` state, and `LevyraAmbientDreamService`, which drives it from a `MediaController` via `AmbientSessionPresenter`. Adds a Quick Settings tile that reuses the existing launch-shortcut path.
- **Rediscover**: `ForgottenFavorites.select` picks favorites whose last local listen is older than thirty days, deduplicated by listening identity and ordered most-forgotten first.
- **Artist exclusions**: `ArtistExclusions` matches by browse id and by accent- and case-insensitive artist identity, including collaboration segments. Applied to the personalized Home projection, Your Orbit, release radar, similar artists, radio tail, autoplay and Levyra Mix. Search and the artist page are deliberately not filtered.
- **Playlist organization**: tag create, rename and delete, multi-tag assignment capped at eight, tag filtering and a hidden-playlist filter in the Library, plus a hide and restore action in the playlist detail screen.
- **Levyra Vault**: playlist entries gain optional `hidden` and `tagIds`; a new optional `data/library_organization.json` section carries the tag catalog and exclusion list.
- **Localization**: 28 new keys across all 26 supported languages.
- **README**: documents both new feature groups.

## Review follow-up

All five findings from CodeRabbit's review are addressed in `2f08dfb1`. Each thread has a reply pointing at that commit.

| Finding | Fix |
|---|---|
| `ORGANIZATION_ENTRY` missing from `ALLOWED_VAULT_ENTRIES` — every backup written by this branch was unrestorable, since `vaultEntryAllowed()` is an allowlist and both read paths throw on an unlisted entry | Added to the allowlist, kept out of `REQUIRED_VAULT_ENTRIES`. Two tests now assert that every section the writer emits is accepted by the reader, and that the new section stays optional. |
| Ambient lyrics never loaded when metadata arrived after the item transition — the media id was latched before the title was known and `loadLyrics` returns early on a blank title | The id is latched only once a non-blank title is present, so a later metadata update retries the lookup. |
| Leaving Ambient cleared `FLAG_KEEP_SCREEN_ON` even when the host window had already set it | The previous flag state is recorded and only cleared on dispose when Ambient was the one that set it. |
| `toggleExcludeArtist` had no generation guard, so two rapid toggles could let the slower reload publish stale state | Guarded with an `excludedArtistsGeneration` counter, matching the followed-artists pattern already in that file. |
| `refreshAfterRestore` did not recompute the Rediscover shelf, leaving it showing pre-restore favourites | `refreshForgottenFavorites()` now runs at the end of the restore. |

Validation after the fixes: `:app:compileDebugKotlin` passes, `AutomaticBackupPolicyTest` passes 10/10, and the full `:app:testDebugUnitTest` suite passes. The vault fix was additionally confirmed end to end on device — see the backup and restore rows under Manual testing.

The manual-verification gaps listed under Validation are unchanged — they were not part of this review round.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor or maintenance
- [x] UI or UX change
- [x] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [x] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** Player / Library / UI / Localization / System integration / Documentation

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [x] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

Run locally on this branch:

| Command | Result |
|---|---|
| `./gradlew --no-daemon :app:compileDebugKotlin` | Pass |
| `./gradlew --no-daemon :app:assembleDebug` | Pass |
| `./gradlew --no-daemon :app:testDebugUnitTest --rerun-tasks` | Pass, full suite with no filter |
| `./gradlew --no-daemon :app:connectedDebugAndroidTest` for `LevyraDatabaseMigrationTest` | Pass, 4 of 4 on device |

The release triple in the template checkbox was not run locally, so it stays unchecked. CI is the authority for it.

New tests: 24 unit tests (`ForgottenFavoritesTest` 7, `ArtistExclusionsTest` 9, `PlaylistOrganizationTest` 8) and `migrate18To19KeepsUserDataAndAddsOrganizationTables`, which seeds a version 18 database with a playlist, a playlist track and a followed artist and asserts all three survive alongside the new tables.

### Manual testing

Physical device, Samsung SM-S936B, Android 16, debug build.

| Environment | Scenario | Result |
|---|---|---|
| SM-S936B / Android 16 | Room upgrade on the real database | `user_version = 19`, three new tables present, `playlists.hidden` added, existing tables intact |
| SM-S936B / Android 16 | Ambient with nothing playing | Black screen, localized empty state, exit control |
| SM-S936B / Android 16 | Ambient during playback | Canvas artwork, title, artist, synced lyric advancing with the track, minimal progress, controls auto-hiding |
| SM-S936B / Android 16 | Ambient does not disturb playback | Playback stayed `PLAYING`; media session count unchanged, so no second player |
| SM-S936B / Android 16 | Exit Ambient with the back gesture | Returns to the previous screen, playback continues |
| SM-S936B / Android 16 | Exclude an artist from the artist page | `excluded_artists` row written, keyed by browse id |
| SM-S936B / Android 16 | Effect of the exclusion | Home hero for that artist disappeared; menu switched to the undo label |
| SM-S936B / Android 16 | Create and assign a playlist tag | `playlist_tags` and `playlist_tag_links` rows written; chip shown in the playlist detail |
| SM-S936B / Android 16 | Hide a playlist | `hidden = 1`; Library reported zero playlists and offered a hidden-playlist filter with the count |
| SM-S936B / Android 16 | Vault backup then restore, end to end | Archive contains `data/library_organization.json`; restore preview reports the backup as compatible and lists `library_organization` among its sections |
| SM-S936B / Android 16 | Restore actually returns the data | Removed the artist exclusion through the UI, restored the backup, and the exclusion came back with its browse id; hidden playlist, tag and tag assignment all intact |
| SM-S936B / Android 16 | Logcat during the session | No crash, no ANR, no Room or SQLite exception |

Not verified on device, stated plainly rather than assumed:

- The **Quick Settings tile** and the **DreamService** were not exercised through the system UI. The tile's launch path was exercised through the same shortcut intent it sends, and Ambient opened correctly, but placing the tile and starting the screensaver were not performed.
- **Rediscover** could not be triggered on the device: it needs favorites whose last listen is older than thirty days, and this install had no such history. Its selection logic is covered by seven unit tests.

- **Rotation, process death and long-run memory** were not measured for the Ambient screen.

## Risk and compatibility

- **Risk level:** Medium
- **Compatibility or migration notes:** Schema 18 to 19 is additive and non-destructive. The Vault format version is unchanged and `data/library_organization.json` is not a required section, so older backups still restore. Backups written by this branch are **not** readable by older builds: `vaultEntryAllowed()` is an allowlist, and a build without the new entry rejects the archive outright. That is a one-way step, same as any other new Vault section.
- **Known limitations:** Rediscover only considers favorites that have a recorded listen; a favorite that was never played is never surfaced, which avoids showing a track the moment it is added. Deleting a tag removes it from every playlist and is not undoable. The DreamService shows static artwork rather than Canvas.
- **Rollback plan:** Revert this PR. The added tables and column stay behind but are unused.

## Reviewer notes

- `LevyraScreenViewModels.withoutExcludedArtists` is the single choke point for display filtering. The `ArtistExclusions` filters return the receiver when nothing is removed; that identity is what `sameHomeDerivedInputs` compares, so without it the Home derived state would recompute on every emission.
- `AmbientSessionPresenter` releases the `MediaController` future when its connect coroutine is cancelled mid-flight, and cancels its position ticker and lyrics job in `release()`.
- Ambient settings are loaded once off the main thread at startup. `LevyraPreferences.read` uses `runBlocking`, so `openAmbient()` deliberately does not read from it.
- The `18.json` repair is unrelated to the features but was required to make any migration test runnable; it is a single `createSql` string.
- Excluding an artist filters recommendations only. Search results, the artist page and anything the user opens explicitly are intentionally untouched.

## Release note

Adds an Ambient now-playing screen, a Rediscover shelf for forgotten favorites, per-artist recommendation exclusions, playlist tags, and hidden playlists.

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims

