### PR TITLE
fix: harden YouTube stream resolution

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackManifestCodec.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackManifestCodec.kt
@@ -3,6 +3,7 @@ package com.luc4n3x.levyra.data
 import com.luc4n3x.levyra.domain.PlaybackDeliveryMethod
 import com.luc4n3x.levyra.domain.PlaybackStreamDescriptor
 import com.luc4n3x.levyra.domain.PlaybackStreamKind
+import com.luc4n3x.levyra.domain.PlaybackStreamProvenance
 import com.luc4n3x.levyra.domain.ResolvedPlaybackManifest
 import org.json.JSONArray
 import org.json.JSONObject
@@ -33,7 +34,7 @@ object PlaybackManifestCodec {
             )
         }
         return JSONObject()
-            .put("schemaVersion", 1)
+            .put("schemaVersion", 2)
             .put("sourceVideoId", manifest.sourceVideoId)
             .put("provider", manifest.provider)
             .put("resolvedAtMs", manifest.resolvedAtMs)
@@ -43,13 +44,14 @@ object PlaybackManifestCodec {
             .put("selectedVideoUrl", manifest.selectedVideoUrl)
             .put("loudnessDb", manifest.loudnessDb)
             .put("perceptualLoudnessDb", manifest.perceptualLoudnessDb)
+            .put("provenance", manifest.provenance?.toJson())
             .put("streams", streams)
             .toString()
     }
 
     fun decode(raw: String): ResolvedPlaybackManifest? = runCatching {
         val root = JSONObject(raw)
-        if (root.optInt("schemaVersion", 0) != 1) return@runCatching null
+        if (root.optInt("schemaVersion", 0) !in 1..2) return@runCatching null
         val streamArray = root.optJSONArray("streams") ?: JSONArray()
         val streams = buildList {
             for (index in 0 until streamArray.length()) {
@@ -91,10 +93,52 @@ object PlaybackManifestCodec {
             selectedVideoUrl = root.optString("selectedVideoUrl"),
             streams = streams,
             loudnessDb = root.optNullableFloat("loudnessDb"),
-            perceptualLoudnessDb = root.optNullableFloat("perceptualLoudnessDb")
+            perceptualLoudnessDb = root.optNullableFloat("perceptualLoudnessDb"),
+            provenance = root.optJSONObject("provenance")?.toPlaybackStreamProvenance()
         )
     }.getOrNull()
 }
+
+private fun PlaybackStreamProvenance.toJson(): JSONObject = JSONObject()
+    .put("clientName", clientName)
+    .put("clientHeaderName", clientHeaderName)
+    .put("clientVersion", clientVersion)
+    .put("userAgent", userAgent)
+    .put("origin", origin)
+    .put("referer", referer)
+    .put("requiresPoToken", requiresPoToken)
+    .put("resolverGeneration", resolverGeneration)
+    .put("playerHash", playerHash)
+    .put("playerConfigIdentity", playerConfigIdentity)
+    .put("playerConfigEpoch", playerConfigEpoch)
+    .put("playerConfigOrigin", playerConfigOrigin)
+    .put("securitySessionGeneration", securitySessionGeneration)
+    .put("poTokenGeneration", poTokenGeneration)
+    .put("networkGeneration", networkGeneration)
+    .put("networkRoute", networkRoute)
+    .put("resolvedAtMs", resolvedAtMs)
+    .put("expiresAtMs", expiresAtMs)
+
+private fun JSONObject.toPlaybackStreamProvenance(): PlaybackStreamProvenance = PlaybackStreamProvenance(
+    clientName = optString("clientName"),
+    clientHeaderName = optString("clientHeaderName"),
+    clientVersion = optString("clientVersion"),
+    userAgent = optString("userAgent"),
+    origin = optString("origin"),
+    referer = optString("referer"),
+    requiresPoToken = optBoolean("requiresPoToken", false),
+    resolverGeneration = optLong("resolverGeneration", -1L),
+    playerHash = optString("playerHash"),
+    playerConfigIdentity = optString("playerConfigIdentity"),
+    playerConfigEpoch = optLong("playerConfigEpoch", -1L),
+    playerConfigOrigin = optString("playerConfigOrigin"),
+    securitySessionGeneration = optLong("securitySessionGeneration", -1L),
+    poTokenGeneration = optLong("poTokenGeneration", -1L),
+    networkGeneration = optLong("networkGeneration", -1L),
+    networkRoute = optString("networkRoute"),
+    resolvedAtMs = optLong("resolvedAtMs", 0L),
+    expiresAtMs = optLong("expiresAtMs", 0L)
+)
 
 private inline fun <reified T : Enum<T>> JSONObject.optEnum(key: String, fallback: T): T {
     return enumValues<T>().firstOrNull { it.name == optString(key) } ?: fallback

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResilienceEngine.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResilienceEngine.kt
@@ -74,6 +74,7 @@ internal fun classifyPlaybackFailureReason(raw: String): PlaybackFailureKind {
             value.contains("accedi per confermare") -> PlaybackFailureKind.LoginRequired
         value.contains("age restrict") ||
             value.contains("age-restrict") -> PlaybackFailureKind.ContentRestricted
+        value.contains("renderer process") || value.contains("webview renderer") -> PlaybackFailureKind.Renderer
         httpStatus == 403 || value.contains("forbidden") -> PlaybackFailureKind.Forbidden
         httpStatus == 410 || value.contains("gone") -> PlaybackFailureKind.Gone
         httpStatus == 429 || value.contains("rate limit") -> PlaybackFailureKind.RateLimited
@@ -95,7 +96,6 @@ internal fun classifyPlaybackFailureReason(raw: String): PlaybackFailureKind {
         value.contains("n-transform") || value.contains("throttling parameter") -> PlaybackFailureKind.NTransform
         value.contains("signature") -> PlaybackFailureKind.Signature
         value.contains("client rejected") || value.contains("invalid client") || value.contains("unsupported client") -> PlaybackFailureKind.ClientRejected
-        value.contains("renderer process") || value.contains("webview renderer") -> PlaybackFailureKind.Renderer
         value.contains("unsupported format") ||
             value.contains("format unsupported") ||
             value.contains("unsupported media") -> PlaybackFailureKind.UnsupportedFormat

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResilienceEngine.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResilienceEngine.kt
@@ -21,6 +21,10 @@ internal enum class PlaybackFailureKind {
     ContentRestricted,
     ExpiredUrl,
     Signature,
+    NTransform,
+    PoToken,
+    ClientRejected,
+    Renderer,
     UnsupportedFormat,
     MalformedContainer,
     Decoder,
@@ -36,7 +40,9 @@ internal data class PlaybackRecoveryPlan(
     val rotateCodec: Boolean,
     val refreshSecurity: Boolean,
     val quarantineMs: Long,
-    val invalidateCache: Boolean = false
+    val invalidateCache: Boolean = false,
+    val refreshDecoder: Boolean = false,
+    val refreshClientPolicy: Boolean = false
 )
 
 internal data class PlaybackTraceEvent(
@@ -85,7 +91,11 @@ internal fun classifyPlaybackFailureReason(raw: String): PlaybackFailureKind {
             value.contains("bad gateway") ||
             value.contains("gateway timeout") -> PlaybackFailureKind.ServerError
         value.contains("expired") || value.contains("scadut") || value.contains("stream non valido") -> PlaybackFailureKind.ExpiredUrl
-        value.contains("signature") || value.contains("n-transform") || value.contains("potoken") || value.contains("po token") -> PlaybackFailureKind.Signature
+        value.contains("potoken") || value.contains("po token") -> PlaybackFailureKind.PoToken
+        value.contains("n-transform") || value.contains("throttling parameter") -> PlaybackFailureKind.NTransform
+        value.contains("signature") -> PlaybackFailureKind.Signature
+        value.contains("client rejected") || value.contains("invalid client") || value.contains("unsupported client") -> PlaybackFailureKind.ClientRejected
+        value.contains("renderer process") || value.contains("webview renderer") -> PlaybackFailureKind.Renderer
         value.contains("unsupported format") ||
             value.contains("format unsupported") ||
             value.contains("unsupported media") -> PlaybackFailureKind.UnsupportedFormat
@@ -106,9 +116,18 @@ internal fun classifyPlaybackFailureReason(raw: String): PlaybackFailureKind {
 
 internal fun playbackRecoveryPlanFor(kind: PlaybackFailureKind): PlaybackRecoveryPlan = when (kind) {
     PlaybackFailureKind.Forbidden,
-    PlaybackFailureKind.Gone,
-    PlaybackFailureKind.RateLimited,
-    PlaybackFailureKind.LoginRequired -> PlaybackRecoveryPlan(true, true, false, true, 10L * 60L * 1000L)
+    PlaybackFailureKind.Gone -> PlaybackRecoveryPlan(true, false, false, false, 10L * 60L * 1000L)
+    PlaybackFailureKind.RateLimited -> PlaybackRecoveryPlan(true, true, false, false, 10L * 60L * 1000L)
+    PlaybackFailureKind.LoginRequired,
+    PlaybackFailureKind.PoToken -> PlaybackRecoveryPlan(true, false, false, true, 10L * 60L * 1000L)
+    PlaybackFailureKind.ClientRejected -> PlaybackRecoveryPlan(
+        invalidateStream = true,
+        rotateClient = true,
+        rotateCodec = false,
+        refreshSecurity = false,
+        quarantineMs = 10L * 60L * 1000L,
+        refreshClientPolicy = true
+    )
     PlaybackFailureKind.ContentRestricted -> PlaybackRecoveryPlan(true, false, false, false, 0L)
     PlaybackFailureKind.NotFound -> PlaybackRecoveryPlan(true, false, false, false, 60_000L)
     PlaybackFailureKind.RangeNotSatisfiable -> PlaybackRecoveryPlan(
@@ -129,8 +148,17 @@ internal fun playbackRecoveryPlanFor(kind: PlaybackFailureKind): PlaybackRecover
     )
     PlaybackFailureKind.ServerError,
     PlaybackFailureKind.Truncated -> PlaybackRecoveryPlan(true, false, false, false, 30_000L)
-    PlaybackFailureKind.ExpiredUrl -> PlaybackRecoveryPlan(true, true, false, false, 2L * 60L * 1000L)
-    PlaybackFailureKind.Signature -> PlaybackRecoveryPlan(true, true, false, true, 10L * 60L * 1000L)
+    PlaybackFailureKind.ExpiredUrl -> PlaybackRecoveryPlan(true, false, false, false, 2L * 60L * 1000L)
+    PlaybackFailureKind.Signature,
+    PlaybackFailureKind.NTransform,
+    PlaybackFailureKind.Renderer -> PlaybackRecoveryPlan(
+        invalidateStream = true,
+        rotateClient = false,
+        rotateCodec = false,
+        refreshSecurity = false,
+        quarantineMs = 10L * 60L * 1000L,
+        refreshDecoder = true
+    )
     PlaybackFailureKind.UnsupportedFormat -> PlaybackRecoveryPlan(true, false, true, false, 0L)
     PlaybackFailureKind.MalformedContainer -> PlaybackRecoveryPlan(
         invalidateStream = true,
@@ -142,8 +170,8 @@ internal fun playbackRecoveryPlanFor(kind: PlaybackFailureKind): PlaybackRecover
     )
     PlaybackFailureKind.Decoder -> PlaybackRecoveryPlan(true, false, true, false, 30L * 60L * 1000L)
     PlaybackFailureKind.Timeout,
-    PlaybackFailureKind.Network -> PlaybackRecoveryPlan(true, true, false, false, 45_000L)
-    PlaybackFailureKind.Unknown -> PlaybackRecoveryPlan(true, true, true, false, 20_000L)
+    PlaybackFailureKind.Network -> PlaybackRecoveryPlan(true, false, false, false, 45_000L)
+    PlaybackFailureKind.Unknown -> PlaybackRecoveryPlan(true, false, false, false, 20_000L)
 }
 
 internal fun isTerminalPlaybackFailure(kind: PlaybackFailureKind): Boolean =

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -7,12 +7,15 @@ import com.luc4n3x.levyra.BuildConfig
 import com.luc4n3x.levyra.data.security.GoogleApiKeyHeaders
 import com.luc4n3x.levyra.data.local.LevyraDatabase
 import com.luc4n3x.levyra.data.network.LevyraHttpClientFactory
+import com.luc4n3x.levyra.data.network.LevyraNetworkConfiguration
+import com.luc4n3x.levyra.data.network.YoutubeClientIdentityInterceptor
 import com.luc4n3x.levyra.data.network.YoutubeStreamClientIdentity
 import com.luc4n3x.levyra.data.network.YoutubeStreamClientIdentityRegistry
 import com.luc4n3x.levyra.domain.LevyraContentLocales
 import com.luc4n3x.levyra.domain.PlaybackDeliveryMethod
 import com.luc4n3x.levyra.domain.PlaybackStreamDescriptor
 import com.luc4n3x.levyra.domain.PlaybackStreamKind
+import com.luc4n3x.levyra.domain.PlaybackStreamProvenance
 import com.luc4n3x.levyra.domain.ResolvedPlaybackManifest
 import com.luc4n3x.levyra.domain.LevyraPersonalOrbit
 import com.luc4n3x.levyra.domain.Track
@@ -324,7 +327,8 @@ class PlaybackResolver private constructor(private val context: Context) {
     private val failedPlaybackUrlsMutationLock = Any()
     private val youtubeEngagementCache = ConcurrentHashMap<String, CachedYoutubeEngagement>()
     private val videoSelector = LevyraVideoStreamSelector(context)
-    private val youtubeHttpClient = LevyraHttpClientFactory.youtubePlayer()
+    private val youtubeHttpClient: OkHttpClient
+        get() = LevyraHttpClientFactory.youtubePlayer(context)
     private val jsonMediaType = "application/json; charset=utf-8".toMediaType()
     private val playbackSecurity = YoutubePlaybackSecurity.getInstance(context)
     private val playbackPolicyStore = PlaybackCompatibilityPolicyStore(
@@ -346,12 +350,13 @@ class PlaybackResolver private constructor(private val context: Context) {
     private val playbackResolveTimeoutMs = 30_000L
     private val offlineResolveTimeoutMs = 60_000L
     private val hedgeBudgetMs = LevyraResolverLatency.INNER_TUBE_HEDGE_BUDGET_MS
-    private val streamProbeClient: OkHttpClient = youtubeHttpClient.newBuilder()
-        .connectTimeout(450, TimeUnit.MILLISECONDS)
-        .readTimeout(800, TimeUnit.MILLISECONDS)
-        .writeTimeout(350, TimeUnit.MILLISECONDS)
-        .callTimeout(950, TimeUnit.MILLISECONDS)
-        .build()
+    private val streamProbeClientLock = Any()
+
+    @Volatile
+    private var streamProbeClientGeneration = -1L
+
+    @Volatile
+    private var streamProbeClient: OkHttpClient? = null
     private val searchFallbackClient: OkHttpClient = youtubeHttpClient.newBuilder()
         .connectTimeout(800, TimeUnit.MILLISECONDS)
         .readTimeout(2_000, TimeUnit.MILLISECONDS)
@@ -576,6 +581,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         val now = System.currentTimeMillis()
         val lower = reason.lowercase()
         val recovery = resilienceEngine.recoveryPlan(reason)
+        val provenance = track.playbackManifest?.provenance
         val attributedUrl = failedUrl?.takeIf { it.isNotBlank() }
             ?: if (isVideoMode) {
                 track.videoStreamUrl.ifBlank { track.streamUrl }
@@ -591,12 +597,18 @@ class PlaybackResolver private constructor(private val context: Context) {
             .filter { it.isNotBlank() }
             .forEach { quarantinePlaybackUrl(it, now + recovery.quarantineMs, now) }
         if (recovery.rotateClient) {
-            profileFromSource(track.source)?.let { profile ->
-                recordClientFailure(profile, null, PlaybackBlockedException(reason))
+            val profile = provenance?.clientName
+                ?.takeIf { it.isNotBlank() }
+                ?.let { expected -> effectiveProfiles().firstOrNull { it.clientName == expected } }
+                ?: profileFromSource(track.source)
+            profile?.let {
+                recordClientFailure(it, null, PlaybackBlockedException(reason))
             }
         }
-        if (recovery.refreshSecurity) {
-            YoutubeLocalDecoder.notifyStreamRejected(track.source)
+        if (recovery.refreshDecoder) {
+            YoutubeLocalDecoder.notifyStreamRejected(track.source, provenance?.playerConfigIdentity)
+        }
+        if (recovery.refreshClientPolicy) {
             resolveScope.launch {
                 val policyChanged = runCatchingPreservingCancellation {
                     playbackPolicyStore.refreshAfterRejection()
@@ -604,8 +616,15 @@ class PlaybackResolver private constructor(private val context: Context) {
                     Timber.w(error, "Playback compatibility policy rejection refresh failed")
                 }.getOrDefault(false)
                 if (policyChanged) clearResolvedStreamCaches()
+            }
+        }
+        if (recovery.refreshSecurity) {
+            resolveScope.launch {
                 runCatchingPreservingCancellation {
-                    playbackSecurity.rotateIfNeeded(PlaybackBlockedException(reason))
+                    playbackSecurity.rotateIfNeeded(
+                        PlaybackBlockedException(reason),
+                        provenance?.securitySessionGeneration
+                    )
                 }.onFailure { error ->
                     Timber.w(error, "YouTube playback security refresh failed")
                 }
@@ -662,37 +681,19 @@ class PlaybackResolver private constructor(private val context: Context) {
         )
     }
 
-    private fun rememberAndroidReelClientIdentity(
-        stream: DirectStream,
-        userAgent: String,
-        clientVersion: String
-    ) {
-        rememberClientIdentity(
-            stream = stream,
-            clientName = ANDROID_REEL_CLIENT_NAME,
-            clientHeaderName = "3",
-            clientVersion = clientVersion,
-            userAgent = userAgent,
-            requiresPoToken = false
-        )
-    }
-
     private fun streamingCapabilityAllows(clientName: String): Boolean =
         playbackPolicyStore.current()
             .isClientCapabilityEnabled(clientName, PlaybackClientCapability.STREAMING)
 
     private fun rememberClientIdentity(
-        stream: DirectStream,
-        clientName: String,
-        clientHeaderName: String,
-        clientVersion: String,
-        userAgent: String,
-        requiresPoToken: Boolean
+        manifest: ResolvedPlaybackManifest
     ) {
+        val provenance = manifest.provenance ?: return
+        if (provenance.clientHeaderName.isBlank() || provenance.userAgent.isBlank()) return
         val urls = buildList {
-            add(stream.url)
-            add(stream.videoUrl)
-            stream.manifest.streams
+            add(manifest.selectedAudioUrl)
+            add(manifest.selectedVideoUrl)
+            manifest.streams
                 .filter { it.deliveryMethod != PlaybackDeliveryMethod.SABR }
                 .forEach { add(it.url) }
         }.filter { it.isNotBlank() }
@@ -700,12 +701,15 @@ class PlaybackResolver private constructor(private val context: Context) {
         YoutubeStreamClientIdentityRegistry.register(
             urls,
             YoutubeStreamClientIdentity(
-                clientName = clientName,
-                clientHeaderName = clientHeaderName,
-                clientVersion = clientVersion,
-                userAgent = userAgent,
-                requiresPoToken = requiresPoToken,
-                videoId = stream.manifest.sourceVideoId
+                clientName = provenance.clientName,
+                clientHeaderName = provenance.clientHeaderName,
+                clientVersion = provenance.clientVersion,
+                userAgent = provenance.userAgent,
+                requiresPoToken = provenance.requiresPoToken,
+                videoId = manifest.sourceVideoId,
+                origin = provenance.origin,
+                referer = provenance.referer,
+                expiresAtMs = provenance.expiresAtMs
             )
         )
     }
@@ -1284,6 +1288,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         track: Track,
         audioQuality: String
     ): Track {
+        val resolutionStartedAtMs = System.currentTimeMillis()
         if (!streamingCapabilityAllows(ANDROID_REEL_CLIENT_NAME)) {
             throw YoutubePlayerRequestException(
                 null,
@@ -1296,7 +1301,16 @@ class PlaybackResolver private constructor(private val context: Context) {
         val locale = LevyraContentLocales.forLanguage(userPreferences.languageCode())
         val reelClientVersion = playbackPolicyStore.current().androidReelClientVersion
         val userAgent = androidReelUserAgent(locale.gl, reelClientVersion)
-        val cachedVisitorData = playbackSecurity.cachedSession().visitorData
+        val reelStreamIdentity = YoutubeStreamClientIdentity(
+            clientName = ANDROID_REEL_CLIENT_NAME,
+            clientHeaderName = "3",
+            clientVersion = reelClientVersion,
+            userAgent = userAgent,
+            requiresPoToken = false,
+            videoId = sourceVideoId
+        )
+        val securitySession = playbackSecurity.cachedSession()
+        val cachedVisitorData = securitySession.visitorData
         val visitorData = runCatchingPreservingCancellation {
             fetchAndroidReelVisitorData(locale.hl, locale.gl, userAgent, reelClientVersion)
         }.getOrNull().orEmpty().ifBlank { cachedVisitorData }
@@ -1368,7 +1382,7 @@ class PlaybackResolver private constructor(private val context: Context) {
 
         var selectedAudio: Triple<JSONObject, String, Int>? = null
         for (candidate in audioCandidates) {
-            if (verifyDirectAudioUrlFast(candidate.second)) {
+            if (verifyDirectAudioUrlFast(candidate.second, identity = reelStreamIdentity)) {
                 selectedAudio = candidate
                 break
             }
@@ -1391,7 +1405,13 @@ class PlaybackResolver private constructor(private val context: Context) {
                 durationMs = duration,
                 selectedAudioUrl = url,
                 selectedVideoUrl = "",
-                streams = listOf(innerTubeAudioDescriptor(format, url, true))
+                streams = listOf(innerTubeAudioDescriptor(format, url, true)),
+                provenance = androidReelProvenance(
+                    userAgent = userAgent,
+                    clientVersion = reelClientVersion,
+                    securityGeneration = securitySession.generation,
+                    resolutionStartedAtMs = resolutionStartedAtMs
+                )
             )
             val reelStream = DirectStream(
                 url = url,
@@ -1401,7 +1421,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 source = "YouTube Android Reel Audio",
                 manifest = manifest
             )
-            rememberAndroidReelClientIdentity(reelStream, userAgent, reelClientVersion)
+            rememberClientIdentity(reelStream.manifest)
             return track.withDirectStream(reelStream)
         }
 
@@ -1409,6 +1429,7 @@ class PlaybackResolver private constructor(private val context: Context) {
     }
 
     private suspend fun resolveVideoWithAndroidReel(track: Track): Track {
+        val resolutionStartedAtMs = System.currentTimeMillis()
         if (!streamingCapabilityAllows(ANDROID_REEL_CLIENT_NAME)) {
             throw YoutubePlayerRequestException(
                 null,
@@ -1421,7 +1442,8 @@ class PlaybackResolver private constructor(private val context: Context) {
         val locale = LevyraContentLocales.forLanguage(userPreferences.languageCode())
         val reelClientVersion = playbackPolicyStore.current().androidReelClientVersion
         val userAgent = androidReelUserAgent(locale.gl, reelClientVersion)
-        val cachedVisitorData = playbackSecurity.cachedSession().visitorData
+        val securitySession = playbackSecurity.cachedSession()
+        val cachedVisitorData = securitySession.visitorData
         val visitorData = runCatchingPreservingCancellation {
             fetchAndroidReelVisitorData(locale.hl, locale.gl, userAgent, reelClientVersion)
         }.getOrNull().orEmpty().ifBlank { cachedVisitorData }
@@ -1513,7 +1535,13 @@ class PlaybackResolver private constructor(private val context: Context) {
             durationMs = duration,
             selectedAudioUrl = selection.candidate.url,
             selectedVideoUrl = "",
-            streams = listOf(videoDescriptor(selection.candidate, true))
+            streams = listOf(videoDescriptor(selection.candidate, true)),
+            provenance = androidReelProvenance(
+                userAgent = userAgent,
+                clientVersion = reelClientVersion,
+                securityGeneration = securitySession.generation,
+                resolutionStartedAtMs = resolutionStartedAtMs
+            )
         )
         val reelStream = DirectStream(
             url = selection.candidate.url,
@@ -1524,7 +1552,7 @@ class PlaybackResolver private constructor(private val context: Context) {
             manifest = manifest,
             videoSubtitleTracks = videoSubtitleTracks(playerResponse)
         )
-        rememberAndroidReelClientIdentity(reelStream, userAgent, reelClientVersion)
+        rememberClientIdentity(reelStream.manifest)
         return track.withDirectStream(reelStream)
     }
 
@@ -1793,6 +1821,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         sourceVideoUrl: String,
         source: String
     ): Track {
+        rememberClientIdentity(manifest)
         return copy(
             streamUrl = manifest.selectedAudioUrl,
             videoStreamUrl = manifest.selectedVideoUrl,
@@ -2252,6 +2281,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 )
                 val audioCache = key.contains("_audio_", ignoreCase = true)
                 if (track != null && streamUrl.isNotBlank() && now < expiresAt && streamStillFresh(streamUrl) && (!audioCache || isPlayableAudioUrl(streamUrl))) {
+                    manifest?.let(::rememberClientIdentity)
                     streamCache[key] = CachedStream(track, expiresAt)
                 } else {
                     editor.remove(key)
@@ -2397,21 +2427,31 @@ class PlaybackResolver private constructor(private val context: Context) {
 
     private suspend fun verifyDirectAudioUrlFast(
         url: String,
+        identity: YoutubeStreamClientIdentity? = YoutubeStreamClientIdentityRegistry.find(url),
         trustAttestedGoogleVideo: Boolean = true
     ): Boolean {
         if (url.isBlank() || !streamStillFresh(url) || !isDirectAudioUrl(url)) return false
         if (SabrStreamSpec.isSabrUri(url)) return SabrStreamSpec.parse(url) != null
-        if (trustAttestedGoogleVideo && isTrustedGoogleVideoUrl(url) && url.containsQueryParameter("pot")) return true
-        val request = Request.Builder()
+        if (
+            trustAttestedGoogleVideo &&
+            YoutubeStreamCapability.isTrustedGoogleVideoMedia(url) &&
+            url.containsQueryParameter("pot")
+        ) return true
+        val requestBuilder = Request.Builder()
             .url(url)
             .get()
             .header("Range", "bytes=0-8191")
             .header("Accept", "*/*")
             .header("Accept-Encoding", "identity")
-            .header("User-Agent", profiles.first().userAgent)
-            .build()
+        val headers = identity?.mediaRequestHeaders().orEmpty()
+        if (headers.isEmpty()) {
+            requestBuilder.header("User-Agent", effectiveProfiles().firstOrNull()?.userAgent ?: profiles.first().userAgent)
+        } else {
+            headers.forEach { (name, value) -> requestBuilder.header(name, value) }
+        }
+        val request = requestBuilder.build()
         val result = runCatchingPreservingCancellation {
-            streamProbeClient.newCall(request).execute().use { response ->
+            currentStreamProbeClient().newCall(request).execute().use { response ->
                 if (response.code == 403 || response.code == 404 || response.code == 410 || response.code == 416 || response.code == 429) return@use false
                 if (response.code !in 200..299 && response.code != 206) return@use false
                 val contentType = response.header("Content-Type").orEmpty().lowercase()
@@ -2424,12 +2464,23 @@ class PlaybackResolver private constructor(private val context: Context) {
         return result
     }
 
-    private fun isTrustedGoogleVideoUrl(url: String): Boolean {
-        val clean = url.lowercase()
-        if (!clean.startsWith("https://")) return false
-        if (!clean.contains("googlevideo.com/")) return false
-        if (clean.contains("mime=audio%2f") || clean.contains("mime=audio/")) return true
-        return clean.contains("/videoplayback") && !isHlsManifestUrl(clean)
+    private fun currentStreamProbeClient(): OkHttpClient {
+        val generation = LevyraNetworkConfiguration.generation
+        streamProbeClient?.takeIf { streamProbeClientGeneration == generation }?.let { return it }
+        return synchronized(streamProbeClientLock) {
+            streamProbeClient?.takeIf { streamProbeClientGeneration == generation } ?: LevyraHttpClientFactory
+                .streaming(context)
+                .newBuilder()
+                .connectTimeout(450, TimeUnit.MILLISECONDS)
+                .readTimeout(800, TimeUnit.MILLISECONDS)
+                .writeTimeout(350, TimeUnit.MILLISECONDS)
+                .callTimeout(950, TimeUnit.MILLISECONDS)
+                .build()
+                .also {
+                    streamProbeClient = it
+                    streamProbeClientGeneration = generation
+                }
+        }
     }
 
     private fun expiresAtFor(url: String): Long {
@@ -2487,14 +2538,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 RuntimeHooks.hot(RuntimeSignal.HOT_FALLBACK)
                 resolveWithInnerTubeOnce(track, profile, isVideoMode, preferMp4Audio, audioQuality)
             }
-            rememberClientIdentity(
-                stream = stream,
-                clientName = profile.clientName,
-                clientHeaderName = profile.clientHeaderName,
-                clientVersion = profile.clientVersion,
-                userAgent = playerUserAgent(profile),
-                requiresPoToken = profile.requiresPoToken
-            )
+            rememberClientIdentity(stream.manifest)
             playbackSecurity.resetFailureState()
             val latency = elapsedMs(startedAt)
             recordClientSuccess(profile, latency)
@@ -2543,6 +2587,7 @@ class PlaybackResolver private constructor(private val context: Context) {
         preferMp4Audio: Boolean,
         audioQuality: String
     ): DirectStream = withContext(Dispatchers.IO) {
+        val resolutionStartedAtMs = System.currentTimeMillis()
         val sourceVideoId = PlaybackSourceIdentity.sourceVideoId(track)
             .takeIf(youtubeVideoIdRegex::matches)
             ?: throw YoutubePlayerRequestException(null, "Identità video YouTube assente o non valida")
@@ -2589,7 +2634,18 @@ class PlaybackResolver private constructor(private val context: Context) {
         if (profile.clientName == "ANDROID_VR") {
             requestBuilder.header("X-Goog-Api-Format-Version", "2")
         }
-        val request = GoogleApiKeyHeaders.applyTo(requestBuilder, context).build()
+        val request = YoutubeClientIdentityInterceptor.normalize(
+            GoogleApiKeyHeaders.applyTo(requestBuilder, context).build()
+        )
+        val clientIdentity = streamClientIdentity(profile, request, sourceVideoId)
+        fun currentProvenance(): PlaybackStreamProvenance = innerTubeProvenance(
+            profile = profile,
+            request = request,
+            sourceVideoId = sourceVideoId,
+            session = session,
+            poTokens = poTokens,
+            resolutionStartedAtMs = resolutionStartedAtMs
+        )
 
         youtubeHttpClient.newCall(request).execute().use responseUse@{ response ->
             val responseText = response.body.string()
@@ -2652,7 +2708,11 @@ class PlaybackResolver private constructor(private val context: Context) {
                 )
                 if (url.isBlank() || isPlaybackUrlBlocked(url) || !streamStillFresh(url)) continue
                 if (!isVideoMode && !preferMp4Audio &&
-                    !verifyDirectAudioUrlFast(url, trustAttestedGoogleVideo = false)
+                    !verifyDirectAudioUrlFast(
+                        url,
+                        identity = clientIdentity,
+                        trustAttestedGoogleVideo = false
+                    )
                 ) continue
                 bestAudioUrl = url
                 bestAudioLabel = label
@@ -2735,7 +2795,8 @@ class PlaybackResolver private constructor(private val context: Context) {
                             selectedAudioUrl = selection.candidate.url,
                             selectedVideoUrl = "",
                             streams = listOf(videoDescriptor(selection.candidate, true)),
-                            loudness = PlaybackLoudness(loudnessDb, perceptualLoudnessDb)
+                            loudness = PlaybackLoudness(loudnessDb, perceptualLoudnessDb),
+                            provenance = currentProvenance()
                         )
                         DirectStream(
                             url = selection.candidate.url,
@@ -2760,7 +2821,8 @@ class PlaybackResolver private constructor(private val context: Context) {
                                 innerTubeAudioDescriptor(bestAudioFormat, bestAudioUrl, true),
                                 videoDescriptor(selection.candidate, true)
                             ) + sabrAudioStreams + sabrVideoStreams,
-                            loudness = PlaybackLoudness(loudnessDb, perceptualLoudnessDb)
+                            loudness = PlaybackLoudness(loudnessDb, perceptualLoudnessDb),
+                            provenance = currentProvenance()
                         )
                         DirectStream(
                             url = bestAudioUrl,
@@ -2782,7 +2844,8 @@ class PlaybackResolver private constructor(private val context: Context) {
                             selectedAudioUrl = hlsUrl,
                             selectedVideoUrl = "",
                             streams = listOf(hlsDescriptor(hlsUrl)),
-                            loudness = PlaybackLoudness(loudnessDb, perceptualLoudnessDb)
+                            loudness = PlaybackLoudness(loudnessDb, perceptualLoudnessDb),
+                            provenance = currentProvenance()
                         )
                         DirectStream(
                             url = hlsUrl,
@@ -2806,7 +2869,8 @@ class PlaybackResolver private constructor(private val context: Context) {
                             selectedAudioUrl = sabrAudio.url,
                             selectedVideoUrl = sabrVideo.url,
                             streams = sabrAudioStreams + sabrVideoStreams,
-                            loudness = PlaybackLoudness(loudnessDb, perceptualLoudnessDb)
+                            loudness = PlaybackLoudness(loudnessDb, perceptualLoudnessDb),
+                            provenance = currentProvenance()
                         )
                         DirectStream(
                             url = sabrAudio.url,
@@ -2845,7 +2909,8 @@ class PlaybackResolver private constructor(private val context: Context) {
                 selectedAudioUrl = selectedAudioUrl,
                 selectedVideoUrl = "",
                 streams = directAudioStreams + sabrAudioStreams,
-                loudness = PlaybackLoudness(loudnessDb, perceptualLoudnessDb)
+                loudness = PlaybackLoudness(loudnessDb, perceptualLoudnessDb),
+                provenance = currentProvenance()
             )
             DirectStream(
                 url = selectedAudioUrl,
@@ -3261,6 +3326,85 @@ class PlaybackResolver private constructor(private val context: Context) {
             .orEmpty()
     }
 
+    private fun streamClientIdentity(
+        profile: ClientProfile,
+        request: Request,
+        sourceVideoId: String
+    ): YoutubeStreamClientIdentity = YoutubeStreamClientIdentity(
+        clientName = profile.clientName,
+        clientHeaderName = request.header("X-Youtube-Client-Name").orEmpty().ifBlank { profile.clientHeaderName },
+        clientVersion = request.header("X-Youtube-Client-Version").orEmpty().ifBlank { profile.clientVersion },
+        userAgent = request.header("User-Agent").orEmpty().ifBlank { playerUserAgent(profile) },
+        requiresPoToken = profile.requiresPoToken,
+        videoId = sourceVideoId,
+        origin = request.header("Origin").orEmpty(),
+        referer = request.header("Referer").orEmpty()
+    )
+
+    private fun androidReelProvenance(
+        userAgent: String,
+        clientVersion: String,
+        securityGeneration: Long,
+        resolutionStartedAtMs: Long
+    ): PlaybackStreamProvenance {
+        val decoder = YoutubeLocalDecoder.provenanceSnapshot()
+            ?.takeIf { it.decodedAtMs >= resolutionStartedAtMs }
+        return basePlaybackProvenance().copy(
+            clientName = ANDROID_REEL_CLIENT_NAME,
+            clientHeaderName = "3",
+            clientVersion = clientVersion,
+            userAgent = userAgent,
+            playerHash = decoder?.playerHash.orEmpty(),
+            playerConfigIdentity = decoder?.configIdentity.orEmpty(),
+            playerConfigEpoch = decoder?.configEpoch ?: -1L,
+            playerConfigOrigin = decoder?.configOrigin?.name.orEmpty(),
+            securitySessionGeneration = securityGeneration
+        )
+    }
+
+    private fun innerTubeProvenance(
+        profile: ClientProfile,
+        request: Request,
+        sourceVideoId: String,
+        session: YoutubeGuestSession,
+        poTokens: YoutubePoTokens?,
+        resolutionStartedAtMs: Long
+    ): PlaybackStreamProvenance {
+        val identity = streamClientIdentity(profile, request, sourceVideoId)
+        val decoder = YoutubeLocalDecoder.provenanceSnapshot()
+            ?.takeIf { it.decodedAtMs >= resolutionStartedAtMs }
+        return basePlaybackProvenance().copy(
+            clientName = identity.clientName,
+            clientHeaderName = identity.clientHeaderName,
+            clientVersion = identity.clientVersion,
+            userAgent = identity.userAgent,
+            origin = identity.origin,
+            referer = identity.referer,
+            requiresPoToken = identity.requiresPoToken,
+            playerHash = decoder?.playerHash.orEmpty(),
+            playerConfigIdentity = decoder?.configIdentity.orEmpty(),
+            playerConfigEpoch = decoder?.configEpoch ?: -1L,
+            playerConfigOrigin = decoder?.configOrigin?.name.orEmpty(),
+            securitySessionGeneration = poTokens?.sessionGeneration ?: session.generation,
+            poTokenGeneration = poTokens?.runtimeGeneration ?: -1L,
+            expiresAtMs = poTokens?.expiresAtMs ?: 0L
+        )
+    }
+
+    private fun basePlaybackProvenance(): PlaybackStreamProvenance {
+        val settings = LevyraNetworkConfiguration.current()
+        val route = when {
+            settings.usesProxy && settings.bypassProxyForStreams -> "streaming-direct"
+            settings.usesProxy -> "streaming-proxy"
+            else -> "streaming-direct"
+        }
+        return PlaybackStreamProvenance(
+            resolverGeneration = resolverGeneration.get(),
+            networkGeneration = LevyraNetworkConfiguration.generation,
+            networkRoute = route
+        )
+    }
+
     private fun buildManifest(
         sourceVideoId: String,
         provider: String,
@@ -3268,8 +3412,10 @@ class PlaybackResolver private constructor(private val context: Context) {
         selectedAudioUrl: String,
         selectedVideoUrl: String,
         streams: List<PlaybackStreamDescriptor>,
-        loudness: PlaybackLoudness = PlaybackLoudness()
+        loudness: PlaybackLoudness = PlaybackLoudness(),
+        provenance: PlaybackStreamProvenance = basePlaybackProvenance()
     ): ResolvedPlaybackManifest {
+        val resolvedAtMs = System.currentTimeMillis()
         val selectedUrls = setOf(selectedAudioUrl, selectedVideoUrl).filter { it.isNotBlank() }.toSet()
         val normalizedStreams = streams
             .filter { it.url.isNotBlank() }
@@ -3280,17 +3426,25 @@ class PlaybackResolver private constructor(private val context: Context) {
             .mapNotNull { it.expiresAtMs.takeIf { expiry -> expiry > 0L } }
             .minOrNull()
             ?: expiresAtFor(selectedAudioUrl)
+        val provenanceExpiry = listOf(selectedExpiry, provenance.expiresAtMs)
+            .filter { it > 0L }
+            .minOrNull()
+            ?: selectedExpiry
         return ResolvedPlaybackManifest(
             sourceVideoId = sourceVideoId,
             provider = provider,
-            resolvedAtMs = System.currentTimeMillis(),
-            expiresAtMs = selectedExpiry,
+            resolvedAtMs = resolvedAtMs,
+            expiresAtMs = provenanceExpiry,
             durationMs = durationMs,
             selectedAudioUrl = selectedAudioUrl,
             selectedVideoUrl = selectedVideoUrl,
             streams = normalizedStreams,
             loudnessDb = loudness.loudnessDb,
-            perceptualLoudnessDb = loudness.perceptualLoudnessDb
+            perceptualLoudnessDb = loudness.perceptualLoudnessDb,
+            provenance = provenance.copy(
+                resolvedAtMs = resolvedAtMs,
+                expiresAtMs = provenanceExpiry
+            )
         ).compact()
     }
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
@@ -56,6 +56,8 @@ class YoutubeLocalDecoder private constructor(
     private val engine = YoutubeLocalDecoderEngine(context.applicationContext, httpClient)
 
     override fun getPlayerData(videoId: String): YoutubeJavaScriptDecoder.PlayerData {
+        callerProvenance.remove()
+        callerProvenanceConflicted.remove()
         return blocking("player metadata") { engine.playerData() }
     }
 
@@ -64,12 +66,26 @@ class YoutubeLocalDecoder private constructor(
         signatures: MutableList<String>?,
         throttlingParameters: MutableList<String>?
     ): YoutubeApiDecoder.BatchDecodeResult {
-        return blocking("batch decode") {
+        val decoded = blocking("batch decode") {
             engine.decodeBatch(
                 playerId = playerId,
                 signatures = signatures.orEmpty(),
                 throttlingParameters = throttlingParameters.orEmpty()
             )
+        }
+        publishCallerProvenance(decoded.provenance)
+        return decoded.result
+    }
+
+    private fun publishCallerProvenance(provenance: YoutubeDecoderProvenance?) {
+        if (provenance == null || callerProvenanceConflicted.get() == true) return
+        val current = callerProvenance.get()
+        val merged = YoutubeDecoderProvenancePolicy.merge(current, provenance)
+        if (current != null && merged == null) {
+            callerProvenance.remove()
+            callerProvenanceConflicted.set(true)
+        } else if (merged != null) {
+            callerProvenance.set(merged)
         }
     }
 
@@ -105,6 +121,8 @@ class YoutubeLocalDecoder private constructor(
     companion object {
         private const val BLOCKING_TIMEOUT_MS = 7_000L
         private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        private val callerProvenance = ThreadLocal<YoutubeDecoderProvenance?>()
+        private val callerProvenanceConflicted = ThreadLocal<Boolean>()
 
         @Volatile
         private var instance: YoutubeLocalDecoder? = null
@@ -134,7 +152,7 @@ class YoutubeLocalDecoder private constructor(
         }
 
         internal fun provenanceSnapshot(): YoutubeDecoderProvenance? =
-            instance?.engine?.provenanceSnapshot()
+            if (callerProvenanceConflicted.get() == true) null else callerProvenance.get()
 
         fun trimMemory() {
             val decoder = instance ?: return
@@ -156,6 +174,42 @@ internal data class YoutubeDecoderProvenance(
     val decodedAtMs: Long
 )
 
+internal object YoutubeDecoderProvenancePolicy {
+    fun merge(
+        first: YoutubeDecoderProvenance?,
+        second: YoutubeDecoderProvenance?
+    ): YoutubeDecoderProvenance? {
+        if (first == null) return second
+        if (second == null) return first
+        val sameProducer = first.playerHash == second.playerHash &&
+            first.configIdentity == second.configIdentity &&
+            first.configEpoch == second.configEpoch &&
+            first.configOrigin == second.configOrigin
+        if (!sameProducer) return null
+        return if (second.decodedAtMs >= first.decodedAtMs) second else first
+    }
+
+    fun coherent(values: Collection<YoutubeDecoderProvenance>): YoutubeDecoderProvenance? {
+        var merged: YoutubeDecoderProvenance? = null
+        values.forEach { value ->
+            val next = merge(merged, value)
+            if (merged != null && next == null) return null
+            merged = next
+        }
+        return merged
+    }
+}
+
+private data class YoutubeDecoderCallResult(
+    val result: YoutubeApiDecoder.BatchDecodeResult,
+    val provenance: YoutubeDecoderProvenance?
+)
+
+private data class YoutubeCachedDecode(
+    val value: String,
+    val provenance: YoutubeDecoderProvenance
+)
+
 private class YoutubeLocalDecoderEngine(
     private val context: Context,
     httpClient: OkHttpClient
@@ -163,7 +217,7 @@ private class YoutubeLocalDecoderEngine(
     private val configStore = YoutubePlayerConfigStore(context, httpClient)
     private val playerSource = YoutubePlayerJsSource(context, httpClient, configStore)
     private val runtimeMutex = Mutex()
-    private val decodeCache = BoundedStringCache(768)
+    private val decodeCache = BoundedDecodeCache(768)
     @Volatile
     private var decodeCacheEpoch = -1L
     private var runtime: YoutubeCipherWebRuntime? = null
@@ -219,20 +273,24 @@ private class YoutubeLocalDecoderEngine(
         playerId: String,
         signatures: List<String>,
         throttlingParameters: List<String>
-    ): YoutubeApiDecoder.BatchDecodeResult {
+    ): YoutubeDecoderCallResult {
         if (!YoutubePlayerConfigParser.isValidHash(playerId)) {
             throw ParsingException("Invalid YouTube player ID: $playerId")
         }
         val signatureInputs = signatures.filter { it.isNotBlank() }.distinct()
         val nInputs = throttlingParameters.filter { it.isNotBlank() }.distinct()
         if (signatureInputs.isEmpty() && nInputs.isEmpty()) {
-            return YoutubeApiDecoder.BatchDecodeResult(emptyMap(), emptyMap())
+            return YoutubeDecoderCallResult(
+                YoutubeApiDecoder.BatchDecodeResult(emptyMap(), emptyMap()),
+                null
+            )
         }
 
         val signatureResults = LinkedHashMap<String, String>()
         val nResults = LinkedHashMap<String, String>()
         val missingSignatures = ArrayList<String>()
         val missingNs = ArrayList<String>()
+        val provenanceCandidates = ArrayList<YoutubeDecoderProvenance>()
 
         val lookupEpoch = configStore.epoch
         if (decodeCacheEpoch != lookupEpoch) {
@@ -241,11 +299,21 @@ private class YoutubeLocalDecoderEngine(
         }
         signatureInputs.forEach { value ->
             val cached = decodeCache.get(cacheKey(lookupEpoch, playerId, "sig", value))
-            if (cached == null) missingSignatures += value else signatureResults[value] = cached
+            if (cached == null) {
+                missingSignatures += value
+            } else {
+                signatureResults[value] = cached.value
+                provenanceCandidates += cached.provenance
+            }
         }
         nInputs.forEach { value ->
             val cached = decodeCache.get(cacheKey(lookupEpoch, playerId, "n", value))
-            if (cached == null) missingNs += value else nResults[value] = cached
+            if (cached == null) {
+                missingNs += value
+            } else {
+                nResults[value] = cached.value
+                provenanceCandidates += cached.provenance
+            }
         }
 
         if (missingSignatures.isNotEmpty() || missingNs.isNotEmpty()) {
@@ -265,23 +333,33 @@ private class YoutubeLocalDecoderEngine(
                     throw ParsingException("Local decode failed for player $playerId", secondError)
                 }
             }
+            provenanceCandidates += decoded.provenance
             decoded.signatures.forEach { (input, output) ->
                 signatureResults[input] = output
                 if (decoded.configEpoch == configStore.epoch) {
-                    decodeCache.put(cacheKey(decoded.configEpoch, playerId, "sig", input), output)
+                    decodeCache.put(
+                        cacheKey(decoded.configEpoch, playerId, "sig", input),
+                        YoutubeCachedDecode(output, decoded.provenance)
+                    )
                     decodeCacheEpoch = decoded.configEpoch
                 }
             }
             decoded.nValues.forEach { (input, output) ->
                 nResults[input] = output
                 if (decoded.configEpoch == configStore.epoch) {
-                    decodeCache.put(cacheKey(decoded.configEpoch, playerId, "n", input), output)
+                    decodeCache.put(
+                        cacheKey(decoded.configEpoch, playerId, "n", input),
+                        YoutubeCachedDecode(output, decoded.provenance)
+                    )
                     decodeCacheEpoch = decoded.configEpoch
                 }
             }
         }
 
-        return YoutubeApiDecoder.BatchDecodeResult(signatureResults, nResults)
+        return YoutubeDecoderCallResult(
+            result = YoutubeApiDecoder.BatchDecodeResult(signatureResults, nResults),
+            provenance = YoutubeDecoderProvenancePolicy.coherent(provenanceCandidates)
+        )
     }
 
     suspend fun prewarm() {
@@ -306,38 +384,39 @@ private class YoutubeLocalDecoderEngine(
     }
 
     suspend fun onStreamRejected(source: String, expectedConfigIdentity: String?) {
-        val feedbackAt = lastSuccessfulDecodeAtMs.get()
+        val expectedIdentity = expectedConfigIdentity?.takeIf { it.isNotBlank() } ?: return
+        val activeSnapshot = provenanceSnapshot()?.takeIf { it.configIdentity == expectedIdentity }
+        val cachedSnapshot = decodeCache.findProvenanceByConfigIdentity(expectedIdentity)
+        val rejected = activeSnapshot ?: cachedSnapshot ?: return
         val now = System.currentTimeMillis()
-        if (!YoutubeLocalDecoderFeedbackPolicy.shouldRefresh(source, now, feedbackAt)) return
-        if (
-            !expectedConfigIdentity.isNullOrBlank() &&
-            expectedConfigIdentity != lastSuccessfulDecodeConfigIdentity
-        ) return
-        val rejectedHash = lastSuccessfulDecodePlayerHash
-        val rejectedOrigin = lastSuccessfulDecodeOrigin
-        if (
-            rejectedOrigin == YoutubePlayerConfigOrigin.ANALYZED &&
-            rejectedHash.isNotBlank() &&
-            lastSuccessfulDecodeAtMs.get() == feedbackAt
-        ) {
-            val snapshot = provenanceSnapshot()
-            if (snapshot != null) playerSource.rejectAnalyzedConfig(rejectedHash, snapshot.configIdentity)
+        if (!YoutubeLocalDecoderFeedbackPolicy.shouldRefresh(source, now, rejected.decodedAtMs)) return
+        decodeCache.removeByConfigIdentity(expectedIdentity)
+        if (rejected.configOrigin == YoutubePlayerConfigOrigin.ANALYZED) {
+            playerSource.rejectAnalyzedConfig(rejected.playerHash, rejected.configIdentity)
         }
         val refreshResult = configStore.refreshAfterStreamRejection()
         if (refreshResult == YoutubeStreamRefreshResult.CHANGED) {
             decodeCache.clear()
             decodeCacheEpoch = configStore.epoch
         }
+        val activeStillMatches = activeSnapshot != null &&
+            lastSuccessfulDecodeConfigIdentity == expectedIdentity &&
+            lastSuccessfulDecodeAtMs.get() == activeSnapshot.decodedAtMs
         val action = YoutubeStreamRejectionActionPolicy.decide(
             refreshResult,
-            generationMatches = lastSuccessfulDecodeAtMs.get() == feedbackAt
+            generationMatches = activeStillMatches
         )
         if (action.invalidateRuntime) {
             runtimeMutex.withLock {
-                if (lastSuccessfulDecodeAtMs.get() == feedbackAt) invalidateRuntimeLocked()
+                if (
+                    lastSuccessfulDecodeConfigIdentity == expectedIdentity &&
+                    lastSuccessfulDecodeAtMs.get() == activeSnapshot?.decodedAtMs
+                ) {
+                    invalidateRuntimeLocked()
+                }
             }
         }
-        if (action.invalidatePlayerSource && lastSuccessfulDecodeAtMs.get() == feedbackAt) {
+        if (action.invalidatePlayerSource && activeStillMatches) {
             playerSource.invalidate()
         }
     }
@@ -390,18 +469,31 @@ private class YoutubeLocalDecoderEngine(
                     }
                     nValues.forEach { input ->
                         val output = active.transformN(input)
-                        if (output.isBlank()) {
-                            throw YoutubeAnalyzedConfigFailureException("Empty local n-transform result")
+                        if (!YoutubePlayerJsSupport.isValidNTransform(input, output)) {
+                            throw YoutubeAnalyzedConfigFailureException("Invalid local n-transform result")
                         }
                         nResults[input] = output
                     }
-                    lastSuccessfulDecodePlayerHash = player.hash
-                    lastSuccessfulDecodeOrigin = selected.config.origin
-                    lastSuccessfulDecodeConfigIdentity = selected.config.identity
-                    lastSuccessfulDecodeConfigEpoch = runtimeConfigEpoch
-                    lastSuccessfulDecodeAtMs.set(System.currentTimeMillis())
+                    val decodedAtMs = System.currentTimeMillis()
+                    val provenance = YoutubeDecoderProvenance(
+                        playerHash = player.hash,
+                        configIdentity = selected.config.identity,
+                        configEpoch = runtimeConfigEpoch,
+                        configOrigin = selected.config.origin,
+                        decodedAtMs = decodedAtMs
+                    )
+                    lastSuccessfulDecodePlayerHash = provenance.playerHash
+                    lastSuccessfulDecodeOrigin = provenance.configOrigin
+                    lastSuccessfulDecodeConfigIdentity = provenance.configIdentity
+                    lastSuccessfulDecodeConfigEpoch = provenance.configEpoch
+                    lastSuccessfulDecodeAtMs.set(decodedAtMs)
                     rendererRecovery.onSuccess()
-                    YoutubeDecodedBatch(signatureResults, nResults, runtimeConfigEpoch)
+                    YoutubeDecodedBatch(
+                        signatureResults,
+                        nResults,
+                        runtimeConfigEpoch,
+                        provenance
+                    )
                 } catch (error: Throwable) {
                     if (YoutubeRendererFailureClassifier.countsAsRendererFailure(error)) {
                         rendererRecovery.onFailure(recoveryIdentity, SystemClock.elapsedRealtime())
@@ -429,7 +521,8 @@ private class YoutubeLocalDecoderEngine(
     private data class YoutubeDecodedBatch(
         val signatures: Map<String, String>,
         val nValues: Map<String, String>,
-        val configEpoch: Long
+        val configEpoch: Long,
+        val provenance: YoutubeDecoderProvenance
     )
 
     private data class SelectedYoutubeRuntime(
@@ -454,10 +547,9 @@ private class YoutubeLocalDecoderEngine(
             } catch (error: Throwable) {
                 lastFailure = error
                 if (config.origin != YoutubePlayerConfigOrigin.ANALYZED) throw error
-                if (YoutubeRendererFailureClassifier.provesAnalyzedConfigWrong(error)) {
-                    rememberRejectedConfig(config.identity)
-                    playerSource.rejectAnalyzedConfig(player.hash, config.identity)
-                }
+                if (!YoutubeRendererFailureClassifier.provesAnalyzedConfigWrong(error)) throw error
+                rememberRejectedConfig(config.identity)
+                playerSource.rejectAnalyzedConfig(player.hash, config.identity)
             }
         }
         throw lastFailure ?: ParsingException("No player.js candidate available for ${player.hash}")
@@ -482,6 +574,9 @@ private class YoutubeLocalDecoderEngine(
             )
         ) {
             return current
+        }
+        if (current?.isDead == true) {
+            invalidateRuntimeLocked()
         }
         val recoveryIdentity = "${player.hash}:${configStore.epoch}"
         if (!rendererRecovery.shouldAttempt(recoveryIdentity, SystemClock.elapsedRealtime())) {
@@ -1783,19 +1878,35 @@ private class YoutubeCipherWebRuntime private constructor(
     }
 }
 
-private class BoundedStringCache(private val maxEntries: Int) {
-    private val values = object : LinkedHashMap<String, String>(maxEntries, 0.75f, true) {
-        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, String>?): Boolean {
+private class BoundedDecodeCache(private val maxEntries: Int) {
+    private val values = object : LinkedHashMap<String, YoutubeCachedDecode>(maxEntries, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, YoutubeCachedDecode>?): Boolean {
             return size > maxEntries
         }
     }
 
     @Synchronized
-    fun get(key: String): String? = values[key]
+    fun get(key: String): YoutubeCachedDecode? = values[key]
 
     @Synchronized
-    fun put(key: String, value: String) {
+    fun put(key: String, value: YoutubeCachedDecode) {
         values[key] = value
+    }
+
+    @Synchronized
+    fun findProvenanceByConfigIdentity(identity: String): YoutubeDecoderProvenance? =
+        values.values
+            .asSequence()
+            .map { it.provenance }
+            .filter { it.configIdentity == identity }
+            .maxByOrNull { it.decodedAtMs }
+
+    @Synchronized
+    fun removeByConfigIdentity(identity: String) {
+        val iterator = values.entries.iterator()
+        while (iterator.hasNext()) {
+            if (iterator.next().value.provenance.configIdentity == identity) iterator.remove()
+        }
     }
 
     @Synchronized

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
@@ -56,8 +56,7 @@ class YoutubeLocalDecoder private constructor(
     private val engine = YoutubeLocalDecoderEngine(context.applicationContext, httpClient)
 
     override fun getPlayerData(videoId: String): YoutubeJavaScriptDecoder.PlayerData {
-        callerProvenance.remove()
-        callerProvenanceConflicted.remove()
+        clearCallerProvenance()
         return blocking("player metadata") { engine.playerData() }
     }
 
@@ -149,6 +148,11 @@ class YoutubeLocalDecoder private constructor(
                 runCatching { decoder.rejectionInternal(source, expectedConfigIdentity) }
                     .onFailure { Timber.w(it, "Local decoder rejection refresh failed") }
             }
+        }
+
+        internal fun clearCallerProvenance() {
+            callerProvenance.remove()
+            callerProvenanceConflicted.remove()
         }
 
         internal fun provenanceSnapshot(): YoutubeDecoderProvenance? =
@@ -1163,6 +1167,9 @@ private class YoutubePlayerJsSource(
 
     suspend fun rejectAnalyzedConfig(hash: String, identity: String) = mutex.withLock {
         if (identity.isBlank()) return@withLock
+        if (rejectedAnalyzerIdentities.size >= MAX_TRACKED_CONFIG_IDENTITIES) {
+            rejectedAnalyzerIdentities.clear()
+        }
         rejectedAnalyzerIdentities += identity
         if (memory?.hash == hash) {
             memory = memory?.copy(

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
@@ -94,8 +94,8 @@ class YoutubeLocalDecoder private constructor(
         engine.prewarm()
     }
 
-    private suspend fun rejectionInternal(source: String) {
-        engine.onStreamRejected(source)
+    private suspend fun rejectionInternal(source: String, expectedConfigIdentity: String?) {
+        engine.onStreamRejected(source, expectedConfigIdentity)
     }
 
     private suspend fun trimInternal() {
@@ -125,13 +125,16 @@ class YoutubeLocalDecoder private constructor(
             instance?.prewarmInternal()
         }
 
-        fun notifyStreamRejected(source: String) {
+        fun notifyStreamRejected(source: String, expectedConfigIdentity: String? = null) {
             val decoder = instance ?: return
             scope.launch {
-                runCatching { decoder.rejectionInternal(source) }
+                runCatching { decoder.rejectionInternal(source, expectedConfigIdentity) }
                     .onFailure { Timber.w(it, "Local decoder rejection refresh failed") }
             }
         }
+
+        internal fun provenanceSnapshot(): YoutubeDecoderProvenance? =
+            instance?.engine?.provenanceSnapshot()
 
         fun trimMemory() {
             val decoder = instance ?: return
@@ -144,6 +147,14 @@ class YoutubeLocalDecoder private constructor(
 }
 
 private const val MAX_TRACKED_CONFIG_IDENTITIES = 64
+
+internal data class YoutubeDecoderProvenance(
+    val playerHash: String,
+    val configIdentity: String,
+    val configEpoch: Long,
+    val configOrigin: YoutubePlayerConfigOrigin,
+    val decodedAtMs: Long
+)
 
 private class YoutubeLocalDecoderEngine(
     private val context: Context,
@@ -170,6 +181,26 @@ private class YoutubeLocalDecoderEngine(
 
     @Volatile
     private var lastSuccessfulDecodeOrigin = YoutubePlayerConfigOrigin.VALIDATED
+
+    @Volatile
+    private var lastSuccessfulDecodeConfigIdentity = ""
+
+    @Volatile
+    private var lastSuccessfulDecodeConfigEpoch = -1L
+
+    fun provenanceSnapshot(): YoutubeDecoderProvenance? {
+        val decodedAtMs = lastSuccessfulDecodeAtMs.get()
+        val playerHash = lastSuccessfulDecodePlayerHash
+        val configIdentity = lastSuccessfulDecodeConfigIdentity
+        if (decodedAtMs <= 0L || playerHash.isBlank() || configIdentity.isBlank()) return null
+        return YoutubeDecoderProvenance(
+            playerHash = playerHash,
+            configIdentity = configIdentity,
+            configEpoch = lastSuccessfulDecodeConfigEpoch,
+            configOrigin = lastSuccessfulDecodeOrigin,
+            decodedAtMs = decodedAtMs
+        )
+    }
 
     suspend fun playerData(): YoutubeJavaScriptDecoder.PlayerData {
         var player = playerSource.get(forceRefresh = false)
@@ -224,9 +255,7 @@ private class YoutubeLocalDecoderEngine(
                 if (firstError is CancellationException) throw firstError
                 if (firstError is YoutubeRendererBackoffException) throw firstError
                 Timber.w(firstError, "Local decoder first attempt failed for player %s", playerId)
-                invalidateRuntime()
                 configStore.refresh(force = true, reason = "decode-failure")
-                playerSource.invalidate()
                 try {
                     decodeAttempt(playerId, missingSignatures, missingNs, forceRefresh = true)
                 } catch (secondError: Throwable) {
@@ -269,16 +298,21 @@ private class YoutubeLocalDecoderEngine(
             player = playerSource.get(forceRefresh = false)
             config = configStore.configFor(player.configKey, refreshUnknown = false)
         }
-        val resolvedConfig = config ?: player.analyzedConfig ?: return
+        val candidateConfigs = config?.let(::listOf) ?: player.analyzedConfigs
+        if (candidateConfigs.isEmpty()) return
         runtimeMutex.withLock {
-            ensureRuntime(player, resolvedConfig)
+            ensureRuntime(player, candidateConfigs, forceReplace = false)
         }
     }
 
-    suspend fun onStreamRejected(source: String) {
+    suspend fun onStreamRejected(source: String, expectedConfigIdentity: String?) {
         val feedbackAt = lastSuccessfulDecodeAtMs.get()
         val now = System.currentTimeMillis()
         if (!YoutubeLocalDecoderFeedbackPolicy.shouldRefresh(source, now, feedbackAt)) return
+        if (
+            !expectedConfigIdentity.isNullOrBlank() &&
+            expectedConfigIdentity != lastSuccessfulDecodeConfigIdentity
+        ) return
         val rejectedHash = lastSuccessfulDecodePlayerHash
         val rejectedOrigin = lastSuccessfulDecodeOrigin
         if (
@@ -286,7 +320,8 @@ private class YoutubeLocalDecoderEngine(
             rejectedHash.isNotBlank() &&
             lastSuccessfulDecodeAtMs.get() == feedbackAt
         ) {
-            playerSource.rejectAnalyzedConfig(rejectedHash)
+            val snapshot = provenanceSnapshot()
+            if (snapshot != null) playerSource.rejectAnalyzedConfig(rejectedHash, snapshot.configIdentity)
         }
         val refreshResult = configStore.refreshAfterStreamRejection()
         if (refreshResult == YoutubeStreamRefreshResult.CHANGED) {
@@ -331,21 +366,25 @@ private class YoutubeLocalDecoderEngine(
             player = playerSource.get(forceRefresh = false)
             config = configStore.configFor(player.configKey, refreshUnknown = false)
         }
-        val resolvedConfig = config ?: player.analyzedConfig ?: throw ParsingException(
+        val candidateConfigs = config?.let(::listOf) ?: player.analyzedConfigs
+        if (candidateConfigs.isEmpty()) throw ParsingException(
             "No validated or analyzed local config for player $playerId using key ${player.configKey}"
         )
 
+        var selectedConfig: YoutubePlayerCipherConfig? = null
         return try {
             runtimeMutex.withLock {
                 val recoveryIdentity = "${player.hash}:${configStore.epoch}"
                 try {
-                    val active = ensureRuntime(player, resolvedConfig)
+                    val selected = ensureRuntime(player, candidateConfigs, forceReplace = forceRefresh)
+                    val active = selected.runtime
+                    selectedConfig = selected.config
                     val signatureResults = LinkedHashMap<String, String>()
                     val nResults = LinkedHashMap<String, String>()
                     signatures.forEach { input ->
                         val output = active.decodeSignature(input)
-                        if (output.isBlank()) {
-                            throw YoutubeAnalyzedConfigFailureException("Empty local signature result")
+                        if (!YoutubePlayerJsSupport.isValidSignatureTransform(input, output)) {
+                            throw YoutubeAnalyzedConfigFailureException("Invalid local signature result")
                         }
                         signatureResults[input] = output
                     }
@@ -357,7 +396,9 @@ private class YoutubeLocalDecoderEngine(
                         nResults[input] = output
                     }
                     lastSuccessfulDecodePlayerHash = player.hash
-                    lastSuccessfulDecodeOrigin = resolvedConfig.origin
+                    lastSuccessfulDecodeOrigin = selected.config.origin
+                    lastSuccessfulDecodeConfigIdentity = selected.config.identity
+                    lastSuccessfulDecodeConfigEpoch = runtimeConfigEpoch
                     lastSuccessfulDecodeAtMs.set(System.currentTimeMillis())
                     rendererRecovery.onSuccess()
                     YoutubeDecodedBatch(signatureResults, nResults, runtimeConfigEpoch)
@@ -369,11 +410,13 @@ private class YoutubeLocalDecoderEngine(
                 }
             }
         } catch (error: Throwable) {
+            val rejected = selectedConfig
             if (
+                rejected != null &&
                 YoutubeRendererFailureClassifier.provesAnalyzedConfigWrong(error) &&
-                resolvedConfig.origin == YoutubePlayerConfigOrigin.ANALYZED
+                rejected.origin == YoutubePlayerConfigOrigin.ANALYZED
             ) {
-                playerSource.rejectAnalyzedConfig(player.hash)
+                playerSource.rejectAnalyzedConfig(player.hash, rejected.identity)
             }
             throw error
         }
@@ -389,13 +432,45 @@ private class YoutubeLocalDecoderEngine(
         val configEpoch: Long
     )
 
+    private data class SelectedYoutubeRuntime(
+        val runtime: YoutubeCipherWebRuntime,
+        val config: YoutubePlayerCipherConfig
+    )
+
     private suspend fun ensureRuntime(
         player: YoutubePlayerScript,
-        config: YoutubePlayerCipherConfig
+        configs: List<YoutubePlayerCipherConfig>,
+        forceReplace: Boolean
+    ): SelectedYoutubeRuntime {
+        var lastFailure: Throwable? = null
+        configs.forEach { config ->
+            try {
+                return SelectedYoutubeRuntime(
+                    runtime = ensureRuntime(player, config, forceReplace),
+                    config = config
+                )
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                lastFailure = error
+                if (config.origin != YoutubePlayerConfigOrigin.ANALYZED) throw error
+                if (YoutubeRendererFailureClassifier.provesAnalyzedConfigWrong(error)) {
+                    rememberRejectedConfig(config.identity)
+                    playerSource.rejectAnalyzedConfig(player.hash, config.identity)
+                }
+            }
+        }
+        throw lastFailure ?: ParsingException("No player.js candidate available for ${player.hash}")
+    }
+
+    private suspend fun ensureRuntime(
+        player: YoutubePlayerScript,
+        config: YoutubePlayerCipherConfig,
+        forceReplace: Boolean
     ): YoutubeCipherWebRuntime {
         val current = runtime
         if (
-            current != null &&
+            !forceReplace && current != null &&
             YoutubeRuntimeReusePolicy.canReuse(
                 isDead = current.isDead,
                 runtimeHash = runtimeHash,
@@ -408,7 +483,6 @@ private class YoutubeLocalDecoderEngine(
         ) {
             return current
         }
-        invalidateRuntimeLocked()
         val recoveryIdentity = "${player.hash}:${configStore.epoch}"
         if (!rendererRecovery.shouldAttempt(recoveryIdentity, SystemClock.elapsedRealtime())) {
             throw YoutubeRendererBackoffException()
@@ -420,11 +494,14 @@ private class YoutubeLocalDecoderEngine(
         }
         val created = YoutubeCipherWebRuntime.create(context, player, config)
         val verification = verifyConfig(created, config)
-        if (verification.provesConfigWrong) {
+        if (
+            verification.provesConfigWrong ||
+            config.origin == YoutubePlayerConfigOrigin.ANALYZED && verification.verdict != YoutubeConfigVerdict.ACCEPTED
+        ) {
             created.close()
             rememberRejectedConfig(config.identity)
             if (config.origin == YoutubePlayerConfigOrigin.ANALYZED) {
-                playerSource.rejectAnalyzedConfig(player.hash)
+                playerSource.rejectAnalyzedConfig(player.hash, config.identity)
             }
             throw YoutubeAnalyzedConfigFailureException(
                 "Player config verification rejected for ${player.hash}: ${verification.reason}"
@@ -436,11 +513,13 @@ private class YoutubeLocalDecoderEngine(
                 "Player config verification left the runtime dead for ${player.hash}"
             )
         }
+        val previous = runtime
         runtime = created
         runtimeHash = player.hash
         runtimeConfigKey = player.configKey
         runtimeConfigEpoch = configStore.epoch
         runtimeConfigOrigin = config.origin
+        if (previous != null && previous !== created) previous.close()
         return created
     }
 
@@ -484,10 +563,6 @@ private class YoutubeLocalDecoderEngine(
             verification.reason
         )
         return verification
-    }
-
-    private suspend fun invalidateRuntime() {
-        runtimeMutex.withLock { invalidateRuntimeLocked() }
     }
 
     private suspend fun invalidateRuntimeLocked() {
@@ -954,8 +1029,11 @@ private data class YoutubePlayerScript(
     val configKey: String,
     val javascript: String,
     val signatureTimestamp: Int?,
-    val analyzedConfig: YoutubePlayerCipherConfig? = null
-)
+    val analyzedConfigs: List<YoutubePlayerCipherConfig> = emptyList()
+) {
+    val analyzedConfig: YoutubePlayerCipherConfig?
+        get() = analyzedConfigs.firstOrNull()
+}
 
 private class YoutubePlayerJsSource(
     private val context: Context,
@@ -966,7 +1044,7 @@ private class YoutubePlayerJsSource(
     private val diskMutex = Mutex()
     private val cacheDir = File(context.filesDir, "youtube_decoder")
     private val metadataFile = File(cacheDir, "current_player.json")
-    private val rejectedAnalyzers = ConcurrentHashMap.newKeySet<String>()
+    private val rejectedAnalyzerIdentities = ConcurrentHashMap.newKeySet<String>()
 
     @Volatile
     private var memory: YoutubePlayerScript? = null
@@ -988,9 +1066,14 @@ private class YoutubePlayerJsSource(
         player
     }
 
-    suspend fun rejectAnalyzedConfig(hash: String) = mutex.withLock {
-        rejectedAnalyzers += hash
-        if (memory?.hash == hash) memory = memory?.copy(analyzedConfig = null)
+    suspend fun rejectAnalyzedConfig(hash: String, identity: String) = mutex.withLock {
+        if (identity.isBlank()) return@withLock
+        rejectedAnalyzerIdentities += identity
+        if (memory?.hash == hash) {
+            memory = memory?.copy(
+                analyzedConfigs = memory?.analyzedConfigs.orEmpty().filterNot { it.identity == identity }
+            )
+        }
     }
 
     private suspend fun resolvePlayer(
@@ -1000,14 +1083,15 @@ private class YoutubePlayerJsSource(
     ): YoutubePlayerScript {
         val configKey = resolveConfigKey(hash, javascript, refreshUnknown) ?: hash
         val validated = configStore.configFor(configKey, refreshUnknown = false)
-        val analyzed = if (validated == null && hash !in rejectedAnalyzers) {
-            YoutubePlayerJsAnalyzer.analyze(hash, javascript)
+        val analyzed = if (validated == null) {
+            YoutubePlayerJsAnalyzer.analyzeCandidates(hash, javascript)
+                .filterNot { it.identity in rejectedAnalyzerIdentities }
         } else {
-            null
+            emptyList()
         }
         val sts = extractSignatureTimestamp(javascript)
             ?: validated?.signatureTimestamp
-            ?: analyzed?.signatureTimestamp
+            ?: analyzed.firstOrNull()?.signatureTimestamp
         return YoutubePlayerScript(hash, configKey, javascript, sts, analyzed)
     }
 
@@ -1018,17 +1102,16 @@ private class YoutubePlayerJsSource(
         val configKey = resolveConfigKey(player.hash, player.javascript, refreshUnknown) ?: player.hash
         val validated = configStore.configFor(configKey, refreshUnknown = false)
         val analyzed = when {
-            validated != null -> null
-            player.hash in rejectedAnalyzers -> null
-            player.analyzedConfig != null -> player.analyzedConfig
-            else -> YoutubePlayerJsAnalyzer.analyze(player.hash, player.javascript)
-        }
+            validated != null -> emptyList()
+            player.analyzedConfigs.isNotEmpty() -> player.analyzedConfigs
+            else -> YoutubePlayerJsAnalyzer.analyzeCandidates(player.hash, player.javascript)
+        }.filterNot { it.identity in rejectedAnalyzerIdentities }
         return player.copy(
             configKey = configKey,
             signatureTimestamp = extractSignatureTimestamp(player.javascript)
                 ?: validated?.signatureTimestamp
-                ?: analyzed?.signatureTimestamp,
-            analyzedConfig = analyzed
+                ?: analyzed.firstOrNull()?.signatureTimestamp,
+            analyzedConfigs = analyzed
         )
     }
 
@@ -1271,18 +1354,31 @@ internal object YoutubePlayerJsAnalyzer {
     private val safeFunctionName = Regex("^[A-Za-z_$][A-Za-z0-9_$]{0,31}$")
 
     fun analyze(hash: String, javascript: String): YoutubePlayerCipherConfig? {
-        if (!YoutubePlayerConfigParser.isValidHash(hash)) return null
-        val signature = uniqueExpression(javascript, signatureRules) ?: return null
-        val nExpression = uniqueExpression(javascript, nRules) ?: return null
-        val sts = extractSignatureTimestamp(javascript) ?: return null
-        return YoutubePlayerCipherConfig(
-            primaryHash = hash,
-            signatureExpression = signature,
-            nClass = null,
-            signatureTimestamp = sts,
-            nExpressionOverride = nExpression,
-            origin = YoutubePlayerConfigOrigin.ANALYZED
-        )
+        return analyzeCandidates(hash, javascript).singleOrNull()
+    }
+
+    fun analyzeCandidates(hash: String, javascript: String): List<YoutubePlayerCipherConfig> {
+        if (!YoutubePlayerConfigParser.isValidHash(hash)) return emptyList()
+        val signatures = expressions(javascript, signatureRules)
+        val nExpressions = expressions(javascript, nRules)
+        val sts = extractSignatureTimestamp(javascript) ?: return emptyList()
+        if (signatures.isEmpty() || nExpressions.isEmpty()) return emptyList()
+        return signatures.asSequence()
+            .flatMap { signature ->
+                nExpressions.asSequence().map { nExpression ->
+                    YoutubePlayerCipherConfig(
+                        primaryHash = hash,
+                        signatureExpression = signature,
+                        nClass = null,
+                        signatureTimestamp = sts,
+                        nExpressionOverride = nExpression,
+                        origin = YoutubePlayerConfigOrigin.ANALYZED
+                    )
+                }
+            }
+            .distinctBy { it.identity }
+            .take(MAX_CANDIDATES)
+            .toList()
     }
 
     fun extractSignatureTimestamp(javascript: String): Int? {
@@ -1290,15 +1386,15 @@ internal object YoutubePlayerJsAnalyzer {
             ?: looseSts.find(javascript)?.groupValues?.getOrNull(1)?.toIntOrNull()
     }
 
-    private fun uniqueExpression(javascript: String, rules: List<Rule>): String? {
+    private fun expressions(javascript: String, rules: List<Rule>): List<String> {
         val expressions = LinkedHashSet<String>()
         for (rule in rules) {
             rule.regex.findAll(javascript).take(MAX_MATCHES_PER_RULE).forEach { match ->
                 rule.expression(match)?.let(expressions::add)
             }
-            if (expressions.size > 1) return null
+            if (expressions.size >= MAX_EXPRESSIONS_PER_KIND) break
         }
-        return expressions.singleOrNull()
+        return expressions.take(MAX_EXPRESSIONS_PER_KIND)
     }
 
     private fun functionExpression(name: String, rawIndex: String?, input: String): String? {
@@ -1310,6 +1406,8 @@ internal object YoutubePlayerJsAnalyzer {
     private fun safeName(name: String): String? = name.takeIf(safeFunctionName::matches)
 
     private const val MAX_MATCHES_PER_RULE = 4
+    private const val MAX_EXPRESSIONS_PER_KIND = 3
+    private const val MAX_CANDIDATES = 6
 }
 
 internal object YoutubeLocalDecoderFeedbackPolicy {
@@ -1435,6 +1533,10 @@ internal object YoutubePlayerJsSupport {
             .take(8)
     }
 
+    fun isValidSignatureTransform(input: String, output: String): Boolean {
+        return output.isNotBlank() && output != input
+    }
+
     fun isValidNTransform(input: String, output: String): Boolean {
         return output != input && output.length >= 5 && transformedNRegex.matches(output)
     }
@@ -1505,6 +1607,10 @@ private class YoutubeCipherWebRuntime private constructor(
                 webView.evaluateJavascript(script, null)
             }
             val output = withTimeout(EVALUATION_TIMEOUT_MS) { deferred.await() }
+            if (kind == "sig" && !YoutubePlayerJsSupport.isValidSignatureTransform(value, output)) {
+                isDead = true
+                throw YoutubeAnalyzedConfigFailureException("Invalid local signature result")
+            }
             if (kind == "n" && !YoutubePlayerJsSupport.isValidNTransform(value, output)) {
                 isDead = true
                 throw YoutubeAnalyzedConfigFailureException("Invalid local n-transform result")

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
@@ -87,7 +87,10 @@ internal class YoutubePlaybackSecurity private constructor(
     private val appContext = context.applicationContext
     private val prefs = appContext.getSharedPreferences("levyra_youtube_guest", Context.MODE_PRIVATE)
     private val sessionMutex = Mutex()
+    private val sessionStateLock = Any()
+    private val failureStateLock = Any()
     private val failureCount = AtomicInteger(0)
+    private val failureGeneration = AtomicLong(-1L)
     private val tokenGenerator = YoutubeWebPoTokenGenerator(appContext, httpClient)
 
     private val warmScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -114,7 +117,12 @@ internal class YoutubePlaybackSecurity private constructor(
     }
 
     fun cachedSession(): YoutubeGuestSession {
-        return YoutubeGuestSession(
+        YoutubeLocalDecoder.clearCallerProvenance()
+        return readCachedSession()
+    }
+
+    private fun readCachedSession(): YoutubeGuestSession = synchronized(sessionStateLock) {
+        YoutubeGuestSession(
             visitorData = prefs.getString(KEY_VISITOR_DATA, "").orEmpty(),
             generation = prefs.getLong(KEY_GENERATION, 0L)
         )
@@ -130,7 +138,7 @@ internal class YoutubePlaybackSecurity private constructor(
     suspend fun currentSessionRequired(): YoutubeGuestSession = ensureCurrentSession()
 
     private suspend fun ensureCurrentSession(): YoutubeGuestSession = sessionMutex.withLock {
-        val cached = cachedSession()
+        val cached = readCachedSession()
         if (cached.visitorData.isNotBlank()) return@withLock cached
         val fresh = fetchVisitorData()
         persistSession(fresh, cached.generation + 1L)
@@ -138,14 +146,19 @@ internal class YoutubePlaybackSecurity private constructor(
 
     fun observeVisitorData(visitorData: String) {
         if (visitorData.isBlank()) return
-        val current = prefs.getString(KEY_VISITOR_DATA, "").orEmpty()
-        if (current == visitorData) return
-        val generation = prefs.getLong(KEY_GENERATION, 0L) + 1L
-        prefs.edit()
-            .putString(KEY_VISITOR_DATA, visitorData)
-            .putLong(KEY_GENERATION, generation)
-            .putLong(KEY_UPDATED_AT, System.currentTimeMillis())
-            .apply()
+        val changed = synchronized(sessionStateLock) {
+            val current = prefs.getString(KEY_VISITOR_DATA, "").orEmpty()
+            if (current == visitorData) return@synchronized false
+            val generation = prefs.getLong(KEY_GENERATION, 0L) + 1L
+            prefs.edit()
+                .putString(KEY_VISITOR_DATA, visitorData)
+                .putLong(KEY_GENERATION, generation)
+                .putLong(KEY_UPDATED_AT, System.currentTimeMillis())
+                .apply()
+            resetFailureStateForGeneration(generation)
+            true
+        }
+        if (!changed) return
         lastWarmAtMs.set(0L)
         tokenGenerator.invalidate()
     }
@@ -154,11 +167,15 @@ internal class YoutubePlaybackSecurity private constructor(
         require(session.visitorData.isNotBlank()) {
             "PO Token visitor identity is required"
         }
-        return tokenGenerator.playerToken(
-            session.visitorData,
-            session.generation,
-            FULL_WAIT_BUDGET_MS
-        )
+        return try {
+            tokenGenerator.playerToken(
+                session.visitorData,
+                session.generation,
+                FULL_WAIT_BUDGET_MS
+            )
+        } finally {
+            YoutubeLocalDecoder.clearCallerProvenance()
+        }
     }
 
     suspend fun poTokensForPlayback(
@@ -176,41 +193,48 @@ internal class YoutubePlaybackSecurity private constructor(
         if (remainingBudgetMs <= 0L) {
             throw YoutubePoTokenRuntimeUnavailableException("Playback security wait budget exhausted")
         }
-        return tokenGenerator.generate(videoId, session.visitorData, session.generation, remainingBudgetMs)
+        return try {
+            tokenGenerator.generate(videoId, session.visitorData, session.generation, remainingBudgetMs)
+        } finally {
+            YoutubeLocalDecoder.clearCallerProvenance()
+        }
     }
 
     suspend fun rotateIfNeeded(error: Throwable, expectedGeneration: Long? = null): Boolean {
-        if (
-            expectedGeneration != null &&
-            expectedGeneration >= 0L &&
-            cachedSession().generation != expectedGeneration
-        ) {
-            return false
-        }
         val decision = classifyFailure(error)
-        if (!decision.rotate) {
-            if (decision.resetCounter) failureCount.set(0)
-            return false
-        }
-        val attempts = failureCount.incrementAndGet()
-        if (!decision.immediate && attempts < 2) return false
         return sessionMutex.withLock {
+            val session = readCachedSession()
             if (
                 expectedGeneration != null &&
                 expectedGeneration >= 0L &&
-                cachedSession().generation != expectedGeneration
+                session.generation != expectedGeneration
             ) {
                 return@withLock false
             }
+            if (!decision.rotate) {
+                if (decision.resetCounter) resetFailureStateForGeneration(session.generation)
+                return@withLock false
+            }
+            val attempts = recordFailureAttempt(session.generation)
+            if (!decision.immediate && attempts < 2) return@withLock false
             val lastRotation = prefs.getLong(KEY_LAST_ROTATION, 0L)
             val now = System.currentTimeMillis()
             if (now - lastRotation < ROTATION_COOLDOWN_MS) return@withLock false
-            val generation = prefs.getLong(KEY_GENERATION, 0L) + 1L
-            prefs.edit()
-                .remove(KEY_VISITOR_DATA)
-                .putLong(KEY_GENERATION, generation)
-                .putLong(KEY_LAST_ROTATION, now)
-                .apply()
+            val generation = synchronized(sessionStateLock) {
+                val latestGeneration = prefs.getLong(KEY_GENERATION, 0L)
+                if (latestGeneration != session.generation) {
+                    null
+                } else {
+                    val nextGeneration = latestGeneration + 1L
+                    prefs.edit()
+                        .remove(KEY_VISITOR_DATA)
+                        .putLong(KEY_GENERATION, nextGeneration)
+                        .putLong(KEY_LAST_ROTATION, now)
+                        .apply()
+                    resetFailureStateForGeneration(nextGeneration)
+                    nextGeneration
+                }
+            } ?: return@withLock false
             lastWarmAtMs.set(0L)
             tokenGenerator.invalidate()
             val fresh = try {
@@ -222,12 +246,24 @@ internal class YoutubePlaybackSecurity private constructor(
                 ""
             }
             if (fresh.isNotBlank()) persistSession(fresh, generation)
-            failureCount.set(0)
             true
         }
     }
 
     fun resetFailureState() {
+        resetFailureStateForGeneration(readCachedSession().generation)
+    }
+
+    private fun recordFailureAttempt(generation: Long): Int = synchronized(failureStateLock) {
+        if (failureGeneration.get() != generation) {
+            failureGeneration.set(generation)
+            failureCount.set(0)
+        }
+        failureCount.incrementAndGet()
+    }
+
+    private fun resetFailureStateForGeneration(generation: Long) = synchronized(failureStateLock) {
+        failureGeneration.set(generation)
         failureCount.set(0)
     }
 
@@ -257,12 +293,22 @@ internal class YoutubePlaybackSecurity private constructor(
     }
 
     private fun persistSession(visitorData: String, generation: Long): YoutubeGuestSession {
-        prefs.edit()
-            .putString(KEY_VISITOR_DATA, visitorData)
-            .putLong(KEY_GENERATION, generation)
-            .putLong(KEY_UPDATED_AT, System.currentTimeMillis())
-            .apply()
-        return YoutubeGuestSession(visitorData, generation)
+        return synchronized(sessionStateLock) {
+            val currentGeneration = prefs.getLong(KEY_GENERATION, 0L)
+            if (currentGeneration > generation) {
+                return@synchronized YoutubeGuestSession(
+                    prefs.getString(KEY_VISITOR_DATA, "").orEmpty(),
+                    currentGeneration
+                )
+            }
+            prefs.edit()
+                .putString(KEY_VISITOR_DATA, visitorData)
+                .putLong(KEY_GENERATION, generation)
+                .putLong(KEY_UPDATED_AT, System.currentTimeMillis())
+                .apply()
+            resetFailureStateForGeneration(generation)
+            YoutubeGuestSession(visitorData, generation)
+        }
     }
 
     private fun classifyFailure(error: Throwable): RotationDecision {

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
@@ -62,7 +62,10 @@ internal data class YoutubeGuestSession(
 
 internal data class YoutubePoTokens(
     val playerToken: String,
-    val streamingToken: String
+    val streamingToken: String,
+    val sessionGeneration: Long,
+    val runtimeGeneration: Long,
+    val expiresAtMs: Long
 )
 
 internal class YoutubePlayerRequestException(
@@ -176,7 +179,14 @@ internal class YoutubePlaybackSecurity private constructor(
         return tokenGenerator.generate(videoId, session.visitorData, session.generation, remainingBudgetMs)
     }
 
-    suspend fun rotateIfNeeded(error: Throwable): Boolean {
+    suspend fun rotateIfNeeded(error: Throwable, expectedGeneration: Long? = null): Boolean {
+        if (
+            expectedGeneration != null &&
+            expectedGeneration >= 0L &&
+            cachedSession().generation != expectedGeneration
+        ) {
+            return false
+        }
         val decision = classifyFailure(error)
         if (!decision.rotate) {
             if (decision.resetCounter) failureCount.set(0)
@@ -185,6 +195,13 @@ internal class YoutubePlaybackSecurity private constructor(
         val attempts = failureCount.incrementAndGet()
         if (!decision.immediate && attempts < 2) return false
         return sessionMutex.withLock {
+            if (
+                expectedGeneration != null &&
+                expectedGeneration >= 0L &&
+                cachedSession().generation != expectedGeneration
+            ) {
+                return@withLock false
+            }
             val lastRotation = prefs.getLong(KEY_LAST_ROTATION, 0L)
             val now = System.currentTimeMillis()
             if (now - lastRotation < ROTATION_COOLDOWN_MS) return@withLock false
@@ -434,7 +451,13 @@ private class YoutubeWebPoTokenGenerator(
             streamingToken = ready.runtime.generate(videoId)
         }
         refreshAheadIfStale(session, visitorData, generation)
-        return YoutubePoTokens(playerToken = ready.playerToken, streamingToken = streamingToken)
+        return YoutubePoTokens(
+            playerToken = ready.playerToken,
+            streamingToken = streamingToken,
+            sessionGeneration = generation,
+            runtimeGeneration = session.version,
+            expiresAtMs = ready.runtime.validUntilMs
+        )
     }
 
     private suspend fun awaitBuild(session: PoTokenSession): ReadyPoTokenRuntime {
@@ -482,7 +505,13 @@ private class YoutubeWebPoTokenGenerator(
         val cached = ready.runtime.cachedToken(videoId) ?: return null
         return CachedPoTokens(
             session = current,
-            tokens = YoutubePoTokens(playerToken = ready.playerToken, streamingToken = cached)
+            tokens = YoutubePoTokens(
+                playerToken = ready.playerToken,
+                streamingToken = cached,
+                sessionGeneration = generation,
+                runtimeGeneration = current.version,
+                expiresAtMs = ready.runtime.validUntilMs
+            )
         )
     }
 
@@ -871,6 +900,9 @@ internal class YoutubePoTokenRuntime private constructor(
 
     val isExpired: Boolean
         get() = closed.get() || dead.get() || expiresAtMs <= System.currentTimeMillis()
+
+    val validUntilMs: Long
+        get() = expiresAtMs
 
     val isStale: Boolean
         get() = isExpired || refreshAtMs <= System.currentTimeMillis()

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlaybackSecurity.kt
@@ -295,11 +295,14 @@ internal class YoutubePlaybackSecurity private constructor(
     private fun persistSession(visitorData: String, generation: Long): YoutubeGuestSession {
         return synchronized(sessionStateLock) {
             val currentGeneration = prefs.getLong(KEY_GENERATION, 0L)
-            if (currentGeneration > generation) {
-                return@synchronized YoutubeGuestSession(
-                    prefs.getString(KEY_VISITOR_DATA, "").orEmpty(),
-                    currentGeneration
-                )
+            val currentVisitorData = prefs.getString(KEY_VISITOR_DATA, "").orEmpty()
+            if (
+                currentGeneration > generation ||
+                currentGeneration == generation &&
+                    currentVisitorData.isNotBlank() &&
+                    currentVisitorData != visitorData
+            ) {
+                return@synchronized YoutubeGuestSession(currentVisitorData, currentGeneration)
             }
             prefs.edit()
                 .putString(KEY_VISITOR_DATA, visitorData)

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeStreamCapability.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeStreamCapability.kt
@@ -1,22 +1,24 @@
 package com.luc4n3x.levyra.data
 
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+
 internal object YoutubeStreamCapability {
     fun servesCompleteStream(url: String): Boolean {
         if (url.isBlank()) return false
         val lower = url.lowercase()
-        if (!isGoogleVideoMedia(lower)) return true
+        if (!isTrustedGoogleVideoMedia(url)) return true
         if (queryParameter(lower, "ratebypass") == "yes") return true
         return !queryParameter(lower, "pot").isNullOrBlank()
     }
 
-    private fun isGoogleVideoMedia(lowerUrl: String): Boolean {
-        if (!lowerUrl.startsWith("https://")) return false
-        val authority = lowerUrl.substringAfter("https://").substringBefore('/')
-        val host = authority.substringBefore(':')
+    fun isTrustedGoogleVideoMedia(url: String): Boolean {
+        val parsed = url.toHttpUrlOrNull() ?: return false
+        if (parsed.scheme != "https" || parsed.port != 443) return false
+        if (parsed.username.isNotEmpty() || parsed.password.isNotEmpty()) return false
+        val host = parsed.host.lowercase()
         if (host != "googlevideo.com" && !host.endsWith(".googlevideo.com")) return false
-        if (isManifestUrl(lowerUrl)) return false
-        val path = lowerUrl.substringAfter("https://$authority").substringBefore('?').substringBefore('#')
-        return path.contains("videoplayback")
+        if (isManifestUrl(url.lowercase())) return false
+        return parsed.encodedPath.split('/').any { it == "videoplayback" }
     }
 
     private fun isManifestUrl(lowerUrl: String): Boolean {

--- a/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeStreamClientIdentity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeStreamClientIdentity.kt
@@ -19,11 +19,7 @@ internal data class YoutubeStreamClientIdentity(
             "Accept" to "*/*",
             "Accept-Encoding" to "identity"
         )
-        val navigation = if (origin.isNotBlank() && referer.isNotBlank()) {
-            YoutubeClientIdentityInterceptor.MediaNavigation(origin, referer)
-        } else {
-            YoutubeClientIdentityInterceptor.mediaNavigationFor(clientHeaderName, videoId)
-        }
+        val navigation = YoutubeClientIdentityInterceptor.mediaNavigationFor(clientHeaderName, videoId)
         if (navigation != null) {
             headers["Origin"] = navigation.origin
             headers["Referer"] = navigation.referer

--- a/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeStreamClientIdentity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/network/YoutubeStreamClientIdentity.kt
@@ -8,7 +8,10 @@ internal data class YoutubeStreamClientIdentity(
     val clientVersion: String,
     val userAgent: String,
     val requiresPoToken: Boolean,
-    val videoId: String = ""
+    val videoId: String = "",
+    val origin: String = "",
+    val referer: String = "",
+    val expiresAtMs: Long = 0L
 ) {
     fun mediaRequestHeaders(): Map<String, String> {
         val headers = linkedMapOf(
@@ -16,7 +19,11 @@ internal data class YoutubeStreamClientIdentity(
             "Accept" to "*/*",
             "Accept-Encoding" to "identity"
         )
-        val navigation = YoutubeClientIdentityInterceptor.mediaNavigationFor(clientHeaderName, videoId)
+        val navigation = if (origin.isNotBlank() && referer.isNotBlank()) {
+            YoutubeClientIdentityInterceptor.MediaNavigation(origin, referer)
+        } else {
+            YoutubeClientIdentityInterceptor.mediaNavigationFor(clientHeaderName, videoId)
+        }
         if (navigation != null) {
             headers["Origin"] = navigation.origin
             headers["Referer"] = navigation.referer
@@ -36,6 +43,7 @@ internal object YoutubeStreamClientIdentityRegistry {
             eldest: MutableMap.MutableEntry<String, YoutubeStreamClientIdentity>
         ): Boolean = size > MAX_ENTRIES
     }
+    private val ambiguousMediaKeys = LinkedHashSet<String>()
 
     fun register(urls: Collection<String>, identity: YoutubeStreamClientIdentity) {
         val keys = urls.asSequence()
@@ -44,21 +52,45 @@ internal object YoutubeStreamClientIdentityRegistry {
             .toList()
         if (keys.isEmpty()) return
         synchronized(entries) {
-            keys.forEach { entries[it] = identity }
+            keys.forEach { key ->
+                if (!key.startsWith("media\u0000")) {
+                    entries[key] = identity
+                } else if (key !in ambiguousMediaKeys) {
+                    val existing = entries[key]
+                    if (existing == null || existing == identity) {
+                        entries[key] = identity
+                    } else {
+                        entries.remove(key)
+                        if (ambiguousMediaKeys.size >= MAX_ENTRIES) ambiguousMediaKeys.clear()
+                        ambiguousMediaKeys += key
+                    }
+                }
+            }
         }
     }
 
     fun find(url: String): YoutubeStreamClientIdentity? {
         if (url.isBlank()) return null
         val keys = keysFor(url)
+        val nowMs = System.currentTimeMillis()
         synchronized(entries) {
-            keys.forEach { key -> entries[key]?.let { return it } }
+            keys.forEach { key ->
+                val identity = entries[key] ?: return@forEach
+                if (identity.expiresAtMs > 0L && identity.expiresAtMs <= nowMs) {
+                    entries.remove(key)
+                } else {
+                    return identity
+                }
+            }
         }
         return null
     }
 
     fun clear() {
-        synchronized(entries) { entries.clear() }
+        synchronized(entries) {
+            entries.clear()
+            ambiguousMediaKeys.clear()
+        }
     }
 
     private fun keysFor(url: String): List<String> {

--- a/app/src/main/java/com/luc4n3x/levyra/domain/PlaybackManifest.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/PlaybackManifest.kt
@@ -15,6 +15,27 @@ enum class PlaybackDeliveryMethod {
     UNKNOWN
 }
 
+data class PlaybackStreamProvenance(
+    val clientName: String = "",
+    val clientHeaderName: String = "",
+    val clientVersion: String = "",
+    val userAgent: String = "",
+    val origin: String = "",
+    val referer: String = "",
+    val requiresPoToken: Boolean = false,
+    val resolverGeneration: Long = -1L,
+    val playerHash: String = "",
+    val playerConfigIdentity: String = "",
+    val playerConfigEpoch: Long = -1L,
+    val playerConfigOrigin: String = "",
+    val securitySessionGeneration: Long = -1L,
+    val poTokenGeneration: Long = -1L,
+    val networkGeneration: Long = -1L,
+    val networkRoute: String = "",
+    val resolvedAtMs: Long = 0L,
+    val expiresAtMs: Long = 0L
+)
+
 data class PlaybackStreamDescriptor(
     val url: String,
     val kind: PlaybackStreamKind,
@@ -69,7 +90,8 @@ data class ResolvedPlaybackManifest(
     val selectedVideoUrl: String,
     val streams: List<PlaybackStreamDescriptor>,
     val loudnessDb: Float? = null,
-    val perceptualLoudnessDb: Float? = null
+    val perceptualLoudnessDb: Float? = null,
+    val provenance: PlaybackStreamProvenance? = null
 ) {
     val isMuxed: Boolean
         get() = selectedAudioUrl.isNotBlank() && selectedVideoUrl.isBlank() &&

--- a/app/src/test/java/com/luc4n3x/levyra/data/DirectAudioFallbackContractTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/DirectAudioFallbackContractTest.kt
@@ -34,10 +34,14 @@ class DirectAudioFallbackContractTest {
         val loop = resolver.indexOf("for ((format, _, label) in audioCandidates)", candidates)
         val assignment = resolver.indexOf("bestAudioUrl = url", loop)
         val candidateProbe = resolver.substring(loop, assignment)
+        val normalizedProbe = candidateProbe.replace(Regex("\\s+"), " ")
 
-        assertTrue(candidateProbe.contains("if (!isVideoMode && !preferMp4Audio &&"))
-        assertTrue(candidateProbe.contains("identity = clientIdentity"))
-        assertTrue(candidateProbe.contains("trustAttestedGoogleVideo = false"))
+        assertTrue(
+            normalizedProbe.contains(
+                "if (!isVideoMode && !preferMp4Audio && !verifyDirectAudioUrlFast( " +
+                    "url, identity = clientIdentity, trustAttestedGoogleVideo = false ) ) continue"
+            )
+        )
         assertTrue(resolver.contains("trustAttestedGoogleVideo: Boolean = true"))
     }
 

--- a/app/src/test/java/com/luc4n3x/levyra/data/DirectAudioFallbackContractTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/DirectAudioFallbackContractTest.kt
@@ -12,29 +12,32 @@ class DirectAudioFallbackContractTest {
         val function = resolver.indexOf("private suspend fun resolveWithInnerTubeOnce")
         val candidates = resolver.indexOf("val audioCandidates = buildList", function)
         val loop = resolver.indexOf("for ((format, _, label) in audioCandidates)", candidates)
-        val strictProbe = resolver.indexOf(
-            "!verifyDirectAudioUrlFast(url, trustAttestedGoogleVideo = false)",
-            loop
-        )
+        val strictProbe = resolver.indexOf("!verifyDirectAudioUrlFast(", loop)
+        val identity = resolver.indexOf("identity = clientIdentity", strictProbe)
+        val strictValidation = resolver.indexOf("trustAttestedGoogleVideo = false", identity)
         val assignment = resolver.indexOf("bestAudioUrl = url", loop)
 
         assertTrue(function >= 0)
         assertTrue(candidates > function)
         assertTrue(loop > candidates)
         assertTrue(strictProbe > loop)
-        assertTrue(assignment > strictProbe)
+        assertTrue(identity > strictProbe)
+        assertTrue(strictValidation > identity)
+        assertTrue(assignment > strictValidation)
     }
 
     @Test
     fun strictCandidateProbeIsLimitedToNormalAudioFallback() {
         val resolver = readSource("data/PlaybackResolver.kt")
+        val function = resolver.indexOf("private suspend fun resolveWithInnerTubeOnce")
+        val candidates = resolver.indexOf("val audioCandidates = buildList", function)
+        val loop = resolver.indexOf("for ((format, _, label) in audioCandidates)", candidates)
+        val assignment = resolver.indexOf("bestAudioUrl = url", loop)
+        val candidateProbe = resolver.substring(loop, assignment)
 
-        assertTrue(
-            resolver.contains(
-                "if (!isVideoMode && !preferMp4Audio &&\n" +
-                    "                    !verifyDirectAudioUrlFast(url, trustAttestedGoogleVideo = false)"
-            )
-        )
+        assertTrue(candidateProbe.contains("if (!isVideoMode && !preferMp4Audio &&"))
+        assertTrue(candidateProbe.contains("identity = clientIdentity"))
+        assertTrue(candidateProbe.contains("trustAttestedGoogleVideo = false"))
         assertTrue(resolver.contains("trustAttestedGoogleVideo: Boolean = true"))
     }
 

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackFailureClassificationTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackFailureClassificationTest.kt
@@ -59,7 +59,7 @@ class PlaybackFailureClassificationTest {
         assertEquals(PlaybackFailureKind.Forbidden, classifyPlaybackFailureReason("HTTP 403"))
         assertEquals(PlaybackFailureKind.Gone, classifyPlaybackFailureReason("HTTP 410"))
         assertEquals(PlaybackFailureKind.RateLimited, classifyPlaybackFailureReason("HTTP 429"))
-        assertEquals(PlaybackFailureKind.Signature, classifyPlaybackFailureReason("PO Token rejected"))
+        assertEquals(PlaybackFailureKind.PoToken, classifyPlaybackFailureReason("PO Token rejected"))
     }
 
     @Test
@@ -110,7 +110,7 @@ class PlaybackFailureClassificationTest {
         listOf(PlaybackFailureKind.Network, PlaybackFailureKind.Timeout).forEach { kind ->
             val plan = playbackRecoveryPlanFor(kind)
             assertTrue(plan.invalidateStream)
-            assertTrue(plan.rotateClient)
+            assertFalse(plan.rotateClient)
             assertFalse(plan.rotateCodec)
             assertFalse(plan.refreshSecurity)
             assertFalse(plan.invalidateCache)
@@ -122,7 +122,7 @@ class PlaybackFailureClassificationTest {
     fun expiredAndRejectedUrlsUseFreshResolutionWithBoundedQuarantine() {
         val expired = playbackRecoveryPlanFor(PlaybackFailureKind.ExpiredUrl)
         assertTrue(expired.invalidateStream)
-        assertTrue(expired.rotateClient)
+        assertFalse(expired.rotateClient)
         assertFalse(expired.rotateCodec)
         assertFalse(expired.refreshSecurity)
         assertFalse(expired.invalidateCache)
@@ -131,11 +131,43 @@ class PlaybackFailureClassificationTest {
         listOf(PlaybackFailureKind.Forbidden, PlaybackFailureKind.Gone).forEach { kind ->
             val plan = playbackRecoveryPlanFor(kind)
             assertTrue(plan.invalidateStream)
-            assertTrue(plan.rotateClient)
-            assertTrue(plan.refreshSecurity)
+            assertFalse(plan.rotateClient)
+            assertFalse(plan.refreshSecurity)
             assertFalse(plan.invalidateCache)
             assertEquals(10L * 60L * 1000L, plan.quarantineMs)
         }
+    }
+
+    @Test
+    fun recoveryInvalidatesOnlyTheAttributedLayer() {
+        listOf(PlaybackFailureKind.Signature, PlaybackFailureKind.NTransform, PlaybackFailureKind.Renderer)
+            .forEach { kind ->
+                val plan = playbackRecoveryPlanFor(kind)
+                assertTrue(plan.refreshDecoder)
+                assertFalse(plan.refreshSecurity)
+                assertFalse(plan.rotateClient)
+                assertFalse(plan.refreshClientPolicy)
+            }
+
+        val poToken = playbackRecoveryPlanFor(PlaybackFailureKind.PoToken)
+        assertTrue(poToken.refreshSecurity)
+        assertFalse(poToken.refreshDecoder)
+        assertFalse(poToken.rotateClient)
+
+        val client = playbackRecoveryPlanFor(PlaybackFailureKind.ClientRejected)
+        assertTrue(client.rotateClient)
+        assertTrue(client.refreshClientPolicy)
+        assertFalse(client.refreshSecurity)
+        assertFalse(client.refreshDecoder)
+    }
+
+    @Test
+    fun decoderSecurityAndClientFailuresRemainDistinct() {
+        assertEquals(PlaybackFailureKind.Signature, classifyPlaybackFailureReason("signature decode failed"))
+        assertEquals(PlaybackFailureKind.NTransform, classifyPlaybackFailureReason("n-transform unchanged"))
+        assertEquals(PlaybackFailureKind.PoToken, classifyPlaybackFailureReason("potoken rejected"))
+        assertEquals(PlaybackFailureKind.ClientRejected, classifyPlaybackFailureReason("invalid client profile"))
+        assertEquals(PlaybackFailureKind.Renderer, classifyPlaybackFailureReason("WebView renderer process gone"))
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackManifestCodecTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackManifestCodecTest.kt
@@ -3,6 +3,7 @@ package com.luc4n3x.levyra.data
 import com.luc4n3x.levyra.domain.PlaybackDeliveryMethod
 import com.luc4n3x.levyra.domain.PlaybackStreamDescriptor
 import com.luc4n3x.levyra.domain.PlaybackStreamKind
+import com.luc4n3x.levyra.domain.PlaybackStreamProvenance
 import com.luc4n3x.levyra.domain.ResolvedPlaybackManifest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -52,6 +53,26 @@ class PlaybackManifestCodecTest {
                     expiresAtMs = now + 3_600_000L,
                     selected = true
                 )
+            ),
+            provenance = PlaybackStreamProvenance(
+                clientName = "WEB",
+                clientHeaderName = "1",
+                clientVersion = "2.20260904.01.00",
+                userAgent = "effective-agent",
+                origin = "https://www.youtube.com",
+                referer = "https://www.youtube.com/",
+                requiresPoToken = true,
+                resolverGeneration = 4L,
+                playerHash = "f572e43c",
+                playerConfigIdentity = "f572e43c:config",
+                playerConfigEpoch = 7L,
+                playerConfigOrigin = "ANALYZED",
+                securitySessionGeneration = 8L,
+                poTokenGeneration = 9L,
+                networkGeneration = 10L,
+                networkRoute = "streaming-direct",
+                resolvedAtMs = now,
+                expiresAtMs = now + 3_600_000L
             )
         )
 
@@ -63,7 +84,18 @@ class PlaybackManifestCodecTest {
         assertEquals(manifest.selectedVideoUrl, decoded.selectedVideoUrl)
         assertEquals("opus", decoded.streams.first { it.kind == PlaybackStreamKind.AUDIO }.codec)
         assertEquals(1080, decoded.streams.first { it.kind == PlaybackStreamKind.VIDEO }.height)
+        assertEquals(manifest.provenance, decoded.provenance)
         assertTrue(decoded.isFresh(now))
+    }
+
+    @Test
+    fun schemaOneManifestRemainsReadableWithoutProvenance() {
+        val decoded = PlaybackManifestCodec.decode(
+            """{"schemaVersion":1,"sourceVideoId":"dQw4w9WgXcQ","provider":"YouTube","resolvedAtMs":1,"expiresAtMs":2,"durationMs":3,"selectedAudioUrl":"https://r1.googlevideo.com/videoplayback","selectedVideoUrl":"","streams":[{"url":"https://r1.googlevideo.com/videoplayback","kind":"AUDIO","deliveryMethod":"PROGRESSIVE","selected":true}]}"""
+        )
+
+        requireNotNull(decoded)
+        assertEquals(null, decoded.provenance)
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeLocalDecoderTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeLocalDecoderTest.kt
@@ -487,6 +487,24 @@ class YoutubeLocalDecoderTest {
     }
 
     @Test
+    fun provenanceMergeKeepsOnlyOneCausalDecoderProducer() {
+        val first = YoutubeDecoderProvenance(
+            playerHash = "2182a2cc",
+            configIdentity = "config-a",
+            configEpoch = 7L,
+            configOrigin = YoutubePlayerConfigOrigin.ANALYZED,
+            decodedAtMs = 100L
+        )
+        val newer = first.copy(decodedAtMs = 200L)
+        val other = first.copy(configIdentity = "config-b", decodedAtMs = 300L)
+
+        assertEquals(newer, YoutubeDecoderProvenancePolicy.merge(first, newer))
+        assertEquals(null, YoutubeDecoderProvenancePolicy.merge(first, other))
+        assertEquals(newer, YoutubeDecoderProvenancePolicy.coherent(listOf(first, newer)))
+        assertEquals(null, YoutubeDecoderProvenancePolicy.coherent(listOf(first, other)))
+    }
+
+    @Test
     fun streamRejectionSkippedOrNetworkFailureNeverInvalidatesPlayerSource() {
         val skipped = YoutubeStreamRejectionActionPolicy.decide(
             YoutubeStreamRefreshResult.SKIPPED,

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeLocalDecoderTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeLocalDecoderTest.kt
@@ -151,6 +151,13 @@ class YoutubeLocalDecoderTest {
     }
 
     @Test
+    fun rejectsUnchangedRealSignatureOutput() {
+        assertTrue(YoutubePlayerJsSupport.isValidSignatureTransform("abcdef", "fedcba"))
+        assertFalse(YoutubePlayerJsSupport.isValidSignatureTransform("abcdef", "abcdef"))
+        assertFalse(YoutubePlayerJsSupport.isValidSignatureTransform("abcdef", ""))
+    }
+
+    @Test
     fun extractsPlayerHashFromEscapedIframeApiResponse() {
         val hash = YoutubePlayerJsSupport.extractPlayerHash(
             "var x={player_js_url:\"\\/s\\/player\\/2182a2cc\\/www-widgetapi.vflset\\/www-widgetapi.js\"};"
@@ -311,6 +318,22 @@ class YoutubeLocalDecoderTest {
         """.trimIndent()
 
         assertEquals(null, YoutubePlayerJsAnalyzer.analyze("2182a2cc", javascript))
+    }
+
+    @Test
+    fun automaticAnalyzerSurfacesAmbiguousCandidatesForRuntimeVerification() {
+        val javascript = """
+            x&&(y=Ab(4,decodeURIComponent(z)));
+            q&&(r=Cd(5,decodeURIComponent(s)));
+            a.get("n"))&&(b=Nz[2](b));
+            var cfg={signatureTimestamp:20644};
+        """.trimIndent()
+
+        val candidates = YoutubePlayerJsAnalyzer.analyzeCandidates("2182a2cc", javascript)
+
+        assertEquals(2, candidates.size)
+        assertEquals(listOf("Ab(4,INPUT)", "Cd(5,INPUT)"), candidates.map { it.signatureExpression })
+        assertTrue(candidates.all { it.nExpression == "Nz[2](INPUT)" })
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlaybackConcurrencyContractTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlaybackConcurrencyContractTest.kt
@@ -48,6 +48,21 @@ class YoutubePlaybackConcurrencyContractTest {
     }
 
     @Test
+    fun sameGenerationVisitorCannotBeOverwrittenByLateFetch() {
+        val security = readSource("data/YoutubePlaybackSecurity.kt")
+        val persist = security.substring(
+            security.indexOf("private fun persistSession("),
+            security.indexOf("private fun classifyFailure(")
+        )
+
+        assertTrue(persist.contains("val currentVisitorData = prefs.getString(KEY_VISITOR_DATA"))
+        assertTrue(persist.contains("currentGeneration == generation"))
+        assertTrue(persist.contains("currentVisitorData.isNotBlank()"))
+        assertTrue(persist.contains("currentVisitorData != visitorData"))
+        assertTrue(persist.indexOf("return@synchronized") < persist.indexOf("prefs.edit()"))
+    }
+
+    @Test
     fun rejectedAnalyzerIdentityTrackingRemainsBounded() {
         val decoder = readSource("data/YoutubeLocalDecoder.kt")
         val reject = decoder.substring(

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlaybackConcurrencyContractTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlaybackConcurrencyContractTest.kt
@@ -1,0 +1,71 @@
+package com.luc4n3x.levyra.data
+
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class YoutubePlaybackConcurrencyContractTest {
+    @Test
+    fun decoderCallerProvenanceIsResetAtResolutionSecurityBoundaries() {
+        val decoder = readSource("data/YoutubeLocalDecoder.kt")
+        val security = readSource("data/YoutubePlaybackSecurity.kt")
+
+        assertTrue(decoder.contains("internal fun clearCallerProvenance()"))
+
+        val cachedSession = security.substring(
+            security.indexOf("fun cachedSession()"),
+            security.indexOf("private fun readCachedSession()")
+        )
+        assertTrue(cachedSession.contains("YoutubeLocalDecoder.clearCallerProvenance()"))
+
+        val poTokens = security.substring(
+            security.indexOf("suspend fun poTokensForPlayback("),
+            security.indexOf("suspend fun rotateIfNeeded(")
+        )
+        assertTrue(poTokens.contains("finally"))
+        assertTrue(poTokens.contains("YoutubeLocalDecoder.clearCallerProvenance()"))
+    }
+
+    @Test
+    fun securityFailureAttemptsAreGenerationFencedInsideRotationMutex() {
+        val security = readSource("data/YoutubePlaybackSecurity.kt")
+        val rotate = security.substring(
+            security.indexOf("suspend fun rotateIfNeeded("),
+            security.indexOf("fun resetFailureState()")
+        )
+        val mutex = rotate.indexOf("sessionMutex.withLock")
+        val generationCheck = rotate.indexOf("session.generation != expectedGeneration")
+        val attempt = rotate.indexOf("recordFailureAttempt(session.generation)")
+        val stateFence = rotate.indexOf("latestGeneration != session.generation")
+
+        assertTrue(mutex >= 0)
+        assertTrue(generationCheck > mutex)
+        assertTrue(attempt > generationCheck)
+        assertTrue(stateFence > attempt)
+        assertTrue(security.contains("private val failureGeneration = AtomicLong(-1L)"))
+        assertTrue(security.contains("resetFailureStateForGeneration(generation)"))
+    }
+
+    @Test
+    fun rejectedAnalyzerIdentityTrackingRemainsBounded() {
+        val decoder = readSource("data/YoutubeLocalDecoder.kt")
+        val reject = decoder.substring(
+            decoder.indexOf("suspend fun rejectAnalyzedConfig("),
+            decoder.indexOf("private suspend fun resolvePlayer(")
+        )
+
+        assertTrue(reject.contains("rejectedAnalyzerIdentities.size >= MAX_TRACKED_CONFIG_IDENTITIES"))
+        assertTrue(reject.contains("rejectedAnalyzerIdentities.clear()"))
+    }
+
+    private fun readSource(relativePath: String): String =
+        Files.readString(sourceFile(relativePath)).replace("\r\n", "\n")
+
+    private fun sourceFile(relativePath: String): Path {
+        return sequenceOf(
+            Path.of("app/src/main/java/com/luc4n3x/levyra/$relativePath"),
+            Path.of("src/main/java/com/luc4n3x/levyra/$relativePath")
+        ).firstOrNull(Files::exists) ?: error("Source file not found: $relativePath")
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubeStreamCapabilityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubeStreamCapabilityTest.kt
@@ -50,6 +50,15 @@ class YoutubeStreamCapabilityTest {
     }
 
     @Test
+    fun `trusted media detection rejects insecure ports credentials and lookalikes`() {
+        assertTrue(YoutubeStreamCapability.isTrustedGoogleVideoMedia(progressiveMuxed))
+        assertFalse(YoutubeStreamCapability.isTrustedGoogleVideoMedia(progressiveMuxed.replace("https://", "http://")))
+        assertFalse(YoutubeStreamCapability.isTrustedGoogleVideoMedia("https://googlevideo.com.evil.test/videoplayback"))
+        assertFalse(YoutubeStreamCapability.isTrustedGoogleVideoMedia("https://user:pass@r1.googlevideo.com/videoplayback"))
+        assertFalse(YoutubeStreamCapability.isTrustedGoogleVideoMedia("https://r1.googlevideo.com:444/videoplayback"))
+    }
+
+    @Test
     fun `extensionless and mime signaled hls urls stay eligible`() {
         assertTrue(
             YoutubeStreamCapability.servesCompleteStream(

--- a/app/src/test/java/com/luc4n3x/levyra/data/network/YoutubeStreamClientIdentityRegistryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/network/YoutubeStreamClientIdentityRegistryTest.kt
@@ -95,6 +95,19 @@ class YoutubeStreamClientIdentityRegistryTest {
     }
 
     @Test
+    fun playerNavigationProvenanceDoesNotOverrideMediaNavigationHeaders() {
+        val capturedPlayerRequest = web.copy(
+            origin = "https://www.youtube.com",
+            referer = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        )
+
+        val headers = capturedPlayerRequest.mediaRequestHeaders()
+
+        assertEquals("https://www.youtube.com", headers["Origin"])
+        assertEquals("https://www.youtube.com/", headers["Referer"])
+    }
+
+    @Test
     fun musicWebClientMediaHeadersUseTheMusicOrigin() {
         val remix = web.copy(clientName = "WEB_REMIX", clientHeaderName = "67")
 

--- a/app/src/test/java/com/luc4n3x/levyra/data/network/YoutubeStreamClientIdentityRegistryTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/network/YoutubeStreamClientIdentityRegistryTest.kt
@@ -163,4 +163,28 @@ class YoutubeStreamClientIdentityRegistryTest {
             YoutubeStreamClientIdentityRegistry.find("$registered&rn=4")
         )
     }
+
+    @Test
+    fun expiredProvenanceIsNotReusedForMediaRequests() {
+        val url = "https://rr3---sn-abc.googlevideo.com/videoplayback?id=expired&itag=140"
+        YoutubeStreamClientIdentityRegistry.register(
+            listOf(url),
+            visionOs.copy(expiresAtMs = 1L)
+        )
+
+        assertNull(YoutubeStreamClientIdentityRegistry.find(url))
+    }
+
+    @Test
+    fun conflictingClientProvenanceDisablesOnlyTheAmbiguousMediaFallback() {
+        val visionOsUrl = "https://rr3---sn-abc.googlevideo.com/videoplayback?id=o-media&itag=140&pot=vision"
+        val webUrl = "https://rr7---sn-xyz.googlevideo.com/videoplayback?id=o-media&itag=140&pot=web"
+        val unseenUrl = "https://rr9---sn-new.googlevideo.com/videoplayback?id=o-media&itag=140&rn=2"
+        YoutubeStreamClientIdentityRegistry.register(listOf(visionOsUrl), visionOs)
+        YoutubeStreamClientIdentityRegistry.register(listOf(webUrl), web)
+
+        assertEquals(visionOs, YoutubeStreamClientIdentityRegistry.find(visionOsUrl))
+        assertEquals(web, YoutubeStreamClientIdentityRegistry.find(webUrl))
+        assertNull(YoutubeStreamClientIdentityRegistry.find(unseenUrl))
+    }
 }

--- a/third_party/LevyraExtractor/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeApiDecoder.java
+++ b/third_party/LevyraExtractor/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeApiDecoder.java
@@ -102,9 +102,7 @@ public final class YoutubeApiDecoder {
                         "n".equals(paramType) ? Collections.singletonList(value) : null);
                 final String decodedValue = "sig".equals(paramType)
                         ? result.getSignatures().get(value) : result.getNParameters().get(value);
-                if (decodedValue == null || decodedValue.isEmpty()) {
-                    throw new ParsingException("Local decoder returned empty value for: " + value);
-                }
+                requireTransformed(value, decodedValue, "Local decoder", paramType);
                 DECODE_CACHE.put(cacheKey, decodedValue);
                 return decodedValue;
             } catch (final Exception error) {
@@ -137,9 +135,7 @@ public final class YoutubeApiDecoder {
             final JsonObject data = firstResponse.getObject("data");
             final String decodedValue = data.getString(value);
 
-            if (decodedValue == null || decodedValue.isEmpty()) {
-                throw new ParsingException("API returned empty decoded value for: " + value);
-            }
+            requireTransformed(value, decodedValue, "API", paramType);
 
             DECODE_CACHE.put(cacheKey, decodedValue);
             return decodedValue;
@@ -226,6 +222,10 @@ public final class YoutubeApiDecoder {
                 throw new ParsingException(
                         "Local decoder returned no " + label + " for: " + value);
             }
+            if (value.equals(result)) {
+                throw new ParsingException(
+                        "Local decoder returned unchanged " + label + " for: " + value);
+            }
         }
     }
 
@@ -246,7 +246,7 @@ public final class YoutubeApiDecoder {
         }
         for (final String value : requested) {
             final String result = decoded.get(value);
-            if (result != null && !result.isEmpty()) {
+            if (result != null && !result.isEmpty() && !value.equals(result)) {
                 DECODE_CACHE.put(playerId + ':' + type + ':' + value, result);
             }
         }
@@ -342,9 +342,7 @@ public final class YoutubeApiDecoder {
                 final JsonObject nData = nResponse.getObject("data");
                 for (final String nParam : uncachedNs) {
                     final String decodedValue = nData.getString(nParam);
-                    if (decodedValue == null || decodedValue.isEmpty()) {
-                        throw new ParsingException("API returned empty decoded value for n parameter: " + nParam);
-                    }
+                    requireTransformed(nParam, decodedValue, "API", "n parameter");
                     nResults.put(nParam, decodedValue);
                     DECODE_CACHE.put(playerId + ":n:" + nParam, decodedValue);
                 }
@@ -359,9 +357,7 @@ public final class YoutubeApiDecoder {
                 final JsonObject sigData = sigResponse.getObject("data");
                 for (final String sig : uncachedSigs) {
                     final String decodedValue = sigData.getString(sig);
-                    if (decodedValue == null || decodedValue.isEmpty()) {
-                        throw new ParsingException("API returned empty decoded value for signature: " + sig);
-                    }
+                    requireTransformed(sig, decodedValue, "API", "signature");
                     sigResults.put(sig, decodedValue);
                     DECODE_CACHE.put(playerId + ":sig:" + sig, decodedValue);
                 }
@@ -376,6 +372,18 @@ public final class YoutubeApiDecoder {
             throw e instanceof ParsingException
                     ? (ParsingException) e
                     : new ParsingException("Unexpected error during batch decoding", e);
+        }
+    }
+
+    private static void requireTransformed(@Nonnull final String input,
+                                           @Nullable final String output,
+                                           @Nonnull final String source,
+                                           @Nonnull final String label) throws ParsingException {
+        if (output == null || output.isEmpty()) {
+            throw new ParsingException(source + " returned empty " + label + " for: " + input);
+        }
+        if (input.equals(output)) {
+            throw new ParsingException(source + " returned unchanged " + label + " for: " + input);
         }
     }
 

--- a/third_party/LevyraExtractor/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeApiDecoderLocalFallbackTest.java
+++ b/third_party/LevyraExtractor/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/YoutubeApiDecoderLocalFallbackTest.java
@@ -52,6 +52,26 @@ class YoutubeApiDecoderLocalFallbackTest {
     }
 
     @Test
+    void unchangedLocalSignatureIsRejectedAndNeverCached() {
+        YoutubeApiDecoder.setLocalDecoder(new StubDecoder(0, true, false));
+
+        assertThrows(ParsingException.class, () -> YoutubeApiDecoder.decodeBatch(
+                "player", Arrays.asList("s1"), null));
+
+        assertEquals(0, YoutubeApiDecoder.getCacheSize());
+    }
+
+    @Test
+    void unchangedLocalNParameterIsRejectedAndNeverCached() {
+        YoutubeApiDecoder.setLocalDecoder(new StubDecoder(0, false, true));
+
+        assertThrows(ParsingException.class, () -> YoutubeApiDecoder.decodeBatch(
+                "player", null, Arrays.asList("n1")));
+
+        assertEquals(0, YoutubeApiDecoder.getCacheSize());
+    }
+
+    @Test
     void decodeCacheStaysBounded() throws Exception {
         YoutubeApiDecoder.setLocalDecoder(new StubDecoder(0));
 
@@ -69,9 +89,19 @@ class YoutubeApiDecoderLocalFallbackTest {
 
     private static final class StubDecoder implements YoutubeJavaScriptDecoder {
         private final int droppedSignatures;
+        private final boolean unchangedSignatures;
+        private final boolean unchangedNParameters;
 
         private StubDecoder(final int droppedSignatures) {
+            this(droppedSignatures, false, false);
+        }
+
+        private StubDecoder(final int droppedSignatures,
+                            final boolean unchangedSignatures,
+                            final boolean unchangedNParameters) {
             this.droppedSignatures = droppedSignatures;
+            this.unchangedSignatures = unchangedSignatures;
+            this.unchangedNParameters = unchangedNParameters;
         }
 
         @Nonnull
@@ -87,17 +117,19 @@ class YoutubeApiDecoderLocalFallbackTest {
                 @Nullable final List<String> signatures,
                 @Nullable final List<String> throttlingParameters) {
             return new YoutubeApiDecoder.BatchDecodeResult(
-                    decodeValues(signatures, droppedSignatures),
-                    decodeValues(throttlingParameters, 0));
+                    decodeValues(signatures, droppedSignatures, unchangedSignatures),
+                    decodeValues(throttlingParameters, 0, unchangedNParameters));
         }
 
         @Nonnull
         private static Map<String, String> decodeValues(@Nullable final List<String> values,
-                                                        final int dropped) {
+                                                        final int dropped,
+                                                        final boolean unchanged) {
             final Map<String, String> decoded = new HashMap<>();
             if (values != null) {
                 for (int i = 0; i < values.size() - dropped; i++) {
-                    decoded.put(values.get(i), "decoded-" + values.get(i));
+                    final String value = values.get(i);
+                    decoded.put(value, unchanged ? value : "decoded-" + value);
                 }
             }
             return decoded;


### PR DESCRIPTION
## Summary

Hardens Levyra's YouTube playback path against stale or invalid decipher results and broad recovery resets. The change rejects no-op `s`/`n` transforms before they can be cached or used, carries the stream's resolving context through the playback manifest, and makes recovery target the decoder, PoToken/security state, or client policy that actually produced the failed stream.

It also extends the local `player.js` analysis path so analyzed candidates are verified before publication while keeping the existing fast path, last-known-good configuration, and extractor fallback intact.

## What changed

- Reject empty or unchanged signature and `n` transform results in both the local decoder path and the common extractor decoder boundary.
- Add versioned playback-manifest provenance for client identity, player/config generation, security/PoToken generation, network route, resolution time, and expiry.
- Make playback recovery causal by separating signature, `n` transform, PoToken, client rejection, and renderer failures instead of refreshing unrelated layers together.
- Preserve stream client identity and headers across resolution/cache/playback boundaries and avoid reusing stale/conflicting identity state.
- Derive GoogleVideo media navigation headers from the resolved YouTube client instead of replaying player-page navigation headers.
- Verify bounded `player.js` analysis candidates before publication and advance to another analyzed candidate only when the failure proves that candidate is wrong.
- Close an already-dead cipher WebView before replacement while preserving a live last-known-good runtime until a replacement validates.
- Bind decoder provenance to the actual synchronous decode call and its bounded local decode-cache entries; reset caller provenance at playback-security boundaries so coroutine resumption cannot inherit another resolution's decoder identity.
- Fence stream-rejection recovery by the exact decoder config identity so stale failures cannot invalidate a newer active decoder runtime.
- Fence playback-security failure counting by guest-session generation, preventing late failures from an old session from contributing to the new session's rotation threshold.
- Keep visitor identity coherent with its generation: a late visitor fetch cannot overwrite a different already-published visitor while retaining the same generation.
- Bound rejected analyzer identities to the same 64-entry tracking contract used by the other decoder identity sets.
- Classify renderer-process failures before generic `gone` failures so renderer recovery remains decoder-scoped.
- Keep strict direct-audio candidate validation identity-aware while preserving the normal-audio-only fallback contract.
- Add focused regression coverage for manifest compatibility/provenance, causal failure classification, decoder no-op rejection, candidate validation policy, provenance coherence, session-generation fencing, visitor publication, stream capability, identity-registry behavior, media navigation semantics, direct-audio fallback, and extractor decoder caching.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactor or maintenance
- [ ] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android / Shared infrastructure
- **Area:** Player / Streaming

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [x] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

Local full Android validation was not completed before publication because the local Gradle environment hit a host loopback socket failure while starting the build process. That remains recorded as an environment blocker rather than a passing local check.

The previous head `759a6c2` had already passed AI Quality Gate, Android runtime compatibility, Extractor Unit Tests, Android Lint, the focused Android/F-Droid regression set, the full Android unit-test suite, PR diagnostics, Release Compile, and upstream artifact checks before the final concurrency review changed the branch again.

Current head `5241bb6` contains the final merge-gate fixes for decoder caller provenance, generation-aware security failure counting, same-generation visitor publication, and bounded analyzer rejection tracking. A fresh PR Check is running for this head. Dependency Review and CodeRabbit are green; do not treat the PR as fully validated until the current-head PR Check completes successfully.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Android emulator | Playback regression pass | Not run for current head |
| Physical Android device | Playback regression pass | Not run |

## Risk and compatibility

- **Risk level:** High
- **Compatibility or migration notes:** Playback manifest schema is bumped to v2 while v1 manifests remain readable. No database migration or user-data migration is introduced.
- **Known limitations:** Runtime playback validation has not been performed for the current revision; current-head GitHub CI is still running.
- **Rollback plan:** Revert this PR

## Reviewer notes

- `YoutubeLocalDecoder` advances through analyzed candidates only for explicit analyzed-config failures; renderer, timeout, backoff, cancellation, and unrelated runtime failures are not treated as proof that another candidate should be tried.
- A dead WebView runtime is released before replacement, while a live runtime remains available until the replacement has been verified and published.
- Decoder provenance follows an actual local decoder call or its bounded local cache. Caller state is cleared before a new resolution/security boundary and again after potentially suspending PoToken work, so a resumed coroutine cannot consume stale provenance left on that thread by another resolution.
- A common extractor decode-cache hit may conservatively produce no decoder provenance; this is intentionally a safe false-negative rather than risking false attribution.
- Stream rejection uses the manifest's exact `playerConfigIdentity`; cache/runtime invalidation is skipped when that identity can no longer be attributed safely to the current decoder state.
- Guest-session failure attempts are tagged to the active generation and mutated under the same serialized rotation path; stale generations cannot contaminate the next generation's threshold.
- Session publication refuses to replace a different non-empty visitor identity at the same generation, preventing visitor/token identity drift.
- Renderer-process wording is classified before generic `gone` wording so the recovery plan refreshes only the decoder layer.
- Direct-audio fallback contract coverage reflects the identity-aware probe introduced by stream provenance instead of matching the obsolete call signature.
- Review `PlaybackResolver` and `PlaybackResilienceEngine` together: provenance is used to avoid refreshing decoder, PoToken/security, and client policy indiscriminately after a playback failure.
- Review `PlaybackManifestCodec` for v1/v2 backward compatibility and ensure provenance remains bounded to metadata rather than signed/private stream credentials.
- Review the extractor `YoutubeApiDecoder` cache boundary to ensure no-op/empty results can never be cached by either local or remote decode paths.

## Release note

Improves YouTube playback recovery when YouTube rotates player logic, stream identity, or playback security requirements.

## Related issues

- N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims

