### PR TITLE
Evolve Living Artwork with palette mesh flow and leaner runtime

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/ui/artwork/LivingArtwork.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/artwork/LivingArtwork.kt
@@ -25,9 +25,7 @@ import kotlinx.coroutines.isActive
 import kotlin.math.cos
 import kotlin.math.sin
 
-private const val STEADY_FRAME_MS = 34L
-private const val BOOST_FRAME_MS = 20L
-private const val BOOST_DURATION_MS = 1_100L
+private const val FRAME_INTERVAL_MS = 34L
 private const val FADE_IN_MS = 520
 private const val FADE_OUT_MS = 260
 private const val SHADER_INTENSITY = 0.62f
@@ -51,12 +49,9 @@ internal fun LivingArtworkLayer(
 
     LaunchedEffect(active, colors) {
         if (!active) return@LaunchedEffect
-        var boostRemainingMs = BOOST_DURATION_MS
         while (isActive) {
-            val intervalMs = if (boostRemainingMs > 0L) BOOST_FRAME_MS else STEADY_FRAME_MS
-            phase.floatValue += intervalMs / 1_000f
-            delay(intervalMs)
-            if (boostRemainingMs > 0L) boostRemainingMs -= intervalMs
+            phase.floatValue += FRAME_INTERVAL_MS / 1_000f
+            delay(FRAME_INTERVAL_MS)
         }
     }
 

--- a/app/src/main/java/com/luc4n3x/levyra/ui/artwork/LivingArtwork.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/artwork/LivingArtwork.kt
@@ -28,7 +28,7 @@ import kotlin.math.sin
 private const val FRAME_INTERVAL_MS = 34L
 private const val FADE_IN_MS = 520
 private const val FADE_OUT_MS = 260
-private const val SHADER_INTENSITY = 0.62f
+private const val SHADER_INTENSITY = 0.74f
 private const val LEGACY_INTENSITY = 0.50f
 
 @Composable
@@ -80,7 +80,7 @@ private fun rememberLivingArtworkShader(colors: LivingArtworkColors): RuntimeSha
     remember(colors) {
         if (!livingArtworkShaderSupported()) return@remember null
         val shader = createLivingArtworkShader() ?: return@remember null
-        if (!shader.applyLivingArtworkTones(colors.tones)) return@remember null
+        if (!shader.applyLivingArtworkColors(colors)) return@remember null
         shader
     }
 

--- a/app/src/main/java/com/luc4n3x/levyra/ui/artwork/LivingArtwork.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/artwork/LivingArtwork.kt
@@ -28,7 +28,7 @@ import kotlin.math.sin
 private const val FRAME_INTERVAL_MS = 34L
 private const val FADE_IN_MS = 520
 private const val FADE_OUT_MS = 260
-private const val SHADER_INTENSITY = 0.74f
+private const val SHADER_INTENSITY = 0.60f
 private const val LEGACY_INTENSITY = 0.50f
 
 @Composable
@@ -101,7 +101,7 @@ private fun LivingArtworkShaderSurface(
                 if (visible <= 0.001f) return@onDrawBehind
                 shader.setFloatUniform("uTime", phase())
                 shader.setFloatUniform("uIntensity", SHADER_INTENSITY * visible)
-                drawRect(brush = brush, blendMode = BlendMode.Screen)
+                drawRect(brush = brush)
             }
         }
     )

--- a/app/src/main/java/com/luc4n3x/levyra/ui/artwork/LivingArtworkShader.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/artwork/LivingArtworkShader.kt
@@ -51,6 +51,11 @@ float2 rotatePoint(float2 p, float angle) {
     return float2(c * p.x - s * p.y, s * p.x + c * p.y);
 }
 
+float softRegion(float2 p, float2 center, float2 scale, float inner, float outer) {
+    float d = length((p - center) * scale);
+    return 1.0 - smoothstep(inner, outer, d);
+}
+
 half4 main(float2 fragCoord) {
     float minSide = max(min(uSize.x, uSize.y), 1.0);
     float2 uv = fragCoord / uSize;
@@ -58,43 +63,66 @@ half4 main(float2 fragCoord) {
     float t = uTime;
     float seed = uSeed;
 
-    float2 drift = float2(t * 0.050, -t * 0.036);
-    float warpX = fbm(p * 0.92 + drift + float2(seed * 0.17, seed * 0.09));
-    float warpY = fbm(p * 0.92 - drift + float2(5.73 + seed * 0.11, 2.19 - seed * 0.07));
-    float2 warped = p + (float2(warpX, warpY) - float2(0.5, 0.5)) * 0.58;
+    float2 drift = float2(t * 0.045, -t * 0.033);
+    float warpX = fbm(p * 0.88 + drift + float2(seed * 0.17, seed * 0.09));
+    float warpY = fbm(p * 0.88 - drift + float2(5.73 + seed * 0.11, 2.19 - seed * 0.07));
+    float2 warped = p + (float2(warpX, warpY) - float2(0.5, 0.5)) * 0.52;
 
     float radius = length(warped);
-    float lens = sin(radius * 3.6 - t * 0.13 + seed * 0.63) * 0.08;
+    float lens = sin(radius * 3.3 - t * 0.12 + seed * 0.63) * 0.07;
     warped = rotatePoint(warped, lens);
-    warped += warped * (0.032 * sin(radius * 2.7 + t * 0.09 + seed));
+    warped += warped * (0.028 * sin(radius * 2.5 + t * 0.085 + seed));
 
-    float2 mesh = warped * 0.52;
-    float mask0 = smoothstep(0.50, 0.74, valueNoise(mesh * 0.66 + float2(t * 0.018, seed * 0.23)));
-    float mask1 = smoothstep(0.52, 0.76, valueNoise(rotatePoint(mesh, 0.58) * 0.78 + float2(-t * 0.017 + 4.1, seed * 0.31 + 1.7)));
-    float mask2 = smoothstep(0.54, 0.78, valueNoise(rotatePoint(mesh, -0.43) * 0.90 + float2(seed * 0.19 + 7.4, t * 0.015 + 3.2)));
-    float mask3 = smoothstep(0.56, 0.80, valueNoise(mesh * 1.04 + float2(t * 0.013 + 2.8, -seed * 0.27 + 8.6)));
-    float mask4 = smoothstep(0.58, 0.82, valueNoise(rotatePoint(mesh, 0.88) * 1.16 + float2(-t * 0.012 + 9.3, seed * 0.37 + 5.1)));
+    float2 c0 = float2(
+        -0.50 + 0.20 * sin(t * 0.13 + seed),
+        -0.40 + 0.17 * cos(t * 0.11 + seed * 0.71)
+    );
+    float2 c1 = float2(
+        0.50 + 0.19 * cos(t * 0.12 + seed * 0.43),
+        -0.22 + 0.19 * sin(t * 0.14 + seed * 0.57)
+    );
+    float2 c2 = float2(
+        -0.38 + 0.19 * cos(t * 0.10 + seed * 0.82),
+        0.45 + 0.16 * sin(t * 0.12 + seed * 0.36)
+    );
+    float2 c3 = float2(
+        0.40 + 0.18 * sin(t * 0.11 + seed * 0.29),
+        0.46 + 0.17 * cos(t * 0.13 + seed * 0.64)
+    );
+    float2 c4 = float2(
+        0.02 + 0.22 * sin(t * 0.09 + seed * 0.51),
+        0.08 + 0.17 * cos(t * 0.10 + seed * 0.93)
+    );
 
-    float macroField = valueNoise(warped * 0.42 + float2(seed * 0.41, t * 0.010));
-    float edgeField = smoothstep(0.26, 0.86, distance(uv, float2(0.5, 0.48)));
+    float region0 = softRegion(warped, c0, float2(0.78, 1.08), 0.08, 0.92);
+    float region1 = softRegion(warped, c1, float2(0.86, 1.00), 0.07, 0.88);
+    float region2 = softRegion(warped, c2, float2(0.82, 1.12), 0.09, 0.94);
+    float region3 = softRegion(warped, c3, float2(0.90, 1.04), 0.08, 0.90);
+    float region4 = softRegion(warped, c4, float2(1.02, 0.94), 0.06, 0.72);
 
-    half3 color = uBase.rgb;
-    color = mix(color, uTone0.rgb, half(mask0 * 0.86));
-    color = mix(color, uTone1.rgb, half(mask1 * 0.78));
-    color = mix(color, uTone2.rgb, half(mask2 * 0.68));
-    color = mix(color, uTone3.rgb, half(mask3 * 0.56));
-    color = mix(color, uTone4.rgb, half(mask4 * 0.46));
+    float regionTotal = max(region0 + region1 + region2 + region3 + region4, 0.001);
+    half3 regionColor = (
+        uTone0.rgb * half(region0) +
+        uTone1.rgb * half(region1) +
+        uTone2.rgb * half(region2) +
+        uTone3.rgb * half(region3) +
+        uTone4.rgb * half(region4)
+    ) / half(regionTotal);
 
-    float sheenNoise = valueNoise(mesh * 1.80 + float2(t * 0.018, -t * 0.014) + float2(seed * 0.41, seed * 0.13));
-    float sheen = 1.0 - smoothstep(0.18, 0.34, abs(sheenNoise - 0.5));
-    color += half3(half(sheen * 0.012));
+    float strongestRegion = max(max(region0, region1), max(region2, max(region3, region4)));
+    float macroPresence = smoothstep(0.18, 0.82, strongestRegion);
+    float palettePresence = 0.48 + macroPresence * 0.38;
 
-    float dominantCoverage = max(max(mask0, mask1), max(mask2, max(mask3, mask4)));
-    float layeredCoverage = (mask0 + mask1 + mask2 + mask3 + mask4) * 0.06;
-    float coverage = 0.22 + dominantCoverage * 0.32 + layeredCoverage + macroField * 0.10 + edgeField * 0.08;
+    half3 color = mix(uBase.rgb, regionColor, half(palettePresence));
+
+    float surfaceNoise = valueNoise(warped * 1.35 + float2(t * 0.014, -t * 0.011) + float2(seed * 0.37, seed * 0.16));
+    color *= half(0.97 + surfaceNoise * 0.05);
+
+    float edgeField = smoothstep(0.28, 0.88, distance(uv, float2(0.5, 0.48)));
+    float coverage = 0.20 + macroPresence * 0.30 + edgeField * 0.07;
 
     float edgeDistance = distance(uv, float2(0.5, 0.47));
-    float vignette = 1.0 - 0.16 * smoothstep(0.36, 0.88, edgeDistance);
+    float vignette = 1.0 - 0.15 * smoothstep(0.36, 0.88, edgeDistance);
 
     float artworkDistance = distance(uv, float2(0.5, 0.34));
     float artworkSafe = 1.0 - 0.42 * (1.0 - smoothstep(0.18, 0.50, artworkDistance));

--- a/app/src/main/java/com/luc4n3x/levyra/ui/artwork/LivingArtworkShader.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/artwork/LivingArtworkShader.kt
@@ -10,6 +10,7 @@ internal const val LIVING_ARTWORK_AGSL = """
 uniform float2 uSize;
 uniform float uTime;
 uniform float uIntensity;
+uniform float uSeed;
 layout(color) uniform half4 uTone0;
 layout(color) uniform half4 uTone1;
 layout(color) uniform half4 uTone2;
@@ -22,27 +23,60 @@ float field(float2 uv, float2 center, float radius) {
     return f * f * (3.0 - 2.0 * f);
 }
 
+float2 flowWarp(float2 uv, float t, float seed) {
+    float2 p = uv - float2(0.5);
+    float xFlow = sin(p.y * 5.1 + t * 0.10 + seed * 1.37);
+    xFlow += 0.55 * sin((p.x + p.y) * 4.2 - t * 0.07 + seed * 0.73);
+    float yFlow = cos(p.x * 4.7 - t * 0.09 + seed * 1.11);
+    yFlow += 0.50 * cos((p.x - p.y) * 3.8 + t * 0.06 + seed * 1.61);
+    return float2(xFlow, yFlow) * 0.042;
+}
+
+float meshModulation(float2 uv, float t, float seed, float phase) {
+    float a = sin((uv.x * 2.3 + uv.y * 1.7) * 3.14159265 + t * 0.075 + seed + phase);
+    float b = cos((uv.x * 1.4 - uv.y * 2.1) * 3.14159265 - t * 0.055 + seed * 0.83 - phase);
+    return 0.82 + 0.18 * (0.5 + 0.25 * a + 0.25 * b);
+}
+
 half4 main(float2 fragCoord) {
     float2 uv = fragCoord / uSize;
     float t = uTime;
+    float seed = uSeed;
+    float2 warpedUv = uv + flowWarp(uv, t, seed);
 
-    float2 c0 = float2(0.30 + 0.17 * sin(t * 0.19), 0.30 + 0.14 * cos(t * 0.23));
-    float2 c1 = float2(0.74 + 0.15 * cos(t * 0.15), 0.28 + 0.16 * sin(t * 0.21));
-    float2 c2 = float2(0.52 + 0.19 * sin(t * 0.11 + 1.7), 0.72 + 0.13 * cos(t * 0.17 + 0.6));
-    float2 c3 = float2(0.20 + 0.13 * cos(t * 0.13 + 2.4), 0.74 + 0.15 * sin(t * 0.12 + 1.1));
-    float2 c4 = float2(0.80 + 0.12 * sin(t * 0.09 + 3.1), 0.66 + 0.12 * cos(t * 0.14 + 2.2));
+    float2 c0 = float2(
+        0.27 + 0.18 * sin(t * 0.105 + seed * 0.91),
+        0.29 + 0.15 * cos(t * 0.121 + seed * 1.17)
+    );
+    float2 c1 = float2(
+        0.73 + 0.16 * cos(t * 0.087 + seed * 1.43),
+        0.27 + 0.17 * sin(t * 0.113 + seed * 0.69)
+    );
+    float2 c2 = float2(
+        0.52 + 0.20 * sin(t * 0.071 + seed * 1.09 + 1.7),
+        0.70 + 0.14 * cos(t * 0.097 + seed * 0.77 + 0.6)
+    );
+    float2 c3 = float2(
+        0.21 + 0.14 * cos(t * 0.079 + seed * 1.31 + 2.4),
+        0.73 + 0.16 * sin(t * 0.067 + seed * 0.57 + 1.1)
+    );
+    float2 c4 = float2(
+        0.79 + 0.13 * sin(t * 0.061 + seed * 0.63 + 3.1),
+        0.65 + 0.13 * cos(t * 0.083 + seed * 1.23 + 2.2)
+    );
 
-    float breathe = 0.94 + 0.06 * sin(t * 0.27);
-    float w0 = field(uv, c0, 0.62 * breathe);
-    float w1 = field(uv, c1, 0.56 * breathe);
-    float w2 = field(uv, c2, 0.58 * breathe);
-    float w3 = field(uv, c3, 0.48 * breathe);
-    float w4 = field(uv, c4, 0.44 * breathe);
+    float breathe = 0.95 + 0.05 * sin(t * 0.19 + seed * 0.4);
+    float w0 = field(warpedUv, c0, 0.63 * breathe) * meshModulation(warpedUv, t, seed, 0.0);
+    float w1 = field(warpedUv, c1, 0.58 * breathe) * meshModulation(warpedUv, t, seed, 1.1);
+    float w2 = field(warpedUv, c2, 0.60 * breathe) * meshModulation(warpedUv, t, seed, 2.2);
+    float w3 = field(warpedUv, c3, 0.51 * breathe) * meshModulation(warpedUv, t, seed, 3.3);
+    float w4 = field(warpedUv, c4, 0.47 * breathe) * meshModulation(warpedUv, t, seed, 4.4);
 
     float total = w0 + w1 + w2 + w3 + w4;
     if (total <= 0.0001) {
         return half4(0.0);
     }
+
     half3 blended =
         uTone0.rgb * half(w0) +
         uTone1.rgb * half(w1) +
@@ -51,9 +85,11 @@ half4 main(float2 fragCoord) {
         uTone4.rgb * half(w4);
     blended = blended / half(total);
 
-    float coverage = clamp(total * 0.55, 0.0, 1.0);
-    float vignette = 1.0 - 0.35 * clamp(distance(uv, float2(0.5, 0.5)) * 1.35, 0.0, 1.0);
-    half alpha = half(clamp(coverage * vignette * uIntensity, 0.0, 1.0));
+    float coverage = clamp(total * 0.52, 0.0, 1.0);
+    float edgeDistance = distance(uv, float2(0.5, 0.48));
+    float vignette = 1.0 - 0.30 * smoothstep(0.28, 0.78, edgeDistance);
+    float controlSafe = 1.0 - 0.16 * smoothstep(0.64, 1.0, uv.y);
+    half alpha = half(clamp(coverage * vignette * controlSafe * uIntensity, 0.0, 1.0));
     return half4(blended * alpha, alpha);
 }
 """
@@ -73,7 +109,17 @@ internal fun RuntimeShader.applyLivingArtworkTones(tones: List<Color>): Boolean 
         val color = tones.getOrElse(index) { tones.lastOrNull() ?: Color.Black }
         setColorUniform("uTone$index", color.toArgb())
     }
+    setFloatUniform("uSeed", livingArtworkSeed(tones))
     true
 } catch (error: IllegalArgumentException) {
     false
+}
+
+internal fun livingArtworkSeed(tones: List<Color>): Float {
+    var hash = 0x811C9DC5.toInt()
+    for (index in 0 until livingArtworkToneCount()) {
+        val color = tones.getOrElse(index) { tones.lastOrNull() ?: Color.Black }
+        hash = (hash xor color.toArgb()) * 16777619
+    }
+    return (hash ushr 1) / Int.MAX_VALUE.toFloat() * 6.2831855f
 }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/artwork/LivingArtworkShader.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/artwork/LivingArtworkShader.kt
@@ -11,78 +11,91 @@ uniform float2 uSize;
 uniform float uTime;
 uniform float uIntensity;
 uniform float uSeed;
+layout(color) uniform half4 uBase;
 layout(color) uniform half4 uTone0;
 layout(color) uniform half4 uTone1;
 layout(color) uniform half4 uTone2;
 layout(color) uniform half4 uTone3;
 layout(color) uniform half4 uTone4;
 
-float field(float2 uv, float2 center, float radius) {
-    float d = distance(uv, center) / radius;
-    float f = 1.0 - clamp(d, 0.0, 1.0);
-    return f * f * (3.0 - 2.0 * f);
+float hash21(float2 p) {
+    p = fract(p * float2(123.34, 345.45));
+    float n = dot(p, p + float2(34.345, 34.345));
+    p += float2(n, n);
+    return fract(p.x * p.y);
 }
 
-float2 flowWarp(float2 uv, float t, float seed) {
-    float2 p = uv - float2(0.5, 0.5);
-    float xFlow = sin((p.y + p.x * 0.34) * 5.0 + t * 0.082 + seed * 1.37);
-    float yFlow = cos((p.x - p.y * 0.29) * 4.6 - t * 0.071 + seed * 1.11);
-    return float2(xFlow, yFlow) * 0.050;
+float valueNoise(float2 p) {
+    float2 cell = floor(p);
+    float2 local = fract(p);
+    float2 curve = local * local * (float2(3.0, 3.0) - 2.0 * local);
+    float a = hash21(cell);
+    float b = hash21(cell + float2(1.0, 0.0));
+    float c = hash21(cell + float2(0.0, 1.0));
+    float d = hash21(cell + float2(1.0, 1.0));
+    return mix(mix(a, b, curve.x), mix(c, d, curve.x), curve.y);
+}
+
+float fbm(float2 p) {
+    float value = 0.0;
+    value += valueNoise(p) * 0.52;
+    p = p * 2.03 + float2(17.1, 9.2);
+    value += valueNoise(p) * 0.26;
+    p = p * 2.01 + float2(8.3, 19.7);
+    value += valueNoise(p) * 0.13;
+    p = p * 2.04 + float2(13.7, 5.9);
+    value += valueNoise(p) * 0.065;
+    return value;
+}
+
+float2 rotatePoint(float2 p, float angle) {
+    float s = sin(angle);
+    float c = cos(angle);
+    return float2(c * p.x - s * p.y, s * p.x + c * p.y);
 }
 
 half4 main(float2 fragCoord) {
+    float minSide = max(min(uSize.x, uSize.y), 1.0);
     float2 uv = fragCoord / uSize;
+    float2 p = (fragCoord * 2.0 - uSize) / minSide;
     float t = uTime;
     float seed = uSeed;
-    float2 warpedUv = uv + flowWarp(uv, t, seed);
 
-    float2 c0 = float2(
-        0.27 + 0.18 * sin(t * 0.105 + seed * 0.91),
-        0.29 + 0.15 * cos(t * 0.121 + seed * 1.17)
-    );
-    float2 c1 = float2(
-        0.73 + 0.16 * cos(t * 0.087 + seed * 1.43),
-        0.27 + 0.17 * sin(t * 0.113 + seed * 0.69)
-    );
-    float2 c2 = float2(
-        0.52 + 0.20 * sin(t * 0.071 + seed * 1.09 + 1.7),
-        0.70 + 0.14 * cos(t * 0.097 + seed * 0.77 + 0.6)
-    );
-    float2 c3 = float2(
-        0.21 + 0.14 * cos(t * 0.079 + seed * 1.31 + 2.4),
-        0.73 + 0.16 * sin(t * 0.067 + seed * 0.57 + 1.1)
-    );
-    float2 c4 = float2(
-        0.79 + 0.13 * sin(t * 0.061 + seed * 0.63 + 3.1),
-        0.65 + 0.13 * cos(t * 0.083 + seed * 1.23 + 2.2)
-    );
+    float2 drift = float2(t * 0.055, -t * 0.041);
+    float warpX = fbm(p * 1.12 + drift + float2(seed * 0.17, seed * 0.09));
+    float warpY = fbm(p * 1.12 - drift + float2(5.73 + seed * 0.11, 2.19 - seed * 0.07));
+    float2 warped = p + (float2(warpX, warpY) - float2(0.5, 0.5)) * 0.56;
 
-    float breathe = 0.95 + 0.05 * sin(t * 0.19 + seed * 0.4);
-    float w0 = field(warpedUv, c0, 0.63 * breathe);
-    float w1 = field(warpedUv, c1, 0.58 * breathe);
-    float w2 = field(warpedUv, c2, 0.60 * breathe);
-    float w3 = field(warpedUv, c3, 0.51 * breathe);
-    float w4 = field(warpedUv, c4, 0.47 * breathe);
+    float radius = length(warped);
+    float lens = sin(radius * 4.4 - t * 0.17 + seed * 0.63) * 0.12;
+    warped = rotatePoint(warped, lens);
+    warped += warped * (0.055 * sin(radius * 3.2 + t * 0.11 + seed));
 
-    float total = w0 + w1 + w2 + w3 + w4;
-    if (total <= 0.0001) {
-        return half4(0.0);
-    }
+    float2 mesh = warped * 0.82;
+    float mask0 = smoothstep(0.26, 0.78, fbm(mesh * 1.03 + float2(t * 0.026, seed * 0.23)));
+    float mask1 = smoothstep(0.30, 0.80, fbm(mesh * 1.17 + float2(-t * 0.021 + 4.1, seed * 0.31 + 1.7)));
+    float mask2 = smoothstep(0.32, 0.82, fbm(mesh * 1.31 + float2(seed * 0.19 + 7.4, t * 0.018 + 3.2)));
+    float mask3 = smoothstep(0.34, 0.84, fbm(mesh * 1.46 + float2(t * 0.016 + 2.8, -seed * 0.27 + 8.6)));
+    float mask4 = smoothstep(0.36, 0.86, fbm(mesh * 1.63 + float2(-t * 0.014 + 9.3, seed * 0.37 + 5.1)));
 
-    half3 blended =
-        uTone0.rgb * half(w0) +
-        uTone1.rgb * half(w1) +
-        uTone2.rgb * half(w2) +
-        uTone3.rgb * half(w3) +
-        uTone4.rgb * half(w4);
-    blended = blended / half(total);
+    half3 color = uBase.rgb;
+    color = mix(color, uTone0.rgb, half(mask0 * 0.94));
+    color = mix(color, uTone1.rgb, half(mask1 * 0.88));
+    color = mix(color, uTone2.rgb, half(mask2 * 0.72));
+    color = mix(color, uTone3.rgb, half(mask3 * 0.64));
+    color = mix(color, uTone4.rgb, half(mask4 * 0.58));
 
-    float coverage = clamp(total * 0.52, 0.0, 1.0);
-    float edgeDistance = distance(uv, float2(0.5, 0.48));
-    float vignette = 1.0 - 0.30 * smoothstep(0.28, 0.78, edgeDistance);
-    float controlSafe = 1.0 - 0.16 * smoothstep(0.64, 1.0, uv.y);
+    float silkNoise = fbm(mesh * 2.35 + float2(t * 0.022, -t * 0.017) + float2(seed * 0.41, seed * 0.13));
+    float silk = 1.0 - smoothstep(0.07, 0.26, abs(silkNoise - 0.5));
+    color += half3(half(silk * 0.055));
+
+    float coverageNoise = fbm(mesh * 0.71 + float2(seed * 0.29, t * 0.012));
+    float coverage = 0.58 + coverageNoise * 0.34;
+    float edgeDistance = distance(uv, float2(0.5, 0.47));
+    float vignette = 1.0 - 0.24 * smoothstep(0.30, 0.80, edgeDistance);
+    float controlSafe = 1.0 - 0.18 * smoothstep(0.63, 1.0, uv.y);
     half alpha = half(clamp(coverage * vignette * controlSafe * uIntensity, 0.0, 1.0));
-    return half4(blended * alpha, alpha);
+    return half4(color * alpha, alpha);
 }
 """
 
@@ -96,12 +109,13 @@ internal fun createLivingArtworkShader(): RuntimeShader? = try {
 }
 
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-internal fun RuntimeShader.applyLivingArtworkTones(tones: List<Color>): Boolean = try {
+internal fun RuntimeShader.applyLivingArtworkColors(colors: LivingArtworkColors): Boolean = try {
+    setColorUniform("uBase", colors.base.toArgb())
     for (index in 0 until livingArtworkToneCount()) {
-        val color = tones.getOrElse(index) { tones.lastOrNull() ?: Color.Black }
+        val color = colors.tones.getOrElse(index) { colors.tones.lastOrNull() ?: Color.Black }
         setColorUniform("uTone$index", color.toArgb())
     }
-    setFloatUniform("uSeed", livingArtworkSeed(tones))
+    setFloatUniform("uSeed", livingArtworkSeed(colors.tones))
     true
 } catch (error: IllegalArgumentException) {
     false

--- a/app/src/main/java/com/luc4n3x/levyra/ui/artwork/LivingArtworkShader.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/artwork/LivingArtworkShader.kt
@@ -24,18 +24,10 @@ float field(float2 uv, float2 center, float radius) {
 }
 
 float2 flowWarp(float2 uv, float t, float seed) {
-    float2 p = uv - float2(0.5);
-    float xFlow = sin(p.y * 5.1 + t * 0.10 + seed * 1.37);
-    xFlow += 0.55 * sin((p.x + p.y) * 4.2 - t * 0.07 + seed * 0.73);
-    float yFlow = cos(p.x * 4.7 - t * 0.09 + seed * 1.11);
-    yFlow += 0.50 * cos((p.x - p.y) * 3.8 + t * 0.06 + seed * 1.61);
-    return float2(xFlow, yFlow) * 0.042;
-}
-
-float meshModulation(float2 uv, float t, float seed, float phase) {
-    float a = sin((uv.x * 2.3 + uv.y * 1.7) * 3.14159265 + t * 0.075 + seed + phase);
-    float b = cos((uv.x * 1.4 - uv.y * 2.1) * 3.14159265 - t * 0.055 + seed * 0.83 - phase);
-    return 0.82 + 0.18 * (0.5 + 0.25 * a + 0.25 * b);
+    float2 p = uv - float2(0.5, 0.5);
+    float xFlow = sin((p.y + p.x * 0.34) * 5.0 + t * 0.082 + seed * 1.37);
+    float yFlow = cos((p.x - p.y * 0.29) * 4.6 - t * 0.071 + seed * 1.11);
+    return float2(xFlow, yFlow) * 0.050;
 }
 
 half4 main(float2 fragCoord) {
@@ -66,11 +58,11 @@ half4 main(float2 fragCoord) {
     );
 
     float breathe = 0.95 + 0.05 * sin(t * 0.19 + seed * 0.4);
-    float w0 = field(warpedUv, c0, 0.63 * breathe) * meshModulation(warpedUv, t, seed, 0.0);
-    float w1 = field(warpedUv, c1, 0.58 * breathe) * meshModulation(warpedUv, t, seed, 1.1);
-    float w2 = field(warpedUv, c2, 0.60 * breathe) * meshModulation(warpedUv, t, seed, 2.2);
-    float w3 = field(warpedUv, c3, 0.51 * breathe) * meshModulation(warpedUv, t, seed, 3.3);
-    float w4 = field(warpedUv, c4, 0.47 * breathe) * meshModulation(warpedUv, t, seed, 4.4);
+    float w0 = field(warpedUv, c0, 0.63 * breathe);
+    float w1 = field(warpedUv, c1, 0.58 * breathe);
+    float w2 = field(warpedUv, c2, 0.60 * breathe);
+    float w3 = field(warpedUv, c3, 0.51 * breathe);
+    float w4 = field(warpedUv, c4, 0.47 * breathe);
 
     float total = w0 + w1 + w2 + w3 + w4;
     if (total <= 0.0001) {

--- a/app/src/main/java/com/luc4n3x/levyra/ui/artwork/LivingArtworkShader.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/artwork/LivingArtworkShader.kt
@@ -58,39 +58,50 @@ half4 main(float2 fragCoord) {
     float t = uTime;
     float seed = uSeed;
 
-    float2 drift = float2(t * 0.055, -t * 0.041);
-    float warpX = fbm(p * 1.12 + drift + float2(seed * 0.17, seed * 0.09));
-    float warpY = fbm(p * 1.12 - drift + float2(5.73 + seed * 0.11, 2.19 - seed * 0.07));
-    float2 warped = p + (float2(warpX, warpY) - float2(0.5, 0.5)) * 0.56;
+    float2 drift = float2(t * 0.050, -t * 0.036);
+    float warpX = fbm(p * 0.92 + drift + float2(seed * 0.17, seed * 0.09));
+    float warpY = fbm(p * 0.92 - drift + float2(5.73 + seed * 0.11, 2.19 - seed * 0.07));
+    float2 warped = p + (float2(warpX, warpY) - float2(0.5, 0.5)) * 0.58;
 
     float radius = length(warped);
-    float lens = sin(radius * 4.4 - t * 0.17 + seed * 0.63) * 0.12;
+    float lens = sin(radius * 3.6 - t * 0.13 + seed * 0.63) * 0.08;
     warped = rotatePoint(warped, lens);
-    warped += warped * (0.055 * sin(radius * 3.2 + t * 0.11 + seed));
+    warped += warped * (0.032 * sin(radius * 2.7 + t * 0.09 + seed));
 
-    float2 mesh = warped * 0.82;
-    float mask0 = smoothstep(0.27, 0.75, valueNoise(mesh * 1.08 + float2(t * 0.026, seed * 0.23)));
-    float mask1 = smoothstep(0.29, 0.77, valueNoise(rotatePoint(mesh, 0.61) * 1.24 + float2(-t * 0.021 + 4.1, seed * 0.31 + 1.7)));
-    float mask2 = smoothstep(0.31, 0.79, valueNoise(rotatePoint(mesh, -0.48) * 1.39 + float2(seed * 0.19 + 7.4, t * 0.018 + 3.2)));
-    float mask3 = smoothstep(0.33, 0.81, valueNoise(mesh * 1.55 + float2(t * 0.016 + 2.8, -seed * 0.27 + 8.6)));
-    float mask4 = smoothstep(0.35, 0.83, valueNoise(rotatePoint(mesh, 0.92) * 1.72 + float2(-t * 0.014 + 9.3, seed * 0.37 + 5.1)));
+    float2 mesh = warped * 0.52;
+    float mask0 = smoothstep(0.50, 0.74, valueNoise(mesh * 0.66 + float2(t * 0.018, seed * 0.23)));
+    float mask1 = smoothstep(0.52, 0.76, valueNoise(rotatePoint(mesh, 0.58) * 0.78 + float2(-t * 0.017 + 4.1, seed * 0.31 + 1.7)));
+    float mask2 = smoothstep(0.54, 0.78, valueNoise(rotatePoint(mesh, -0.43) * 0.90 + float2(seed * 0.19 + 7.4, t * 0.015 + 3.2)));
+    float mask3 = smoothstep(0.56, 0.80, valueNoise(mesh * 1.04 + float2(t * 0.013 + 2.8, -seed * 0.27 + 8.6)));
+    float mask4 = smoothstep(0.58, 0.82, valueNoise(rotatePoint(mesh, 0.88) * 1.16 + float2(-t * 0.012 + 9.3, seed * 0.37 + 5.1)));
+
+    float macroField = valueNoise(warped * 0.42 + float2(seed * 0.41, t * 0.010));
+    float edgeField = smoothstep(0.26, 0.86, distance(uv, float2(0.5, 0.48)));
 
     half3 color = uBase.rgb;
-    color = mix(color, uTone0.rgb, half(mask0 * 0.94));
-    color = mix(color, uTone1.rgb, half(mask1 * 0.88));
-    color = mix(color, uTone2.rgb, half(mask2 * 0.72));
-    color = mix(color, uTone3.rgb, half(mask3 * 0.64));
-    color = mix(color, uTone4.rgb, half(mask4 * 0.58));
+    color = mix(color, uTone0.rgb, half(mask0 * 0.86));
+    color = mix(color, uTone1.rgb, half(mask1 * 0.78));
+    color = mix(color, uTone2.rgb, half(mask2 * 0.68));
+    color = mix(color, uTone3.rgb, half(mask3 * 0.56));
+    color = mix(color, uTone4.rgb, half(mask4 * 0.46));
 
-    float silkNoise = valueNoise(mesh * 2.85 + float2(t * 0.022, -t * 0.017) + float2(seed * 0.41, seed * 0.13));
-    float silk = 1.0 - smoothstep(0.07, 0.24, abs(silkNoise - 0.5));
-    color += half3(half(silk * 0.055));
+    float sheenNoise = valueNoise(mesh * 1.80 + float2(t * 0.018, -t * 0.014) + float2(seed * 0.41, seed * 0.13));
+    float sheen = 1.0 - smoothstep(0.18, 0.34, abs(sheenNoise - 0.5));
+    color += half3(half(sheen * 0.012));
 
-    float coverage = 0.60 + (warpX + warpY) * 0.12 + max(mask0, mask1) * 0.08;
+    float dominantCoverage = max(max(mask0, mask1), max(mask2, max(mask3, mask4)));
+    float layeredCoverage = (mask0 + mask1 + mask2 + mask3 + mask4) * 0.06;
+    float coverage = 0.22 + dominantCoverage * 0.32 + layeredCoverage + macroField * 0.10 + edgeField * 0.08;
+
     float edgeDistance = distance(uv, float2(0.5, 0.47));
-    float vignette = 1.0 - 0.24 * smoothstep(0.30, 0.80, edgeDistance);
-    float controlSafe = 1.0 - 0.18 * smoothstep(0.63, 1.0, uv.y);
-    half alpha = half(clamp(coverage * vignette * controlSafe * uIntensity, 0.0, 1.0));
+    float vignette = 1.0 - 0.16 * smoothstep(0.36, 0.88, edgeDistance);
+
+    float artworkDistance = distance(uv, float2(0.5, 0.34));
+    float artworkSafe = 1.0 - 0.42 * (1.0 - smoothstep(0.18, 0.50, artworkDistance));
+
+    float controlSafe = 1.0 - 0.24 * smoothstep(0.60, 1.0, uv.y);
+
+    half alpha = half(clamp(coverage * vignette * artworkSafe * controlSafe * uIntensity, 0.0, 1.0));
     return half4(color * alpha, alpha);
 }
 """

--- a/app/src/main/java/com/luc4n3x/levyra/ui/artwork/LivingArtworkShader.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/artwork/LivingArtworkShader.kt
@@ -37,14 +37,11 @@ float valueNoise(float2 p) {
 }
 
 float fbm(float2 p) {
-    float value = 0.0;
-    value += valueNoise(p) * 0.52;
+    float value = valueNoise(p) * 0.58;
     p = p * 2.03 + float2(17.1, 9.2);
-    value += valueNoise(p) * 0.26;
+    value += valueNoise(p) * 0.28;
     p = p * 2.01 + float2(8.3, 19.7);
-    value += valueNoise(p) * 0.13;
-    p = p * 2.04 + float2(13.7, 5.9);
-    value += valueNoise(p) * 0.065;
+    value += valueNoise(p) * 0.14;
     return value;
 }
 
@@ -72,11 +69,11 @@ half4 main(float2 fragCoord) {
     warped += warped * (0.055 * sin(radius * 3.2 + t * 0.11 + seed));
 
     float2 mesh = warped * 0.82;
-    float mask0 = smoothstep(0.26, 0.78, fbm(mesh * 1.03 + float2(t * 0.026, seed * 0.23)));
-    float mask1 = smoothstep(0.30, 0.80, fbm(mesh * 1.17 + float2(-t * 0.021 + 4.1, seed * 0.31 + 1.7)));
-    float mask2 = smoothstep(0.32, 0.82, fbm(mesh * 1.31 + float2(seed * 0.19 + 7.4, t * 0.018 + 3.2)));
-    float mask3 = smoothstep(0.34, 0.84, fbm(mesh * 1.46 + float2(t * 0.016 + 2.8, -seed * 0.27 + 8.6)));
-    float mask4 = smoothstep(0.36, 0.86, fbm(mesh * 1.63 + float2(-t * 0.014 + 9.3, seed * 0.37 + 5.1)));
+    float mask0 = smoothstep(0.27, 0.75, valueNoise(mesh * 1.08 + float2(t * 0.026, seed * 0.23)));
+    float mask1 = smoothstep(0.29, 0.77, valueNoise(rotatePoint(mesh, 0.61) * 1.24 + float2(-t * 0.021 + 4.1, seed * 0.31 + 1.7)));
+    float mask2 = smoothstep(0.31, 0.79, valueNoise(rotatePoint(mesh, -0.48) * 1.39 + float2(seed * 0.19 + 7.4, t * 0.018 + 3.2)));
+    float mask3 = smoothstep(0.33, 0.81, valueNoise(mesh * 1.55 + float2(t * 0.016 + 2.8, -seed * 0.27 + 8.6)));
+    float mask4 = smoothstep(0.35, 0.83, valueNoise(rotatePoint(mesh, 0.92) * 1.72 + float2(-t * 0.014 + 9.3, seed * 0.37 + 5.1)));
 
     half3 color = uBase.rgb;
     color = mix(color, uTone0.rgb, half(mask0 * 0.94));
@@ -85,12 +82,11 @@ half4 main(float2 fragCoord) {
     color = mix(color, uTone3.rgb, half(mask3 * 0.64));
     color = mix(color, uTone4.rgb, half(mask4 * 0.58));
 
-    float silkNoise = fbm(mesh * 2.35 + float2(t * 0.022, -t * 0.017) + float2(seed * 0.41, seed * 0.13));
-    float silk = 1.0 - smoothstep(0.07, 0.26, abs(silkNoise - 0.5));
+    float silkNoise = valueNoise(mesh * 2.85 + float2(t * 0.022, -t * 0.017) + float2(seed * 0.41, seed * 0.13));
+    float silk = 1.0 - smoothstep(0.07, 0.24, abs(silkNoise - 0.5));
     color += half3(half(silk * 0.055));
 
-    float coverageNoise = fbm(mesh * 0.71 + float2(seed * 0.29, t * 0.012));
-    float coverage = 0.58 + coverageNoise * 0.34;
+    float coverage = 0.60 + (warpX + warpY) * 0.12 + max(mask0, mask1) * 0.08;
     float edgeDistance = distance(uv, float2(0.5, 0.47));
     float vignette = 1.0 - 0.24 * smoothstep(0.30, 0.80, edgeDistance);
     float controlSafe = 1.0 - 0.18 * smoothstep(0.63, 1.0, uv.y);

--- a/app/src/test/java/com/luc4n3x/levyra/ui/MotionArtworkLayerTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/MotionArtworkLayerTest.kt
@@ -1,0 +1,44 @@
+package com.luc4n3x.levyra.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MotionArtworkLayerTest {
+
+    @Test
+    fun livingArtworkRunsOnlyWhenEveryGateAllowsIt() {
+        assertTrue(
+            livingArtworkActive(
+                enabled = true,
+                lifecycleActive = true,
+                localAllowed = true,
+                isPlaying = true,
+                realCanvasReady = false
+            )
+        )
+    }
+
+    @Test
+    fun livingArtworkStopsWhenAnyGateCloses() {
+        val blockedStates = listOf(
+            booleanArrayOf(false, true, true, true, false),
+            booleanArrayOf(true, false, true, true, false),
+            booleanArrayOf(true, true, false, true, false),
+            booleanArrayOf(true, true, true, false, false),
+            booleanArrayOf(true, true, true, true, true)
+        )
+
+        blockedStates.forEach { state ->
+            assertFalse(
+                livingArtworkActive(
+                    enabled = state[0],
+                    lifecycleActive = state[1],
+                    localAllowed = state[2],
+                    isPlaying = state[3],
+                    realCanvasReady = state[4]
+                )
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/ui/artwork/LivingArtworkShaderTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/artwork/LivingArtworkShaderTest.kt
@@ -1,0 +1,59 @@
+package com.luc4n3x.levyra.ui.artwork
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LivingArtworkShaderTest {
+
+    @Test
+    fun seedIsStableForSamePalette() {
+        val tones = listOf(
+            Color(0xFF1B4DFF),
+            Color(0xFFFF6B35),
+            Color(0xFF7B2CBF),
+            Color(0xFF121826),
+            Color(0xFFFFC857)
+        )
+
+        assertEquals(livingArtworkSeed(tones), livingArtworkSeed(tones), 0f)
+    }
+
+    @Test
+    fun seedChangesWithPalette() {
+        val first = listOf(
+            Color(0xFF1B4DFF),
+            Color(0xFFFF6B35),
+            Color(0xFF7B2CBF),
+            Color(0xFF121826),
+            Color(0xFFFFC857)
+        )
+        val second = listOf(
+            Color(0xFF00A896),
+            Color(0xFFF0F3BD),
+            Color(0xFF05668D),
+            Color(0xFF028090),
+            Color(0xFF02C39A)
+        )
+
+        assertNotEquals(livingArtworkSeed(first), livingArtworkSeed(second))
+    }
+
+    @Test
+    fun seedRemainsInsideOnePhaseRotation() {
+        val palettes = listOf(
+            emptyList(),
+            listOf(Color.Black),
+            listOf(Color.White),
+            listOf(Color.Red, Color.Green, Color.Blue)
+        )
+
+        palettes.forEach { tones ->
+            val seed = livingArtworkSeed(tones)
+            assertTrue(seed >= 0f)
+            assertTrue(seed <= 6.2831855f)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Combines the full Living Artwork work into one Android PR. The Android 13+ fallback now uses a palette-driven macro mesh with layered noise and subtle radial deformation, tuned after device screenshots to keep the cover readable instead of washing it with a uniform color veil. The implementation stays inside Levyra's existing Living Artwork owner and keeps real Canvas priority, static artwork fallback, lifecycle gating, battery/low-RAM policy, playback isolation, and the legacy Android renderer unchanged.

This PR supersedes #536 and contains both the visual shader work and the runtime scheduling follow-up.

## What changed

- Added a deterministic phase seed derived from the existing five-tone artwork palette.
- Reworked the Android 13+ AGSL path around a dark palette base, bounded FBM/value noise, domain warping and large independently moving palette regions.
- Removed `BlendMode.Screen` from the Android 13+ shader composition after device testing showed that it washed out the artwork.
- Tuned shader intensity to 0.60 and shifted the visual emphasis from global brightness to larger, more separated color masses.
- Added macro-field and edge contribution so movement reads more clearly around the artwork rather than as a flat overlay.
- Added stronger artwork and lower-control safe zones while keeping the animated background visible.
- Reduced the sheen contribution so highlights do not turn into a uniform haze.
- Kept the shader work bounded: palette/base uniforms are applied when the palette changes, while animation frames update only time and intensity.
- Removed the temporary 20 ms startup ticker boost and now uses the existing 34 ms cadence throughout.
- Added focused tests for deterministic palette seeds and Living Artwork activation gates, including lifecycle, local animation policy, playback activity, and real Canvas priority.
- Used the permissive HypnoticCanvas core as a design/algorithm reference only. No HypnoticCanvas dependency or external shader source was vendored.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactor or maintenance
- [x] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** Player / UI

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [x] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

CI is required on the final PR head before this implementation can be treated as validated. Earlier device screenshots were useful acceptance evidence for the compositing problem, but the latest macro-mesh revision still needs a fresh APK/device pass.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Android 13+ device/emulator | Living Artwork with Canvas unavailable | Pending latest head |
| Android 13+ device/emulator | Real Canvas becomes ready and takes priority | Pending latest head |
| Android 13+ device/emulator | Play, pause, track change, background/foreground | Pending latest head |
| Android 12 or earlier | Legacy Living Artwork fallback | Pending latest head |

## Risk and compatibility

- **Risk level:** Medium
- **Compatibility or migration notes:** No settings, persistence, versioning, playback, MediaSession, queue, notification, or native-video behavior changed.
- **Known limitations:** AGSL visual quality, runtime shader compilation, frame cost, GPU cost, and power use still need direct validation on the final APK/device.
- **Rollback plan:** Revert this PR

## Reviewer notes

- The change stays inside the existing Living Artwork and Motion Artwork ownership model. No parallel renderer, state owner, or dependency was introduced.
- Real Canvas remains authoritative once its first frame is ready. Living Artwork remains a decorative fallback only.
- Android 13+ now uses larger palette regions over a domain-warped noise field; Android 12 and earlier continue using the existing legacy renderer.
- The noise implementation is intentionally bounded rather than evaluating multi-octave FBM for every palette layer.
- The Android 13+ composition no longer uses Screen blending. The latest revision protects artwork contrast with explicit safe-zone attenuation instead.
- The runtime follow-up removes the previous temporary 20 ms ticker boost and keeps a steady 34 ms cadence.
- Palette/base/seed uniforms are applied when the shader is created for a palette, not on animation frames.

## Release note

Living Artwork now uses a more distinctive palette-driven mesh flow while keeping album artwork clearer when a real Canvas is not available.

## Related issues

- Supersedes #536

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through the repository humanizer constraints without changing its claims

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated living artwork visuals with a more organic, noise-based animated pattern.
  - Added richer color blending, silk-like sheen, shading, and depth effects.
  - Improved artwork animation consistency with a steady frame rate.
  - Artwork variations now respond more distinctly to their selected color palettes.
  - Refined artwork compositing and visual intensity for a more balanced appearance.

- **Tests**
  - Added coverage for artwork activation conditions and palette-based visual variation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->