### PR TITLE
feat(player): add Similar Songs recommendations to Now Playing

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/domain/LevyraPersonalOrbit.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/LevyraPersonalOrbit.kt
@@ -253,6 +253,10 @@ object LevyraPersonalOrbit {
         }
     }
 
+    internal fun musicTitleKey(track: Track): String = normalizedMusicTitle(track.title)
+
+    internal fun artistKeys(track: Track): Set<String> = normalizedArtists(track.artist).toSet()
+
     fun sameRecording(first: Track, second: Track): Boolean =
         fingerprintsMatch(recordingFingerprint(first), recordingFingerprint(second))
 

--- a/app/src/main/java/com/luc4n3x/levyra/domain/SimilarSongs.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/SimilarSongs.kt
@@ -1,0 +1,62 @@
+package com.luc4n3x.levyra.domain
+
+object SimilarSongsSelector {
+
+    const val POOL_SIZE: Int = 24
+    const val DISPLAY_LIMIT: Int = 12
+
+    private const val SEED_TITLE_CONTAINS_MIN_LENGTH = 6
+
+    fun select(
+        candidates: List<Track>,
+        seed: Track?,
+        excludedIdentities: Set<String>,
+        limit: Int = DISPLAY_LIMIT
+    ): List<Track> {
+        if (limit <= 0 || candidates.isEmpty()) return emptyList()
+        val blocked = HashSet<String>(excludedIdentities.size + 1)
+        blocked.addAll(excludedIdentities)
+        seed?.let { blocked.add(LevyraPersonalOrbit.identityKey(it)) }
+        val seedTitle = seed?.let(LevyraPersonalOrbit::musicTitleKey).orEmpty()
+        val seedArtists = seed?.let(LevyraPersonalOrbit::artistKeys).orEmpty()
+
+        val selected = LinkedHashMap<String, Track>(limit * 2)
+        for (candidate in candidates) {
+            if (candidate.id.isBlank() || candidate.title.isBlank()) continue
+            val identity = LevyraPersonalOrbit.identityKey(candidate)
+            if (identity in blocked) continue
+            if (isSeedDerivative(candidate, seedTitle, seedArtists)) continue
+            val existing = selected[identity]
+            when {
+                existing == null -> {
+                    if (selected.size >= limit) continue
+                    selected[identity] = candidate
+                }
+
+                prefersOver(candidate, existing) -> selected[identity] = candidate
+            }
+        }
+        return selected.values.toList()
+    }
+
+    private fun isSeedDerivative(candidate: Track, seedTitle: String, seedArtists: Set<String>): Boolean {
+        if (seedTitle.isBlank()) return false
+        val candidateTitle = LevyraPersonalOrbit.musicTitleKey(candidate)
+        if (candidateTitle.isBlank()) return false
+        val repeatsSeedTitle = candidateTitle == seedTitle ||
+            (seedTitle.length >= SEED_TITLE_CONTAINS_MIN_LENGTH && candidateTitle.contains(seedTitle))
+        if (!repeatsSeedTitle) return false
+        if (seedArtists.isEmpty()) return true
+        val candidateArtists = LevyraPersonalOrbit.artistKeys(candidate)
+        if (candidateArtists.isEmpty()) return true
+        return candidateArtists.none { artist -> artist in seedArtists }
+    }
+
+    private fun prefersOver(candidate: Track, current: Track): Boolean {
+        val candidateIsVideo = YoutubeMusicVideoType.isVideo(candidate.videoType)
+        val currentIsVideo = YoutubeMusicVideoType.isVideo(current.videoType)
+        if (candidateIsVideo != currentIsVideo) return currentIsVideo
+        if (candidate.durationMs > 0L && current.durationMs <= 0L) return true
+        return false
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/player/queue/PersistentQueueEngine.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/queue/PersistentQueueEngine.kt
@@ -87,6 +87,9 @@ internal fun radioCandidateTracks(
         .toList()
 }
 
+internal fun radioInsertionIndex(currentIndex: Int, queueSize: Int, afterCurrent: Boolean): Int =
+    if (afterCurrent) (currentIndex + 1).coerceIn(0, queueSize) else queueSize
+
 private fun radioTitleKey(track: Track): String =
     "${track.artist.trim().lowercase(Locale.ROOT)}|${track.title.trim().lowercase(Locale.ROOT)}"
 
@@ -514,7 +517,15 @@ class PersistentQueueEngine private constructor(context: Context) {
         return indices.mapNotNull(current.tracks::getOrNull)
     }
 
-    fun appendRadioTracks(tracks: List<Track>): PlaybackQueueSnapshot = mutate(structural = true, immediatePersist = true) { current ->
+    fun appendRadioTracks(tracks: List<Track>): PlaybackQueueSnapshot = addRadioTracks(tracks, afterCurrent = false)
+
+    fun insertRadioTracksAfterCurrent(tracks: List<Track>): PlaybackQueueSnapshot =
+        addRadioTracks(tracks, afterCurrent = true)
+
+    private fun addRadioTracks(
+        tracks: List<Track>,
+        afterCurrent: Boolean
+    ): PlaybackQueueSnapshot = mutate(structural = true, immediatePersist = true) { current ->
         val candidates = radioCandidateTracks(
             existingTracks = current.tracks,
             candidates = tracks,
@@ -528,7 +539,13 @@ class PersistentQueueEngine private constructor(context: Context) {
             .take(minOf(RADIO_BATCH_SIZE, available))
             .map { it.queueStoredCopy() }
         if (additions.isEmpty()) return@mutate current
-        rebuildAfterStructureChange(prepared, prepared.tracks + additions, prepared.currentIndex)
+        val insertionIndex = radioInsertionIndex(
+            currentIndex = prepared.currentIndex,
+            queueSize = prepared.tracks.size,
+            afterCurrent = afterCurrent
+        )
+        val nextTracks = prepared.tracks.toMutableList().apply { addAll(insertionIndex, additions) }
+        rebuildAfterStructureChange(prepared, nextTracks, prepared.currentIndex)
     }
 
     private fun trimPlayedRadioHistory(current: PlaybackQueueSnapshot, desiredSlots: Int): PlaybackQueueSnapshot {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -547,6 +547,7 @@ private val CinematicHairline = Color.White.copy(alpha = 0.105f)
 private val HomeHorizontalInset = LevyraHomeDesign.HorizontalInset
 private val HomeHorizontalShelfEndPadding = 30.dp
 private val SimilarSongCardWidth = 118.dp
+private val SimilarSongBadgeSize = 30.dp
 private val PlayerQuickActionIndicatorSize = 4.dp
 private val PlayerQuickActionIndicatorGap = 5.dp
 private val SimilarSongsPeekSize = 32.dp
@@ -13388,8 +13389,8 @@ private fun PlayerAdvancedControlsPanel(
 
 @Composable
 private fun PlayerSimilarSongsSection(
-    seedTrackId: String,
     similarSongs: List<Track>,
+    queuedTrackIds: Set<String>,
     loading: Boolean,
     radioEnabled: Boolean,
     accent: Color,
@@ -13401,7 +13402,6 @@ private fun PlayerSimilarSongsSection(
 ) {
     if (similarSongs.isEmpty() && !loading) return
     var expanded by rememberSaveable { mutableStateOf(false) }
-    var queuedIds by remember(seedTrackId) { mutableStateOf(emptySet<String>()) }
     val animationsEnabled = LocalAnimationsEnabled.current
     val chevronRotation by animateFloatAsState(
         targetValue = if (expanded) 180f else 0f,
@@ -13510,16 +13510,13 @@ private fun PlayerSimilarSongsSection(
                 items(similarSongs, key = { "similar-${it.id}" }) { candidate ->
                     PlayerSimilarSongCard(
                         track = candidate,
-                        queued = candidate.id in queuedIds,
+                        queued = candidate.id in queuedTrackIds,
                         accent = accent,
-                        playLabel = strings.similarSongsPlay,
-                        addLabel = strings.similarSongsAddToQueue,
+                        playLabel = strings.playNow,
+                        addLabel = strings.addToQueue,
                         onPlay = { onPlay(candidate) },
                         onAddToQueue = {
-                            if (candidate.id !in queuedIds) {
-                                queuedIds = queuedIds + candidate.id
-                                onAddToQueue(candidate)
-                            }
+                            if (candidate.id !in queuedTrackIds) onAddToQueue(candidate)
                         }
                     )
                 }
@@ -13654,19 +13651,25 @@ private fun PlayerSimilarSongCard(
             Box(
                 modifier = Modifier
                     .align(Alignment.BottomEnd)
-                    .padding(6.dp)
-                    .size(30.dp)
-                    .clip(CircleShape)
-                    .background(Color.Black.copy(alpha = 0.62f))
+                    .size(LevyraPlayerDesign.MinimumTouchTarget)
                     .pressable(onClick = onAddToQueue),
                 contentAlignment = Alignment.Center
             ) {
-                Icon(
-                    if (queued) Icons.Rounded.Check else Icons.Rounded.Add,
-                    addLabel,
-                    tint = if (queued) accent else LevyraPlayerDesign.TextPrimary,
-                    modifier = Modifier.size(18.dp)
-                )
+                Box(
+                    modifier = Modifier
+                        .padding(6.dp)
+                        .size(SimilarSongBadgeSize)
+                        .clip(CircleShape)
+                        .background(Color.Black.copy(alpha = 0.62f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        if (queued) Icons.Rounded.Check else Icons.Rounded.Add,
+                        addLabel,
+                        tint = if (queued) accent else LevyraPlayerDesign.TextPrimary,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
             }
         }
         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
@@ -14643,10 +14646,16 @@ private fun PlayerScreen(
             )
         }
 
-        val similarSongsBlock: @Composable (Track) -> Unit = { activeTrack ->
+        val queuedTrackIds = remember(state.queue) {
+            state.queue.mapTo(HashSet(state.queue.size)) { it.id }
+        }
+        val visibleSimilarSongs = remember(state.similarSongs, state.artistExclusions) {
+            state.artistExclusions.filterTracks(state.similarSongs)
+        }
+        val similarSongsBlock: @Composable (Track) -> Unit = {
             PlayerSimilarSongsSection(
-                seedTrackId = activeTrack.id,
-                similarSongs = state.similarSongs,
+                similarSongs = visibleSimilarSongs,
+                queuedTrackIds = queuedTrackIds,
                 loading = state.similarSongsLoading,
                 radioEnabled = state.radioEnabled,
                 accent = primary.playerMix(Color.White, 0.48f),

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -13391,6 +13391,7 @@ private fun PlayerAdvancedControlsPanel(
 private fun PlayerSimilarSongsSection(
     similarSongs: List<Track>,
     queuedTrackIds: Set<String>,
+    canPlayNow: Boolean,
     loading: Boolean,
     radioEnabled: Boolean,
     accent: Color,
@@ -13512,7 +13513,7 @@ private fun PlayerSimilarSongsSection(
                         track = candidate,
                         queued = candidate.id in queuedTrackIds,
                         accent = accent,
-                        playLabel = strings.playNow,
+                        playLabel = if (canPlayNow) strings.playNow else strings.addToQueue,
                         addLabel = strings.addToQueue,
                         onPlay = { onPlay(candidate) },
                         onAddToQueue = {
@@ -14656,6 +14657,7 @@ private fun PlayerScreen(
             PlayerSimilarSongsSection(
                 similarSongs = visibleSimilarSongs,
                 queuedTrackIds = queuedTrackIds,
+                canPlayNow = !state.jam.isActive || state.jam.canControlPlayback,
                 loading = state.similarSongsLoading,
                 radioEnabled = state.radioEnabled,
                 accent = primary.playerMix(Color.White, 0.48f),

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -548,6 +548,7 @@ private val HomeHorizontalInset = LevyraHomeDesign.HorizontalInset
 private val HomeHorizontalShelfEndPadding = 30.dp
 private val SimilarSongCardWidth = 118.dp
 private val SimilarSongBadgeSize = 30.dp
+private const val SimilarSongDisabledAlpha = 0.38f
 private val PlayerQuickActionIndicatorSize = 4.dp
 private val PlayerQuickActionIndicatorGap = 5.dp
 private val SimilarSongsPeekSize = 32.dp
@@ -13392,6 +13393,7 @@ private fun PlayerSimilarSongsSection(
     similarSongs: List<Track>,
     queuedTrackIds: Set<String>,
     canPlayNow: Boolean,
+    canAddToQueue: Boolean,
     loading: Boolean,
     radioEnabled: Boolean,
     accent: Color,
@@ -13513,6 +13515,8 @@ private fun PlayerSimilarSongsSection(
                         track = candidate,
                         queued = candidate.id in queuedTrackIds,
                         accent = accent,
+                        canPlay = canPlayNow || canAddToQueue,
+                        canAddToQueue = canAddToQueue,
                         playLabel = if (canPlayNow) strings.playNow else strings.addToQueue,
                         addLabel = strings.addToQueue,
                         onPlay = { onPlay(candidate) },
@@ -13613,6 +13617,8 @@ private fun PlayerSimilarSongsRadioTile(
 private fun PlayerSimilarSongCard(
     track: Track,
     queued: Boolean,
+    canPlay: Boolean,
+    canAddToQueue: Boolean,
     accent: Color,
     playLabel: String,
     addLabel: String,
@@ -13622,7 +13628,8 @@ private fun PlayerSimilarSongCard(
     Column(
         modifier = Modifier
             .width(SimilarSongCardWidth)
-            .pressable(onClick = onPlay),
+            .graphicsLayer { alpha = if (canPlay) 1f else SimilarSongDisabledAlpha }
+            .pressable(enabled = canPlay, onClick = onPlay),
         verticalArrangement = Arrangement.spacedBy(LevyraPlayerDesign.SpaceSm)
     ) {
         Box(
@@ -13653,7 +13660,7 @@ private fun PlayerSimilarSongCard(
                 modifier = Modifier
                     .align(Alignment.BottomEnd)
                     .size(LevyraPlayerDesign.MinimumTouchTarget)
-                    .pressable(onClick = onAddToQueue),
+                    .pressable(enabled = canAddToQueue, onClick = onAddToQueue),
                 contentAlignment = Alignment.Center
             ) {
                 Box(
@@ -14658,6 +14665,7 @@ private fun PlayerScreen(
                 similarSongs = visibleSimilarSongs,
                 queuedTrackIds = queuedTrackIds,
                 canPlayNow = !state.jam.isActive || state.jam.canControlPlayback,
+                canAddToQueue = !state.jam.isActive || state.jam.canAddTracks,
                 loading = state.similarSongsLoading,
                 radioEnabled = state.radioEnabled,
                 accent = primary.playerMix(Color.White, 0.48f),

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -156,6 +156,7 @@ import android.Manifest
 import android.content.pm.PackageManager
 import androidx.core.content.ContextCompat
 import androidx.compose.material.icons.rounded.GraphicEq
+import androidx.compose.material.icons.rounded.Radio
 import androidx.compose.material.icons.rounded.Headphones
 import androidx.compose.material.icons.rounded.Equalizer
 import androidx.compose.material.icons.rounded.Favorite
@@ -545,6 +546,13 @@ private val CinematicGlassDeep = Color(0xFF0B0A14)
 private val CinematicHairline = Color.White.copy(alpha = 0.105f)
 private val HomeHorizontalInset = LevyraHomeDesign.HorizontalInset
 private val HomeHorizontalShelfEndPadding = 30.dp
+private val SimilarSongCardWidth = 118.dp
+private val PlayerQuickActionIndicatorSize = 4.dp
+private val PlayerQuickActionIndicatorGap = 5.dp
+private val SimilarSongsPeekSize = 32.dp
+private val SimilarSongsPeekOverlap = 22.dp
+private val SimilarSongsUnderlineWidth = 52.dp
+private const val SIMILAR_SONGS_PEEK_COUNT = 3
 private const val HOME_ARTIST_SHELF_SIZE = 13
 private const val HOME_DEFERRED_SECTION_REVEAL_MS = 180L
 private const val HOME_HORIZONTAL_ROW_CONTENT_TYPE = "home-horizontal-row"
@@ -12853,29 +12861,11 @@ private fun PlayerQuickActionsBar(
             .height(LevyraPlayerDesign.MinimumTouchTarget),
         contentAlignment = Alignment.Center
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(if (compact) 44.dp else 48.dp)
-                .background(Color.White.copy(alpha = 0.05f), CircleShape)
-                .border(
-                    BorderStroke(
-                        1.dp,
-                        Brush.verticalGradient(
-                            listOf(
-                                Color.White.copy(alpha = 0.14f),
-                                Color.White.copy(alpha = 0.04f)
-                            )
-                        )
-                    ),
-                    CircleShape
-                )
-        )
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(LevyraPlayerDesign.MinimumTouchTarget)
-                .padding(horizontal = 4.dp),
+                .padding(horizontal = LevyraPlayerDesign.SpaceSm),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceEvenly
         ) {
@@ -12991,22 +12981,11 @@ private fun PlayerQuickAction(
     onClick: () -> Unit
 ) {
     val animationsEnabled = LocalAnimationsEnabled.current
-    val fill by animateColorAsState(
-        targetValue = if (active) tint.copy(alpha = 0.14f) else Color.Transparent,
+    val indicatorAlpha by animateFloatAsState(
+        targetValue = if (active) 1f else 0f,
         animationSpec = if (animationsEnabled) LevyraPlayerDesign.standardTween(170) else snap(),
-        label = "player-quick-fill"
+        label = "player-quick-indicator"
     )
-    val borderTop by animateColorAsState(
-        targetValue = if (active) tint.copy(alpha = 0.36f) else Color.Transparent,
-        animationSpec = if (animationsEnabled) LevyraPlayerDesign.standardTween(170) else snap(),
-        label = "player-quick-border-top"
-    )
-    val borderBottom by animateColorAsState(
-        targetValue = if (active) tint.copy(alpha = 0.12f) else Color.Transparent,
-        animationSpec = if (animationsEnabled) LevyraPlayerDesign.standardTween(170) else snap(),
-        label = "player-quick-border-bottom"
-    )
-    val shape = CircleShape
 
     Box(
         modifier = modifier
@@ -13023,29 +13002,13 @@ private fun PlayerQuickAction(
             .pressable(enabled = enabled, pressedScale = 0.90f, onClick = onClick),
         contentAlignment = Alignment.Center
     ) {
-        Box(
-            modifier = Modifier
-                .size(if (compact) 34.dp else 36.dp)
-                .then(
-                    if (active) {
-                        Modifier
-                            .background(fill, shape)
-                            .border(
-                                BorderStroke(
-                                    LevyraPlayerDesign.Hairline,
-                                    Brush.verticalGradient(listOf(borderTop, borderBottom))
-                                ),
-                                shape
-                            )
-                    } else {
-                        Modifier
-                    }
-                ),
-            contentAlignment = Alignment.Center
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(PlayerQuickActionIndicatorGap)
         ) {
             if (busy) {
                 CircularProgressIndicator(
-                    modifier = Modifier.size(if (compact) 16.dp else 18.dp),
+                    modifier = Modifier.size(if (compact) 18.dp else 20.dp),
                     strokeWidth = 2.dp,
                     color = tint
                 )
@@ -13053,9 +13016,15 @@ private fun PlayerQuickAction(
                 PlayerIcon(
                     icon = icon,
                     tint = tint,
-                    modifier = Modifier.size(if (compact) 18.dp else 20.dp)
+                    modifier = Modifier.size(if (compact) 21.dp else 23.dp)
                 )
             }
+            Box(
+                modifier = Modifier
+                    .size(PlayerQuickActionIndicatorSize)
+                    .graphicsLayer { alpha = indicatorAlpha }
+                    .background(tint, CircleShape)
+            )
         }
     }
 }
@@ -13412,6 +13381,310 @@ private fun PlayerAdvancedControlsPanel(
                 compact = compact,
                 strings = strings,
                 onSeek = viewModel::seekTo
+            )
+        }
+    }
+}
+
+@Composable
+private fun PlayerSimilarSongsSection(
+    seedTrackId: String,
+    similarSongs: List<Track>,
+    loading: Boolean,
+    radioEnabled: Boolean,
+    accent: Color,
+    compact: Boolean,
+    strings: LevyraStrings,
+    onPlay: (Track) -> Unit,
+    onAddToQueue: (Track) -> Unit,
+    onStartRadio: () -> Unit
+) {
+    if (similarSongs.isEmpty() && !loading) return
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    var queuedIds by remember(seedTrackId) { mutableStateOf(emptySet<String>()) }
+    val animationsEnabled = LocalAnimationsEnabled.current
+    val chevronRotation by animateFloatAsState(
+        targetValue = if (expanded) 180f else 0f,
+        animationSpec = if (animationsEnabled) LevyraPlayerDesign.standardTween(180) else snap(),
+        label = "similar-songs-chevron"
+    )
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(LevyraPlayerDesign.SpaceSm)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(LevyraPlayerDesign.ShapeMd)
+                .background(
+                    Brush.horizontalGradient(
+                        listOf(accent.copy(alpha = 0.16f), Color.Transparent)
+                    )
+                )
+                .heightIn(min = LevyraPlayerDesign.MinimumTouchTarget)
+                .pressable { expanded = !expanded }
+                .padding(
+                    start = LevyraPlayerDesign.SpaceMd,
+                    end = LevyraPlayerDesign.SpaceMd,
+                    top = if (compact) 8.dp else 10.dp,
+                    bottom = if (compact) 8.dp else 10.dp
+                ),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(LevyraPlayerDesign.SpaceMd)
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(5.dp)
+            ) {
+                Text(
+                    text = strings.youMightAlsoLike,
+                    color = LevyraPlayerDesign.TextPrimary,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Black,
+                    letterSpacing = (-0.2).sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Box(
+                    modifier = Modifier
+                        .width(SimilarSongsUnderlineWidth)
+                        .height(3.dp)
+                        .background(
+                            Brush.horizontalGradient(
+                                listOf(
+                                    accent.playerMix(Color.White, 0.35f),
+                                    accent.copy(alpha = 0.45f),
+                                    Color.Transparent
+                                )
+                            ),
+                            LevyraPlayerDesign.ShapePill
+                        )
+                )
+            }
+            when {
+                loading && similarSongs.isEmpty() -> CircularProgressIndicator(
+                    color = accent,
+                    strokeWidth = 2.dp,
+                    modifier = Modifier.size(18.dp)
+                )
+
+                !expanded -> PlayerSimilarSongsPeek(similarSongs)
+            }
+            Icon(
+                Icons.Rounded.KeyboardArrowDown,
+                null,
+                tint = LevyraPlayerDesign.TextTertiary,
+                modifier = Modifier
+                    .size(20.dp)
+                    .graphicsLayer { rotationZ = chevronRotation }
+            )
+        }
+
+        AnimatedVisibility(
+            visible = expanded && similarSongs.isNotEmpty(),
+            enter = if (animationsEnabled) {
+                fadeIn(tween(120)) + expandVertically(tween(180, easing = FastOutSlowInEasing))
+            } else {
+                EnterTransition.None
+            },
+            exit = if (animationsEnabled) {
+                fadeOut(tween(90)) + shrinkVertically(tween(140, easing = FastOutSlowInEasing))
+            } else {
+                ExitTransition.None
+            }
+        ) {
+            LazyRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(LevyraPlayerDesign.SpaceMd),
+                contentPadding = PaddingValues(horizontal = LevyraPlayerDesign.SpaceXxs)
+            ) {
+                item(key = "similar-start-radio") {
+                    PlayerSimilarSongsRadioTile(
+                        active = radioEnabled,
+                        accent = accent,
+                        label = strings.startRadio,
+                        onClick = onStartRadio
+                    )
+                }
+                items(similarSongs, key = { "similar-${it.id}" }) { candidate ->
+                    PlayerSimilarSongCard(
+                        track = candidate,
+                        queued = candidate.id in queuedIds,
+                        accent = accent,
+                        playLabel = strings.similarSongsPlay,
+                        addLabel = strings.similarSongsAddToQueue,
+                        onPlay = { onPlay(candidate) },
+                        onAddToQueue = {
+                            if (candidate.id !in queuedIds) {
+                                queuedIds = queuedIds + candidate.id
+                                onAddToQueue(candidate)
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlayerSimilarSongsPeek(similarSongs: List<Track>) {
+    val peek = remember(similarSongs) { similarSongs.take(SIMILAR_SONGS_PEEK_COUNT) }
+    if (peek.isEmpty()) return
+    val stackWidth = SimilarSongsPeekSize + SimilarSongsPeekOverlap * (peek.size - 1)
+    Box(modifier = Modifier.width(stackWidth)) {
+        peek.asReversed().forEachIndexed { index, candidate ->
+            val artworkUrl = candidate.thumbnailUrl.ifBlank { candidate.largeThumbnailUrl }
+            Box(
+                modifier = Modifier
+                    .offset(x = SimilarSongsPeekOverlap * index)
+                    .size(SimilarSongsPeekSize)
+                    .clip(LevyraPlayerDesign.ShapeXxs)
+                    .background(LevyraPanelSoft)
+                    .border(
+                        LevyraPlayerDesign.Hairline,
+                        Color.White.copy(alpha = 0.22f),
+                        LevyraPlayerDesign.ShapeXxs
+                    )
+            ) {
+                if (artworkUrl.isNotBlank()) {
+                    StableRemoteArtwork(
+                        url = artworkUrl,
+                        contentDescription = "",
+                        modifier = Modifier.matchParentSize(),
+                        contentScale = ContentScale.Crop
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlayerSimilarSongsRadioTile(
+    active: Boolean,
+    accent: Color,
+    label: String,
+    onClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .width(SimilarSongCardWidth)
+            .pressable(onClick = onClick),
+        verticalArrangement = Arrangement.spacedBy(LevyraPlayerDesign.SpaceSm)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(SimilarSongCardWidth)
+                .clip(LevyraPlayerDesign.ShapeSm)
+                .background(
+                    Brush.linearGradient(
+                        listOf(
+                            accent.copy(alpha = if (active) 0.42f else 0.24f),
+                            Color.White.copy(alpha = 0.06f)
+                        )
+                    )
+                )
+                .border(
+                    LevyraPlayerDesign.Hairline,
+                    if (active) accent.copy(alpha = 0.55f) else LevyraPlayerDesign.GlassBorderTop,
+                    LevyraPlayerDesign.ShapeSm
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                Icons.Rounded.Radio,
+                null,
+                tint = LevyraPlayerDesign.TextPrimary,
+                modifier = Modifier.size(28.dp)
+            )
+        }
+        Text(
+            text = label,
+            color = LevyraPlayerDesign.TextPrimary,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Bold,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun PlayerSimilarSongCard(
+    track: Track,
+    queued: Boolean,
+    accent: Color,
+    playLabel: String,
+    addLabel: String,
+    onPlay: () -> Unit,
+    onAddToQueue: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .width(SimilarSongCardWidth)
+            .pressable(onClick = onPlay),
+        verticalArrangement = Arrangement.spacedBy(LevyraPlayerDesign.SpaceSm)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(SimilarSongCardWidth)
+                .clip(LevyraPlayerDesign.ShapeSm)
+                .background(LevyraPanelSoft)
+        ) {
+            val artworkUrl = track.thumbnailUrl.ifBlank { track.largeThumbnailUrl }
+            if (artworkUrl.isNotBlank()) {
+                StableRemoteArtwork(
+                    url = artworkUrl,
+                    contentDescription = playLabel,
+                    modifier = Modifier.matchParentSize(),
+                    contentScale = ContentScale.Crop
+                )
+            } else {
+                Icon(
+                    Icons.Rounded.MusicNote,
+                    null,
+                    tint = LevyraMuted,
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .size(30.dp)
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(6.dp)
+                    .size(30.dp)
+                    .clip(CircleShape)
+                    .background(Color.Black.copy(alpha = 0.62f))
+                    .pressable(onClick = onAddToQueue),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    if (queued) Icons.Rounded.Check else Icons.Rounded.Add,
+                    addLabel,
+                    tint = if (queued) accent else LevyraPlayerDesign.TextPrimary,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                text = track.title,
+                color = LevyraPlayerDesign.TextPrimary,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = track.artist,
+                color = LevyraPlayerDesign.TextTertiary,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
         }
     }
@@ -14370,6 +14643,21 @@ private fun PlayerScreen(
             )
         }
 
+        val similarSongsBlock: @Composable (Track) -> Unit = { activeTrack ->
+            PlayerSimilarSongsSection(
+                seedTrackId = activeTrack.id,
+                similarSongs = state.similarSongs,
+                loading = state.similarSongsLoading,
+                radioEnabled = state.radioEnabled,
+                accent = primary.playerMix(Color.White, 0.48f),
+                compact = compactPlayer,
+                strings = strings,
+                onPlay = viewModel::playSimilarSong,
+                onAddToQueue = viewModel::addToQueue,
+                onStartRadio = viewModel::startSongRadio
+            )
+        }
+
         if (playerPane == LevyraPlayerPane.SideBySide && track != null) {
             Column(
                 modifier = Modifier
@@ -14407,6 +14695,7 @@ private fun PlayerScreen(
                         timelineBlock()
                         transportBlock()
                         quickActionsBlock(track)
+                        similarSongsBlock(track)
                         PlayerError(state.playerError)
                     }
                 }
@@ -14468,6 +14757,7 @@ private fun PlayerScreen(
                         timelineBlock()
                         transportBlock()
                         quickActionsBlock(track)
+                        similarSongsBlock(track)
                         PlayerError(state.playerError)
                     }
                 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraSimilarSongsStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraSimilarSongsStrings.kt
@@ -1,0 +1,51 @@
+package com.luc4n3x.levyra.ui.i18n
+
+internal val similarSongsKeys = setOf(
+    "startRadio",
+    "similarSongsPlay",
+    "similarSongsAddToQueue"
+)
+
+private fun similarSongs(
+    startRadio: String,
+    play: String,
+    addToQueue: String
+): Map<String, String> = mapOf(
+    "startRadio" to startRadio,
+    "similarSongsPlay" to play,
+    "similarSongsAddToQueue" to addToQueue
+)
+
+private val similarSongsBundles: Map<String, Map<String, String>> = mapOf(
+    "en" to similarSongs("Start radio", "Play now", "Add to queue"),
+    "it" to similarSongs("Avvia radio", "Riproduci ora", "Aggiungi alla coda"),
+    "es" to similarSongs("Iniciar radio", "Reproducir ahora", "Añadir a la cola"),
+    "fr" to similarSongs("Lancer la radio", "Lire maintenant", "Ajouter à la file"),
+    "de" to similarSongs("Radio starten", "Jetzt abspielen", "Zur Warteschlange"),
+    "pt" to similarSongs("Iniciar rádio", "Reproduzir agora", "Adicionar à fila"),
+    "nl" to similarSongs("Radio starten", "Nu afspelen", "Aan wachtrij toevoegen"),
+    "pl" to similarSongs("Włącz radio", "Odtwórz teraz", "Dodaj do kolejki"),
+    "ro" to similarSongs("Pornește radio", "Redă acum", "Adaugă la coadă"),
+    "el" to similarSongs("Έναρξη ραδιοφώνου", "Αναπαραγωγή τώρα", "Προσθήκη στη λίστα"),
+    "sv" to similarSongs("Starta radio", "Spela nu", "Lägg till i kön"),
+    "da" to similarSongs("Start radio", "Afspil nu", "Føj til køen"),
+    "cs" to similarSongs("Spustit rádio", "Přehrát nyní", "Přidat do fronty"),
+    "uk" to similarSongs("Запустити радіо", "Відтворити зараз", "Додати до черги"),
+    "ru" to similarSongs("Запустить радио", "Воспроизвести сейчас", "Добавить в очередь"),
+    "tr" to similarSongs("Radyoyu başlat", "Şimdi çal", "Sıraya ekle"),
+    "ar" to similarSongs("تشغيل الراديو", "تشغيل الآن", "إضافة إلى قائمة الانتظار"),
+    "zh" to similarSongs("开始电台", "立即播放", "加入队列"),
+    "ja" to similarSongs("ラジオを開始", "今すぐ再生", "キューに追加"),
+    "ko" to similarSongs("라디오 시작", "지금 재생", "대기열에 추가"),
+    "hi" to similarSongs("रेडियो शुरू करें", "अभी चलाएँ", "कतार में जोड़ें"),
+    "id" to similarSongs("Mulai radio", "Putar sekarang", "Tambahkan ke antrean"),
+    "vi" to similarSongs("Bật radio", "Phát ngay", "Thêm vào hàng đợi"),
+    "th" to similarSongs("เริ่มวิทยุ", "เล่นตอนนี้", "เพิ่มในคิว"),
+    "fil" to similarSongs("Simulan ang radyo", "Patugtugin ngayon", "Idagdag sa pila"),
+    "he" to similarSongs("הפעלת רדיו", "נגן עכשיו", "הוספה לתור")
+)
+
+internal fun similarSongsLocalizationEntries(code: String): Map<String, String> =
+    similarSongsBundles.getValue(code)
+
+internal fun similarSongsLocalizationCodes(): Set<String> = similarSongsBundles.keys

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraSimilarSongsStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraSimilarSongsStrings.kt
@@ -1,48 +1,38 @@
 package com.luc4n3x.levyra.ui.i18n
 
-internal val similarSongsKeys = setOf(
-    "startRadio",
-    "similarSongsPlay",
-    "similarSongsAddToQueue"
-)
+internal val similarSongsKeys = setOf("startRadio")
 
-private fun similarSongs(
-    startRadio: String,
-    play: String,
-    addToQueue: String
-): Map<String, String> = mapOf(
-    "startRadio" to startRadio,
-    "similarSongsPlay" to play,
-    "similarSongsAddToQueue" to addToQueue
+private fun similarSongs(startRadio: String): Map<String, String> = mapOf(
+    "startRadio" to startRadio
 )
 
 private val similarSongsBundles: Map<String, Map<String, String>> = mapOf(
-    "en" to similarSongs("Start radio", "Play now", "Add to queue"),
-    "it" to similarSongs("Avvia radio", "Riproduci ora", "Aggiungi alla coda"),
-    "es" to similarSongs("Iniciar radio", "Reproducir ahora", "Añadir a la cola"),
-    "fr" to similarSongs("Lancer la radio", "Lire maintenant", "Ajouter à la file"),
-    "de" to similarSongs("Radio starten", "Jetzt abspielen", "Zur Warteschlange"),
-    "pt" to similarSongs("Iniciar rádio", "Reproduzir agora", "Adicionar à fila"),
-    "nl" to similarSongs("Radio starten", "Nu afspelen", "Aan wachtrij toevoegen"),
-    "pl" to similarSongs("Włącz radio", "Odtwórz teraz", "Dodaj do kolejki"),
-    "ro" to similarSongs("Pornește radio", "Redă acum", "Adaugă la coadă"),
-    "el" to similarSongs("Έναρξη ραδιοφώνου", "Αναπαραγωγή τώρα", "Προσθήκη στη λίστα"),
-    "sv" to similarSongs("Starta radio", "Spela nu", "Lägg till i kön"),
-    "da" to similarSongs("Start radio", "Afspil nu", "Føj til køen"),
-    "cs" to similarSongs("Spustit rádio", "Přehrát nyní", "Přidat do fronty"),
-    "uk" to similarSongs("Запустити радіо", "Відтворити зараз", "Додати до черги"),
-    "ru" to similarSongs("Запустить радио", "Воспроизвести сейчас", "Добавить в очередь"),
-    "tr" to similarSongs("Radyoyu başlat", "Şimdi çal", "Sıraya ekle"),
-    "ar" to similarSongs("تشغيل الراديو", "تشغيل الآن", "إضافة إلى قائمة الانتظار"),
-    "zh" to similarSongs("开始电台", "立即播放", "加入队列"),
-    "ja" to similarSongs("ラジオを開始", "今すぐ再生", "キューに追加"),
-    "ko" to similarSongs("라디오 시작", "지금 재생", "대기열에 추가"),
-    "hi" to similarSongs("रेडियो शुरू करें", "अभी चलाएँ", "कतार में जोड़ें"),
-    "id" to similarSongs("Mulai radio", "Putar sekarang", "Tambahkan ke antrean"),
-    "vi" to similarSongs("Bật radio", "Phát ngay", "Thêm vào hàng đợi"),
-    "th" to similarSongs("เริ่มวิทยุ", "เล่นตอนนี้", "เพิ่มในคิว"),
-    "fil" to similarSongs("Simulan ang radyo", "Patugtugin ngayon", "Idagdag sa pila"),
-    "he" to similarSongs("הפעלת רדיו", "נגן עכשיו", "הוספה לתור")
+    "en" to similarSongs("Start radio"),
+    "it" to similarSongs("Avvia radio"),
+    "es" to similarSongs("Iniciar radio"),
+    "fr" to similarSongs("Lancer la radio"),
+    "de" to similarSongs("Radio starten"),
+    "pt" to similarSongs("Iniciar rádio"),
+    "nl" to similarSongs("Radio starten"),
+    "pl" to similarSongs("Włącz radio"),
+    "ro" to similarSongs("Pornește radio"),
+    "el" to similarSongs("Έναρξη ραδιοφώνου"),
+    "sv" to similarSongs("Starta radio"),
+    "da" to similarSongs("Start radio"),
+    "cs" to similarSongs("Spustit rádio"),
+    "uk" to similarSongs("Запустити радіо"),
+    "ru" to similarSongs("Запустить радио"),
+    "tr" to similarSongs("Radyoyu başlat"),
+    "ar" to similarSongs("تشغيل الراديو"),
+    "zh" to similarSongs("开始电台"),
+    "ja" to similarSongs("ラジオを開始"),
+    "ko" to similarSongs("라디오 시작"),
+    "hi" to similarSongs("रेडियो शुरू करें"),
+    "id" to similarSongs("Mulai radio"),
+    "vi" to similarSongs("Bật radio"),
+    "th" to similarSongs("เริ่มวิทยุ"),
+    "fil" to similarSongs("Simulan ang radyo"),
+    "he" to similarSongs("הפעלת רדיו")
 )
 
 internal fun similarSongsLocalizationEntries(code: String): Map<String, String> =

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
@@ -400,8 +400,6 @@ class LevyraStrings private constructor(
     val lyricsRomanization: String get() = value("lyricsRomanization")
     val lyricsCompact: String get() = value("lyricsCompact")
     val startRadio: String get() = value("startRadio")
-    val similarSongsPlay: String get() = value("similarSongsPlay")
-    val similarSongsAddToQueue: String get() = value("similarSongsAddToQueue")
     val changeLyrics: String get() = value("changeLyrics")
     val automaticLyrics: String get() = value("automaticLyrics")
     val selectVerses: String get() = value("selectVerses")

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
@@ -399,6 +399,9 @@ class LevyraStrings private constructor(
     val lyricsPage: String get() = value("lyricsPage")
     val lyricsRomanization: String get() = value("lyricsRomanization")
     val lyricsCompact: String get() = value("lyricsCompact")
+    val startRadio: String get() = value("startRadio")
+    val similarSongsPlay: String get() = value("similarSongsPlay")
+    val similarSongsAddToQueue: String get() = value("similarSongsAddToQueue")
     val changeLyrics: String get() = value("changeLyrics")
     val automaticLyrics: String get() = value("automaticLyrics")
     val selectVerses: String get() = value("selectVerses")
@@ -1464,8 +1467,8 @@ class LevyraStrings private constructor(
         }
 
         private fun bundle(code: String, entries: Map<String, String>): LevyraStrings {
-            val resolvedEntries = entries + homeEditorialLocalizationEntries(code) + lyricsActionLocalizationEntries(code) + playerExperienceLocalizationEntries(code) + exploreLocalizationEntries(code) + canvasLocalizationEntries(code) + audioLocalizationEntries(code) + autoEqLocalizationEntries(code) + experienceLocalizationEntries(code) + insightLocalizationEntries(code) + systemActionLocalizationEntries(code) + integrationLocalizationEntries(code) + recognitionLocalizationEntries(code) + jamLocalizationEntries(code) + networkLocalizationEntries(code) + resonanceLocalizationEntries(code) + organizationLocalizationEntries(code)
-            val allRequiredKeys = requiredKeys + "removeFromPlaylist" + motionArtworkKeys + canvasKeys + audioKeys + autoEqKeys + experienceKeys + insightKeys + systemActionKeys + integrationKeys + recognitionKeys + jamKeys + networkKeys + resonanceKeys + organizationKeys
+            val resolvedEntries = entries + homeEditorialLocalizationEntries(code) + lyricsActionLocalizationEntries(code) + playerExperienceLocalizationEntries(code) + exploreLocalizationEntries(code) + canvasLocalizationEntries(code) + audioLocalizationEntries(code) + autoEqLocalizationEntries(code) + experienceLocalizationEntries(code) + insightLocalizationEntries(code) + systemActionLocalizationEntries(code) + integrationLocalizationEntries(code) + recognitionLocalizationEntries(code) + jamLocalizationEntries(code) + networkLocalizationEntries(code) + resonanceLocalizationEntries(code) + organizationLocalizationEntries(code) + similarSongsLocalizationEntries(code)
+            val allRequiredKeys = requiredKeys + "removeFromPlaylist" + motionArtworkKeys + canvasKeys + audioKeys + autoEqKeys + experienceKeys + insightKeys + systemActionKeys + integrationKeys + recognitionKeys + jamKeys + networkKeys + resonanceKeys + organizationKeys + similarSongsKeys
             require(resolvedEntries.keys == allRequiredKeys) {
                 "Invalid localization bundle $code: missing=${allRequiredKeys - resolvedEntries.keys}, extra=${resolvedEntries.keys - allRequiredKeys}"
             }

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -9,6 +9,7 @@ import com.luc4n3x.levyra.data.HomeEditorialEngine
 import com.luc4n3x.levyra.data.LevyraStartupCatalog
 import com.luc4n3x.levyra.data.deduplicateHomeAlbums
 import com.luc4n3x.levyra.domain.AlbumHit
+import com.luc4n3x.levyra.domain.ArtistExclusions
 import com.luc4n3x.levyra.domain.BatchDownload
 import com.luc4n3x.levyra.domain.PlaylistHit
 import com.luc4n3x.levyra.domain.ArtistHit
@@ -1185,7 +1186,9 @@ internal data class PlayerProjection(
     val youtubeEngagement: YoutubeEngagementState,
     val similarSongs: List<Track>,
     val similarSongsLoading: Boolean,
-    val radioEnabled: Boolean
+    val radioEnabled: Boolean,
+    val queue: List<Track>,
+    val artistExclusions: ArtistExclusions
 )
 
 internal fun playerProjection(state: LevyraUiState): PlayerProjection = PlayerProjection(
@@ -1216,5 +1219,7 @@ internal fun playerProjection(state: LevyraUiState): PlayerProjection = PlayerPr
     youtubeEngagement = state.youtubeEngagement,
     similarSongs = state.similarSongs,
     similarSongsLoading = state.similarSongsLoading,
-    radioEnabled = state.radioEnabled
+    radioEnabled = state.radioEnabled,
+    queue = state.queue,
+    artistExclusions = state.artistExclusions
 )

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -378,9 +378,12 @@ class LibraryViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::li
 
 class PlayerViewModel(root: LevyraViewModel) : LevyraScreenViewModel(root, ::playerProjection) {
     fun addToPlaylist(playlistId: String, track: Track) = root.addToPlaylist(playlistId, track)
+    fun addToQueue(track: Track) = root.addToQueue(track)
     fun closePlayer() = root.closePlayer()
     fun createPlaylist(name: String, firstTrack: Track? = null) = root.createPlaylist(name, firstTrack)
     fun cycleSpeed() = root.cycleSpeed()
+    fun playSimilarSong(track: Track) = root.playSimilarSong(track)
+    fun startSongRadio() = root.startSongRadio()
     fun openSleepTimer() = root.openSleepTimer()
     fun openAmbient() = root.openAmbient()
     fun exportCurrentTrack() = root.exportCurrentTrack()
@@ -1154,7 +1157,7 @@ internal fun libraryProjection(state: LevyraUiState): LibraryProjection = Librar
     recentListens = state.recentListens
 )
 
-private data class PlayerProjection(
+internal data class PlayerProjection(
     val animationsEnabled: Boolean,
     val motionArtworkEnabled: Boolean,
     val motionArtwork: MotionArtwork?,
@@ -1179,10 +1182,13 @@ private data class PlayerProjection(
     val sleepTimerMinutes: Int,
     val sleepTimerEndOfTrack: Boolean,
     val interfaceSettings: LevyraInterfaceSettings,
-    val youtubeEngagement: YoutubeEngagementState
+    val youtubeEngagement: YoutubeEngagementState,
+    val similarSongs: List<Track>,
+    val similarSongsLoading: Boolean,
+    val radioEnabled: Boolean
 )
 
-private fun playerProjection(state: LevyraUiState): PlayerProjection = PlayerProjection(
+internal fun playerProjection(state: LevyraUiState): PlayerProjection = PlayerProjection(
     animationsEnabled = state.animationsEnabled,
     motionArtworkEnabled = state.motionArtworkEnabled,
     motionArtwork = state.motionArtwork,
@@ -1207,5 +1213,8 @@ private fun playerProjection(state: LevyraUiState): PlayerProjection = PlayerPro
     sleepTimerMinutes = state.sleepTimerMinutes,
     sleepTimerEndOfTrack = state.sleepTimerEndOfTrack,
     interfaceSettings = state.interfaceSettings,
-    youtubeEngagement = state.youtubeEngagement
+    youtubeEngagement = state.youtubeEngagement,
+    similarSongs = state.similarSongs,
+    similarSongsLoading = state.similarSongsLoading,
+    radioEnabled = state.radioEnabled
 )

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -1188,7 +1188,8 @@ internal data class PlayerProjection(
     val similarSongsLoading: Boolean,
     val radioEnabled: Boolean,
     val queue: List<Track>,
-    val artistExclusions: ArtistExclusions
+    val artistExclusions: ArtistExclusions,
+    val canPlaySimilarSongNow: Boolean
 )
 
 internal fun playerProjection(state: LevyraUiState): PlayerProjection = PlayerProjection(
@@ -1221,5 +1222,6 @@ internal fun playerProjection(state: LevyraUiState): PlayerProjection = PlayerPr
     similarSongsLoading = state.similarSongsLoading,
     radioEnabled = state.radioEnabled,
     queue = state.queue,
-    artistExclusions = state.artistExclusions
+    artistExclusions = state.artistExclusions,
+    canPlaySimilarSongNow = !state.jam.isActive || state.jam.canControlPlayback
 )

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -1189,7 +1189,8 @@ internal data class PlayerProjection(
     val radioEnabled: Boolean,
     val queue: List<Track>,
     val artistExclusions: ArtistExclusions,
-    val canPlaySimilarSongNow: Boolean
+    val canPlaySimilarSongNow: Boolean,
+    val canQueueSimilarSong: Boolean
 )
 
 internal fun playerProjection(state: LevyraUiState): PlayerProjection = PlayerProjection(
@@ -1223,5 +1224,6 @@ internal fun playerProjection(state: LevyraUiState): PlayerProjection = PlayerPr
     radioEnabled = state.radioEnabled,
     queue = state.queue,
     artistExclusions = state.artistExclusions,
-    canPlaySimilarSongNow = !state.jam.isActive || state.jam.canControlPlayback
+    canPlaySimilarSongNow = !state.jam.isActive || state.jam.canControlPlayback,
+    canQueueSimilarSong = !state.jam.isActive || state.jam.canAddTracks
 )

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
@@ -136,6 +136,8 @@ data class LevyraUiState(
     val motionArtwork: MotionArtwork? = null,
     val motionArtworkLoading: Boolean = false,
     val youtubeEngagement: YoutubeEngagementState = YoutubeEngagementState(),
+    val similarSongs: List<Track> = emptyList(),
+    val similarSongsLoading: Boolean = false,
     val lyrics: List<LyricLine> = emptyList(),
     val lyricsSections: List<LyricSection> = emptyList(),
     val activeLyric: LyricLine? = null,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -4392,12 +4392,13 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     fun startSongRadio() {
         if (jamController.rejectGuestLocalMutation()) return
         if (!queueEngine.state.value.radioEnabled) queueEngine.setRadioEnabled(true)
-        ensureRadioTail(force = true)
+        radioJob?.cancel()
+        ensureRadioTail(force = true, insertAfterCurrent = true)
     }
 
     fun playSimilarSong(track: Track) {
-        if (_state.value.jam.isActive) {
-            routeJamAction(JamAction.AddTrack(toJamTrack(track)))
+        if (_state.value.jam.role == JamRole.Guest) {
+            play(track)
             return
         }
         queueEngine.playNext(track)
@@ -8217,10 +8218,14 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         val generation: Long
     )
 
-    private fun ensureRadioTail(force: Boolean, playWhenReady: Boolean = false) {
+    private fun ensureRadioTail(
+        force: Boolean,
+        playWhenReady: Boolean = false,
+        insertAfterCurrent: Boolean = false
+    ) {
         val request = radioTailRequest(force) ?: return
         radioJob = viewModelScope.launch(Dispatchers.IO) {
-            appendRadioTail(request, playWhenReady)
+            appendRadioTail(request, playWhenReady, insertAfterCurrent)
         }
     }
 
@@ -8236,7 +8241,8 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
 
     private suspend fun appendRadioTail(
         request: RadioTailRequest,
-        playWhenReady: Boolean
+        playWhenReady: Boolean,
+        insertAfterCurrent: Boolean = false
     ) {
         val fetchedRadioTracks = try {
             repository.radio(request.seed, _state.value.languageCode, 5)
@@ -8259,7 +8265,11 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 contextArtist = request.seed.artist
             )
         } ?: radioTracks
-        queueEngine.appendRadioTracks(orderedRadioTracks)
+        if (insertAfterCurrent) {
+            queueEngine.insertRadioTracksAfterCurrent(orderedRadioTracks)
+        } else {
+            queueEngine.appendRadioTracks(orderedRadioTracks)
+        }
         if (!playWhenReady) return
         withContext(Dispatchers.Main) {
             queueEngine.next(respectRepeatOne = false)?.let(::startResolve)

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -106,6 +106,7 @@ import com.luc4n3x.levyra.domain.isValidPlaylistTagName
 import com.luc4n3x.levyra.domain.ReleaseRadarEntry
 import com.luc4n3x.levyra.domain.SearchFilter
 import com.luc4n3x.levyra.domain.SearchResults
+import com.luc4n3x.levyra.domain.SimilarSongsSelector
 import com.luc4n3x.levyra.domain.SmartMusicProfile
 import com.luc4n3x.levyra.domain.SponsorSegment
 import com.luc4n3x.levyra.domain.LevyraCanvasSource
@@ -234,6 +235,9 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.isActive
@@ -256,6 +260,7 @@ import java.util.concurrent.atomic.AtomicReference
 private const val ARTIST_PROFILE_UNAVAILABLE_ERROR = "artist_profile_unavailable"
 private const val ARTIST_INITIAL_BIOGRAPHY_WAIT_MS = 4_500L
 private const val EXPLORE_SHORTS_FEED_LIMIT = 24
+private const val SIMILAR_SONGS_DEBOUNCE_MS = 400L
 
 private const val REMOTE_PLAYLIST_TRACK_LIMIT = 150
 private val ACTIVE_DOWNLOAD_STATES = setOf("QUEUED", "RUNNING", "PAUSED", "RETRYING")
@@ -755,6 +760,10 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private var motionArtworkPrefetchJob: Job? = null
     private var sleepTimerCollectorJob: Job? = null
     private var audioSettingsPersistJob: Job? = null
+    private var similarSongsSeedJob: Job? = null
+    private var similarSongsJob: Job? = null
+    private var similarSongsSeedIdentity: String = ""
+    private val similarSongsGeneration = AtomicLong(0L)
     private var lyricsJob: Job? = null
     private var lyricsVersionsJob: Job? = null
     private var lyricsPrefetchJob: Job? = null
@@ -1053,6 +1062,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         }
         observeRecognitionHistory()
         observeJamState()
+        observeSimilarSongsSeed()
         val favorites = favoritesStore.load()
         val settings = startupSettings
         val repairedRecentSearches = settings.recentSearches
@@ -4377,6 +4387,85 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         val enabled = !queueEngine.state.value.radioEnabled
         queueEngine.setRadioEnabled(enabled)
         if (enabled) ensureRadioTail(force = true) else radioJob?.cancel()
+    }
+
+    fun startSongRadio() {
+        if (jamController.rejectGuestLocalMutation()) return
+        if (!queueEngine.state.value.radioEnabled) queueEngine.setRadioEnabled(true)
+        ensureRadioTail(force = true)
+    }
+
+    fun playSimilarSong(track: Track) {
+        if (_state.value.jam.isActive) {
+            routeJamAction(JamAction.AddTrack(toJamTrack(track)))
+            return
+        }
+        queueEngine.playNext(track)
+        playQueueTrack(track)
+    }
+
+    private fun observeSimilarSongsSeed() {
+        similarSongsSeedJob?.cancel()
+        similarSongsSeedJob = viewModelScope.launch {
+            val seedTrack = _state.map { it.currentTrack }.distinctUntilChanged()
+            val playerVisible = _state.map { it.selectedTab == LevyraTab.Player }.distinctUntilChanged()
+            combine(seedTrack, playerVisible, ::Pair).collect { (track, visible) ->
+                refreshSimilarSongs(track, visible)
+            }
+        }
+    }
+
+    private fun refreshSimilarSongs(track: Track?, playerVisible: Boolean) {
+        if (track == null || !playerVisible) {
+            if (similarSongsJob?.isActive == true) {
+                similarSongsJob?.cancel()
+                similarSongsSeedIdentity = ""
+            }
+            similarSongsJob = null
+            if (track == null) {
+                similarSongsSeedIdentity = ""
+                if (_state.value.similarSongs.isNotEmpty() || _state.value.similarSongsLoading) {
+                    _state.update { it.copy(similarSongs = emptyList(), similarSongsLoading = false) }
+                }
+            }
+            return
+        }
+
+        val seedIdentity = playbackIdentity(track)
+        if (seedIdentity == similarSongsSeedIdentity) return
+        similarSongsJob?.cancel()
+        similarSongsSeedIdentity = seedIdentity
+        val generation = similarSongsGeneration.incrementAndGet()
+        _state.update { it.copy(similarSongs = emptyList(), similarSongsLoading = true) }
+        similarSongsJob = viewModelScope.launch {
+            try {
+                delay(SIMILAR_SONGS_DEBOUNCE_MS)
+                val pool = try {
+                    repository.radio(track, _state.value.languageCode, SimilarSongsSelector.POOL_SIZE)
+                } catch (cancelled: CancellationException) {
+                    throw cancelled
+                } catch (_: Exception) {
+                    emptyList()
+                }
+                if (generation != similarSongsGeneration.get()) return@launch
+                val exclusions = _state.value.artistExclusions
+                val queuedTracks = queueEngine.state.value.tracks
+                val selected = withContext(Dispatchers.Default) {
+                    SimilarSongsSelector.select(
+                        candidates = exclusions.filterTracks(pool),
+                        seed = track,
+                        excludedIdentities = queuedTracks.mapTo(HashSet(), ::playbackIdentity)
+                    )
+                }
+                if (generation != similarSongsGeneration.get()) return@launch
+                if (selected.isEmpty()) similarSongsSeedIdentity = ""
+                _state.update { it.copy(similarSongs = selected, similarSongsLoading = false) }
+            } finally {
+                if (generation == similarSongsGeneration.get() && _state.value.similarSongsLoading) {
+                    _state.update { it.copy(similarSongsLoading = false) }
+                }
+            }
+        }
     }
 
     fun setLyricsTranslationEnabled(value: Boolean) {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -184,6 +184,7 @@ import com.luc4n3x.levyra.feature.jam.JamPlayerBridge
 import com.luc4n3x.levyra.feature.jam.JamRole
 import com.luc4n3x.levyra.feature.jam.JamSessionState
 import com.luc4n3x.levyra.feature.jam.JamTrack
+import com.luc4n3x.levyra.feature.jam.JamUiState
 import com.luc4n3x.levyra.feature.recognition.RecognitionCatalogMatcher
 import com.luc4n3x.levyra.feature.recognition.RecognitionErrorKind
 import com.luc4n3x.levyra.feature.recognition.RecognitionHistoryEntry
@@ -237,6 +238,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.updateAndGet
@@ -261,6 +263,7 @@ private const val ARTIST_PROFILE_UNAVAILABLE_ERROR = "artist_profile_unavailable
 private const val ARTIST_INITIAL_BIOGRAPHY_WAIT_MS = 4_500L
 private const val EXPLORE_SHORTS_FEED_LIMIT = 24
 private const val SIMILAR_SONGS_DEBOUNCE_MS = 400L
+private const val JAM_SIMILAR_SONG_SELECT_TIMEOUT_MS = 5_000L
 
 private const val REMOTE_PLAYLIST_TRACK_LIMIT = 150
 private val ACTIVE_DOWNLOAD_STATES = setOf("QUEUED", "RUNNING", "PAUSED", "RETRYING")
@@ -761,6 +764,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private var sleepTimerCollectorJob: Job? = null
     private var audioSettingsPersistJob: Job? = null
     private var similarSongsSeedJob: Job? = null
+    private var jamSimilarSongJob: Job? = null
     private var similarSongsJob: Job? = null
     private var similarSongsSeedIdentity: String = ""
     private val similarSongsGeneration = AtomicLong(0L)
@@ -4397,12 +4401,32 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     fun playSimilarSong(track: Track) {
-        if (_state.value.jam.role == JamRole.Guest) {
-            play(track)
+        val jam = _state.value.jam
+        if (jam.role != JamRole.Guest) {
+            queueEngine.playNext(track)
+            playQueueTrack(track)
             return
         }
-        queueEngine.playNext(track)
-        playQueueTrack(track)
+        val existingIndex = jam.session?.queue?.indexOfFirst { it.id == track.id } ?: -1
+        when (jamSimilarSongAction(jam, existingIndex)) {
+            JamSimilarSongAction.SelectExisting -> routeJamAction(JamAction.SelectIndex(existingIndex))
+            JamSimilarSongAction.AddOnly -> routeJamAction(JamAction.AddTrack(toJamTrack(track)))
+            JamSimilarSongAction.Reject -> jamController.rejectGuestLocalMutation()
+            JamSimilarSongAction.AddThenSelect -> addAndSelectJamTrack(track)
+        }
+    }
+
+    private fun addAndSelectJamTrack(track: Track) {
+        jamSimilarSongJob?.cancel()
+        jamSimilarSongJob = viewModelScope.launch {
+            if (!routeJamAction(JamAction.AddTrack(toJamTrack(track)))) return@launch
+            val index = withTimeoutOrNull(JAM_SIMILAR_SONG_SELECT_TIMEOUT_MS) {
+                jamController.state
+                    .map { jam -> jam.session?.queue?.indexOfFirst { it.id == track.id } ?: -1 }
+                    .first { it >= 0 }
+            } ?: return@launch
+            routeJamAction(JamAction.SelectIndex(index))
+        }
     }
 
     private fun observeSimilarSongsSeed() {
@@ -9515,6 +9539,20 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             }
         }
     }
+}
+
+internal enum class JamSimilarSongAction {
+    SelectExisting,
+    AddThenSelect,
+    AddOnly,
+    Reject
+}
+
+internal fun jamSimilarSongAction(jam: JamUiState, existingIndex: Int): JamSimilarSongAction = when {
+    jam.canControlPlayback && existingIndex >= 0 -> JamSimilarSongAction.SelectExisting
+    jam.canControlPlayback && jam.canAddTracks -> JamSimilarSongAction.AddThenSelect
+    jam.canAddTracks -> JamSimilarSongAction.AddOnly
+    else -> JamSimilarSongAction.Reject
 }
 
 internal fun playbackIdentity(track: Track): String = LevyraPersonalOrbit.identityKey(track)

--- a/app/src/test/java/com/luc4n3x/levyra/domain/SimilarSongsSelectorTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/domain/SimilarSongsSelectorTest.kt
@@ -1,0 +1,170 @@
+package com.luc4n3x.levyra.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SimilarSongsSelectorTest {
+
+    @Test
+    fun dropsTheSeedRecordingEvenWhenTheVideoIdDiffers() {
+        val seed = track("aaaaaaaaaaa", "Blinding Lights", "The Weeknd")
+        val candidates = listOf(
+            track("bbbbbbbbbbb", "Blinding Lights", "The Weeknd", videoType = "MUSIC_VIDEO_TYPE_OMV"),
+            track("ccccccccccc", "Save Your Tears", "The Weeknd")
+        )
+
+        val result = SimilarSongsSelector.select(candidates, seed, emptySet())
+
+        assertEquals(listOf("ccccccccccc"), result.map { it.id })
+    }
+
+    @Test
+    fun dropsRecordingsAlreadyPresentInTheQueue() {
+        val seed = track("aaaaaaaaaaa", "Blinding Lights", "The Weeknd")
+        val queued = track("ddddddddddd", "Starboy", "The Weeknd")
+        val candidates = listOf(
+            track("eeeeeeeeeee", "Starboy", "The Weeknd"),
+            track("fffffffffff", "Take On Me", "a-ha")
+        )
+
+        val result = SimilarSongsSelector.select(
+            candidates = candidates,
+            seed = seed,
+            excludedIdentities = setOf(LevyraPersonalOrbit.identityKey(queued))
+        )
+
+        assertEquals(listOf("fffffffffff"), result.map { it.id })
+    }
+
+    @Test
+    fun dropsReuploadsAndCoversOfTheCurrentRecording() {
+        val seed = track("aaaaaaaaaaa", "2 Hard 4 The Radio", "Drake")
+        val candidates = listOf(
+            track("ttttttttttt", "Drake 2 Hard 4 The Radio", "Deshawn Cavanaugh"),
+            track("uuuuuuuuuuu", "2 Hard 4 The Radio (cover)", "Some Channel"),
+            track("vvvvvvvvvvv", "2 Hard 4 the Fuckin Radio", "Mac Dre")
+        )
+
+        val result = SimilarSongsSelector.select(candidates, seed, emptySet())
+
+        assertEquals(listOf("vvvvvvvvvvv"), result.map { it.id })
+    }
+
+    @Test
+    fun keepsARemixCreditedToTheSameArtist() {
+        val seed = track("aaaaaaaaaaa", "Blinding Lights", "The Weeknd")
+        val candidates = listOf(track("wwwwwwwwwww", "Blinding Lights Remix", "The Weeknd"))
+
+        val result = SimilarSongsSelector.select(candidates, seed, emptySet())
+
+        assertEquals(listOf("wwwwwwwwwww"), result.map { it.id })
+    }
+
+    @Test
+    fun doesNotTreatAShortSeedTitleAsASubstringMatch() {
+        val seed = track("aaaaaaaaaaa", "Go", "Artist One")
+        val candidates = listOf(track("xxxxxxxxxxx", "Gold", "Artist Two"))
+
+        val result = SimilarSongsSelector.select(candidates, seed, emptySet())
+
+        assertEquals(listOf("xxxxxxxxxxx"), result.map { it.id })
+    }
+
+    @Test
+    fun collapsesRepeatedRecommendationsToASingleEntry() {
+        val candidates = listOf(
+            track("ggggggggggg", "After Hours", "The Weeknd"),
+            track("hhhhhhhhhhh", "After Hours", "The Weeknd"),
+            track("iiiiiiiiiii", "After Hours", "The Weeknd")
+        )
+
+        val result = SimilarSongsSelector.select(candidates, seed = null, excludedIdentities = emptySet())
+
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun prefersTheAudioTrackOverTheMusicVideoDuplicate() {
+        val candidates = listOf(
+            track("jjjjjjjjjjj", "Take On Me", "a-ha", videoType = "MUSIC_VIDEO_TYPE_OMV"),
+            track("kkkkkkkkkkk", "Take On Me", "a-ha", videoType = "MUSIC_VIDEO_TYPE_ATV")
+        )
+
+        val result = SimilarSongsSelector.select(candidates, seed = null, excludedIdentities = emptySet())
+
+        assertEquals(listOf("kkkkkkkkkkk"), result.map { it.id })
+    }
+
+    @Test
+    fun keepsTheMusicVideoWhenNoAudioVariantIsAvailable() {
+        val candidates = listOf(track("lllllllllll", "Take On Me", "a-ha", videoType = "MUSIC_VIDEO_TYPE_OMV"))
+
+        val result = SimilarSongsSelector.select(candidates, seed = null, excludedIdentities = emptySet())
+
+        assertEquals(listOf("lllllllllll"), result.map { it.id })
+    }
+
+    @Test
+    fun skipsCandidatesWithoutAPlayableIdentifierOrTitle() {
+        val candidates = listOf(
+            track("", "Ghost Entry", "Nobody"),
+            track("mmmmmmmmmmm", "", "Nobody"),
+            track("nnnnnnnnnnn", "Real Song", "Somebody")
+        )
+
+        val result = SimilarSongsSelector.select(candidates, seed = null, excludedIdentities = emptySet())
+
+        assertEquals(listOf("nnnnnnnnnnn"), result.map { it.id })
+    }
+
+    @Test
+    fun honoursTheRequestedLimitWhileStillUpgradingSelectedEntries() {
+        val candidates = listOf(
+            track("ooooooooooo", "First", "Artist", videoType = "MUSIC_VIDEO_TYPE_OMV"),
+            track("ppppppppppp", "Second", "Artist"),
+            track("qqqqqqqqqqq", "Third", "Artist"),
+            track("rrrrrrrrrrr", "First", "Artist", videoType = "MUSIC_VIDEO_TYPE_ATV")
+        )
+
+        val result = SimilarSongsSelector.select(candidates, seed = null, excludedIdentities = emptySet(), limit = 2)
+
+        assertEquals(2, result.size)
+        assertEquals(listOf("rrrrrrrrrrr", "ppppppppppp"), result.map { it.id })
+    }
+
+    @Test
+    fun returnsNothingForAnEmptyOrDisabledRequest() {
+        val candidates = listOf(track("sssssssssss", "Song", "Artist"))
+
+        assertTrue(SimilarSongsSelector.select(emptyList(), null, emptySet()).isEmpty())
+        assertTrue(SimilarSongsSelector.select(candidates, null, emptySet(), limit = 0).isEmpty())
+    }
+
+    private fun track(
+        id: String,
+        title: String,
+        artist: String,
+        videoType: String = "",
+        durationMs: Long = 180_000L
+    ): Track = Track(
+        id = id,
+        title = title,
+        artist = artist,
+        album = title,
+        durationMs = durationMs,
+        streamUrl = "",
+        videoUrl = if (id.isBlank()) "" else "https://www.youtube.com/watch?v=$id",
+        thumbnailUrl = "https://example.test/$id.jpg",
+        largeThumbnailUrl = "https://example.test/$id-large.jpg",
+        source = "YouTube Music Radio",
+        moodTags = emptySet(),
+        energy = 50,
+        vocal = 50,
+        replayScore = 70,
+        cacheScore = 70,
+        accentStart = 0,
+        accentEnd = 0,
+        videoType = videoType
+    )
+}

--- a/app/src/test/java/com/luc4n3x/levyra/player/queue/PersistentQueueRadioPolicyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/queue/PersistentQueueRadioPolicyTest.kt
@@ -80,6 +80,23 @@ class PersistentQueueRadioPolicyTest {
         assertEquals(listOf("fresh"), selected.map(Track::id))
     }
 
+    @Test
+    fun radioInsertsRightAfterTheCurrentTrackWhenStartedFromIt() {
+        assertEquals(3, radioInsertionIndex(currentIndex = 2, queueSize = 9, afterCurrent = true))
+    }
+
+    @Test
+    fun radioAppendsToTheTailWhenItIsAContinuationBatch() {
+        assertEquals(9, radioInsertionIndex(currentIndex = 2, queueSize = 9, afterCurrent = false))
+    }
+
+    @Test
+    fun radioInsertionStaysInsideTheQueueBounds() {
+        assertEquals(0, radioInsertionIndex(currentIndex = -1, queueSize = 4, afterCurrent = true))
+        assertEquals(4, radioInsertionIndex(currentIndex = 3, queueSize = 4, afterCurrent = true))
+        assertEquals(0, radioInsertionIndex(currentIndex = 7, queueSize = 0, afterCurrent = true))
+    }
+
     private fun track(id: String, title: String, artist: String = "Artist") = Track(
         id = id,
         title = title,

--- a/app/src/test/java/com/luc4n3x/levyra/ui/i18n/LevyraStringsTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/i18n/LevyraStringsTest.kt
@@ -21,6 +21,7 @@ class LevyraStringsTest {
         assertEquals(catalogCodes, insightLocalizationCodes())
         assertEquals(catalogCodes, integrationLocalizationCodes())
         assertEquals(catalogCodes, resonanceLocalizationCodes())
+        assertEquals(catalogCodes, similarSongsLocalizationCodes())
         LevyraStrings.all().forEach { strings ->
             assertTrue(strings.commentsLabel.isNotBlank())
             assertTrue(strings.mostCommentedTracks.isNotBlank())
@@ -43,6 +44,9 @@ class LevyraStringsTest {
             assertTrue(strings.lyricsCalibrate.isNotBlank())
             assertTrue(strings.motionArtworkSubtitle.isNotBlank())
             assertTrue(strings.lyricsFocus.isNotBlank())
+            assertTrue(strings.startRadio.isNotBlank())
+            assertTrue(strings.similarSongsPlay.isNotBlank())
+            assertTrue(strings.similarSongsAddToQueue.isNotBlank())
             assertTrue(strings.changeLyrics.isNotBlank())
             assertTrue(strings.automaticLyrics.isNotBlank())
             assertTrue(strings.selectVerses.isNotBlank())

--- a/app/src/test/java/com/luc4n3x/levyra/ui/i18n/LevyraStringsTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/i18n/LevyraStringsTest.kt
@@ -45,8 +45,6 @@ class LevyraStringsTest {
             assertTrue(strings.motionArtworkSubtitle.isNotBlank())
             assertTrue(strings.lyricsFocus.isNotBlank())
             assertTrue(strings.startRadio.isNotBlank())
-            assertTrue(strings.similarSongsPlay.isNotBlank())
-            assertTrue(strings.similarSongsAddToQueue.isNotBlank())
             assertTrue(strings.changeLyrics.isNotBlank())
             assertTrue(strings.automaticLyrics.isNotBlank())
             assertTrue(strings.selectVerses.isNotBlank())

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/JamSimilarSongActionTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/JamSimilarSongActionTest.kt
@@ -1,0 +1,51 @@
+package com.luc4n3x.levyra.viewmodel
+
+import com.luc4n3x.levyra.feature.jam.JamGuestPermission
+import com.luc4n3x.levyra.feature.jam.JamRole
+import com.luc4n3x.levyra.feature.jam.JamUiState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class JamSimilarSongActionTest {
+
+    @Test
+    fun collaborativeGuestSelectsATrackTheSharedQueueAlreadyHolds() {
+        assertEquals(
+            JamSimilarSongAction.SelectExisting,
+            jamSimilarSongAction(guest(JamGuestPermission.Collaborative), existingIndex = 4)
+        )
+    }
+
+    @Test
+    fun collaborativeGuestAddsThenSelectsATrackThatIsMissing() {
+        assertEquals(
+            JamSimilarSongAction.AddThenSelect,
+            jamSimilarSongAction(guest(JamGuestPermission.Collaborative), existingIndex = -1)
+        )
+    }
+
+    @Test
+    fun addSongsGuestOnlyProposesTheTrack() {
+        assertEquals(
+            JamSimilarSongAction.AddOnly,
+            jamSimilarSongAction(guest(JamGuestPermission.AddSongs), existingIndex = -1)
+        )
+        assertEquals(
+            JamSimilarSongAction.AddOnly,
+            jamSimilarSongAction(guest(JamGuestPermission.AddSongs), existingIndex = 2)
+        )
+    }
+
+    @Test
+    fun hostOnlyGuestIsRejected() {
+        assertEquals(
+            JamSimilarSongAction.Reject,
+            jamSimilarSongAction(guest(JamGuestPermission.HostOnly), existingIndex = -1)
+        )
+    }
+
+    private fun guest(permission: JamGuestPermission) = JamUiState(
+        role = JamRole.Guest,
+        permission = permission
+    )
+}

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/JamSimilarSongActionTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/JamSimilarSongActionTest.kt
@@ -4,6 +4,8 @@ import com.luc4n3x.levyra.feature.jam.JamGuestPermission
 import com.luc4n3x.levyra.feature.jam.JamRole
 import com.luc4n3x.levyra.feature.jam.JamUiState
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class JamSimilarSongActionTest {
@@ -42,6 +44,29 @@ class JamSimilarSongActionTest {
             JamSimilarSongAction.Reject,
             jamSimilarSongAction(guest(JamGuestPermission.HostOnly), existingIndex = -1)
         )
+    }
+
+    @Test
+    fun similarSongCardOffersOnlyWhatTheSessionPermissionAllows() {
+        val collaborative = playerProjection(LevyraUiState(jam = guest(JamGuestPermission.Collaborative)))
+        assertTrue(collaborative.canPlaySimilarSongNow)
+        assertTrue(collaborative.canQueueSimilarSong)
+
+        val addSongs = playerProjection(LevyraUiState(jam = guest(JamGuestPermission.AddSongs)))
+        assertFalse(addSongs.canPlaySimilarSongNow)
+        assertTrue(addSongs.canQueueSimilarSong)
+
+        val hostOnly = playerProjection(LevyraUiState(jam = guest(JamGuestPermission.HostOnly)))
+        assertFalse(hostOnly.canPlaySimilarSongNow)
+        assertFalse(hostOnly.canQueueSimilarSong)
+    }
+
+    @Test
+    fun similarSongCardStaysFullyEnabledOutsideAJam() {
+        val solo = playerProjection(LevyraUiState())
+
+        assertTrue(solo.canPlaySimilarSongNow)
+        assertTrue(solo.canQueueSimilarSong)
     }
 
     private fun guest(permission: JamGuestPermission) = JamUiState(

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/ScreenProjectionCoverageTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/ScreenProjectionCoverageTest.kt
@@ -6,6 +6,7 @@ import com.luc4n3x.levyra.domain.BatchDownloadState
 import com.luc4n3x.levyra.domain.PlaylistHit
 import com.luc4n3x.levyra.domain.SearchFilter
 import com.luc4n3x.levyra.domain.SearchResults
+import com.luc4n3x.levyra.domain.Track
 import com.luc4n3x.levyra.feature.recognition.RecognitionState
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
@@ -78,6 +79,49 @@ class ScreenProjectionCoverageTest {
 
         assertNotEquals(libraryProjection(early), libraryProjection(later))
     }
+
+    @Test
+    fun `player projection reacts to similar songs`() {
+        val withSimilar = base.copy(similarSongs = listOf(similarTrack()))
+
+        assertNotEquals(playerProjection(base), playerProjection(withSimilar))
+    }
+
+    @Test
+    fun `player projection reacts to similar songs loading`() {
+        assertNotEquals(
+            playerProjection(base),
+            playerProjection(base.copy(similarSongsLoading = true))
+        )
+    }
+
+    @Test
+    fun `player projection reacts to continuous radio state`() {
+        assertNotEquals(
+            playerProjection(base),
+            playerProjection(base.copy(radioEnabled = !base.radioEnabled))
+        )
+    }
+
+    private fun similarTrack() = Track(
+        id = "abcdefghijk",
+        title = "Similar",
+        artist = "Artist",
+        album = "Album",
+        durationMs = 180_000L,
+        streamUrl = "",
+        videoUrl = "https://www.youtube.com/watch?v=abcdefghijk",
+        thumbnailUrl = "",
+        largeThumbnailUrl = "",
+        source = "YouTube Music Radio",
+        moodTags = emptySet(),
+        energy = 50,
+        vocal = 50,
+        replayScore = 70,
+        cacheScore = 70,
+        accentStart = 0,
+        accentEnd = 0
+    )
 
     private fun batch(completed: Int, progress: Int) = BatchDownload(
         key = "album:test",


### PR DESCRIPTION
## Summary

Now Playing now shows a "You might also like" section built from the track that is currently playing, so discovering something adjacent no longer means leaving the player and searching by hand. The list is seeded with real YouTube Music watch/radio and related data rather than a text query, it refreshes when the track changes, and each card can be played immediately or dropped at the end of the queue. A leading tile starts continuous radio from the current song.

## What changed

- Added `SimilarSongsSelector`, a pure selector that filters and orders a recommendation pool: it drops the current recording, anything already in the queue, repeated entries, and obvious re-uploads or covers of the playing song, and prefers the audio track when a music-video duplicate of the same recording is also present.
- Added `similarSongs` / `similarSongsLoading` to `LevyraUiState` and projected them, together with `radioEnabled`, into `PlayerProjection`.
- `LevyraViewModel` observes the current track together with player visibility and refreshes recommendations through the existing `YoutubeMusicRepository.radio()` path. The fetch is debounced, guarded by request generation and seed identity, and the selection runs on `Dispatchers.Default`.
- Added `playSimilarSong()`, which inserts the chosen track right after the current one through the queue engine and then plays it, and `startSongRadio()`, which enables continuous radio and forces a radio tail append through the existing `ensureRadioTail` path.
- Added the Now Playing section itself: a header with a gradient section rule and a stacked artwork peek of the first three suggestions, expanding into a horizontal shelf with a "Start radio" tile, tap-to-play cards and an add-to-queue badge.
- Reworked the player quick-action bar and the new section header to drop their boxed containers in favour of free-standing glyphs with an accent dot for the active state, which is what the surrounding Now Playing surface already reads like.
- Exposed `LevyraPersonalOrbit.musicTitleKey` / `artistKeys` so the selector reuses the existing recording normalisation instead of duplicating it.
- Added `startRadio`, `similarSongsPlay` and `similarSongsAddToQueue` in all 26 supported languages.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor or maintenance
- [x] UI or UX change
- [x] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** Player / UI / Localization

## Validation

### Automated checks

- [x] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [x] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

`python3 scripts/ai_quality_gate.py --profile full` passed on this branch: agent configuration, AI efficiency, Matt skills, claude-mem, F-Droid review contract, repository script tests, Android runtime compatibility, `:app:testDebugUnitTest` (1721 tests, 0 failures), `:app:lintRelease -PlevyraFdroidBuild=true` and the unsigned F-Droid `:app:assembleRelease`. Desktop was not run because this change does not touch `desktop/`.

New tests: `SimilarSongsSelectorTest` covers seed removal, queue exclusion, repeated entries, re-upload and cover rejection, same-artist remixes being kept, short-title safety, audio-over-video preference and limit handling. `ScreenProjectionCoverageTest` covers the three new player projection fields. `LevyraStringsTest` now asserts that the new bundle covers every catalogue language.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Pixel 8 emulator, API 37 | Open Now Playing on a streamed track | Section appears once recommendations resolve |
| Pixel 8 emulator, API 37 | Skip to the next track | Section reloads and shows suggestions for the new song |
| Pixel 8 emulator, API 37 | Tap a recommended card | Song plays immediately and the shelf reloads around it |
| Pixel 8 emulator, API 37 | Tap the add-to-queue badge | Track is appended, the badge switches to a check mark, confirmation toast shown |
| Pixel 8 emulator, API 37 | Tap the "Start radio" tile | Continuous radio stays on and the queue grows with matching songs |

Not verified: physical device, Android Auto, notification and PiP behaviour, and a sustained memory run.

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** None. No schema, preference or protocol change.
- **Known limitations:** Recommendations are only fetched while the player screen is visible. When the seed track resolves no candidates, for example on a downloaded local file, the section stays hidden. On a cold start the queue snapshot used for exclusion may not be fully restored yet, so a track already queued can appear once until the next seed change.
- **Rollback plan:** Revert this PR

Playback ownership is unchanged: the recommendation fetch is debounced, cancelled and generation-guarded, publishes only when the seed identity still matches, and never blocks resolution. Playing a suggestion and starting radio both go through the existing queue engine entry points rather than new queue logic.

## Reviewer notes

- `LevyraViewModel.refreshSimilarSongs` is the piece worth the closest look: cancellation ordering against the request generation, clearing the seed identity after an empty result so a later visit can retry, and the fact that both the artist-exclusion filter and the queue identity set are computed inside `withContext(Dispatchers.Default)`.
- `SimilarSongsSelector.isSeedDerivative` intentionally keeps same-artist variants such as remixes and radio edits, and only drops title repeats coming from a different artist. The minimum title length exists so a short seed title cannot match by substring.
- The quick-action bar restyle touches a shared player component. Semantics, toggle state and the 48dp touch targets are unchanged; only the container chrome and the active-state treatment were replaced.

## Release note

Now Playing suggests similar songs based on what you are listening to, and lets you play them, queue them, or start a radio from the current track.

## Related issues

- Closes #526
- Related to #

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims