### PR TITLE
feat: add semantic player.js intelligence v2

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubeLocalDecoder.kt
@@ -1461,22 +1461,38 @@ internal object YoutubePlayerJsAnalyzer {
 
     fun analyzeCandidates(hash: String, javascript: String): List<YoutubePlayerCipherConfig> {
         if (!YoutubePlayerConfigParser.isValidHash(hash)) return emptyList()
-        val signatures = expressions(javascript, signatureRules)
-        val nExpressions = expressions(javascript, nRules)
         val sts = extractSignatureTimestamp(javascript) ?: return emptyList()
+        val semantic = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+        val signatures = mergeExpressions(
+            semantic.signatures,
+            expressions(javascript, signatureRules)
+        )
+        val nExpressions = mergeExpressions(
+            semantic.nTransforms,
+            expressions(javascript, nRules)
+        )
         if (signatures.isEmpty() || nExpressions.isEmpty()) return emptyList()
-        return signatures.asSequence()
-            .flatMap { signature ->
-                nExpressions.asSequence().map { nExpression ->
-                    YoutubePlayerCipherConfig(
-                        primaryHash = hash,
-                        signatureExpression = signature,
-                        nClass = null,
-                        signatureTimestamp = sts,
-                        nExpressionOverride = nExpression,
-                        origin = YoutubePlayerConfigOrigin.ANALYZED
-                    )
-                }
+
+        val combinations = ArrayList<Pair<YoutubeSemanticTransformCandidate, YoutubeSemanticTransformCandidate>>()
+        signatures.forEach { signature ->
+            nExpressions.forEach { nExpression -> combinations += signature to nExpression }
+        }
+        combinations.sortWith(
+            compareByDescending<Pair<YoutubeSemanticTransformCandidate, YoutubeSemanticTransformCandidate>> {
+                it.first.confidence + it.second.confidence
+            }.thenByDescending { it.first.confidence }
+                .thenByDescending { it.second.confidence }
+        )
+        return combinations.asSequence()
+            .map { (signature, nExpression) ->
+                YoutubePlayerCipherConfig(
+                    primaryHash = hash,
+                    signatureExpression = signature.expression,
+                    nClass = null,
+                    signatureTimestamp = sts,
+                    nExpressionOverride = nExpression.expression,
+                    origin = YoutubePlayerConfigOrigin.ANALYZED
+                )
             }
             .distinctBy { it.identity }
             .take(MAX_CANDIDATES)
@@ -1486,6 +1502,29 @@ internal object YoutubePlayerJsAnalyzer {
     fun extractSignatureTimestamp(javascript: String): Int? {
         return anchoredSts.find(javascript)?.groupValues?.getOrNull(1)?.toIntOrNull()
             ?: looseSts.find(javascript)?.groupValues?.getOrNull(1)?.toIntOrNull()
+    }
+
+    private fun mergeExpressions(
+        semantic: List<YoutubeSemanticTransformCandidate>,
+        legacy: List<String>
+    ): List<YoutubeSemanticTransformCandidate> {
+        val output = LinkedHashMap<String, YoutubeSemanticTransformCandidate>()
+        semantic.take(MAX_SEMANTIC_EXPRESSIONS_PER_KIND).forEach { candidate ->
+            output[candidate.expression] = candidate
+        }
+        legacy.forEach { expression ->
+            if (output.size >= MAX_EXPRESSIONS_PER_KIND) return@forEach
+            output.putIfAbsent(
+                expression,
+                YoutubeSemanticTransformCandidate(expression, LEGACY_CONFIDENCE)
+            )
+        }
+        if (output.size < MAX_EXPRESSIONS_PER_KIND) {
+            semantic.drop(MAX_SEMANTIC_EXPRESSIONS_PER_KIND).forEach { candidate ->
+                if (output.size < MAX_EXPRESSIONS_PER_KIND) output.putIfAbsent(candidate.expression, candidate)
+            }
+        }
+        return output.values.toList()
     }
 
     private fun expressions(javascript: String, rules: List<Rule>): List<String> {
@@ -1507,7 +1546,9 @@ internal object YoutubePlayerJsAnalyzer {
 
     private fun safeName(name: String): String? = name.takeIf(safeFunctionName::matches)
 
+    private const val LEGACY_CONFIDENCE = 40
     private const val MAX_MATCHES_PER_RULE = 4
+    private const val MAX_SEMANTIC_EXPRESSIONS_PER_KIND = 2
     private const val MAX_EXPRESSIONS_PER_KIND = 3
     private const val MAX_CANDIDATES = 6
 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2.kt
@@ -11,15 +11,15 @@ internal data class YoutubeSemanticDiscoveryResult(
 )
 
 internal object YoutubePlayerSemanticAnalyzerV2 {
-    private enum class TokenKind {
+    private enum class LexemeKind {
         IDENTIFIER,
         NUMBER,
         STRING,
         SYMBOL
     }
 
-    private data class Token(
-        val kind: TokenKind,
+    private data class Lexeme(
+        val kind: LexemeKind,
         val text: String,
         val start: Int,
         val end: Int
@@ -53,31 +53,32 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         val output = ArrayList<YoutubeSemanticTransformCandidate>()
         scanWindows(javascript, listOf("decodeURIComponent"), SIGNATURE_BEFORE_CHARS, SIGNATURE_AFTER_CHARS)
             .forEach { window ->
-                val tokens = tokenize(javascript, window.start, window.end)
-                val decode = tokens.indexOfFirst { token ->
-                    token.kind == TokenKind.IDENTIFIER &&
-                        token.text == "decodeURIComponent" &&
-                        window.anchor in token.start until token.end
+                val lexemes = tokenize(javascript, window.start, window.end)
+                val decode = lexemes.indexOfFirst { lexeme ->
+                    lexeme.kind == LexemeKind.IDENTIFIER &&
+                        lexeme.text == "decodeURIComponent" &&
+                        window.anchor in lexeme.start until lexeme.end
                 }
-                if (decode < 0 || tokens.getOrNull(decode + 1)?.text != "(") return@forEach
-                val decodeClose = matchingParen(tokens, decode + 1) ?: return@forEach
-                val sourceEvidence = if (mentionsKey(tokens, decode + 2, decodeClose - 1, "s")) 30 else 0
+                if (decode < 0 || lexemes.getOrNull(decode + 1)?.text != "(") return@forEach
+                val decodeClose = matchingParen(lexemes, decode + 1) ?: return@forEach
+                val sourceEvidence = if (mentionsKey(lexemes, decode + 2, decodeClose - 1, "s")) 30 else 0
 
-                enclosingCalls(tokens, decode, decodeClose).forEach { call ->
-                    val expression = expressionForRange(tokens, call, decode, decodeClose) ?: return@forEach
-                    val outputVariable = assignedVariableForExpression(tokens, call.targetStart)
+                enclosingCalls(lexemes, decode, decodeClose).forEach { call ->
+                    if (isNonTransformTarget(call.target)) return@forEach
+                    val expression = expressionForRange(lexemes, call, decode, decodeClose) ?: return@forEach
+                    val outputVariable = assignedVariableForExpression(lexemes, call.targetStart)
                     val sinkEvidence = when {
-                        outputVariable != null -> signatureSinkScore(tokens, call.close + 1, outputVariable)
-                        isNestedInCallable(tokens, call.targetStart, call.close, "encodeURIComponent") -> 35
+                        outputVariable != null -> signatureSinkScore(lexemes, call.close + 1, outputVariable)
+                        isNestedInCallable(lexemes, call.targetStart, call.close, "encodeURIComponent") -> 35
                         else -> 0
                     }
                     addIfConfident(output, expression, 70 + sourceEvidence + sinkEvidence)
                 }
 
-                val sourceVariable = assignedVariableForExpression(tokens, decode)
+                val sourceVariable = assignedVariableForExpression(lexemes, decode)
                 if (sourceVariable != null) {
                     output += followVariableFlow(
-                        tokens = tokens,
+                        lexemes = lexemes,
                         startIndex = decodeClose + 1,
                         sourceVariable = sourceVariable,
                         baseConfidence = 70 + sourceEvidence,
@@ -92,31 +93,32 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         val output = ArrayList<YoutubeSemanticTransformCandidate>()
         scanWindows(javascript, listOf("\"n\"", "'n'"), N_BEFORE_CHARS, N_AFTER_CHARS)
             .forEach { window ->
-                val tokens = tokenize(javascript, window.start, window.end)
-                val keyIndex = tokens.indexOfFirst { token ->
-                    token.kind == TokenKind.STRING &&
-                        token.text == "n" &&
-                        window.anchor in token.start until token.end
+                val lexemes = tokenize(javascript, window.start, window.end)
+                val keyIndex = lexemes.indexOfFirst { lexeme ->
+                    lexeme.kind == LexemeKind.STRING &&
+                        lexeme.text == "n" &&
+                        window.anchor in lexeme.start until lexeme.end
                 }
-                if (!isGetCallKey(tokens, keyIndex)) return@forEach
-                val getClose = matchingParen(tokens, keyIndex - 1) ?: return@forEach
+                if (!isGetCallKey(lexemes, keyIndex)) return@forEach
+                val getClose = matchingParen(lexemes, keyIndex - 1) ?: return@forEach
                 val getStart = keyIndex - 3
 
-                enclosingCalls(tokens, getStart, getClose).forEach { call ->
-                    val expression = expressionForRange(tokens, call, getStart, getClose) ?: return@forEach
-                    val outputVariable = assignedVariableForExpression(tokens, call.targetStart)
+                enclosingCalls(lexemes, getStart, getClose).forEach { call ->
+                    if (isNonTransformTarget(call.target)) return@forEach
+                    val expression = expressionForRange(lexemes, call, getStart, getClose) ?: return@forEach
+                    val outputVariable = assignedVariableForExpression(lexemes, call.targetStart)
                     val sinkEvidence = when {
-                        outputVariable != null -> nSinkScore(tokens, call.close + 1, outputVariable)
-                        isNestedInNSet(tokens, call.targetStart, call.close) -> 45
+                        outputVariable != null -> nSinkScore(lexemes, call.close + 1, outputVariable)
+                        isNestedInNSet(lexemes, call.targetStart, call.close) -> 45
                         else -> 0
                     }
                     addIfConfident(output, expression, 70 + sinkEvidence)
                 }
 
-                val sourceVariable = assignedVariableForExpression(tokens, getStart)
+                val sourceVariable = assignedVariableForExpression(lexemes, getStart)
                 if (sourceVariable != null) {
                     output += followVariableFlow(
-                        tokens = tokens,
+                        lexemes = lexemes,
                         startIndex = getClose + 1,
                         sourceVariable = sourceVariable,
                         baseConfidence = 70,
@@ -128,53 +130,54 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
     }
 
     private fun followVariableFlow(
-        tokens: List<Token>,
+        lexemes: List<Lexeme>,
         startIndex: Int,
         sourceVariable: String,
         baseConfidence: Int,
-        sinkScore: (List<Token>, Int, String) -> Int
+        sinkScore: (List<Lexeme>, Int, String) -> Int
     ): List<YoutubeSemanticTransformCandidate> {
         val output = ArrayList<YoutubeSemanticTransformCandidate>()
         val tainted = LinkedHashSet<String>()
         tainted += sourceVariable
         var index = startIndex.coerceAtLeast(0)
-        val limit = minOf(tokens.size, index + MAX_FLOW_TOKENS)
+        val limit = minOf(lexemes.size, index + MAX_FLOW_TOKENS)
 
         while (index < limit) {
-            if (tokens[index].text != "=" || !isAssignmentOperator(tokens, index)) {
+            if (lexemes[index].text != "=" || !isAssignmentOperator(lexemes, index)) {
                 index++
                 continue
             }
-            val lhs = tokens.getOrNull(index - 1)
-                ?.takeIf { it.kind == TokenKind.IDENTIFIER }
+            val lhs = lexemes.getOrNull(index - 1)
+                ?.takeIf { it.kind == LexemeKind.IDENTIFIER }
                 ?.text
             if (lhs == null) {
                 index++
                 continue
             }
-            val statementEnd = statementEnd(tokens, index + 1, limit)
-            val rhs = (index + 1 until statementEnd).toList()
-            val identifiers = rhs
-                .mapNotNull { tokenIndex -> tokens[tokenIndex].takeIf { it.kind == TokenKind.IDENTIFIER }?.text }
+            val expressionEnd = statementEnd(lexemes, index + 1, limit)
+            val rhs = (index + 1 until expressionEnd).toList()
+            val identifiers = rhs.mapNotNull { lexemeIndex ->
+                lexemes[lexemeIndex].takeIf { it.kind == LexemeKind.IDENTIFIER }?.text
+            }
             if (identifiers.size == 1 && identifiers.first() in tainted) {
                 tainted += lhs
-                index = statementEnd + 1
+                index = expressionEnd + 1
                 continue
             }
 
-            callsBetween(tokens, index + 1, statementEnd).forEach { call ->
-                val expression = expressionForIdentifiers(tokens, call, tainted) ?: return@forEach
-                val confidence = baseConfidence + sinkScore(tokens, statementEnd + 1, lhs)
+            callsBetween(lexemes, index + 1, expressionEnd).forEach { call ->
+                val expression = expressionForIdentifiers(lexemes, call, tainted) ?: return@forEach
+                val confidence = baseConfidence + sinkScore(lexemes, expressionEnd + 1, lhs)
                 addIfConfident(output, expression, confidence)
                 tainted += lhs
             }
-            index = statementEnd + 1
+            index = expressionEnd + 1
         }
         return output
     }
 
     private fun expressionForRange(
-        tokens: List<Token>,
+        lexemes: List<Lexeme>,
         call: CallSite,
         sourceStart: Int,
         sourceEnd: Int
@@ -186,7 +189,7 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
                 arguments += "INPUT"
                 replaced++
             } else {
-                arguments += safeConstantArgument(tokens, range) ?: return null
+                arguments += safeConstantArgument(lexemes, range) ?: return null
             }
         }
         if (replaced != 1) return null
@@ -194,45 +197,48 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
     }
 
     private fun expressionForIdentifiers(
-        tokens: List<Token>,
+        lexemes: List<Lexeme>,
         call: CallSite,
         tainted: Set<String>
     ): String? {
         var replaced = 0
         val arguments = ArrayList<String>(call.arguments.size)
         call.arguments.forEach { range ->
-            val names = range.mapNotNull { index ->
-                tokens[index].takeIf { it.kind == TokenKind.IDENTIFIER }?.text
+            val names = range.mapNotNull { lexemeIndex ->
+                lexemes[lexemeIndex].takeIf { it.kind == LexemeKind.IDENTIFIER }?.text
             }
             if (names.any { it in tainted }) {
                 if (names.count { it in tainted } != 1) return null
-                if (range.any { index ->
-                        val token = tokens[index]
-                        token.kind == TokenKind.IDENTIFIER && token.text !in tainted
+                if (range.any { lexemeIndex ->
+                        val lexeme = lexemes[lexemeIndex]
+                        lexeme.kind == LexemeKind.IDENTIFIER && lexeme.text !in tainted
                     }
                 ) return null
                 arguments += "INPUT"
                 replaced++
             } else {
-                arguments += safeConstantArgument(tokens, range) ?: return null
+                arguments += safeConstantArgument(lexemes, range) ?: return null
             }
         }
         if (replaced != 1) return null
         return "${call.target}(${arguments.joinToString(",")})"
     }
 
-    private fun safeConstantArgument(tokens: List<Token>, range: IntRange): String? {
+    private fun safeConstantArgument(lexemes: List<Lexeme>, range: IntRange): String? {
         if (range.isEmpty()) return null
-        val slice = range.map { tokens[it] }
+        val slice = range.map { lexemes[it] }
         return when {
-            slice.size == 1 && slice[0].kind == TokenKind.NUMBER -> slice[0].text
-            slice.size == 2 && slice[0].text == "-" && slice[1].kind == TokenKind.NUMBER -> "-${slice[1].text}"
+            slice.size == 1 && isSafeInteger(slice[0]) -> slice[0].text
+            slice.size == 2 && slice[0].text == "-" && isSafeInteger(slice[1]) -> "-${slice[1].text}"
             else -> null
         }
     }
 
+    private fun isSafeInteger(lexeme: Lexeme): Boolean =
+        lexeme.kind == LexemeKind.NUMBER && lexeme.text.isNotEmpty() && lexeme.text.all(Char::isDigit)
+
     private fun enclosingCalls(
-        tokens: List<Token>,
+        lexemes: List<Lexeme>,
         sourceStart: Int,
         sourceEnd: Int
     ): List<CallSite> {
@@ -240,14 +246,10 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         var index = sourceStart - 1
         var inspected = 0
         while (index >= 0 && inspected < MAX_PARENT_SCAN_TOKENS && output.size < MAX_ENCLOSING_CALLS) {
-            if (tokens[index].text == "(") {
-                val close = matchingParen(tokens, index)
+            if (lexemes[index].text == "(") {
+                val close = matchingParen(lexemes, index)
                 if (close != null && close >= sourceEnd) {
-                    callSite(tokens, index, close)?.let { call ->
-                        if (call.target != "decodeURIComponent" && call.target != "encodeURIComponent") {
-                            output += call
-                        }
-                    }
+                    callSite(lexemes, index, close)?.let(output::add)
                 }
             }
             index--
@@ -256,16 +258,16 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         return output
     }
 
-    private fun callsBetween(tokens: List<Token>, start: Int, endExclusive: Int): List<CallSite> {
+    private fun callsBetween(lexemes: List<Lexeme>, start: Int, endExclusive: Int): List<CallSite> {
         val output = ArrayList<CallSite>()
         var index = start.coerceAtLeast(0)
-        val end = minOf(tokens.size, endExclusive)
+        val end = minOf(lexemes.size, endExclusive)
         while (index < end && output.size < MAX_CALLS_PER_FLOW) {
-            if (tokens[index].text == "(") {
-                val close = matchingParen(tokens, index)
+            if (lexemes[index].text == "(") {
+                val close = matchingParen(lexemes, index)
                 if (close != null && close < end) {
-                    callSite(tokens, index, close)?.let { call ->
-                        if (call.target !in NON_TRANSFORM_CALLS) output += call
+                    callSite(lexemes, index, close)?.let { call ->
+                        if (!isNonTransformTarget(call.target)) output += call
                     }
                 }
             }
@@ -274,35 +276,40 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         return output
     }
 
-    private fun callSite(tokens: List<Token>, open: Int, close: Int): CallSite? {
-        val target = callableTarget(tokens, open) ?: return null
+    private fun isNonTransformTarget(target: String): Boolean =
+        target in NON_TRANSFORM_CALLS ||
+            target.endsWith(".get") ||
+            target.endsWith(".set")
+
+    private fun callSite(lexemes: List<Lexeme>, open: Int, close: Int): CallSite? {
+        val target = callableTarget(lexemes, open) ?: return null
         return CallSite(
             target = target.first,
             targetStart = target.second,
             open = open,
             close = close,
-            arguments = splitArguments(tokens, open + 1, close)
+            arguments = splitArguments(lexemes, open + 1, close)
         )
     }
 
-    private fun callableTarget(tokens: List<Token>, open: Int): Pair<String, Int>? {
+    private fun callableTarget(lexemes: List<Lexeme>, open: Int): Pair<String, Int>? {
         var index = open - 1
         if (index < 0) return null
         var target: String
         var start: Int
 
-        if (tokens[index].text == "]") {
+        if (lexemes[index].text == "]") {
             if (
                 index < 3 ||
-                tokens[index - 1].kind != TokenKind.NUMBER ||
-                tokens[index - 2].text != "[" ||
-                tokens[index - 3].kind != TokenKind.IDENTIFIER
+                !isSafeInteger(lexemes[index - 1]) ||
+                lexemes[index - 2].text != "[" ||
+                lexemes[index - 3].kind != LexemeKind.IDENTIFIER
             ) return null
-            target = "${tokens[index - 3].text}[${tokens[index - 1].text}]"
+            target = "${lexemes[index - 3].text}[${lexemes[index - 1].text}]"
             start = index - 3
             index -= 4
         } else {
-            val last = tokens[index].takeIf { it.kind == TokenKind.IDENTIFIER } ?: return null
+            val last = lexemes[index].takeIf { it.kind == LexemeKind.IDENTIFIER } ?: return null
             target = last.text
             start = index
             index--
@@ -310,10 +317,10 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
 
         while (
             index >= 1 &&
-            tokens[index].text == "." &&
-            tokens[index - 1].kind == TokenKind.IDENTIFIER
+            lexemes[index].text == "." &&
+            lexemes[index - 1].kind == LexemeKind.IDENTIFIER
         ) {
-            target = "${tokens[index - 1].text}.$target"
+            target = "${lexemes[index - 1].text}.$target"
             start = index - 1
             index -= 2
         }
@@ -321,7 +328,7 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         return target to start
     }
 
-    private fun splitArguments(tokens: List<Token>, start: Int, close: Int): List<IntRange> {
+    private fun splitArguments(lexemes: List<Lexeme>, start: Int, close: Int): List<IntRange> {
         if (start >= close) return emptyList()
         val output = ArrayList<IntRange>()
         var argStart = start
@@ -330,7 +337,7 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         var brace = 0
         var index = start
         while (index < close) {
-            when (tokens[index].text) {
+            when (lexemes[index].text) {
                 "(" -> paren++
                 ")" -> paren--
                 "[" -> bracket++
@@ -350,15 +357,15 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         return output
     }
 
-    private fun assignedVariableForExpression(tokens: List<Token>, expressionStart: Int): String? {
+    private fun assignedVariableForExpression(lexemes: List<Lexeme>, expressionStart: Int): String? {
         var index = expressionStart - 1
         var inspected = 0
         while (index >= 1 && inspected < MAX_ASSIGNMENT_SCAN_TOKENS) {
-            val symbol = tokens[index].text
-            if (symbol == ";" || symbol == "{" || symbol == "}") return null
-            if (symbol == "=" && isAssignmentOperator(tokens, index)) {
-                return tokens[index - 1]
-                    .takeIf { it.kind == TokenKind.IDENTIFIER }
+            val symbol = lexemes[index].text
+            if (symbol == ";" || symbol == "," || symbol == "{" || symbol == "}") return null
+            if (symbol == "=" && isAssignmentOperator(lexemes, index)) {
+                return lexemes[index - 1]
+                    .takeIf { it.kind == LexemeKind.IDENTIFIER }
                     ?.text
             }
             index--
@@ -367,28 +374,29 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         return null
     }
 
-    private fun isAssignmentOperator(tokens: List<Token>, index: Int): Boolean {
-        return tokens.getOrNull(index - 1)?.text != "=" &&
-            tokens.getOrNull(index + 1)?.text != "=" &&
-            tokens.getOrNull(index - 1)?.text != "!" &&
-            tokens.getOrNull(index - 1)?.text != ">" &&
-            tokens.getOrNull(index - 1)?.text != "<"
+    private fun isAssignmentOperator(lexemes: List<Lexeme>, index: Int): Boolean {
+        return lexemes.getOrNull(index - 1)?.text != "=" &&
+            lexemes.getOrNull(index + 1)?.text != "=" &&
+            lexemes.getOrNull(index + 1)?.text != ">" &&
+            lexemes.getOrNull(index - 1)?.text != "!" &&
+            lexemes.getOrNull(index - 1)?.text != ">" &&
+            lexemes.getOrNull(index - 1)?.text != "<"
     }
 
-    private fun signatureSinkScore(tokens: List<Token>, start: Int, variable: String): Int {
+    private fun signatureSinkScore(lexemes: List<Lexeme>, start: Int, variable: String): Int {
         var score = 0
-        val end = minOf(tokens.size, start + MAX_SINK_SCAN_TOKENS)
+        val end = minOf(lexemes.size, start + MAX_SINK_SCAN_TOKENS)
         var index = start.coerceAtLeast(0)
         while (index < end) {
-            if (tokens[index].text == "encodeURIComponent" && tokens.getOrNull(index + 1)?.text == "(") {
-                val close = matchingParen(tokens, index + 1)
-                if (close != null && close < end && containsIdentifier(tokens, index + 2, close, variable)) {
+            if (lexemes[index].text == "encodeURIComponent" && lexemes.getOrNull(index + 1)?.text == "(") {
+                val close = matchingParen(lexemes, index + 1)
+                if (close != null && close < end && containsIdentifier(lexemes, index + 2, close, variable)) {
                     score = maxOf(score, 25)
                 }
             }
-            if (tokens[index].text == "set" && tokens.getOrNull(index - 1)?.text == "." && tokens.getOrNull(index + 1)?.text == "(") {
-                val close = matchingParen(tokens, index + 1)
-                if (close != null && close < end && containsIdentifier(tokens, index + 2, close, variable)) {
+            if (lexemes[index].text == "set" && lexemes.getOrNull(index - 1)?.text == "." && lexemes.getOrNull(index + 1)?.text == "(") {
+                val close = matchingParen(lexemes, index + 1)
+                if (close != null && close < end && containsIdentifier(lexemes, index + 2, close, variable)) {
                     score = maxOf(score, 40)
                 }
             }
@@ -397,18 +405,18 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         return score
     }
 
-    private fun nSinkScore(tokens: List<Token>, start: Int, variable: String): Int {
-        val end = minOf(tokens.size, start + MAX_SINK_SCAN_TOKENS)
+    private fun nSinkScore(lexemes: List<Lexeme>, start: Int, variable: String): Int {
+        val end = minOf(lexemes.size, start + MAX_SINK_SCAN_TOKENS)
         var index = start.coerceAtLeast(0)
         while (index < end) {
-            if (tokens[index].text == "set" && tokens.getOrNull(index - 1)?.text == "." && tokens.getOrNull(index + 1)?.text == "(") {
-                val close = matchingParen(tokens, index + 1)
+            if (lexemes[index].text == "set" && lexemes.getOrNull(index - 1)?.text == "." && lexemes.getOrNull(index + 1)?.text == "(") {
+                val close = matchingParen(lexemes, index + 1)
                 if (close != null && close < end) {
-                    val args = splitArguments(tokens, index + 2, close)
+                    val args = splitArguments(lexemes, index + 2, close)
                     if (
                         args.size >= 2 &&
-                        singleString(tokens, args[0]) == "n" &&
-                        containsIdentifier(tokens, args[1].first, args[1].last + 1, variable)
+                        singleString(lexemes, args[0]) == "n" &&
+                        containsIdentifier(lexemes, args[1].first, args[1].last + 1, variable)
                     ) return 45
                 }
             }
@@ -418,84 +426,84 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
     }
 
     private fun isNestedInCallable(
-        tokens: List<Token>,
+        lexemes: List<Lexeme>,
         sourceStart: Int,
         sourceEnd: Int,
         callable: String
     ): Boolean {
-        return enclosingCalls(tokens, sourceStart, sourceEnd).any { it.target == callable }
+        return enclosingCalls(lexemes, sourceStart, sourceEnd).any { it.target == callable }
     }
 
-    private fun isNestedInNSet(tokens: List<Token>, sourceStart: Int, sourceEnd: Int): Boolean {
-        return enclosingCalls(tokens, sourceStart, sourceEnd).any { call ->
+    private fun isNestedInNSet(lexemes: List<Lexeme>, sourceStart: Int, sourceEnd: Int): Boolean {
+        return enclosingCalls(lexemes, sourceStart, sourceEnd).any { call ->
             call.target.endsWith(".set") &&
-                call.arguments.firstOrNull()?.let { singleString(tokens, it) == "n" } == true
+                call.arguments.firstOrNull()?.let { singleString(lexemes, it) == "n" } == true
         }
     }
 
-    private fun isGetCallKey(tokens: List<Token>, keyIndex: Int): Boolean {
+    private fun isGetCallKey(lexemes: List<Lexeme>, keyIndex: Int): Boolean {
         if (keyIndex < 3) return false
-        return tokens[keyIndex - 1].text == "(" &&
-            tokens[keyIndex - 2].text == "get" &&
-            tokens[keyIndex - 3].text == "."
+        return lexemes[keyIndex - 1].text == "(" &&
+            lexemes[keyIndex - 2].text == "get" &&
+            lexemes[keyIndex - 3].text == "."
     }
 
-    private fun mentionsKey(tokens: List<Token>, start: Int, endInclusive: Int, key: String): Boolean {
+    private fun mentionsKey(lexemes: List<Lexeme>, start: Int, endInclusive: Int, key: String): Boolean {
         if (start > endInclusive) return false
-        for (index in start..minOf(endInclusive, tokens.lastIndex)) {
-            val token = tokens[index]
-            if (token.kind == TokenKind.STRING && token.text == key) return true
+        for (index in start..minOf(endInclusive, lexemes.lastIndex)) {
+            val lexeme = lexemes[index]
+            if (lexeme.kind == LexemeKind.STRING && lexeme.text == key) return true
             if (
-                token.kind == TokenKind.IDENTIFIER &&
-                token.text == key &&
-                tokens.getOrNull(index - 1)?.text == "."
+                lexeme.kind == LexemeKind.IDENTIFIER &&
+                lexeme.text == key &&
+                lexemes.getOrNull(index - 1)?.text == "."
             ) return true
         }
         return false
     }
 
-    private fun singleString(tokens: List<Token>, range: IntRange): String? {
+    private fun singleString(lexemes: List<Lexeme>, range: IntRange): String? {
         if (range.first != range.last) return null
-        return tokens[range.first].takeIf { it.kind == TokenKind.STRING }?.text
+        return lexemes[range.first].takeIf { it.kind == LexemeKind.STRING }?.text
     }
 
     private fun containsIdentifier(
-        tokens: List<Token>,
+        lexemes: List<Lexeme>,
         start: Int,
         endExclusive: Int,
         identifier: String
     ): Boolean {
-        for (index in start.coerceAtLeast(0) until minOf(endExclusive, tokens.size)) {
-            if (tokens[index].kind == TokenKind.IDENTIFIER && tokens[index].text == identifier) return true
+        for (index in start.coerceAtLeast(0) until minOf(endExclusive, lexemes.size)) {
+            if (lexemes[index].kind == LexemeKind.IDENTIFIER && lexemes[index].text == identifier) return true
         }
         return false
     }
 
-    private fun statementEnd(tokens: List<Token>, start: Int, limit: Int): Int {
+    private fun statementEnd(lexemes: List<Lexeme>, start: Int, limit: Int): Int {
         var paren = 0
         var bracket = 0
         var brace = 0
         var index = start
         while (index < limit) {
-            when (tokens[index].text) {
+            when (lexemes[index].text) {
                 "(" -> paren++
                 ")" -> if (paren > 0) paren--
                 "[" -> bracket++
                 "]" -> if (bracket > 0) bracket--
                 "{" -> brace++
                 "}" -> if (brace > 0) brace--
-                ";" -> if (paren == 0 && bracket == 0 && brace == 0) return index
+                ";", "," -> if (paren == 0 && bracket == 0 && brace == 0) return index
             }
             index++
         }
         return limit
     }
 
-    private fun matchingParen(tokens: List<Token>, open: Int): Int? {
-        if (tokens.getOrNull(open)?.text != "(") return null
+    private fun matchingParen(lexemes: List<Lexeme>, open: Int): Int? {
+        if (lexemes.getOrNull(open)?.text != "(") return null
         var depth = 0
-        for (index in open until tokens.size) {
-            when (tokens[index].text) {
+        for (index in open until lexemes.size) {
+            when (lexemes[index].text) {
                 "(" -> depth++
                 ")" -> {
                     depth--
@@ -516,21 +524,27 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         val seen = HashSet<Long>()
         needles.forEach { needle ->
             var cursor = 0
-            while (cursor < javascript.length && output.size < MAX_ANCHORS_PER_KIND) {
+            var foundForNeedle = 0
+            while (
+                cursor < javascript.length &&
+                foundForNeedle < MAX_ANCHORS_PER_NEEDLE &&
+                output.size < MAX_ANCHORS_PER_KIND
+            ) {
                 val anchor = javascript.indexOf(needle, cursor)
                 if (anchor < 0) break
                 val start = (anchor - before).coerceAtLeast(0)
                 val end = (anchor + needle.length + after).coerceAtMost(javascript.length)
                 val identity = (start.toLong() shl 32) xor end.toLong()
                 if (seen.add(identity)) output += ScanWindow(start, end, anchor)
+                foundForNeedle++
                 cursor = anchor + needle.length
             }
         }
         return output.sortedBy { it.anchor }
     }
 
-    private fun tokenize(source: String, start: Int, endExclusive: Int): List<Token> {
-        val output = ArrayList<Token>()
+    private fun tokenize(source: String, start: Int, endExclusive: Int): List<Lexeme> {
+        val output = ArrayList<Lexeme>()
         var index = start
         while (index < endExclusive && output.size < MAX_WINDOW_TOKENS) {
             val char = source[index]
@@ -550,7 +564,7 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
                 }
                 char == '\'' || char == '"' -> {
                     val quote = char
-                    val tokenStart = index
+                    val lexemeStart = index
                     index++
                     val value = StringBuilder()
                     while (index < endExclusive) {
@@ -567,7 +581,7 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
                         value.append(current)
                         index++
                     }
-                    output += Token(TokenKind.STRING, value.toString(), tokenStart, index)
+                    output += Lexeme(LexemeKind.STRING, value.toString(), lexemeStart, index)
                 }
                 char == '`' -> {
                     index++
@@ -584,19 +598,19 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
                     }
                 }
                 isIdentifierStart(char) -> {
-                    val tokenStart = index
+                    val lexemeStart = index
                     index++
                     while (index < endExclusive && isIdentifierPart(source[index])) index++
-                    output += Token(TokenKind.IDENTIFIER, source.substring(tokenStart, index), tokenStart, index)
+                    output += Lexeme(LexemeKind.IDENTIFIER, source.substring(lexemeStart, index), lexemeStart, index)
                 }
                 char.isDigit() -> {
-                    val tokenStart = index
+                    val lexemeStart = index
                     index++
                     while (index < endExclusive && (source[index].isDigit() || source[index] == '.')) index++
-                    output += Token(TokenKind.NUMBER, source.substring(tokenStart, index), tokenStart, index)
+                    output += Lexeme(LexemeKind.NUMBER, source.substring(lexemeStart, index), lexemeStart, index)
                 }
                 else -> {
-                    output += Token(TokenKind.SYMBOL, char.toString(), index, index + 1)
+                    output += Lexeme(LexemeKind.SYMBOL, char.toString(), index, index + 1)
                     index++
                 }
             }
@@ -642,8 +656,9 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         "set"
     )
 
-    private const val MIN_CONFIDENCE = 100
-    private const val MAX_ANCHORS_PER_KIND = 24
+    private const val MIN_CONFIDENCE = 110
+    private const val MAX_ANCHORS_PER_NEEDLE = 16
+    private const val MAX_ANCHORS_PER_KIND = 32
     private const val MAX_WINDOW_TOKENS = 900
     private const val MAX_FLOW_TOKENS = 260
     private const val MAX_SINK_SCAN_TOKENS = 180

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2.kt
@@ -167,13 +167,17 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
                 continue
             }
 
+            val sourceTaint = LinkedHashSet(tainted)
+            tainted.remove(lhs)
+            var derivesFromTaint = false
             callsBetween(lexemes, expressionStart, expressionEnd).forEach { call ->
                 if (!coversExpression(call, expressionStart, expressionEnd)) return@forEach
-                val expression = expressionForIdentifiers(lexemes, call, tainted) ?: return@forEach
+                val expression = expressionForIdentifiers(lexemes, call, sourceTaint) ?: return@forEach
                 val confidence = baseConfidence + sinkScore(lexemes, expressionEnd + 1, lhs)
                 addIfConfident(output, expression, confidence)
-                tainted += lhs
+                derivesFromTaint = true
             }
+            if (derivesFromTaint) tainted += lhs
             index = expressionEnd + 1
         }
         return output

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2.kt
@@ -1,0 +1,660 @@
+package com.luc4n3x.levyra.data
+
+internal data class YoutubeSemanticTransformCandidate(
+    val expression: String,
+    val confidence: Int
+)
+
+internal data class YoutubeSemanticDiscoveryResult(
+    val signatures: List<YoutubeSemanticTransformCandidate>,
+    val nTransforms: List<YoutubeSemanticTransformCandidate>
+)
+
+internal object YoutubePlayerSemanticAnalyzerV2 {
+    private enum class TokenKind {
+        IDENTIFIER,
+        NUMBER,
+        STRING,
+        SYMBOL
+    }
+
+    private data class Token(
+        val kind: TokenKind,
+        val text: String,
+        val start: Int,
+        val end: Int
+    )
+
+    private data class ScanWindow(
+        val start: Int,
+        val end: Int,
+        val anchor: Int
+    )
+
+    private data class CallSite(
+        val target: String,
+        val targetStart: Int,
+        val open: Int,
+        val close: Int,
+        val arguments: List<IntRange>
+    )
+
+    fun discover(javascript: String): YoutubeSemanticDiscoveryResult {
+        if (javascript.isBlank()) {
+            return YoutubeSemanticDiscoveryResult(emptyList(), emptyList())
+        }
+        return YoutubeSemanticDiscoveryResult(
+            signatures = rank(discoverSignatures(javascript)),
+            nTransforms = rank(discoverNTransforms(javascript))
+        )
+    }
+
+    private fun discoverSignatures(javascript: String): List<YoutubeSemanticTransformCandidate> {
+        val output = ArrayList<YoutubeSemanticTransformCandidate>()
+        scanWindows(javascript, listOf("decodeURIComponent"), SIGNATURE_BEFORE_CHARS, SIGNATURE_AFTER_CHARS)
+            .forEach { window ->
+                val tokens = tokenize(javascript, window.start, window.end)
+                val decode = tokens.indexOfFirst { token ->
+                    token.kind == TokenKind.IDENTIFIER &&
+                        token.text == "decodeURIComponent" &&
+                        window.anchor in token.start until token.end
+                }
+                if (decode < 0 || tokens.getOrNull(decode + 1)?.text != "(") return@forEach
+                val decodeClose = matchingParen(tokens, decode + 1) ?: return@forEach
+                val sourceEvidence = if (mentionsKey(tokens, decode + 2, decodeClose - 1, "s")) 30 else 0
+
+                enclosingCalls(tokens, decode, decodeClose).forEach { call ->
+                    val expression = expressionForRange(tokens, call, decode, decodeClose) ?: return@forEach
+                    val outputVariable = assignedVariableForExpression(tokens, call.targetStart)
+                    val sinkEvidence = when {
+                        outputVariable != null -> signatureSinkScore(tokens, call.close + 1, outputVariable)
+                        isNestedInCallable(tokens, call.targetStart, call.close, "encodeURIComponent") -> 35
+                        else -> 0
+                    }
+                    addIfConfident(output, expression, 70 + sourceEvidence + sinkEvidence)
+                }
+
+                val sourceVariable = assignedVariableForExpression(tokens, decode)
+                if (sourceVariable != null) {
+                    output += followVariableFlow(
+                        tokens = tokens,
+                        startIndex = decodeClose + 1,
+                        sourceVariable = sourceVariable,
+                        baseConfidence = 70 + sourceEvidence,
+                        sinkScore = ::signatureSinkScore
+                    )
+                }
+            }
+        return output
+    }
+
+    private fun discoverNTransforms(javascript: String): List<YoutubeSemanticTransformCandidate> {
+        val output = ArrayList<YoutubeSemanticTransformCandidate>()
+        scanWindows(javascript, listOf("\"n\"", "'n'"), N_BEFORE_CHARS, N_AFTER_CHARS)
+            .forEach { window ->
+                val tokens = tokenize(javascript, window.start, window.end)
+                val keyIndex = tokens.indexOfFirst { token ->
+                    token.kind == TokenKind.STRING &&
+                        token.text == "n" &&
+                        window.anchor in token.start until token.end
+                }
+                if (!isGetCallKey(tokens, keyIndex)) return@forEach
+                val getClose = matchingParen(tokens, keyIndex - 1) ?: return@forEach
+                val getStart = keyIndex - 3
+
+                enclosingCalls(tokens, getStart, getClose).forEach { call ->
+                    val expression = expressionForRange(tokens, call, getStart, getClose) ?: return@forEach
+                    val outputVariable = assignedVariableForExpression(tokens, call.targetStart)
+                    val sinkEvidence = when {
+                        outputVariable != null -> nSinkScore(tokens, call.close + 1, outputVariable)
+                        isNestedInNSet(tokens, call.targetStart, call.close) -> 45
+                        else -> 0
+                    }
+                    addIfConfident(output, expression, 70 + sinkEvidence)
+                }
+
+                val sourceVariable = assignedVariableForExpression(tokens, getStart)
+                if (sourceVariable != null) {
+                    output += followVariableFlow(
+                        tokens = tokens,
+                        startIndex = getClose + 1,
+                        sourceVariable = sourceVariable,
+                        baseConfidence = 70,
+                        sinkScore = ::nSinkScore
+                    )
+                }
+            }
+        return output
+    }
+
+    private fun followVariableFlow(
+        tokens: List<Token>,
+        startIndex: Int,
+        sourceVariable: String,
+        baseConfidence: Int,
+        sinkScore: (List<Token>, Int, String) -> Int
+    ): List<YoutubeSemanticTransformCandidate> {
+        val output = ArrayList<YoutubeSemanticTransformCandidate>()
+        val tainted = LinkedHashSet<String>()
+        tainted += sourceVariable
+        var index = startIndex.coerceAtLeast(0)
+        val limit = minOf(tokens.size, index + MAX_FLOW_TOKENS)
+
+        while (index < limit) {
+            if (tokens[index].text != "=" || !isAssignmentOperator(tokens, index)) {
+                index++
+                continue
+            }
+            val lhs = tokens.getOrNull(index - 1)
+                ?.takeIf { it.kind == TokenKind.IDENTIFIER }
+                ?.text
+            if (lhs == null) {
+                index++
+                continue
+            }
+            val statementEnd = statementEnd(tokens, index + 1, limit)
+            val rhs = (index + 1 until statementEnd).toList()
+            val identifiers = rhs
+                .mapNotNull { tokenIndex -> tokens[tokenIndex].takeIf { it.kind == TokenKind.IDENTIFIER }?.text }
+            if (identifiers.size == 1 && identifiers.first() in tainted) {
+                tainted += lhs
+                index = statementEnd + 1
+                continue
+            }
+
+            callsBetween(tokens, index + 1, statementEnd).forEach { call ->
+                val expression = expressionForIdentifiers(tokens, call, tainted) ?: return@forEach
+                val confidence = baseConfidence + sinkScore(tokens, statementEnd + 1, lhs)
+                addIfConfident(output, expression, confidence)
+                tainted += lhs
+            }
+            index = statementEnd + 1
+        }
+        return output
+    }
+
+    private fun expressionForRange(
+        tokens: List<Token>,
+        call: CallSite,
+        sourceStart: Int,
+        sourceEnd: Int
+    ): String? {
+        var replaced = 0
+        val arguments = ArrayList<String>(call.arguments.size)
+        call.arguments.forEach { range ->
+            if (range.first <= sourceStart && range.last >= sourceEnd) {
+                arguments += "INPUT"
+                replaced++
+            } else {
+                arguments += safeConstantArgument(tokens, range) ?: return null
+            }
+        }
+        if (replaced != 1) return null
+        return "${call.target}(${arguments.joinToString(",")})"
+    }
+
+    private fun expressionForIdentifiers(
+        tokens: List<Token>,
+        call: CallSite,
+        tainted: Set<String>
+    ): String? {
+        var replaced = 0
+        val arguments = ArrayList<String>(call.arguments.size)
+        call.arguments.forEach { range ->
+            val names = range.mapNotNull { index ->
+                tokens[index].takeIf { it.kind == TokenKind.IDENTIFIER }?.text
+            }
+            if (names.any { it in tainted }) {
+                if (names.count { it in tainted } != 1) return null
+                if (range.any { index ->
+                        val token = tokens[index]
+                        token.kind == TokenKind.IDENTIFIER && token.text !in tainted
+                    }
+                ) return null
+                arguments += "INPUT"
+                replaced++
+            } else {
+                arguments += safeConstantArgument(tokens, range) ?: return null
+            }
+        }
+        if (replaced != 1) return null
+        return "${call.target}(${arguments.joinToString(",")})"
+    }
+
+    private fun safeConstantArgument(tokens: List<Token>, range: IntRange): String? {
+        if (range.isEmpty()) return null
+        val slice = range.map { tokens[it] }
+        return when {
+            slice.size == 1 && slice[0].kind == TokenKind.NUMBER -> slice[0].text
+            slice.size == 2 && slice[0].text == "-" && slice[1].kind == TokenKind.NUMBER -> "-${slice[1].text}"
+            else -> null
+        }
+    }
+
+    private fun enclosingCalls(
+        tokens: List<Token>,
+        sourceStart: Int,
+        sourceEnd: Int
+    ): List<CallSite> {
+        val output = ArrayList<CallSite>(MAX_ENCLOSING_CALLS)
+        var index = sourceStart - 1
+        var inspected = 0
+        while (index >= 0 && inspected < MAX_PARENT_SCAN_TOKENS && output.size < MAX_ENCLOSING_CALLS) {
+            if (tokens[index].text == "(") {
+                val close = matchingParen(tokens, index)
+                if (close != null && close >= sourceEnd) {
+                    callSite(tokens, index, close)?.let { call ->
+                        if (call.target != "decodeURIComponent" && call.target != "encodeURIComponent") {
+                            output += call
+                        }
+                    }
+                }
+            }
+            index--
+            inspected++
+        }
+        return output
+    }
+
+    private fun callsBetween(tokens: List<Token>, start: Int, endExclusive: Int): List<CallSite> {
+        val output = ArrayList<CallSite>()
+        var index = start.coerceAtLeast(0)
+        val end = minOf(tokens.size, endExclusive)
+        while (index < end && output.size < MAX_CALLS_PER_FLOW) {
+            if (tokens[index].text == "(") {
+                val close = matchingParen(tokens, index)
+                if (close != null && close < end) {
+                    callSite(tokens, index, close)?.let { call ->
+                        if (call.target !in NON_TRANSFORM_CALLS) output += call
+                    }
+                }
+            }
+            index++
+        }
+        return output
+    }
+
+    private fun callSite(tokens: List<Token>, open: Int, close: Int): CallSite? {
+        val target = callableTarget(tokens, open) ?: return null
+        return CallSite(
+            target = target.first,
+            targetStart = target.second,
+            open = open,
+            close = close,
+            arguments = splitArguments(tokens, open + 1, close)
+        )
+    }
+
+    private fun callableTarget(tokens: List<Token>, open: Int): Pair<String, Int>? {
+        var index = open - 1
+        if (index < 0) return null
+        var target: String
+        var start: Int
+
+        if (tokens[index].text == "]") {
+            if (
+                index < 3 ||
+                tokens[index - 1].kind != TokenKind.NUMBER ||
+                tokens[index - 2].text != "[" ||
+                tokens[index - 3].kind != TokenKind.IDENTIFIER
+            ) return null
+            target = "${tokens[index - 3].text}[${tokens[index - 1].text}]"
+            start = index - 3
+            index -= 4
+        } else {
+            val last = tokens[index].takeIf { it.kind == TokenKind.IDENTIFIER } ?: return null
+            target = last.text
+            start = index
+            index--
+        }
+
+        while (
+            index >= 1 &&
+            tokens[index].text == "." &&
+            tokens[index - 1].kind == TokenKind.IDENTIFIER
+        ) {
+            target = "${tokens[index - 1].text}.$target"
+            start = index - 1
+            index -= 2
+        }
+        if (target.length > MAX_CALLABLE_LENGTH || target.split('.').any { it.isBlank() }) return null
+        return target to start
+    }
+
+    private fun splitArguments(tokens: List<Token>, start: Int, close: Int): List<IntRange> {
+        if (start >= close) return emptyList()
+        val output = ArrayList<IntRange>()
+        var argStart = start
+        var paren = 0
+        var bracket = 0
+        var brace = 0
+        var index = start
+        while (index < close) {
+            when (tokens[index].text) {
+                "(" -> paren++
+                ")" -> paren--
+                "[" -> bracket++
+                "]" -> bracket--
+                "{" -> brace++
+                "}" -> brace--
+                "," -> if (paren == 0 && bracket == 0 && brace == 0) {
+                    if (argStart >= index) return emptyList()
+                    output += argStart..(index - 1)
+                    argStart = index + 1
+                }
+            }
+            index++
+        }
+        if (argStart >= close) return emptyList()
+        output += argStart..(close - 1)
+        return output
+    }
+
+    private fun assignedVariableForExpression(tokens: List<Token>, expressionStart: Int): String? {
+        var index = expressionStart - 1
+        var inspected = 0
+        while (index >= 1 && inspected < MAX_ASSIGNMENT_SCAN_TOKENS) {
+            val symbol = tokens[index].text
+            if (symbol == ";" || symbol == "{" || symbol == "}") return null
+            if (symbol == "=" && isAssignmentOperator(tokens, index)) {
+                return tokens[index - 1]
+                    .takeIf { it.kind == TokenKind.IDENTIFIER }
+                    ?.text
+            }
+            index--
+            inspected++
+        }
+        return null
+    }
+
+    private fun isAssignmentOperator(tokens: List<Token>, index: Int): Boolean {
+        return tokens.getOrNull(index - 1)?.text != "=" &&
+            tokens.getOrNull(index + 1)?.text != "=" &&
+            tokens.getOrNull(index - 1)?.text != "!" &&
+            tokens.getOrNull(index - 1)?.text != ">" &&
+            tokens.getOrNull(index - 1)?.text != "<"
+    }
+
+    private fun signatureSinkScore(tokens: List<Token>, start: Int, variable: String): Int {
+        var score = 0
+        val end = minOf(tokens.size, start + MAX_SINK_SCAN_TOKENS)
+        var index = start.coerceAtLeast(0)
+        while (index < end) {
+            if (tokens[index].text == "encodeURIComponent" && tokens.getOrNull(index + 1)?.text == "(") {
+                val close = matchingParen(tokens, index + 1)
+                if (close != null && close < end && containsIdentifier(tokens, index + 2, close, variable)) {
+                    score = maxOf(score, 25)
+                }
+            }
+            if (tokens[index].text == "set" && tokens.getOrNull(index - 1)?.text == "." && tokens.getOrNull(index + 1)?.text == "(") {
+                val close = matchingParen(tokens, index + 1)
+                if (close != null && close < end && containsIdentifier(tokens, index + 2, close, variable)) {
+                    score = maxOf(score, 40)
+                }
+            }
+            index++
+        }
+        return score
+    }
+
+    private fun nSinkScore(tokens: List<Token>, start: Int, variable: String): Int {
+        val end = minOf(tokens.size, start + MAX_SINK_SCAN_TOKENS)
+        var index = start.coerceAtLeast(0)
+        while (index < end) {
+            if (tokens[index].text == "set" && tokens.getOrNull(index - 1)?.text == "." && tokens.getOrNull(index + 1)?.text == "(") {
+                val close = matchingParen(tokens, index + 1)
+                if (close != null && close < end) {
+                    val args = splitArguments(tokens, index + 2, close)
+                    if (
+                        args.size >= 2 &&
+                        singleString(tokens, args[0]) == "n" &&
+                        containsIdentifier(tokens, args[1].first, args[1].last + 1, variable)
+                    ) return 45
+                }
+            }
+            index++
+        }
+        return 0
+    }
+
+    private fun isNestedInCallable(
+        tokens: List<Token>,
+        sourceStart: Int,
+        sourceEnd: Int,
+        callable: String
+    ): Boolean {
+        return enclosingCalls(tokens, sourceStart, sourceEnd).any { it.target == callable }
+    }
+
+    private fun isNestedInNSet(tokens: List<Token>, sourceStart: Int, sourceEnd: Int): Boolean {
+        return enclosingCalls(tokens, sourceStart, sourceEnd).any { call ->
+            call.target.endsWith(".set") &&
+                call.arguments.firstOrNull()?.let { singleString(tokens, it) == "n" } == true
+        }
+    }
+
+    private fun isGetCallKey(tokens: List<Token>, keyIndex: Int): Boolean {
+        if (keyIndex < 3) return false
+        return tokens[keyIndex - 1].text == "(" &&
+            tokens[keyIndex - 2].text == "get" &&
+            tokens[keyIndex - 3].text == "."
+    }
+
+    private fun mentionsKey(tokens: List<Token>, start: Int, endInclusive: Int, key: String): Boolean {
+        if (start > endInclusive) return false
+        for (index in start..minOf(endInclusive, tokens.lastIndex)) {
+            val token = tokens[index]
+            if (token.kind == TokenKind.STRING && token.text == key) return true
+            if (
+                token.kind == TokenKind.IDENTIFIER &&
+                token.text == key &&
+                tokens.getOrNull(index - 1)?.text == "."
+            ) return true
+        }
+        return false
+    }
+
+    private fun singleString(tokens: List<Token>, range: IntRange): String? {
+        if (range.first != range.last) return null
+        return tokens[range.first].takeIf { it.kind == TokenKind.STRING }?.text
+    }
+
+    private fun containsIdentifier(
+        tokens: List<Token>,
+        start: Int,
+        endExclusive: Int,
+        identifier: String
+    ): Boolean {
+        for (index in start.coerceAtLeast(0) until minOf(endExclusive, tokens.size)) {
+            if (tokens[index].kind == TokenKind.IDENTIFIER && tokens[index].text == identifier) return true
+        }
+        return false
+    }
+
+    private fun statementEnd(tokens: List<Token>, start: Int, limit: Int): Int {
+        var paren = 0
+        var bracket = 0
+        var brace = 0
+        var index = start
+        while (index < limit) {
+            when (tokens[index].text) {
+                "(" -> paren++
+                ")" -> if (paren > 0) paren--
+                "[" -> bracket++
+                "]" -> if (bracket > 0) bracket--
+                "{" -> brace++
+                "}" -> if (brace > 0) brace--
+                ";" -> if (paren == 0 && bracket == 0 && brace == 0) return index
+            }
+            index++
+        }
+        return limit
+    }
+
+    private fun matchingParen(tokens: List<Token>, open: Int): Int? {
+        if (tokens.getOrNull(open)?.text != "(") return null
+        var depth = 0
+        for (index in open until tokens.size) {
+            when (tokens[index].text) {
+                "(" -> depth++
+                ")" -> {
+                    depth--
+                    if (depth == 0) return index
+                }
+            }
+        }
+        return null
+    }
+
+    private fun scanWindows(
+        javascript: String,
+        needles: List<String>,
+        before: Int,
+        after: Int
+    ): List<ScanWindow> {
+        val output = ArrayList<ScanWindow>()
+        val seen = HashSet<Long>()
+        needles.forEach { needle ->
+            var cursor = 0
+            while (cursor < javascript.length && output.size < MAX_ANCHORS_PER_KIND) {
+                val anchor = javascript.indexOf(needle, cursor)
+                if (anchor < 0) break
+                val start = (anchor - before).coerceAtLeast(0)
+                val end = (anchor + needle.length + after).coerceAtMost(javascript.length)
+                val identity = (start.toLong() shl 32) xor end.toLong()
+                if (seen.add(identity)) output += ScanWindow(start, end, anchor)
+                cursor = anchor + needle.length
+            }
+        }
+        return output.sortedBy { it.anchor }
+    }
+
+    private fun tokenize(source: String, start: Int, endExclusive: Int): List<Token> {
+        val output = ArrayList<Token>()
+        var index = start
+        while (index < endExclusive && output.size < MAX_WINDOW_TOKENS) {
+            val char = source[index]
+            when {
+                char.isWhitespace() -> index++
+                char == '/' && source.getOrNull(index + 1) == '/' -> {
+                    index += 2
+                    while (index < endExclusive && source[index] != '\n') index++
+                }
+                char == '/' && source.getOrNull(index + 1) == '*' -> {
+                    index += 2
+                    while (
+                        index + 1 < endExclusive &&
+                        !(source[index] == '*' && source[index + 1] == '/')
+                    ) index++
+                    index = minOf(endExclusive, index + 2)
+                }
+                char == '\'' || char == '"' -> {
+                    val quote = char
+                    val tokenStart = index
+                    index++
+                    val value = StringBuilder()
+                    while (index < endExclusive) {
+                        val current = source[index]
+                        if (current == '\\' && index + 1 < endExclusive) {
+                            value.append(source[index + 1])
+                            index += 2
+                            continue
+                        }
+                        if (current == quote) {
+                            index++
+                            break
+                        }
+                        value.append(current)
+                        index++
+                    }
+                    output += Token(TokenKind.STRING, value.toString(), tokenStart, index)
+                }
+                char == '`' -> {
+                    index++
+                    while (index < endExclusive) {
+                        if (source[index] == '\\' && index + 1 < endExclusive) {
+                            index += 2
+                            continue
+                        }
+                        if (source[index] == '`') {
+                            index++
+                            break
+                        }
+                        index++
+                    }
+                }
+                isIdentifierStart(char) -> {
+                    val tokenStart = index
+                    index++
+                    while (index < endExclusive && isIdentifierPart(source[index])) index++
+                    output += Token(TokenKind.IDENTIFIER, source.substring(tokenStart, index), tokenStart, index)
+                }
+                char.isDigit() -> {
+                    val tokenStart = index
+                    index++
+                    while (index < endExclusive && (source[index].isDigit() || source[index] == '.')) index++
+                    output += Token(TokenKind.NUMBER, source.substring(tokenStart, index), tokenStart, index)
+                }
+                else -> {
+                    output += Token(TokenKind.SYMBOL, char.toString(), index, index + 1)
+                    index++
+                }
+            }
+        }
+        return output
+    }
+
+    private fun rank(values: List<YoutubeSemanticTransformCandidate>): List<YoutubeSemanticTransformCandidate> {
+        val best = LinkedHashMap<String, YoutubeSemanticTransformCandidate>()
+        values.forEach { candidate ->
+            val current = best[candidate.expression]
+            if (current == null || candidate.confidence > current.confidence) {
+                best[candidate.expression] = candidate
+            }
+        }
+        return best.values
+            .sortedWith(
+                compareByDescending<YoutubeSemanticTransformCandidate> { it.confidence }
+                    .thenBy { it.expression }
+            )
+            .take(MAX_CANDIDATES_PER_KIND)
+    }
+
+    private fun addIfConfident(
+        output: MutableList<YoutubeSemanticTransformCandidate>,
+        expression: String,
+        confidence: Int
+    ) {
+        if (confidence >= MIN_CONFIDENCE) {
+            output += YoutubeSemanticTransformCandidate(expression, confidence.coerceAtMost(200))
+        }
+    }
+
+    private fun isIdentifierStart(char: Char): Boolean =
+        char == '_' || char == '$' || char in 'a'..'z' || char in 'A'..'Z'
+
+    private fun isIdentifierPart(char: Char): Boolean = isIdentifierStart(char) || char.isDigit()
+
+    private val NON_TRANSFORM_CALLS = setOf(
+        "decodeURIComponent",
+        "encodeURIComponent",
+        "get",
+        "set"
+    )
+
+    private const val MIN_CONFIDENCE = 100
+    private const val MAX_ANCHORS_PER_KIND = 24
+    private const val MAX_WINDOW_TOKENS = 900
+    private const val MAX_FLOW_TOKENS = 260
+    private const val MAX_SINK_SCAN_TOKENS = 180
+    private const val MAX_PARENT_SCAN_TOKENS = 80
+    private const val MAX_ASSIGNMENT_SCAN_TOKENS = 32
+    private const val MAX_CALLS_PER_FLOW = 16
+    private const val MAX_ENCLOSING_CALLS = 4
+    private const val MAX_CANDIDATES_PER_KIND = 4
+    private const val MAX_CALLABLE_LENGTH = 64
+    private const val SIGNATURE_BEFORE_CHARS = 1_200
+    private const val SIGNATURE_AFTER_CHARS = 2_600
+    private const val N_BEFORE_CHARS = 1_800
+    private const val N_AFTER_CHARS = 2_600
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2.kt
@@ -632,6 +632,9 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
                     .thenBy { it.expression }
             )
             .take(MAX_CANDIDATES_PER_KIND)
+            .mapIndexed { index, candidate ->
+                if (index == 0) candidate else candidate.copy(confidence = SECONDARY_RESERVE_CONFIDENCE)
+            }
     }
 
     private fun addIfConfident(
@@ -657,6 +660,7 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
     )
 
     private const val MIN_CONFIDENCE = 110
+    private const val SECONDARY_RESERVE_CONFIDENCE = 0
     private const val MAX_ANCHORS_PER_NEEDLE = 16
     private const val MAX_ANCHORS_PER_KIND = 32
     private const val MAX_WINDOW_TOKENS = 900

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2.kt
@@ -61,7 +61,8 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
                 }
                 if (decode < 0 || lexemes.getOrNull(decode + 1)?.text != "(") return@forEach
                 val decodeClose = matchingParen(lexemes, decode + 1) ?: return@forEach
-                val sourceEvidence = if (mentionsKey(lexemes, decode + 2, decodeClose - 1, "s")) 30 else 0
+                if (!mentionsKey(lexemes, decode + 2, decodeClose - 1, "s")) return@forEach
+                val sourceEvidence = 30
 
                 enclosingCalls(lexemes, decode, decodeClose).forEach { call ->
                     if (isNonTransformTarget(call.target)) return@forEach
@@ -154,18 +155,16 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
                 index++
                 continue
             }
-            val expressionEnd = statementEnd(lexemes, index + 1, limit)
-            val rhs = (index + 1 until expressionEnd).toList()
-            val identifiers = rhs.mapNotNull { lexemeIndex ->
-                lexemes[lexemeIndex].takeIf { it.kind == LexemeKind.IDENTIFIER }?.text
-            }
-            if (identifiers.size == 1 && identifiers.first() in tainted) {
+            val expressionStart = index + 1
+            val expressionEnd = statementEnd(lexemes, expressionStart, limit)
+            if (isPureAlias(lexemes, expressionStart, expressionEnd, tainted)) {
                 tainted += lhs
                 index = expressionEnd + 1
                 continue
             }
 
-            callsBetween(lexemes, index + 1, expressionEnd).forEach { call ->
+            callsBetween(lexemes, expressionStart, expressionEnd).forEach { call ->
+                if (!coversExpression(call, expressionStart, expressionEnd)) return@forEach
                 val expression = expressionForIdentifiers(lexemes, call, tainted) ?: return@forEach
                 val confidence = baseConfidence + sinkScore(lexemes, expressionEnd + 1, lhs)
                 addIfConfident(output, expression, confidence)
@@ -175,6 +174,20 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         }
         return output
     }
+
+    private fun isPureAlias(
+        lexemes: List<Lexeme>,
+        start: Int,
+        endExclusive: Int,
+        tainted: Set<String>
+    ): Boolean {
+        if (endExclusive - start != 1) return false
+        val lexeme = lexemes.getOrNull(start) ?: return false
+        return lexeme.kind == LexemeKind.IDENTIFIER && lexeme.text in tainted
+    }
+
+    private fun coversExpression(call: CallSite, start: Int, endExclusive: Int): Boolean =
+        call.targetStart == start && call.close == endExclusive - 1
 
     private fun expressionForRange(
         lexemes: List<Lexeme>,
@@ -204,16 +217,9 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         var replaced = 0
         val arguments = ArrayList<String>(call.arguments.size)
         call.arguments.forEach { range ->
-            val names = range.mapNotNull { lexemeIndex ->
-                lexemes[lexemeIndex].takeIf { it.kind == LexemeKind.IDENTIFIER }?.text
-            }
-            if (names.any { it in tainted }) {
-                if (names.count { it in tainted } != 1) return null
-                if (range.any { lexemeIndex ->
-                        val lexeme = lexemes[lexemeIndex]
-                        lexeme.kind == LexemeKind.IDENTIFIER && lexeme.text !in tainted
-                    }
-                ) return null
+            val sole = lexemes.getOrNull(range.first)
+                ?.takeIf { range.first == range.last }
+            if (sole?.kind == LexemeKind.IDENTIFIER && sole.text in tainted) {
                 arguments += "INPUT"
                 replaced++
             } else {
@@ -383,11 +389,18 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
             lexemes.getOrNull(index - 1)?.text != "<"
     }
 
+    private fun isAssignmentTo(lexemes: List<Lexeme>, index: Int, variable: String): Boolean {
+        if (lexemes.getOrNull(index)?.kind != LexemeKind.IDENTIFIER || lexemes[index].text != variable) return false
+        val assignment = index + 1
+        return lexemes.getOrNull(assignment)?.text == "=" && isAssignmentOperator(lexemes, assignment)
+    }
+
     private fun signatureSinkScore(lexemes: List<Lexeme>, start: Int, variable: String): Int {
         var score = 0
         val end = minOf(lexemes.size, start + MAX_SINK_SCAN_TOKENS)
         var index = start.coerceAtLeast(0)
         while (index < end) {
+            if (isAssignmentTo(lexemes, index, variable)) return score
             if (lexemes[index].text == "encodeURIComponent" && lexemes.getOrNull(index + 1)?.text == "(") {
                 val close = matchingParen(lexemes, index + 1)
                 if (close != null && close < end && containsIdentifier(lexemes, index + 2, close, variable)) {
@@ -409,6 +422,7 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         val end = minOf(lexemes.size, start + MAX_SINK_SCAN_TOKENS)
         var index = start.coerceAtLeast(0)
         while (index < end) {
+            if (isAssignmentTo(lexemes, index, variable)) return 0
             if (lexemes[index].text == "set" && lexemes.getOrNull(index - 1)?.text == "." && lexemes.getOrNull(index + 1)?.text == "(") {
                 val close = matchingParen(lexemes, index + 1)
                 if (close != null && close < end) {

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2.kt
@@ -69,7 +69,8 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
                     val expression = expressionForRange(lexemes, call, decode, decodeClose) ?: return@forEach
                     val outputVariable = assignedVariableForExpression(lexemes, call.targetStart)
                     val sinkEvidence = when {
-                        outputVariable != null -> signatureSinkScore(lexemes, call.close + 1, outputVariable)
+                        outputVariable != null && isWholeAssignedExpression(lexemes, call) ->
+                            signatureSinkScore(lexemes, call.close + 1, outputVariable)
                         isNestedInCallable(lexemes, call.targetStart, call.close, "encodeURIComponent") -> 35
                         else -> 0
                     }
@@ -92,41 +93,41 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
 
     private fun discoverNTransforms(javascript: String): List<YoutubeSemanticTransformCandidate> {
         val output = ArrayList<YoutubeSemanticTransformCandidate>()
-        scanWindows(javascript, listOf("\"n\"", "'n'"), N_BEFORE_CHARS, N_AFTER_CHARS)
-            .forEach { window ->
-                val lexemes = tokenize(javascript, window.start, window.end)
-                val keyIndex = lexemes.indexOfFirst { lexeme ->
-                    lexeme.kind == LexemeKind.STRING &&
-                        lexeme.text == "n" &&
-                        window.anchor in lexeme.start until lexeme.end
-                }
-                if (!isGetCallKey(lexemes, keyIndex)) return@forEach
-                val getClose = matchingParen(lexemes, keyIndex - 1) ?: return@forEach
-                val getStart = keyIndex - 3
-
-                enclosingCalls(lexemes, getStart, getClose).forEach { call ->
-                    if (isNonTransformTarget(call.target)) return@forEach
-                    val expression = expressionForRange(lexemes, call, getStart, getClose) ?: return@forEach
-                    val outputVariable = assignedVariableForExpression(lexemes, call.targetStart)
-                    val sinkEvidence = when {
-                        outputVariable != null -> nSinkScore(lexemes, call.close + 1, outputVariable)
-                        isNestedInNSet(lexemes, call.targetStart, call.close) -> 45
-                        else -> 0
-                    }
-                    addIfConfident(output, expression, 70 + sinkEvidence)
-                }
-
-                val sourceVariable = assignedVariableForExpression(lexemes, getStart)
-                if (sourceVariable != null) {
-                    output += followVariableFlow(
-                        lexemes = lexemes,
-                        startIndex = getClose + 1,
-                        sourceVariable = sourceVariable,
-                        baseConfidence = 70,
-                        sinkScore = ::nSinkScore
-                    )
-                }
+        scanNWindows(javascript).forEach { window ->
+            val lexemes = tokenize(javascript, window.start, window.end)
+            val keyIndex = lexemes.indexOfFirst { lexeme ->
+                lexeme.kind == LexemeKind.STRING &&
+                    lexeme.text == "n" &&
+                    window.anchor in lexeme.start until lexeme.end
             }
+            if (!isGetCallKey(lexemes, keyIndex)) return@forEach
+            val getClose = matchingParen(lexemes, keyIndex - 1) ?: return@forEach
+            val getStart = keyIndex - 3
+
+            enclosingCalls(lexemes, getStart, getClose).forEach { call ->
+                if (isNonTransformTarget(call.target)) return@forEach
+                val expression = expressionForRange(lexemes, call, getStart, getClose) ?: return@forEach
+                val outputVariable = assignedVariableForExpression(lexemes, call.targetStart)
+                val sinkEvidence = when {
+                    outputVariable != null && isWholeAssignedExpression(lexemes, call) ->
+                        nSinkScore(lexemes, call.close + 1, outputVariable)
+                    isNestedInNSet(lexemes, call.targetStart, call.close) -> 45
+                    else -> 0
+                }
+                addIfConfident(output, expression, 70 + sinkEvidence)
+            }
+
+            val sourceVariable = assignedVariableForExpression(lexemes, getStart)
+            if (sourceVariable != null) {
+                output += followVariableFlow(
+                    lexemes = lexemes,
+                    startIndex = getClose + 1,
+                    sourceVariable = sourceVariable,
+                    baseConfidence = 70,
+                    sinkScore = ::nSinkScore
+                )
+            }
+        }
         return output
     }
 
@@ -198,7 +199,7 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         var replaced = 0
         val arguments = ArrayList<String>(call.arguments.size)
         call.arguments.forEach { range ->
-            if (range.first <= sourceStart && range.last >= sourceEnd) {
+            if (range.first == sourceStart && range.last == sourceEnd) {
                 arguments += "INPUT"
                 replaced++
             } else {
@@ -363,21 +364,34 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         return output
     }
 
-    private fun assignedVariableForExpression(lexemes: List<Lexeme>, expressionStart: Int): String? {
+    private fun assignmentIndexForExpression(lexemes: List<Lexeme>, expressionStart: Int): Int? {
         var index = expressionStart - 1
         var inspected = 0
         while (index >= 1 && inspected < MAX_ASSIGNMENT_SCAN_TOKENS) {
             val symbol = lexemes[index].text
             if (symbol == ";" || symbol == "," || symbol == "{" || symbol == "}") return null
-            if (symbol == "=" && isAssignmentOperator(lexemes, index)) {
-                return lexemes[index - 1]
-                    .takeIf { it.kind == LexemeKind.IDENTIFIER }
-                    ?.text
-            }
+            if (symbol == "=" && isAssignmentOperator(lexemes, index)) return index
             index--
             inspected++
         }
         return null
+    }
+
+    private fun assignedVariableForExpression(lexemes: List<Lexeme>, expressionStart: Int): String? {
+        val assignment = assignmentIndexForExpression(lexemes, expressionStart) ?: return null
+        return lexemes.getOrNull(assignment - 1)
+            ?.takeIf { it.kind == LexemeKind.IDENTIFIER }
+            ?.text
+    }
+
+    private fun isWholeAssignedExpression(lexemes: List<Lexeme>, call: CallSite): Boolean {
+        val assignment = assignmentIndexForExpression(lexemes, call.targetStart) ?: return false
+        val end = statementEnd(
+            lexemes,
+            assignment + 1,
+            minOf(lexemes.size, assignment + 1 + MAX_FLOW_TOKENS)
+        )
+        return call.targetStart == assignment + 1 && call.close == end - 1
     }
 
     private fun isAssignmentOperator(lexemes: List<Lexeme>, index: Int): Boolean {
@@ -395,6 +409,12 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         return lexemes.getOrNull(assignment)?.text == "=" && isAssignmentOperator(lexemes, assignment)
     }
 
+    private fun singleIdentifier(lexemes: List<Lexeme>, range: IntRange, identifier: String): Boolean {
+        if (range.first != range.last) return false
+        val lexeme = lexemes.getOrNull(range.first) ?: return false
+        return lexeme.kind == LexemeKind.IDENTIFIER && lexeme.text == identifier
+    }
+
     private fun signatureSinkScore(lexemes: List<Lexeme>, start: Int, variable: String): Int {
         var score = 0
         val end = minOf(lexemes.size, start + MAX_SINK_SCAN_TOKENS)
@@ -403,14 +423,20 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
             if (isAssignmentTo(lexemes, index, variable)) return score
             if (lexemes[index].text == "encodeURIComponent" && lexemes.getOrNull(index + 1)?.text == "(") {
                 val close = matchingParen(lexemes, index + 1)
-                if (close != null && close < end && containsIdentifier(lexemes, index + 2, close, variable)) {
-                    score = maxOf(score, 25)
+                if (close != null && close < end) {
+                    val args = splitArguments(lexemes, index + 2, close)
+                    if (args.size == 1 && singleIdentifier(lexemes, args[0], variable)) {
+                        score = maxOf(score, 25)
+                    }
                 }
             }
             if (lexemes[index].text == "set" && lexemes.getOrNull(index - 1)?.text == "." && lexemes.getOrNull(index + 1)?.text == "(") {
                 val close = matchingParen(lexemes, index + 1)
-                if (close != null && close < end && containsIdentifier(lexemes, index + 2, close, variable)) {
-                    score = maxOf(score, 40)
+                if (close != null && close < end) {
+                    val args = splitArguments(lexemes, index + 2, close)
+                    if (args.size >= 2 && singleIdentifier(lexemes, args[1], variable)) {
+                        score = maxOf(score, 40)
+                    }
                 }
             }
             index++
@@ -430,7 +456,7 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
                     if (
                         args.size >= 2 &&
                         singleString(lexemes, args[0]) == "n" &&
-                        containsIdentifier(lexemes, args[1].first, args[1].last + 1, variable)
+                        singleIdentifier(lexemes, args[1], variable)
                     ) return 45
                 }
             }
@@ -445,13 +471,21 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         sourceEnd: Int,
         callable: String
     ): Boolean {
-        return enclosingCalls(lexemes, sourceStart, sourceEnd).any { it.target == callable }
+        return enclosingCalls(lexemes, sourceStart, sourceEnd).any { call ->
+            call.target == callable &&
+                call.arguments.size == 1 &&
+                call.arguments[0].first == sourceStart &&
+                call.arguments[0].last == sourceEnd
+        }
     }
 
     private fun isNestedInNSet(lexemes: List<Lexeme>, sourceStart: Int, sourceEnd: Int): Boolean {
         return enclosingCalls(lexemes, sourceStart, sourceEnd).any { call ->
             call.target.endsWith(".set") &&
-                call.arguments.firstOrNull()?.let { singleString(lexemes, it) == "n" } == true
+                call.arguments.size >= 2 &&
+                singleString(lexemes, call.arguments[0]) == "n" &&
+                call.arguments[1].first == sourceStart &&
+                call.arguments[1].last == sourceEnd
         }
     }
 
@@ -466,7 +500,12 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         if (start > endInclusive) return false
         for (index in start..minOf(endInclusive, lexemes.lastIndex)) {
             val lexeme = lexemes[index]
-            if (lexeme.kind == LexemeKind.STRING && lexeme.text == key) return true
+            if (
+                lexeme.kind == LexemeKind.STRING &&
+                lexeme.text == key &&
+                lexemes.getOrNull(index - 1)?.text == "[" &&
+                lexemes.getOrNull(index + 1)?.text == "]"
+            ) return true
             if (
                 lexeme.kind == LexemeKind.IDENTIFIER &&
                 lexeme.text == key &&
@@ -479,18 +518,6 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
     private fun singleString(lexemes: List<Lexeme>, range: IntRange): String? {
         if (range.first != range.last) return null
         return lexemes[range.first].takeIf { it.kind == LexemeKind.STRING }?.text
-    }
-
-    private fun containsIdentifier(
-        lexemes: List<Lexeme>,
-        start: Int,
-        endExclusive: Int,
-        identifier: String
-    ): Boolean {
-        for (index in start.coerceAtLeast(0) until minOf(endExclusive, lexemes.size)) {
-            if (lexemes[index].kind == LexemeKind.IDENTIFIER && lexemes[index].text == identifier) return true
-        }
-        return false
     }
 
     private fun statementEnd(lexemes: List<Lexeme>, start: Int, limit: Int): Int {
@@ -526,6 +553,45 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
             }
         }
         return null
+    }
+
+    private fun scanNWindows(javascript: String): List<ScanWindow> {
+        val output = ArrayList<ScanWindow>()
+        val seen = HashSet<Long>()
+        listOf("\"n\"", "'n'").forEach { needle ->
+            var cursor = 0
+            var foundForNeedle = 0
+            while (
+                cursor < javascript.length &&
+                foundForNeedle < MAX_ANCHORS_PER_NEEDLE &&
+                output.size < MAX_ANCHORS_PER_KIND
+            ) {
+                val anchor = javascript.indexOf(needle, cursor)
+                if (anchor < 0) break
+                if (isRawGetKey(javascript, anchor)) {
+                    val start = (anchor - N_BEFORE_CHARS).coerceAtLeast(0)
+                    val end = (anchor + needle.length + N_AFTER_CHARS).coerceAtMost(javascript.length)
+                    val identity = (start.toLong() shl 32) xor end.toLong()
+                    if (seen.add(identity)) output += ScanWindow(start, end, anchor)
+                    foundForNeedle++
+                }
+                cursor = anchor + needle.length
+            }
+        }
+        return output.sortedBy { it.anchor }
+    }
+
+    private fun isRawGetKey(source: String, keyStart: Int): Boolean {
+        var index = keyStart - 1
+        while (index >= 0 && source[index].isWhitespace()) index--
+        if (index < 0 || source[index] != '(') return false
+        index--
+        while (index >= 0 && source[index].isWhitespace()) index--
+        val identifierEnd = index + 1
+        while (index >= 0 && isIdentifierPart(source[index])) index--
+        if (source.substring(index + 1, identifierEnd) != "get") return false
+        while (index >= 0 && source[index].isWhitespace()) index--
+        return index >= 0 && source[index] == '.'
     }
 
     private fun scanWindows(
@@ -675,8 +741,8 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
 
     private const val MIN_CONFIDENCE = 110
     private const val SECONDARY_RESERVE_CONFIDENCE = 0
-    private const val MAX_ANCHORS_PER_NEEDLE = 16
-    private const val MAX_ANCHORS_PER_KIND = 32
+    private const val MAX_ANCHORS_PER_NEEDLE = 32
+    private const val MAX_ANCHORS_PER_KIND = 64
     private const val MAX_WINDOW_TOKENS = 900
     private const val MAX_FLOW_TOKENS = 260
     private const val MAX_SINK_SCAN_TOKENS = 180

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2.kt
@@ -39,19 +39,46 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         val arguments: List<IntRange>
     )
 
+    private data class AnchorIndex(
+        val signatureAnchors: List<Int>,
+        val nAnchors: List<Int>
+    )
+
     fun discover(javascript: String): YoutubeSemanticDiscoveryResult {
         if (javascript.isBlank()) {
             return YoutubeSemanticDiscoveryResult(emptyList(), emptyList())
         }
+
+        val anchors = scanAnchors(javascript)
+        val signatureBudget = if (LEGACY_SIGNATURE_PRESENCE.containsMatchIn(javascript)) {
+            0
+        } else {
+            MAX_SEMANTIC_CANDIDATES_PER_KIND
+        }
+        val nBudget = if (LEGACY_N_PRESENCE.containsMatchIn(javascript)) {
+            0
+        } else {
+            MAX_SEMANTIC_CANDIDATES_PER_KIND
+        }
+
         return YoutubeSemanticDiscoveryResult(
-            signatures = rank(discoverSignatures(javascript)),
-            nTransforms = rank(discoverNTransforms(javascript))
+            signatures = rank(
+                discoverSignatures(javascript, anchors.signatureAnchors),
+                signatureBudget
+            ),
+            nTransforms = rank(
+                discoverNTransforms(javascript, anchors.nAnchors),
+                nBudget
+            )
         )
     }
 
-    private fun discoverSignatures(javascript: String): List<YoutubeSemanticTransformCandidate> {
+    private fun discoverSignatures(
+        javascript: String,
+        anchors: List<Int>
+    ): List<YoutubeSemanticTransformCandidate> {
         val output = ArrayList<YoutubeSemanticTransformCandidate>()
-        scanSignatureWindows(javascript).forEach { window ->
+        signatureWindows(javascript, anchors).forEach { window ->
             val lexemes = tokenize(javascript, window.start, window.end)
             val decode = lexemes.indexOfFirst { lexeme ->
                 lexeme.kind == LexemeKind.IDENTIFIER &&
@@ -60,29 +87,37 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
             }
             if (decode < 0 || lexemes.getOrNull(decode + 1)?.text != "(") return@forEach
             val decodeClose = matchingParen(lexemes, decode + 1) ?: return@forEach
-            if (!mentionsKey(lexemes, decode + 2, decodeClose - 1, "s")) return@forEach
-            val sourceEvidence = 30
+            if (signatureSourceRange(lexemes, decode, decodeClose) == null) return@forEach
 
-            enclosingCalls(lexemes, decode, decodeClose).forEach { call ->
-                if (isNonTransformTarget(call.target)) return@forEach
-                val expression = expressionForRange(lexemes, call, decode, decodeClose) ?: return@forEach
-                val outputVariable = assignedVariableForExpression(lexemes, call.targetStart)
+            enclosingCalls(lexemes, decode, decodeClose).forEach callLoop@{ call ->
+                if (isNonTransformTarget(call.target)) return@callLoop
+                val expression = expressionForRange(lexemes, call, decode, decodeClose) ?: return@callLoop
+                val outputVariable = assignedVariableForWholeRange(
+                    lexemes,
+                    call.targetStart,
+                    call.close
+                )
                 val sinkEvidence = when {
-                    outputVariable != null && isWholeAssignedExpression(lexemes, call) ->
+                    outputVariable != null ->
                         signatureSinkScore(lexemes, call.close + 1, outputVariable)
-                    isNestedInCallable(lexemes, call.targetStart, call.close, "encodeURIComponent") -> 35
+                    isNestedInCallable(
+                        lexemes,
+                        call.targetStart,
+                        call.close,
+                        "encodeURIComponent"
+                    ) -> SIGNATURE_NESTED_SINK_SCORE
                     else -> 0
                 }
-                addIfConfident(output, expression, 70 + sourceEvidence + sinkEvidence)
+                addIfConfident(output, expression, SIGNATURE_BASE_CONFIDENCE + sinkEvidence)
             }
 
-            val sourceVariable = assignedVariableForExpression(lexemes, decode)
+            val sourceVariable = assignedVariableForWholeRange(lexemes, decode, decodeClose)
             if (sourceVariable != null) {
                 output += followVariableFlow(
                     lexemes = lexemes,
                     startIndex = decodeClose + 1,
                     sourceVariable = sourceVariable,
-                    baseConfidence = 70 + sourceEvidence,
+                    baseConfidence = SIGNATURE_BASE_CONFIDENCE,
                     sinkScore = ::signatureSinkScore
                 )
             }
@@ -90,44 +125,73 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         return output
     }
 
-    private fun discoverNTransforms(javascript: String): List<YoutubeSemanticTransformCandidate> {
+    private fun discoverNTransforms(
+        javascript: String,
+        anchors: List<Int>
+    ): List<YoutubeSemanticTransformCandidate> {
         val output = ArrayList<YoutubeSemanticTransformCandidate>()
-        scanNWindows(javascript).forEach { window ->
+        nWindows(javascript, anchors).forEach { window ->
             val lexemes = tokenize(javascript, window.start, window.end)
             val keyIndex = lexemes.indexOfFirst { lexeme ->
                 lexeme.kind == LexemeKind.STRING &&
                     lexeme.text == "n" &&
                     window.anchor in lexeme.start until lexeme.end
             }
-            if (!isGetCallKey(lexemes, keyIndex)) return@forEach
+            if (keyIndex < 0) return@forEach
+
             val getOpen = keyIndex - 1
             val getClose = matchingParen(lexemes, getOpen) ?: return@forEach
             val getCall = callSite(lexemes, getOpen, getClose)
-                ?.takeIf { it.target.endsWith(".get") }
+                ?.takeIf { call ->
+                    call.target.endsWith(".get") &&
+                        call.arguments.size == 1 &&
+                        singleString(lexemes, call.arguments[0]) == "n"
+                }
                 ?: return@forEach
-            val getStart = getCall.targetStart
+            val receiver = getCall.target.removeSuffix(".get")
+            if (!isSafeReceiverName(receiver)) return@forEach
 
-            enclosingCalls(lexemes, getStart, getClose).forEach { call ->
-                if (isNonTransformTarget(call.target)) return@forEach
-                val expression = expressionForRange(lexemes, call, getStart, getClose) ?: return@forEach
-                val outputVariable = assignedVariableForExpression(lexemes, call.targetStart)
+            enclosingCalls(lexemes, getCall.targetStart, getClose).forEach callLoop@{ call ->
+                if (isNonTransformTarget(call.target)) return@callLoop
+                val expression = expressionForRange(
+                    lexemes,
+                    call,
+                    getCall.targetStart,
+                    getClose
+                ) ?: return@callLoop
+                val outputVariable = assignedVariableForWholeRange(
+                    lexemes,
+                    call.targetStart,
+                    call.close
+                )
                 val sinkEvidence = when {
-                    outputVariable != null && isWholeAssignedExpression(lexemes, call) ->
-                        nSinkScore(lexemes, call.close + 1, outputVariable)
-                    isNestedInNSet(lexemes, call.targetStart, call.close) -> 45
+                    outputVariable != null ->
+                        nSinkScore(lexemes, call.close + 1, outputVariable, receiver)
+                    isNestedInNSet(
+                        lexemes,
+                        call.targetStart,
+                        call.close,
+                        receiver
+                    ) -> N_SINK_SCORE
                     else -> 0
                 }
-                addIfConfident(output, expression, 70 + sinkEvidence)
+                addIfConfident(output, expression, N_BASE_CONFIDENCE + sinkEvidence)
             }
 
-            val sourceVariable = assignedVariableForExpression(lexemes, getStart)
+            val sourceVariable = assignedVariableForWholeRange(
+                lexemes,
+                getCall.targetStart,
+                getClose
+            )
             if (sourceVariable != null) {
                 output += followVariableFlow(
                     lexemes = lexemes,
                     startIndex = getClose + 1,
                     sourceVariable = sourceVariable,
-                    baseConfidence = 70,
-                    sinkScore = ::nSinkScore
+                    baseConfidence = N_BASE_CONFIDENCE,
+                    sinkScore = { values, start, variable ->
+                        nSinkScore(values, start, variable, receiver)
+                    }
                 )
             }
         }
@@ -145,22 +209,24 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         val tainted = LinkedHashSet<String>()
         tainted += sourceVariable
         var index = startIndex.coerceAtLeast(0)
-        val limit = minOf(lexemes.size, index + MAX_FLOW_TOKENS)
+        val hardLimit = minOf(lexemes.size, index + MAX_FLOW_TOKENS)
+        val scopeLimit = minOf(hardLimit, scopeEnd(lexemes, index, hardLimit))
 
-        while (index < limit) {
+        while (index < scopeLimit) {
+            if (startsNestedFunction(lexemes, index)) break
             if (lexemes[index].text != "=" || !isAssignmentOperator(lexemes, index)) {
                 index++
                 continue
             }
-            val lhs = lexemes.getOrNull(index - 1)
-                ?.takeIf { it.kind == LexemeKind.IDENTIFIER }
-                ?.text
+
+            val lhs = simpleAssignmentLhs(lexemes, index)
             if (lhs == null) {
                 index++
                 continue
             }
+
             val expressionStart = index + 1
-            val expressionEnd = statementEnd(lexemes, expressionStart, limit)
+            val expressionEnd = statementEnd(lexemes, expressionStart, scopeLimit)
             if (isPureAlias(lexemes, expressionStart, expressionEnd, tainted)) {
                 tainted += lhs
                 index = expressionEnd + 1
@@ -181,6 +247,76 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
             index = expressionEnd + 1
         }
         return output
+    }
+
+    private fun signatureSourceRange(
+        lexemes: List<Lexeme>,
+        decode: Int,
+        decodeClose: Int
+    ): IntRange? {
+        if (lexemes.getOrNull(decode + 1)?.text != "(") return null
+        val arguments = splitArguments(lexemes, decode + 2, decodeClose)
+        if (arguments.size != 1) return null
+        return arguments[0].takeIf { range ->
+            isDirectPropertyRead(lexemes, range, "s")
+        }
+    }
+
+    private fun isDirectPropertyRead(
+        lexemes: List<Lexeme>,
+        range: IntRange,
+        key: String
+    ): Boolean {
+        if (range.isEmpty()) return false
+
+        if (
+            range.last - range.first >= 2 &&
+            lexemes[range.last].kind == LexemeKind.IDENTIFIER &&
+            lexemes[range.last].text == key &&
+            lexemes.getOrNull(range.last - 1)?.text == "."
+        ) {
+            return isSafeReceiver(lexemes, range.first, range.last - 2)
+        }
+
+        if (
+            range.last - range.first >= 3 &&
+            lexemes[range.last].text == "]" &&
+            lexemes.getOrNull(range.last - 1)?.kind == LexemeKind.STRING &&
+            lexemes[range.last - 1].text == key &&
+            lexemes.getOrNull(range.last - 2)?.text == "["
+        ) {
+            return isSafeReceiver(lexemes, range.first, range.last - 3)
+        }
+
+        return false
+    }
+
+    private fun isSafeReceiver(
+        lexemes: List<Lexeme>,
+        start: Int,
+        endInclusive: Int
+    ): Boolean {
+        if (start > endInclusive) return false
+        var index = start
+        if (lexemes.getOrNull(index)?.kind != LexemeKind.IDENTIFIER) return false
+        index++
+        while (index <= endInclusive) {
+            if (
+                lexemes.getOrNull(index)?.text != "." ||
+                lexemes.getOrNull(index + 1)?.kind != LexemeKind.IDENTIFIER
+            ) return false
+            index += 2
+        }
+        return index == endInclusive + 1
+    }
+
+    private fun isSafeReceiverName(receiver: String): Boolean {
+        if (receiver.isBlank() || receiver.length > MAX_CALLABLE_LENGTH) return false
+        return receiver.split('.').all { part ->
+            part.isNotBlank() &&
+                isIdentifierStart(part.first()) &&
+                part.drop(1).all(::isIdentifierPart)
+        }
     }
 
     private fun isPureAlias(
@@ -238,18 +374,25 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         return "${call.target}(${arguments.joinToString(",")})"
     }
 
-    private fun safeConstantArgument(lexemes: List<Lexeme>, range: IntRange): String? {
+    private fun safeConstantArgument(
+        lexemes: List<Lexeme>,
+        range: IntRange
+    ): String? {
         if (range.isEmpty()) return null
         val slice = range.map { lexemes[it] }
         return when {
             slice.size == 1 && isSafeInteger(slice[0]) -> slice[0].text
-            slice.size == 2 && slice[0].text == "-" && isSafeInteger(slice[1]) -> "-${slice[1].text}"
+            slice.size == 2 &&
+                slice[0].text == "-" &&
+                isSafeInteger(slice[1]) -> "-${slice[1].text}"
             else -> null
         }
     }
 
     private fun isSafeInteger(lexeme: Lexeme): Boolean =
-        lexeme.kind == LexemeKind.NUMBER && lexeme.text.isNotEmpty() && lexeme.text.all(Char::isDigit)
+        lexeme.kind == LexemeKind.NUMBER &&
+            lexeme.text.isNotEmpty() &&
+            lexeme.text.all(Char::isDigit)
 
     private fun enclosingCalls(
         lexemes: List<Lexeme>,
@@ -259,7 +402,11 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         val output = ArrayList<CallSite>(MAX_ENCLOSING_CALLS)
         var index = sourceStart - 1
         var inspected = 0
-        while (index >= 0 && inspected < MAX_PARENT_SCAN_TOKENS && output.size < MAX_ENCLOSING_CALLS) {
+        while (
+            index >= 0 &&
+            inspected < MAX_PARENT_SCAN_TOKENS &&
+            output.size < MAX_ENCLOSING_CALLS
+        ) {
             if (lexemes[index].text == "(") {
                 val close = matchingParen(lexemes, index)
                 if (close != null && close >= sourceEnd) {
@@ -272,7 +419,11 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         return output
     }
 
-    private fun callsBetween(lexemes: List<Lexeme>, start: Int, endExclusive: Int): List<CallSite> {
+    private fun callsBetween(
+        lexemes: List<Lexeme>,
+        start: Int,
+        endExclusive: Int
+    ): List<CallSite> {
         val output = ArrayList<CallSite>()
         var index = start.coerceAtLeast(0)
         val end = minOf(lexemes.size, endExclusive)
@@ -295,7 +446,11 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
             target.endsWith(".get") ||
             target.endsWith(".set")
 
-    private fun callSite(lexemes: List<Lexeme>, open: Int, close: Int): CallSite? {
+    private fun callSite(
+        lexemes: List<Lexeme>,
+        open: Int,
+        close: Int
+    ): CallSite? {
         val target = callableTarget(lexemes, open) ?: return null
         return CallSite(
             target = target.first,
@@ -306,7 +461,10 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         )
     }
 
-    private fun callableTarget(lexemes: List<Lexeme>, open: Int): Pair<String, Int>? {
+    private fun callableTarget(
+        lexemes: List<Lexeme>,
+        open: Int
+    ): Pair<String, Int>? {
         var index = open - 1
         if (index < 0) return null
         var target: String
@@ -323,7 +481,9 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
             start = index - 3
             index -= 4
         } else {
-            val last = lexemes[index].takeIf { it.kind == LexemeKind.IDENTIFIER } ?: return null
+            val last = lexemes[index]
+                .takeIf { it.kind == LexemeKind.IDENTIFIER }
+                ?: return null
             target = last.text
             start = index
             index--
@@ -338,11 +498,19 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
             start = index - 1
             index -= 2
         }
-        if (target.length > MAX_CALLABLE_LENGTH || target.split('.').any { it.isBlank() }) return null
+
+        if (
+            target.length > MAX_CALLABLE_LENGTH ||
+            target.split('.').any { it.isBlank() }
+        ) return null
         return target to start
     }
 
-    private fun splitArguments(lexemes: List<Lexeme>, start: Int, close: Int): List<IntRange> {
+    private fun splitArguments(
+        lexemes: List<Lexeme>,
+        start: Int,
+        close: Int
+    ): List<IntRange> {
         if (start >= close) return emptyList()
         val output = ArrayList<IntRange>()
         var argStart = start
@@ -371,12 +539,20 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         return output
     }
 
-    private fun assignmentIndexForExpression(lexemes: List<Lexeme>, expressionStart: Int): Int? {
+    private fun assignmentIndexForExpression(
+        lexemes: List<Lexeme>,
+        expressionStart: Int
+    ): Int? {
         var index = expressionStart - 1
         var inspected = 0
         while (index >= 1 && inspected < MAX_ASSIGNMENT_SCAN_TOKENS) {
             val symbol = lexemes[index].text
-            if (symbol == ";" || symbol == "," || symbol == "{" || symbol == "}") return null
+            if (
+                symbol == ";" ||
+                symbol == "," ||
+                symbol == "{" ||
+                symbol == "}"
+            ) return null
             if (symbol == "=" && isAssignmentOperator(lexemes, index)) return index
             index--
             inspected++
@@ -384,24 +560,41 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         return null
     }
 
-    private fun assignedVariableForExpression(lexemes: List<Lexeme>, expressionStart: Int): String? {
+    private fun assignedVariableForWholeRange(
+        lexemes: List<Lexeme>,
+        expressionStart: Int,
+        expressionEndInclusive: Int
+    ): String? {
         val assignment = assignmentIndexForExpression(lexemes, expressionStart) ?: return null
-        return lexemes.getOrNull(assignment - 1)
-            ?.takeIf { it.kind == LexemeKind.IDENTIFIER }
-            ?.text
-    }
-
-    private fun isWholeAssignedExpression(lexemes: List<Lexeme>, call: CallSite): Boolean {
-        val assignment = assignmentIndexForExpression(lexemes, call.targetStart) ?: return false
-        val end = statementEnd(
+        val lhs = simpleAssignmentLhs(lexemes, assignment) ?: return null
+        val rhsEnd = statementEnd(
             lexemes,
             assignment + 1,
             minOf(lexemes.size, assignment + 1 + MAX_FLOW_TOKENS)
         )
-        return call.targetStart == assignment + 1 && call.close == end - 1
+        if (
+            expressionStart != assignment + 1 ||
+            expressionEndInclusive != rhsEnd - 1
+        ) return null
+        return lhs
     }
 
-    private fun isAssignmentOperator(lexemes: List<Lexeme>, index: Int): Boolean {
+    private fun simpleAssignmentLhs(
+        lexemes: List<Lexeme>,
+        assignment: Int
+    ): String? {
+        val lhsIndex = assignment - 1
+        val lhs = lexemes.getOrNull(lhsIndex)
+            ?.takeIf { it.kind == LexemeKind.IDENTIFIER }
+            ?: return null
+        if (lexemes.getOrNull(lhsIndex - 1)?.text == ".") return null
+        return lhs.text
+    }
+
+    private fun isAssignmentOperator(
+        lexemes: List<Lexeme>,
+        index: Int
+    ): Boolean {
         return lexemes.getOrNull(index - 1)?.text != "=" &&
             lexemes.getOrNull(index + 1)?.text != "=" &&
             lexemes.getOrNull(index + 1)?.text != ">" &&
@@ -410,61 +603,79 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
             lexemes.getOrNull(index - 1)?.text != "<"
     }
 
-    private fun isAssignmentTo(lexemes: List<Lexeme>, index: Int, variable: String): Boolean {
-        if (lexemes.getOrNull(index)?.kind != LexemeKind.IDENTIFIER || lexemes[index].text != variable) return false
+    private fun isAssignmentTo(
+        lexemes: List<Lexeme>,
+        index: Int,
+        variable: String
+    ): Boolean {
+        if (
+            lexemes.getOrNull(index)?.kind != LexemeKind.IDENTIFIER ||
+            lexemes[index].text != variable ||
+            lexemes.getOrNull(index - 1)?.text == "."
+        ) return false
         val assignment = index + 1
-        return lexemes.getOrNull(assignment)?.text == "=" && isAssignmentOperator(lexemes, assignment)
+        return lexemes.getOrNull(assignment)?.text == "=" &&
+            isAssignmentOperator(lexemes, assignment)
     }
 
-    private fun singleIdentifier(lexemes: List<Lexeme>, range: IntRange, identifier: String): Boolean {
+    private fun singleIdentifier(
+        lexemes: List<Lexeme>,
+        range: IntRange,
+        identifier: String
+    ): Boolean {
         if (range.first != range.last) return false
         val lexeme = lexemes.getOrNull(range.first) ?: return false
-        return lexeme.kind == LexemeKind.IDENTIFIER && lexeme.text == identifier
+        return lexeme.kind == LexemeKind.IDENTIFIER &&
+            lexeme.text == identifier
     }
 
-    private fun signatureSinkScore(lexemes: List<Lexeme>, start: Int, variable: String): Int {
-        var score = 0
-        val end = minOf(lexemes.size, start + MAX_SINK_SCAN_TOKENS)
-        var index = start.coerceAtLeast(0)
-        while (index < end) {
-            if (isAssignmentTo(lexemes, index, variable)) return score
-            if (lexemes[index].text == "encodeURIComponent" && lexemes.getOrNull(index + 1)?.text == "(") {
-                val close = matchingParen(lexemes, index + 1)
-                if (close != null && close < end) {
-                    val args = splitArguments(lexemes, index + 2, close)
-                    if (args.size == 1 && singleIdentifier(lexemes, args[0], variable)) {
-                        score = maxOf(score, 25)
-                    }
-                }
-            }
-            if (lexemes[index].text == "set" && lexemes.getOrNull(index - 1)?.text == "." && lexemes.getOrNull(index + 1)?.text == "(") {
-                val close = matchingParen(lexemes, index + 1)
-                if (close != null && close < end) {
-                    val args = splitArguments(lexemes, index + 2, close)
-                    if (args.size >= 2 && singleIdentifier(lexemes, args[1], variable)) {
-                        score = maxOf(score, 40)
-                    }
-                }
-            }
-            index++
-        }
-        return score
-    }
-
-    private fun nSinkScore(lexemes: List<Lexeme>, start: Int, variable: String): Int {
+    private fun signatureSinkScore(
+        lexemes: List<Lexeme>,
+        start: Int,
+        variable: String
+    ): Int {
         val end = minOf(lexemes.size, start + MAX_SINK_SCAN_TOKENS)
         var index = start.coerceAtLeast(0)
         while (index < end) {
             if (isAssignmentTo(lexemes, index, variable)) return 0
-            if (lexemes[index].text == "set" && lexemes.getOrNull(index - 1)?.text == "." && lexemes.getOrNull(index + 1)?.text == "(") {
+            if (
+                lexemes[index].text == "encodeURIComponent" &&
+                lexemes.getOrNull(index + 1)?.text == "("
+            ) {
                 val close = matchingParen(lexemes, index + 1)
                 if (close != null && close < end) {
                     val args = splitArguments(lexemes, index + 2, close)
                     if (
-                        args.size >= 2 &&
-                        singleString(lexemes, args[0]) == "n" &&
-                        singleIdentifier(lexemes, args[1], variable)
-                    ) return 45
+                        args.size == 1 &&
+                        singleIdentifier(lexemes, args[0], variable)
+                    ) return SIGNATURE_SINK_SCORE
+                }
+            }
+            index++
+        }
+        return 0
+    }
+
+    private fun nSinkScore(
+        lexemes: List<Lexeme>,
+        start: Int,
+        variable: String,
+        receiver: String
+    ): Int {
+        val end = minOf(lexemes.size, start + MAX_SINK_SCAN_TOKENS)
+        var index = start.coerceAtLeast(0)
+        while (index < end) {
+            if (isAssignmentTo(lexemes, index, variable)) return 0
+            if (lexemes[index].text == "(") {
+                val close = matchingParen(lexemes, index)
+                if (close != null && close < end) {
+                    val call = callSite(lexemes, index, close)
+                    if (
+                        call?.target == "$receiver.set" &&
+                        call.arguments.size >= 2 &&
+                        singleString(lexemes, call.arguments[0]) == "n" &&
+                        singleIdentifier(lexemes, call.arguments[1], variable)
+                    ) return N_SINK_SCORE
                 }
             }
             index++
@@ -486,9 +697,14 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         }
     }
 
-    private fun isNestedInNSet(lexemes: List<Lexeme>, sourceStart: Int, sourceEnd: Int): Boolean {
+    private fun isNestedInNSet(
+        lexemes: List<Lexeme>,
+        sourceStart: Int,
+        sourceEnd: Int,
+        receiver: String
+    ): Boolean {
         return enclosingCalls(lexemes, sourceStart, sourceEnd).any { call ->
-            call.target.endsWith(".set") &&
+            call.target == "$receiver.set" &&
                 call.arguments.size >= 2 &&
                 singleString(lexemes, call.arguments[0]) == "n" &&
                 call.arguments[1].first == sourceStart &&
@@ -496,38 +712,21 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         }
     }
 
-    private fun isGetCallKey(lexemes: List<Lexeme>, keyIndex: Int): Boolean {
-        if (keyIndex < 3) return false
-        return lexemes[keyIndex - 1].text == "(" &&
-            lexemes[keyIndex - 2].text == "get" &&
-            lexemes[keyIndex - 3].text == "."
-    }
-
-    private fun mentionsKey(lexemes: List<Lexeme>, start: Int, endInclusive: Int, key: String): Boolean {
-        if (start > endInclusive) return false
-        for (index in start..minOf(endInclusive, lexemes.lastIndex)) {
-            val lexeme = lexemes[index]
-            if (
-                lexeme.kind == LexemeKind.STRING &&
-                lexeme.text == key &&
-                lexemes.getOrNull(index - 1)?.text == "[" &&
-                lexemes.getOrNull(index + 1)?.text == "]"
-            ) return true
-            if (
-                lexeme.kind == LexemeKind.IDENTIFIER &&
-                lexeme.text == key &&
-                lexemes.getOrNull(index - 1)?.text == "."
-            ) return true
-        }
-        return false
-    }
-
-    private fun singleString(lexemes: List<Lexeme>, range: IntRange): String? {
+    private fun singleString(
+        lexemes: List<Lexeme>,
+        range: IntRange
+    ): String? {
         if (range.first != range.last) return null
-        return lexemes[range.first].takeIf { it.kind == LexemeKind.STRING }?.text
+        return lexemes.getOrNull(range.first)
+            ?.takeIf { it.kind == LexemeKind.STRING }
+            ?.text
     }
 
-    private fun statementEnd(lexemes: List<Lexeme>, start: Int, limit: Int): Int {
+    private fun statementEnd(
+        lexemes: List<Lexeme>,
+        start: Int,
+        limit: Int
+    ): Int {
         var paren = 0
         var bracket = 0
         var brace = 0
@@ -540,14 +739,48 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
                 "]" -> if (bracket > 0) bracket--
                 "{" -> brace++
                 "}" -> if (brace > 0) brace--
-                ";", "," -> if (paren == 0 && bracket == 0 && brace == 0) return index
+                ";", "," -> if (paren == 0 && bracket == 0 && brace == 0) {
+                    return index
+                }
             }
             index++
         }
         return limit
     }
 
-    private fun matchingParen(lexemes: List<Lexeme>, open: Int): Int? {
+    private fun scopeEnd(
+        lexemes: List<Lexeme>,
+        start: Int,
+        limit: Int
+    ): Int {
+        var depth = 0
+        var index = start
+        while (index < limit) {
+            when (lexemes[index].text) {
+                "{" -> depth++
+                "}" -> {
+                    if (depth == 0) return index
+                    depth--
+                }
+            }
+            index++
+        }
+        return limit
+    }
+
+    private fun startsNestedFunction(
+        lexemes: List<Lexeme>,
+        index: Int
+    ): Boolean {
+        if (lexemes[index].text == "function") return true
+        return lexemes[index].text == "=" &&
+            lexemes.getOrNull(index + 1)?.text == ">"
+    }
+
+    private fun matchingParen(
+        lexemes: List<Lexeme>,
+        open: Int
+    ): Int? {
         if (lexemes.getOrNull(open)?.text != "(") return null
         var depth = 0
         for (index in open until lexemes.size) {
@@ -562,28 +795,136 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         return null
     }
 
-    private fun scanSignatureWindows(javascript: String): List<ScanWindow> {
-        val output = ArrayList<ScanWindow>()
-        val seenAnchors = HashSet<Int>()
-        var cursor = 0
-        while (cursor < javascript.length && output.size < MAX_ANCHORS_PER_KIND) {
-            val anchor = javascript.indexOf("decodeURIComponent", cursor)
-            if (anchor < 0) break
-            if (isSignatureDecodeAnchor(javascript, anchor) && seenAnchors.add(anchor)) {
-                val start = (anchor - SIGNATURE_BEFORE_CHARS).coerceAtLeast(0)
-                val end = (anchor + "decodeURIComponent".length + SIGNATURE_AFTER_CHARS)
-                    .coerceAtMost(javascript.length)
-                output += ScanWindow(start, end, anchor)
-            }
-            cursor = anchor + "decodeURIComponent".length
+    private fun signatureWindows(
+        source: String,
+        anchors: List<Int>
+    ): List<ScanWindow> {
+        return anchors.take(MAX_ANCHORS_PER_KIND).map { anchor ->
+            ScanWindow(
+                start = boundedWindowStart(source, anchor, SIGNATURE_BEFORE_CHARS),
+                end = (anchor + SIGNATURE_AFTER_CHARS).coerceAtMost(source.length),
+                anchor = anchor
+            )
         }
-        return output
     }
 
-    private fun isSignatureDecodeAnchor(source: String, anchor: Int): Boolean {
-        val start = anchor.coerceAtLeast(0)
+    private fun nWindows(
+        source: String,
+        anchors: List<Int>
+    ): List<ScanWindow> {
+        return anchors.take(MAX_ANCHORS_PER_KIND).map { anchor ->
+            ScanWindow(
+                start = boundedWindowStart(source, anchor, N_BEFORE_CHARS),
+                end = (anchor + N_AFTER_CHARS).coerceAtMost(source.length),
+                anchor = anchor
+            )
+        }
+    }
+
+    private fun boundedWindowStart(
+        source: String,
+        anchor: Int,
+        beforeChars: Int
+    ): Int {
+        val floor = (anchor - beforeChars).coerceAtLeast(0)
+        var index = anchor - 1
+        while (index >= floor) {
+            when (source[index]) {
+                ';', '{', '}' -> return index + 1
+            }
+            index--
+        }
+        return floor
+    }
+
+    private fun scanAnchors(source: String): AnchorIndex {
+        val signatures = ArrayList<Int>()
+        val nAnchors = ArrayList<Int>()
+        var index = 0
+        var regexCanStart = true
+
+        while (
+            index < source.length &&
+            (
+                signatures.size < MAX_ANCHORS_PER_KIND ||
+                    nAnchors.size < MAX_ANCHORS_PER_KIND
+                )
+        ) {
+            val char = source[index]
+            when {
+                char.isWhitespace() -> index++
+
+                char == '/' && source.getOrNull(index + 1) == '/' -> {
+                    index = skipLineComment(source, index + 2, source.length)
+                }
+
+                char == '/' && source.getOrNull(index + 1) == '*' -> {
+                    index = skipBlockComment(source, index + 2, source.length)
+                }
+
+                char == '/' && regexCanStart -> {
+                    index = skipRegexLiteral(source, index, source.length)
+                    regexCanStart = false
+                }
+
+                char == '\'' || char == '"' -> {
+                    val parsed = readString(source, index, source.length)
+                    if (
+                        parsed.value == "n" &&
+                        nAnchors.size < MAX_ANCHORS_PER_KIND &&
+                        isNGetAnchorSource(source, index, parsed.end)
+                    ) {
+                        nAnchors += index
+                    }
+                    index = parsed.end
+                    regexCanStart = false
+                }
+
+                char == '`' -> {
+                    index = skipTemplateLiteral(source, index, source.length)
+                    regexCanStart = false
+                }
+
+                isIdentifierStart(char) -> {
+                    val start = index
+                    index++
+                    while (index < source.length && isIdentifierPart(source[index])) index++
+                    val identifier = source.substring(start, index)
+                    if (
+                        identifier == "decodeURIComponent" &&
+                        signatures.size < MAX_ANCHORS_PER_KIND &&
+                        isSignatureAnchorSource(source, start)
+                    ) {
+                        signatures += start
+                    }
+                    regexCanStart = identifier in REGEX_PREFIX_KEYWORDS
+                }
+
+                char.isDigit() -> {
+                    index++
+                    while (
+                        index < source.length &&
+                        (source[index].isDigit() || source[index] == '.')
+                    ) index++
+                    regexCanStart = false
+                }
+
+                else -> {
+                    regexCanStart = symbolAllowsRegexAfter(char)
+                    index++
+                }
+            }
+        }
+
+        return AnchorIndex(signatures, nAnchors)
+    }
+
+    private fun isSignatureAnchorSource(
+        source: String,
+        anchor: Int
+    ): Boolean {
         val end = (anchor + SIGNATURE_SOURCE_PROBE_CHARS).coerceAtMost(source.length)
-        val lexemes = tokenize(source, start, end)
+        val lexemes = tokenize(source, anchor, end)
         val decode = lexemes.indexOfFirst { lexeme ->
             lexeme.kind == LexemeKind.IDENTIFIER &&
                 lexeme.text == "decodeURIComponent" &&
@@ -591,114 +932,240 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         }
         if (decode < 0 || lexemes.getOrNull(decode + 1)?.text != "(") return false
         val close = matchingParen(lexemes, decode + 1) ?: return false
-        return mentionsKey(lexemes, decode + 2, close - 1, "s")
+        return signatureSourceRange(lexemes, decode, close) != null
     }
 
-    private fun scanNWindows(javascript: String): List<ScanWindow> {
-        val output = ArrayList<ScanWindow>()
-        val seenAnchors = HashSet<Int>()
-        listOf("\"n\"", "'n'").forEach { needle ->
-            var cursor = 0
-            var foundForNeedle = 0
-            while (
-                cursor < javascript.length &&
-                foundForNeedle < MAX_ANCHORS_PER_NEEDLE &&
-                output.size < MAX_ANCHORS_PER_KIND
-            ) {
-                val anchor = javascript.indexOf(needle, cursor)
-                if (anchor < 0) break
-                if (isNGetAnchor(javascript, anchor)) {
-                    val start = (anchor - N_BEFORE_CHARS).coerceAtLeast(0)
-                    val end = (anchor + needle.length + N_AFTER_CHARS).coerceAtMost(javascript.length)
-                    if (seenAnchors.add(anchor)) output += ScanWindow(start, end, anchor)
-                    foundForNeedle++
-                }
-                cursor = anchor + needle.length
+    private fun isNGetAnchorSource(
+        source: String,
+        stringStart: Int,
+        stringEnd: Int
+    ): Boolean {
+        var index = stringStart - 1
+        while (index >= 0 && source[index].isWhitespace()) index--
+        if (index < 0 || source[index] != '(') return false
+
+        index--
+        while (index >= 0 && source[index].isWhitespace()) index--
+        val identifierEnd = index + 1
+        while (index >= 0 && isIdentifierPart(source[index])) index--
+        if (source.substring(index + 1, identifierEnd) != "get") return false
+
+        while (index >= 0 && source[index].isWhitespace()) index--
+        if (index < 0 || source[index] != '.') return false
+
+        index = stringEnd
+        while (index < source.length && source[index].isWhitespace()) index++
+        return source.getOrNull(index) == ')'
+    }
+
+    private data class ParsedString(
+        val value: String,
+        val end: Int
+    )
+
+    private fun readString(
+        source: String,
+        start: Int,
+        endExclusive: Int
+    ): ParsedString {
+        val quote = source[start]
+        val value = StringBuilder()
+        var index = start + 1
+        while (index < endExclusive) {
+            val current = source[index]
+            if (current == '\\' && index + 1 < endExclusive) {
+                value.append(source[index + 1])
+                index += 2
+                continue
             }
+            if (current == quote) {
+                return ParsedString(value.toString(), index + 1)
+            }
+            value.append(current)
+            index++
         }
-        return output.sortedBy { it.anchor }
+        return ParsedString(value.toString(), endExclusive)
     }
 
-    private fun isNGetAnchor(source: String, anchor: Int): Boolean {
-        val start = (anchor - N_SOURCE_PROBE_BEFORE_CHARS).coerceAtLeast(0)
-        val end = (anchor + N_SOURCE_PROBE_AFTER_CHARS).coerceAtMost(source.length)
-        val lexemes = tokenize(source, start, end)
-        val keyIndex = lexemes.indexOfFirst { lexeme ->
-            lexeme.kind == LexemeKind.STRING &&
-                lexeme.text == "n" &&
-                anchor in lexeme.start until lexeme.end
-        }
-        return isGetCallKey(lexemes, keyIndex)
+    private fun skipLineComment(
+        source: String,
+        start: Int,
+        endExclusive: Int
+    ): Int {
+        var index = start
+        while (index < endExclusive && source[index] != '\n') index++
+        return index
     }
 
-    private fun tokenize(source: String, start: Int, endExclusive: Int): List<Lexeme> {
+    private fun skipBlockComment(
+        source: String,
+        start: Int,
+        endExclusive: Int
+    ): Int {
+        var index = start
+        while (
+            index + 1 < endExclusive &&
+            !(source[index] == '*' && source[index + 1] == '/')
+        ) index++
+        return minOf(endExclusive, index + 2)
+    }
+
+    private fun skipTemplateLiteral(
+        source: String,
+        start: Int,
+        endExclusive: Int
+    ): Int {
+        var index = start + 1
+        while (index < endExclusive) {
+            if (source[index] == '\\' && index + 1 < endExclusive) {
+                index += 2
+                continue
+            }
+            if (source[index] == '`') return index + 1
+            index++
+        }
+        return endExclusive
+    }
+
+    private fun skipRegexLiteral(
+        source: String,
+        start: Int,
+        endExclusive: Int
+    ): Int {
+        var index = start + 1
+        var inClass = false
+        while (index < endExclusive) {
+            val current = source[index]
+            if (current == '\\' && index + 1 < endExclusive) {
+                index += 2
+                continue
+            }
+            if (current == '[') {
+                inClass = true
+                index++
+                continue
+            }
+            if (current == ']' && inClass) {
+                inClass = false
+                index++
+                continue
+            }
+            if (current == '/' && !inClass) {
+                index++
+                while (
+                    index < endExclusive &&
+                    source[index].isLetter()
+                ) index++
+                return index
+            }
+            if (current == '\n' || current == '\r') return index
+            index++
+        }
+        return endExclusive
+    }
+
+    private fun tokenize(
+        source: String,
+        start: Int,
+        endExclusive: Int
+    ): List<Lexeme> {
         val output = ArrayList<Lexeme>()
         var index = start
-        while (index < endExclusive && output.size < MAX_WINDOW_TOKENS) {
+        var regexCanStart = true
+
+        while (
+            index < endExclusive &&
+            output.size < MAX_WINDOW_TOKENS
+        ) {
             val char = source[index]
             when {
                 char.isWhitespace() -> index++
+
                 char == '/' && source.getOrNull(index + 1) == '/' -> {
-                    index += 2
-                    while (index < endExclusive && source[index] != '\n') index++
+                    index = skipLineComment(source, index + 2, endExclusive)
                 }
+
                 char == '/' && source.getOrNull(index + 1) == '*' -> {
-                    index += 2
-                    while (
-                        index + 1 < endExclusive &&
-                        !(source[index] == '*' && source[index + 1] == '/')
-                    ) index++
-                    index = minOf(endExclusive, index + 2)
+                    index = skipBlockComment(source, index + 2, endExclusive)
                 }
+
+                char == '/' && regexCanStart -> {
+                    val regexStart = index
+                    index = skipRegexLiteral(source, index, endExclusive)
+                    output += Lexeme(
+                        LexemeKind.STRING,
+                        "<regex>",
+                        regexStart,
+                        index
+                    )
+                    regexCanStart = false
+                }
+
                 char == '\'' || char == '"' -> {
-                    val quote = char
-                    val lexemeStart = index
-                    index++
-                    val value = StringBuilder()
-                    while (index < endExclusive) {
-                        val current = source[index]
-                        if (current == '\\' && index + 1 < endExclusive) {
-                            value.append(source[index + 1])
-                            index += 2
-                            continue
-                        }
-                        if (current == quote) {
-                            index++
-                            break
-                        }
-                        value.append(current)
-                        index++
-                    }
-                    output += Lexeme(LexemeKind.STRING, value.toString(), lexemeStart, index)
+                    val parsed = readString(source, index, endExclusive)
+                    output += Lexeme(
+                        LexemeKind.STRING,
+                        parsed.value,
+                        index,
+                        parsed.end
+                    )
+                    index = parsed.end
+                    regexCanStart = false
                 }
+
                 char == '`' -> {
-                    index++
-                    while (index < endExclusive) {
-                        if (source[index] == '\\' && index + 1 < endExclusive) {
-                            index += 2
-                            continue
-                        }
-                        if (source[index] == '`') {
-                            index++
-                            break
-                        }
-                        index++
-                    }
+                    val literalStart = index
+                    index = skipTemplateLiteral(source, index, endExclusive)
+                    output += Lexeme(
+                        LexemeKind.STRING,
+                        "<template>",
+                        literalStart,
+                        index
+                    )
+                    regexCanStart = false
                 }
+
                 isIdentifierStart(char) -> {
                     val lexemeStart = index
                     index++
-                    while (index < endExclusive && isIdentifierPart(source[index])) index++
-                    output += Lexeme(LexemeKind.IDENTIFIER, source.substring(lexemeStart, index), lexemeStart, index)
+                    while (
+                        index < endExclusive &&
+                        isIdentifierPart(source[index])
+                    ) index++
+                    val text = source.substring(lexemeStart, index)
+                    output += Lexeme(
+                        LexemeKind.IDENTIFIER,
+                        text,
+                        lexemeStart,
+                        index
+                    )
+                    regexCanStart = text in REGEX_PREFIX_KEYWORDS
                 }
+
                 char.isDigit() -> {
                     val lexemeStart = index
                     index++
-                    while (index < endExclusive && (source[index].isDigit() || source[index] == '.')) index++
-                    output += Lexeme(LexemeKind.NUMBER, source.substring(lexemeStart, index), lexemeStart, index)
+                    while (
+                        index < endExclusive &&
+                        (source[index].isDigit() || source[index] == '.')
+                    ) index++
+                    output += Lexeme(
+                        LexemeKind.NUMBER,
+                        source.substring(lexemeStart, index),
+                        lexemeStart,
+                        index
+                    )
+                    regexCanStart = false
                 }
+
                 else -> {
-                    output += Lexeme(LexemeKind.SYMBOL, char.toString(), index, index + 1)
+                    output += Lexeme(
+                        LexemeKind.SYMBOL,
+                        char.toString(),
+                        index,
+                        index + 1
+                    )
+                    regexCanStart = symbolAllowsRegexAfter(char)
                     index++
                 }
             }
@@ -706,7 +1173,14 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         return output
     }
 
-    private fun rank(values: List<YoutubeSemanticTransformCandidate>): List<YoutubeSemanticTransformCandidate> {
+    private fun symbolAllowsRegexAfter(char: Char): Boolean =
+        char !in setOf(')', ']', '}')
+
+    private fun rank(
+        values: List<YoutubeSemanticTransformCandidate>,
+        budget: Int
+    ): List<YoutubeSemanticTransformCandidate> {
+        if (budget <= 0) return emptyList()
         val best = LinkedHashMap<String, YoutubeSemanticTransformCandidate>()
         values.forEach { candidate ->
             val current = best[candidate.expression]
@@ -719,10 +1193,7 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
                 compareByDescending<YoutubeSemanticTransformCandidate> { it.confidence }
                     .thenBy { it.expression }
             )
-            .take(MAX_CANDIDATES_PER_KIND)
-            .mapIndexed { index, candidate ->
-                if (index == 0) candidate else candidate.copy(confidence = SECONDARY_RESERVE_CONFIDENCE)
-            }
+            .take(minOf(MAX_SEMANTIC_CANDIDATES_PER_KIND, budget))
     }
 
     private fun addIfConfident(
@@ -731,14 +1202,21 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         confidence: Int
     ) {
         if (confidence >= MIN_CONFIDENCE) {
-            output += YoutubeSemanticTransformCandidate(expression, confidence.coerceAtMost(200))
+            output += YoutubeSemanticTransformCandidate(
+                expression,
+                confidence.coerceAtMost(MAX_DISCOVERY_CONFIDENCE)
+            )
         }
     }
 
     private fun isIdentifierStart(char: Char): Boolean =
-        char == '_' || char == '$' || char in 'a'..'z' || char in 'A'..'Z'
+        char == '_' ||
+            char == '$' ||
+            char in 'a'..'z' ||
+            char in 'A'..'Z'
 
-    private fun isIdentifierPart(char: Char): Boolean = isIdentifierStart(char) || char.isDigit()
+    private fun isIdentifierPart(char: Char): Boolean =
+        isIdentifierStart(char) || char.isDigit()
 
     private val NON_TRANSFORM_CALLS = setOf(
         "decodeURIComponent",
@@ -747,24 +1225,56 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         "set"
     )
 
+    private val REGEX_PREFIX_KEYWORDS = setOf(
+        "return",
+        "throw",
+        "case",
+        "delete",
+        "void",
+        "typeof",
+        "new",
+        "in",
+        "of",
+        "yield",
+        "await",
+        "else",
+        "do"
+    )
+
+    private val LEGACY_SIGNATURE_PRESENCE = Regex(
+        "(?:&&\\s*\\(\\s*[A-Za-z0-9_$]+\\s*=\\s*[A-Za-z0-9_$]+\\s*\\(\\s*\\d+\\s*,\\s*decodeURIComponent\\s*\\(\\s*[A-Za-z0-9_$]+\\s*\\))" +
+            "|(?:\\b[cs]\\s*&&\\s*[adf]\\.set\\([^,]+\\s*,\\s*encodeURIComponent\\([A-Za-z0-9_$]+\\()" +
+            "|(?:\\b[A-Za-z0-9_$]+\\s*&&\\s*[A-Za-z0-9_$]+\\.set\\([^,]+\\s*,\\s*encodeURIComponent\\([A-Za-z0-9_$]+\\()" +
+            "|(?:\\bm=[A-Za-z0-9_$]{2,}\\(decodeURIComponent\\(h\\.s\\)\\))" +
+            "|(?:\\bc\\s*&&\\s*d\\.set\\([^,]+\\s*,\\s*(?:encodeURIComponent\\s*\\()?[A-Za-z0-9_$]+\\()"
+    )
+
+    private val LEGACY_N_PRESENCE = Regex(
+        "(?:\\.get\\(\\\"n\\\"\\)\\)&&\\(b=[A-Za-z0-9_$]+(?:\\[\\d+])?\\([A-Za-z0-9_$]\\))" +
+            "|(?:\\.get\\(\\\"n\\\"\\)\\)\\s*&&\\s*\\([A-Za-z0-9_$]+\\s*=\\s*[A-Za-z0-9_$]+(?:\\[\\d+])?\\([A-Za-z0-9_$]+\\))" +
+            "|(?:[A-Za-z0-9_$]+\\s*=\\s*function\\([A-Za-z0-9_$]\\)\\s*\\{[^}]{0,2000}?enhanced_except_)"
+    )
+
     private const val MIN_CONFIDENCE = 110
-    private const val SECONDARY_RESERVE_CONFIDENCE = 0
-    private const val MAX_ANCHORS_PER_NEEDLE = 32
+    private const val MAX_DISCOVERY_CONFIDENCE = 200
+    private const val SIGNATURE_BASE_CONFIDENCE = 100
+    private const val N_BASE_CONFIDENCE = 70
+    private const val SIGNATURE_SINK_SCORE = 35
+    private const val SIGNATURE_NESTED_SINK_SCORE = 35
+    private const val N_SINK_SCORE = 45
     private const val MAX_ANCHORS_PER_KIND = 64
-    private const val MAX_WINDOW_TOKENS = 900
+    private const val MAX_WINDOW_TOKENS = 1_600
     private const val MAX_FLOW_TOKENS = 260
     private const val MAX_SINK_SCAN_TOKENS = 180
     private const val MAX_PARENT_SCAN_TOKENS = 80
     private const val MAX_ASSIGNMENT_SCAN_TOKENS = 32
     private const val MAX_CALLS_PER_FLOW = 16
     private const val MAX_ENCLOSING_CALLS = 4
-    private const val MAX_CANDIDATES_PER_KIND = 4
+    private const val MAX_SEMANTIC_CANDIDATES_PER_KIND = 2
     private const val MAX_CALLABLE_LENGTH = 64
-    private const val SIGNATURE_BEFORE_CHARS = 1_200
+    private const val SIGNATURE_BEFORE_CHARS = 512
     private const val SIGNATURE_AFTER_CHARS = 2_600
     private const val SIGNATURE_SOURCE_PROBE_CHARS = 320
-    private const val N_BEFORE_CHARS = 1_800
+    private const val N_BEFORE_CHARS = 512
     private const val N_AFTER_CHARS = 2_600
-    private const val N_SOURCE_PROBE_BEFORE_CHARS = 64
-    private const val N_SOURCE_PROBE_AFTER_CHARS = 32
 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2.kt
@@ -51,43 +51,42 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
 
     private fun discoverSignatures(javascript: String): List<YoutubeSemanticTransformCandidate> {
         val output = ArrayList<YoutubeSemanticTransformCandidate>()
-        scanWindows(javascript, listOf("decodeURIComponent"), SIGNATURE_BEFORE_CHARS, SIGNATURE_AFTER_CHARS)
-            .forEach { window ->
-                val lexemes = tokenize(javascript, window.start, window.end)
-                val decode = lexemes.indexOfFirst { lexeme ->
-                    lexeme.kind == LexemeKind.IDENTIFIER &&
-                        lexeme.text == "decodeURIComponent" &&
-                        window.anchor in lexeme.start until lexeme.end
-                }
-                if (decode < 0 || lexemes.getOrNull(decode + 1)?.text != "(") return@forEach
-                val decodeClose = matchingParen(lexemes, decode + 1) ?: return@forEach
-                if (!mentionsKey(lexemes, decode + 2, decodeClose - 1, "s")) return@forEach
-                val sourceEvidence = 30
-
-                enclosingCalls(lexemes, decode, decodeClose).forEach { call ->
-                    if (isNonTransformTarget(call.target)) return@forEach
-                    val expression = expressionForRange(lexemes, call, decode, decodeClose) ?: return@forEach
-                    val outputVariable = assignedVariableForExpression(lexemes, call.targetStart)
-                    val sinkEvidence = when {
-                        outputVariable != null && isWholeAssignedExpression(lexemes, call) ->
-                            signatureSinkScore(lexemes, call.close + 1, outputVariable)
-                        isNestedInCallable(lexemes, call.targetStart, call.close, "encodeURIComponent") -> 35
-                        else -> 0
-                    }
-                    addIfConfident(output, expression, 70 + sourceEvidence + sinkEvidence)
-                }
-
-                val sourceVariable = assignedVariableForExpression(lexemes, decode)
-                if (sourceVariable != null) {
-                    output += followVariableFlow(
-                        lexemes = lexemes,
-                        startIndex = decodeClose + 1,
-                        sourceVariable = sourceVariable,
-                        baseConfidence = 70 + sourceEvidence,
-                        sinkScore = ::signatureSinkScore
-                    )
-                }
+        scanSignatureWindows(javascript).forEach { window ->
+            val lexemes = tokenize(javascript, window.start, window.end)
+            val decode = lexemes.indexOfFirst { lexeme ->
+                lexeme.kind == LexemeKind.IDENTIFIER &&
+                    lexeme.text == "decodeURIComponent" &&
+                    window.anchor in lexeme.start until lexeme.end
             }
+            if (decode < 0 || lexemes.getOrNull(decode + 1)?.text != "(") return@forEach
+            val decodeClose = matchingParen(lexemes, decode + 1) ?: return@forEach
+            if (!mentionsKey(lexemes, decode + 2, decodeClose - 1, "s")) return@forEach
+            val sourceEvidence = 30
+
+            enclosingCalls(lexemes, decode, decodeClose).forEach { call ->
+                if (isNonTransformTarget(call.target)) return@forEach
+                val expression = expressionForRange(lexemes, call, decode, decodeClose) ?: return@forEach
+                val outputVariable = assignedVariableForExpression(lexemes, call.targetStart)
+                val sinkEvidence = when {
+                    outputVariable != null && isWholeAssignedExpression(lexemes, call) ->
+                        signatureSinkScore(lexemes, call.close + 1, outputVariable)
+                    isNestedInCallable(lexemes, call.targetStart, call.close, "encodeURIComponent") -> 35
+                    else -> 0
+                }
+                addIfConfident(output, expression, 70 + sourceEvidence + sinkEvidence)
+            }
+
+            val sourceVariable = assignedVariableForExpression(lexemes, decode)
+            if (sourceVariable != null) {
+                output += followVariableFlow(
+                    lexemes = lexemes,
+                    startIndex = decodeClose + 1,
+                    sourceVariable = sourceVariable,
+                    baseConfidence = 70 + sourceEvidence,
+                    sinkScore = ::signatureSinkScore
+                )
+            }
+        }
         return output
     }
 
@@ -555,6 +554,39 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         return null
     }
 
+    private fun scanSignatureWindows(javascript: String): List<ScanWindow> {
+        val output = ArrayList<ScanWindow>()
+        val seen = HashSet<Long>()
+        var cursor = 0
+        while (cursor < javascript.length && output.size < MAX_ANCHORS_PER_KIND) {
+            val anchor = javascript.indexOf("decodeURIComponent", cursor)
+            if (anchor < 0) break
+            if (isSignatureDecodeAnchor(javascript, anchor)) {
+                val start = (anchor - SIGNATURE_BEFORE_CHARS).coerceAtLeast(0)
+                val end = (anchor + "decodeURIComponent".length + SIGNATURE_AFTER_CHARS)
+                    .coerceAtMost(javascript.length)
+                val identity = (start.toLong() shl 32) xor end.toLong()
+                if (seen.add(identity)) output += ScanWindow(start, end, anchor)
+            }
+            cursor = anchor + "decodeURIComponent".length
+        }
+        return output
+    }
+
+    private fun isSignatureDecodeAnchor(source: String, anchor: Int): Boolean {
+        val start = anchor.coerceAtLeast(0)
+        val end = (anchor + SIGNATURE_SOURCE_PROBE_CHARS).coerceAtMost(source.length)
+        val lexemes = tokenize(source, start, end)
+        val decode = lexemes.indexOfFirst { lexeme ->
+            lexeme.kind == LexemeKind.IDENTIFIER &&
+                lexeme.text == "decodeURIComponent" &&
+                anchor in lexeme.start until lexeme.end
+        }
+        if (decode < 0 || lexemes.getOrNull(decode + 1)?.text != "(") return false
+        val close = matchingParen(lexemes, decode + 1) ?: return false
+        return mentionsKey(lexemes, decode + 2, close - 1, "s")
+    }
+
     private fun scanNWindows(javascript: String): List<ScanWindow> {
         val output = ArrayList<ScanWindow>()
         val seen = HashSet<Long>()
@@ -568,7 +600,7 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
             ) {
                 val anchor = javascript.indexOf(needle, cursor)
                 if (anchor < 0) break
-                if (isRawGetKey(javascript, anchor)) {
+                if (isNGetAnchor(javascript, anchor)) {
                     val start = (anchor - N_BEFORE_CHARS).coerceAtLeast(0)
                     val end = (anchor + needle.length + N_AFTER_CHARS).coerceAtMost(javascript.length)
                     val identity = (start.toLong() shl 32) xor end.toLong()
@@ -581,46 +613,16 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
         return output.sortedBy { it.anchor }
     }
 
-    private fun isRawGetKey(source: String, keyStart: Int): Boolean {
-        var index = keyStart - 1
-        while (index >= 0 && source[index].isWhitespace()) index--
-        if (index < 0 || source[index] != '(') return false
-        index--
-        while (index >= 0 && source[index].isWhitespace()) index--
-        val identifierEnd = index + 1
-        while (index >= 0 && isIdentifierPart(source[index])) index--
-        if (source.substring(index + 1, identifierEnd) != "get") return false
-        while (index >= 0 && source[index].isWhitespace()) index--
-        return index >= 0 && source[index] == '.'
-    }
-
-    private fun scanWindows(
-        javascript: String,
-        needles: List<String>,
-        before: Int,
-        after: Int
-    ): List<ScanWindow> {
-        val output = ArrayList<ScanWindow>()
-        val seen = HashSet<Long>()
-        needles.forEach { needle ->
-            var cursor = 0
-            var foundForNeedle = 0
-            while (
-                cursor < javascript.length &&
-                foundForNeedle < MAX_ANCHORS_PER_NEEDLE &&
-                output.size < MAX_ANCHORS_PER_KIND
-            ) {
-                val anchor = javascript.indexOf(needle, cursor)
-                if (anchor < 0) break
-                val start = (anchor - before).coerceAtLeast(0)
-                val end = (anchor + needle.length + after).coerceAtMost(javascript.length)
-                val identity = (start.toLong() shl 32) xor end.toLong()
-                if (seen.add(identity)) output += ScanWindow(start, end, anchor)
-                foundForNeedle++
-                cursor = anchor + needle.length
-            }
+    private fun isNGetAnchor(source: String, anchor: Int): Boolean {
+        val start = (anchor - N_SOURCE_PROBE_BEFORE_CHARS).coerceAtLeast(0)
+        val end = (anchor + N_SOURCE_PROBE_AFTER_CHARS).coerceAtMost(source.length)
+        val lexemes = tokenize(source, start, end)
+        val keyIndex = lexemes.indexOfFirst { lexeme ->
+            lexeme.kind == LexemeKind.STRING &&
+                lexeme.text == "n" &&
+                anchor in lexeme.start until lexeme.end
         }
-        return output.sortedBy { it.anchor }
+        return isGetCallKey(lexemes, keyIndex)
     }
 
     private fun tokenize(source: String, start: Int, endExclusive: Int): List<Lexeme> {
@@ -754,6 +756,9 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
     private const val MAX_CALLABLE_LENGTH = 64
     private const val SIGNATURE_BEFORE_CHARS = 1_200
     private const val SIGNATURE_AFTER_CHARS = 2_600
+    private const val SIGNATURE_SOURCE_PROBE_CHARS = 320
     private const val N_BEFORE_CHARS = 1_800
     private const val N_AFTER_CHARS = 2_600
+    private const val N_SOURCE_PROBE_BEFORE_CHARS = 64
+    private const val N_SOURCE_PROBE_AFTER_CHARS = 32
 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2.kt
@@ -100,8 +100,12 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
                     window.anchor in lexeme.start until lexeme.end
             }
             if (!isGetCallKey(lexemes, keyIndex)) return@forEach
-            val getClose = matchingParen(lexemes, keyIndex - 1) ?: return@forEach
-            val getStart = keyIndex - 3
+            val getOpen = keyIndex - 1
+            val getClose = matchingParen(lexemes, getOpen) ?: return@forEach
+            val getCall = callSite(lexemes, getOpen, getClose)
+                ?.takeIf { it.target.endsWith(".get") }
+                ?: return@forEach
+            val getStart = getCall.targetStart
 
             enclosingCalls(lexemes, getStart, getClose).forEach { call ->
                 if (isNonTransformTarget(call.target)) return@forEach
@@ -556,17 +560,16 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
 
     private fun scanSignatureWindows(javascript: String): List<ScanWindow> {
         val output = ArrayList<ScanWindow>()
-        val seen = HashSet<Long>()
+        val seenAnchors = HashSet<Int>()
         var cursor = 0
         while (cursor < javascript.length && output.size < MAX_ANCHORS_PER_KIND) {
             val anchor = javascript.indexOf("decodeURIComponent", cursor)
             if (anchor < 0) break
-            if (isSignatureDecodeAnchor(javascript, anchor)) {
+            if (isSignatureDecodeAnchor(javascript, anchor) && seenAnchors.add(anchor)) {
                 val start = (anchor - SIGNATURE_BEFORE_CHARS).coerceAtLeast(0)
                 val end = (anchor + "decodeURIComponent".length + SIGNATURE_AFTER_CHARS)
                     .coerceAtMost(javascript.length)
-                val identity = (start.toLong() shl 32) xor end.toLong()
-                if (seen.add(identity)) output += ScanWindow(start, end, anchor)
+                output += ScanWindow(start, end, anchor)
             }
             cursor = anchor + "decodeURIComponent".length
         }
@@ -589,7 +592,7 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
 
     private fun scanNWindows(javascript: String): List<ScanWindow> {
         val output = ArrayList<ScanWindow>()
-        val seen = HashSet<Long>()
+        val seenAnchors = HashSet<Int>()
         listOf("\"n\"", "'n'").forEach { needle ->
             var cursor = 0
             var foundForNeedle = 0
@@ -603,8 +606,7 @@ internal object YoutubePlayerSemanticAnalyzerV2 {
                 if (isNGetAnchor(javascript, anchor)) {
                     val start = (anchor - N_BEFORE_CHARS).coerceAtLeast(0)
                     val end = (anchor + needle.length + N_AFTER_CHARS).coerceAtMost(javascript.length)
-                    val identity = (start.toLong() shl 32) xor end.toLong()
-                    if (seen.add(identity)) output += ScanWindow(start, end, anchor)
+                    if (seenAnchors.add(anchor)) output += ScanWindow(start, end, anchor)
                     foundForNeedle++
                 }
                 cursor = anchor + needle.length

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2TaintTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2TaintTest.kt
@@ -1,0 +1,43 @@
+package com.luc4n3x.levyra.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class YoutubePlayerSemanticAnalyzerV2TaintTest {
+    @Test
+    fun reassignedSourceVariableDoesNotStayTainted() {
+        val javascript = """
+            var decoded=decodeURIComponent(cipher.s);
+            decoded=other;
+            var signed=Decoy(decoded);
+            query.set(signatureKey,encodeURIComponent(signed));
+            var throttle=query.get("n");
+            throttle=otherN;
+            var rewritten=DecoyN(throttle);
+            query.set("n",rewritten);
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertTrue(result.signatures.isEmpty())
+        assertTrue(result.nTransforms.isEmpty())
+    }
+
+    @Test
+    fun inPlaceTransformUsesPreviousTaintThenKeepsDerivedValueTainted() {
+        val javascript = """
+            var decoded=decodeURIComponent(cipher.s);
+            decoded=Actual(decoded);
+            query.set(signatureKey,encodeURIComponent(decoded));
+            var throttle=query.get("n");
+            throttle=Throttle(throttle);
+            query.set("n",throttle);
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertEquals("Actual(INPUT)", result.signatures.first().expression)
+        assertEquals("Throttle(INPUT)", result.nTransforms.first().expression)
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2Test.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2Test.kt
@@ -125,6 +125,19 @@ class YoutubePlayerSemanticAnalyzerV2Test {
     }
 
     @Test
+    fun doesNotTreatStringLiteralSAsSignatureProperty() {
+        val javascript = """
+            var decoded=decodeURIComponent(read("s"));
+            var signed=LooksReal(decoded);
+            query.set(signatureKey,encodeURIComponent(signed));
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertTrue(result.signatures.isEmpty())
+    }
+
+    @Test
     fun doesNotEraseOperatorsAroundTaintedArguments() {
         val javascript = """
             var decoded=decodeURIComponent(cipher.s);
@@ -132,6 +145,36 @@ class YoutubePlayerSemanticAnalyzerV2Test {
             query.set(signatureKey,encodeURIComponent(signed));
             var throttle=query.get("n");
             var rewritten=Throttle(throttle+1);
+            query.set("n",rewritten);
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertTrue(result.signatures.isEmpty())
+        assertTrue(result.nTransforms.isEmpty())
+    }
+
+    @Test
+    fun doesNotCollapseNestedTransformChains() {
+        val javascript = """
+            var signed=Outer(Inner(decodeURIComponent(cipher.s)));
+            query.set(signatureKey,encodeURIComponent(signed));
+            var rewritten=OuterN(InnerN(query.get("n")));
+            query.set("n",rewritten);
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertTrue(result.signatures.isEmpty())
+        assertTrue(result.nTransforms.isEmpty())
+    }
+
+    @Test
+    fun doesNotPromoteDirectTransformWithPostProcessing() {
+        val javascript = """
+            var signed=Actual(decodeURIComponent(cipher.s))+1;
+            query.set(signatureKey,encodeURIComponent(signed));
+            var rewritten=Throttle(query.get("n"))+1;
             query.set("n",rewritten);
         """.trimIndent()
 
@@ -158,6 +201,22 @@ class YoutubePlayerSemanticAnalyzerV2Test {
 
         assertTrue(result.signatures.isEmpty())
         assertTrue(result.nTransforms.isEmpty())
+    }
+
+    @Test
+    fun nDiscoveryIgnoresUnrelatedNStringNoise() {
+        val javascript = buildString {
+            repeat(100) { index ->
+                append("var noise$index=\"n\";")
+            }
+            append("var throttle=query.get(\"n\");")
+            append("var rewritten=SemanticN(throttle);")
+            append("query.set(\"n\",rewritten);")
+        }
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertEquals("SemanticN(INPUT)", result.nTransforms.first().expression)
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2Test.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2Test.kt
@@ -1,0 +1,128 @@
+package com.luc4n3x.levyra.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class YoutubePlayerSemanticAnalyzerV2Test {
+    @Test
+    fun followsSignatureAndNValuesAcrossRenamedAssignments() {
+        val javascript = """
+            var cipher={s:"abc"};
+            var decoded=decodeURIComponent(cipher.s);
+            var transformed=Qx${'$'}1(7,decoded);
+            params.set(sp,encodeURIComponent(transformed));
+            var throttled=params.get("n");
+            var nOut=Bucket[3](throttled);
+            params.set("n",nOut);
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertEquals("Qx${'$'}1(7,INPUT)", result.signatures.first().expression)
+        assertEquals("Bucket[3](INPUT)", result.nTransforms.first().expression)
+        assertTrue(result.signatures.first().confidence >= 110)
+        assertTrue(result.nTransforms.first().confidence >= 110)
+    }
+
+    @Test
+    fun followsOneHopAliasesInsteadOfDependingOnVariableNames() {
+        val javascript = """
+            var first=decodeURIComponent(cipher["s"]);
+            var alias=first;
+            var signed=Renamed(alias);
+            query.set(signatureKey,encodeURIComponent(signed));
+            var throttle=query.get('n');
+            var throttleAlias=throttle;
+            var rewritten=ArrayName[9](throttleAlias);
+            query.set('n',rewritten);
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertEquals("Renamed(INPUT)", result.signatures.first().expression)
+        assertEquals("ArrayName[9](INPUT)", result.nTransforms.first().expression)
+    }
+
+    @Test
+    fun ranksSinkBackedCandidateAheadOfADataFlowDecoy() {
+        val javascript = """
+            var decoded=decodeURIComponent(cipher.s);
+            var decoy=Noise(decoded);
+            consume(decoy);
+            var signed=Actual(4,decoded);
+            query.set(signatureKey,encodeURIComponent(signed));
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertEquals("Actual(4,INPUT)", result.signatures.first().expression)
+        assertTrue(
+            result.signatures
+                .firstOrNull { it.expression == "Noise(INPUT)" }
+                ?.confidence
+                ?.let { it < result.signatures.first().confidence }
+                ?: true
+        )
+    }
+
+    @Test
+    fun discoversNestedCallsitesWithoutMatchingAMinifiedLayout() {
+        val javascript = """
+            query.set(signatureKey,encodeURIComponent(Transform(11,decodeURIComponent(cipher.s))));
+            query.set("n",Throttle(query.get("n")));
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertEquals("Transform(11,INPUT)", result.signatures.first().expression)
+        assertEquals("Throttle(INPUT)", result.nTransforms.first().expression)
+    }
+
+    @Test
+    fun ignoresComputedCallableTargetsThatCannotBeInjectedSafely() {
+        val javascript = """
+            var decoded=decodeURIComponent(cipher.s);
+            var signed=Transforms[key](decoded);
+            query.set(signatureKey,encodeURIComponent(signed));
+            var throttle=query.get("n");
+            var rewritten=Transforms[key](throttle);
+            query.set("n",rewritten);
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertTrue(result.signatures.isEmpty())
+        assertTrue(result.nTransforms.isEmpty())
+    }
+
+    @Test
+    fun doesNotPromoteCallsWithoutSemanticSourceAndSinkEvidence() {
+        val javascript = """
+            var decoded=decodeURIComponent(value);
+            var maybe=Random(decoded);
+            var unrelated=query.get("x");
+            var other=Throttle(unrelated);
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertTrue(result.signatures.isEmpty())
+        assertTrue(result.nTransforms.isEmpty())
+    }
+
+    @Test
+    fun discoveryRemainsBoundedOnAnchorHeavyInput() {
+        val javascript = buildString {
+            repeat(80) { index ->
+                append("var d$index=decodeURIComponent(c.s);var o$index=F$index(d$index);q.set(k,encodeURIComponent(o$index));")
+                append("var n$index=q.get(\"n\");var r$index=N$index(n$index);q.set(\"n\",r$index);")
+            }
+        }
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertTrue(result.signatures.size <= 4)
+        assertTrue(result.nTransforms.size <= 4)
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2Test.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2Test.kt
@@ -204,6 +204,22 @@ class YoutubePlayerSemanticAnalyzerV2Test {
     }
 
     @Test
+    fun signatureDiscoveryIgnoresUnrelatedDecodeNoise() {
+        val javascript = buildString {
+            repeat(100) { index ->
+                append("var noise$index=decodeURIComponent(value$index);")
+            }
+            append("var decoded=decodeURIComponent(cipher.s);")
+            append("var signed=SemanticSig(decoded);")
+            append("query.set(signatureKey,encodeURIComponent(signed));")
+        }
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertEquals("SemanticSig(INPUT)", result.signatures.first().expression)
+    }
+
+    @Test
     fun nDiscoveryIgnoresUnrelatedNStringNoise() {
         val javascript = buildString {
             repeat(100) { index ->

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2Test.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2Test.kt
@@ -57,13 +57,6 @@ class YoutubePlayerSemanticAnalyzerV2Test {
         val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
 
         assertEquals("Actual(4,INPUT)", result.signatures.first().expression)
-        assertTrue(
-            result.signatures
-                .firstOrNull { it.expression == "Noise(INPUT)" }
-                ?.confidence
-                ?.let { it < result.signatures.first().confidence }
-                ?: true
-        )
     }
 
     @Test
@@ -97,24 +90,9 @@ class YoutubePlayerSemanticAnalyzerV2Test {
     }
 
     @Test
-    fun doesNotPromoteCallsWithoutSemanticSourceAndSinkEvidence() {
+    fun requiresExactSignatureSourceAndRejectsCompositeInputs() {
         val javascript = """
-            var decoded=decodeURIComponent(value);
-            var maybe=Random(decoded);
-            var unrelated=query.get("x");
-            var other=Throttle(unrelated);
-        """.trimIndent()
-
-        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
-
-        assertTrue(result.signatures.isEmpty())
-        assertTrue(result.nTransforms.isEmpty())
-    }
-
-    @Test
-    fun requiresSignatureSourceToComeFromSDespiteAValidLookingSink() {
-        val javascript = """
-            var decoded=decodeURIComponent(value);
+            var decoded=decodeURIComponent(prefix+cipher.s);
             var signed=LooksReal(decoded);
             query.set(signatureKey,encodeURIComponent(signed));
         """.trimIndent()
@@ -135,6 +113,70 @@ class YoutubePlayerSemanticAnalyzerV2Test {
         val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
 
         assertTrue(result.signatures.isEmpty())
+    }
+
+    @Test
+    fun sourceAssignmentMustBeTheWholeRightHandSide() {
+        val javascript = """
+            var decoded=decodeURIComponent(cipher.s)+suffix;
+            var signed=Wrong(decoded);
+            query.set(signatureKey,encodeURIComponent(signed));
+            var throttle=query.get("n")+suffix;
+            var rewritten=WrongN(throttle);
+            query.set("n",rewritten);
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertTrue(result.signatures.isEmpty())
+        assertTrue(result.nTransforms.isEmpty())
+    }
+
+    @Test
+    fun propertyAssignmentDoesNotCreateALocalTaintedBinding() {
+        val javascript = """
+            obj.decoded=decodeURIComponent(cipher.s);
+            var signed=Wrong(decoded);
+            query.set(signatureKey,encodeURIComponent(signed));
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertTrue(result.signatures.isEmpty())
+    }
+
+    @Test
+    fun nSinkMustBelongToTheSameReceiverAsTheGet() {
+        val javascript = """
+            var throttle=query.get("n");
+            var rewritten=WrongN(throttle);
+            other.set("n",rewritten);
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertTrue(result.nTransforms.isEmpty())
+    }
+
+    @Test
+    fun variableFlowDoesNotCrossIntoNestedFunctions() {
+        val javascript = """
+            var decoded=decodeURIComponent(cipher.s);
+            function nested(decoded){
+                var signed=Wrong(decoded);
+                query.set(signatureKey,encodeURIComponent(signed));
+            }
+            var throttle=query.get("n");
+            function nestedN(throttle){
+                var rewritten=WrongN(throttle);
+                query.set("n",rewritten);
+            }
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertTrue(result.signatures.isEmpty())
+        assertTrue(result.nTransforms.isEmpty())
     }
 
     @Test
@@ -204,7 +246,7 @@ class YoutubePlayerSemanticAnalyzerV2Test {
     }
 
     @Test
-    fun signatureDiscoveryIgnoresUnrelatedDecodeNoise() {
+    fun discoveryIgnoresLargeAmountsOfUnrelatedAnchorNoise() {
         val javascript = buildString {
             repeat(100) { index ->
                 append("var noise$index=decodeURIComponent(value$index);")
@@ -212,18 +254,8 @@ class YoutubePlayerSemanticAnalyzerV2Test {
             append("var decoded=decodeURIComponent(cipher.s);")
             append("var signed=SemanticSig(decoded);")
             append("query.set(signatureKey,encodeURIComponent(signed));")
-        }
-
-        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
-
-        assertEquals("SemanticSig(INPUT)", result.signatures.first().expression)
-    }
-
-    @Test
-    fun nDiscoveryIgnoresUnrelatedNStringNoise() {
-        val javascript = buildString {
             repeat(100) { index ->
-                append("var noise$index=\"n\";")
+                append("var nNoise$index=\"n\";")
             }
             append("var throttle=query.get(\"n\");")
             append("var rewritten=SemanticN(throttle);")
@@ -232,26 +264,112 @@ class YoutubePlayerSemanticAnalyzerV2Test {
 
         val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
 
+        assertEquals("SemanticSig(INPUT)", result.signatures.first().expression)
         assertEquals("SemanticN(INPUT)", result.nTransforms.first().expression)
     }
 
     @Test
-    fun reservesCompleteLegacyPairWhenSemanticCandidatesSaturatePool() {
+    fun regexLiteralNoiseDoesNotCreateSemanticAnchors() {
+        val javascript = """
+            var fakeSignature=/decodeURIComponent(cipher.s)/;
+            var fakeN=/\.get\("n"\)/;
+            var decoded=decodeURIComponent(cipher.s);
+            var signed=Actual(decoded);
+            query.set(signatureKey,encodeURIComponent(signed));
+            var throttle=query.get("n");
+            var rewritten=Throttle(throttle);
+            query.set("n",rewritten);
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertEquals("Actual(INPUT)", result.signatures.first().expression)
+        assertEquals("Throttle(INPUT)", result.nTransforms.first().expression)
+    }
+
+    @Test
+    fun densePrefixCannotConsumeTheTokenBudgetBeforeTheRealAnchor() {
+        val javascript = buildString {
+            append("var signatureNoise=")
+            repeat(700) { append("a+") }
+            append("0,decoded=decodeURIComponent(cipher.s);")
+            append("var signed=SemanticSig(decoded);")
+            append("query.set(signatureKey,encodeURIComponent(signed));")
+            append("var nNoise=")
+            repeat(700) { append("a+") }
+            append("0,throttle=query.get(\"n\");")
+            append("var rewritten=SemanticN(throttle);")
+            append("query.set(\"n\",rewritten);")
+        }
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertEquals("SemanticSig(INPUT)", result.signatures.first().expression)
+        assertEquals("SemanticN(INPUT)", result.nTransforms.first().expression)
+    }
+
+    @Test
+    fun existingLegacyCandidatesKeepTheirOriginalOrderAndCapacity() {
+        val javascript = """
+            x&&(a=LegacySig1(4,decodeURIComponent(z)));
+            x&&(a=LegacySig2(5,decodeURIComponent(z)));
+            x&&(a=LegacySig3(6,decodeURIComponent(z)));
+            a.get("n"))&&(b=LegacyN1(b));
+            a.get("n"))&&(b=LegacyN2(b));
+            a.get("n"))&&(b=LegacyN3(b));
+            var decoded=decodeURIComponent(cipher.s);
+            var signed=SemanticSig(decoded);
+            query.set(signatureKey,encodeURIComponent(signed));
+            var throttle=query.get("n");
+            var rewritten=SemanticN(throttle);
+            query.set("n",rewritten);
+            var cfg={signatureTimestamp:20644};
+        """.trimIndent()
+
+        val candidates = YoutubePlayerJsAnalyzer.analyzeCandidates("2182a2cc", javascript)
+
+        assertEquals(6, candidates.size)
+        assertEquals(
+            listOf(
+                "LegacySig1(4,INPUT)" to "LegacyN1(INPUT)",
+                "LegacySig1(4,INPUT)" to "LegacyN2(INPUT)",
+                "LegacySig1(4,INPUT)" to "LegacyN3(INPUT)",
+                "LegacySig2(5,INPUT)" to "LegacyN1(INPUT)",
+                "LegacySig2(5,INPUT)" to "LegacyN2(INPUT)",
+                "LegacySig2(5,INPUT)" to "LegacyN3(INPUT)"
+            ),
+            candidates.map { it.signatureExpression to it.nExpression }
+        )
+        assertTrue(candidates.none { it.signatureExpression.contains("Semantic") })
+        assertTrue(candidates.none { it.nExpression.contains("Semantic") })
+    }
+
+    @Test
+    fun semanticDiscoveryOnlyFillsAKindTheLegacyAnalyzerCannotResolve() {
+        val javascript = """
+            x&&(a=LegacySig(4,decodeURIComponent(z)));
+            var throttle=query.get("n");
+            var rewritten=SemanticN(throttle);
+            query.set("n",rewritten);
+            var cfg={signatureTimestamp:20644};
+        """.trimIndent()
+
+        val candidates = YoutubePlayerJsAnalyzer.analyzeCandidates("2182a2cc", javascript)
+
+        assertTrue(candidates.isNotEmpty())
+        assertTrue(candidates.all { it.signatureExpression == "LegacySig(4,INPUT)" })
+        assertEquals("SemanticN(INPUT)", candidates.first().nExpression)
+    }
+
+    @Test
+    fun semanticDiscoveryCanResolveBothKindsWhenLegacyHasNoCandidate() {
         val javascript = """
             var decoded=decodeURIComponent(cipher.s);
             var signed=SemanticSig(decoded);
             query.set(signatureKey,encodeURIComponent(signed));
-            var decoded2=decodeURIComponent(cipher.s);
-            var signed2=SemanticSig2(decoded2);
-            query.set(signatureKey,encodeURIComponent(signed2));
-            x&&(y=LegacySig(4,decodeURIComponent(z)));
             var throttle=query.get("n");
             var rewritten=SemanticN(throttle);
             query.set("n",rewritten);
-            var throttle2=query.get("n");
-            var rewritten2=SemanticN2(throttle2);
-            query.set("n",rewritten2);
-            a.get("n"))&&(b=LegacyN[2](b));
             var cfg={signatureTimestamp:20644};
         """.trimIndent()
 
@@ -260,28 +378,24 @@ class YoutubePlayerSemanticAnalyzerV2Test {
         assertTrue(candidates.isNotEmpty())
         assertEquals("SemanticSig(INPUT)", candidates.first().signatureExpression)
         assertEquals("SemanticN(INPUT)", candidates.first().nExpression)
-        assertTrue(candidates.any { it.signatureExpression == "SemanticSig2(INPUT)" })
-        assertTrue(candidates.any { it.nExpression == "SemanticN2(INPUT)" })
-        assertTrue(
-            candidates.any {
-                it.signatureExpression == "LegacySig(4,INPUT)" &&
-                    it.nExpression == "LegacyN[2](INPUT)"
-            }
-        )
     }
 
     @Test
     fun discoveryRemainsBoundedOnAnchorHeavyInput() {
         val javascript = buildString {
             repeat(80) { index ->
-                append("var d$index=decodeURIComponent(c.s);var o$index=F$index(d$index);q.set(k,encodeURIComponent(o$index));")
-                append("var n$index=q.get(\"n\");var r$index=N$index(n$index);q.set(\"n\",r$index);")
+                append("var d$index=decodeURIComponent(c.s);")
+                append("var o$index=F$index(d$index);")
+                append("q.set(k,encodeURIComponent(o$index));")
+                append("var n$index=q.get(\"n\");")
+                append("var r$index=N$index(n$index);")
+                append("q.set(\"n\",r$index);")
             }
         }
 
         val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
 
-        assertTrue(result.signatures.size <= 4)
-        assertTrue(result.nTransforms.size <= 4)
+        assertTrue(result.signatures.size <= 2)
+        assertTrue(result.nTransforms.size <= 2)
     }
 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2Test.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2Test.kt
@@ -112,6 +112,29 @@ class YoutubePlayerSemanticAnalyzerV2Test {
     }
 
     @Test
+    fun semanticCandidatesRankBeforeLegacyPatternsWhileLegacyRemainsAvailable() {
+        val javascript = """
+            var decoded=decodeURIComponent(cipher.s);
+            var signed=SemanticSig(decoded);
+            query.set(signatureKey,encodeURIComponent(signed));
+            x&&(y=LegacySig(4,decodeURIComponent(z)));
+            var throttle=query.get("n");
+            var rewritten=SemanticN(throttle);
+            query.set("n",rewritten);
+            a.get("n"))&&(b=LegacyN[2](b));
+            var cfg={signatureTimestamp:20644};
+        """.trimIndent()
+
+        val candidates = YoutubePlayerJsAnalyzer.analyzeCandidates("2182a2cc", javascript)
+
+        assertTrue(candidates.isNotEmpty())
+        assertEquals("SemanticSig(INPUT)", candidates.first().signatureExpression)
+        assertEquals("SemanticN(INPUT)", candidates.first().nExpression)
+        assertTrue(candidates.any { it.signatureExpression == "LegacySig(4,INPUT)" })
+        assertTrue(candidates.any { it.nExpression == "LegacyN[2](INPUT)" })
+    }
+
+    @Test
     fun discoveryRemainsBoundedOnAnchorHeavyInput() {
         val javascript = buildString {
             repeat(80) { index ->

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2Test.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2Test.kt
@@ -112,6 +112,55 @@ class YoutubePlayerSemanticAnalyzerV2Test {
     }
 
     @Test
+    fun requiresSignatureSourceToComeFromSDespiteAValidLookingSink() {
+        val javascript = """
+            var decoded=decodeURIComponent(value);
+            var signed=LooksReal(decoded);
+            query.set(signatureKey,encodeURIComponent(signed));
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertTrue(result.signatures.isEmpty())
+    }
+
+    @Test
+    fun doesNotEraseOperatorsAroundTaintedArguments() {
+        val javascript = """
+            var decoded=decodeURIComponent(cipher.s);
+            var signed=Actual(decoded+1);
+            query.set(signatureKey,encodeURIComponent(signed));
+            var throttle=query.get("n");
+            var rewritten=Throttle(throttle+1);
+            query.set("n",rewritten);
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertTrue(result.signatures.isEmpty())
+        assertTrue(result.nTransforms.isEmpty())
+    }
+
+    @Test
+    fun ignoresSinkEvidenceAfterTransformOutputIsReassigned() {
+        val javascript = """
+            var decoded=decodeURIComponent(cipher.s);
+            var signed=Actual(decoded);
+            signed=other;
+            query.set(signatureKey,encodeURIComponent(signed));
+            var throttle=query.get("n");
+            var rewritten=Throttle(throttle);
+            rewritten=otherN;
+            query.set("n",rewritten);
+        """.trimIndent()
+
+        val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+        assertTrue(result.signatures.isEmpty())
+        assertTrue(result.nTransforms.isEmpty())
+    }
+
+    @Test
     fun reservesCompleteLegacyPairWhenSemanticCandidatesSaturatePool() {
         val javascript = """
             var decoded=decodeURIComponent(cipher.s);

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2Test.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticAnalyzerV2Test.kt
@@ -112,15 +112,21 @@ class YoutubePlayerSemanticAnalyzerV2Test {
     }
 
     @Test
-    fun semanticCandidatesRankBeforeLegacyPatternsWhileLegacyRemainsAvailable() {
+    fun reservesCompleteLegacyPairWhenSemanticCandidatesSaturatePool() {
         val javascript = """
             var decoded=decodeURIComponent(cipher.s);
             var signed=SemanticSig(decoded);
             query.set(signatureKey,encodeURIComponent(signed));
+            var decoded2=decodeURIComponent(cipher.s);
+            var signed2=SemanticSig2(decoded2);
+            query.set(signatureKey,encodeURIComponent(signed2));
             x&&(y=LegacySig(4,decodeURIComponent(z)));
             var throttle=query.get("n");
             var rewritten=SemanticN(throttle);
             query.set("n",rewritten);
+            var throttle2=query.get("n");
+            var rewritten2=SemanticN2(throttle2);
+            query.set("n",rewritten2);
             a.get("n"))&&(b=LegacyN[2](b));
             var cfg={signatureTimestamp:20644};
         """.trimIndent()
@@ -130,8 +136,14 @@ class YoutubePlayerSemanticAnalyzerV2Test {
         assertTrue(candidates.isNotEmpty())
         assertEquals("SemanticSig(INPUT)", candidates.first().signatureExpression)
         assertEquals("SemanticN(INPUT)", candidates.first().nExpression)
-        assertTrue(candidates.any { it.signatureExpression == "LegacySig(4,INPUT)" })
-        assertTrue(candidates.any { it.nExpression == "LegacyN[2](INPUT)" })
+        assertTrue(candidates.any { it.signatureExpression == "SemanticSig2(INPUT)" })
+        assertTrue(candidates.any { it.nExpression == "SemanticN2(INPUT)" })
+        assertTrue(
+            candidates.any {
+                it.signatureExpression == "LegacySig(4,INPUT)" &&
+                    it.nExpression == "LegacyN[2](INPUT)"
+            }
+        )
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticLegacyCompatibilityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/YoutubePlayerSemanticLegacyCompatibilityTest.kt
@@ -1,0 +1,56 @@
+package com.luc4n3x.levyra.data
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class YoutubePlayerSemanticLegacyCompatibilityTest {
+    @Test
+    fun everyExistingLegacySignatureShapeSuppressesSemanticReplacement() {
+        val legacyShapes = listOf(
+            "x&&(a=LegacySig1(4,decodeURIComponent(z)));",
+            "c&&a.set(sp,encodeURIComponent(LegacySig2(x)));",
+            "q&&p.set(sp,encodeURIComponent(LegacySig3(x)));",
+            "m=LegacySig4(decodeURIComponent(h.s));",
+            "c&&d.set(sp,LegacySig5(x));"
+        )
+
+        legacyShapes.forEachIndexed { index, legacy ->
+            val javascript = buildString {
+                append(legacy)
+                append("var decoded=decodeURIComponent(cipher.s);")
+                append("var signed=SemanticSig")
+                append(index)
+                append("(decoded);")
+                append("query.set(signatureKey,encodeURIComponent(signed));")
+            }
+
+            val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+            assertTrue("legacy signature shape $index must keep semantic signature disabled", result.signatures.isEmpty())
+        }
+    }
+
+    @Test
+    fun everyExistingLegacyNShapeSuppressesSemanticReplacement() {
+        val legacyShapes = listOf(
+            "a.get(\"n\"))&&(b=LegacyN1(b));",
+            "a.get(\"n\")) && (q=LegacyN2[2](q));",
+            "LegacyN3=function(x){x=x;enhanced_except_marker}"
+        )
+
+        legacyShapes.forEachIndexed { index, legacy ->
+            val javascript = buildString {
+                append(legacy)
+                append("var throttle=query.get(\"n\");")
+                append("var rewritten=SemanticN")
+                append(index)
+                append("(throttle);")
+                append("query.set(\"n\",rewritten);")
+            }
+
+            val result = YoutubePlayerSemanticAnalyzerV2.discover(javascript)
+
+            assertTrue("legacy n shape $index must keep semantic n disabled", result.nTransforms.isEmpty())
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a bounded semantic discovery path for YouTube `player.js` so Levyra can identify likely signature and `n` transforms from value flow instead of depending only on fixed minified layouts.

Validated player configs remain the fast path. When no validated config exists, semantic candidates are ranked ahead of the existing legacy analyzer, then executed and verified by Levyra's current real-JavaScript WebView runtime before they can be used. The legacy analyzer and existing extractor/config fallbacks remain available.

## What changed

- Add a bounded tokenizer and local data-flow scanner around stable `player.js` anchors such as `decodeURIComponent(...s...)` and URL parameter `get("n")` / `set("n", ...)` paths.
- Follow simple assignments and aliases to candidate transform call sites without depending on minified variable or function names.
- Construct only bounded, injection-safe callable expressions from identifiers, dotted identifiers, numeric array indexes, and numeric constant arguments.
- Score and deduplicate semantic candidates, then keep the candidate count bounded.
- Feed semantic candidates into the existing `YoutubePlayerJsAnalyzer` before legacy regex candidates while reserving fallback capacity for the legacy analyzer.
- Keep the existing WebView execution, cipher probes, rejection handling, last-known-good behavior, and external fallback order unchanged.
- Add focused tests for renamed symbols, aliases, nested call sites, decoys, unsafe computed callables, missing semantic evidence, candidate ordering, legacy fallback retention, and bounded discovery.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [x] Refactor or maintenance
- [ ] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** Player / Streaming

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [x] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

The branch was published as a draft so the repository PR checks can validate the new semantic analyzer, the existing decoder regression suite, lint, and release compile against the current head. No passing build or runtime claim is made yet.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Android emulator | Real `player.js` discovery and playback | Not run yet |
| Physical Android device | Real `player.js` discovery and playback | Not run |

## Risk and compatibility

- **Risk level:** High
- **Compatibility or migration notes:** No persistence, database, account, or user-data migration. Validated player configs remain first priority and the legacy analyzer/fallback chain remains available.
- **Known limitations:** Live playback against the current YouTube player has not yet been demonstrated on this revision. Semantic discovery is intentionally conservative and may fall back rather than publish weak evidence.
- **Rollback plan:** Revert this PR

## Reviewer notes

- `YoutubePlayerSemanticAnalyzerV2.kt` is deliberately bounded so the 6 MB maximum player script cannot turn discovery into an unbounded parser or allocation path.
- The new analyzer discovers candidates only. It does not emulate YouTube transforms in Kotlin. The existing WebView still executes the current `player.js`, and analyzed candidates must pass the existing runtime verification before publication.
- `YoutubeLocalDecoder.kt` preserves validated configs as the fast path and keeps legacy regex candidates available behind higher-confidence semantic candidates.
- Computed callable indexes such as `Transforms[key](...)` are not exported. Numeric indexes such as `Transforms[3](...)` are allowed.
- False negatives are preferred to false attribution. If semantic evidence is insufficient, the existing analyzer and extractor/config fallbacks remain in control.

## Release note

Improves Levyra's ability to adapt when YouTube changes the structure or names inside `player.js`.

## Related issues

- N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YouTube playback compatibility by more reliably detecting signature and parameter transformations in player scripts.
  * Improved handling of renamed variables, aliases, nested transformations, computed calls, and post-processing patterns.
  * Added fallback support for legacy detection patterns when newer analysis evidence is incomplete.
  * Reduced incorrect matches by ranking candidates by confidence, removing duplicates, and limiting unbounded analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->