### PR TITLE
fix(home): remove legacy energy shelf

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraStartupCatalog.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraStartupCatalog.kt
@@ -20,7 +20,7 @@ object LevyraStartupCatalog {
             track("Billie Jean", "Michael Jackson", "Thriller", "Zi_XLOBDo_Y", setOf("pop", "classic", "groove"), 82, 68, 96),
             track("Numb", "Linkin Park", "Meteora", "kXYiU_JCYtU", setOf("rock", "alt", "energy"), 88, 76, 93),
             track("Viva La Vida", "Coldplay", "Viva La Vida", "dvgZkm1xWPE", setOf("pop", "anthem", "mood"), 74, 70, 90)
-        )
+        ) + focusTracks()
         return listOf(
             HomeSection(locale.quickSectionTitle, quick),
             HomeSection(locale.localSectionTitle, localTracks(languageCode))
@@ -28,24 +28,46 @@ object LevyraStartupCatalog {
     }
 
     fun chartTracks(languageCode: String = LevyraLanguageCatalog.deviceDefault()): List<Track> =
-        (homeSections(languageCode).flatMap { it.tracks } + focusTracks())
+        homeSections(languageCode)
+            .flatMap { it.tracks }
             .distinctBy { it.title.lowercase() to it.artist.lowercase() }
             .take(20)
 
     fun repairHomeSections(sections: List<HomeSection>, languageCode: String): List<HomeSection> {
         if (sections.isEmpty()) return sections
-        val energyTitle = LevyraContentLocales.forLanguage(languageCode).energySectionTitle.trim()
-        return sections
+        val locale = LevyraContentLocales.forLanguage(languageCode)
+        val energyTitle = locale.energySectionTitle.trim()
+        val legacyEnergyTracks = sections
+            .asSequence()
+            .filter { section -> section.title.trim().equals(energyTitle, ignoreCase = true) }
+            .flatMap { section -> section.tracks.asSequence() }
+            .toList()
+        val repairedSections = sections
             .filterNot { section -> section.title.trim().equals(energyTitle, ignoreCase = true) }
             .map { section ->
                 section.copy(tracks = repairTracks(section.tracks, languageCode))
             }
+        if (legacyEnergyTracks.isEmpty()) return repairedSections
+
+        val quickIndex = repairedSections.indexOfFirst { section ->
+            section.title.trim().equals(locale.quickSectionTitle.trim(), ignoreCase = true)
+        }
+        if (quickIndex < 0) return repairedSections
+
+        val repairedEnergyTracks = repairTracks(legacyEnergyTracks, languageCode)
+        if (repairedEnergyTracks.isEmpty()) return repairedSections
+        val quickSection = repairedSections[quickIndex]
+        val mergedQuickTracks = (quickSection.tracks + repairedEnergyTracks)
+            .distinctBy { track -> seedTrackKey(track.title, track.artist) }
+        return repairedSections.toMutableList().apply {
+            this[quickIndex] = quickSection.copy(tracks = mergedQuickTracks)
+        }
     }
 
     fun repairTracks(tracks: List<Track>, languageCode: String): List<Track> {
         if (tracks.isEmpty()) return tracks
         val normalizedLanguage = LevyraLanguageCatalog.normalize(languageCode)
-        val canonical = homeSections(normalizedLanguage).flatMap { it.tracks } + focusTracks()
+        val canonical = homeSections(normalizedLanguage).flatMap { it.tracks }
         val exact = canonical.associateBy { seedTrackKey(it.title, it.artist) }
         val byTitle = canonical.groupBy { seedTitleKey(it.title) }
         return tracks.map { current ->

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraStartupCatalog.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraStartupCatalog.kt
@@ -35,22 +35,31 @@ object LevyraStartupCatalog {
 
     fun repairHomeSections(sections: List<HomeSection>, languageCode: String): List<HomeSection> {
         if (sections.isEmpty()) return sections
-        val locale = LevyraContentLocales.forLanguage(languageCode)
-        val energyTitle = locale.energySectionTitle.trim()
+        val legacyEnergyTitles = LevyraLanguageCatalog.languages
+            .map { language -> LevyraContentLocales.forLanguage(language.code).energySectionTitle.trim() }
+            .filter { it.isNotEmpty() }
+        val legacyQuickTitles = LevyraLanguageCatalog.languages
+            .map { language -> LevyraContentLocales.forLanguage(language.code).quickSectionTitle.trim() }
+            .filter { it.isNotEmpty() }
+        fun matchesTitle(section: HomeSection, titles: List<String>): Boolean {
+            val sectionTitle = section.title.trim()
+            return titles.any { title -> sectionTitle.equals(title, ignoreCase = true) }
+        }
+
         val legacyEnergyTracks = sections
             .asSequence()
-            .filter { section -> section.title.trim().equals(energyTitle, ignoreCase = true) }
+            .filter { section -> matchesTitle(section, legacyEnergyTitles) }
             .flatMap { section -> section.tracks.asSequence() }
             .toList()
         val repairedSections = sections
-            .filterNot { section -> section.title.trim().equals(energyTitle, ignoreCase = true) }
+            .filterNot { section -> matchesTitle(section, legacyEnergyTitles) }
             .map { section ->
                 section.copy(tracks = repairTracks(section.tracks, languageCode))
             }
         if (legacyEnergyTracks.isEmpty()) return repairedSections
 
         val quickIndex = repairedSections.indexOfFirst { section ->
-            section.title.trim().equals(locale.quickSectionTitle.trim(), ignoreCase = true)
+            matchesTitle(section, legacyQuickTitles)
         }
         if (quickIndex < 0) return repairedSections
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraStartupCatalog.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraStartupCatalog.kt
@@ -21,34 +21,31 @@ object LevyraStartupCatalog {
             track("Numb", "Linkin Park", "Meteora", "kXYiU_JCYtU", setOf("rock", "alt", "energy"), 88, 76, 93),
             track("Viva La Vida", "Coldplay", "Viva La Vida", "dvgZkm1xWPE", setOf("pop", "anthem", "mood"), 74, 70, 90)
         )
-        val focus = listOf(
-            track("Midnight City", "M83", "Hurry Up, We're Dreaming", "dX3k_QDnzHE", setOf("electronic", "night", "drive"), 78, 45, 88),
-            track("Starboy", "The Weeknd", "Starboy", "34Na4j8AVgA", setOf("pop", "night", "drive"), 84, 68, 91),
-            track("Believer", "Imagine Dragons", "Evolve", "7wtfhZwyrcc", setOf("rock", "gym", "energy"), 90, 72, 89),
-            track("One More Time", "Daft Punk", "Discovery", "FGBhQbmPwH8", setOf("electronic", "dance", "classic"), 88, 48, 92),
-            track("Take On Me", "a-ha", "Hunting High and Low", "djV11Xbc914", setOf("pop", "classic", "drive"), 80, 72, 90),
-            track("In The End", "Linkin Park", "Hybrid Theory", "eVTXPUF4Oz4", setOf("rock", "alt", "energy"), 86, 76, 93)
-        )
         return listOf(
             HomeSection(locale.quickSectionTitle, quick),
-            HomeSection(locale.localSectionTitle, localTracks(languageCode)),
-            HomeSection(locale.energySectionTitle, focus)
+            HomeSection(locale.localSectionTitle, localTracks(languageCode))
         )
     }
 
-    fun chartTracks(languageCode: String = LevyraLanguageCatalog.deviceDefault()): List<Track> = homeSections(languageCode).flatMap { it.tracks }.distinctBy { it.title.lowercase() to it.artist.lowercase() }.take(20)
+    fun chartTracks(languageCode: String = LevyraLanguageCatalog.deviceDefault()): List<Track> =
+        (homeSections(languageCode).flatMap { it.tracks } + focusTracks())
+            .distinctBy { it.title.lowercase() to it.artist.lowercase() }
+            .take(20)
 
     fun repairHomeSections(sections: List<HomeSection>, languageCode: String): List<HomeSection> {
         if (sections.isEmpty()) return sections
-        return sections.map { section ->
-            section.copy(tracks = repairTracks(section.tracks, languageCode))
-        }
+        val energyTitle = LevyraContentLocales.forLanguage(languageCode).energySectionTitle.trim()
+        return sections
+            .filterNot { section -> section.title.trim().equals(energyTitle, ignoreCase = true) }
+            .map { section ->
+                section.copy(tracks = repairTracks(section.tracks, languageCode))
+            }
     }
 
     fun repairTracks(tracks: List<Track>, languageCode: String): List<Track> {
         if (tracks.isEmpty()) return tracks
         val normalizedLanguage = LevyraLanguageCatalog.normalize(languageCode)
-        val canonical = homeSections(normalizedLanguage).flatMap { it.tracks }
+        val canonical = homeSections(normalizedLanguage).flatMap { it.tracks } + focusTracks()
         val exact = canonical.associateBy { seedTrackKey(it.title, it.artist) }
         val byTitle = canonical.groupBy { seedTitleKey(it.title) }
         return tracks.map { current ->
@@ -85,6 +82,15 @@ object LevyraStartupCatalog {
             .replace(Regex("""\s+"""), " ")
             .trim()
     }
+
+    private fun focusTracks(): List<Track> = listOf(
+        track("Midnight City", "M83", "Hurry Up, We're Dreaming", "dX3k_QDnzHE", setOf("electronic", "night", "drive"), 78, 45, 88),
+        track("Starboy", "The Weeknd", "Starboy", "34Na4j8AVgA", setOf("pop", "night", "drive"), 84, 68, 91),
+        track("Believer", "Imagine Dragons", "Evolve", "7wtfhZwyrcc", setOf("rock", "gym", "energy"), 90, 72, 89),
+        track("One More Time", "Daft Punk", "Discovery", "FGBhQbmPwH8", setOf("electronic", "dance", "classic"), 88, 48, 92),
+        track("Take On Me", "a-ha", "Hunting High and Low", "djV11Xbc914", setOf("pop", "classic", "drive"), 80, 72, 90),
+        track("In The End", "Linkin Park", "Hybrid Theory", "eVTXPUF4Oz4", setOf("rock", "alt", "energy"), 86, 76, 93)
+    )
 
     private fun localTracks(languageCode: String): List<Track> {
         return when (LevyraLanguageCatalog.normalize(languageCode)) {

--- a/app/src/test/java/com/luc4n3x/levyra/data/LevyraStartupCatalogTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/LevyraStartupCatalogTest.kt
@@ -72,6 +72,43 @@ class LevyraStartupCatalogTest {
     }
 
     @Test
+    fun repairHomeSectionsMigratesLegacyEnergyShelfAfterLanguageChange() {
+        val allEnergyTitles = LevyraLanguageCatalog.languages
+            .map { language -> LevyraContentLocales.forLanguage(language.code).energySectionTitle.trim() }
+            .filter { it.isNotEmpty() }
+
+        LevyraLanguageCatalog.languages.forEach { savedLanguage ->
+            val targetLanguageCode = if (savedLanguage.code == "en") "it" else "en"
+            val savedLocale = LevyraContentLocales.forLanguage(savedLanguage.code)
+            val startupTracks = LevyraStartupCatalog.homeSections(savedLanguage.code).flatMap { it.tracks }
+            val quickTrack = startupTracks.first { it.title == "Bohemian Rhapsody" }
+            val energyTrack = startupTracks.first { it.title == "Midnight City" }
+
+            val repaired = LevyraStartupCatalog.repairHomeSections(
+                listOf(
+                    HomeSection(savedLocale.quickSectionTitle, listOf(quickTrack)),
+                    HomeSection(savedLocale.energySectionTitle, listOf(energyTrack))
+                ),
+                targetLanguageCode
+            )
+
+            assertFalse(
+                "Legacy ${savedLanguage.code} energy shelf survived after switching to $targetLanguageCode",
+                repaired.any { section ->
+                    allEnergyTitles.any { title -> section.title.trim().equals(title, ignoreCase = true) }
+                }
+            )
+            val quick = repaired.single { section ->
+                section.title.trim().equals(savedLocale.quickSectionTitle.trim(), ignoreCase = true)
+            }
+            assertEquals(
+                setOf("Bohemian Rhapsody", "Midnight City"),
+                quick.tracks.mapTo(mutableSetOf()) { it.title }
+            )
+        }
+    }
+
+    @Test
     fun chartFallbackStillContainsTwentyStartupSeeds() {
         val tracks = LevyraStartupCatalog.chartTracks("en")
         val titles = tracks.mapTo(mutableSetOf()) { it.title }

--- a/app/src/test/java/com/luc4n3x/levyra/data/LevyraStartupCatalogTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/LevyraStartupCatalogTest.kt
@@ -25,29 +25,58 @@ class LevyraStartupCatalogTest {
     }
 
     @Test
-    fun repairHomeSectionsDropsPersistedLegacyEnergyShelfInAnyLanguage() {
+    fun startupHomeKeepsFullLegacySeedPoolWithoutEnergyShelf() {
+        LevyraLanguageCatalog.languages.forEach { language ->
+            val tracks = LevyraStartupCatalog.homeSections(language.code)
+                .flatMap { it.tracks }
+                .distinctBy { it.title.lowercase() to it.artist.lowercase() }
+            val titles = tracks.mapTo(mutableSetOf()) { it.title }
+
+            assertEquals("Startup seed count changed for ${language.code}", 20, tracks.size)
+            assertTrue("Midnight City missing for ${language.code}", "Midnight City" in titles)
+            assertTrue("Starboy missing for ${language.code}", "Starboy" in titles)
+            assertTrue("Believer missing for ${language.code}", "Believer" in titles)
+        }
+    }
+
+    @Test
+    fun repairHomeSectionsMovesPersistedLegacyEnergyTracksIntoQuickPicks() {
         LevyraLanguageCatalog.languages.forEach { language ->
             val locale = LevyraContentLocales.forLanguage(language.code)
+            val startupTracks = LevyraStartupCatalog.homeSections(language.code).flatMap { it.tracks }
+            val quickTrack = startupTracks.first { it.title == "Bohemian Rhapsody" }
+            val energyTrack = startupTracks.first { it.title == "Midnight City" }
+
             val repaired = LevyraStartupCatalog.repairHomeSections(
                 listOf(
-                    HomeSection(locale.quickSectionTitle, emptyList()),
-                    HomeSection(locale.energySectionTitle, emptyList())
+                    HomeSection(locale.quickSectionTitle, listOf(quickTrack)),
+                    HomeSection(locale.energySectionTitle, listOf(energyTrack))
                 ),
                 language.code
             )
 
-            assertEquals(
+            assertFalse(
                 "Legacy energy shelf still restored for ${language.code}",
-                listOf(locale.quickSectionTitle),
-                repaired.map { it.title }
+                repaired.any { section ->
+                    section.title.trim().equals(locale.energySectionTitle.trim(), ignoreCase = true)
+                }
+            )
+            val quick = repaired.single { section ->
+                section.title.trim().equals(locale.quickSectionTitle.trim(), ignoreCase = true)
+            }
+            assertEquals(
+                setOf("Bohemian Rhapsody", "Midnight City"),
+                quick.tracks.mapTo(mutableSetOf()) { it.title }
             )
         }
     }
 
     @Test
-    fun chartFallbackKeepsLegacyFocusSeedsWithoutRenderingTheirShelf() {
-        val titles = LevyraStartupCatalog.chartTracks("en").mapTo(mutableSetOf()) { it.title }
+    fun chartFallbackStillContainsTwentyStartupSeeds() {
+        val tracks = LevyraStartupCatalog.chartTracks("en")
+        val titles = tracks.mapTo(mutableSetOf()) { it.title }
 
+        assertEquals(20, tracks.size)
         assertTrue("Midnight City" in titles)
         assertTrue("Starboy" in titles)
         assertTrue("Believer" in titles)

--- a/app/src/test/java/com/luc4n3x/levyra/data/LevyraStartupCatalogTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/LevyraStartupCatalogTest.kt
@@ -25,21 +25,23 @@ class LevyraStartupCatalogTest {
     }
 
     @Test
-    fun repairHomeSectionsDropsPersistedLegacyEnergyShelf() {
-        val locale = LevyraContentLocales.forLanguage("en")
-        val chartTracks = LevyraStartupCatalog.chartTracks("en")
-        val quickTrack = chartTracks.first { it.title == "Bohemian Rhapsody" }
-        val energyTrack = chartTracks.first { it.title == "Midnight City" }
+    fun repairHomeSectionsDropsPersistedLegacyEnergyShelfInAnyLanguage() {
+        LevyraLanguageCatalog.languages.forEach { language ->
+            val locale = LevyraContentLocales.forLanguage(language.code)
+            val repaired = LevyraStartupCatalog.repairHomeSections(
+                listOf(
+                    HomeSection(locale.quickSectionTitle, emptyList()),
+                    HomeSection(locale.energySectionTitle, emptyList())
+                ),
+                language.code
+            )
 
-        val repaired = LevyraStartupCatalog.repairHomeSections(
-            listOf(
-                HomeSection(locale.quickSectionTitle, listOf(quickTrack)),
-                HomeSection(locale.energySectionTitle, listOf(energyTrack))
-            ),
-            "en"
-        )
-
-        assertEquals(listOf(locale.quickSectionTitle), repaired.map { it.title })
+            assertEquals(
+                "Legacy energy shelf still restored for ${language.code}",
+                listOf(locale.quickSectionTitle),
+                repaired.map { it.title }
+            )
+        }
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/data/LevyraStartupCatalogTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/LevyraStartupCatalogTest.kt
@@ -1,0 +1,53 @@
+package com.luc4n3x.levyra.data
+
+import com.luc4n3x.levyra.domain.HomeSection
+import com.luc4n3x.levyra.domain.LevyraContentLocales
+import com.luc4n3x.levyra.domain.LevyraLanguageCatalog
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LevyraStartupCatalogTest {
+    @Test
+    fun homeSectionsDoNotExposeLegacyEnergyShelfInAnyLanguage() {
+        LevyraLanguageCatalog.languages.forEach { language ->
+            val locale = LevyraContentLocales.forLanguage(language.code)
+            val sections = LevyraStartupCatalog.homeSections(language.code)
+
+            assertFalse(
+                "Legacy energy shelf still visible for ${language.code}",
+                sections.any { section ->
+                    section.title.trim().equals(locale.energySectionTitle.trim(), ignoreCase = true)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun repairHomeSectionsDropsPersistedLegacyEnergyShelf() {
+        val locale = LevyraContentLocales.forLanguage("en")
+        val chartTracks = LevyraStartupCatalog.chartTracks("en")
+        val quickTrack = chartTracks.first { it.title == "Bohemian Rhapsody" }
+        val energyTrack = chartTracks.first { it.title == "Midnight City" }
+
+        val repaired = LevyraStartupCatalog.repairHomeSections(
+            listOf(
+                HomeSection(locale.quickSectionTitle, listOf(quickTrack)),
+                HomeSection(locale.energySectionTitle, listOf(energyTrack))
+            ),
+            "en"
+        )
+
+        assertEquals(listOf(locale.quickSectionTitle), repaired.map { it.title })
+    }
+
+    @Test
+    fun chartFallbackKeepsLegacyFocusSeedsWithoutRenderingTheirShelf() {
+        val titles = LevyraStartupCatalog.chartTracks("en").mapTo(mutableSetOf()) { it.title }
+
+        assertTrue("Midnight City" in titles)
+        assertTrue("Starboy" in titles)
+        assertTrue("Believer" in titles)
+    }
+}


### PR DESCRIPTION
## Summary

Removes the obsolete Energy shelf from the Android Home across every supported language. This fixes the extra "Instant energy" section visible in English while keeping the existing comments/Resonance shelf unchanged.

The legacy Energy tracks are retained as startup/Quick Picks seeds instead of being discarded, so cold-start discovery keeps the same 20-track seed pool. Persisted Energy shelves from older builds are removed during startup and their tracks are folded into Quick Picks when that canonical section is present.

## What changed

- Stop exposing the legacy Energy section from `LevyraStartupCatalog.homeSections`.
- Keep the former Energy tracks inside the normal startup seed pool rather than relying only on chart fallback.
- Migrate tracks from a persisted localized Energy shelf into Quick Picks while removing the obsolete shelf title.
- Preserve `chartTracks` with the full 20 startup seeds.
- Add regression coverage across all supported languages for shelf removal, cold-start seed preservation, persisted data repair, and chart fallback.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor or maintenance
- [x] UI or UX change
- [x] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** Home / Localization

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [x] Targeted regression tests were added or updated
- [ ] Not applicable, with the reason explained below

The repository could not be checked out in the available execution environment because outbound GitHub DNS resolution was unavailable, so local Gradle commands and repository quality gates were not run here. GitHub Actions is validating the current PR head.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Android user screenshot | English Home before the fix | Reproduced the extra "Instant energy" shelf directly below "Most discussed tracks" |
| Android device after fix | English and alternate-language Home | Not run in this environment |

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** Existing cached Energy shelves are removed through the normal Home repair path; their startup seed tracks are retained in Quick Picks when available. No data migration or schema change is required.
- **Known limitations:** Post-fix device rendering is not manually verified in this environment.
- **Rollback plan:** Revert this PR

## Reviewer notes

- The change is confined to the startup Home catalog and focused regression tests.
- Resonance/comment retrieval, translations, cards, and interaction behavior are untouched.
- The previous review finding about reducing the cold-start seed pool is addressed: `homeSections` still supplies 20 distinct startup seeds without creating an Energy shelf.

## Release note

Removed the obsolete Energy shelf from Home across languages without reducing startup discovery seeds.

## Related issues

N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description was kept factual and scoped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the home screen by integrating energy and focus tracks into Quick Picks instead of displaying a separate energy shelf.
  * Preserved all startup tracks across supported languages.
  * Recovered previously saved energy tracks into Quick Picks, removing duplicates.
  * Maintained the expected startup tracks when chart data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->