### PR TITLE
feat: add project-scoped AI usage observability

### DIFF
--- a/.agents/claude/settings.json
+++ b/.agents/claude/settings.json
@@ -65,6 +65,12 @@
       "Edit(./**/.env.*)"
     ]
   },
+  "statusLine": {
+    "type": "command",
+    "command": "bash -lc 'bash \"${CLAUDE_PROJECT_DIR}/scripts/claude-statusline.sh\"'",
+    "padding": 0,
+    "refreshInterval": 10
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,8 @@ skills-lock.json
 /.claude/
 /.codex/
 
+# Project-local AI usage tooling binaries and caches
+/.levyra-tools/
+
 # Local build diagnostics
 /[Bb]uild log.txt

--- a/docs/ai/USAGE_OBSERVABILITY.md
+++ b/docs/ai/USAGE_OBSERVABILITY.md
@@ -7,7 +7,7 @@ dependencies, playback behavior, application telemetry, or release artifacts.
 ## Components
 
 - **RTK** remains the output-reduction layer already managed by Levyra.
-- **CodeBurn 0.9.20** reads local coding-agent session data and reports usage,
+- **CodeBurn 0.9.24** reads local coding-agent session data and reports usage,
   cost, model, tool, retry, and waste patterns. Levyra runs it through pinned
   `npx` wrappers and always adds the `Levyra-deepsound` project filter.
 - **Headroom v0.3.0** provides Claude Code's status line for model, context,
@@ -19,6 +19,9 @@ The project-local tool directory is ignored by Git. No downloaded binary is
 committed.
 
 ## Setup
+
+CodeBurn requires Node.js 22.13+ with npm/npx. Headroom does not depend on
+CodeBurn, so its project-local setup remains usable when Node is unavailable.
 
 Windows:
 
@@ -74,8 +77,8 @@ bash ./scripts/codeburn-levyra.sh optimize --provider claude
 bash ./scripts/codeburn-levyra.sh models --by-agent
 ```
 
-With no arguments the wrapper shows the last week. Explicit commands remain
-scoped to Levyra by appending `--project Levyra-deepsound`.
+With no arguments the wrapper prints a weekly `overview`. Explicit commands
+remain scoped to Levyra by appending `--project Levyra-deepsound`.
 
 Treat `codeburn optimize` findings as evidence to review, not as automatic
 authorization to rewrite Levyra configuration. Do not use `--apply` until each

--- a/docs/ai/USAGE_OBSERVABILITY.md
+++ b/docs/ai/USAGE_OBSERVABILITY.md
@@ -1,0 +1,118 @@
+# AI Usage Observability
+
+Levyra keeps token observability and Claude rate-limit visibility project-scoped.
+The integration is tooling-only: it does not change Android or Desktop runtime
+dependencies, playback behavior, application telemetry, or release artifacts.
+
+## Components
+
+- **RTK** remains the output-reduction layer already managed by Levyra.
+- **CodeBurn 0.9.20** reads local coding-agent session data and reports usage,
+  cost, model, tool, retry, and waste patterns. Levyra runs it through pinned
+  `npx` wrappers and always adds the `Levyra-deepsound` project filter.
+- **Headroom v0.3.0** provides Claude Code's status line for model, context,
+  spend, and usage headroom. Levyra installs its verified release binary under
+  `/.levyra-tools/headroom/` and does not let the upstream installer rewrite
+  global Claude settings or the user's PATH.
+
+The project-local tool directory is ignored by Git. No downloaded binary is
+committed.
+
+## Setup
+
+Windows:
+
+```powershell
+.\scripts\setup-usage-tools.ps1 -DryRun
+.\scripts\setup-usage-tools.ps1
+```
+
+Linux/macOS:
+
+```bash
+bash ./scripts/setup-usage-tools.sh --dry-run
+bash ./scripts/setup-usage-tools.sh
+```
+
+The setup downloads the pinned Headroom installer from its matching release tag,
+uses Headroom's `NoWire`/`--no-wire` and `NoPath`/`--no-path` modes, installs the
+binary only inside Levyra's ignored tool directory, then verifies the binary.
+If `npx` is available it also verifies the pinned CodeBurn package without a
+global npm installation.
+
+Claude's tracked source of truth remains `.agents/claude/settings.json`. Its
+`statusLine` calls `scripts/claude-statusline.sh`, which forwards the status-line
+payload to Levyra's local Headroom binary when present and otherwise exits
+cleanly. Run the normal Levyra runtime projection after changing tracked Claude
+settings:
+
+```powershell
+.\scripts\setup-ai.ps1
+```
+
+or:
+
+```bash
+./scripts/setup-ai.sh
+```
+
+## CodeBurn
+
+Windows:
+
+```powershell
+.\scripts\codeburn-levyra.ps1
+.\scripts\codeburn-levyra.ps1 optimize --provider claude
+.\scripts\codeburn-levyra.ps1 models --by-agent
+```
+
+Linux/macOS:
+
+```bash
+bash ./scripts/codeburn-levyra.sh
+bash ./scripts/codeburn-levyra.sh optimize --provider claude
+bash ./scripts/codeburn-levyra.sh models --by-agent
+```
+
+With no arguments the wrapper shows the last week. Explicit commands remain
+scoped to Levyra by appending `--project Levyra-deepsound`.
+
+Treat `codeburn optimize` findings as evidence to review, not as automatic
+authorization to rewrite Levyra configuration. Do not use `--apply` until each
+suggested change has been checked against current `AGENTS.md`, the applicable
+skills, and Levyra's validation rules.
+
+CodeBurn reads agent session files from the local machine. The Levyra wrapper
+does not add an API key, proxy, telemetry hook, or MCP server. CodeBurn may fetch
+public model-pricing metadata used for cost estimates.
+
+## Headroom
+
+Headroom is deliberately not wired through its global `--install` behavior.
+Levyra owns the status line in tracked project settings so a setup run cannot
+replace another project's or the user's global Claude status line.
+
+If the local binary is absent, Claude Code continues without the Headroom line.
+Re-run the project setup to restore it:
+
+```powershell
+.\scripts\setup-usage-tools.ps1
+```
+
+The status line refreshes every 10 seconds. Headroom can still show its core
+context and limit information without optional spend tooling; upstream optional
+dependencies determine which extra spend segments are available.
+
+## Validation
+
+Run:
+
+```bash
+python3 scripts/validate_usage_observability.py
+python3 scripts/validate_agent_config.py
+python3 scripts/validate_ai_efficiency.py
+```
+
+For a PR, also run Levyra's required full quality gate and inspect the complete
+final diff. A missing Node.js/npm, network connection, Python runtime, or
+platform-compatible Headroom binary is `BLOCKED`, not `PASS`.

--- a/scripts/claude-statusline.sh
+++ b/scripts/claude-statusline.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+for candidate in \
+  "$REPO_ROOT/.levyra-tools/headroom/headroom" \
+  "$REPO_ROOT/.levyra-tools/headroom/headroom.exe"
+do
+  if [[ -x "$candidate" ]]; then
+    exec "$candidate"
+  fi
+done
+
+exit 0

--- a/scripts/codeburn-levyra.ps1
+++ b/scripts/codeburn-levyra.ps1
@@ -1,0 +1,24 @@
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $CodeBurnArgs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$projectFilter = 'Levyra-deepsound'
+
+if (-not (Get-Command npx -ErrorAction SilentlyContinue)) {
+    throw 'CodeBurn requires Node.js/npm with npx.'
+}
+
+$commandArgs = if ($CodeBurnArgs -and $CodeBurnArgs.Count -gt 0) {
+    $CodeBurnArgs
+}
+else {
+    @('report', '-p', 'week')
+}
+
+& npx -y "codeburn@0.9.20" @commandArgs --project $projectFilter
+exit $LASTEXITCODE

--- a/scripts/codeburn-levyra.ps1
+++ b/scripts/codeburn-levyra.ps1
@@ -10,15 +10,15 @@ $ErrorActionPreference = 'Stop'
 $projectFilter = 'Levyra-deepsound'
 
 if (-not (Get-Command npx -ErrorAction SilentlyContinue)) {
-    throw 'CodeBurn requires Node.js/npm with npx.'
+    throw 'CodeBurn requires Node.js 22.13+ with npm/npx.'
 }
 
 $commandArgs = if ($CodeBurnArgs -and $CodeBurnArgs.Count -gt 0) {
     $CodeBurnArgs
 }
 else {
-    @('report', '-p', 'week')
+    @('overview', '-p', 'week')
 }
 
-& npx -y "codeburn@0.9.20" @commandArgs --project $projectFilter
+& npx -y "codeburn@0.9.24" @commandArgs --project $projectFilter
 exit $LASTEXITCODE

--- a/scripts/codeburn-levyra.sh
+++ b/scripts/codeburn-levyra.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_FILTER="Levyra-deepsound"
+
+if ! command -v npx >/dev/null 2>&1; then
+  echo "CodeBurn requires Node.js/npm with npx." >&2
+  exit 1
+fi
+
+if [[ $# -eq 0 ]]; then
+  set -- report -p week
+fi
+
+exec npx -y "codeburn@0.9.20" "$@" --project "$PROJECT_FILTER"

--- a/scripts/codeburn-levyra.sh
+++ b/scripts/codeburn-levyra.sh
@@ -4,12 +4,12 @@ set -euo pipefail
 PROJECT_FILTER="Levyra-deepsound"
 
 if ! command -v npx >/dev/null 2>&1; then
-  echo "CodeBurn requires Node.js/npm with npx." >&2
+  echo "CodeBurn requires Node.js 22.13+ with npm/npx." >&2
   exit 1
 fi
 
 if [[ $# -eq 0 ]]; then
-  set -- report -p week
+  set -- overview -p week
 fi
 
-exec npx -y "codeburn@0.9.20" "$@" --project "$PROJECT_FILTER"
+exec npx -y "codeburn@0.9.24" "$@" --project "$PROJECT_FILTER"

--- a/scripts/setup-usage-tools.ps1
+++ b/scripts/setup-usage-tools.ps1
@@ -1,0 +1,64 @@
+[CmdletBinding()]
+param(
+    [switch] $DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+$toolRoot = Join-Path $repoRoot '.levyra-tools'
+$headroomPrefix = Join-Path $toolRoot 'headroom'
+$headroomVersion = 'v0.3.0'
+$codeBurnVersion = '0.9.20'
+$headroomInstallerUrl = "https://raw.githubusercontent.com/anthonybo/headroom/$headroomVersion/install.ps1"
+
+function Test-Command {
+    param([Parameter(Mandatory)][string] $Name)
+    return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+Write-Output 'Levyra AI usage tooling setup'
+Write-Output "Repository: $repoRoot"
+
+if ($DryRun) {
+    Write-Output "[dry-run] Install Headroom $headroomVersion into $headroomPrefix without changing global Claude settings or PATH"
+}
+else {
+    $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("levyra-headroom-" + [guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
+    try {
+        $installerPath = Join-Path $tempDir 'install.ps1'
+        Invoke-WebRequest -Uri $headroomInstallerUrl -OutFile $installerPath -UseBasicParsing
+        & $installerPath -NoWire -NoPath -Version $headroomVersion -Prefix $headroomPrefix
+        if ($LASTEXITCODE -ne 0) {
+            throw "Headroom installer failed with exit code $LASTEXITCODE"
+        }
+        $headroomExe = Join-Path $headroomPrefix 'headroom.exe'
+        & $headroomExe --version
+        if ($LASTEXITCODE -ne 0) {
+            throw "Headroom verification failed with exit code $LASTEXITCODE"
+        }
+    }
+    finally {
+        Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+if (-not (Test-Command 'npx')) {
+    Write-Warning "CodeBurn $codeBurnVersion requires Node.js/npm with npx. Headroom setup can still be used."
+}
+elseif ($DryRun) {
+    Write-Output "[dry-run] Verify CodeBurn $codeBurnVersion through npx without installing it globally"
+}
+else {
+    & npx -y "codeburn@$codeBurnVersion" --version
+    if ($LASTEXITCODE -ne 0) {
+        throw "CodeBurn verification failed with exit code $LASTEXITCODE"
+    }
+}
+
+Write-Output ''
+Write-Output 'Setup complete.'
+Write-Output 'Headroom is project-local under .levyra-tools/ and is wired by the tracked Claude statusLine configuration.'
+Write-Output 'CodeBurn stays uninstalled globally and is invoked through scripts/codeburn-levyra.ps1.'

--- a/scripts/setup-usage-tools.ps1
+++ b/scripts/setup-usage-tools.ps1
@@ -10,7 +10,7 @@ $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
 $toolRoot = Join-Path $repoRoot '.levyra-tools'
 $headroomPrefix = Join-Path $toolRoot 'headroom'
 $headroomVersion = 'v0.3.0'
-$codeBurnVersion = '0.9.20'
+$codeBurnVersion = '0.9.24'
 $headroomInstallerUrl = "https://raw.githubusercontent.com/anthonybo/headroom/$headroomVersion/install.ps1"
 
 function Test-Command {
@@ -46,7 +46,7 @@ else {
 }
 
 if (-not (Test-Command 'npx')) {
-    Write-Warning "CodeBurn $codeBurnVersion requires Node.js/npm with npx. Headroom setup can still be used."
+    Write-Warning "CodeBurn $codeBurnVersion requires Node.js 22.13+ with npm/npx. Headroom setup can still be used."
 }
 elseif ($DryRun) {
     Write-Output "[dry-run] Verify CodeBurn $codeBurnVersion through npx without installing it globally"

--- a/scripts/setup-usage-tools.sh
+++ b/scripts/setup-usage-tools.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DRY_RUN=0
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=1
+  shift
+fi
+if [[ $# -ne 0 ]]; then
+  echo "Usage: bash ./scripts/setup-usage-tools.sh [--dry-run]" >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+TOOL_ROOT="$REPO_ROOT/.levyra-tools"
+HEADROOM_PREFIX="$TOOL_ROOT/headroom"
+HEADROOM_VERSION="v0.3.0"
+CODEBURN_VERSION="0.9.20"
+HEADROOM_INSTALLER_URL="https://raw.githubusercontent.com/anthonybo/headroom/$HEADROOM_VERSION/install.sh"
+
+echo "Levyra AI usage tooling setup"
+echo "Repository: $REPO_ROOT"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "[dry-run] Install Headroom $HEADROOM_VERSION into $HEADROOM_PREFIX without changing global Claude settings or PATH"
+else
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "curl is required to install Headroom." >&2
+    exit 1
+  fi
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$tmp_dir"' EXIT
+  installer="$tmp_dir/install.sh"
+  curl -fsSL "$HEADROOM_INSTALLER_URL" -o "$installer"
+  PREFIX="$HEADROOM_PREFIX" VERSION="$HEADROOM_VERSION" sh "$installer" --no-wire --no-path
+  "$HEADROOM_PREFIX/headroom" --version
+  rm -rf "$tmp_dir"
+  trap - EXIT
+fi
+
+if ! command -v npx >/dev/null 2>&1; then
+  echo "[warn] CodeBurn $CODEBURN_VERSION requires Node.js/npm with npx. Headroom setup can still be used." >&2
+elif [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "[dry-run] Verify CodeBurn $CODEBURN_VERSION through npx without installing it globally"
+else
+  npx -y "codeburn@$CODEBURN_VERSION" --version
+fi
+
+echo
+echo "Setup complete."
+echo "Headroom is project-local under .levyra-tools/ and is wired by the tracked Claude statusLine configuration."
+echo "CodeBurn stays uninstalled globally and is invoked through scripts/codeburn-levyra.sh."

--- a/scripts/setup-usage-tools.sh
+++ b/scripts/setup-usage-tools.sh
@@ -16,7 +16,7 @@ REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 TOOL_ROOT="$REPO_ROOT/.levyra-tools"
 HEADROOM_PREFIX="$TOOL_ROOT/headroom"
 HEADROOM_VERSION="v0.3.0"
-CODEBURN_VERSION="0.9.20"
+CODEBURN_VERSION="0.9.24"
 HEADROOM_INSTALLER_URL="https://raw.githubusercontent.com/anthonybo/headroom/$HEADROOM_VERSION/install.sh"
 
 echo "Levyra AI usage tooling setup"
@@ -40,7 +40,7 @@ else
 fi
 
 if ! command -v npx >/dev/null 2>&1; then
-  echo "[warn] CodeBurn $CODEBURN_VERSION requires Node.js/npm with npx. Headroom setup can still be used." >&2
+  echo "[warn] CodeBurn $CODEBURN_VERSION requires Node.js 22.13+ with npm/npx. Headroom setup can still be used." >&2
 elif [[ "$DRY_RUN" -eq 1 ]]; then
   echo "[dry-run] Verify CodeBurn $CODEBURN_VERSION through npx without installing it globally"
 else

--- a/scripts/tests/test_usage_observability.py
+++ b/scripts/tests/test_usage_observability.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class UsageObservabilityValidationTest(unittest.TestCase):
+    def test_usage_observability_validator(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(ROOT / "scripts/validate_usage_observability.py")],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_usage_observability.py
+++ b/scripts/validate_usage_observability.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CODEBURN_VERSION = "0.9.20"
+HEADROOM_VERSION = "v0.3.0"
+
+errors: list[str] = []
+
+required = (
+    ".agents/claude/settings.json",
+    "scripts/setup-usage-tools.ps1",
+    "scripts/setup-usage-tools.sh",
+    "scripts/codeburn-levyra.ps1",
+    "scripts/codeburn-levyra.sh",
+    "scripts/claude-statusline.sh",
+    "docs/ai/USAGE_OBSERVABILITY.md",
+)
+
+for relative in required:
+    if not (ROOT / relative).is_file():
+        errors.append(f"missing required file: {relative}")
+
+settings_path = ROOT / ".agents/claude/settings.json"
+if settings_path.is_file():
+    try:
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        errors.append(f"invalid Claude settings JSON: {exc}")
+    else:
+        status_line = settings.get("statusLine")
+        if not isinstance(status_line, dict):
+            errors.append("Claude settings must define statusLine")
+        else:
+            if status_line.get("type") != "command":
+                errors.append("Claude statusLine type must be command")
+            if "scripts/claude-statusline.sh" not in str(status_line.get("command", "")):
+                errors.append("Claude statusLine must route through scripts/claude-statusline.sh")
+            if status_line.get("refreshInterval") != 10:
+                errors.append("Claude statusLine refreshInterval must remain 10 seconds")
+
+for relative in ("scripts/codeburn-levyra.ps1", "scripts/codeburn-levyra.sh"):
+    path = ROOT / relative
+    if path.is_file():
+        text = path.read_text(encoding="utf-8")
+        if f"codeburn@{CODEBURN_VERSION}" not in text:
+            errors.append(f"{relative} must pin CodeBurn {CODEBURN_VERSION}")
+        if "Levyra-deepsound" not in text or "--project" not in text:
+            errors.append(f"{relative} must force the Levyra project filter")
+
+for relative in ("scripts/setup-usage-tools.ps1", "scripts/setup-usage-tools.sh"):
+    path = ROOT / relative
+    if path.is_file():
+        text = path.read_text(encoding="utf-8")
+        if HEADROOM_VERSION not in text:
+            errors.append(f"{relative} must pin Headroom {HEADROOM_VERSION}")
+        if ".levyra-tools" not in text:
+            errors.append(f"{relative} must keep Headroom project-local")
+        if "no-wire" not in text.lower() and "NoWire" not in text:
+            errors.append(f"{relative} must not let Headroom rewrite global Claude settings")
+        if "no-path" not in text.lower() and "NoPath" not in text:
+            errors.append(f"{relative} must not let Headroom rewrite PATH")
+
+gitignore = ROOT / ".gitignore"
+if gitignore.is_file() and "/.levyra-tools/" not in gitignore.read_text(encoding="utf-8"):
+    errors.append(".gitignore must exclude /.levyra-tools/")
+
+if errors:
+    for error in errors:
+        print(f"FAIL: {error}")
+    raise SystemExit(1)
+
+print("PASS: Levyra AI usage observability configuration is coherent")

--- a/scripts/validate_usage_observability.py
+++ b/scripts/validate_usage_observability.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-CODEBURN_VERSION = "0.9.20"
+CODEBURN_VERSION = "0.9.24"
 HEADROOM_VERSION = "v0.3.0"
 
 errors: list[str] = []
@@ -49,6 +49,8 @@ for relative in ("scripts/codeburn-levyra.ps1", "scripts/codeburn-levyra.sh"):
             errors.append(f"{relative} must pin CodeBurn {CODEBURN_VERSION}")
         if "Levyra-deepsound" not in text or "--project" not in text:
             errors.append(f"{relative} must force the Levyra project filter")
+        if "overview" not in text or "week" not in text:
+            errors.append(f"{relative} must default to a weekly overview")
 
 for relative in ("scripts/setup-usage-tools.ps1", "scripts/setup-usage-tools.sh"):
     path = ROOT / relative
@@ -56,6 +58,8 @@ for relative in ("scripts/setup-usage-tools.ps1", "scripts/setup-usage-tools.sh"
         text = path.read_text(encoding="utf-8")
         if HEADROOM_VERSION not in text:
             errors.append(f"{relative} must pin Headroom {HEADROOM_VERSION}")
+        if CODEBURN_VERSION not in text:
+            errors.append(f"{relative} must pin CodeBurn {CODEBURN_VERSION}")
         if ".levyra-tools" not in text:
             errors.append(f"{relative} must keep Headroom project-local")
         if "no-wire" not in text.lower() and "NoWire" not in text:


### PR DESCRIPTION
## Summary

- add project-scoped CodeBurn wrappers pinned to `0.9.24` and force the `Levyra-deepsound` project filter
- add project-local Headroom `v0.3.0` setup and wire Claude Code through Levyra's canonical tracked `statusLine`
- keep downloaded tooling under ignored `.levyra-tools/` and prevent the upstream installer from changing global Claude settings or the user's PATH
- add a dedicated configuration validator plus repository unittest coverage
- document the RTK + CodeBurn + Headroom workflow and keep `codeburn optimize` findings review-only by default

## Scope and safety

No Android or Desktop runtime code, app dependencies, versions, playback behavior, telemetry, or release artifacts are changed. Headroom is installed only when the explicit setup script is run, and CodeBurn is invoked through pinned `npx` wrappers rather than installed globally. CodeBurn requires Node.js 22.13+.

## Validation

- PASS: canonical Claude settings JSON parses successfully
- PASS: `bash -n` for `setup-usage-tools.sh`, `codeburn-levyra.sh`, and `claude-statusline.sh`
- PASS: `scripts/validate_usage_observability.py` on the initial integration generation
- PASS: Python compile check for the validator on the initial integration generation
- UNRUN/BLOCKED here: PowerShell runtime validation because `pwsh` is unavailable in this execution environment
- UNRUN/BLOCKED here: full `python3 scripts/ai_quality_gate.py --profile full` because this execution environment could not materialize the complete repository checkout; PR CI should validate the latest head

The latest revision also aligns the wrapper with CodeBurn's current `0.9.24` CLI and uses `overview -p week` as the default report. Latest head: `d2eead17d93a8b63ae145c47c165b9d029f0a5ad`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added project-local AI usage observability tools for tracking usage, costs, models, retries, and available context.
  - Added a Claude status line displaying model, context, spending, and usage headroom with periodic refreshes.
  - Added setup scripts for Windows, Linux, and macOS, including dry-run support.

- **Documentation**
  - Added setup, usage, platform requirements, and validation guidance for the observability tools.

- **Tests**
  - Added automated validation to confirm the observability configuration and tooling are correctly installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->