### PR TITLE
feat: add SponsorBlock skip-once and queue multi-select

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/SponsorBlockRepository.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/SponsorBlockRepository.kt
@@ -1,5 +1,6 @@
 package com.luc4n3x.levyra.data
 
+import com.luc4n3x.levyra.domain.SPONSOR_SEGMENT_ACTION_SKIP
 import com.luc4n3x.levyra.domain.SponsorSegment
 import java.io.ByteArrayOutputStream
 import java.io.Closeable
@@ -93,7 +94,17 @@ internal fun parseSponsorBlockSegments(body: String, videoId: String): List<Spon
                 val startMs = (range.optDouble(0, 0.0) * 1000).toLong()
                 val endMs = (range.optDouble(1, 0.0) * 1000).toLong()
                 if (endMs > startMs) {
-                    add(SponsorSegment(startMs, endMs, item.optString("category", "sponsor")))
+                    add(
+                        SponsorSegment(
+                            startMs = startMs,
+                            endMs = endMs,
+                            category = item.optString("category", "sponsor"),
+                            uuid = item.optString("UUID").trim(),
+                            actionType = item.optString("actionType")
+                                .trim()
+                                .ifBlank { SPONSOR_SEGMENT_ACTION_SKIP }
+                        )
+                    )
                 }
             }
         }.sortedBy { it.startMs }

--- a/app/src/main/java/com/luc4n3x/levyra/domain/Models.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/Models.kt
@@ -270,10 +270,14 @@ enum class RepeatMode {
     One
 }
 
+const val SPONSOR_SEGMENT_ACTION_SKIP = "skip"
+
 data class SponsorSegment(
     val startMs: Long,
     val endMs: Long,
-    val category: String
+    val category: String,
+    val uuid: String = "",
+    val actionType: String = SPONSOR_SEGMENT_ACTION_SKIP
 )
 
 data class AppUpdateInfo(

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraPlayer.kt
@@ -136,6 +136,7 @@ class LevyraPlayer(context: Context) {
     private var audioNormalization: Boolean? = null
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var sponsorJob: Job? = null
+    private val sponsorSkipTracker = SponsorBlockSkipOnceTracker()
 
     private val videoRenderListener = object : Player.Listener {
         override fun onRenderedFirstFrame() {
@@ -608,14 +609,18 @@ class LevyraPlayer(context: Context) {
 
     private fun startSponsorBlockMonitor(track: Track) {
         sponsorJob?.cancel()
-        if (track.sponsorSegments.isEmpty()) return
+        sponsorJob = null
+        val segments = track.sponsorSegments
+        if (segments.isEmpty()) {
+            sponsorSkipTracker.reset()
+            return
+        }
+        val mediaKey = track.id
+        sponsorSkipTracker.bind(mediaKey)
         sponsorJob = scope.launch {
             while (isActive) {
                 if (isPlaying) {
-                    val current = positionMs
-                    track.sponsorSegments.firstOrNull { current >= it.startMs && current < it.endMs }?.let {
-                        seekTo(it.endMs)
-                    }
+                    sponsorSkipTracker.planSkip(mediaKey, positionMs, segments)?.let(::seekTo)
                 }
                 delay(500L)
             }
@@ -627,6 +632,7 @@ class LevyraPlayer(context: Context) {
     }
 
     private fun clearLoadedState() {
+        sponsorSkipTracker.reset()
         pendingStartPositionMs = null
         loadedTrack = null
         loadedStreamIdentity = null

--- a/app/src/main/java/com/luc4n3x/levyra/player/SponsorBlockSkipOnce.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/SponsorBlockSkipOnce.kt
@@ -1,5 +1,6 @@
 package com.luc4n3x.levyra.player
 
+import com.luc4n3x.levyra.domain.SPONSOR_SEGMENT_ACTION_SKIP
 import com.luc4n3x.levyra.domain.SponsorSegment
 
 internal const val SPONSOR_BLOCK_SKIP_GUARD_MS = 250L
@@ -14,7 +15,8 @@ internal data class SponsorBlockSkipDecision(
 )
 
 private fun SponsorSegment.coversSkipPosition(positionMs: Long): Boolean =
-    endMs > startMs &&
+    actionType.equals(SPONSOR_SEGMENT_ACTION_SKIP, ignoreCase = true) &&
+        endMs > startMs &&
         positionMs >= startMs &&
         positionMs < endMs - SPONSOR_BLOCK_SKIP_GUARD_MS
 
@@ -39,13 +41,14 @@ internal fun sponsorBlockSkipDecision(
 
 /**
  * Skip-once bookkeeping for one media item. The consumed set is bounded by the segment count of the
- * bound media and is cleared whenever a different media item or a new playback session takes over,
- * so consumed state can never leak across videos.
+ * bound media and is cleared whenever a different media item, segment set or playback session takes
+ * over, so consumed state can never leak across videos.
  */
 internal class SponsorBlockSkipOnceTracker {
 
     private val lock = Any()
     private var boundMediaKey: String? = null
+    private var boundSegments: List<SponsorSegment>? = null
     private val consumedIdentities = LinkedHashSet<String>()
 
     val activeMediaKey: String?
@@ -58,6 +61,7 @@ internal class SponsorBlockSkipOnceTracker {
         synchronized(lock) {
             if (boundMediaKey == mediaKey) return@synchronized
             boundMediaKey = mediaKey
+            boundSegments = null
             consumedIdentities.clear()
         }
     }
@@ -65,6 +69,7 @@ internal class SponsorBlockSkipOnceTracker {
     fun beginPlayback(mediaKey: String) {
         synchronized(lock) {
             boundMediaKey = mediaKey
+            boundSegments = null
             consumedIdentities.clear()
         }
     }
@@ -72,6 +77,7 @@ internal class SponsorBlockSkipOnceTracker {
     fun reset() {
         synchronized(lock) {
             boundMediaKey = null
+            boundSegments = null
             consumedIdentities.clear()
         }
     }
@@ -79,6 +85,10 @@ internal class SponsorBlockSkipOnceTracker {
     fun planSkip(mediaKey: String, positionMs: Long, segments: List<SponsorSegment>): Long? =
         synchronized(lock) {
             if (boundMediaKey != mediaKey) return@synchronized null
+            if (boundSegments !== segments) {
+                boundSegments = segments
+                consumedIdentities.clear()
+            }
             val decision = sponsorBlockSkipDecision(segments, positionMs, consumedIdentities)
                 ?: return@synchronized null
             consumedIdentities += decision.encounteredIdentities

--- a/app/src/main/java/com/luc4n3x/levyra/player/SponsorBlockSkipOnce.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/SponsorBlockSkipOnce.kt
@@ -1,0 +1,87 @@
+package com.luc4n3x.levyra.player
+
+import com.luc4n3x.levyra.domain.SponsorSegment
+
+internal const val SPONSOR_BLOCK_SKIP_GUARD_MS = 250L
+
+internal fun sponsorSegmentIdentity(segment: SponsorSegment): String =
+    segment.uuid.takeIf { it.isNotBlank() }
+        ?: "${segment.startMs}:${segment.endMs}:${segment.category}"
+
+internal data class SponsorBlockSkipDecision(
+    val targetPositionMs: Long,
+    val encounteredIdentities: List<String>
+)
+
+private fun SponsorSegment.coversSkipPosition(positionMs: Long): Boolean =
+    endMs > startMs &&
+        positionMs >= startMs &&
+        positionMs < endMs - SPONSOR_BLOCK_SKIP_GUARD_MS
+
+internal fun sponsorBlockSkipDecision(
+    segments: List<SponsorSegment>,
+    positionMs: Long,
+    consumedIdentities: Set<String>
+): SponsorBlockSkipDecision? {
+    var targetPositionMs = Long.MIN_VALUE
+    for (segment in segments) {
+        if (!segment.coversSkipPosition(positionMs)) continue
+        if (sponsorSegmentIdentity(segment) in consumedIdentities) continue
+        if (segment.endMs > targetPositionMs) targetPositionMs = segment.endMs
+    }
+    if (targetPositionMs == Long.MIN_VALUE) return null
+    val encountered = ArrayList<String>(2)
+    for (segment in segments) {
+        if (segment.coversSkipPosition(positionMs)) encountered += sponsorSegmentIdentity(segment)
+    }
+    return SponsorBlockSkipDecision(targetPositionMs, encountered)
+}
+
+/**
+ * Skip-once bookkeeping for one media item. The consumed set is bounded by the segment count of the
+ * bound media and is cleared whenever a different media item or a new playback session takes over,
+ * so consumed state can never leak across videos.
+ */
+internal class SponsorBlockSkipOnceTracker {
+
+    private val lock = Any()
+    private var boundMediaKey: String? = null
+    private val consumedIdentities = LinkedHashSet<String>()
+
+    val activeMediaKey: String?
+        get() = synchronized(lock) { boundMediaKey }
+
+    val consumedCount: Int
+        get() = synchronized(lock) { consumedIdentities.size }
+
+    fun bind(mediaKey: String) {
+        synchronized(lock) {
+            if (boundMediaKey == mediaKey) return@synchronized
+            boundMediaKey = mediaKey
+            consumedIdentities.clear()
+        }
+    }
+
+    fun beginPlayback(mediaKey: String) {
+        synchronized(lock) {
+            boundMediaKey = mediaKey
+            consumedIdentities.clear()
+        }
+    }
+
+    fun reset() {
+        synchronized(lock) {
+            boundMediaKey = null
+            consumedIdentities.clear()
+        }
+    }
+
+    fun planSkip(mediaKey: String, positionMs: Long, segments: List<SponsorSegment>): Long? =
+        synchronized(lock) {
+            if (boundMediaKey != mediaKey) return@synchronized null
+            val decision = sponsorBlockSkipDecision(segments, positionMs, consumedIdentities)
+                ?: return@synchronized null
+            consumedIdentities += decision.encounteredIdentities
+            decision.targetPositionMs
+        }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/player/queue/PersistentQueueEngine.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/queue/PersistentQueueEngine.kt
@@ -30,6 +30,16 @@ internal fun queueRemovalCurrentIndex(removedIndex: Int, currentIndex: Int, newL
     else -> currentIndex.coerceAtMost(newLastIndex)
 }
 
+internal fun queueMultiRemovalCurrentIndex(
+    removedIndices: Set<Int>,
+    currentIndex: Int,
+    newLastIndex: Int
+): Int = when {
+    newLastIndex < 0 -> -1
+    currentIndex < 0 -> -1
+    else -> (currentIndex - removedIndices.count { it < currentIndex }).coerceIn(0, newLastIndex)
+}
+
 internal fun queueUndoInsertionIndex(originalIndex: Int, size: Int): Int = originalIndex.coerceIn(0, size)
 
 internal fun queueUndoCurrentIndex(insertionIndex: Int, currentIndex: Int): Int = when {
@@ -299,6 +309,19 @@ class PersistentQueueEngine private constructor(context: Context) {
         val nextTracks = current.tracks.toMutableList().apply { removeAt(index) }
         val nextCurrentIndex = queueRemovalCurrentIndex(index, current.currentIndex, nextTracks.lastIndex)
         rebuildAfterStructureChange(current, nextTracks, nextCurrentIndex).copy(undoAvailable = true)
+    }
+
+    fun removeIndices(indices: Collection<Int>): PlaybackQueueSnapshot = mutate(structural = true, immediatePersist = true) { current ->
+        val targets = indices.filterTo(sortedSetOf<Int>()) { it in current.tracks.indices }
+        if (targets.isEmpty()) return@mutate current
+        undoRemoval = targets.singleOrNull()?.let { QueueRemoval(current.tracks[it], it) }
+        val currentIdentity = current.currentTrack?.let(::playbackQueueIdentity)
+        val nextTracks = current.tracks.filterIndexed { index, _ -> index !in targets }
+        val nextCurrentIndex = currentIdentity
+            ?.let { key -> nextTracks.indexOfFirst { playbackQueueIdentity(it) == key } }
+            ?.takeIf { it >= 0 }
+            ?: queueMultiRemovalCurrentIndex(targets, current.currentIndex, nextTracks.lastIndex)
+        rebuildAfterStructureChange(current, nextTracks, nextCurrentIndex)
     }
 
     fun undoRemove(): PlaybackQueueSnapshot = mutate(structural = true, immediatePersist = true) { current ->

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -182,7 +182,9 @@ import androidx.compose.material.icons.rounded.BookmarkAdd
 import androidx.compose.material.icons.rounded.Bolt
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.ContentCopy
+import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.RadioButtonUnchecked
 import androidx.compose.material.icons.rounded.DragHandle
 import androidx.compose.material.icons.automirrored.rounded.Undo
 import androidx.compose.material.icons.rounded.Translate
@@ -277,6 +279,7 @@ import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
@@ -487,6 +490,8 @@ import com.luc4n3x.levyra.ui.theme.glassmorphism
 import com.luc4n3x.levyra.ui.i18n.LocalLevyraStrings
 import com.luc4n3x.levyra.ui.i18n.localizedAudioPresetLabel
 import com.luc4n3x.levyra.ui.ambient.LevyraAmbientOverlay
+import com.luc4n3x.levyra.ui.library.AddTracksToPlaylistDialog
+import com.luc4n3x.levyra.ui.library.LibrarySelectionAction
 import com.luc4n3x.levyra.ui.library.LevyraLibraryScreen
 import com.luc4n3x.levyra.ui.library.LevyraPlaylistDetailScreen
 import com.luc4n3x.levyra.ui.library.SavedAlbumBookmarkOverlay
@@ -1885,15 +1890,24 @@ fun LevyraApp(
             }
 
             AnimatedVisibility(visible = state.showQueue, enter = overlayEnter, exit = overlayExit) {
+                val offlineLabel = LocalLevyraStrings.current.offline
                 QueueOverlay(
                     state = state,
                     onPlay = viewModel::playQueueTrack,
                     onPlayNext = viewModel::playNext,
                     onRemove = viewModel::removeFromQueue,
+                    onRemoveSelected = viewModel::removeTracksFromQueue,
                     onMove = viewModel::moveQueueItem,
                     onUndo = viewModel::undoQueueRemoval,
                     onToggleRadio = viewModel::toggleContinuousRadio,
                     onSaveSelection = { name -> viewModel.saveActiveMixAsPlaylist(name) },
+                    onAddSelectedToPlaylist = { playlistId, tracks ->
+                        viewModel.addTracksToPlaylist(playlistId, tracks)
+                    },
+                    onCreatePlaylistWithSelected = { name, tracks ->
+                        viewModel.createPlaylistWithTracks(name, tracks)
+                    },
+                    onDownloadSelected = { tracks -> viewModel.exportTracks(tracks, offlineLabel) },
                     onClose = viewModel::closeQueue
                 )
             }
@@ -4398,22 +4412,59 @@ private fun openExternalUrl(
     }
 }
 
+internal fun queueSelectionKeys(queue: List<Track>): List<String> {
+    val occurrences = HashMap<String, Int>(queue.size)
+    return queue.map { track ->
+        val base = "${track.id}|${track.videoUrl}"
+        val occurrence = (occurrences[base] ?: 0) + 1
+        occurrences[base] = occurrence
+        "$base#$occurrence"
+    }
+}
+
+private val queueSelectionSaver = listSaver<Set<String>, String>(
+    save = { it.toList() },
+    restore = { it.toSet() }
+)
+
 @Composable
 private fun QueueOverlay(
     state: LevyraUiState,
     onPlay: (Track) -> Unit,
     onPlayNext: (Track) -> Unit,
     onRemove: (Int) -> Unit,
+    onRemoveSelected: (List<Int>) -> Unit,
     onMove: (Int, Int) -> Unit,
     onUndo: () -> Unit,
     onToggleRadio: () -> Unit,
     onSaveSelection: (String) -> Unit,
+    onAddSelectedToPlaylist: (String, List<Track>) -> Unit,
+    onCreatePlaylistWithSelected: (String, List<Track>) -> Unit,
+    onDownloadSelected: (List<Track>) -> Unit,
     onClose: () -> Unit
 ) {
     val strings = LocalLevyraStrings.current
     val haptics = LocalLevyraHaptics.current
     val queueAccent = rememberNowPlayingAccent(state.currentTrack, LevyraCyan)
     val connectedStyle = LevyraConnectedDefaults.style(accent = queueAccent)
+    var selectedQueueKeys by rememberSaveable(stateSaver = queueSelectionSaver) {
+        mutableStateOf(emptySet<String>())
+    }
+    var addToPlaylistTracks by remember { mutableStateOf(emptyList<Track>()) }
+    val rowSelectionKeys = remember(state.queue) { queueSelectionKeys(state.queue) }
+    val selectedTracks = remember(state.queue, rowSelectionKeys, selectedQueueKeys) {
+        state.queue.filterIndexed { index, _ -> rowSelectionKeys[index] in selectedQueueKeys }
+    }
+    val removableIndices = remember(rowSelectionKeys, selectedQueueKeys, state.queueCurrentIndex) {
+        rowSelectionKeys.indices.filter { index ->
+            index != state.queueCurrentIndex && rowSelectionKeys[index] in selectedQueueKeys
+        }
+    }
+    val selectionActive = selectedTracks.isNotEmpty()
+    val allSelected = state.queue.isNotEmpty() && selectedTracks.size == state.queue.size
+
+    BackHandler(enabled = selectionActive) { selectedQueueKeys = emptySet() }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -4424,7 +4475,12 @@ private fun QueueOverlay(
             modifier = Modifier
                 .fillMaxSize()
                 .statusBarsPadding(),
-            contentPadding = PaddingValues(start = 18.dp, end = 18.dp, top = 18.dp, bottom = 120.dp),
+            contentPadding = PaddingValues(
+                start = 18.dp,
+                end = 18.dp,
+                top = 18.dp,
+                bottom = if (selectionActive) 210.dp else 120.dp
+            ),
             verticalArrangement = Arrangement.spacedBy(connectedStyle.gap)
         ) {
             item(contentType = "queue-header") {
@@ -4521,6 +4577,8 @@ private fun QueueOverlay(
                     contentType = { _, _ -> "queue-track" }
                 ) { index, track ->
                     val isCurrent = index == state.queueCurrentIndex
+                    val rowKey = rowSelectionKeys[index]
+                    val rowSelected = rowKey in selectedQueueKeys
                     var dragDistance by remember(track) { mutableFloatStateOf(0f) }
                     val latestQueue by rememberUpdatedState(state.queue)
                     val latestMove by rememberUpdatedState(onMove)
@@ -4540,28 +4598,31 @@ private fun QueueOverlay(
                     SwipeToDismissBox(
                         state = dismissState,
                         enableDismissFromStartToEnd = false,
-                        enableDismissFromEndToStart = !isCurrent,
+                        enableDismissFromEndToStart = !isCurrent && !selectionActive,
                         backgroundContent = {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .clip(connectedStyle.shapes.forPosition(queuePosition))
-                                    .background(LevyraCyan.copy(alpha = 0.16f))
-                                    .padding(horizontal = 18.dp),
-                                contentAlignment = Alignment.CenterEnd
-                            ) {
-                                Icon(
-                                    Icons.Rounded.Delete,
-                                    strings.remove,
-                                    tint = LevyraCyan,
-                                    modifier = Modifier.size(22.dp)
-                                )
+                            if (!selectionActive) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .clip(connectedStyle.shapes.forPosition(queuePosition))
+                                        .background(LevyraCyan.copy(alpha = 0.16f))
+                                        .padding(horizontal = 18.dp),
+                                    contentAlignment = Alignment.CenterEnd
+                                ) {
+                                    Icon(
+                                        Icons.Rounded.Delete,
+                                        strings.remove,
+                                        tint = LevyraCyan,
+                                        modifier = Modifier.size(22.dp)
+                                    )
+                                }
                             }
                         },
                         modifier = Modifier
                             .fillMaxWidth()
                             .semantics {
-                                if (!isCurrent) {
+                                if (selectionActive) selected = rowSelected
+                                if (!isCurrent && !selectionActive) {
                                     customActions = listOf(
                                         CustomAccessibilityAction(strings.remove) {
                                             onRemove(index)
@@ -4574,59 +4635,90 @@ private fun QueueOverlay(
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .levyraConnectedSurface(queuePosition, connectedStyle, selected = isCurrent)
+                                .levyraConnectedSurface(
+                                    queuePosition,
+                                    connectedStyle,
+                                    selected = isCurrent || rowSelected
+                                )
                         ) {
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .levyraPressable(
-                                        onClick = { onPlay(track) },
-                                        pressedScale = LevyraPressScale.Row
+                                        onClick = {
+                                            if (selectionActive) {
+                                                selectedQueueKeys = if (rowSelected) {
+                                                    selectedQueueKeys - rowKey
+                                                } else {
+                                                    selectedQueueKeys + rowKey
+                                                }
+                                            } else {
+                                                onPlay(track)
+                                            }
+                                        },
+                                        pressedScale = LevyraPressScale.Row,
+                                        role = if (selectionActive) Role.Checkbox else Role.Button,
+                                        onClickLabel = when {
+                                            !selectionActive -> strings.play
+                                            rowSelected -> strings.deselectTrack
+                                            else -> strings.selectTrack
+                                        },
+                                        onLongClickLabel = strings.selectTrack,
+                                        onLongClick = { selectedQueueKeys = selectedQueueKeys + rowKey }
                                     )
                                     .padding(horizontal = 10.dp, vertical = 9.dp),
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.spacedBy(10.dp)
                             ) {
-                                Icon(
-                                    Icons.Rounded.DragHandle,
-                                    LocalLevyraStrings.current.dragToReorder,
-                                    tint = LevyraMuted,
-                                    modifier = Modifier
-                                        .size(24.dp)
-                                        .pointerInput(track) {
-                                            var dragIndex = index
-                                            detectDragGesturesAfterLongPress(
-                                                onDragStart = {
-                                                    dragDistance = 0f
-                                                    dragIndex = latestQueue.indexOfFirst { it === track }
-                                                        .takeIf { it >= 0 }
-                                                        ?: latestQueue.indexOf(track).takeIf { it >= 0 }
-                                                        ?: index
-                                                },
-                                                onDragCancel = { dragDistance = 0f },
-                                                onDragEnd = { dragDistance = 0f },
-                                                onDrag = { change, amount ->
-                                                    change.consume()
-                                                    dragDistance += amount.y
-                                                    val threshold = 46.dp.toPx()
-                                                    val lastIndex = latestQueue.lastIndex
-                                                    when {
-                                                        dragDistance > threshold && dragIndex < lastIndex -> {
-                                                            latestMove(dragIndex, dragIndex + 1)
-                                                            dragIndex += 1
-                                                            dragDistance = 0f
-                                                            haptics.perform(LevyraHapticAction.Reorder)
-                                                        }
-                                                        dragDistance < -threshold && dragIndex > 0 -> {
-                                                            latestMove(dragIndex, dragIndex - 1)
-                                                            dragIndex -= 1
-                                                            dragDistance = 0f
-                                                            haptics.perform(LevyraHapticAction.Reorder)
-                                                        }
+                                val reorderModifier = if (selectionActive) {
+                                    Modifier
+                                } else {
+                                    Modifier.pointerInput(track) {
+                                        var dragIndex = index
+                                        detectDragGesturesAfterLongPress(
+                                            onDragStart = {
+                                                dragDistance = 0f
+                                                dragIndex = latestQueue.indexOfFirst { it === track }
+                                                    .takeIf { it >= 0 }
+                                                    ?: latestQueue.indexOf(track).takeIf { it >= 0 }
+                                                    ?: index
+                                            },
+                                            onDragCancel = { dragDistance = 0f },
+                                            onDragEnd = { dragDistance = 0f },
+                                            onDrag = { change, amount ->
+                                                change.consume()
+                                                dragDistance += amount.y
+                                                val threshold = 46.dp.toPx()
+                                                val lastIndex = latestQueue.lastIndex
+                                                when {
+                                                    dragDistance > threshold && dragIndex < lastIndex -> {
+                                                        latestMove(dragIndex, dragIndex + 1)
+                                                        dragIndex += 1
+                                                        dragDistance = 0f
+                                                        haptics.perform(LevyraHapticAction.Reorder)
+                                                    }
+                                                    dragDistance < -threshold && dragIndex > 0 -> {
+                                                        latestMove(dragIndex, dragIndex - 1)
+                                                        dragIndex -= 1
+                                                        dragDistance = 0f
+                                                        haptics.perform(LevyraHapticAction.Reorder)
                                                     }
                                                 }
-                                            )
-                                        }
+                                            }
+                                        )
+                                    }
+                                }
+                                Icon(
+                                    Icons.Rounded.DragHandle,
+                                    if (selectionActive) null else strings.dragToReorder,
+                                    tint = if (selectionActive) {
+                                        LevyraMuted.copy(alpha = 0.35f)
+                                    } else {
+                                        LevyraMuted
+                                    },
+                                    modifier = Modifier
+                                        .size(24.dp)
+                                        .then(reorderModifier)
                                 )
                                 CoverImage(track, Modifier.size(48.dp).clip(LevyraPlayerDesign.ShapeXs))
                                 Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
@@ -4640,7 +4732,19 @@ private fun QueueOverlay(
                                         size = 18.dp,
                                         contentDescription = strings.playing
                                     )
-                                } else {
+                                }
+                                if (selectionActive) {
+                                    Icon(
+                                        if (rowSelected) {
+                                            Icons.Rounded.CheckCircle
+                                        } else {
+                                            Icons.Rounded.RadioButtonUnchecked
+                                        },
+                                        contentDescription = null,
+                                        tint = if (rowSelected) queueAccent else LevyraMuted.copy(alpha = 0.35f),
+                                        modifier = Modifier.padding(horizontal = 6.dp)
+                                    )
+                                } else if (!isCurrent) {
                                     IconButton(onClick = { onPlayNext(track) }, modifier = Modifier.size(34.dp)) {
                                         Icon(Icons.Rounded.SkipNext, strings.playNext, tint = LevyraText, modifier = Modifier.size(19.dp))
                                     }
@@ -4652,6 +4756,131 @@ private fun QueueOverlay(
                         }
                     }
                 }
+            }
+        }
+
+        AnimatedVisibility(
+            visible = selectionActive,
+            enter = fadeIn(),
+            exit = fadeOut(),
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .navigationBarsPadding()
+                .padding(start = 12.dp, end = 12.dp, bottom = 20.dp)
+        ) {
+            QueueSelectionBar(
+                count = selectedTracks.size,
+                allSelected = allSelected,
+                canRemove = removableIndices.isNotEmpty(),
+                onSelectAll = { selectedQueueKeys = rowSelectionKeys.toSet() },
+                onClear = { selectedQueueKeys = emptySet() },
+                onAddToPlaylist = { addToPlaylistTracks = selectedTracks },
+                onDownload = {
+                    onDownloadSelected(selectedTracks)
+                    selectedQueueKeys = emptySet()
+                },
+                onRemove = {
+                    onRemoveSelected(removableIndices)
+                    selectedQueueKeys = emptySet()
+                }
+            )
+        }
+    }
+
+    if (addToPlaylistTracks.isNotEmpty()) {
+        val pendingTracks = addToPlaylistTracks
+        AddTracksToPlaylistDialog(
+            tracks = pendingTracks,
+            playlists = state.playlists,
+            onDismiss = { addToPlaylistTracks = emptyList() },
+            onAdd = { playlistId ->
+                onAddSelectedToPlaylist(playlistId, pendingTracks)
+                addToPlaylistTracks = emptyList()
+                selectedQueueKeys = emptySet()
+            },
+            onCreate = { name ->
+                onCreatePlaylistWithSelected(name, pendingTracks)
+                addToPlaylistTracks = emptyList()
+                selectedQueueKeys = emptySet()
+            }
+        )
+    }
+}
+
+@Composable
+private fun QueueSelectionBar(
+    count: Int,
+    allSelected: Boolean,
+    canRemove: Boolean,
+    onSelectAll: () -> Unit,
+    onClear: () -> Unit,
+    onAddToPlaylist: () -> Unit,
+    onDownload: () -> Unit,
+    onRemove: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val strings = LocalLevyraStrings.current
+    Surface(
+        color = LevyraPanel.copy(alpha = 0.98f),
+        shape = RoundedCornerShape(24.dp),
+        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.12f)),
+        shadowElevation = 14.dp,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                IconButton(onClick = onClear) {
+                    Icon(Icons.Rounded.Close, contentDescription = strings.clear, tint = LevyraText)
+                }
+                Text(
+                    strings.formatTrackCount(count),
+                    color = LevyraText,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Black,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+                TextButton(onClick = onSelectAll, enabled = !allSelected) {
+                    Text(
+                        strings.selectAll,
+                        color = if (allSelected) LevyraMuted.copy(alpha = 0.35f) else LevyraCyan,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                LibrarySelectionAction(
+                    icon = Icons.AutoMirrored.Rounded.PlaylistAdd,
+                    label = strings.addToPlaylist,
+                    enabled = true,
+                    onClick = onAddToPlaylist,
+                    tint = LevyraText,
+                    modifier = Modifier.weight(1f)
+                )
+                LibrarySelectionAction(
+                    icon = Icons.Rounded.Download,
+                    label = strings.offline,
+                    enabled = true,
+                    onClick = onDownload,
+                    tint = LevyraText,
+                    modifier = Modifier.weight(1f)
+                )
+                LibrarySelectionAction(
+                    icon = Icons.Rounded.Delete,
+                    label = strings.removeFromQueue,
+                    enabled = canRemove,
+                    onClick = onRemove,
+                    tint = LevyraPink,
+                    modifier = Modifier.weight(1f)
+                )
             }
         }
     }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraQueueSelectionStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraQueueSelectionStrings.kt
@@ -1,0 +1,54 @@
+package com.luc4n3x.levyra.ui.i18n
+
+internal val queueSelectionKeys = setOf(
+    "selectAll",
+    "removeFromQueue",
+    "selectTrack",
+    "deselectTrack"
+)
+
+private fun queueSelection(
+    selectAll: String,
+    removeFromQueue: String,
+    selectTrack: String,
+    deselectTrack: String
+): Map<String, String> = mapOf(
+    "selectAll" to selectAll,
+    "removeFromQueue" to removeFromQueue,
+    "selectTrack" to selectTrack,
+    "deselectTrack" to deselectTrack
+)
+
+private val queueSelectionBundles: Map<String, Map<String, String>> = mapOf(
+    "en" to queueSelection("Select all", "Remove from queue", "Select track", "Deselect track"),
+    "it" to queueSelection("Seleziona tutto", "Rimuovi dalla coda", "Seleziona brano", "Deseleziona brano"),
+    "es" to queueSelection("Seleccionar todo", "Quitar de la cola", "Seleccionar canción", "Anular selección"),
+    "fr" to queueSelection("Tout sélectionner", "Retirer de la file", "Sélectionner le morceau", "Désélectionner le morceau"),
+    "de" to queueSelection("Alle auswählen", "Aus der Warteschlange entfernen", "Titel auswählen", "Titelauswahl aufheben"),
+    "pt" to queueSelection("Selecionar tudo", "Remover da fila", "Selecionar faixa", "Desmarcar faixa"),
+    "nl" to queueSelection("Alles selecteren", "Uit de wachtrij verwijderen", "Nummer selecteren", "Nummer deselecteren"),
+    "pl" to queueSelection("Zaznacz wszystko", "Usuń z kolejki", "Zaznacz utwór", "Odznacz utwór"),
+    "ro" to queueSelection("Selectează tot", "Elimină din coadă", "Selectează piesa", "Deselectează piesa"),
+    "el" to queueSelection("Επιλογή όλων", "Αφαίρεση από την ουρά", "Επιλογή κομματιού", "Κατάργηση επιλογής κομματιού"),
+    "sv" to queueSelection("Markera alla", "Ta bort från kön", "Markera låt", "Avmarkera låt"),
+    "da" to queueSelection("Vælg alle", "Fjern fra køen", "Vælg nummer", "Fravælg nummer"),
+    "cs" to queueSelection("Vybrat vše", "Odebrat z fronty", "Vybrat skladbu", "Zrušit výběr skladby"),
+    "uk" to queueSelection("Вибрати все", "Прибрати з черги", "Вибрати трек", "Скасувати вибір треку"),
+    "ru" to queueSelection("Выбрать все", "Убрать из очереди", "Выбрать трек", "Снять выбор трека"),
+    "tr" to queueSelection("Tümünü seç", "Sıradan kaldır", "Parçayı seç", "Parça seçimini kaldır"),
+    "ar" to queueSelection("تحديد الكل", "إزالة من قائمة الانتظار", "تحديد المقطع", "إلغاء تحديد المقطع"),
+    "zh" to queueSelection("全选", "从队列中移除", "选择歌曲", "取消选择歌曲"),
+    "ja" to queueSelection("すべて選択", "キューから削除", "曲を選択", "曲の選択を解除"),
+    "ko" to queueSelection("모두 선택", "대기열에서 제거", "트랙 선택", "트랙 선택 해제"),
+    "hi" to queueSelection("सभी चुनें", "कतार से हटाएं", "ट्रैक चुनें", "ट्रैक अचयनित करें"),
+    "id" to queueSelection("Pilih semua", "Hapus dari antrean", "Pilih lagu", "Batalkan pilihan lagu"),
+    "vi" to queueSelection("Chọn tất cả", "Xóa khỏi hàng đợi", "Chọn bài hát", "Bỏ chọn bài hát"),
+    "th" to queueSelection("เลือกทั้งหมด", "นำออกจากคิว", "เลือกเพลง", "ยกเลิกการเลือกเพลง"),
+    "fil" to queueSelection("Piliin lahat", "Alisin sa queue", "Piliin ang track", "Alisin sa pagkakapili"),
+    "he" to queueSelection("בחירת הכול", "הסרה מהתור", "בחירת רצועה", "ביטול בחירת רצועה")
+)
+
+internal fun queueSelectionLocalizationEntries(code: String): Map<String, String> =
+    queueSelectionBundles.getValue(code)
+
+internal fun queueSelectionLocalizationCodes(): Set<String> = queueSelectionBundles.keys

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraStrings.kt
@@ -413,6 +413,10 @@ class LevyraStrings private constructor(
     val lyricsRomanization: String get() = value("lyricsRomanization")
     val lyricsCompact: String get() = value("lyricsCompact")
     val startRadio: String get() = value("startRadio")
+    val selectAll: String get() = value("selectAll")
+    val removeFromQueue: String get() = value("removeFromQueue")
+    val selectTrack: String get() = value("selectTrack")
+    val deselectTrack: String get() = value("deselectTrack")
     val moreLikeThis: String get() = value("moreLikeThis")
     val lessLikeThis: String get() = value("lessLikeThis")
     val playbackDiagnostics: String get() = value("playbackDiagnostics")
@@ -1494,8 +1498,8 @@ class LevyraStrings private constructor(
         }
 
         private fun bundle(code: String, entries: Map<String, String>): LevyraStrings {
-            val resolvedEntries = entries + homeEditorialLocalizationEntries(code) + lyricsActionLocalizationEntries(code) + playerExperienceLocalizationEntries(code) + exploreLocalizationEntries(code) + canvasLocalizationEntries(code) + audioLocalizationEntries(code) + autoEqLocalizationEntries(code) + experienceLocalizationEntries(code) + insightLocalizationEntries(code) + systemActionLocalizationEntries(code) + integrationLocalizationEntries(code) + recognitionLocalizationEntries(code) + jamLocalizationEntries(code) + networkLocalizationEntries(code) + resonanceLocalizationEntries(code) + organizationLocalizationEntries(code) + similarSongsLocalizationEntries(code) + playerVisualLocalizationEntries(code)
-            val allRequiredKeys = requiredKeys + "removeFromPlaylist" + motionArtworkKeys + canvasKeys + audioKeys + autoEqKeys + experienceKeys + insightKeys + systemActionKeys + integrationKeys + recognitionKeys + jamKeys + networkKeys + resonanceKeys + organizationKeys + similarSongsKeys + playerVisualKeys
+            val resolvedEntries = entries + homeEditorialLocalizationEntries(code) + lyricsActionLocalizationEntries(code) + playerExperienceLocalizationEntries(code) + exploreLocalizationEntries(code) + canvasLocalizationEntries(code) + audioLocalizationEntries(code) + autoEqLocalizationEntries(code) + experienceLocalizationEntries(code) + insightLocalizationEntries(code) + systemActionLocalizationEntries(code) + integrationLocalizationEntries(code) + recognitionLocalizationEntries(code) + jamLocalizationEntries(code) + networkLocalizationEntries(code) + resonanceLocalizationEntries(code) + organizationLocalizationEntries(code) + similarSongsLocalizationEntries(code) + playerVisualLocalizationEntries(code) + queueSelectionLocalizationEntries(code)
+            val allRequiredKeys = requiredKeys + "removeFromPlaylist" + motionArtworkKeys + canvasKeys + audioKeys + autoEqKeys + experienceKeys + insightKeys + systemActionKeys + integrationKeys + recognitionKeys + jamKeys + networkKeys + resonanceKeys + organizationKeys + similarSongsKeys + playerVisualKeys + queueSelectionKeys
             require(resolvedEntries.keys == allRequiredKeys) {
                 "Invalid localization bundle $code: missing=${allRequiredKeys - resolvedEntries.keys}, extra=${resolvedEntries.keys - allRequiredKeys}"
             }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/library/LibraryActions.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/library/LibraryActions.kt
@@ -359,7 +359,7 @@ internal fun LibrarySelectionBar(
 }
 
 @Composable
-private fun LibrarySelectionAction(
+internal fun LibrarySelectionAction(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     label: String,
     enabled: Boolean,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -213,6 +213,7 @@ import com.luc4n3x.levyra.player.LevyraPlayer
 import com.luc4n3x.levyra.player.PlaybackService
 import com.luc4n3x.levyra.player.PlaybackSleepTimerState
 import com.luc4n3x.levyra.player.PlaybackWarmup
+import com.luc4n3x.levyra.player.SponsorBlockSkipOnceTracker
 import com.luc4n3x.levyra.player.queuePrefetchPrimeBytes
 import com.luc4n3x.levyra.player.queue.PersistentQueueEngine
 import com.luc4n3x.levyra.player.queue.PlaybackQueueSnapshot
@@ -807,6 +808,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private var followedArtistsGeneration = 0L
     private var radioJob: Job? = null
     private var sponsorSegments: List<SponsorSegment> = emptyList()
+    private val sponsorSkipTracker = SponsorBlockSkipOnceTracker()
     private val tabBackStack = ArrayDeque<LevyraTab>()
 
     private sealed interface DetailPage {
@@ -4415,6 +4417,23 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         removeFromQueueLocal(index)
     }
 
+    fun removeTracksFromQueue(indices: Collection<Int>) {
+        val snapshot = _state.value
+        val currentIndex = snapshot.queueCurrentIndex
+        val targets = indices.filterTo(sortedSetOf<Int>()) {
+            it in snapshot.queue.indices && it != currentIndex
+        }
+        if (targets.isEmpty()) return
+        if (snapshot.jam.isActive) {
+            targets.forEach { index ->
+                snapshot.queue.getOrNull(index)?.let { routeJamAction(JamAction.RemoveTrack(it.id)) }
+            }
+            return
+        }
+        val updated = queueEngine.removeIndices(targets)
+        if (updated.tracks.isEmpty()) closePlayer() else refreshQueuePrefetch()
+    }
+
     private fun removeFromQueueLocal(index: Int) {
         val snapshot = queueEngine.remove(index)
         if (snapshot.tracks.isEmpty()) {
@@ -7798,12 +7817,14 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
     private fun fetchSponsorSegments(track: Track) {
         sponsorJob?.cancel()
         sponsorSegments = emptyList()
+        sponsorSkipTracker.reset()
         if (
             !_state.value.sponsorBlockEnabled ||
             isLocalPlaybackTrack(track) ||
             track.id.isBlank() ||
             track.id.startsWith("chart-")
         ) return
+        sponsorSkipTracker.beginPlayback(track.id)
         sponsorJob = viewModelScope.launch {
             val result = runCatching { sponsorBlockRepository.segments(track.id) }.getOrDefault(emptyList())
             if (_state.value.currentTrack?.id == track.id) sponsorSegments = result
@@ -7816,6 +7837,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         if (!value) {
             sponsorJob?.cancel()
             sponsorSegments = emptyList()
+            sponsorSkipTracker.reset()
         } else {
             _state.value.currentTrack?.let { fetchSponsorSegments(it) }
         }
@@ -8565,6 +8587,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         radioJob = null
         PlaybackService.cancelSleepTimer()
         sponsorSegments = emptyList()
+        sponsorSkipTracker.reset()
         cancelBackgroundWarmups(cancelList = true)
         pendingSeekMs = 0L
         queueIndex = -1
@@ -8762,10 +8785,16 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 val current = snapshot.currentTrack
                 val duration = current?.let { effectiveDuration(it) } ?: player.durationMs
 
-                if (snapshot.sponsorBlockEnabled && sponsorSegments.isNotEmpty() && player.isPlaying) {
-                    val pos = player.positionMs
-                    val segment = sponsorSegments.firstOrNull { pos >= it.startMs && pos < it.endMs - 250 }
-                    if (segment != null) player.seekTo(segment.endMs)
+                val sponsorMediaKey = current?.id
+                if (
+                    snapshot.sponsorBlockEnabled &&
+                    sponsorSegments.isNotEmpty() &&
+                    sponsorMediaKey != null &&
+                    player.isPlaying
+                ) {
+                    sponsorSkipTracker
+                        .planSkip(sponsorMediaKey, player.positionMs, sponsorSegments)
+                        ?.let(player::seekTo)
                 }
 
                 val nowElapsed = android.os.SystemClock.elapsedRealtime()

--- a/app/src/test/java/com/luc4n3x/levyra/data/SponsorBlockRepositoryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/SponsorBlockRepositoryTest.kt
@@ -178,6 +178,55 @@ class SponsorBlockRepositoryTest {
         assertEquals(SPONSORBLOCK_CACHE_LIMIT, cache.size)
     }
 
+    @Test
+    fun upstreamSegmentIdentityIsPreserved() {
+        val fetcher = QueueSponsorBlockFetcher(
+            response(
+                200,
+                """[{"videoID":"video","segments":[{"UUID":"seg-uuid-1","segment":[1.0,2.5],"category":"sponsor","actionType":"skip"}]}]"""
+            )
+        )
+        val repository = SponsorBlockRepository(fetcher) { 1_000L }
+
+        val segment = repositorySegments(repository, "video").single()
+
+        assertEquals("seg-uuid-1", segment.uuid)
+        assertEquals("sponsor", segment.category)
+        assertEquals("skip", segment.actionType)
+        assertEquals(1_000L, segment.startMs)
+        assertEquals(2_500L, segment.endMs)
+    }
+
+    @Test
+    fun legacyResponseWithoutIdentityFieldsStillParses() {
+        val fetcher = QueueSponsorBlockFetcher(
+            response(200, """[{"videoID":"video","segments":[{"segment":[1.0,2.5],"category":"intro"}]}]""")
+        )
+        val repository = SponsorBlockRepository(fetcher) { 1_000L }
+
+        val segment = repositorySegments(repository, "video").single()
+
+        assertEquals("", segment.uuid)
+        assertEquals("intro", segment.category)
+        assertEquals("skip", segment.actionType)
+    }
+
+    @Test
+    fun nonSkipActionTypeIsPreservedVerbatim() {
+        val fetcher = QueueSponsorBlockFetcher(
+            response(
+                200,
+                """[{"videoID":"video","segments":[{"UUID":"poi-1","segment":[3.0,4.0],"category":"poi_highlight","actionType":"poi"}]}]"""
+            )
+        )
+        val repository = SponsorBlockRepository(fetcher) { 1_000L }
+
+        val segment = repositorySegments(repository, "video").single()
+
+        assertEquals("poi", segment.actionType)
+        assertEquals("poi_highlight", segment.category)
+    }
+
     private fun repositorySegments(repository: SponsorBlockRepository, videoId: String): List<SponsorSegment> =
         kotlinx.coroutines.runBlocking { repository.segments(videoId) }
 

--- a/app/src/test/java/com/luc4n3x/levyra/player/SponsorBlockSkipOnceTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/SponsorBlockSkipOnceTest.kt
@@ -1,0 +1,202 @@
+package com.luc4n3x.levyra.player
+
+import com.luc4n3x.levyra.domain.SponsorSegment
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SponsorBlockSkipOnceTest {
+
+    private fun segment(
+        startMs: Long,
+        endMs: Long,
+        uuid: String = "",
+        category: String = "sponsor"
+    ) = SponsorSegment(startMs = startMs, endMs = endMs, category = category, uuid = uuid)
+
+    @Test
+    fun firstEncounterSkipsToSegmentEnd() {
+        val tracker = SponsorBlockSkipOnceTracker()
+        val segments = listOf(segment(5_000L, 15_000L, uuid = "a"))
+        tracker.beginPlayback("video")
+
+        assertEquals(15_000L, tracker.planSkip("video", 5_100L, segments))
+    }
+
+    @Test
+    fun rewindIntoConsumedSegmentDoesNotSkipAgain() {
+        val tracker = SponsorBlockSkipOnceTracker()
+        val segments = listOf(segment(5_000L, 15_000L, uuid = "a"))
+        tracker.beginPlayback("video")
+        tracker.planSkip("video", 5_100L, segments)
+
+        assertNull(tracker.planSkip("video", 6_000L, segments))
+        assertNull(tracker.planSkip("video", 14_000L, segments))
+    }
+
+    @Test
+    fun otherSegmentStillSkipsAfterFirstOneIsConsumed() {
+        val tracker = SponsorBlockSkipOnceTracker()
+        val segments = listOf(
+            segment(5_000L, 15_000L, uuid = "a"),
+            segment(40_000L, 50_000L, uuid = "b")
+        )
+        tracker.beginPlayback("video")
+        tracker.planSkip("video", 5_100L, segments)
+
+        assertEquals(50_000L, tracker.planSkip("video", 41_000L, segments))
+        assertNull(tracker.planSkip("video", 6_000L, segments))
+    }
+
+    @Test
+    fun mediaChangeResetsConsumedState() {
+        val tracker = SponsorBlockSkipOnceTracker()
+        val segments = listOf(segment(5_000L, 15_000L, uuid = "a"))
+        tracker.beginPlayback("video")
+        tracker.planSkip("video", 5_100L, segments)
+
+        tracker.bind("other-video")
+        assertEquals(0, tracker.consumedCount)
+        tracker.bind("video")
+
+        assertEquals(15_000L, tracker.planSkip("video", 5_100L, segments))
+    }
+
+    @Test
+    fun replayingSameMediaResetsConsumedState() {
+        val tracker = SponsorBlockSkipOnceTracker()
+        val segments = listOf(segment(5_000L, 15_000L, uuid = "a"))
+        tracker.beginPlayback("video")
+        tracker.planSkip("video", 5_100L, segments)
+
+        tracker.beginPlayback("video")
+
+        assertEquals(15_000L, tracker.planSkip("video", 5_100L, segments))
+    }
+
+    @Test
+    fun bindKeepsConsumedStateWhenMediaIsUnchanged() {
+        val tracker = SponsorBlockSkipOnceTracker()
+        val segments = listOf(segment(5_000L, 15_000L, uuid = "a"))
+        tracker.beginPlayback("video")
+        tracker.planSkip("video", 5_100L, segments)
+
+        tracker.bind("video")
+
+        assertNull(tracker.planSkip("video", 5_100L, segments))
+    }
+
+    @Test
+    fun stateFromOneMediaNeverAppliesToAnother() {
+        val tracker = SponsorBlockSkipOnceTracker()
+        val segments = listOf(segment(5_000L, 15_000L, uuid = "shared"))
+        tracker.beginPlayback("video-a")
+        tracker.planSkip("video-a", 5_100L, segments)
+
+        assertNull(tracker.planSkip("video-b", 5_100L, segments))
+
+        tracker.beginPlayback("video-b")
+        assertEquals(15_000L, tracker.planSkip("video-b", 5_100L, segments))
+    }
+
+    @Test
+    fun resetClearsBindingAndConsumedState() {
+        val tracker = SponsorBlockSkipOnceTracker()
+        val segments = listOf(segment(5_000L, 15_000L, uuid = "a"))
+        tracker.beginPlayback("video")
+        tracker.planSkip("video", 5_100L, segments)
+
+        tracker.reset()
+
+        assertNull(tracker.activeMediaKey)
+        assertEquals(0, tracker.consumedCount)
+        assertNull(tracker.planSkip("video", 5_100L, segments))
+    }
+
+    @Test
+    fun overlappingSegmentsSkipToFurthestEndAndAreAllConsumed() {
+        val tracker = SponsorBlockSkipOnceTracker()
+        val segments = listOf(
+            segment(5_000L, 12_000L, uuid = "a"),
+            segment(6_000L, 20_000L, uuid = "b")
+        )
+        tracker.beginPlayback("video")
+
+        assertEquals(20_000L, tracker.planSkip("video", 7_000L, segments))
+        assertEquals(2, tracker.consumedCount)
+        assertNull(tracker.planSkip("video", 7_000L, segments))
+    }
+
+    @Test
+    fun adjacentSegmentsAreSkippedOneAfterTheOther() {
+        val tracker = SponsorBlockSkipOnceTracker()
+        val segments = listOf(
+            segment(0L, 5_000L, uuid = "a"),
+            segment(5_000L, 9_000L, uuid = "b")
+        )
+        tracker.beginPlayback("video")
+
+        assertEquals(5_000L, tracker.planSkip("video", 100L, segments))
+        assertEquals(9_000L, tracker.planSkip("video", 5_000L, segments))
+        assertNull(tracker.planSkip("video", 100L, segments))
+    }
+
+    @Test
+    fun consumedOuterSegmentDoesNotBlockUnconsumedInnerSegment() {
+        val tracker = SponsorBlockSkipOnceTracker()
+        val outer = segment(1_000L, 20_000L, uuid = "outer")
+        val inner = segment(5_000L, 8_000L, uuid = "inner")
+        val segments = listOf(outer, inner)
+        tracker.beginPlayback("video")
+
+        assertEquals(20_000L, tracker.planSkip("video", 1_100L, segments))
+        assertEquals(8_000L, tracker.planSkip("video", 5_500L, segments))
+        assertNull(tracker.planSkip("video", 5_500L, segments))
+    }
+
+    @Test
+    fun segmentTailGuardPreventsSkipLoopAtSegmentEnd() {
+        val segments = listOf(segment(5_000L, 15_000L, uuid = "a"))
+
+        assertNull(sponsorBlockSkipDecision(segments, 14_800L, emptySet()))
+        assertEquals(
+            15_000L,
+            sponsorBlockSkipDecision(segments, 14_700L, emptySet())?.targetPositionMs
+        )
+    }
+
+    @Test
+    fun positionOutsideEverySegmentYieldsNoDecision() {
+        val segments = listOf(segment(5_000L, 15_000L, uuid = "a"))
+
+        assertNull(sponsorBlockSkipDecision(segments, 4_999L, emptySet()))
+        assertNull(sponsorBlockSkipDecision(segments, 15_000L, emptySet()))
+    }
+
+    @Test
+    fun degenerateSegmentIsIgnored() {
+        val segments = listOf(segment(5_000L, 5_000L, uuid = "a"))
+
+        assertNull(sponsorBlockSkipDecision(segments, 5_000L, emptySet()))
+    }
+
+    @Test
+    fun segmentsWithoutUuidFallBackToBoundsAndCategoryIdentity() {
+        val tracker = SponsorBlockSkipOnceTracker()
+        val segments = listOf(
+            segment(5_000L, 15_000L, category = "sponsor"),
+            segment(5_000L, 15_000L, category = "intro")
+        )
+        tracker.beginPlayback("video")
+
+        assertEquals(15_000L, tracker.planSkip("video", 5_100L, segments))
+        assertEquals(2, tracker.consumedCount)
+        assertNull(tracker.planSkip("video", 5_100L, segments))
+    }
+
+    @Test
+    fun identityPrefersUpstreamUuidOverBounds() {
+        assertEquals("uuid-1", sponsorSegmentIdentity(segment(0L, 1_000L, uuid = "uuid-1")))
+        assertEquals("0:1000:sponsor", sponsorSegmentIdentity(segment(0L, 1_000L)))
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/player/queue/QueueMultiRemovalContractTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/queue/QueueMultiRemovalContractTest.kt
@@ -1,0 +1,106 @@
+package com.luc4n3x.levyra.player.queue
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class QueueMultiRemovalContractTest {
+
+    @Test
+    fun removalsBeforeCurrentShiftCurrentBackByRemovedCount() {
+        assertEquals(
+            2,
+            queueMultiRemovalCurrentIndex(
+                removedIndices = setOf(0, 1),
+                currentIndex = 4,
+                newLastIndex = 3
+            )
+        )
+    }
+
+    @Test
+    fun removalsAfterCurrentKeepCurrent() {
+        assertEquals(
+            1,
+            queueMultiRemovalCurrentIndex(
+                removedIndices = setOf(3, 4),
+                currentIndex = 1,
+                newLastIndex = 2
+            )
+        )
+    }
+
+    @Test
+    fun mixedRemovalsOnlyCountEntriesBeforeCurrent() {
+        assertEquals(
+            2,
+            queueMultiRemovalCurrentIndex(
+                removedIndices = setOf(0, 5, 6),
+                currentIndex = 3,
+                newLastIndex = 3
+            )
+        )
+    }
+
+    @Test
+    fun removingCurrentLandsOnTheNextSurvivingEntry() {
+        assertEquals(
+            1,
+            queueMultiRemovalCurrentIndex(
+                removedIndices = setOf(0, 2),
+                currentIndex = 2,
+                newLastIndex = 2
+            )
+        )
+    }
+
+    @Test
+    fun removingEveryTrackYieldsInvalidCurrent() {
+        assertEquals(
+            -1,
+            queueMultiRemovalCurrentIndex(
+                removedIndices = setOf(0, 1, 2),
+                currentIndex = 1,
+                newLastIndex = -1
+            )
+        )
+    }
+
+    @Test
+    fun queueWithoutCurrentTrackStaysWithoutCurrent() {
+        assertEquals(
+            -1,
+            queueMultiRemovalCurrentIndex(
+                removedIndices = setOf(0),
+                currentIndex = -1,
+                newLastIndex = 1
+            )
+        )
+    }
+
+    @Test
+    fun resultIsClampedIntoTheNewBounds() {
+        assertEquals(
+            1,
+            queueMultiRemovalCurrentIndex(
+                removedIndices = setOf(4, 5),
+                currentIndex = 3,
+                newLastIndex = 1
+            )
+        )
+    }
+
+    @Test
+    fun singleRemovalMatchesTheSingleEntryContract() {
+        listOf(
+            Triple(0, 2, 3),
+            Triple(2, 3, 4),
+            Triple(4, 1, 4),
+            Triple(5, 0, 4)
+        ).forEach { (removed, current, newLastIndex) ->
+            assertEquals(
+                queueRemovalCurrentIndex(removed, current, newLastIndex),
+                queueMultiRemovalCurrentIndex(setOf(removed), current, newLastIndex)
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/ui/QueueSelectionKeyTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/QueueSelectionKeyTest.kt
@@ -1,0 +1,81 @@
+package com.luc4n3x.levyra.ui
+
+import com.luc4n3x.levyra.domain.Track
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class QueueSelectionKeyTest {
+
+    @Test
+    fun eachQueueEntryGetsOneKey() {
+        val queue = listOf(track("a"), track("b"), track("c"))
+
+        assertEquals(queue.size, queueSelectionKeys(queue).size)
+    }
+
+    @Test
+    fun duplicatedTracksKeepDistinctKeys() {
+        val duplicated = track("a")
+        val keys = queueSelectionKeys(listOf(duplicated, track("b"), duplicated))
+
+        assertEquals(3, keys.toSet().size)
+        assertNotEquals(keys[0], keys[2])
+    }
+
+    @Test
+    fun keysAreStableAcrossMetadataRefreshOfTheSameQueue() {
+        val original = listOf(track("a"), track("b"))
+        val refreshed = original.map { it.copy(title = "refreshed ${it.id}", streamUrl = "https://cdn/${it.id}") }
+
+        assertEquals(queueSelectionKeys(original), queueSelectionKeys(refreshed))
+    }
+
+    @Test
+    fun appendingToTheQueueKeepsExistingKeys() {
+        val original = listOf(track("a"), track("b"))
+        val extended = original + track("c")
+
+        assertEquals(queueSelectionKeys(original), queueSelectionKeys(extended).take(original.size))
+    }
+
+    @Test
+    fun differentVideoUrlsForTheSameIdStayDistinct() {
+        val keys = queueSelectionKeys(
+            listOf(
+                track("a", videoUrl = "https://levyra.test/a"),
+                track("a", videoUrl = "https://levyra.test/a-alt")
+            )
+        )
+
+        assertNotEquals(keys[0], keys[1])
+    }
+
+    @Test
+    fun emptyQueueProducesNoKeys() {
+        assertEquals(emptyList<String>(), queueSelectionKeys(emptyList()))
+    }
+
+    private fun track(
+        id: String,
+        videoUrl: String = "https://levyra.test/$id"
+    ): Track = Track(
+        id = id,
+        title = "Title $id",
+        artist = "Artist $id",
+        album = "Album $id",
+        durationMs = 190_000L,
+        streamUrl = "",
+        videoUrl = videoUrl,
+        thumbnailUrl = "https://levyra.test/$id.jpg",
+        largeThumbnailUrl = "https://levyra.test/$id-large.jpg",
+        source = "YouTube Music",
+        moodTags = emptySet(),
+        energy = 50,
+        vocal = 50,
+        replayScore = 70,
+        cacheScore = 70,
+        accentStart = 0xFF00E5FF.toInt(),
+        accentEnd = 0xFF2979FF.toInt()
+    )
+}

--- a/app/src/test/java/com/luc4n3x/levyra/ui/i18n/LevyraStringsTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/ui/i18n/LevyraStringsTest.kt
@@ -23,6 +23,7 @@ class LevyraStringsTest {
         assertEquals(catalogCodes, resonanceLocalizationCodes())
         assertEquals(catalogCodes, similarSongsLocalizationCodes())
         assertEquals(catalogCodes, playerVisualLocalizationCodes())
+        assertEquals(catalogCodes, queueSelectionLocalizationCodes())
         LevyraStrings.all().forEach { strings ->
             assertTrue(strings.moreLikeThis.isNotBlank())
             assertTrue(strings.lessLikeThis.isNotBlank())


### PR DESCRIPTION
## Summary

Two independent quality-of-life changes.

SponsorBlock used to re-skip a segment every single time playback entered it, so deliberately rewinding into a sponsor you wanted to hear was impossible: the player jumped away again. A segment is now skipped only the first time it is met during the current playback. Rewind into it and it plays; every other segment still skips as before.

The queue overlay gains multi-selection. Long-press a row to enter selection mode, tap other rows to toggle them, then add the selection to a playlist, download it offline, or remove it from the queue in one action.

## What changed

- New `SponsorBlockSkipOnce.kt` with the pure skip decision and a `SponsorBlockSkipOnceTracker` that remembers which segments were already consumed for the bound media item.
- `LevyraViewModel` ticker and `LevyraPlayer.startSponsorBlockMonitor` both go through the tracker instead of scanning segments directly. Consumed state is cleared on media change, on a new playback session, on stop and recovery failure, and when SponsorBlock is switched off.
- `SponsorSegment` now carries the upstream `uuid` and `actionType` next to category and timestamps, and `parseSponsorBlockSegments` reads them. Both fields have defaults, so cached entries and older payloads keep parsing unchanged and the k-anonymity request, TTLs and cache behaviour are untouched.
- `PersistentQueueEngine.removeIndices` removes several entries in a single mutation, resolving the new current index by track identity with `queueMultiRemovalCurrentIndex` as fallback.
- `LevyraViewModel.removeTracksFromQueue` validates the indices against the live snapshot, always excludes the currently playing entry, and routes through Jam like the single-item removal does.
- `QueueOverlay` gains selection state, a selection bar with the count and Select All, and reuses the existing `LibrarySelectionAction` and `AddTracksToPlaylistDialog` from the library instead of duplicating them.
- Four new localization keys across all 26 supported languages, in a dedicated `LevyraQueueSelectionStrings` bundle wired into `LevyraStrings.bundle`.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor or maintenance
- [x] UI or UX change
- [x] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** Player / UI / Localization

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [x] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

`./gradlew --no-daemon :app:compileDebugKotlin :app:testDebugUnitTest` passes: 250 classes, 1818 tests, no failures and no errors. `git diff --check` is clean.

The release triple in the first box was not run here. The run was stopped by the repository owner before `lintRelease` and `assembleRelease` completed, so those two are unverified and CI is the authority on them. The desktop module is untouched by this change.

New tests: `SponsorBlockSkipOnceTest` (16 cases: first skip, rewind into a consumed segment, another segment still skipping, media change and replay resets, no cross-media leakage, overlapping and adjacent segments, the tail guard, and segments without a UUID), `QueueMultiRemovalContractTest` (index math, including agreement with the single-removal contract), `QueueSelectionKeyTest` (duplicate handling and stability across metadata refresh), plus three cases in `SponsorBlockRepositoryTest` for identity parsing and legacy payloads.

## Risk and compatibility

- **Risk level:** Medium
- **Compatibility or migration notes:** None. `SponsorSegment` gains two defaulted fields, so existing cache entries and stored queues keep deserializing.
- **Known limitations:** SponsorBlock skip-once was not exercised on a device against a real segment; the behaviour is covered by unit tests only. The multi-removal path is not undoable when more than one entry is selected, while single removal keeps its undo.
- **Rollback plan:** Revert this PR

The tracker's consumed set is bounded by the segment count of the bound media and is cleared whenever another item or a new session takes over, so it cannot grow with playback duration. The media-key guard also fixes a latent issue: on a deferred playback start, segments belonging to the previous track could previously be applied to the new one.

## Reviewer notes

- `SponsorBlockSkipOnce.kt` is the core of the first feature. `sponsorBlockSkipDecision` allocates nothing until an actual skip is decided, which matters because it runs on the playback tick.
- `PersistentQueueEngine.removeIndices` deliberately clears the undo entry when more than one index is removed, and keeps it for a single one so the existing swipe-to-remove undo is unaffected.
- Selection keys pair the track id and video URL with an occurrence counter, so duplicates in the queue stay distinct and the keys survive a metadata refresh.
- `LibrarySelectionAction` was widened from private to internal so the queue bar can reuse it rather than growing a second copy.
- Reorder, swipe-to-dismiss and row playback are all suppressed while selection is active; back clears the selection before it closes the overlay.

## Release note

SponsorBlock segments are now skipped only the first time you reach them, and the queue supports selecting several tracks at once.

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims
