### PR TITLE
Fix AI usage tooling and bound retry/context waste

### DIFF
--- a/.agents/claude/rules/context-efficiency.md
+++ b/.agents/claude/rules/context-efficiency.md
@@ -25,4 +25,14 @@ large textual adb command without a dedicated filter. Keep tiny deterministic ad
 queries raw. Never route binary capture/transfer such as `adb exec-out screencap
 -p`, redirected screenshots, or exact device evidence through a text filter.
 
+Do not retry the same materially unchanged approach more than twice. After the
+second failure, stop that approach, revisit the evidence and root-cause
+hypothesis, then switch to a materially different strategy or report the
+blocker. Cosmetic command or prompt changes do not reset the retry count.
+
+When accumulated conversation, exploratory output, or superseded hypotheses no
+longer materially help the current deliverable, suggest a fresh session at the
+next natural task boundary and provide a compact verified handoff. Do not stop
+an active deliverable solely because the context is large.
+
 Token savings never override correctness, validation, or publication controls.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,12 +122,7 @@ the evidence and root-cause hypothesis, then switch to a materially different
 strategy or report the blocker. Cosmetic command or prompt changes do not reset
 the retry count.
 
-For long-running work, when the accumulated conversation, exploratory logs, or
-superseded hypotheses no longer materially help the current deliverable, suggest
-a fresh session at the next natural task boundary and provide a compact verified
-handoff. Do not abandon an active deliverable merely because the context is
-large; recommend a reset when stale context is now overhead or before a distinct
-next task.
+For long-running work, when the accumulated conversation, exploratory logs, or superseded hypotheses no longer materially help the current deliverable, suggest a fresh session at the next natural task boundary and provide a compact verified handoff. Do not abandon an active deliverable merely because the context is large; recommend a reset when stale context is now overhead or before a distinct next task.
 
 Keep blocking network, database, disk, parsing, decoding, extraction, and native
 media work off UI threads. Preserve lifecycle, cancellation, shared-work,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ output could hide decisive diagnostics, security, signing, Perfetto, or R8 evide
 - `docs/ai/`: detailed cross-runtime engineering procedures.
 - `.agents/skills/`: the single canonical Levyra skill tree.
 - `.agents/claude/`: canonical Claude-specific settings, hooks, agents, and rules.
-- `.agents/codex/`: canonical Codex-specific configuration and hooks.
+- `.agents/codex/`: canonical Codex project configuration and hooks.
 - `.claude/` and `.codex/`: generated local runtime projections; never sources of truth.
 
 Claude Code has a tracked root `CLAUDE.md` whose sole purpose is reliable native
@@ -115,6 +115,19 @@ Use `Plan -> Execute -> Verify` for non-trivial implementation:
 5. run the narrowest useful checks after the latest material edit;
 6. inspect the complete final diff and run `git diff --check`;
 7. report exactly what changed, what passed, what failed, and what is unverified.
+
+Treat repeated failures as evidence. Do not retry the same materially unchanged
+approach more than twice. After the second failure, stop that approach, revisit
+the evidence and root-cause hypothesis, then switch to a materially different
+strategy or report the blocker. Cosmetic command or prompt changes do not reset
+the retry count.
+
+For long-running work, when the accumulated conversation, exploratory logs, or
+superseded hypotheses no longer materially help the current deliverable, suggest
+a fresh session at the next natural task boundary and provide a compact verified
+handoff. Do not abandon an active deliverable merely because the context is
+large; recommend a reset when stale context is now overhead or before a distinct
+next task.
 
 Keep blocking network, database, disk, parsing, decoding, extraction, and native
 media work off UI threads. Preserve lifecycle, cancellation, shared-work,

--- a/docs/ai/USAGE_OBSERVABILITY.md
+++ b/docs/ai/USAGE_OBSERVABILITY.md
@@ -9,7 +9,8 @@ dependencies, playback behavior, application telemetry, or release artifacts.
 - **RTK** remains the output-reduction layer already managed by Levyra.
 - **CodeBurn 0.9.24** reads local coding-agent session data and reports usage,
   cost, model, tool, retry, and waste patterns. Levyra runs it through pinned
-  `npx` wrappers and always adds the `Levyra-deepsound` project filter.
+  `npx` wrappers and adds the `Levyra-deepsound` project filter only to CodeBurn
+  commands that support `--project`.
 - **Headroom v0.3.0** provides Claude Code's status line for model, context,
   spend, and usage headroom. Levyra installs its verified release binary under
   `/.levyra-tools/headroom/` and does not let the upstream installer rewrite
@@ -40,8 +41,10 @@ bash ./scripts/setup-usage-tools.sh
 The setup downloads the pinned Headroom installer from its matching release tag,
 uses Headroom's `NoWire`/`--no-wire` and `NoPath`/`--no-path` modes, installs the
 binary only inside Levyra's ignored tool directory, then verifies the binary.
-If `npx` is available it also verifies the pinned CodeBurn package without a
-global npm installation.
+On Windows, an upstream installer error that occurs after the binary was written
+is treated as recoverable only when the project-local `headroom.exe` still passes
+its version check. If `npx` is available the setup also verifies the pinned
+CodeBurn package without a global npm installation.
 
 Claude's tracked source of truth remains `.agents/claude/settings.json`. Its
 `statusLine` calls `scripts/claude-statusline.sh`, which forwards the status-line
@@ -65,7 +68,7 @@ Windows:
 
 ```powershell
 .\scripts\codeburn-levyra.ps1
-.\scripts\codeburn-levyra.ps1 optimize --provider claude
+.\scripts\codeburn-levyra.ps1 optimize -p week
 .\scripts\codeburn-levyra.ps1 models --by-agent
 ```
 
@@ -73,12 +76,21 @@ Linux/macOS:
 
 ```bash
 bash ./scripts/codeburn-levyra.sh
-bash ./scripts/codeburn-levyra.sh optimize --provider claude
+bash ./scripts/codeburn-levyra.sh optimize -p week
 bash ./scripts/codeburn-levyra.sh models --by-agent
 ```
 
-With no arguments the wrapper prints a weekly `overview`. Explicit commands
-remain scoped to Levyra by appending `--project Levyra-deepsound`.
+With no arguments the wrapper prints a weekly `overview` scoped to
+`Levyra-deepsound`. Commands that CodeBurn documents with `--project` support
+(`report`, `today`, `month`, `overview`, `status`, `export`, and `web`) receive
+the Levyra filter automatically. Analysis commands such as `optimize`, `models`,
+`sessions`, `compare`, `audit`, and `yield` are passed through without an
+unsupported project flag. Their output can therefore include other local
+projects and must be interpreted accordingly.
+
+The PowerShell wrapper intentionally uses native argument passthrough rather than
+advanced script parameter binding, so CodeBurn flags such as `-p week` reach the
+CLI unchanged.
 
 Treat `codeburn optimize` findings as evidence to review, not as automatic
 authorization to rewrite Levyra configuration. Do not use `--apply` until each

--- a/scripts/codeburn-levyra.ps1
+++ b/scripts/codeburn-levyra.ps1
@@ -1,24 +1,32 @@
-[CmdletBinding()]
-param(
-    [Parameter(ValueFromRemainingArguments = $true)]
-    [string[]] $CodeBurnArgs
-)
-
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $projectFilter = 'Levyra-deepsound'
+$projectAwareCommands = @(
+    'report',
+    'today',
+    'month',
+    'overview',
+    'status',
+    'export',
+    'web'
+)
 
 if (-not (Get-Command npx -ErrorAction SilentlyContinue)) {
     throw 'CodeBurn requires Node.js 22.13+ with npm/npx.'
 }
 
-$commandArgs = if ($CodeBurnArgs -and $CodeBurnArgs.Count -gt 0) {
-    $CodeBurnArgs
-}
-else {
-    @('overview', '-p', 'week')
+$commandArgs = @($args)
+if ($commandArgs.Count -eq 0) {
+    $commandArgs = @('overview', '-p', 'week')
 }
 
-& npx -y "codeburn@0.9.24" @commandArgs --project $projectFilter
+$subcommand = [string] $commandArgs[0]
+if ($projectAwareCommands -contains $subcommand) {
+    & npx -y "codeburn@0.9.24" @commandArgs --project $projectFilter
+}
+else {
+    & npx -y "codeburn@0.9.24" @commandArgs
+}
+
 exit $LASTEXITCODE

--- a/scripts/codeburn-levyra.sh
+++ b/scripts/codeburn-levyra.sh
@@ -12,4 +12,11 @@ if [[ $# -eq 0 ]]; then
   set -- overview -p week
 fi
 
-exec npx -y "codeburn@0.9.24" "$@" --project "$PROJECT_FILTER"
+case "$1" in
+  report|today|month|overview|status|export|web)
+    exec npx -y "codeburn@0.9.24" "$@" --project "$PROJECT_FILTER"
+    ;;
+  *)
+    exec npx -y "codeburn@0.9.24" "$@"
+    ;;
+esac

--- a/scripts/setup-usage-tools.ps1
+++ b/scripts/setup-usage-tools.ps1
@@ -9,6 +9,7 @@ $ErrorActionPreference = 'Stop'
 $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
 $toolRoot = Join-Path $repoRoot '.levyra-tools'
 $headroomPrefix = Join-Path $toolRoot 'headroom'
+$headroomExe = Join-Path $headroomPrefix 'headroom.exe'
 $headroomVersion = 'v0.3.0'
 $codeBurnVersion = '0.9.24'
 $headroomInstallerUrl = "https://raw.githubusercontent.com/anthonybo/headroom/$headroomVersion/install.ps1"
@@ -18,11 +19,29 @@ function Test-Command {
     return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
 }
 
+function Test-HeadroomBinary {
+    if (-not (Test-Path -LiteralPath $headroomExe -PathType Leaf)) {
+        return $false
+    }
+
+    try {
+        $global:LASTEXITCODE = 0
+        & $headroomExe --version
+        return $LASTEXITCODE -eq 0
+    }
+    catch {
+        return $false
+    }
+}
+
 Write-Output 'Levyra AI usage tooling setup'
 Write-Output "Repository: $repoRoot"
 
 if ($DryRun) {
     Write-Output "[dry-run] Install Headroom $headroomVersion into $headroomPrefix without changing global Claude settings or PATH"
+}
+elseif (Test-HeadroomBinary) {
+    Write-Output "[ok] Headroom $headroomVersion already installed: $headroomExe"
 }
 else {
     $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("levyra-headroom-" + [guid]::NewGuid().ToString('N'))
@@ -30,14 +49,29 @@ else {
     try {
         $installerPath = Join-Path $tempDir 'install.ps1'
         Invoke-WebRequest -Uri $headroomInstallerUrl -OutFile $installerPath -UseBasicParsing
-        & $installerPath -NoWire -NoPath -Version $headroomVersion -Prefix $headroomPrefix
-        if ($LASTEXITCODE -ne 0) {
-            throw "Headroom installer failed with exit code $LASTEXITCODE"
+
+        $installerError = $null
+        $installerExitCode = 0
+        try {
+            $global:LASTEXITCODE = 0
+            & $installerPath -NoWire -NoPath -Version $headroomVersion -Prefix $headroomPrefix
+            $installerExitCode = $LASTEXITCODE
         }
-        $headroomExe = Join-Path $headroomPrefix 'headroom.exe'
-        & $headroomExe --version
-        if ($LASTEXITCODE -ne 0) {
-            throw "Headroom verification failed with exit code $LASTEXITCODE"
+        catch {
+            $installerError = $_.Exception.Message
+            $installerExitCode = $LASTEXITCODE
+        }
+
+        if (-not (Test-HeadroomBinary)) {
+            if ($installerError) {
+                throw "Headroom installer failed and the installed binary did not verify: $installerError"
+            }
+            throw "Headroom installer failed with exit code $installerExitCode and the installed binary did not verify"
+        }
+
+        if ($installerError -or $installerExitCode -ne 0) {
+            $detail = if ($installerError) { $installerError } else { "exit code $installerExitCode" }
+            Write-Warning "Headroom installer reported an error after writing the binary, but the binary passed verification. Continuing. Details: $detail"
         }
     }
     finally {

--- a/scripts/validate_ai_efficiency.py
+++ b/scripts/validate_ai_efficiency.py
@@ -252,6 +252,18 @@ def main() -> int:
     require_terms(
         errors,
         "AGENTS.md",
+        "root retry and session-reset contract",
+        (
+            "more than twice",
+            "materially different",
+            "suggest a fresh session",
+            "compact verified handoff",
+            "stale context",
+        ),
+    )
+    require_terms(
+        errors,
+        "AGENTS.md",
         "root AI quality-gate contract",
         (
             "Mandatory AI quality gate",
@@ -397,6 +409,10 @@ def main() -> int:
             "Rerun the exact command raw",
             "rtk adb logcat -d -t 400",
             "adb exec-out screencap",
+            "more than twice",
+            "materially different strategy",
+            "suggest a fresh session",
+            "compact verified handoff",
         ),
     )
     require_terms(
@@ -421,7 +437,8 @@ def main() -> int:
     print(
         "AI efficiency validation passed: native compact Claude bridge, canonical .agents runtime layout, "
         f"{len(EXPECTED_FILTERS)} project filters, {len(EXPECTED_PLUGINS)} verified plugin, "
-        "cross-runtime security routing, dependency-review preflight, and no local-model profiles."
+        "bounded retry/context reset discipline, cross-runtime security routing, dependency-review preflight, "
+        "and no local-model profiles."
     )
     return 0
 

--- a/scripts/validate_usage_observability.py
+++ b/scripts/validate_usage_observability.py
@@ -48,9 +48,28 @@ for relative in ("scripts/codeburn-levyra.ps1", "scripts/codeburn-levyra.sh"):
         if f"codeburn@{CODEBURN_VERSION}" not in text:
             errors.append(f"{relative} must pin CodeBurn {CODEBURN_VERSION}")
         if "Levyra-deepsound" not in text or "--project" not in text:
-            errors.append(f"{relative} must force the Levyra project filter")
+            errors.append(f"{relative} must keep the Levyra project filter for supported reports")
         if "overview" not in text or "week" not in text:
             errors.append(f"{relative} must default to a weekly overview")
+
+powershell_wrapper = ROOT / "scripts/codeburn-levyra.ps1"
+if powershell_wrapper.is_file():
+    text = powershell_wrapper.read_text(encoding="utf-8")
+    for term in ("$projectAwareCommands", "'overview'", "'status'", "'export'", "'web'", "@($args)"):
+        if term not in text:
+            errors.append(f"scripts/codeburn-levyra.ps1 is missing native passthrough contract: {term}")
+    for forbidden in ("[CmdletBinding()]", "ValueFromRemainingArguments"):
+        if forbidden in text:
+            errors.append(
+                "scripts/codeburn-levyra.ps1 must not use advanced parameter binding because CodeBurn flags such as -p must pass through unchanged"
+            )
+
+shell_wrapper = ROOT / "scripts/codeburn-levyra.sh"
+if shell_wrapper.is_file():
+    text = shell_wrapper.read_text(encoding="utf-8")
+    for term in ('case "$1" in', "report|today|month|overview|status|export|web", 'exec npx -y "codeburn@0.9.24" "$@"'):
+        if term not in text:
+            errors.append(f"scripts/codeburn-levyra.sh is missing project-aware passthrough contract: {term}")
 
 for relative in ("scripts/setup-usage-tools.ps1", "scripts/setup-usage-tools.sh"):
     path = ROOT / relative
@@ -66,6 +85,20 @@ for relative in ("scripts/setup-usage-tools.ps1", "scripts/setup-usage-tools.sh"
             errors.append(f"{relative} must not let Headroom rewrite global Claude settings")
         if "no-path" not in text.lower() and "NoPath" not in text:
             errors.append(f"{relative} must not let Headroom rewrite PATH")
+
+windows_setup = ROOT / "scripts/setup-usage-tools.ps1"
+if windows_setup.is_file():
+    text = windows_setup.read_text(encoding="utf-8")
+    for term in ("Test-HeadroomBinary", "$installerError", "passed verification", "Continuing"):
+        if term not in text:
+            errors.append(f"scripts/setup-usage-tools.ps1 is missing verified Headroom recovery behavior: {term}")
+
+usage_docs = ROOT / "docs/ai/USAGE_OBSERVABILITY.md"
+if usage_docs.is_file():
+    text = usage_docs.read_text(encoding="utf-8")
+    for term in ("optimize -p week", "commands that support `--project`", "passed through without an", "native argument passthrough"):
+        if term not in text:
+            errors.append(f"usage observability docs are missing current wrapper behavior: {term}")
 
 gitignore = ROOT / ".gitignore"
 if gitignore.is_file() and "/.levyra-tools/" not in gitignore.read_text(encoding="utf-8"):

--- a/scripts/validate_usage_observability.py
+++ b/scripts/validate_usage_observability.py
@@ -96,7 +96,7 @@ if windows_setup.is_file():
 usage_docs = ROOT / "docs/ai/USAGE_OBSERVABILITY.md"
 if usage_docs.is_file():
     text = usage_docs.read_text(encoding="utf-8")
-    for term in ("optimize -p week", "commands that support `--project`", "passed through without an", "native argument passthrough"):
+    for term in ("optimize -p week", "CodeBurn documents with `--project` support", "passed through without an", "native argument passthrough"):
         if term not in text:
             errors.append(f"usage observability docs are missing current wrapper behavior: {term}")
 


### PR DESCRIPTION
## Summary

Fixes the Windows AI usage-tooling failures reproduced while setting up Levyra and adds two cross-runtime guardrails from the CodeBurn findings: stop retrying the same failed approach after two attempts, and recommend a fresh session when stale accumulated context no longer helps the current deliverable.

The change is limited to repository tooling, agent instructions, documentation, and validators. Android and Desktop product code are unchanged.

## What changed

- Fixed the PowerShell CodeBurn wrapper so native flags such as `-p week` pass through instead of being captured by PowerShell common-parameter binding.
- Made both CodeBurn wrappers append `--project Levyra-deepsound` only to commands that actually support that flag. Analysis commands such as `optimize` now run without an invalid project option.
- Hardened the Windows Headroom setup so an upstream installer exception that occurs after `headroom.exe` is written does not abort Levyra setup when the installed binary passes verification.
- Added a root Levyra rule for Claude/Codex: the same materially unchanged approach may be attempted at most twice before the agent must reassess the evidence and switch strategy or report a blocker.
- Added a context-reset rule: when accumulated conversation or superseded exploration no longer helps the current deliverable, the agent should suggest a fresh session at a natural boundary and provide a compact verified handoff.
- Mirrored the retry/context-reset behavior in Claude's context-efficiency rule.
- Updated usage-observability and AI-efficiency validators so these behaviors cannot disappear silently.
- Corrected the usage-tooling documentation to match CodeBurn 0.9.24 command capabilities.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Performance improvement
- [x] Refactor or maintenance
- [ ] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [x] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Shared infrastructure
- **Area:** Build and release / Documentation

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [x] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

Static regression coverage was added to `scripts/validate_usage_observability.py` and `scripts/validate_ai_efficiency.py`. This ChatGPT/GitHub connector session cannot execute repository shell commands, so the validators, `git diff --check`, and `scripts/ai_quality_gate.py --profile full` have not been run here. CI and local validation remain required before merge.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Windows PowerShell, current `main` | `setup-usage-tools.ps1` installs Headroom | `headroom.exe` v0.3.0 was written with checksum OK, then the upstream installer raised `The property 'Count' cannot be found on this object` |
| Windows PowerShell, current `main` | `codeburn-levyra.ps1 optimize -p week` | Failed before CodeBurn because PowerShell treated `-p` as an ambiguous common parameter |
| Windows PowerShell, current `main` | CodeBurn optimize with the wrapper's forced project flag | CodeBurn 0.9.24 rejected `--project` for `optimize` |
| Windows PowerShell, direct CodeBurn CLI | `npx -y codeburn@0.9.24 optimize -p week` | Succeeded and produced the optimization report |
| GitHub branch inspection | Compare branch against `main` | 8 tooling/instruction files changed; no Android or Desktop product code changed |

The fixed branch wrappers and Headroom recovery path have not yet been executed on the Windows machine.

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** None. CodeBurn remains pinned to 0.9.24 and Headroom remains pinned to v0.3.0 under `.levyra-tools/`.
- **Known limitations:** CodeBurn analysis commands that do not support `--project`, including `optimize`, may include sessions from other local projects. The documentation now states this explicitly.
- **Rollback plan:** Revert this PR

## Reviewer notes

- Review `scripts/codeburn-levyra.ps1` first. It intentionally drops advanced PowerShell parameter binding so CodeBurn CLI flags reach `npx` unchanged.
- Review `scripts/setup-usage-tools.ps1` for the recovery boundary: an installer error is tolerated only when the project-local Headroom binary verifies successfully.
- `AGENTS.md` is the cross-runtime owner for the two-retry rule, so Codex receives it without a Codex-only duplicate. Claude also gets the concise rule in `.agents/claude/rules/context-efficiency.md`.
- The session-reset rule is advisory at a natural task boundary. It must not abandon an active deliverable just because the context is large.

## Release note

None

## Related issues

- Closes N/A
- Related to N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims