### PR TITLE
feat(home): tighten shelf layout on narrow screens

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -2,6 +2,7 @@
 package com.luc4n3x.levyra.ui
 
 import com.luc4n3x.levyra.ui.components.LevyraIonicons
+import com.luc4n3x.levyra.ui.components.formatSeekbarMillis
 import com.luc4n3x.levyra.ui.components.PlayerAccentColors
 import com.luc4n3x.levyra.ui.components.PlayerControlLabels
 import com.luc4n3x.levyra.ui.components.PlayerGlassIconButton
@@ -556,6 +557,15 @@ private val HOME_DENSE_SHELF_MIN_WIDTH = 286.dp
 private val HOME_DENSE_SHELF_MAX_WIDTH = 338.dp
 private val HOME_DENSE_SHELF_END_PADDING = 38.dp
 private val HOME_COLLECTION_CARD_WIDTH = 154.dp
+private val HOME_COLLECTION_CARD_HEIGHT = 140.dp
+private val HOME_COLLECTION_CARD_CORNER = 18.dp
+private val HOME_COLLECTION_COMPACT_WIDTH = 168.dp
+private val HOME_COLLECTION_ART_SIZE = 58.dp
+private val HOME_COLLECTION_ART_INSET = 10.dp
+private val HOME_COLLECTION_TEXT_END_PADDING = 12.dp
+private val HOME_COLLECTION_ART_TEXT_KEEPOUT =
+    HOME_COLLECTION_ART_SIZE + HOME_COLLECTION_ART_INSET - HOME_COLLECTION_TEXT_END_PADDING + 4.dp
+private val HOME_VIDEO_CARD_WIDTH = 218.dp
 private val HOME_ALBUM_CARD_WIDTH = 154.dp
 private val HOME_ARTIST_CARD_WIDTH = 148.dp
 private val HOME_ARTIST_ARTWORK_SIZE = 140.dp
@@ -920,7 +930,9 @@ private fun HomeSectionHeader(
                     color = LevyraMuted,
                     fontSize = 12.5.sp,
                     lineHeight = LevyraTypeRhythm.lineHeight(12.5.sp),
-                    fontWeight = FontWeight.Medium
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
                 )
             }
         }
@@ -7498,12 +7510,13 @@ private fun HomeEditorialCollectionCard(
     val interaction = remember { MutableInteractionSource() }
     val isPressed by interaction.collectIsPressedAsState()
     val scale by animateFloatAsState(
-        targetValue = if (isPressed && effectiveAnimationsEnabled) 0.975f else 1f,
+        targetValue = if (isPressed && effectiveAnimationsEnabled) 0.972f else 1f,
         animationSpec = tween(150, easing = FastOutSlowInEasing),
         label = "homeCollectionScale-${collection.id}"
     )
     val primaryTrack = collection.tracks.firstOrNull()
     val palette = remember(collection.kind) { homeCollectionPalette(collection.kind) }
+    val title = homeCollectionTitle(strings, collection)
     val artistLine = remember(collection.id, collection.tracks) {
         collection.tracks
             .asSequence()
@@ -7513,16 +7526,20 @@ private fun HomeEditorialCollectionCard(
             .take(2)
             .joinToString(" · ")
     }
-    val shape = RoundedCornerShape(17.dp)
+    val compact = cardWidth < HOME_COLLECTION_COMPACT_WIDTH
+    val titleSize = if (compact) 15.sp else 16.5.sp
+    val titleLineHeight = if (compact) 16.5.sp else 18.sp
+    val artworkTilt = if (visualIndex % 2 == 0) 6f else -5f
+    val shape = RoundedCornerShape(HOME_COLLECTION_CARD_CORNER)
 
     Surface(
         color = Color.Transparent,
         shape = shape,
-        border = BorderStroke(Dp.Hairline, Color.White.copy(alpha = 0.12f)),
+        border = BorderStroke(Dp.Hairline, Color.White.copy(alpha = 0.14f)),
         shadowElevation = 0.dp,
         modifier = Modifier
             .width(cardWidth)
-            .height(116.dp)
+            .height(HOME_COLLECTION_CARD_HEIGHT)
             .graphicsLayer {
                 scaleX = scale
                 scaleY = scale
@@ -7530,6 +7547,7 @@ private fun HomeEditorialCollectionCard(
             .clickable(
                 interactionSource = interaction,
                 indication = null,
+                role = Role.Button,
                 onClick = onOpen
             )
     ) {
@@ -7546,12 +7564,10 @@ private fun HomeEditorialCollectionCard(
                 modifier = Modifier
                     .matchParentSize()
                     .background(
-                        Brush.horizontalGradient(
-                            colors = listOf(
-                                Color.Black.copy(alpha = 0.16f),
-                                Color.Transparent,
-                                Color.Black.copy(alpha = 0.06f)
-                            )
+                        Brush.verticalGradient(
+                            0f to Color.White.copy(alpha = 0.10f),
+                            0.42f to Color.Transparent,
+                            1f to Color.Black.copy(alpha = 0.26f)
                         )
                     )
             )
@@ -7560,54 +7576,57 @@ private fun HomeEditorialCollectionCard(
                     track = primaryTrack,
                     modifier = Modifier
                         .align(Alignment.BottomEnd)
-                        .offset(x = 13.dp, y = 15.dp)
-                        .size(76.dp)
-                        .clip(RoundedCornerShape(9.dp))
-                        .graphicsLayer {
-                            rotationZ = if (visualIndex % 2 == 0) 10f else -8f
-                            shadowElevation = 8f
-                        },
+                        .padding(end = HOME_COLLECTION_ART_INSET, bottom = HOME_COLLECTION_ART_INSET)
+                        .size(HOME_COLLECTION_ART_SIZE)
+                        .graphicsLayer { rotationZ = artworkTilt }
+                        .shadow(9.dp, RoundedCornerShape(9.dp)),
                     highRes = false,
                     zoom = 1.02f
                 )
             }
             Column(
                 modifier = Modifier
-                    .fillMaxHeight()
-                    .fillMaxWidth(0.68f)
-                    .padding(start = 13.dp, top = 11.dp, bottom = 11.dp),
+                    .fillMaxSize()
+                    .padding(
+                        start = 14.dp,
+                        top = 12.dp,
+                        end = HOME_COLLECTION_TEXT_END_PADDING,
+                        bottom = 11.dp
+                    ),
                 verticalArrangement = Arrangement.SpaceBetween
             ) {
-                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Column(verticalArrangement = Arrangement.spacedBy(5.dp)) {
                     Text(
                         text = "LEVYRA",
-                        color = Color.White.copy(alpha = 0.78f),
+                        color = Color.White.copy(alpha = 0.72f),
                         fontSize = 8.5.sp,
                         lineHeight = LevyraTypeRhythm.lineHeight(8.5.sp),
                         fontWeight = FontWeight.Black,
-                        letterSpacing = 0.65.sp,
+                        letterSpacing = 0.75.sp,
                         maxLines = 1
                     )
                     Text(
-                        text = homeCollectionTitle(strings, collection),
+                        text = title,
                         color = Color.White,
-                        fontSize = 17.sp,
-                        lineHeight = 18.5.sp,
+                        fontSize = titleSize,
+                        lineHeight = titleLineHeight,
                         fontWeight = FontWeight.Black,
-                        letterSpacing = (-0.30).sp,
+                        letterSpacing = (-0.25).sp,
                         maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.fillMaxWidth()
                     )
                 }
                 if (artistLine.isNotBlank()) {
                     Text(
                         text = artistLine,
-                        color = Color.White.copy(alpha = 0.78f),
+                        color = Color.White.copy(alpha = 0.80f),
                         fontSize = 10.sp,
                         lineHeight = 12.sp,
                         fontWeight = FontWeight.SemiBold,
                         maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(end = HOME_COLLECTION_ART_TEXT_KEEPOUT)
                     )
                 }
             }
@@ -8406,104 +8425,134 @@ private fun HomeMusicVideoShelf(
     if (videos.isEmpty()) return
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         HomeSectionInset { HomeSectionHeader(title) }
-        LazyRow(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(LevyraHomeDesign.ShelfItemGap),
-            contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
-        ) {
-            itemsIndexed(
-                items = videos,
-                key = { index, track -> "home-video-$index-${LevyraPersonalOrbit.identityKey(track)}" },
-                contentType = { _, _ -> "home-video-card" }
-            ) { _, track ->
-                val active = currentId != null && track.id == currentId
-                val shape = RoundedCornerShape(15.dp)
-                Column(
-                    modifier = Modifier
-                        .width(218.dp)
-                        .pressable(onClick = { if (active && !isResolving) onToggleCurrent() else onPlay(track) }),
-                    verticalArrangement = Arrangement.spacedBy(7.dp)
-                ) {
-                    Box(
+        BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val videoCardWidth = rememberShelfItemWidth(maxWidth, HOME_VIDEO_CARD_WIDTH)
+            LazyRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(LevyraHomeDesign.ShelfItemGap),
+                contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
+            ) {
+                itemsIndexed(
+                    items = videos,
+                    key = { index, track -> "home-video-$index-${LevyraPersonalOrbit.identityKey(track)}" },
+                    contentType = { _, _ -> "home-video-card" }
+                ) { _, track ->
+                    val active = currentId != null && track.id == currentId
+                    val shape = RoundedCornerShape(15.dp)
+                    val durationLabel = remember(track.durationMs) {
+                        if (track.durationMs > 0L) formatSeekbarMillis(track.durationMs) else ""
+                    }
+                    Column(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .aspectRatio(16f / 9f)
-                            .clip(shape)
-                            .border(
-                                if (active) 1.5.dp else Dp.Hairline,
-                                if (active) LevyraCyan.copy(alpha = 0.86f) else LevyraAdaptiveSoftHairline,
-                                shape
-                            )
+                            .width(videoCardWidth)
+                            .semantics(mergeDescendants = true) { role = Role.Button }
+                            .pressable(onClick = { if (active && !isResolving) onToggleCurrent() else onPlay(track) }),
+                        verticalArrangement = Arrangement.spacedBy(9.dp)
                     ) {
-                        CoverImage(
-                            track = track,
-                            modifier = Modifier.fillMaxSize(),
-                            highRes = true,
-                            zoom = 1f
-                        )
                         Box(
                             modifier = Modifier
-                                .matchParentSize()
-                                .background(
-                                    Brush.verticalGradient(
-                                        colorStops = arrayOf(
-                                            0f to Color.Black.copy(alpha = 0.04f),
-                                            0.56f to Color.Transparent,
-                                            1f to Color.Black.copy(alpha = 0.58f)
+                                .fillMaxWidth()
+                                .aspectRatio(16f / 9f)
+                                .clip(shape)
+                                .border(
+                                    if (active) 1.5.dp else Dp.Hairline,
+                                    if (active) LevyraCyan.copy(alpha = 0.86f) else LevyraAdaptiveSoftHairline,
+                                    shape
+                                )
+                        ) {
+                            CoverImage(
+                                track = track,
+                                modifier = Modifier.fillMaxSize(),
+                                highRes = true,
+                                zoom = 1f
+                            )
+                            Box(
+                                modifier = Modifier
+                                    .matchParentSize()
+                                    .background(
+                                        Brush.verticalGradient(
+                                            colorStops = arrayOf(
+                                                0f to Color.Black.copy(alpha = 0.04f),
+                                                0.56f to Color.Transparent,
+                                                1f to Color.Black.copy(alpha = 0.58f)
+                                            )
                                         )
                                     )
-                                )
-                        )
-                        Surface(
-                            color = Color.Black.copy(alpha = 0.70f),
-                            border = BorderStroke(Dp.Hairline, Color.White.copy(alpha = 0.18f)),
-                            shape = CircleShape,
-                            modifier = Modifier
-                                .align(Alignment.BottomEnd)
-                                .padding(9.dp)
-                                .size(38.dp)
-                        ) {
-                            Box(contentAlignment = Alignment.Center) {
-                                when {
-                                    active && isResolving -> CircularProgressIndicator(
-                                        modifier = Modifier.size(17.dp),
-                                        strokeWidth = 2.dp,
-                                        color = LevyraCyan
-                                    )
-                                    active && isPlaying -> ActiveTrackEqualizer(
-                                        color = LevyraCyan,
-                                        isPlaying = true,
-                                        width = 16.dp,
-                                        height = 12.dp
-                                    )
-                                    else -> Icon(
-                                        imageVector = Icons.Rounded.PlayArrow,
-                                        contentDescription = null,
-                                        tint = Color.White,
-                                        modifier = Modifier.size(22.dp)
+                            )
+                            if (durationLabel.isNotBlank()) {
+                                Surface(
+                                    color = Color.Black.copy(alpha = 0.66f),
+                                    shape = RoundedCornerShape(7.dp),
+                                    modifier = Modifier
+                                        .align(Alignment.BottomStart)
+                                        .padding(9.dp)
+                                ) {
+                                    Text(
+                                        text = durationLabel,
+                                        color = Color.White,
+                                        fontSize = 10.5.sp,
+                                        lineHeight = LevyraTypeRhythm.lineHeight(10.5.sp),
+                                        fontWeight = FontWeight.Bold,
+                                        letterSpacing = 0.2.sp,
+                                        maxLines = 1,
+                                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 3.dp)
                                     )
                                 }
                             }
+                            Surface(
+                                color = Color.Black.copy(alpha = 0.70f),
+                                border = BorderStroke(Dp.Hairline, Color.White.copy(alpha = 0.18f)),
+                                shape = CircleShape,
+                                modifier = Modifier
+                                    .align(Alignment.BottomEnd)
+                                    .padding(9.dp)
+                                    .size(38.dp)
+                            ) {
+                                Box(contentAlignment = Alignment.Center) {
+                                    when {
+                                        active && isResolving -> CircularProgressIndicator(
+                                            modifier = Modifier.size(17.dp),
+                                            strokeWidth = 2.dp,
+                                            color = LevyraCyan
+                                        )
+                                        active && isPlaying -> ActiveTrackEqualizer(
+                                            color = LevyraCyan,
+                                            isPlaying = true,
+                                            width = 16.dp,
+                                            height = 12.dp
+                                        )
+                                        else -> Icon(
+                                            imageVector = Icons.Rounded.PlayArrow,
+                                            contentDescription = null,
+                                            tint = Color.White,
+                                            modifier = Modifier.size(22.dp)
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                            Text(
+                                text = track.title,
+                                color = if (active) LevyraCyan else LevyraText,
+                                fontSize = 14.5.sp,
+                                lineHeight = LevyraTypeRhythm.lineHeight(14.5.sp),
+                                fontWeight = FontWeight.ExtraBold,
+                                letterSpacing = (-0.15).sp,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            Text(
+                                text = track.artist,
+                                color = LevyraMuted,
+                                fontSize = 11.5.sp,
+                                lineHeight = LevyraTypeRhythm.lineHeight(11.5.sp),
+                                fontWeight = FontWeight.Medium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
                         }
                     }
-                    Text(
-                        text = track.title,
-                        color = LevyraText,
-                        fontSize = 15.sp,
-                        lineHeight = LevyraTypeRhythm.lineHeight(15.sp),
-                        fontWeight = FontWeight.ExtraBold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    Text(
-                        text = track.artist,
-                        color = LevyraMuted,
-                        fontSize = 12.sp,
-                        lineHeight = LevyraTypeRhythm.lineHeight(12.sp),
-                        fontWeight = FontWeight.Medium,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
                 }
             }
         }
@@ -18358,38 +18407,41 @@ private fun SectionHeaderAction(title: String, onPlayAll: () -> Unit) {
 
 @Composable
 private fun HomeAlbumLoadingRow() {
-    LazyRow(
-        horizontalArrangement = Arrangement.spacedBy(LevyraHomeDesign.ShelfItemGap),
-        contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
-    ) {
-        items(4, key = { "home-album-loading-$it" }) {
-            Column(
-                modifier = Modifier
-                    .width(HOME_ALBUM_CARD_WIDTH)
-                    .levyraShimmer(),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Box(
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val cardWidth = rememberShelfItemWidth(maxWidth, HOME_ALBUM_CARD_WIDTH)
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(LevyraHomeDesign.ShelfItemGap),
+            contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
+        ) {
+            items(4, key = { "home-album-loading-$it" }) {
+                Column(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(1f)
-                        .clip(RoundedCornerShape(20.dp))
-                        .background(Color.White.copy(alpha = 0.07f))
-                )
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth(0.82f)
-                        .height(17.dp)
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(Color.White.copy(alpha = 0.07f))
-                )
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth(0.62f)
-                        .height(13.dp)
-                        .clip(RoundedCornerShape(7.dp))
-                        .background(Color.White.copy(alpha = 0.045f))
-                )
+                        .width(cardWidth)
+                        .levyraShimmer(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(1f)
+                            .clip(RoundedCornerShape(20.dp))
+                            .background(Color.White.copy(alpha = 0.07f))
+                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(0.82f)
+                            .height(17.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(Color.White.copy(alpha = 0.07f))
+                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(0.62f)
+                            .height(13.dp)
+                            .clip(RoundedCornerShape(7.dp))
+                            .background(Color.White.copy(alpha = 0.045f))
+                    )
+                }
             }
         }
     }
@@ -18399,85 +18451,96 @@ private fun HomeAlbumLoadingRow() {
 private fun HomeAlbumHitRow(albums: List<AlbumHit>, animationsEnabled: Boolean, onOpen: (AlbumHit) -> Unit) {
     if (albums.isEmpty()) return
     val effectiveAnimationsEnabled = animationsEnabled && LocalAnimationsEnabled.current
-    LazyRow(
-        horizontalArrangement = Arrangement.spacedBy(LevyraHomeDesign.ShelfItemGap),
-        contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
-    ) {
-        itemsIndexed(
-            items = albums,
-            key = { index, album -> "home-album-$index-${album.browseId.ifBlank { "${album.title.trim().lowercase()}|${album.artist.trim().lowercase()}" }}" },
-            contentType = { _, _ -> "home-album-card" }
-        ) { _, album ->
-            val interaction = remember { MutableInteractionSource() }
-            val isPressed by interaction.collectIsPressedAsState()
-            val scale by animateFloatAsState(
-                targetValue = if (isPressed && effectiveAnimationsEnabled) 0.975f else 1f,
-                animationSpec = tween(durationMillis = 150, easing = FastOutSlowInEasing),
-                label = "homeAlbumScale"
-            )
-            Column(
-                modifier = Modifier
-                    .graphicsLayer {
-                        scaleX = scale
-                        scaleY = scale
-                    }
-                    .width(HOME_ALBUM_CARD_WIDTH)
-                    .clickable(
-                        interactionSource = interaction,
-                        indication = null,
-                        onClick = { onOpen(album) }
-                    ),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                val artworkShape = LevyraHomeDesign.ArtworkShape
-                Box(
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val cardWidth = rememberShelfItemWidth(maxWidth, HOME_ALBUM_CARD_WIDTH)
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(LevyraHomeDesign.ShelfItemGap),
+            contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
+        ) {
+            itemsIndexed(
+                items = albums,
+                key = { index, album -> "home-album-$index-${album.browseId.ifBlank { "${album.title.trim().lowercase()}|${album.artist.trim().lowercase()}" }}" },
+                contentType = { _, _ -> "home-album-card" }
+            ) { _, album ->
+                val interaction = remember { MutableInteractionSource() }
+                val isPressed by interaction.collectIsPressedAsState()
+                val scale by animateFloatAsState(
+                    targetValue = if (isPressed && effectiveAnimationsEnabled) 0.975f else 1f,
+                    animationSpec = tween(durationMillis = 150, easing = FastOutSlowInEasing),
+                    label = "homeAlbumScale"
+                )
+                Column(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(1f)
-                        .clip(artworkShape)
-                        .background(Brush.linearGradient(listOf(LevyraPanel, LevyraInk)))
+                        .graphicsLayer {
+                            scaleX = scale
+                            scaleY = scale
+                        }
+                        .width(cardWidth)
+                        .clickable(
+                            interactionSource = interaction,
+                            indication = null,
+                            onClick = { onOpen(album) }
+                        ),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    if (album.thumbnailUrl.isNotBlank()) {
-                        StableRemoteArtwork(
-                            url = album.thumbnailUrl,
-                            contentDescription = album.title,
-                            contentScale = ContentScale.Crop,
-                            modifier = Modifier.fillMaxSize()
-                        )
-                    } else {
-                        Box(
-                            modifier = Modifier.fillMaxSize(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                imageVector = Icons.Rounded.Album,
-                                contentDescription = null,
-                                tint = LevyraCyan.copy(alpha = 0.78f),
-                                modifier = Modifier.size(42.dp)
+                    val artworkShape = LevyraHomeDesign.ArtworkShape
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(1f)
+                            .clip(artworkShape)
+                            .background(Brush.linearGradient(listOf(LevyraPanel, LevyraInk)))
+                    ) {
+                        if (album.thumbnailUrl.isNotBlank()) {
+                            StableRemoteArtwork(
+                                url = album.thumbnailUrl,
+                                contentDescription = album.title,
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier.fillMaxSize()
                             )
+                        } else {
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.Album,
+                                    contentDescription = null,
+                                    tint = LevyraCyan.copy(alpha = 0.78f),
+                                    modifier = Modifier.size(42.dp)
+                                )
+                            }
                         }
                     }
-                }
-                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                    Text(
-                        text = album.title,
-                        color = LevyraText,
-                        fontSize = 14.5.sp,
-                        lineHeight = LevyraTypeRhythm.lineHeight(14.5.sp),
-                        fontWeight = FontWeight.SemiBold,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                        minLines = 2
-                    )
-                    Text(
-                        text = album.artist,
-                        color = LevyraMuted,
-                        fontSize = 12.sp,
-                        lineHeight = LevyraTypeRhythm.lineHeight(12.sp),
-                        fontWeight = FontWeight.Medium,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
+                    Column(
+                        modifier = Modifier.heightIn(
+                            min = rememberCardCaptionHeight(
+                                titleSize = HOME_ALBUM_HIT_CAPTION_TITLE_SIZE,
+                                subtitleSize = HOME_ALBUM_CAPTION_SUBTITLE_SIZE,
+                                gap = HOME_CARD_CAPTION_GAP
+                            )
+                        ),
+                        verticalArrangement = Arrangement.spacedBy(HOME_CARD_CAPTION_GAP)
+                    ) {
+                        Text(
+                            text = album.title,
+                            color = LevyraText,
+                            fontSize = HOME_ALBUM_HIT_CAPTION_TITLE_SIZE,
+                            lineHeight = LevyraTypeRhythm.lineHeight(HOME_ALBUM_HIT_CAPTION_TITLE_SIZE),
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Text(
+                            text = album.artist,
+                            color = LevyraMuted,
+                            fontSize = HOME_ALBUM_CAPTION_SUBTITLE_SIZE,
+                            lineHeight = LevyraTypeRhythm.lineHeight(HOME_ALBUM_CAPTION_SUBTITLE_SIZE),
+                            fontWeight = FontWeight.Medium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
                 }
             }
         }
@@ -18487,22 +18550,67 @@ private fun HomeAlbumHitRow(albums: List<AlbumHit>, animationsEnabled: Boolean, 
 @Composable
 private fun AlbumCardRow(tracks: List<Track>, currentId: String?, animationsEnabled: Boolean, onPlay: (Track) -> Unit) {
     if (tracks.isEmpty()) return
-    LazyRow(
-        horizontalArrangement = Arrangement.spacedBy(LevyraHomeDesign.ShelfItemGap),
-        contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
-    ) {
-        itemsIndexed(
-            items = tracks,
-            key = { index, track -> "album-card-$index-${track.id.ifBlank { "${track.title.trim().lowercase()}|${track.artist.trim().lowercase()}" }}" },
-            contentType = { _, _ -> "album-card" }
-        ) { _, track ->
-            AlbumArtworkCard(
-                track = track,
-                isCurrent = track.id == currentId,
-                animationsEnabled = animationsEnabled,
-                width = LevyraHomeDesign.ArtworkCardWidth,
-                onPlay = { onPlay(track) }
-            )
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val cardWidth = rememberShelfItemWidth(maxWidth, LevyraHomeDesign.ArtworkCardWidth)
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(LevyraHomeDesign.ShelfItemGap),
+            contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
+        ) {
+            itemsIndexed(
+                items = tracks,
+                key = { index, track -> "album-card-$index-${track.id.ifBlank { "${track.title.trim().lowercase()}|${track.artist.trim().lowercase()}" }}" },
+                contentType = { _, _ -> "album-card" }
+            ) { _, track ->
+                AlbumArtworkCard(
+                    track = track,
+                    isCurrent = track.id == currentId,
+                    animationsEnabled = animationsEnabled,
+                    width = cardWidth,
+                    onPlay = { onPlay(track) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun rememberShelfItemWidth(
+    availableWidth: Dp,
+    baseWidth: Dp,
+    itemGap: Dp = LevyraHomeDesign.ShelfItemGap,
+    maxGrowth: Float = 1.15f
+): Dp = remember(availableWidth, baseWidth, itemGap, maxGrowth) {
+    val visible = availableWidth - HomeHorizontalInset
+    val usable = visible - HomeHorizontalShelfEndPadding
+    if (usable <= baseWidth) {
+        baseWidth
+    } else {
+        val columns = ((visible + itemGap).value / (baseWidth + itemGap).value)
+            .toInt()
+            .coerceAtLeast(1)
+        val exact = (usable - itemGap * (columns - 1)) / columns
+        exact.coerceIn(baseWidth, baseWidth * maxGrowth)
+    }
+}
+
+private val HOME_ALBUM_CAPTION_TITLE_SIZE = 14.8.sp
+private val HOME_ALBUM_CAPTION_SUBTITLE_SIZE = 12.sp
+private val HOME_ALBUM_HIT_CAPTION_TITLE_SIZE = 14.5.sp
+private val HOME_CARD_CAPTION_GAP = 4.dp
+
+@Composable
+private fun rememberCardCaptionHeight(
+    titleSize: TextUnit,
+    subtitleSize: TextUnit,
+    gap: Dp,
+    titleLines: Int = 2
+): Dp {
+    val density = LocalDensity.current
+    return remember(density, titleSize, subtitleSize, gap, titleLines) {
+        with(density) {
+            LevyraTypeRhythm.lineHeight(titleSize).toDp() * titleLines +
+                LevyraTypeRhythm.lineHeight(subtitleSize).toDp() +
+                gap
         }
     }
 }
@@ -18513,27 +18621,30 @@ private fun AlbumCardGrid(tracks: List<Track>, currentId: String?, animationsEna
     val columns = remember(tracks) {
         tracks.take(HomeSectionLayoutPolicy.ARTWORK_GRID_CAPACITY).chunked(2)
     }
-    LazyRow(
-        horizontalArrangement = Arrangement.spacedBy(LevyraHomeDesign.ShelfItemGap),
-        contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
-    ) {
-        itemsIndexed(
-            items = columns,
-            key = { index, column -> "album-grid-$index-${column.firstOrNull()?.id.orEmpty()}" },
-            contentType = { _, _ -> "album-grid-column" }
-        ) { _, column ->
-            Column(
-                modifier = Modifier.width(LevyraHomeDesign.ArtworkGridCardWidth),
-                verticalArrangement = Arrangement.spacedBy(14.dp)
-            ) {
-                column.forEach { track ->
-                    AlbumArtworkCard(
-                        track = track,
-                        isCurrent = track.id == currentId,
-                        animationsEnabled = animationsEnabled,
-                        width = LevyraHomeDesign.ArtworkGridCardWidth,
-                        onPlay = { onPlay(track) }
-                    )
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val cardWidth = rememberShelfItemWidth(maxWidth, LevyraHomeDesign.ArtworkGridCardWidth)
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(LevyraHomeDesign.ShelfItemGap),
+            contentPadding = PaddingValues(start = HomeHorizontalInset, end = HomeHorizontalShelfEndPadding)
+        ) {
+            itemsIndexed(
+                items = columns,
+                key = { index, column -> "album-grid-$index-${column.firstOrNull()?.id.orEmpty()}" },
+                contentType = { _, _ -> "album-grid-column" }
+            ) { _, column ->
+                Column(
+                    modifier = Modifier.width(cardWidth),
+                    verticalArrangement = Arrangement.spacedBy(14.dp)
+                ) {
+                    column.forEach { track ->
+                        AlbumArtworkCard(
+                            track = track,
+                            isCurrent = track.id == currentId,
+                            animationsEnabled = animationsEnabled,
+                            width = cardWidth,
+                            onPlay = { onPlay(track) }
+                        )
+                    }
                 }
             }
         }
@@ -18661,23 +18772,31 @@ private fun AlbumArtworkCard(
                 }
             }
         }
-        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Column(
+            modifier = Modifier.heightIn(
+                min = rememberCardCaptionHeight(
+                    titleSize = HOME_ALBUM_CAPTION_TITLE_SIZE,
+                    subtitleSize = HOME_ALBUM_CAPTION_SUBTITLE_SIZE,
+                    gap = HOME_CARD_CAPTION_GAP
+                )
+            ),
+            verticalArrangement = Arrangement.spacedBy(HOME_CARD_CAPTION_GAP)
+        ) {
             Text(
                 text = track.title,
                 color = if (isCurrent) accentStart.playerAdjustBackgroundFor(Color.White, PlayerStrongContrast).color else LevyraText,
-                fontSize = 14.8.sp,
-                lineHeight = LevyraTypeRhythm.lineHeight(14.8.sp),
+                fontSize = HOME_ALBUM_CAPTION_TITLE_SIZE,
+                lineHeight = LevyraTypeRhythm.lineHeight(HOME_ALBUM_CAPTION_TITLE_SIZE),
                 fontWeight = FontWeight.Bold,
                 letterSpacing = (-0.28).sp,
                 maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                minLines = 2
+                overflow = TextOverflow.Ellipsis
             )
             Text(
                 text = track.artist,
                 color = LevyraMuted,
-                fontSize = 12.sp,
-                lineHeight = LevyraTypeRhythm.lineHeight(12.sp),
+                fontSize = HOME_ALBUM_CAPTION_SUBTITLE_SIZE,
+                lineHeight = LevyraTypeRhythm.lineHeight(HOME_ALBUM_CAPTION_SUBTITLE_SIZE),
                 fontWeight = FontWeight.Medium,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraHomeEditorialStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraHomeEditorialStrings.kt
@@ -35,7 +35,7 @@ Available today
 Released this week
 Popular in the charts
 Levyra Collections
-Curated playlists for every moment, shaped around the music you love
+Curated playlists around the music you love
 Fresh right now
 Local essentials
 Workout energy
@@ -79,7 +79,7 @@ Disponible desde hoy
 Lanzado esta semana
 Popular en las listas
 Levyra Collections
-Playlists seleccionadas para cada momento, creadas alrededor de la música que te gusta
+Playlists seleccionadas en torno a la música que amas
 Novedades del momento
 Esenciales locales
 Energía para entrenar
@@ -101,7 +101,7 @@ Disponible dès aujourd’hui
 Sorti cette semaine
 Populaire dans les classements
 Levyra Collections
-Des playlists soigneusement sélectionnées pour chaque moment, pensées autour de la musique que vous aimez
+Playlists pensées autour de la musique que vous aimez
 Nouveautés du moment
 Essentiels locaux
 Énergie pour l’entraînement
@@ -123,7 +123,7 @@ Ab heute verfügbar
 Diese Woche erschienen
 Beliebt in den Charts
 Levyra Collections
-Kuratierte Playlists für jeden Moment, abgestimmt auf die Musik, die du liebst
+Kuratierte Playlists rund um die Musik, die du liebst
 Gerade neu
 Lokale Essentials
 Workout-Energie
@@ -145,7 +145,7 @@ Disponível a partir de hoje
 Lançado esta semana
 Popular nos tops
 Levyra Collections
-Playlists selecionadas para cada momento, pensadas em torno da música que você ama
+Playlists selecionadas em torno da música que você ama
 Novidades do momento
 Essenciais locais
 Energia para treinar
@@ -167,7 +167,7 @@ Vanaf vandaag beschikbaar
 Deze week uitgebracht
 Populair in de hitlijsten
 Levyra Collections
-Samengestelde playlists voor elk moment, afgestemd op de muziek waar je van houdt
+Playlists rond de muziek waar je van houdt
 Nu vers
 Lokale essentials
 Workoutenergie
@@ -189,7 +189,7 @@ Dostępne od dzisiaj
 Wydane w tym tygodniu
 Popularne na listach
 Levyra Collections
-Starannie wybrane playlisty na każdą chwilę, dopasowane do muzyki, którą lubisz
+Playlisty dopasowane do muzyki, którą lubisz
 Świeże teraz
 Lokalne klasyki
 Energia do treningu
@@ -211,7 +211,7 @@ Disponibil de astăzi
 Lansat săptămâna aceasta
 Popular în topuri
 Levyra Collections
-Playlisturi atent selectate pentru fiecare moment, create în jurul muzicii pe care o iubești
+Playlisturi create în jurul muzicii pe care o iubești
 Noutăți acum
 Esențiale locale
 Energie pentru antrenament
@@ -233,7 +233,7 @@ Colecție editorială
 Κυκλοφόρησε αυτή την εβδομάδα
 Δημοφιλές στα charts
 Levyra Collections
-Επιμελημένες λίστες για κάθε στιγμή, προσαρμοσμένες στη μουσική που αγαπάς
+Λίστες φτιαγμένες γύρω από τη μουσική που αγαπάς
 Φρέσκα τώρα
 Τοπικά απαραίτητα
 Ενέργεια για προπόνηση
@@ -255,7 +255,7 @@ Tillgängligt från idag
 Släppt den här veckan
 Populär på topplistorna
 Levyra Collections
-Utvalda spellistor för varje stund, formade kring musiken du älskar
+Spellistor formade kring musiken du älskar
 Nytt just nu
 Lokala måsten
 Träningsenergi
@@ -277,7 +277,7 @@ Tilgængelig fra i dag
 Udgivet i denne uge
 Populær på hitlisterne
 Levyra Collections
-Håndplukkede playlister til ethvert øjeblik, tilpasset den musik du elsker
+Playlister tilpasset den musik du elsker
 Nyt lige nu
 Lokale favoritter
 Træningsenergi
@@ -299,7 +299,7 @@ Dostupné ode dneška
 Vydáno tento týden
 Populární v žebříčcích
 Levyra Collections
-Pečlivě vybrané playlisty pro každý okamžik, sestavené podle hudby, kterou máš rád
+Playlisty sestavené podle hudby, kterou máš rád
 Čerstvé novinky
 Místní essentials
 Energie na trénink
@@ -321,7 +321,7 @@ Redakční kolekce
 Вийшло цього тижня
 Популярне в чартах
 Levyra Collections
-Добірні плейлисти для кожного моменту, створені навколо музики, яку ви любите
+Плейлисти, створені навколо музики, яку ви любите
 Свіже зараз
 Місцеві хіти
 Енергія для тренування
@@ -343,7 +343,7 @@ Levyra Collections
 Вышло на этой неделе
 Популярно в чартах
 Levyra Collections
-Тщательно подобранные плейлисты для любого момента, созданные вокруг любимой музыки
+Плейлисты, собранные вокруг любимой музыки
 Свежее сейчас
 Местные хиты
 Энергия для тренировки
@@ -365,7 +365,7 @@ Bugünden itibaren kullanılabilir
 Bu hafta yayınlandı
 Listelerde popüler
 Levyra Collections
-Her ana özel, sevdiğin müziğe göre hazırlanmış seçkin çalma listeleri
+Sevdiğin müziğe göre hazırlanmış çalma listeleri
 Şu an yeni
 Yerel vazgeçilmezler
 Antrenman enerjisi
@@ -387,7 +387,7 @@ Editoryal koleksiyon
 صدر هذا الأسبوع
 رائج في القوائم
 مجموعات Levyra
-قوائم تشغيل مختارة لكل لحظة، مصممة حول الموسيقى التي تحبها
+قوائم تشغيل مصممة حول الموسيقى التي تحبها
 جديد الآن
 أساسيات محلية
 طاقة للتمرين
@@ -409,7 +409,7 @@ Levyra 精选
 本周发行
 榜单中的热门歌曲
 Levyra 合集
-为每个时刻精心挑选的歌单，围绕你喜爱的音乐打造
+围绕你喜爱的音乐打造的歌单
 此刻新鲜
 本地精选
 训练能量
@@ -431,7 +431,7 @@ Levyra セレクション
 今週リリース
 チャートで注目
 Levyra Collections
-あらゆる時間に寄り添う、あなたの好きな音楽を中心に選んだプレイリスト
+あなたの好きな音楽を中心に選んだプレイリスト
 今すぐ聴きたい新曲
 ローカル定番
 ワークアウト・エナジー
@@ -453,7 +453,7 @@ Levyra 셀렉션
 이번 주 발매
 차트에서 인기
 Levyra Collections
-모든 순간을 위한 엄선된 플레이리스트, 좋아하는 음악을 중심으로 구성했습니다
+좋아하는 음악을 중심으로 구성한 플레이리스트
 지금 막 나온 음악
 로컬 필수곡
 운동 에너지
@@ -475,7 +475,7 @@ Levyra चयन
 इस सप्ताह रिलीज़
 चार्ट में लोकप्रिय गीत
 Levyra Collections
-हर पल के लिए चुनी गई प्लेलिस्ट, आपके पसंदीदा संगीत के आसपास तैयार
+आपके पसंदीदा संगीत के आसपास तैयार प्लेलिस्ट
 अभी नया
 स्थानीय पसंदीदा
 वर्कआउट ऊर्जा
@@ -497,7 +497,7 @@ Tersedia mulai hari ini
 Dirilis minggu ini
 Populer di tangga lagu
 Levyra Collections
-Playlist pilihan untuk setiap suasana, disusun berdasarkan musik yang kamu sukai
+Playlist yang disusun dari musik yang kamu sukai
 Baru saat ini
 Esensial lokal
 Energi olahraga
@@ -519,7 +519,7 @@ Có từ hôm nay
 Phát hành tuần này
 Phổ biến trên bảng xếp hạng
 Levyra Collections
-Playlist được tuyển chọn cho từng khoảnh khắc, xây dựng quanh âm nhạc bạn yêu thích
+Playlist được xây dựng quanh âm nhạc bạn yêu thích
 Mới ngay lúc này
 Tinh hoa địa phương
 Năng lượng luyện tập
@@ -541,7 +541,7 @@ Levyra คัดสรร
 เปิดตัวสัปดาห์นี้
 เพลงยอดนิยมในชาร์ต
 Levyra Collections
-เพลย์ลิสต์คัดสรรสำหรับทุกช่วงเวลา จัดขึ้นจากเพลงที่คุณชื่นชอบ
+เพลย์ลิสต์ที่จัดขึ้นจากเพลงที่คุณชื่นชอบ
 เพลงใหม่ตอนนี้
 เพลงท้องถิ่นที่ต้องฟัง
 พลังสำหรับออกกำลังกาย
@@ -563,7 +563,7 @@ Available simula ngayon
 Inilabas ngayong linggo
 Popular sa charts
 Levyra Collections
-Mga piling playlist para sa bawat sandali, binuo ayon sa musikang gusto mo
+Mga playlist na binuo ayon sa musikang gusto mo
 Bagong-bago ngayon
 Lokal na essentials
 Enerhiya sa workout
@@ -585,7 +585,7 @@ Editorial collection
 יצא השבוע
 בין השירים הפופולריים במצעדים
 אוספי Levyra
-פלייליסטים שנבחרו בקפידה לכל רגע, סביב המוזיקה שאתם אוהבים
+פלייליסטים סביב המוזיקה שאתם אוהבים
 חדש עכשיו
 מקומיים חיוניים
 אנרגיה לאימון


### PR DESCRIPTION
## Summary

Home shelves looked crowded on narrow phones, and the Levyra Collections cards had a few rough edges that were visible on any screen. The collection artwork was positioned outside the card, so the rounded corner sliced it; long titles broke mid-word because the text column was capped at 68% of the card; and album captions left a blank line between a one-line title and its artist. This PR fixes those and makes shelf card widths follow the available width instead of staying fixed.

The result is the same visual language, with less ragged spacing: artwork stays inside its card, titles wrap on word boundaries, captions are compact, and the trailing sliver of the next card lands in a consistent place across screen sizes.

## What changed

- Levyra Collections card: artwork moved fully inside the card with a real shadow, title spans the card and scales down on narrow cards, card height raised so a two-line title never reaches the artwork, and the artist line keeps an explicit keep-out area.
- Album captions: replaced `minLines = 2` on the title with a minimum height on the caption block, so title and artist stay adjacent while cards keep a common height.
- Music video card: duration badge (via `formatSeekbarMillis`, so hour-long uploads read `1:13:15`), tighter caption, active-state title colour.
- `rememberShelfItemWidth`: shelf card widths derive from the available width. Column count comes from the visible width, cards never shrink below their previous size, and grow at most 15%. Applied to the album row, album grid, album hit row (and its shimmer), and the video shelf.
- Localization: the Collections subtitle was a two-clause sentence in every locale except Italian and wrapped to two lines at 384dp. All 25 locales now use the shorter Italian phrasing, and section subtitles are capped at two lines.
- Accessibility: collection and video cards expose `Role.Button`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor or maintenance
- [x] UI or UX change
- [x] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** UI / Localization

## Validation

### Automated checks

- [x] Android: `python scripts/ai_quality_gate.py --profile full` (covers `:app:lintRelease`, all Android unit tests, Android runtime compatibility, and the unsigned F-Droid release compile) — passed
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [ ] Targeted tests were added or updated
- [x] Not applicable, with the reason explained below

Desktop is untouched by this change. No targeted tests were added: the change is layout geometry inside private composables with no screenshot-test harness in the repository, so it was verified on a device instead.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Pixel 8 API 37 emulator, 411dp width | Home scrolled end to end, Collections + Video + album shelves | Artwork inside the card, captions compact, peek consistent |
| Same emulator forced to 1080x2340 @ 450dpi (384dp, matching a Galaxy S25) | Same pass | Blank caption line gone, Collections subtitle on one line, duration badges visible |

The final revision — the taller collection card, the smaller artwork, the shelf-width column fix, and the album hit row — is verified by compilation and the full quality gate, but has not been re-checked on a device. The geometry was derived so that a two-line title clears the rotated artwork, and that specific case still deserves a look on hardware.

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** None. No data, playback, queue, or persistence code is touched.
- **Known limitations:** The collection artist line is still tight on the narrowest cards, where two joined artist names ellipsize early.
- **Rollback plan:** Revert this PR

## Reviewer notes

- `rememberShelfItemWidth` derives the column count from the visible width (`availableWidth - HomeHorizontalInset`) but distributes the width after also subtracting the trailing peek. That split is deliberate: using the peek for both made a 360dp phone drop from roughly 2.2 to 1.9 visible cards.
- `rememberCardCaptionHeight` reserves height as `lines x lineHeight`, which tracks the system font scale. It relies on `Trim.None` and `includeFontPadding = false` from the theme.
- Collection card geometry is coupled: `HOME_COLLECTION_CARD_HEIGHT`, `HOME_COLLECTION_ART_SIZE`, `HOME_COLLECTION_ART_INSET` and the artwork tilt together guarantee that a two-line title clears the artwork. Changing one of them means re-checking that clearance.
- The diff includes an indentation-only shift where three shelves gained a `BoxWithConstraints` wrapper. `git diff -w` shows the real change: 193 lines in `LevyraApp.kt`.

## Release note

Home shelves and Levyra Collections cards now stay tidy on smaller phones.

## Related issues

- Closes #
- Related to #

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Redesigned home screen collection cards with updated sizing, styling, artwork presentation, and responsive layouts.
  * Improved album and video shelf interactions with press animations, clearer active states, and better accessibility behavior.
  * Added video duration badges and improved caption sizing and text overflow handling.
  * Loading rows now adapt to available screen width.

* **Localization**
  * Shortened the home collection subtitle across supported languages for more concise messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->