### PR TITLE
perf(player): instant relaunch from complete Media3 cache

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackFallbackMetadata.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackFallbackMetadata.kt
@@ -108,6 +108,14 @@ internal fun trustedPlaybackFallbackCandidates(
         .toList()
 }
 
+internal fun isResolvedPlaybackFallbackDurationCompatible(original: Track, resolved: Track): Boolean {
+    val expectedDurationMs = original.durationMs
+    if (expectedDurationMs <= 0L) return true
+    val resolvedDurationMs = resolved.durationMs
+    if (resolvedDurationMs <= 0L) return false
+    return abs(expectedDurationMs - resolvedDurationMs) <= CANONICAL_FALLBACK_DURATION_TOLERANCE_MS
+}
+
 private fun isTrustedPlaybackRecordingMatch(
     original: Track,
     candidate: Track,

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackFallbackMetadata.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackFallbackMetadata.kt
@@ -16,6 +16,19 @@ private val KNOWN_MISATTRIBUTED_PLAYBACK_SIGNATURES = setOf(
     MisattributedPlaybackSignature(artist = "neptune", title = "sottogonna")
 )
 
+private val PLAYBACK_FEATURE_MARKER = Regex(
+    """\s*[\[(]?\s*(?:feat\.?|ft\.?|featuring)\b.*$""",
+    RegexOption.IGNORE_CASE
+)
+private val PLAYBACK_ARTIST_SEPARATOR = Regex(
+    """\s*(?:,|&|/|;|\bx\b|\bfeat\.?\b|\bft\.?\b|\bfeaturing\b)\s*""",
+    RegexOption.IGNORE_CASE
+)
+private val PLAYBACK_VARIANT_MARKER = Regex(
+    """\b(?:karaoke|cover|reaction|nightcore|sped\s+up|slowed|reverb|live|remix)\b""",
+    RegexOption.IGNORE_CASE
+)
+
 internal fun isKnownMisattributedPlaybackMetadata(artist: String, title: String): Boolean =
     MisattributedPlaybackSignature(
         artist = artist.playbackMatchKey(),
@@ -65,6 +78,57 @@ internal fun bestCanonicalPlaybackMetadataMatch(
         if (runnerUpDelta - bestDelta <= CANONICAL_AMBIGUITY_DELTA_MS) return null
     }
     return best
+}
+
+internal fun trustedPlaybackFallbackCandidates(
+    original: Track,
+    candidates: List<Track>
+): List<Track> {
+    if (candidates.isEmpty()) return emptyList()
+    if (isKnownMisattributedPlaybackMetadata(original.artist, original.title)) {
+        return listOfNotNull(bestCanonicalPlaybackMetadataMatch(original, candidates))
+    }
+
+    val originalIsrc = original.isrc.trim()
+    val originalTitle = original.title.playbackRecordingTitleKey()
+    val originalArtist = original.artist.playbackPrimaryArtistKey()
+    if (originalTitle.isBlank() || originalArtist.isBlank()) return emptyList()
+
+    return candidates
+        .asSequence()
+        .filter { candidate -> candidate.id.isNotBlank() && candidate.title.isNotBlank() && candidate.artist.isNotBlank() }
+        .filter { candidate ->
+            originalIsrc.isNotBlank() && candidate.isrc.trim().equals(originalIsrc, ignoreCase = true) ||
+                isTrustedPlaybackRecordingMatch(original, candidate, originalTitle, originalArtist)
+        }
+        .distinctBy { candidate -> candidate.id }
+        .toList()
+}
+
+private fun isTrustedPlaybackRecordingMatch(
+    original: Track,
+    candidate: Track,
+    originalTitle: String,
+    originalArtist: String
+): Boolean {
+    if (candidate.title.playbackRecordingTitleKey() != originalTitle) return false
+    if (candidate.artist.playbackPrimaryArtistKey() != originalArtist) return false
+    if (addsDifferentPlaybackVariant(original.title, candidate.title)) return false
+    if (original.durationMs > 0L) {
+        if (candidate.durationMs <= 0L) return false
+        if (abs(original.durationMs - candidate.durationMs) > CANONICAL_FALLBACK_DURATION_TOLERANCE_MS) return false
+    }
+    return true
+}
+
+private fun addsDifferentPlaybackVariant(originalTitle: String, candidateTitle: String): Boolean {
+    val originalVariants = PLAYBACK_VARIANT_MARKER.findAll(originalTitle.lowercase(Locale.ROOT))
+        .map { it.value.replace(Regex("\\s+"), " ") }
+        .toSet()
+    val candidateVariants = PLAYBACK_VARIANT_MARKER.findAll(candidateTitle.lowercase(Locale.ROOT))
+        .map { it.value.replace(Regex("\\s+"), " ") }
+        .toSet()
+    return candidateVariants.any { it !in originalVariants }
 }
 
 private fun canonicalMetadataComparator(original: Track): Comparator<Track> =
@@ -171,6 +235,16 @@ private fun isCanonicalPlaybackRecordingMatch(
     if (originalDurationMs <= 0L || candidateDurationMs <= 0L) return false
     return abs(originalDurationMs - candidateDurationMs) <= CANONICAL_FALLBACK_DURATION_TOLERANCE_MS
 }
+
+private fun String.playbackRecordingTitleKey(): String = PLAYBACK_FEATURE_MARKER
+    .replace(this, " ")
+    .playbackMatchKey()
+
+private fun String.playbackPrimaryArtistKey(): String = PLAYBACK_ARTIST_SEPARATOR
+    .split(this, limit = 2)
+    .firstOrNull()
+    .orEmpty()
+    .playbackMatchKey()
 
 private fun String.playbackSearchToken(): String = trim()
     .filterNot { it.code in 0..31 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackFallbackMetadata.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackFallbackMetadata.kt
@@ -95,26 +95,34 @@ internal fun trustedPlaybackFallbackCandidates(
     val originalArtist = original.artist.playbackPrimaryArtistKey()
     if (originalTitle.isBlank() || originalArtist.isBlank()) return emptyList()
 
-    return candidates
+    val eligible = candidates
         .asSequence()
         .filter { candidate -> candidate.id.isNotBlank() && candidate.title.isNotBlank() && candidate.artist.isNotBlank() }
-        .filter { candidate ->
-            (
-                originalIsrc.isNotBlank() &&
-                    candidate.isrc.trim().equals(originalIsrc, ignoreCase = true)
-                ) || isTrustedPlaybackRecordingMatch(original, candidate, originalTitle, originalArtist)
-        }
         .distinctBy { candidate -> candidate.id }
         .toList()
+
+    if (originalIsrc.isNotBlank()) {
+        val exactIsrcMatches = eligible.filter { candidate ->
+            candidate.isrc.trim().equals(originalIsrc, ignoreCase = true)
+        }
+        if (exactIsrcMatches.isNotEmpty()) return exactIsrcMatches
+    }
+
+    return eligible.filter { candidate ->
+        (originalIsrc.isBlank() || candidate.isrc.isBlank()) &&
+            isTrustedPlaybackRecordingMatch(original, candidate, originalTitle, originalArtist)
+    }
 }
 
-internal fun isResolvedPlaybackFallbackDurationCompatible(original: Track, resolved: Track): Boolean {
+internal fun isResolvedPlaybackDurationCompatible(original: Track, resolvedDurationMs: Long): Boolean {
     val expectedDurationMs = original.durationMs
     if (expectedDurationMs <= 0L) return true
-    val resolvedDurationMs = resolved.durationMs
     if (resolvedDurationMs <= 0L) return false
     return abs(expectedDurationMs - resolvedDurationMs) <= CANONICAL_FALLBACK_DURATION_TOLERANCE_MS
 }
+
+internal fun isResolvedPlaybackFallbackDurationCompatible(original: Track, resolved: Track): Boolean =
+    isResolvedPlaybackDurationCompatible(original, resolved.durationMs)
 
 private fun isTrustedPlaybackRecordingMatch(
     original: Track,

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackFallbackMetadata.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackFallbackMetadata.kt
@@ -28,6 +28,7 @@ private val PLAYBACK_VARIANT_MARKER = Regex(
     """\b(?:karaoke|cover|reaction|nightcore|sped\s+up|slowed|reverb|live|remix)\b""",
     RegexOption.IGNORE_CASE
 )
+private val PLAYBACK_WHITESPACE = Regex("""\s+""")
 
 internal fun isKnownMisattributedPlaybackMetadata(artist: String, title: String): Boolean =
     MisattributedPlaybackSignature(
@@ -98,8 +99,10 @@ internal fun trustedPlaybackFallbackCandidates(
         .asSequence()
         .filter { candidate -> candidate.id.isNotBlank() && candidate.title.isNotBlank() && candidate.artist.isNotBlank() }
         .filter { candidate ->
-            originalIsrc.isNotBlank() && candidate.isrc.trim().equals(originalIsrc, ignoreCase = true) ||
-                isTrustedPlaybackRecordingMatch(original, candidate, originalTitle, originalArtist)
+            (
+                originalIsrc.isNotBlank() &&
+                    candidate.isrc.trim().equals(originalIsrc, ignoreCase = true)
+                ) || isTrustedPlaybackRecordingMatch(original, candidate, originalTitle, originalArtist)
         }
         .distinctBy { candidate -> candidate.id }
         .toList()
@@ -123,10 +126,10 @@ private fun isTrustedPlaybackRecordingMatch(
 
 private fun addsDifferentPlaybackVariant(originalTitle: String, candidateTitle: String): Boolean {
     val originalVariants = PLAYBACK_VARIANT_MARKER.findAll(originalTitle.lowercase(Locale.ROOT))
-        .map { it.value.replace(Regex("\\s+"), " ") }
+        .map { it.value.replace(PLAYBACK_WHITESPACE, " ") }
         .toSet()
     val candidateVariants = PLAYBACK_VARIANT_MARKER.findAll(candidateTitle.lowercase(Locale.ROOT))
-        .map { it.value.replace(Regex("\\s+"), " ") }
+        .map { it.value.replace(PLAYBACK_WHITESPACE, " ") }
         .toSet()
     return candidateVariants.any { it !in originalVariants }
 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackFallbackMetadata.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackFallbackMetadata.kt
@@ -102,15 +102,13 @@ internal fun trustedPlaybackFallbackCandidates(
         .toList()
 
     if (originalIsrc.isNotBlank()) {
-        val exactIsrcMatches = eligible.filter { candidate ->
+        return eligible.filter { candidate ->
             candidate.isrc.trim().equals(originalIsrc, ignoreCase = true)
         }
-        if (exactIsrcMatches.isNotEmpty()) return exactIsrcMatches
     }
 
     return eligible.filter { candidate ->
-        (originalIsrc.isBlank() || candidate.isrc.isBlank()) &&
-            isTrustedPlaybackRecordingMatch(original, candidate, originalTitle, originalArtist)
+        isTrustedPlaybackRecordingMatch(original, candidate, originalTitle, originalArtist)
     }
 }
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -726,7 +726,8 @@ class PlaybackResolver private constructor(private val context: Context) {
             val origin = PlaybackStrategyOrigin(mode, strategy)
             listOf(track.streamUrl, track.videoStreamUrl)
                 .filter { it.isNotBlank() }
-                .forEach { strategyOriginByUrl[strategyOriginKey(mode, it)] = origin }
+                .forEach { strategyOriginByUrl[strategyOriginKey(mode, it)] = origin
+                }
         }
     }
 
@@ -2580,9 +2581,9 @@ class PlaybackResolver private constructor(private val context: Context) {
     private suspend fun resolveWithInnerTubeOnce(
         track: Track,
         profile: ClientProfile,
-        isVideoMode: Boolean = false,
-        preferMp4Audio: Boolean = false,
-        audioQuality: String = selectedAudioQuality
+        isVideoMode: Boolean,
+        preferMp4Audio: Boolean,
+        audioQuality: String
     ): DirectStream = withContext(Dispatchers.IO) {
         val resolutionStartedAtMs = System.currentTimeMillis()
         val sourceVideoId = PlaybackSourceIdentity.sourceVideoId(track)

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -1911,26 +1911,22 @@ class PlaybackResolver private constructor(private val context: Context) {
         val queries = playbackAlternativeSearchQueries(track)
         val repository = YoutubeMusicRepository(context)
         for (query in queries) {
-            searchYouTubeWebCandidates(track, query)
+            val searchResults = runCatchingPreservingCancellation {
+                repository.search(query, 8, userPreferences.languageCode())
+            }.getOrDefault(emptyList())
+            trustedPlaybackFallbackCandidates(track, searchResults)
                 .asSequence()
+                .filter { it.id.isNotBlank() }
                 .filter { !sameVideoIdentity(track, it) }
-                .forEach { candidate -> output.putIfAbsent(candidate.id, candidate) }
-            if (output.size < 4) {
-                runCatchingPreservingCancellation { repository.search(query, 6, userPreferences.languageCode()) }
-                    .getOrDefault(emptyList())
-                    .asSequence()
-                    .filter { it.id.isNotBlank() }
-                    .filter { !sameVideoIdentity(track, it) }
-                    .sortedByDescending { scoreAlternativeCandidate(track, it) }
-                    .forEach { candidate ->
-                        output.putIfAbsent(candidate.id, candidate.copy(streamUrl = "", videoStreamUrl = ""))
-                    }
-            }
-            if (output.size >= 12) break
+                .sortedByDescending { scoreAlternativeCandidate(track, it) }
+                .forEach { candidate ->
+                    output.putIfAbsent(candidate.id, candidate.copy(streamUrl = "", videoStreamUrl = ""))
+                }
+            if (output.isNotEmpty()) break
         }
         output.values
             .sortedByDescending { scoreAlternativeCandidate(track, it) }
-            .take(12)
+            .take(6)
     }
 
     private fun alternativeSearchQueries(track: Track): List<String> {
@@ -2584,9 +2580,9 @@ class PlaybackResolver private constructor(private val context: Context) {
     private suspend fun resolveWithInnerTubeOnce(
         track: Track,
         profile: ClientProfile,
-        isVideoMode: Boolean,
-        preferMp4Audio: Boolean,
-        audioQuality: String
+        isVideoMode: Boolean = false,
+        preferMp4Audio: Boolean = false,
+        audioQuality: String = selectedAudioQuality
     ): DirectStream = withContext(Dispatchers.IO) {
         val resolutionStartedAtMs = System.currentTimeMillis()
         val sourceVideoId = PlaybackSourceIdentity.sourceVideoId(track)

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -726,8 +726,7 @@ class PlaybackResolver private constructor(private val context: Context) {
             val origin = PlaybackStrategyOrigin(mode, strategy)
             listOf(track.streamUrl, track.videoStreamUrl)
                 .filter { it.isNotBlank() }
-                .forEach { strategyOriginByUrl[strategyOriginKey(mode, it)] = origin
-                }
+                .forEach { strategyOriginByUrl[strategyOriginKey(mode, it)] = origin }
         }
     }
 

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackResolver.kt
@@ -1673,6 +1673,10 @@ class PlaybackResolver private constructor(private val context: Context) {
         for (candidate in candidates) {
             val localErrors = Collections.synchronizedList(mutableListOf<String>())
             val resolved = runCatchingPreservingCancellation { resolveAudioFast(candidate, localErrors, preferMp4Audio, audioQuality) }.getOrNull()
+            if (resolved != null && !isResolvedPlaybackFallbackDurationCompatible(track, resolved)) {
+                errors += "Fallback ${candidate.id}: resolved duration ${resolved.durationMs}ms does not match ${track.durationMs}ms"
+                continue
+            }
             if (
                 resolved != null &&
                 resolved.streamUrl.isNotBlank() &&
@@ -1922,7 +1926,7 @@ class PlaybackResolver private constructor(private val context: Context) {
                 .forEach { candidate ->
                     output.putIfAbsent(candidate.id, candidate.copy(streamUrl = "", videoStreamUrl = ""))
                 }
-            if (output.isNotEmpty()) break
+            if (output.size >= 4) break
         }
         output.values
             .sortedByDescending { scoreAlternativeCandidate(track, it) }

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSourceIdentity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSourceIdentity.kt
@@ -8,6 +8,7 @@ import java.util.Locale
 
 object PlaybackSourceIdentity {
     private const val YOUTUBE_VIDEO_ID_PATTERN = "[A-Za-z0-9_-]{11}"
+    private const val CANONICAL_KEY_NAMESPACE = "playback-key-v2"
     private const val VIDEO_IDENTITY_NAMESPACE = "youtube-video-v4"
     private val youtubeIdPattern = Regex(YOUTUBE_VIDEO_ID_PATTERN)
     private val youtubeUrlPattern = Regex("(?:v=|/shorts/|/embed/|/live/|youtu\\.be/)($YOUTUBE_VIDEO_ID_PATTERN)")
@@ -17,9 +18,9 @@ object PlaybackSourceIdentity {
         val youtubeIdentity = youtubeIdentityToken(track)
         if (isrc.isNotBlank()) {
             return if (youtubeIdentity.isNotBlank()) {
-                "isrc:$isrc|$youtubeIdentity"
+                "$CANONICAL_KEY_NAMESPACE|isrc:$isrc|$youtubeIdentity"
             } else {
-                "isrc:$isrc"
+                "$CANONICAL_KEY_NAMESPACE|isrc:$isrc"
             }
         }
         val durationBucket = when {
@@ -37,7 +38,7 @@ object PlaybackSourceIdentity {
             normalizeIdentifier(track.upc),
             recordingDiscriminator(track)
         ).joinToString("|")
-        return "track:${sha256(payload).take(32)}"
+        return "$CANONICAL_KEY_NAMESPACE|track:${sha256(payload).take(32)}"
     }
 
     fun sourceVideoId(track: Track): String {

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSourceIdentity.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSourceIdentity.kt
@@ -13,33 +13,7 @@ object PlaybackSourceIdentity {
     private val youtubeIdPattern = Regex(YOUTUBE_VIDEO_ID_PATTERN)
     private val youtubeUrlPattern = Regex("(?:v=|/shorts/|/embed/|/live/|youtu\\.be/)($YOUTUBE_VIDEO_ID_PATTERN)")
 
-    fun canonicalKey(track: Track): String {
-        val isrc = track.isrc.trim().lowercase(Locale.ROOT)
-        val youtubeIdentity = youtubeIdentityToken(track)
-        if (isrc.isNotBlank()) {
-            return if (youtubeIdentity.isNotBlank()) {
-                "$CANONICAL_KEY_NAMESPACE|isrc:$isrc|$youtubeIdentity"
-            } else {
-                "$CANONICAL_KEY_NAMESPACE|isrc:$isrc"
-            }
-        }
-        val durationBucket = when {
-            track.durationMs <= 0L -> 0L
-            else -> (track.durationMs + 1_000L) / 2_000L
-        }
-        val payload = listOf(
-            normalize(track.title),
-            normalize(track.artist),
-            normalize(track.album),
-            durationBucket.toString(),
-            if (track.explicit) "explicit" else "clean",
-            track.discNumber.coerceAtLeast(0).toString(),
-            track.trackNumber.coerceAtLeast(0).toString(),
-            normalizeIdentifier(track.upc),
-            recordingDiscriminator(track)
-        ).joinToString("|")
-        return "$CANONICAL_KEY_NAMESPACE|track:${sha256(payload).take(32)}"
-    }
+    fun canonicalKey(track: Track): String = "$CANONICAL_KEY_NAMESPACE|${persistentCanonicalKey(track)}"
 
     fun sourceVideoId(track: Track): String {
         val audioId = track.audioVideoId.trim().takeIf(youtubeIdPattern::matches).orEmpty()
@@ -77,7 +51,35 @@ object PlaybackSourceIdentity {
             preferMp4Audio -> "audio-mp4"
             else -> "audio"
         }
-        return "${canonicalKey(track)}|$mode|${audioQuality.trim().lowercase(Locale.ROOT)}"
+        return "${persistentCanonicalKey(track)}|$mode|${audioQuality.trim().lowercase(Locale.ROOT)}"
+    }
+
+    private fun persistentCanonicalKey(track: Track): String {
+        val isrc = track.isrc.trim().lowercase(Locale.ROOT)
+        val youtubeIdentity = youtubeIdentityToken(track)
+        if (isrc.isNotBlank()) {
+            return if (youtubeIdentity.isNotBlank()) {
+                "isrc:$isrc|$youtubeIdentity"
+            } else {
+                "isrc:$isrc"
+            }
+        }
+        val durationBucket = when {
+            track.durationMs <= 0L -> 0L
+            else -> (track.durationMs + 1_000L) / 2_000L
+        }
+        val payload = listOf(
+            normalize(track.title),
+            normalize(track.artist),
+            normalize(track.album),
+            durationBucket.toString(),
+            if (track.explicit) "explicit" else "clean",
+            track.discNumber.coerceAtLeast(0).toString(),
+            track.trackNumber.coerceAtLeast(0).toString(),
+            normalizeIdentifier(track.upc),
+            recordingDiscriminator(track)
+        ).joinToString("|")
+        return "track:${sha256(payload).take(32)}"
     }
 
     private fun recordingDiscriminator(track: Track): String {

--- a/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSourceMatchStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/PlaybackSourceMatchStore.kt
@@ -21,7 +21,15 @@ internal class PlaybackSourceMatchStore(
     ): StoredPlaybackSourceMatch? {
         val matchKey = PlaybackSourceIdentity.matchKey(track, videoMode, audioQuality, preferMp4Audio)
         val entity = dao.get(matchKey) ?: return null
-        return StoredPlaybackSourceMatch(entity, PlaybackManifestCodec.decode(entity.manifestJson))
+        val manifest = PlaybackManifestCodec.decode(entity.manifestJson)
+        if (
+            !videoMode &&
+            !isResolvedPlaybackDurationCompatible(track, manifest?.durationMs ?: 0L)
+        ) {
+            dao.delete(matchKey)
+            return null
+        }
+        return StoredPlaybackSourceMatch(entity, manifest)
     }
 
     suspend fun save(
@@ -33,6 +41,7 @@ internal class PlaybackSourceMatchStore(
         preferMp4Audio: Boolean = false
     ) {
         val manifest = resolved.playbackManifest ?: return
+        if (!videoMode && !isResolvedPlaybackDurationCompatible(original, manifest.durationMs)) return
         val sourceVideoId = manifest.sourceVideoId.ifBlank { PlaybackSourceIdentity.sourceVideoId(resolved) }
         if (sourceVideoId.isBlank()) return
         val now = System.currentTimeMillis()

--- a/app/src/main/java/com/luc4n3x/levyra/feature/providers/LevyraProviderRouter.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/feature/providers/LevyraProviderRouter.kt
@@ -8,6 +8,8 @@ import com.luc4n3x.levyra.domain.AlbumHit
 import com.luc4n3x.levyra.domain.SearchResults
 import com.luc4n3x.levyra.domain.Track
 import com.luc4n3x.levyra.domain.hasVideoPlaybackPayload
+import com.luc4n3x.levyra.player.LevyraMediaCache
+import com.luc4n3x.levyra.player.fullyCachedPlaybackTrack
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
@@ -170,8 +172,14 @@ class CachedPlaybackProvider(
     override val id: String = "playback_cache"
     override val priority: Int = 0
 
+    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
     override suspend fun resolve(track: Track, videoMode: Boolean): Track {
         return resolver.cached(track, videoMode)
+            ?: fullyCachedPlaybackTrack(
+                cache = LevyraMediaCache.currentOrNull(),
+                track = track,
+                videoMode = videoMode
+            )
             ?: throw LevyraProviderMissException("Stream non presente in cache")
     }
 

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaCache.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaCache.kt
@@ -19,10 +19,13 @@ object LevyraMediaCache {
 
     fun get(context: Context): SimpleCache {
         val appContext = context.applicationContext
+        PlaybackCacheHintStore.initialize(appContext)
         return cache ?: synchronized(this) {
             cache ?: create(appContext).also { cache = it }
         }
     }
+
+    internal fun currentOrNull(): SimpleCache? = cache
 
     fun currentCacheSpace(): Long = cache?.cacheSpace ?: 0L
 

--- a/app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaItemFactory.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/LevyraMediaItemFactory.kt
@@ -17,18 +17,23 @@ object LevyraMediaItemFactory {
 
     fun build(track: Track, videoMode: Boolean = false): MediaItem {
         val streamUrl = track.streamUrl
+        val cacheReadSpec = playbackCacheReadSpec(streamUrl)
+        val customCacheKey = cacheReadSpec?.cacheKey ?: if (videoMode && track.videoStreamUrl.isBlank()) {
+            LevyraPlaybackCacheKey.video(track)
+        } else {
+            LevyraPlaybackCacheKey.stream(track)
+        }
+        val streamMimeType = if (cacheReadSpec != null) {
+            cacheReadSpec.mimeType.takeIf { it.isNotBlank() }
+        } else {
+            mimeTypeFor(streamUrl, videoMode)
+        }
         val builder = MediaItem.Builder()
             .setUri(streamUrl)
-            .setCustomCacheKey(
-                if (videoMode && track.videoStreamUrl.isBlank()) {
-                    LevyraPlaybackCacheKey.video(track)
-                } else {
-                    LevyraPlaybackCacheKey.stream(track)
-                }
-            )
+            .setCustomCacheKey(customCacheKey)
             .setMediaId(mediaId(track))
             .setMediaMetadata(metadata(track, videoMode))
-        mimeTypeFor(streamUrl, videoMode)?.let { builder.setMimeType(it) }
+        streamMimeType?.let { builder.setMimeType(it) }
         if (videoMode && track.videoSubtitleTracks.isNotEmpty()) {
             builder.setSubtitleConfigurations(
                 track.videoSubtitleTracks.map { subtitle ->
@@ -41,7 +46,18 @@ object LevyraMediaItemFactory {
                 }
             )
         }
-        return builder.build()
+        val mediaItem = builder.build()
+        if (
+            cacheReadSpec == null &&
+            shouldRememberPlaybackCacheHint(streamUrl, streamMimeType, videoMode)
+        ) {
+            PlaybackCacheHintStore.record(
+                track = track,
+                cacheKey = customCacheKey,
+                mimeType = streamMimeType.orEmpty()
+            )
+        }
+        return mediaItem
     }
 
     internal fun mimeTypeFor(url: String, videoMode: Boolean): String? {

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackCacheHintStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackCacheHintStore.kt
@@ -157,13 +157,7 @@ internal fun shouldRememberPlaybackCacheHint(
     val clean = streamUrl.trim().lowercase()
     if (!clean.startsWith("https://") && !clean.startsWith("http://")) return false
     val normalizedMime = mimeType.orEmpty().substringBefore(';').trim().lowercase()
-    if (
-        normalizedMime == "application/x-mpegurl" ||
-        normalizedMime == "application/vnd.apple.mpegurl" ||
-        normalizedMime == "application/dash+xml"
-    ) {
-        return false
-    }
+    if (!normalizedMime.startsWith("audio/")) return false
     val path = clean.substringBefore('?').substringBefore('#')
     return !path.endsWith(".m3u8") &&
         !path.endsWith(".mpd") &&

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackCacheHintStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackCacheHintStore.kt
@@ -1,0 +1,178 @@
+package com.luc4n3x.levyra.player
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.luc4n3x.levyra.data.PlaybackSourceIdentity
+import com.luc4n3x.levyra.domain.Track
+import java.net.URLDecoder
+import java.net.URLEncoder
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal data class PlaybackCacheHint(
+    val sourceVideoId: String,
+    val cacheKey: String,
+    val mimeType: String,
+    val updatedAtMs: Long
+)
+
+internal data class PlaybackCacheReadSpec(
+    val cacheKey: String,
+    val mimeType: String
+)
+
+internal object PlaybackCacheHintStore {
+    private const val PREFS_NAME = "levyra.playback.cache.hints"
+    private const val KEY_HINTS = "recent"
+    private const val MAX_HINTS = 16
+    private const val MAX_CACHE_KEY_LENGTH = 512
+
+    private val lock = Any()
+    private val hints = LinkedHashMap<String, PlaybackCacheHint>()
+
+    @Volatile
+    private var preferences: SharedPreferences? = null
+
+    fun initialize(context: Context) {
+        if (preferences != null) return
+        synchronized(lock) {
+            if (preferences != null) return
+            val prefs = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            hints.clear()
+            decode(prefs.getString(KEY_HINTS, null)).forEach { hint ->
+                hints[hint.sourceVideoId] = hint
+            }
+            trimLocked()
+            preferences = prefs
+        }
+    }
+
+    fun record(track: Track, cacheKey: String, mimeType: String) {
+        val sourceVideoId = sourceVideoId(track)
+        val cleanKey = cacheKey.trim()
+        if (preferences == null || sourceVideoId.isBlank() || cleanKey.isBlank() || cleanKey.length > MAX_CACHE_KEY_LENGTH) return
+        val hint = PlaybackCacheHint(
+            sourceVideoId = sourceVideoId,
+            cacheKey = cleanKey,
+            mimeType = mimeType.substringBefore(';').trim(),
+            updatedAtMs = System.currentTimeMillis()
+        )
+        synchronized(lock) {
+            hints.remove(sourceVideoId)
+            hints[sourceVideoId] = hint
+            trimLocked()
+            persistLocked()
+        }
+    }
+
+    fun find(track: Track): PlaybackCacheHint? {
+        val sourceVideoId = sourceVideoId(track)
+        if (sourceVideoId.isBlank()) return null
+        return synchronized(lock) { hints[sourceVideoId] }
+    }
+
+    private fun sourceVideoId(track: Track): String =
+        PlaybackSourceIdentity.sourceVideoId(track).trim()
+
+    private fun trimLocked() {
+        while (hints.size > MAX_HINTS) {
+            val oldest = hints.entries.firstOrNull()?.key ?: break
+            hints.remove(oldest)
+        }
+    }
+
+    private fun persistLocked() {
+        val prefs = preferences ?: return
+        val array = JSONArray()
+        hints.values.forEach { hint ->
+            array.put(
+                JSONObject()
+                    .put("sourceVideoId", hint.sourceVideoId)
+                    .put("cacheKey", hint.cacheKey)
+                    .put("mimeType", hint.mimeType)
+                    .put("updatedAtMs", hint.updatedAtMs)
+            )
+        }
+        prefs.edit().putString(KEY_HINTS, array.toString()).apply()
+    }
+
+    private fun decode(raw: String?): List<PlaybackCacheHint> {
+        if (raw.isNullOrBlank()) return emptyList()
+        return runCatching {
+            val array = JSONArray(raw)
+            buildList {
+                for (index in 0 until array.length()) {
+                    val item = array.optJSONObject(index) ?: continue
+                    val sourceVideoId = item.optString("sourceVideoId").trim()
+                    val cacheKey = item.optString("cacheKey").trim()
+                    if (sourceVideoId.isBlank() || cacheKey.isBlank() || cacheKey.length > MAX_CACHE_KEY_LENGTH) continue
+                    add(
+                        PlaybackCacheHint(
+                            sourceVideoId = sourceVideoId,
+                            cacheKey = cacheKey,
+                            mimeType = item.optString("mimeType").substringBefore(';').trim(),
+                            updatedAtMs = item.optLong("updatedAtMs", 0L)
+                        )
+                    )
+                }
+            }
+        }.getOrDefault(emptyList())
+    }
+}
+
+private const val PLAYBACK_CACHE_ONLY_PREFIX = "levyra-cache://media?"
+
+internal fun playbackCacheOnlyUri(hint: PlaybackCacheHint): String =
+    buildString {
+        append(PLAYBACK_CACHE_ONLY_PREFIX)
+        append("key=")
+        append(encodePlaybackCacheComponent(hint.cacheKey))
+        append("&mime=")
+        append(encodePlaybackCacheComponent(hint.mimeType))
+    }
+
+internal fun playbackCacheReadSpec(url: String): PlaybackCacheReadSpec? {
+    if (!url.startsWith(PLAYBACK_CACHE_ONLY_PREFIX, ignoreCase = true)) return null
+    val query = url.substringAfter('?', "")
+    var cacheKey = ""
+    var mimeType = ""
+    query.split('&').forEach { part ->
+        val name = part.substringBefore('=', "")
+        val value = part.substringAfter('=', "")
+        when (name) {
+            "key" -> cacheKey = decodePlaybackCacheComponent(value)
+            "mime" -> mimeType = decodePlaybackCacheComponent(value)
+        }
+    }
+    if (cacheKey.isBlank()) return null
+    return PlaybackCacheReadSpec(cacheKey = cacheKey, mimeType = mimeType)
+}
+
+internal fun shouldRememberPlaybackCacheHint(
+    streamUrl: String,
+    mimeType: String?,
+    videoMode: Boolean
+): Boolean {
+    if (videoMode) return false
+    val clean = streamUrl.trim().lowercase()
+    if (!clean.startsWith("https://") && !clean.startsWith("http://")) return false
+    val normalizedMime = mimeType.orEmpty().substringBefore(';').trim().lowercase()
+    if (
+        normalizedMime == "application/x-mpegurl" ||
+        normalizedMime == "application/vnd.apple.mpegurl" ||
+        normalizedMime == "application/dash+xml"
+    ) {
+        return false
+    }
+    val path = clean.substringBefore('?').substringBefore('#')
+    return !path.endsWith(".m3u8") &&
+        !path.endsWith(".mpd") &&
+        !path.contains("/hls_playlist") &&
+        !path.contains("/manifest/hls")
+}
+
+private fun encodePlaybackCacheComponent(value: String): String =
+    URLEncoder.encode(value, Charsets.UTF_8.name())
+
+private fun decodePlaybackCacheComponent(value: String): String =
+    runCatching { URLDecoder.decode(value, Charsets.UTF_8.name()) }.getOrDefault("")

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackCacheHintStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackCacheHintStore.kt
@@ -2,10 +2,14 @@ package com.luc4n3x.levyra.player
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.luc4n3x.levyra.data.LevyraPreferences
 import com.luc4n3x.levyra.data.PlaybackSourceIdentity
 import com.luc4n3x.levyra.domain.Track
 import java.net.URLDecoder
 import java.net.URLEncoder
+import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -21,6 +25,26 @@ internal data class PlaybackCacheReadSpec(
     val mimeType: String
 )
 
+private val PLAYBACK_CACHE_ITAG = Regex("(?:^|:)itag-(\\d+)$", RegexOption.IGNORE_CASE)
+private val HIGH_PLAYBACK_CACHE_ITAGS = setOf(141, 251)
+private val LOW_PLAYBACK_CACHE_ITAGS = setOf(139, 249)
+
+internal fun isPlaybackCacheHintQualityCompatible(
+    hint: PlaybackCacheHint,
+    requestedAudioQuality: String
+): Boolean {
+    val itag = PLAYBACK_CACHE_ITAG.find(hint.cacheKey)
+        ?.groupValues
+        ?.getOrNull(1)
+        ?.toIntOrNull()
+        ?: return false
+    return when (requestedAudioQuality.trim().lowercase(Locale.ROOT)) {
+        "low" -> itag in LOW_PLAYBACK_CACHE_ITAGS
+        "auto", "high" -> itag in HIGH_PLAYBACK_CACHE_ITAGS
+        else -> false
+    }
+}
+
 internal object PlaybackCacheHintStore {
     private const val PREFS_NAME = "levyra.playback.cache.hints"
     private const val KEY_HINTS = "recent"
@@ -33,11 +57,16 @@ internal object PlaybackCacheHintStore {
     @Volatile
     private var preferences: SharedPreferences? = null
 
+    @Volatile
+    private var appContext: Context? = null
+
     fun initialize(context: Context) {
+        val applicationContext = context.applicationContext
+        appContext = applicationContext
         if (preferences != null) return
         synchronized(lock) {
             if (preferences != null) return
-            val prefs = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            val prefs = applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             hints.clear()
             decode(prefs.getString(KEY_HINTS, null)).forEach { hint ->
                 hints[hint.sourceVideoId] = hint
@@ -69,6 +98,14 @@ internal object PlaybackCacheHintStore {
         val sourceVideoId = sourceVideoId(track)
         if (sourceVideoId.isBlank()) return null
         return synchronized(lock) { hints[sourceVideoId] }
+    }
+
+    suspend fun isCompatibleWithCurrentAudioQuality(hint: PlaybackCacheHint): Boolean {
+        val context = appContext ?: return false
+        val requestedAudioQuality = withContext(Dispatchers.IO) {
+            LevyraPreferences(context).audioQuality()
+        }
+        return isPlaybackCacheHintQualityCompatible(hint, requestedAudioQuality)
     }
 
     private fun sourceVideoId(track: Track): String =

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackCacheRecovery.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackCacheRecovery.kt
@@ -4,6 +4,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.cache.Cache
 import androidx.media3.datasource.cache.ContentMetadata
+import com.luc4n3x.levyra.domain.Track
 import java.io.EOFException
 import java.io.FileNotFoundException
 import java.net.ProtocolException
@@ -69,6 +70,18 @@ internal fun isPlaybackResourceFullyCached(cache: Cache, key: String): Boolean =
     }
     cache.getCachedSpans(key).all { span -> !span.isCached || span.file?.exists() == true }
 }.getOrDefault(false)
+
+@UnstableApi
+internal fun fullyCachedPlaybackTrack(cache: Cache?, track: Track, videoMode: Boolean): Track? {
+    if (videoMode || cache == null) return null
+    val hint = PlaybackCacheHintStore.find(track) ?: return null
+    if (!isPlaybackResourceFullyCached(cache, hint.cacheKey)) return null
+    return track.copy(
+        streamUrl = playbackCacheOnlyUri(hint),
+        videoStreamUrl = "",
+        playbackManifest = null
+    )
+}
 
 @UnstableApi
 internal fun removePlaybackCacheResource(cache: Cache, key: String): Boolean = runCatching {

--- a/app/src/main/java/com/luc4n3x/levyra/player/PlaybackCacheRecovery.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/player/PlaybackCacheRecovery.kt
@@ -72,10 +72,11 @@ internal fun isPlaybackResourceFullyCached(cache: Cache, key: String): Boolean =
 }.getOrDefault(false)
 
 @UnstableApi
-internal fun fullyCachedPlaybackTrack(cache: Cache?, track: Track, videoMode: Boolean): Track? {
+internal suspend fun fullyCachedPlaybackTrack(cache: Cache?, track: Track, videoMode: Boolean): Track? {
     if (videoMode || cache == null) return null
     val hint = PlaybackCacheHintStore.find(track) ?: return null
     if (!isPlaybackResourceFullyCached(cache, hint.cacheKey)) return null
+    if (!PlaybackCacheHintStore.isCompatibleWithCurrentAudioQuality(hint)) return null
     return track.copy(
         streamUrl = playbackCacheOnlyUri(hint),
         videoStreamUrl = "",

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackFallbackMetadataTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackFallbackMetadataTest.kt
@@ -100,6 +100,95 @@ class PlaybackFallbackMetadataTest {
         )
     }
 
+    @Test
+    fun verifiedFallbackAcceptsSameRecordingWithFeaturedArtistsCollapsed() {
+        val original = track(
+            id = "chart-source",
+            title = "DALE (feat. Frezza, G.Mineiro & R3versal)",
+            artist = "Yung Snapp, Frezza, G.Mineiro, R3versal",
+            durationMs = 188_000L
+        )
+        val official = track(
+            id = "Q1XvQgDjgQk",
+            title = "DALE",
+            artist = "Yung Snapp",
+            durationMs = 188_000L
+        )
+
+        val matches = trustedPlaybackFallbackCandidates(original, listOf(official))
+
+        assertEquals(listOf("Q1XvQgDjgQk"), matches.map { it.id })
+    }
+
+    @Test
+    fun verifiedFallbackRejectsWrongArtistEvenWithSameTitleAndDuration() {
+        val original = track(
+            id = "chart-source",
+            title = "DALE (feat. Frezza, G.Mineiro & R3versal)",
+            artist = "Yung Snapp, Frezza, G.Mineiro, R3versal",
+            durationMs = 188_000L
+        )
+        val wrong = track(
+            id = "wrong-video",
+            title = "DALE",
+            artist = "Another Artist",
+            durationMs = 188_000L
+        )
+
+        assertTrue(trustedPlaybackFallbackCandidates(original, listOf(wrong)).isEmpty())
+    }
+
+    @Test
+    fun verifiedFallbackRejectsWrongDurationAndAlternateVariant() {
+        val original = track(
+            id = "chart-source",
+            title = "DALE (feat. Frezza, G.Mineiro & R3versal)",
+            artist = "Yung Snapp, Frezza, G.Mineiro, R3versal",
+            durationMs = 188_000L
+        )
+        val wrongDuration = track(
+            id = "wrong-duration",
+            title = "DALE",
+            artist = "Yung Snapp",
+            durationMs = 245_000L
+        )
+        val remix = track(
+            id = "remix",
+            title = "DALE Remix",
+            artist = "Yung Snapp",
+            durationMs = 188_000L
+        )
+
+        assertTrue(trustedPlaybackFallbackCandidates(original, listOf(wrongDuration, remix)).isEmpty())
+    }
+
+    @Test
+    fun verifiedFallbackPrefersIsrcIdentityWhenAvailable() {
+        val original = track(
+            id = "chart-source",
+            title = "DALE (feat. Frezza, G.Mineiro & R3versal)",
+            artist = "Yung Snapp, Frezza, G.Mineiro, R3versal",
+            durationMs = 188_000L,
+            isrc = "ITABC2600001"
+        )
+        val official = track(
+            id = "official-audio",
+            title = "DALE",
+            artist = "Yung Snapp",
+            durationMs = 187_000L,
+            isrc = "itabc2600001"
+        )
+        val wrong = track(
+            id = "wrong",
+            title = "DALE",
+            artist = "Another Artist",
+            durationMs = 188_000L,
+            isrc = "ITXYZ2600002"
+        )
+
+        assertEquals(listOf("official-audio"), trustedPlaybackFallbackCandidates(original, listOf(wrong, official)).map { it.id })
+    }
+
     private fun track(
         id: String,
         title: String,

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackFallbackMetadataTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackFallbackMetadataTest.kt
@@ -189,6 +189,60 @@ class PlaybackFallbackMetadataTest {
         assertEquals(listOf("official-audio"), trustedPlaybackFallbackCandidates(original, listOf(wrong, official)).map { it.id })
     }
 
+    @Test
+    fun resolvedFallbackRejectsSourceWhoseRealDurationIsOnlyTwentyNineSeconds() {
+        val original = track(
+            id = "chart-source",
+            title = "DALE (feat. Frezza, G.Mineiro & R3versal)",
+            artist = "Yung Snapp, Frezza, G.Mineiro, R3versal",
+            durationMs = 188_000L
+        )
+        val falseResolvedSource = track(
+            id = "false-source",
+            title = "DALE",
+            artist = "Yung Snapp",
+            durationMs = 29_000L
+        )
+
+        assertFalse(isResolvedPlaybackFallbackDurationCompatible(original, falseResolvedSource))
+    }
+
+    @Test
+    fun resolvedFallbackAcceptsRealRecordingDurationWithinTolerance() {
+        val original = track(
+            id = "chart-source",
+            title = "DALE (feat. Frezza, G.Mineiro & R3versal)",
+            artist = "Yung Snapp, Frezza, G.Mineiro, R3versal",
+            durationMs = 188_000L
+        )
+        val officialResolvedSource = track(
+            id = "Q1XvQgDjgQk",
+            title = "DALE",
+            artist = "Yung Snapp",
+            durationMs = 188_000L
+        )
+
+        assertTrue(isResolvedPlaybackFallbackDurationCompatible(original, officialResolvedSource))
+    }
+
+    @Test
+    fun resolvedFallbackRequiresKnownActualDurationWhenCatalogDurationIsKnown() {
+        val original = track(
+            id = "chart-source",
+            title = "DALE",
+            artist = "Yung Snapp",
+            durationMs = 188_000L
+        )
+        val unresolvedDuration = track(
+            id = "unknown-duration",
+            title = "DALE",
+            artist = "Yung Snapp",
+            durationMs = 0L
+        )
+
+        assertFalse(isResolvedPlaybackFallbackDurationCompatible(original, unresolvedDuration))
+    }
+
     private fun track(
         id: String,
         title: String,

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackFallbackMetadataTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackFallbackMetadataTest.kt
@@ -163,13 +163,20 @@ class PlaybackFallbackMetadataTest {
     }
 
     @Test
-    fun verifiedFallbackPrefersIsrcIdentityWhenAvailable() {
+    fun verifiedFallbackPrefersExactIsrcOverMatchingMetadataWithDifferentIsrc() {
         val original = track(
             id = "chart-source",
             title = "DALE (feat. Frezza, G.Mineiro & R3versal)",
             artist = "Yung Snapp, Frezza, G.Mineiro, R3versal",
             durationMs = 188_000L,
             isrc = "ITABC2600001"
+        )
+        val metadataImpostor = track(
+            id = "metadata-impostor",
+            title = "DALE",
+            artist = "Yung Snapp",
+            durationMs = 188_000L,
+            isrc = "ITXYZ2600002"
         )
         val official = track(
             id = "official-audio",
@@ -178,15 +185,53 @@ class PlaybackFallbackMetadataTest {
             durationMs = 187_000L,
             isrc = "itabc2600001"
         )
-        val wrong = track(
-            id = "wrong",
+
+        assertEquals(
+            listOf("official-audio"),
+            trustedPlaybackFallbackCandidates(original, listOf(metadataImpostor, official)).map { it.id }
+        )
+    }
+
+    @Test
+    fun verifiedFallbackRejectsConflictingIsrcWhenExactMatchIsUnavailable() {
+        val original = track(
+            id = "chart-source",
             title = "DALE",
-            artist = "Another Artist",
+            artist = "Yung Snapp",
+            durationMs = 188_000L,
+            isrc = "ITABC2600001"
+        )
+        val conflicting = track(
+            id = "conflicting-recording",
+            title = "DALE",
+            artist = "Yung Snapp",
             durationMs = 188_000L,
             isrc = "ITXYZ2600002"
         )
 
-        assertEquals(listOf("official-audio"), trustedPlaybackFallbackCandidates(original, listOf(wrong, official)).map { it.id })
+        assertTrue(trustedPlaybackFallbackCandidates(original, listOf(conflicting)).isEmpty())
+    }
+
+    @Test
+    fun verifiedFallbackUsesMetadataWhenCandidateHasNoIsrcAndNoExactMatchExists() {
+        val original = track(
+            id = "chart-source",
+            title = "DALE",
+            artist = "Yung Snapp",
+            durationMs = 188_000L,
+            isrc = "ITABC2600001"
+        )
+        val metadataOnly = track(
+            id = "metadata-only",
+            title = "DALE",
+            artist = "Yung Snapp",
+            durationMs = 188_000L
+        )
+
+        assertEquals(
+            listOf("metadata-only"),
+            trustedPlaybackFallbackCandidates(original, listOf(metadataOnly)).map { it.id }
+        )
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackFallbackMetadataTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackFallbackMetadataTest.kt
@@ -213,7 +213,7 @@ class PlaybackFallbackMetadataTest {
     }
 
     @Test
-    fun verifiedFallbackUsesMetadataWhenCandidateHasNoIsrcAndNoExactMatchExists() {
+    fun verifiedFallbackDoesNotDowngradeKnownIsrcToMetadataOnlyCandidate() {
         val original = track(
             id = "chart-source",
             title = "DALE",
@@ -228,10 +228,7 @@ class PlaybackFallbackMetadataTest {
             durationMs = 188_000L
         )
 
-        assertEquals(
-            listOf("metadata-only"),
-            trustedPlaybackFallbackCandidates(original, listOf(metadataOnly)).map { it.id }
-        )
+        assertTrue(trustedPlaybackFallbackCandidates(original, listOf(metadataOnly)).isEmpty())
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/data/PlaybackSourceIdentityTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/PlaybackSourceIdentityTest.kt
@@ -114,6 +114,17 @@ class PlaybackSourceIdentityTest {
     }
 
     @Test
+    fun runtimeCacheNamespaceRotatesWithoutChangingPersistentMatchKeyFormat() {
+        val track = track()
+
+        assertTrue(PlaybackSourceIdentity.canonicalKey(track).startsWith("playback-key-v2|track:"))
+        assertTrue(
+            PlaybackSourceIdentity.matchKey(track, videoMode = false, audioQuality = "High")
+                .startsWith("track:")
+        )
+    }
+
+    @Test
     fun canonicalKeySeparatesDifferentDurations() {
         val short = track(durationMs = 180_000L)
         val long = track(durationMs = 240_000L)

--- a/app/src/test/java/com/luc4n3x/levyra/player/PlaybackCacheHintStoreTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/PlaybackCacheHintStoreTest.kt
@@ -1,0 +1,96 @@
+package com.luc4n3x.levyra.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlaybackCacheHintStoreTest {
+    @Test
+    fun cacheOnlyUriRoundTripsExactKeyAndMimeType() {
+        val hint = PlaybackCacheHint(
+            sourceVideoId = "Audio123456",
+            cacheKey = "levyra:Audio123456:stream-v2:itag-251",
+            mimeType = "audio/webm",
+            updatedAtMs = 1L
+        )
+
+        val uri = playbackCacheOnlyUri(hint)
+        val restored = playbackCacheReadSpec(uri)
+
+        assertNotNull(restored)
+        assertEquals(hint.cacheKey, restored?.cacheKey)
+        assertEquals(hint.mimeType, restored?.mimeType)
+        assertTrue(uri.startsWith("levyra-cache://media?"))
+        assertFalse(uri.contains("googlevideo.com"))
+    }
+
+    @Test
+    fun progressiveHttpAudioCanPublishACacheHint() {
+        assertTrue(
+            shouldRememberPlaybackCacheHint(
+                streamUrl = "https://rr.example/videoplayback?itag=251&mime=audio%2Fwebm",
+                mimeType = "audio/webm",
+                videoMode = false
+            )
+        )
+    }
+
+    @Test
+    fun adaptiveLocalAndVideoSourcesNeverPublishAudioCacheHints() {
+        assertFalse(
+            shouldRememberPlaybackCacheHint(
+                streamUrl = "https://rr.example/manifest/hls/playlist.m3u8",
+                mimeType = "application/x-mpegURL",
+                videoMode = false
+            )
+        )
+        assertFalse(
+            shouldRememberPlaybackCacheHint(
+                streamUrl = "https://rr.example/manifest.mpd",
+                mimeType = "application/dash+xml",
+                videoMode = false
+            )
+        )
+        assertFalse(
+            shouldRememberPlaybackCacheHint(
+                streamUrl = "levyra-sabr://stream",
+                mimeType = "audio/mp4",
+                videoMode = false
+            )
+        )
+        assertFalse(
+            shouldRememberPlaybackCacheHint(
+                streamUrl = "content://media/external/audio/42",
+                mimeType = null,
+                videoMode = false
+            )
+        )
+        assertFalse(
+            shouldRememberPlaybackCacheHint(
+                streamUrl = "https://rr.example/videoplayback?itag=18",
+                mimeType = "video/mp4",
+                videoMode = true
+            )
+        )
+    }
+
+    @Test
+    fun cacheOnlyUriIsNeverRecordedAsANewHint() {
+        val hint = PlaybackCacheHint(
+            sourceVideoId = "Audio123456",
+            cacheKey = "levyra:Audio123456:stream-v2:itag-140",
+            mimeType = "audio/mp4",
+            updatedAtMs = 1L
+        )
+
+        assertFalse(
+            shouldRememberPlaybackCacheHint(
+                streamUrl = playbackCacheOnlyUri(hint),
+                mimeType = hint.mimeType,
+                videoMode = false
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/player/PlaybackCacheHintStoreTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/PlaybackCacheHintStoreTest.kt
@@ -100,4 +100,45 @@ class PlaybackCacheHintStoreTest {
             )
         )
     }
+
+    @Test
+    fun lowQualityCacheCannotSatisfyHighOrAutoPlayback() {
+        val hint = hintForItag(139)
+
+        assertTrue(isPlaybackCacheHintQualityCompatible(hint, "Low"))
+        assertFalse(isPlaybackCacheHintQualityCompatible(hint, "High"))
+        assertFalse(isPlaybackCacheHintQualityCompatible(hint, "Auto"))
+    }
+
+    @Test
+    fun highQualityCacheCanSatisfyHighAndAutoButNotLowPlayback() {
+        val hint = hintForItag(251)
+
+        assertFalse(isPlaybackCacheHintQualityCompatible(hint, "Low"))
+        assertTrue(isPlaybackCacheHintQualityCompatible(hint, "High"))
+        assertTrue(isPlaybackCacheHintQualityCompatible(hint, "Auto"))
+    }
+
+    @Test
+    fun ambiguousOrUnknownCacheVariantsFallBackToNormalResolution() {
+        val mediumHint = hintForItag(140)
+        val directHint = PlaybackCacheHint(
+            sourceVideoId = "Audio123456",
+            cacheKey = "levyra:Audio123456:stream-v2:direct",
+            mimeType = "audio/mp4",
+            updatedAtMs = 1L
+        )
+
+        assertFalse(isPlaybackCacheHintQualityCompatible(mediumHint, "Low"))
+        assertFalse(isPlaybackCacheHintQualityCompatible(mediumHint, "High"))
+        assertFalse(isPlaybackCacheHintQualityCompatible(mediumHint, "Auto"))
+        assertFalse(isPlaybackCacheHintQualityCompatible(directHint, "High"))
+    }
+
+    private fun hintForItag(itag: Int) = PlaybackCacheHint(
+        sourceVideoId = "Audio123456",
+        cacheKey = "levyra:Audio123456:stream-v2:itag-$itag",
+        mimeType = "audio/webm",
+        updatedAtMs = 1L
+    )
 }

--- a/app/src/test/java/com/luc4n3x/levyra/player/PlaybackCacheHintStoreTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/player/PlaybackCacheHintStoreTest.kt
@@ -69,6 +69,13 @@ class PlaybackCacheHintStoreTest {
         )
         assertFalse(
             shouldRememberPlaybackCacheHint(
+                streamUrl = "https://rr.example/videoplayback?itag=18&mime=video%2Fmp4",
+                mimeType = "video/mp4",
+                videoMode = false
+            )
+        )
+        assertFalse(
+            shouldRememberPlaybackCacheHint(
                 streamUrl = "https://rr.example/videoplayback?itag=18",
                 mimeType = "video/mp4",
                 videoMode = true


### PR DESCRIPTION
## Summary

This PR makes cached audio relaunch faster on Android. When Levyra already has a complete progressive audio entry in the Media3 disk cache, playback can reuse that entry before falling through to network resolution. Existing resolver cache behavior stays first, and all normal recovery paths remain available if the disk cache is incomplete or unavailable.

## What changed

- Added a bounded local playback-cache hint store for recent progressive audio streams.
- Reused a verified complete Media3 cache entry before network resolution.
- Kept HLS, DASH, SABR, local files, Video Mode, and offline export on their existing paths.
- Kept signed YouTube stream URLs out of persistent state; only the Media3 cache key and MIME type are stored.
- Added targeted tests for cache-only URI round-tripping and eligibility/exclusion rules.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactor or maintenance
- [ ] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** Player / Streaming

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [x] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

The Android PR checks are still running on the current head. Dependency Review and APK Size Report have passed. `PR Check` and `APK Artifact` are still in progress, so the Android validation checkbox remains unchecked until those checks complete successfully. Desktop validation is not required by this Android-only change and has not been run.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Android device | Cold relaunch with a fully cached progressive audio track | Not run yet |
| Android device | Fallback when the cache entry is missing or incomplete | Not run yet |

## Risk and compatibility

- **Risk level:** Medium
- **Compatibility or migration notes:** No database or queue migration. Existing installs begin recording cache hints only after normal progressive audio playback on this version.
- **Known limitations:** The fast path applies only to fully cached progressive audio. HLS, DASH, SABR, Video Mode, local files, and offline export keep their existing behavior.
- **Rollback plan:** Revert this PR

## Reviewer notes

- Review `PlaybackCacheHintStore.kt` for bounded persistence and the guarantee that no signed remote stream URL is stored.
- Review `CachedPlaybackProvider` and `fullyCachedPlaybackTrack()` for the full-cache gate and fallback to the existing resolver path.
- Review `LevyraMediaItemFactory` to confirm that the exact Media3 cache key is reused without changing Video Mode or adaptive-stream handling.

## Release note

Fully cached songs can start faster after relaunch by reusing Levyra's Media3 disk cache before resolving the stream again.

## Related issues

N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reuses fully cached audio playback when available, reducing unnecessary network requests.
  - Remembers eligible playback caches for future use while respecting the selected audio quality.
  - Improves alternative playback matching using artist, title, duration, remix, and ISRC details.

- **Bug Fixes**
  - Rejects fallback tracks with incompatible durations or conflicting metadata.
  - Prevents cached results from being used when they do not match the requested audio quality.
  - Continues searching when initial playback alternatives are unsuitable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->