### PR TITLE
Publish a permanent latest APK download alias

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -91,6 +91,7 @@ jobs:
 
           TAG="v${VERSION}"
           APK_NAME="LEVYRA-${VERSION}.apk"
+          DIRECT_APK_NAME="Levyra.apk"
           CHECKSUM_NAME="${APK_NAME}.sha256"
           PUBLISH="true"
 
@@ -112,6 +113,7 @@ jobs:
             echo "VERSION_CODE=${VERSION_CODE}"
             echo "TAG=${TAG}"
             echo "APK_NAME=${APK_NAME}"
+            echo "DIRECT_APK_NAME=${DIRECT_APK_NAME}"
             echo "CHECKSUM_NAME=${CHECKSUM_NAME}"
           } >> "${GITHUB_ENV}"
 
@@ -253,6 +255,7 @@ jobs:
           mkdir -p release-assets
           SOURCE_APK="app/build/outputs/apk/release/app-release.apk"
           APK_PATH="release-assets/${APK_NAME}"
+          DIRECT_APK_PATH="release-assets/${DIRECT_APK_NAME}"
           CHECKSUM_PATH="release-assets/${CHECKSUM_NAME}"
           test -f "${SOURCE_APK}"
 
@@ -268,10 +271,12 @@ jobs:
           test "${SIGNER_SHA256}" = "${LEVYRA_SIGNING_CERT_SHA256}"
 
           cp "${SOURCE_APK}" "${APK_PATH}"
+          cp "${SOURCE_APK}" "${DIRECT_APK_PATH}"
           (cd release-assets && sha256sum "${APK_NAME}" > "${CHECKSUM_NAME}")
 
           {
             echo "APK_PATH=${APK_PATH}"
+            echo "DIRECT_APK_PATH=${DIRECT_APK_PATH}"
             echo "CHECKSUM_PATH=${CHECKSUM_PATH}"
             echo "APK_SHA256=$(sha256sum "${APK_PATH}" | awk '{print $1}')"
           } >> "${GITHUB_ENV}"
@@ -299,6 +304,7 @@ jobs:
 
           gh release create "${TAG}" \
             "${APK_PATH}#LEVYRA Android APK" \
+            "${DIRECT_APK_PATH}#Latest Levyra Android APK" \
             "${CHECKSUM_PATH}#SHA-256 checksum" \
             "${RELEASE_FLAGS[@]}"
 
@@ -314,16 +320,20 @@ jobs:
 
           gh release download "${TAG}" \
             --pattern "${APK_NAME}" \
+            --pattern "${DIRECT_APK_NAME}" \
             --pattern "${CHECKSUM_NAME}" \
             --dir release-verification \
             --clobber \
             --repo "${GITHUB_REPOSITORY}"
 
           PUBLISHED_APK="release-verification/${APK_NAME}"
+          PUBLISHED_DIRECT_APK="release-verification/${DIRECT_APK_NAME}"
           PUBLISHED_CHECKSUM="release-verification/${CHECKSUM_NAME}"
           test -f "${PUBLISHED_APK}"
+          test -f "${PUBLISHED_DIRECT_APK}"
           test -f "${PUBLISHED_CHECKSUM}"
           test "$(sha256sum "${PUBLISHED_APK}" | awk '{print $1}')" = "${APK_SHA256}"
+          test "$(sha256sum "${PUBLISHED_DIRECT_APK}" | awk '{print $1}')" = "${APK_SHA256}"
           (
             cd release-verification
             sha256sum --check "${CHECKSUM_NAME}"


### PR DESCRIPTION
## Summary

Android releases will publish a stable `Levyra.apk` asset alongside the existing versioned APK. This gives Levyra a permanent GitHub-only direct-download URL for future releases without removing or renaming the canonical versioned artifact.

## What changed

- Add `Levyra.apk` as a second name for the already verified signed Android release APK.
- Keep `LEVYRA-${VERSION}.apk` and its SHA-256 file unchanged for existing consumers and F-Droid verification.
- Verify the published stable alias exists and has the same SHA-256 as the canonical APK.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor or maintenance
- [ ] UI or UX change
- [ ] Localization or accessibility
- [x] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Shared infrastructure
- **Area:** Build and release

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [ ] Targeted tests were added or updated
- [x] Not applicable, with the reason explained below

This ChatGPT runtime does not have an executable Levyra checkout, so the repository `ai_quality_gate` profiles and `git diff --check` were not run locally. The final GitHub diff was reviewed and contains only 10 added workflow lines. PR CI remains the validation source for this branch.

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| N/A | No release was published or modified as part of this PR | Not run |

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** The existing versioned APK name, checksum, signing checks, Android/Desktop version separation, and F-Droid canonical verification remain unchanged.
- **Known limitations:** `https://github.com/LUC4N3X/Levyra-deepsound/releases/latest/download/Levyra.apk` becomes valid starting with the first Android release published after this change. The current v2.5.3 release is intentionally not modified by this PR.
- **Rollback plan:** Revert this PR

## Reviewer notes

- The stable asset is copied only after the source APK has passed the existing size, version, and signer checks.
- Published-release verification requires the stable alias to match the canonical APK hash.
- This PR does not create a tag, release, or release asset by itself.

## Release note

Android releases now include a stable `Levyra.apk` asset for permanent direct-download links.

## Related issues

- Closes: N/A
- Related to: N/A

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims
