### PR TITLE
perf: reduce Home album startup latency

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/HomeStartupPerformance.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/HomeStartupPerformance.kt
@@ -31,12 +31,6 @@ internal data class HomeStartupWorkPlan(
     val releasesPerArtist: Int
 )
 
-// The artist shelf used to start 8.5-12s after launch, behind the album wave,
-// which left a visibly empty section on every cold start. It now runs ahead of
-// the album wave instead. Concurrency, artwork counts and the album budgets are
-// untouched, so peak memory is unchanged: only the ordering moved. Constrained
-// tiers still wait for the secondary wave first, and awaitHomeUiIdle keeps the
-// work off the main thread while the user is flinging.
 internal object HomeStartupWorkPolicy {
     fun create(lowRam: Boolean, powerConstrained: Boolean): HomeStartupWorkPlan {
         return when {
@@ -44,7 +38,7 @@ internal object HomeStartupWorkPolicy {
                 idleWindowMs = 900L,
                 homeFeedStartDelayMs = 1_400L,
                 secondaryStartDelayMs = 6_000L,
-                albumStartDelayMs = 9_000L,
+                albumStartDelayMs = 0L,
                 artistStartDelayMs = 7_500L,
                 chartRefreshStartDelayMs = 4_500L,
                 chartPrefetchStartDelayMs = 9_000L,
@@ -68,7 +62,7 @@ internal object HomeStartupWorkPolicy {
                 idleWindowMs = 800L,
                 homeFeedStartDelayMs = 1_100L,
                 secondaryStartDelayMs = 5_000L,
-                albumStartDelayMs = 7_500L,
+                albumStartDelayMs = 0L,
                 artistStartDelayMs = 5_600L,
                 chartRefreshStartDelayMs = 3_800L,
                 chartPrefetchStartDelayMs = 7_500L,
@@ -92,7 +86,7 @@ internal object HomeStartupWorkPolicy {
                 idleWindowMs = 700L,
                 homeFeedStartDelayMs = 850L,
                 secondaryStartDelayMs = 4_200L,
-                albumStartDelayMs = 6_500L,
+                albumStartDelayMs = 0L,
                 artistStartDelayMs = 2_200L,
                 chartRefreshStartDelayMs = 3_000L,
                 chartPrefetchStartDelayMs = 6_500L,

--- a/app/src/test/java/com/luc4n3x/levyra/data/HomeStartupPerformanceTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/HomeStartupPerformanceTest.kt
@@ -11,7 +11,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 class HomeStartupPerformanceTest {
     @Test
-    fun lowRamPlanKeepsBackgroundWorkSmallAndLate() {
+    fun lowRamPlanKeepsBackgroundWorkBounded() {
         val plan = HomeStartupWorkPolicy.create(lowRam = true, powerConstrained = true)
         assertTrue(plan.priorityArtworkCount <= 2)
         assertTrue(plan.refreshedArtworkCount <= 4)
@@ -22,11 +22,8 @@ class HomeStartupPerformanceTest {
         assertTrue(plan.idleWindowMs >= 850L)
         assertTrue(plan.homeFeedStartDelayMs >= 1_200L)
         assertTrue(plan.secondaryStartDelayMs >= 6_000L)
-        assertTrue(plan.albumStartDelayMs > plan.secondaryStartDelayMs)
-        // The artist shelf is visible content, so it starts right after the home
-        // feed and ahead of the album and maintenance waves.
+        assertEquals(0L, plan.albumStartDelayMs)
         assertTrue(plan.artistStartDelayMs > plan.homeFeedStartDelayMs)
-        assertTrue(plan.artistStartDelayMs < plan.albumStartDelayMs)
         assertTrue(plan.chartPrefetchStartDelayMs > plan.chartRefreshStartDelayMs)
         assertTrue(plan.maintenanceStartDelayMs >= 20_000L)
         assertTrue(plan.activePlaybackProtectionMs >= 14_000L)
@@ -36,7 +33,7 @@ class HomeStartupPerformanceTest {
     }
 
     @Test
-    fun normalPlanKeepsFirstSecondsFreeFromNonessentialWork() {
+    fun normalPlanKeepsBackgroundWorkBounded() {
         val plan = HomeStartupWorkPolicy.create(lowRam = false, powerConstrained = false)
         assertTrue(plan.priorityArtworkCount in 2..3)
         assertTrue(plan.refreshedArtworkCount in 4..5)
@@ -49,16 +46,24 @@ class HomeStartupPerformanceTest {
         assertTrue(plan.secondaryStartDelayMs >= 4_000L)
         assertTrue(plan.chartPrefetchStartDelayMs >= 6_000L)
         assertTrue(plan.chartMemoryWarmStartDelayMs > plan.chartPrefetchStartDelayMs)
-        assertTrue(plan.albumStartDelayMs > plan.secondaryStartDelayMs)
-        // The artist shelf is visible content, so it starts right after the home
-        // feed and ahead of the album and maintenance waves.
+        assertEquals(0L, plan.albumStartDelayMs)
         assertTrue(plan.artistStartDelayMs > plan.homeFeedStartDelayMs)
-        assertTrue(plan.artistStartDelayMs < plan.albumStartDelayMs)
         assertTrue(plan.maintenanceStartDelayMs >= 15_000L)
         assertTrue(plan.activePlaybackProtectionMs >= 10_000L)
         assertEquals(1, plan.albumConcurrency)
         assertTrue(plan.albumSeedCount <= 6)
         assertTrue(plan.albumCandidateCount <= 12)
+    }
+
+    @Test
+    fun powerConstrainedPlanKeepsAlbumWorkBoundedWithImmediateHandoff() {
+        val plan = HomeStartupWorkPolicy.create(lowRam = false, powerConstrained = true)
+
+        assertTrue(plan.homeFeedStartDelayMs >= 1_000L)
+        assertEquals(0L, plan.albumStartDelayMs)
+        assertEquals(1, plan.albumConcurrency)
+        assertTrue(plan.albumSeedCount <= 5)
+        assertTrue(plan.albumCandidateCount <= 11)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Home album recommendations were waiting for an extra tier-specific delay after the remote Home feed had already gone through its startup delay and interaction-idle gate. This removes that second wait. Album work can start as soon as the feed hands off, while the existing per-device limits on seeds, candidates, concurrency, artwork, chart work, and maintenance stay unchanged.

The earlier queue fast-path experiment is not part of this PR. Review found no runtime evidence that queue replacement was the tap-to-play bottleneck, and temporarily changing queue state was not worth the risk.

## What changed

- Set the Home album handoff delay to `0L` for standard, power-constrained, and low-RAM startup plans.
- Keep the existing Home interaction-idle gate and all bounded work limits unchanged.
- Update `HomeStartupPerformanceTest` for all three device tiers.
- Keep playback queue behavior unchanged.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactor or maintenance
- [ ] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** UI / Home startup

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [x] Targeted tests were added or updated
- [x] Not applicable, with the reason explained below

The repository PR workflow is running the Android quality gate, lint, unit-test, diagnostics, and release compile checks on commit `314f6d86e053c515f959beabeeb17dc9c5ad862c`. Desktop validation is not applicable because this diff is Android-only. No local Gradle command was run from this connector-only session.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Physical Android device | Cold start, Home album timing, first-play contention, sustained memory | Not run in this connector-only session |

## Risk and compatibility

- **Risk level:** Medium
- **Compatibility or migration notes:** None
- **Known limitations:** Physical-device startup timing, playback contention, and sustained-memory behavior are not yet measured.
- **Rollback plan:** Revert this PR.

## Reviewer notes

- The runtime change is limited to the Home startup policy. Playback queue behavior is unchanged from `main`.
- `loadHomeAlbums()` still passes through the existing interaction-idle gate before remote album work when cold-start deferral is enabled.
- The main remaining runtime question is whether the earlier album work creates measurable contention with first playback on constrained devices; this is not claimed as resolved without device evidence.

## Release note

Home album recommendations can begin loading sooner after the Home feed is ready.

## Related issues

- Closes: N/A
- Related to: N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests were updated for the changed startup policy
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved