### PR TITLE
perf: eliminate blocking preference access

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/LevyraApplication.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/LevyraApplication.kt
@@ -11,6 +11,7 @@ import com.luc4n3x.levyra.data.NewPipeRuntime
 import com.luc4n3x.levyra.data.PlaybackResolver
 import com.luc4n3x.levyra.data.ReleaseRadarWorker
 import com.luc4n3x.levyra.data.YoutubeLocalDecoder
+import com.luc4n3x.levyra.data.preloadLevyraPreferences
 import com.luc4n3x.levyra.data.network.LevyraNetworkController
 import com.luc4n3x.levyra.feature.cast.CastRuntimeInitializer
 import com.luc4n3x.levyra.player.PlaybackNetworkStack
@@ -31,6 +32,7 @@ class LevyraApplication : Application() {
         CastRuntimeInitializer.initialize(this)
         RuntimeHooks.start(this)
         if (BuildConfig.DEBUG) Timber.plant(Timber.DebugTree())
+        preloadLevyraPreferences(this)
         LevyraArtworkStartupMetrics.beginSession()
         runCatching { LevyraNetworkController.applyStoredConfiguration(this) }
             .onFailure { Timber.w(it, "Network configuration bootstrap failed") }

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
@@ -6,8 +6,6 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
@@ -37,16 +35,14 @@ import com.luc4n3x.levyra.domain.PlayerBackgroundMode
 import com.luc4n3x.levyra.domain.PlayerVisualMode
 import com.luc4n3x.levyra.domain.Track
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.runBlocking
 import org.json.JSONArray
 import org.json.JSONObject
 import timber.log.Timber
-import java.io.IOException
 
 private const val PREFERENCES_NAME = "levyra_prefs"
 internal const val DEFAULT_SPONSORBLOCK_ENABLED = true
@@ -87,10 +83,25 @@ data class LevyraPreferencesSnapshot(
     val jamDisplayName: String = ""
 )
 
-class LevyraPreferences(context: Context) {
-    private val dataStore = context.applicationContext.levyraDataStore
+@Volatile
+private var sharedPreferencesStore: LevyraPreferencesStore? = null
 
-    fun snapshot(): LevyraPreferencesSnapshot = read(defaultSnapshot()) { snapshotFrom(it) }
+private fun sharedPreferencesStore(context: Context): LevyraPreferencesStore =
+    sharedPreferencesStore ?: synchronized(LevyraPreferencesStore::class.java) {
+        sharedPreferencesStore ?: LevyraPreferencesStore(
+            context.applicationContext.levyraDataStore,
+            CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        ).also { sharedPreferencesStore = it }
+    }
+
+internal fun preloadLevyraPreferences(context: Context) {
+    sharedPreferencesStore(context)
+}
+
+class LevyraPreferences internal constructor(private val store: LevyraPreferencesStore) {
+    constructor(context: Context) : this(sharedPreferencesStore(context))
+
+    fun snapshot(): LevyraPreferencesSnapshot = store.derived("snapshot") { snapshotFrom(it) }
 
     suspend fun restoreSnapshot(snapshot: LevyraPreferencesSnapshot) {
         val normalizedLanguage = LevyraLanguageCatalog.normalize(snapshot.languageCode)
@@ -102,7 +113,7 @@ class LevyraPreferences(context: Context) {
         val personalOrbitJson = JSONArray().apply {
             snapshot.personalOrbitTracks.take(LevyraPersonalOrbit.DISPLAY_LIMIT).forEach { put(TrackJson.toJson(it)) }
         }.toString()
-        dataStore.edit { mutable ->
+        store.commit { mutable ->
             mutable[KEY_ONBOARDED] = snapshot.onboarded
             mutable[KEY_TASTES] = snapshot.tastes
             mutable[KEY_USER_NAME] = snapshot.userName
@@ -180,7 +191,7 @@ class LevyraPreferences(context: Context) {
         }
     }
 
-    fun isOnboarded(): Boolean = read(false) { it[KEY_ONBOARDED] ?: false }
+    fun isOnboarded(): Boolean = read { it[KEY_ONBOARDED] ?: false }
 
     fun setOnboarded(tastes: Set<String>) {
         setOnboardingState(true, tastes)
@@ -193,21 +204,21 @@ class LevyraPreferences(context: Context) {
         }
     }
 
-    fun tastes(): Set<String> = read(emptySet<String>()) { it[KEY_TASTES].orEmpty() }
+    fun tastes(): Set<String> = read { it[KEY_TASTES].orEmpty() }
 
-    fun userName(): String = read("") { it[KEY_USER_NAME].orEmpty() }
+    fun userName(): String = read { it[KEY_USER_NAME].orEmpty() }
 
     fun setUserName(name: String) {
         write { it[KEY_USER_NAME] = name }
     }
 
-    fun languageCode(): String = read(LevyraLanguageCatalog.deviceDefault()) { LevyraLanguageCatalog.normalize(it[KEY_LANGUAGE_CODE].orEmpty().ifBlank { LevyraLanguageCatalog.deviceDefault() }) }
+    fun languageCode(): String = read { LevyraLanguageCatalog.normalize(it[KEY_LANGUAGE_CODE].orEmpty().ifBlank { LevyraLanguageCatalog.deviceDefault() }) }
 
     fun setLanguageCode(code: String) {
         write { it[KEY_LANGUAGE_CODE] = LevyraLanguageCatalog.normalize(code) }
     }
 
-    fun animationsEnabled(): Boolean = read(true) { it[KEY_ANIMATIONS] ?: true }
+    fun animationsEnabled(): Boolean = read { it[KEY_ANIMATIONS] ?: true }
 
     fun setAnimationsEnabled(value: Boolean) {
         write { it[KEY_ANIMATIONS] = value }
@@ -215,7 +226,7 @@ class LevyraPreferences(context: Context) {
 
     suspend fun setMotionArtworkEnabled(value: Boolean) {
         try {
-            dataStore.edit { it[KEY_MOTION_ARTWORK] = value }
+            store.commit { it[KEY_MOTION_ARTWORK] = value }
         } catch (error: CancellationException) {
             throw error
         } catch (error: Throwable) {
@@ -223,7 +234,7 @@ class LevyraPreferences(context: Context) {
         }
     }
 
-    fun themePreset(): String = read(com.luc4n3x.levyra.ui.theme.LevyraThemes.APPLE_MUSIC) {
+    fun themePreset(): String = read {
         com.luc4n3x.levyra.ui.theme.LevyraThemes.normalize(it[KEY_THEME_PRESET].orEmpty())
     }
 
@@ -231,13 +242,13 @@ class LevyraPreferences(context: Context) {
         write { it[KEY_THEME_PRESET] = com.luc4n3x.levyra.ui.theme.LevyraThemes.normalize(value) }
     }
 
-    fun dynamicColor(): Boolean = read(true) { it[KEY_DYNAMIC_COLOR] ?: true }
+    fun dynamicColor(): Boolean = read { it[KEY_DYNAMIC_COLOR] ?: true }
 
     fun setDynamicColor(value: Boolean) {
         write { it[KEY_DYNAMIC_COLOR] = value }
     }
 
-    fun sponsorBlock(): Boolean = read(DEFAULT_SPONSORBLOCK_ENABLED) {
+    fun sponsorBlock(): Boolean = read {
         it[KEY_SPONSORBLOCK] ?: DEFAULT_SPONSORBLOCK_ENABLED
     }
 
@@ -245,25 +256,25 @@ class LevyraPreferences(context: Context) {
         write { it[KEY_SPONSORBLOCK] = value }
     }
 
-    fun skipSilence(): Boolean = read(false) { it[KEY_SKIP_SILENCE] ?: false }
+    fun skipSilence(): Boolean = read { it[KEY_SKIP_SILENCE] ?: false }
 
     fun setSkipSilence(value: Boolean) {
         write { it[KEY_SKIP_SILENCE] = value }
     }
 
-    fun audioNormalization(): Boolean = read(false) { it[KEY_AUDIO_NORMALIZATION] ?: false }
+    fun audioNormalization(): Boolean = read { it[KEY_AUDIO_NORMALIZATION] ?: false }
 
     fun setAudioNormalization(value: Boolean) {
         write { it[KEY_AUDIO_NORMALIZATION] = value }
     }
 
-    fun lyricsTranslationEnabled(): Boolean = read(false) { it[KEY_LYRICS_TRANSLATION] ?: false }
+    fun lyricsTranslationEnabled(): Boolean = read { it[KEY_LYRICS_TRANSLATION] ?: false }
 
     fun setLyricsTranslationEnabled(value: Boolean) {
         write { it[KEY_LYRICS_TRANSLATION] = value }
     }
 
-    fun interfaceSettings(): LevyraInterfaceSettings = read(LevyraInterfaceSettings()) { interfaceSettingsFrom(it) }
+    fun interfaceSettings(): LevyraInterfaceSettings = read { interfaceSettingsFrom(it) }
 
     fun setInterfaceSettings(value: LevyraInterfaceSettings) {
         val normalized = value.normalized()
@@ -291,7 +302,7 @@ class LevyraPreferences(context: Context) {
         }
     }
 
-    fun ambientSettings(): LevyraAmbientSettings = read(LevyraAmbientSettings()) { ambientSettingsFrom(it) }
+    fun ambientSettings(): LevyraAmbientSettings = read { ambientSettingsFrom(it) }
 
     fun setAmbientSettings(value: LevyraAmbientSettings) {
         val normalized = value.normalized()
@@ -306,7 +317,7 @@ class LevyraPreferences(context: Context) {
         }
     }
 
-    fun downloadSettings(): LevyraDownloadSettings = read(LevyraDownloadSettings()) { downloadSettingsFrom(it) }
+    fun downloadSettings(): LevyraDownloadSettings = read { downloadSettingsFrom(it) }
 
     fun setDownloadSettings(value: LevyraDownloadSettings) {
         val normalized = value.normalized()
@@ -325,7 +336,7 @@ class LevyraPreferences(context: Context) {
         }
     }
 
-    fun backupSettings(): LevyraBackupSettings = read(LevyraBackupSettings()) { backupSettingsFrom(it) }
+    fun backupSettings(): LevyraBackupSettings = read { backupSettingsFrom(it) }
 
     fun setBackupSettings(value: LevyraBackupSettings) {
         val normalized = value.normalized()
@@ -338,33 +349,33 @@ class LevyraPreferences(context: Context) {
         }
     }
 
-    fun lastBackupAt(): Long = read(0L) { it[KEY_VAULT_LAST_BACKUP] ?: 0L }
+    fun lastBackupAt(): Long = read { it[KEY_VAULT_LAST_BACKUP] ?: 0L }
 
     fun setLastBackupAt(value: Long) {
         write { it[KEY_VAULT_LAST_BACKUP] = value.coerceAtLeast(0L) }
     }
 
-    fun backupTreeUri(): String = read("") { it[KEY_VAULT_BACKUP_TREE_URI].orEmpty() }
+    fun backupTreeUri(): String = read { it[KEY_VAULT_BACKUP_TREE_URI].orEmpty() }
 
     fun setBackupTreeUri(value: String) {
         write { it[KEY_VAULT_BACKUP_TREE_URI] = value }
     }
 
     suspend fun persistBackupTreeUri(value: String) {
-        dataStore.edit { it[KEY_VAULT_BACKUP_TREE_URI] = value }
+        store.commit { it[KEY_VAULT_BACKUP_TREE_URI] = value }
     }
 
-    fun vaultRuntimeState(): Pair<Long, String> = read(0L to "") {
+    fun vaultRuntimeState(): Pair<Long, String> = read {
         (it[KEY_VAULT_LAST_BACKUP] ?: 0L) to it[KEY_VAULT_BACKUP_TREE_URI].orEmpty()
     }
 
-    fun jamDisplayName(): String = read("") { it[KEY_JAM_DISPLAY_NAME].orEmpty() }
+    fun jamDisplayName(): String = read { it[KEY_JAM_DISPLAY_NAME].orEmpty() }
 
     fun setJamDisplayName(value: String) {
         write { it[KEY_JAM_DISPLAY_NAME] = normalizeJamDisplayName(value) }
     }
 
-    fun audioSettings(): LevyraAudioSettings = read(LevyraAudioSettings()) { audioSettingsFrom(it) }
+    fun audioSettings(): LevyraAudioSettings = store.derived("audio_settings") { audioSettingsFrom(it) }
 
     fun setAudioSettings(value: LevyraAudioSettings) {
         val normalized = value.normalized()
@@ -386,13 +397,13 @@ class LevyraPreferences(context: Context) {
         }
     }
 
-    fun audioQuality(): String = read("Auto") { normalizeAudioQuality(it[KEY_AUDIO_QUALITY].orEmpty()) }
+    fun audioQuality(): String = read { normalizeAudioQuality(it[KEY_AUDIO_QUALITY].orEmpty()) }
 
     fun setAudioQuality(value: String) {
         write { it[KEY_AUDIO_QUALITY] = normalizeAudioQuality(value) }
     }
 
-    fun dismissedUpdateVersion(): String = read("") { it[KEY_DISMISSED_UPDATE_VERSION].orEmpty() }
+    fun dismissedUpdateVersion(): String = read { it[KEY_DISMISSED_UPDATE_VERSION].orEmpty() }
 
     fun setDismissedUpdateVersion(version: String) {
         write { it[KEY_DISMISSED_UPDATE_VERSION] = version }
@@ -412,15 +423,15 @@ class LevyraPreferences(context: Context) {
 
     fun lastTrack(): Track? = snapshot().lastTrack
 
-    fun lastPositionMs(): Long = read(0L) { it[KEY_LAST_POSITION] ?: 0L }
+    fun lastPositionMs(): Long = read { it[KEY_LAST_POSITION] ?: 0L }
 
-    fun listeningLifetimeBackfillVersion(): Int = read(0) { it[KEY_LISTENING_LIFETIME_BACKFILL] ?: 0 }
+    fun listeningLifetimeBackfillVersion(): Int = read { it[KEY_LISTENING_LIFETIME_BACKFILL] ?: 0 }
 
     fun setListeningLifetimeBackfillVersion(value: Int) {
         write { it[KEY_LISTENING_LIFETIME_BACKFILL] = value.coerceAtLeast(0) }
     }
 
-    fun listeningPulseLastPruneMs(): Long = read(0L) { it[KEY_LISTENING_PULSE_LAST_PRUNE] ?: 0L }
+    fun listeningPulseLastPruneMs(): Long = read { it[KEY_LISTENING_PULSE_LAST_PRUNE] ?: 0L }
 
     fun setListeningPulseLastPruneMs(value: Long) {
         write { it[KEY_LISTENING_PULSE_LAST_PRUNE] = value.coerceAtLeast(0L) }
@@ -436,9 +447,8 @@ class LevyraPreferences(context: Context) {
 
     fun loadHomeSections(languageCode: String = languageCode()): List<HomeSection> {
         val normalized = LevyraLanguageCatalog.normalize(languageCode)
-        return read(emptyList()) { preferences ->
-            val localized = preferences[homeSectionsKey(normalized)].orEmpty()
-            parseHomeSections(localized)
+        return store.derived("home_sections:$normalized") { preferences ->
+            parseHomeSections(preferences[homeSectionsKey(normalized)].orEmpty())
         }
     }
 
@@ -457,7 +467,7 @@ class LevyraPreferences(context: Context) {
 
     fun loadHomeAlbums(languageCode: String = languageCode()): List<AlbumHit> {
         val normalized = LevyraLanguageCatalog.normalize(languageCode)
-        return read(emptyList()) { preferences ->
+        return store.derived("home_albums:$normalized") { preferences ->
             parseAlbumHits(preferences[homeAlbumsKey(normalized)].orEmpty())
         }
     }
@@ -490,24 +500,18 @@ class LevyraPreferences(context: Context) {
     fun loadChartTracks(languageCode: String = languageCode(), regionId: String = ""): List<Track> {
         val normalized = LevyraLanguageCatalog.normalize(languageCode)
         val chartRegion = regionId.ifBlank { com.luc4n3x.levyra.domain.ChartsCatalog.defaultRegionForLanguage(normalized).id }
-        return read(emptyList()) { preferences ->
-            val localized = preferences[chartTracksKey(normalized, chartRegion)].orEmpty()
-            parseTrackList(localized)
+        return store.derived("chart_tracks:$normalized:${chartRegion.lowercase()}") { preferences ->
+            parseTrackList(preferences[chartTracksKey(normalized, chartRegion)].orEmpty())
         }
     }
 
-    /**
-     * Reads several chart regions from a single DataStore snapshot. Calling [loadChartTracks] once
-     * per region blocks a thread on its own snapshot read each time, which is too expensive when
-     * warming every region up front.
-     */
     fun loadChartTracksByRegion(
         languageCode: String = languageCode(),
         regionIds: List<String>
     ): Map<String, List<Track>> {
         if (regionIds.isEmpty()) return emptyMap()
         val normalized = LevyraLanguageCatalog.normalize(languageCode)
-        return read<Map<String, List<Track>>>(emptyMap()) { preferences ->
+        return read { preferences ->
             val out = LinkedHashMap<String, List<Track>>(regionIds.size)
             regionIds.forEach { regionId ->
                 val region = regionId.trim().lowercase()
@@ -531,9 +535,8 @@ class LevyraPreferences(context: Context) {
 
     fun loadPersonalOrbitTracks(languageCode: String = languageCode()): List<Track> {
         val normalized = LevyraLanguageCatalog.normalize(languageCode)
-        return read(emptyList()) { preferences ->
-            val localized = preferences[personalOrbitTracksKey(normalized)].orEmpty()
-            parseTrackList(localized)
+        return store.derived("personal_orbit:$normalized") { preferences ->
+            parseTrackList(preferences[personalOrbitTracksKey(normalized)].orEmpty())
         }
     }
 
@@ -574,33 +577,6 @@ class LevyraPreferences(context: Context) {
             jamDisplayName = preferences[KEY_JAM_DISPLAY_NAME].orEmpty()
         )
     }
-
-    private fun defaultSnapshot(): LevyraPreferencesSnapshot = LevyraPreferencesSnapshot(
-        onboarded = false,
-        tastes = emptySet(),
-        userName = "",
-        languageCode = LevyraLanguageCatalog.deviceDefault(),
-        animationsEnabled = true,
-        motionArtworkEnabled = true,
-        dynamicColor = true,
-        sponsorBlock = DEFAULT_SPONSORBLOCK_ENABLED,
-        skipSilence = false,
-        audioQuality = "Auto",
-        dismissedUpdateVersion = "",
-        lastTrack = null,
-        lastPositionMs = 0L,
-        recentSearches = emptyList(),
-        personalOrbitTracks = emptyList(),
-        audioNormalization = false,
-        lyricsTranslationEnabled = false,
-        themePreset = com.luc4n3x.levyra.ui.theme.LevyraThemes.APPLE_MUSIC,
-        audioSettings = LevyraAudioSettings(),
-        interfaceSettings = LevyraInterfaceSettings(),
-        downloadSettings = LevyraDownloadSettings(),
-        backupSettings = LevyraBackupSettings(),
-        automationSettings = LevyraAutomationSettings(),
-        jamDisplayName = ""
-    )
 
 
     private fun interfaceSettingsFrom(preferences: Preferences): LevyraInterfaceSettings {
@@ -787,22 +763,14 @@ class LevyraPreferences(context: Context) {
         return raw.split(',').mapNotNull { it.trim().toIntOrNull() }
     }
 
-    val automationSettingsFlow: kotlinx.coroutines.flow.Flow<LevyraAutomationSettings> = dataStore.data
-        .catch { error ->
-            if (error is IOException) {
-                Timber.w(error, "DataStore automation read failed")
-                emit(emptyPreferences())
-            } else {
-                throw error
-            }
-        }
+    val automationSettingsFlow: kotlinx.coroutines.flow.Flow<LevyraAutomationSettings> = store.preferences
         .map { preferences -> automationSettingsFrom(preferences) }
         .distinctUntilChanged()
 
     suspend fun setAutomationSettings(value: LevyraAutomationSettings) {
         val normalized = value.normalized()
         try {
-            dataStore.edit { writeAutomationSettings(it, normalized) }
+            store.commit { writeAutomationSettings(it, normalized) }
         } catch (error: CancellationException) {
             throw error
         } catch (error: Throwable) {
@@ -851,24 +819,10 @@ class LevyraPreferences(context: Context) {
         ).normalized()
     }
 
-    private fun <T> read(default: T, selector: (Preferences) -> T): T = runBlocking(Dispatchers.IO) {
-        dataStore.data
-            .catch { error ->
-                if (error is IOException) {
-                    Timber.w(error, "DataStore read failed")
-                    emit(emptyPreferences())
-                } else {
-                    throw error
-                }
-            }
-            .map(selector)
-            .first() ?: default
-    }
+    private fun <T> read(selector: (Preferences) -> T): T = selector(store.current())
 
     private fun write(block: (androidx.datastore.preferences.core.MutablePreferences) -> Unit) {
-        runBlocking(Dispatchers.IO) {
-            runCatching { dataStore.edit(block) }.onFailure { Timber.w(it, "DataStore write failed") }
-        }
+        store.edit(block)
     }
 
     private companion object {

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferences.kt
@@ -590,7 +590,7 @@ class LevyraPreferences internal constructor(private val store: LevyraPreference
                     PlayerVisualMode.Artwork
                 }
             }
-            else -> PlayerVisualMode.Artwork
+            else -> PlayerVisualMode.CanvasImmersive
         }
         val storedBackground = preferences[KEY_UI_PLAYER_BACKGROUND]
         val background = when {

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferencesStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferencesStore.kt
@@ -1,0 +1,120 @@
+package com.luc4n3x.levyra.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+internal class LevyraPreferencesStore(
+    private val dataStore: DataStore<Preferences>,
+    scope: CoroutineScope
+) {
+    private class PendingWrite(val block: (MutablePreferences) -> Unit) {
+        val completion = CompletableDeferred<Unit>()
+    }
+
+    private class DerivedValues(val source: Preferences) {
+        val values = ConcurrentHashMap<String, Any>()
+    }
+
+    private val lock = Any()
+    private val initialLoad = CountDownLatch(1)
+    private val state = MutableStateFlow<Preferences?>(null)
+    private val writesBeforeLoad = ArrayList<(MutablePreferences) -> Unit>()
+    private val pendingWrites = Channel<PendingWrite>(Channel.UNLIMITED)
+
+    @Volatile
+    private var derivedValues = DerivedValues(emptyPreferences())
+
+    val preferences: Flow<Preferences> = state.filterNotNull()
+
+    init {
+        scope.launch {
+            publishInitial(readPersisted())
+            for (write in pendingWrites) persist(write)
+        }
+    }
+
+    fun current(): Preferences {
+        state.value?.let { return it }
+        initialLoad.await()
+        return checkNotNull(state.value)
+    }
+
+    suspend fun awaitCurrent(): Preferences = preferences.first()
+
+    fun <T : Any> derived(key: String, compute: (Preferences) -> T): T {
+        val source = current()
+        val cache = derivedValues.takeIf { it.source === source }
+            ?: DerivedValues(source).also { derivedValues = it }
+        @Suppress("UNCHECKED_CAST")
+        return cache.values.getOrPut(key) { compute(source) } as T
+    }
+
+    fun edit(block: (MutablePreferences) -> Unit): Deferred<Unit> {
+        val write = PendingWrite(block)
+        synchronized(lock) {
+            val loaded = state.value
+            if (loaded == null) {
+                writesBeforeLoad += block
+            } else {
+                state.value = loaded.edited(listOf(block))
+            }
+            pendingWrites.trySend(write)
+        }
+        return write.completion
+    }
+
+    suspend fun commit(block: (MutablePreferences) -> Unit) {
+        edit(block).await()
+    }
+
+    private suspend fun readPersisted(): Preferences = try {
+        dataStore.data.first()
+    } catch (error: CancellationException) {
+        throw error
+    } catch (error: Throwable) {
+        Timber.w(error, "DataStore read failed")
+        emptyPreferences()
+    }
+
+    private fun publishInitial(persisted: Preferences) {
+        synchronized(lock) {
+            state.value = persisted.edited(writesBeforeLoad)
+            writesBeforeLoad.clear()
+        }
+        initialLoad.countDown()
+    }
+
+    private suspend fun persist(write: PendingWrite) {
+        try {
+            dataStore.edit(write.block)
+            write.completion.complete(Unit)
+        } catch (error: CancellationException) {
+            write.completion.cancel(error)
+            throw error
+        } catch (error: Throwable) {
+            Timber.w(error, "DataStore write failed")
+            write.completion.completeExceptionally(error)
+        }
+    }
+
+    private fun Preferences.edited(blocks: List<(MutablePreferences) -> Unit>): Preferences {
+        if (blocks.isEmpty()) return this
+        return toMutablePreferences().apply { blocks.forEach { block -> block(this) } }.toPreferences()
+    }
+}

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferencesStore.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraPreferencesStore.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
+import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import kotlinx.coroutines.CancellationException
@@ -12,6 +13,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterNotNull
@@ -34,8 +36,10 @@ internal class LevyraPreferencesStore(
     private val lock = Any()
     private val initialLoad = CountDownLatch(1)
     private val state = MutableStateFlow<Preferences?>(null)
-    private val writesBeforeLoad = ArrayList<(MutablePreferences) -> Unit>()
+    private val optimisticWrites = ArrayList<PendingWrite>()
     private val pendingWrites = Channel<PendingWrite>(Channel.UNLIMITED)
+
+    private var persistedState: Preferences? = null
 
     @Volatile
     private var derivedValues = DerivedValues(emptyPreferences())
@@ -68,10 +72,8 @@ internal class LevyraPreferencesStore(
     fun edit(block: (MutablePreferences) -> Unit): Deferred<Unit> {
         val write = PendingWrite(block)
         synchronized(lock) {
-            val loaded = state.value
-            if (loaded == null) {
-                writesBeforeLoad += block
-            } else {
+            optimisticWrites += write
+            state.value?.let { loaded ->
                 state.value = loaded.edited(listOf(block))
             }
             pendingWrites.trySend(write)
@@ -83,31 +85,50 @@ internal class LevyraPreferencesStore(
         edit(block).await()
     }
 
-    private suspend fun readPersisted(): Preferences = try {
-        dataStore.data.first()
-    } catch (error: CancellationException) {
-        throw error
-    } catch (error: Throwable) {
-        Timber.w(error, "DataStore read failed")
-        emptyPreferences()
+    private suspend fun readPersisted(): Preferences {
+        repeat(3) { attempt ->
+            try {
+                return dataStore.data.first()
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: IOException) {
+                Timber.w(error, "DataStore read failed (attempt %d)", attempt + 1)
+                if (attempt < 2) delay(75L * (attempt + 1))
+            } catch (error: Throwable) {
+                Timber.w(error, "DataStore read failed")
+                return emptyPreferences()
+            }
+        }
+        return emptyPreferences()
     }
 
     private fun publishInitial(persisted: Preferences) {
         synchronized(lock) {
-            state.value = persisted.edited(writesBeforeLoad)
-            writesBeforeLoad.clear()
+            persistedState = persisted
+            state.value = persisted.edited(optimisticWrites.map { it.block })
         }
         initialLoad.countDown()
     }
 
     private suspend fun persist(write: PendingWrite) {
         try {
-            dataStore.edit(write.block)
+            val persisted = dataStore.edit(write.block)
+            synchronized(lock) {
+                persistedState = persisted
+                optimisticWrites.remove(write)
+                state.value = persisted.edited(optimisticWrites.map { it.block })
+            }
             write.completion.complete(Unit)
         } catch (error: CancellationException) {
             write.completion.cancel(error)
             throw error
         } catch (error: Throwable) {
+            synchronized(lock) {
+                optimisticWrites.remove(write)
+                persistedState?.let { persisted ->
+                    state.value = persisted.edited(optimisticWrites.map { it.block })
+                }
+            }
             Timber.w(error, "DataStore write failed")
             write.completion.completeExceptionally(error)
         }

--- a/app/src/main/java/com/luc4n3x/levyra/data/LevyraStartupCatalog.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/LevyraStartupCatalog.kt
@@ -27,6 +27,12 @@ object LevyraStartupCatalog {
         )
     }
 
+    fun quickPickSeeds(languageCode: String = LevyraLanguageCatalog.deviceDefault()): List<Track> =
+        (homeSections(languageCode).flatMap { it.tracks } + localTracks("en"))
+            .distinctBy { it.title.lowercase() to it.artist.lowercase() }
+
+    fun isStartupSeedId(id: String): Boolean = id.startsWith("chart-seed-")
+
     fun chartTracks(languageCode: String = LevyraLanguageCatalog.deviceDefault()): List<Track> =
         homeSections(languageCode)
             .flatMap { it.tracks }

--- a/app/src/main/java/com/luc4n3x/levyra/domain/LevyraExperienceSettings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/domain/LevyraExperienceSettings.kt
@@ -109,7 +109,7 @@ data class LevyraInterfaceSettings(
     val enhanceVideoMetadata: Boolean = false,
     val pureBlack: Boolean = false,
     val hapticFeedback: Boolean = true,
-    val playerVisualMode: PlayerVisualMode = PlayerVisualMode.Artwork,
+    val playerVisualMode: PlayerVisualMode = PlayerVisualMode.CanvasImmersive,
     val playerBackground: PlayerBackgroundMode = PlayerBackgroundMode.Dynamic,
     val librarySort: LibrarySort = LibrarySort.Recent,
     val librarySortDirection: LibrarySortDirection = LibrarySort.Recent.defaultDirection

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -598,6 +598,10 @@ private const val HOME_DEFERRED_SECTION_REVEAL_MS = 180L
 private const val HOME_HORIZONTAL_ROW_CONTENT_TYPE = "home-horizontal-row"
 private const val HOME_SECTION_HEADER_CONTENT_TYPE = "home-section-header"
 private const val HOME_DENSE_SHELF_CONTENT_TYPE = "home-dense-shelf"
+private const val HOME_QUICK_ACCESS_LIMIT = 20
+private const val HOME_QUICK_ACCESS_PAGE_SIZE = 8
+private val HOME_QUICK_ACCESS_CARD_HEIGHT = 58.dp
+private val HOME_QUICK_ACCESS_PAGE_PEEK = 28.dp
 private const val HOME_ARTWORK_GRID_CONTENT_TYPE = "home-artwork-grid"
 private const val ORBIT_TRACKS_PER_PAGE = 4
 private val HOME_DENSE_SHELF_PEEK = 34.dp
@@ -8197,18 +8201,23 @@ private fun homeCollectionTitle(strings: LevyraStrings, collection: HomeEditoria
     return cleanHomeSectionTitle(title)
 }
 
-private fun homeCollectionPalette(kind: HomeCollectionKind): Pair<Color, Color> = when (kind) {
-    HomeCollectionKind.Fresh -> Color(0xFFE31587) to Color(0xFF8D33D8)
-    HomeCollectionKind.Local -> Color(0xFF087C69) to Color(0xFF12A99A)
-    HomeCollectionKind.Workout -> Color(0xFF4C7F08) to Color(0xFF91AE12)
-    HomeCollectionKind.Chill -> Color(0xFF7040B8) to Color(0xFF9866DD)
-    HomeCollectionKind.Focus -> Color(0xFF1F5FC7) to Color(0xFF3849B7)
-    HomeCollectionKind.Party -> Color(0xFFD91D67) to Color(0xFF8F36C5)
-    HomeCollectionKind.Rap -> Color(0xFF0755B5) to Color(0xFF4B3CCB)
-    HomeCollectionKind.Pop -> Color(0xFFB3218F) to Color(0xFFE24587)
-    HomeCollectionKind.Discovery -> Color(0xFFD65319) to Color(0xFFF08B22)
-    HomeCollectionKind.Editorial -> Color(0xFF6F42A5) to Color(0xFFB83E83)
-}
+private val homeCollectionPalettes = listOf(
+    Color(0xFFE13300) to Color(0xFFFF7A45),
+    Color(0xFF1E3264) to Color(0xFF4A6FD1),
+    Color(0xFF148A08) to Color(0xFF47C13A),
+    Color(0xFFDC148C) to Color(0xFFFF5FB4),
+    Color(0xFF006450) to Color(0xFF1EB7A0),
+    Color(0xFF8D67AB) to Color(0xFFB794D6),
+    Color(0xFFBA5D07) to Color(0xFFF2A33A),
+    Color(0xFF0D73EC) to Color(0xFF5AA9FF),
+    Color(0xFF8C1932) to Color(0xFFD3455F),
+    Color(0xFF477D95) to Color(0xFF7FB3C9),
+    Color(0xFF503750) to Color(0xFF9A5B9A),
+    Color(0xFF777777) to Color(0xFFB3B3B3)
+)
+
+private fun homeCollectionPalette(visualIndex: Int): Pair<Color, Color> =
+    homeCollectionPalettes[visualIndex.mod(homeCollectionPalettes.size)]
 
 @Composable
 private fun HomeEditorialCollectionsShelf(
@@ -8280,7 +8289,7 @@ private fun HomeEditorialCollectionCard(
         label = "homeCollectionScale-${collection.id}"
     )
     val primaryTrack = collection.tracks.firstOrNull()
-    val palette = remember(collection.kind) { homeCollectionPalette(collection.kind) }
+    val palette = remember(visualIndex) { homeCollectionPalette(visualIndex) }
     val title = homeCollectionTitle(strings, collection)
     val artistLine = remember(collection.id, collection.tracks) {
         collection.tracks
@@ -8501,43 +8510,62 @@ private fun HomeQuickAccessShelf(
     onPlay: (Track) -> Unit,
     onTrackActions: ((Track) -> Unit)? = null
 ) {
-    val displayTracks = remember(tracks) {
-        tracks.distinctBy(LevyraPersonalOrbit::identityKey).take(10)
+    val pages = remember(tracks) {
+        tracks
+            .distinctBy(LevyraPersonalOrbit::identityKey)
+            .take(HOME_QUICK_ACCESS_LIMIT)
+            .chunked(HOME_QUICK_ACCESS_PAGE_SIZE)
     }
-    if (displayTracks.isEmpty()) return
+    if (pages.isEmpty()) return
 
-    Column(verticalArrangement = Arrangement.spacedBy(9.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
         HomeSectionInset {
             HomeSectionHeader(title = title)
         }
         BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-            val cardGap = 10.dp
-            val nextCardPeek = 18.dp
-            val tileWidth = (
-                (maxWidth - HomeHorizontalInset - cardGap - cardGap - nextCardPeek) / 2f
-                ).coerceAtMost(178.dp)
+            val pageGap = 12.dp
+            val pageWidth = maxWidth - HomeHorizontalInset - pageGap - HOME_QUICK_ACCESS_PAGE_PEEK
             LazyRow(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(cardGap),
+                horizontalArrangement = Arrangement.spacedBy(pageGap),
                 contentPadding = PaddingValues(
                     start = HomeHorizontalInset,
                     end = HomeHorizontalShelfEndPadding
                 )
             ) {
                 itemsIndexed(
-                    items = displayTracks,
-                    key = { index, track -> "quick-access-$index-${LevyraPersonalOrbit.identityKey(track)}" },
-                    contentType = { _, _ -> "quick-access-card" }
-                ) { _, track ->
-                    HomeQuickAccessCard(
-                        track = track,
-                        width = tileWidth,
-                        isCurrent = track.id == currentId,
-                        isPlaying = isPlaying && track.id == currentId,
-                        isResolving = isResolving && track.id == currentId,
-                        onPlay = { onPlay(track) },
-                        onActions = onTrackActions?.let { actions -> { actions(track) } }
-                    )
+                    items = pages,
+                    key = { _, page ->
+                        page.joinToString(prefix = "quick-access-page-", separator = "|") {
+                            LevyraPersonalOrbit.identityKey(it)
+                        }
+                    },
+                    contentType = { _, _ -> "quick-access-page" }
+                ) { _, page ->
+                    Column(
+                        modifier = Modifier.width(pageWidth),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        page.chunked(2).forEach { row ->
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                row.forEach { track ->
+                                    HomeQuickAccessCard(
+                                        track = track,
+                                        isCurrent = track.id == currentId,
+                                        isPlaying = isPlaying && track.id == currentId,
+                                        isResolving = isResolving && track.id == currentId,
+                                        onPlay = { onPlay(track) },
+                                        onActions = onTrackActions?.let { actions -> { actions(track) } },
+                                        modifier = Modifier.weight(1f)
+                                    )
+                                }
+                                if (row.size == 1) Spacer(modifier = Modifier.weight(1f))
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -8547,122 +8575,102 @@ private fun HomeQuickAccessShelf(
 @Composable
 private fun HomeQuickAccessCard(
     track: Track,
-    width: Dp,
     isCurrent: Boolean,
     isPlaying: Boolean,
     isResolving: Boolean,
     onPlay: () -> Unit,
-    onActions: (() -> Unit)?
+    onActions: (() -> Unit)?,
+    modifier: Modifier = Modifier
 ) {
     val strings = LocalLevyraStrings.current
-    val shape = RoundedCornerShape(15.dp)
-    val accentStart = remember(track.id, track.accentStart) { Color(track.accentStart) }
-    val accentEnd = remember(track.id, track.accentEnd) { Color(track.accentEnd) }
-    val background = remember(accentStart, accentEnd, LevyraIsLight) {
-        Brush.linearGradient(
+    val shape = RoundedCornerShape(12.dp)
+    val accent = remember(track.id, track.accentStart) { Color(track.accentStart) }
+    val background = remember(accent, LevyraIsLight) {
+        Brush.horizontalGradient(
             listOf(
-                accentStart.copy(alpha = if (LevyraIsLight) 0.10f else 0.16f),
-                LevyraPanelSoft.copy(alpha = if (LevyraIsLight) 0.68f else 0.50f),
-                accentEnd.copy(alpha = if (LevyraIsLight) 0.05f else 0.08f)
+                accent.copy(alpha = if (LevyraIsLight) 0.07f else 0.12f),
+                LevyraPanelSoft.copy(alpha = if (LevyraIsLight) 0.72f else 0.56f)
             )
         )
     }
 
-    Surface(
-        color = Color.Transparent,
-        shape = shape,
-        border = BorderStroke(
-            if (isCurrent) 1.25.dp else Dp.Hairline,
-            if (isCurrent) LevyraCyan.copy(alpha = 0.78f) else LevyraAdaptiveSoftHairline
-        ),
-        modifier = Modifier
-            .width(width)
-            .height(126.dp)
+    Row(
+        modifier = modifier
+            .height(HOME_QUICK_ACCESS_CARD_HEIGHT)
+            .clip(shape)
+            .background(background)
+            .border(
+                width = if (isCurrent) 1.dp else Dp.Hairline,
+                color = if (isCurrent) LevyraCyan.copy(alpha = 0.72f) else LevyraAdaptiveSoftHairline,
+                shape = shape
+            )
             .levyraPressable(
                 onClick = onPlay,
-                pressedScale = LevyraPressScale.Tile
-            )
+                pressedScale = LevyraPressScale.Tile,
+                onLongClick = onActions,
+                onLongClickLabel = strings.songOptions
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
     ) {
-        Column(
+        Box(
             modifier = Modifier
-                .fillMaxSize()
-                .background(background)
-                .padding(horizontal = 9.dp, vertical = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
+                .fillMaxHeight()
+                .aspectRatio(1f),
+            contentAlignment = Alignment.Center
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
+            CoverImage(
+                track = track,
+                modifier = Modifier.fillMaxSize(),
+                highRes = false
+            )
+            if (isCurrent) {
                 Box(
                     modifier = Modifier
-                        .size(48.dp)
-                        .clip(RoundedCornerShape(10.dp)),
+                        .matchParentSize()
+                        .background(Color.Black.copy(alpha = 0.26f)),
                     contentAlignment = Alignment.Center
                 ) {
-                    CoverImage(
-                        track = track,
-                        modifier = Modifier.fillMaxSize(),
-                        highRes = false
-                    )
-                    if (isCurrent) {
-                        Box(
-                            modifier = Modifier
-                                .matchParentSize()
-                                .background(Color.Black.copy(alpha = 0.24f)),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            if (isResolving) {
-                                CircularProgressIndicator(
-                                    modifier = Modifier.size(16.dp),
-                                    strokeWidth = 1.8.dp,
-                                    color = LevyraCyan
-                                )
-                            } else {
-                                ActiveTrackEqualizer(
-                                    color = LevyraCyan,
-                                    isPlaying = isPlaying,
-                                    width = 16.dp,
-                                    height = 11.dp
-                                )
-                            }
-                        }
-                    }
-                }
-                Spacer(modifier = Modifier.weight(1f))
-                if (onActions != null) {
-                    IconButton(
-                        onClick = onActions,
-                        modifier = Modifier.size(40.dp)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Rounded.MoreVert,
-                            contentDescription = strings.songOptions,
-                            tint = LevyraMuted,
-                            modifier = Modifier.size(18.dp)
+                    if (isResolving) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            strokeWidth = 1.8.dp,
+                            color = LevyraCyan
+                        )
+                    } else {
+                        ActiveTrackEqualizer(
+                            color = LevyraCyan,
+                            isPlaying = isPlaying,
+                            width = 16.dp,
+                            height = 11.dp
                         )
                     }
                 }
             }
+        }
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(end = 10.dp),
+            verticalArrangement = Arrangement.spacedBy(1.dp)
+        ) {
             Text(
                 text = track.title,
                 color = if (isCurrent) LevyraCyan else LevyraText,
-                fontSize = 13.5.sp,
-                lineHeight = LevyraTypeRhythm.lineHeight(13.5.sp),
-                fontWeight = FontWeight.Bold,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.fillMaxWidth()
+                fontSize = 13.sp,
+                lineHeight = LevyraTypeRhythm.lineHeight(13.sp),
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
             Text(
                 text = track.artist,
                 color = LevyraMuted,
-                fontSize = 11.5.sp,
-                lineHeight = LevyraTypeRhythm.lineHeight(11.5.sp),
+                fontSize = 11.sp,
+                lineHeight = LevyraTypeRhythm.lineHeight(11.sp),
                 fontWeight = FontWeight.Medium,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.fillMaxWidth()
+                overflow = TextOverflow.Ellipsis
             )
         }
     }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -599,7 +599,7 @@ private const val HOME_HORIZONTAL_ROW_CONTENT_TYPE = "home-horizontal-row"
 private const val HOME_SECTION_HEADER_CONTENT_TYPE = "home-section-header"
 private const val HOME_DENSE_SHELF_CONTENT_TYPE = "home-dense-shelf"
 private const val HOME_QUICK_ACCESS_LIMIT = 20
-private const val HOME_QUICK_ACCESS_PAGE_SIZE = 8
+private const val HOME_QUICK_ACCESS_PAGE_SIZE = 10
 private val HOME_QUICK_ACCESS_CARD_HEIGHT = 58.dp
 private val HOME_QUICK_ACCESS_PAGE_PEEK = 28.dp
 private const val HOME_ARTWORK_GRID_CONTENT_TYPE = "home-artwork-grid"
@@ -8514,6 +8514,13 @@ private fun HomeQuickAccessShelf(
         tracks
             .distinctBy(LevyraPersonalOrbit::identityKey)
             .take(HOME_QUICK_ACCESS_LIMIT)
+            .let { list ->
+                if (list.size > HOME_QUICK_ACCESS_PAGE_SIZE) {
+                    list.take(list.size - list.size % HOME_QUICK_ACCESS_PAGE_SIZE)
+                } else {
+                    list
+                }
+            }
             .chunked(HOME_QUICK_ACCESS_PAGE_SIZE)
     }
     if (pages.isEmpty()) return

--- a/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraHomeEditorialStrings.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/i18n/LevyraHomeEditorialStrings.kt
@@ -36,15 +36,15 @@ Released this week
 Popular in the charts
 Levyra Collections
 Curated playlists around the music you love
-Fresh right now
-Local essentials
-Workout energy
-After hours
+New this week
+Local hits
+Workout
+Chill vibes
 Deep focus
-Party mode
-Rap rotation
-Pop pulse
-Discover something new
+Party hits
+Rap hits
+Pop hits
+Discover mix
 Updated today
 Editorial collection
 @@it
@@ -58,15 +58,15 @@ Uscito questa settimana
 Tra i brani in classifica
 Levyra Collections
 Playlist curate intorno alla musica che ami
-Novità del momento
-Essenziali locali
-Energia per allenarti
-Dopo il tramonto
-Concentrazione profonda
-Modalità festa
-Rotazione rap
-Impulso pop
-Scopri qualcosa di nuovo
+Novità della settimana
+Hit italiane
+Allenamento
+Chill vibes
+Concentrazione
+Party hits
+Rap del momento
+Pop hits
+Discover mix
 Aggiornata oggi
 Collezione editoriale
 @@es

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -533,6 +533,7 @@ private data class HomeDerivedInput(
     val homeSections: List<HomeSection>,
     val homeAlbums: List<AlbumHit>,
     val charts: List<Track>,
+    val quickPickSeeds: List<Track>,
     val cachedResonanceTracks: List<Track>,
     val releaseRadar: List<ReleaseRadarEntry>,
     val similarArtists: List<ArtistHit>,
@@ -619,6 +620,7 @@ private fun sameHomeDerivedInputs(previous: LevyraUiState, current: LevyraUiStat
         previous.homeSections === current.homeSections &&
         previous.homeAlbums === current.homeAlbums &&
         previous.charts === current.charts &&
+        previous.quickPickSeeds === current.quickPickSeeds &&
         previous.homeResonanceTracks === current.homeResonanceTracks &&
         previous.releaseRadar === current.releaseRadar &&
         previous.similarArtists === current.similarArtists &&
@@ -643,6 +645,7 @@ private fun LevyraUiState.toHomeDerivedInput(): HomeDerivedInput {
         homeSections = homeSections,
         homeAlbums = homeAlbums,
         charts = charts,
+        quickPickSeeds = quickPickSeeds,
         cachedResonanceTracks = homeResonanceTracks,
         releaseRadar = releaseRadar,
         similarArtists = similarArtists,
@@ -779,10 +782,7 @@ private fun buildQuickPicks(input: HomeDerivedInput): HomeSection? {
         addAll(input.favorites)
         addAll(input.tracks)
         input.currentTrack?.let(::add)
-        LevyraStartupCatalog.homeSections(input.languageCode)
-            .firstOrNull { isHomeQuickPicksSectionTitle(it.title) }
-            ?.tracks
-            ?.let(::addAll)
+        addAll(input.quickPickSeeds.ifEmpty { LevyraStartupCatalog.quickPickSeeds(input.languageCode) })
     })
 
     val selected = ArrayList<Track>(HOME_QUICK_PICKS_LIMIT)
@@ -791,7 +791,8 @@ private fun buildQuickPicks(input: HomeDerivedInput): HomeSection? {
 
     fun addCandidate(track: Track, enforceArtistLimit: Boolean) {
         if (selected.size >= HOME_QUICK_PICKS_LIMIT) return
-        if (track.id.length != 11 || !isReliableHomeMusicCandidate(track)) return
+        if (track.id.length != 11 && !LevyraStartupCatalog.isStartupSeedId(track.id)) return
+        if (!isReliableHomeMusicCandidate(track)) return
         val identity = LevyraPersonalOrbit.identityKey(track)
         if (identity.isBlank() || identity in orbitKeys || !seen.add(identity)) return
         val artistKey = track.artist.trim().lowercase(Locale.ROOT)

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraUiState.kt
@@ -67,6 +67,7 @@ data class LevyraUiState(
     val selectedTab: LevyraTab = LevyraTab.Home,
     val moods: List<Mood> = emptyList(),
     val tastes: List<Taste> = emptyList(),
+    val quickPickSeeds: List<Track> = emptyList(),
     val showOnboarding: Boolean = false,
     val isVideoMode: Boolean = false,
     val pendingVideoMode: Boolean? = null,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -719,6 +719,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         LevyraUiState(
             moods = startupMoods,
             tastes = moodEngine.tastesForLanguage(startupSettings.languageCode),
+            quickPickSeeds = LevyraStartupCatalog.quickPickSeeds(startupSettings.languageCode),
             chartRegions = ChartsCatalog.regions,
             selectedChartId = ChartsCatalog.defaultRegionForLanguage(startupSettings.languageCode).id,
             selectedMood = startupMoods.firstOrNull(),
@@ -1838,7 +1839,13 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                         current
                     }
                 }
-                delay(maxOf(HOME_ARTIST_STARTUP_GRACE_MS, startupPlan.artistStartDelayMs))
+                delay(
+                    if (visibleArtists.isEmpty()) {
+                        HOME_ARTIST_STARTUP_GRACE_MS
+                    } else {
+                        maxOf(HOME_ARTIST_STARTUP_GRACE_MS, startupPlan.artistStartDelayMs)
+                    }
+                )
                 awaitHomeUiIdle(startupPlan)
             }
 
@@ -1883,6 +1890,12 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                             isArtistShelfNameEligible(hit.name)
                         ) {
                             resolved.putIfAbsent(hit.browseId.lowercase(), hit)
+                        }
+                    }
+                    if (!freezeVisibleShelf && resolved.isNotEmpty() && homeArtistsFingerprint == fingerprint) {
+                        val partialArtists = resolved.values.take(HOME_ARTIST_SHELF_SIZE)
+                        _state.update { current ->
+                            if (current.languageCode == languageCode) current.copy(homeArtists = partialArtists) else current
                         }
                     }
                     if (resolved.size >= HOME_ARTIST_SHELF_SIZE) break
@@ -4567,6 +4580,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
         _state.update {
             it.copy(
                 languageCode = languageCode,
+                quickPickSeeds = LevyraStartupCatalog.quickPickSeeds(languageCode),
                 moods = localizedMoods,
                 tastes = moodEngine.tastesForLanguage(languageCode),
                 selectedMood = selectedMood,
@@ -6564,6 +6578,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             delay(if (deferUntilHomeIdle) startupPlan.secondaryStartDelayMs else 250L)
             if (deferUntilHomeIdle) awaitHomeUiIdle(startupPlan)
             enqueueOfficialMetadata(tracks, LevyraPersonalOrbit.DISPLAY_LIMIT, false)
+            _state.value.quickPickSeeds
+                .chunked(OFFICIAL_METADATA_MAX_BATCH_SIZE)
+                .forEach { seeds -> enqueueOfficialMetadata(seeds, OFFICIAL_METADATA_MAX_BATCH_SIZE, false) }
         }
     }
 
@@ -6799,6 +6816,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
             val searchResults = current.searchResults.map(::withArtwork)
             val favorites = current.favorites.map(::withArtwork)
             val charts = current.charts.map(::withArtwork)
+            val quickPickSeeds = current.quickPickSeeds.map(::withArtwork)
             val homeAlbums = current.homeAlbums
                 .map(::withAlbumMetadata)
                 .distinctBy(::albumRecommendationDeduplicationKey)
@@ -6868,6 +6886,7 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 searchResults = searchResults,
                 favorites = favorites,
                 charts = charts,
+                quickPickSeeds = quickPickSeeds,
                 homeAlbums = homeAlbums,
                 homeSections = homeSections,
                 exploreTracks = exploreTracks,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -1893,7 +1893,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                         }
                     }
                     if (!freezeVisibleShelf && resolved.isNotEmpty() && homeArtistsFingerprint == fingerprint) {
-                        val partialArtists = resolved.values.take(HOME_ARTIST_SHELF_SIZE)
+                        val partialArtists = (resolved.values + visibleArtists)
+                            .distinctBy { it.browseId.lowercase() }
+                            .take(HOME_ARTIST_SHELF_SIZE)
                         _state.update { current ->
                             if (current.languageCode == languageCode) current.copy(homeArtists = partialArtists) else current
                         }

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraViewModel.kt
@@ -1484,9 +1484,9 @@ class LevyraViewModel(application: Application) : AndroidViewModel(application) 
                 awaitHomeUiIdle(startupPlan)
                 LevyraArtworkCache.preloadPriority(appContext, orbitSeed, LevyraPersonalOrbit.DISPLAY_LIMIT)
                 warmPersistentOrbit(orbitSeed, LevyraPersonalOrbit.DISPLAY_LIMIT, persist = false)
-                refreshMissingOfficialOrbitArtwork(orbitSeed, deferUntilHomeIdle = true)
             }
         }
+        refreshMissingOfficialOrbitArtwork(orbitSeed, deferUntilHomeIdle = true)
 
         viewModelScope.launch {
             delay(startupPlan.homeFeedStartDelayMs)

--- a/app/src/test/java/com/luc4n3x/levyra/data/LevyraPreferencesDefaultsTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/LevyraPreferencesDefaultsTest.kt
@@ -83,8 +83,8 @@ class LevyraPreferencesDefaultsTest {
     }
 
     @Test
-    fun defaultPlayerVisualModeIsArtwork() {
-        assertEquals(PlayerVisualMode.Artwork, LevyraInterfaceSettings().playerVisualMode)
+    fun defaultPlayerVisualModeIsCanvasImmersive() {
+        assertEquals(PlayerVisualMode.CanvasImmersive, LevyraInterfaceSettings().playerVisualMode)
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/data/LevyraPreferencesStoreTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/LevyraPreferencesStoreTest.kt
@@ -1,0 +1,293 @@
+package com.luc4n3x.levyra.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.luc4n3x.levyra.domain.LevyraAudioPreset
+import com.luc4n3x.levyra.domain.LevyraAudioPresets
+import com.luc4n3x.levyra.domain.LevyraAudioSettings
+import com.luc4n3x.levyra.domain.LevyraAutomationSettings
+import com.luc4n3x.levyra.domain.LevyraInterfaceSettings
+import com.luc4n3x.levyra.domain.PlayerVisualMode
+import com.luc4n3x.levyra.domain.Track
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LevyraPreferencesStoreTest {
+    private class InMemoryPreferencesDataStore : DataStore<Preferences> {
+        private val mutex = Mutex()
+        private val persisted = MutableStateFlow(emptyPreferences())
+
+        @Volatile
+        var readGate: CompletableDeferred<Unit>? = null
+
+        override val data: Flow<Preferences> = flow {
+            readGate?.await()
+            emitAll(persisted)
+        }
+
+        override suspend fun updateData(transform: suspend (t: Preferences) -> Preferences): Preferences =
+            mutex.withLock { transform(persisted.value).also { persisted.value = it } }
+    }
+
+    private val scopes = mutableListOf<CoroutineScope>()
+    private val disk = InMemoryPreferencesDataStore()
+
+    @After
+    fun tearDown() {
+        scopes.forEach { it.cancel() }
+    }
+
+    private fun open(): Pair<LevyraPreferencesStore, LevyraPreferences> {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO).also { scopes += it }
+        val store = LevyraPreferencesStore(disk, scope)
+        return store to LevyraPreferences(store)
+    }
+
+    private fun reopen(): LevyraPreferences = open().second
+
+    private fun flush(store: LevyraPreferencesStore) = runBlocking { store.commit { } }
+
+    @Test
+    fun emptyStoreExposesExistingDefaults() {
+        val (_, preferences) = open()
+        val snapshot = preferences.snapshot()
+
+        assertFalse(snapshot.onboarded)
+        assertTrue(snapshot.animationsEnabled)
+        assertTrue(snapshot.dynamicColor)
+        assertEquals(DEFAULT_SPONSORBLOCK_ENABLED, snapshot.sponsorBlock)
+        assertEquals("Auto", snapshot.audioQuality)
+        assertEquals(LevyraAudioSettings().normalized(), preferences.audioSettings())
+        assertEquals(PlayerVisualMode.Artwork, preferences.interfaceSettings().playerVisualMode)
+        assertNull(snapshot.lastTrack)
+        assertEquals(LevyraAutomationSettings().normalized(), runBlocking { preferences.automationSettingsFlow.first() })
+    }
+
+    @Test
+    fun persistedValuesAndLegacyMappingsLoadIntoMemory() {
+        runBlocking {
+            disk.edit {
+                it[booleanPreferencesKey("onboarded")] = true
+                it[stringPreferencesKey("user_name")] = "Luca"
+                it[intPreferencesKey("audio_crossfade_seconds")] = 6
+                it[booleanPreferencesKey("motion_artwork_enabled")] = true
+            }
+        }
+        val (_, preferences) = open()
+
+        assertTrue(preferences.isOnboarded())
+        assertEquals("Luca", preferences.userName())
+        assertEquals(6, preferences.audioSettings().crossfadeSeconds)
+        assertEquals(PlayerVisualMode.CanvasCard, preferences.interfaceSettings().playerVisualMode)
+    }
+
+    @Test
+    fun writesAreVisibleImmediatelyAndSurviveRecreation() {
+        val (store, preferences) = open()
+
+        preferences.setUserName("Luca")
+        preferences.setLanguageCode("it")
+        preferences.setDynamicColor(false)
+        preferences.setSkipSilence(true)
+        preferences.setJamDisplayName("  DJ Luca  ")
+        assertEquals("Luca", preferences.userName())
+        assertEquals("it", preferences.languageCode())
+        assertFalse(preferences.dynamicColor())
+        assertTrue(preferences.skipSilence())
+        assertEquals("DJ Luca", preferences.jamDisplayName())
+
+        flush(store)
+        val reopened = reopen()
+
+        assertEquals("Luca", reopened.userName())
+        assertEquals("it", reopened.languageCode())
+        assertFalse(reopened.dynamicColor())
+        assertTrue(reopened.skipSilence())
+        assertEquals("DJ Luca", reopened.jamDisplayName())
+    }
+
+    @Test
+    fun rapidWritesKeepLastIntent() {
+        val (store, preferences) = open()
+
+        repeat(200) { index ->
+            preferences.setAudioSettings(LevyraAudioSettings(crossfadeSeconds = index % 12))
+        }
+        preferences.setAudioSettings(LevyraAudioSettings(crossfadeSeconds = 3, playbackSpeed = 1.25f, pitch = 0.9f))
+        assertEquals(3, preferences.audioSettings().crossfadeSeconds)
+
+        flush(store)
+        val reopened = reopen().audioSettings()
+
+        assertEquals(3, reopened.crossfadeSeconds)
+        assertEquals(1.25f, reopened.playbackSpeed, 0f)
+        assertEquals(0.9f, reopened.pitch, 0f)
+    }
+
+    @Test
+    fun concurrentWritesToDifferentKeysAreAllKept() {
+        val (store, preferences) = open()
+
+        runBlocking {
+            (0 until 50).map { index ->
+                async(Dispatchers.Default) {
+                    if (index % 2 == 0) preferences.setUserName("user-$index") else preferences.setAudioQuality("High")
+                    preferences.setListeningLifetimeBackfillVersion(7)
+                }
+            }.awaitAll()
+        }
+        preferences.setUserName("final")
+        flush(store)
+
+        val reopened = reopen()
+        assertEquals("final", reopened.userName())
+        assertEquals("High", reopened.audioQuality())
+        assertEquals(7, reopened.listeningLifetimeBackfillVersion())
+    }
+
+    @Test
+    fun writesIssuedBeforeInitialLoadAreAppliedOverPersistedState() {
+        runBlocking {
+            disk.edit {
+                it[stringPreferencesKey("user_name")] = "Persisted"
+                it[booleanPreferencesKey("onboarded")] = true
+            }
+        }
+        val gate = CompletableDeferred<Unit>()
+        disk.readGate = gate
+        val (store, preferences) = open()
+
+        preferences.setUserName("Newer")
+        gate.complete(Unit)
+
+        assertEquals("Newer", preferences.userName())
+        assertTrue(preferences.isOnboarded())
+        flush(store)
+        disk.readGate = null
+        val reopened = reopen()
+        assertEquals("Newer", reopened.userName())
+        assertTrue(reopened.isOnboarded())
+    }
+
+    @Test
+    fun restoreSnapshotIsVisibleImmediatelyAndDurable() {
+        val (_, preferences) = open()
+        val customPreset = LevyraAudioPreset(
+            id = "${LevyraAudioPresets.CUSTOM_PRESET_PREFIX}night",
+            fallbackLabel = "Night",
+            levels = List(LevyraAudioPresets.bandCount) { it - 2 },
+            bassBoost = 60,
+            virtualizer = 40,
+            preampDb = -2f
+        )
+        val restored = preferences.snapshot().copy(
+            onboarded = true,
+            userName = "Restored",
+            languageCode = "de",
+            audioSettings = LevyraAudioSettings(
+                equalizerEnabled = true,
+                presetId = customPreset.id,
+                bandLevels = customPreset.levels,
+                customPresets = listOf(customPreset),
+                crossfadeSeconds = 5
+            ),
+            interfaceSettings = LevyraInterfaceSettings(playerVisualMode = PlayerVisualMode.CanvasCard),
+            automationSettings = LevyraAutomationSettings(pauseOnMute = true),
+            jamDisplayName = "Jam"
+        )
+        preferences.setUserName("Before restore")
+
+        runBlocking { preferences.restoreSnapshot(restored) }
+
+        assertEquals("Restored", preferences.userName())
+        assertEquals("de", preferences.languageCode())
+        assertEquals(listOf(customPreset), preferences.audioSettings().customPresets)
+        assertTrue(runBlocking { preferences.automationSettingsFlow.first() }.pauseOnMute)
+
+        val snapshot = reopen().snapshot()
+        assertTrue(snapshot.onboarded)
+        assertEquals("Restored", snapshot.userName)
+        assertEquals("de", snapshot.languageCode)
+        assertEquals(customPreset.id, snapshot.audioSettings.presetId)
+        assertEquals(listOf(customPreset), snapshot.audioSettings.customPresets)
+        assertEquals(5, snapshot.audioSettings.crossfadeSeconds)
+        assertEquals(PlayerVisualMode.CanvasCard, snapshot.interfaceSettings.playerVisualMode)
+        assertTrue(snapshot.automationSettings.pauseOnMute)
+        assertEquals("Jam", snapshot.jamDisplayName)
+    }
+
+    @Test
+    fun structuredValuesAreParsedOncePerStateAndRefreshAfterWrites() {
+        val (store, preferences) = open()
+        val track = Track(
+            id = "abc",
+            title = "Song",
+            artist = "Artist",
+            album = "",
+            durationMs = 1000L,
+            streamUrl = "",
+            videoUrl = "",
+            thumbnailUrl = "",
+            largeThumbnailUrl = "",
+            source = "youtube",
+            moodTags = emptySet(),
+            energy = 0,
+            vocal = 0,
+            replayScore = 0,
+            cacheScore = 0,
+            accentStart = 0,
+            accentEnd = 0
+        )
+        preferences.saveRecentSearches(listOf(track))
+        preferences.saveLastPlayback(track, 4200L)
+
+        val first = preferences.snapshot()
+        assertSame(first, preferences.snapshot())
+        assertEquals(listOf("abc"), preferences.loadRecentSearches().map { it.id })
+        assertEquals("abc", preferences.lastTrack()?.id)
+        assertEquals(4200L, preferences.lastPositionMs())
+
+        flush(store)
+        val reopened = reopen()
+        assertEquals("abc", reopened.lastTrack()?.id)
+        assertEquals(4200L, reopened.lastPositionMs())
+
+        preferences.saveLastPlayback(null, 0L)
+        assertNull(preferences.lastTrack())
+        assertEquals(0L, preferences.lastPositionMs())
+    }
+
+    @Test
+    fun automationFlowFollowsInMemoryWrites() {
+        val (_, preferences) = open()
+
+        runBlocking { preferences.setAutomationSettings(LevyraAutomationSettings(resumeOnBluetoothReconnect = true)) }
+
+        assertTrue(runBlocking { preferences.automationSettingsFlow.first() }.resumeOnBluetoothReconnect)
+    }
+}

--- a/app/src/test/java/com/luc4n3x/levyra/data/LevyraPreferencesStoreTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/LevyraPreferencesStoreTest.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.luc4n3x.levyra.domain.LevyraAudioPreset
+import java.io.IOException
 import com.luc4n3x.levyra.domain.LevyraAudioPresets
 import com.luc4n3x.levyra.domain.LevyraAudioSettings
 import com.luc4n3x.levyra.domain.LevyraAutomationSettings
@@ -45,13 +46,28 @@ class LevyraPreferencesStoreTest {
         @Volatile
         var readGate: CompletableDeferred<Unit>? = null
 
+        @Volatile
+        var readFailuresRemaining: Int = 0
+
+        @Volatile
+        var writeFailuresRemaining: Int = 0
+
         override val data: Flow<Preferences> = flow {
+            if (readFailuresRemaining > 0) {
+                readFailuresRemaining -= 1
+                throw IOException("Injected read failure")
+            }
             readGate?.await()
             emitAll(persisted)
         }
 
-        override suspend fun updateData(transform: suspend (t: Preferences) -> Preferences): Preferences =
-            mutex.withLock { transform(persisted.value).also { persisted.value = it } }
+        override suspend fun updateData(transform: suspend (t: Preferences) -> Preferences): Preferences {
+            if (writeFailuresRemaining > 0) {
+                writeFailuresRemaining -= 1
+                throw IOException("Injected write failure")
+            }
+            return mutex.withLock { transform(persisted.value).also { persisted.value = it } }
+        }
     }
 
     private val scopes = mutableListOf<CoroutineScope>()
@@ -168,6 +184,46 @@ class LevyraPreferencesStoreTest {
         assertEquals("final", reopened.userName())
         assertEquals("High", reopened.audioQuality())
         assertEquals(7, reopened.listeningLifetimeBackfillVersion())
+    }
+
+    @Test
+    fun transientInitialReadFailureRecoversPersistedValues() {
+        runBlocking {
+            disk.edit {
+                it[stringPreferencesKey("user_name")] = "Recovered"
+                it[booleanPreferencesKey("onboarded")] = true
+            }
+        }
+        disk.readFailuresRemaining = 1
+
+        val (_, preferences) = open()
+
+        assertEquals("Recovered", preferences.userName())
+        assertTrue(preferences.isOnboarded())
+    }
+
+    @Test
+    fun failedWriteRollsBackOptimisticValueAndKeepsNewerWrites() {
+        runBlocking {
+            disk.edit {
+                it[stringPreferencesKey("user_name")] = "Persisted"
+                it[stringPreferencesKey("audio_quality")] = "Auto"
+            }
+        }
+        val (store, preferences) = open()
+        assertEquals("Persisted", preferences.userName())
+        disk.writeFailuresRemaining = 1
+
+        preferences.setUserName("Failed")
+        preferences.setAudioQuality("High")
+        flush(store)
+
+        assertEquals("Persisted", preferences.userName())
+        assertEquals("High", preferences.audioQuality())
+
+        val reopened = reopen()
+        assertEquals("Persisted", reopened.userName())
+        assertEquals("High", reopened.audioQuality())
     }
 
     @Test

--- a/app/src/test/java/com/luc4n3x/levyra/data/LevyraPreferencesStoreTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/LevyraPreferencesStoreTest.kt
@@ -83,7 +83,7 @@ class LevyraPreferencesStoreTest {
         assertEquals(DEFAULT_SPONSORBLOCK_ENABLED, snapshot.sponsorBlock)
         assertEquals("Auto", snapshot.audioQuality)
         assertEquals(LevyraAudioSettings().normalized(), preferences.audioSettings())
-        assertEquals(PlayerVisualMode.Artwork, preferences.interfaceSettings().playerVisualMode)
+        assertEquals(PlayerVisualMode.CanvasImmersive, preferences.interfaceSettings().playerVisualMode)
         assertNull(snapshot.lastTrack)
         assertEquals(LevyraAutomationSettings().normalized(), runBlocking { preferences.automationSettingsFlow.first() })
     }

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/HomeRenderSnapshotTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/HomeRenderSnapshotTest.kt
@@ -103,7 +103,10 @@ class HomeRenderSnapshotTest {
 
         val snapshot = buildHomeRenderSnapshot(state)
 
-        assertEquals(listOf(quickTrack), snapshot.derived.quickPicks?.tracks)
+        val quickPicks = snapshot.derived.quickPicks?.tracks.orEmpty()
+        assertEquals(quickTrack, quickPicks.first())
+        assertEquals(20, quickPicks.size)
+        assertEquals(quickPicks.size, quickPicks.map { it.id }.distinct().size)
         assertEquals(emptyList<HomeSection>(), snapshot.derived.otherSections)
     }
 


### PR DESCRIPTION
## Summary

`LevyraPreferences` wrapped every getter and setter in `runBlocking(Dispatchers.IO)`. Switching the dispatcher does not help: the caller, often the main thread during ViewModel, service or UI work, still parks until DataStore finishes. This PR serves preference reads from a single in-memory snapshot and writes to DataStore through one ordered background writer.

The same PR also fixes Home first-launch issues found during device testing: Quick Picks was empty on a fresh install, artists took a long time to appear, the player opened in artwork mode instead of Canvas, and Levyra Collections cards shared similar colours.

## What changed

- New process-wide `LevyraPreferencesStore`. It loads DataStore once, keeps the latest `Preferences` in memory, applies edits to memory synchronously and persists them in FIFO order through a single writer coroutine in an owned `SupervisorJob + Dispatchers.IO` scope.
- `LevyraPreferences` getters read the snapshot. Structured values (full snapshot, audio settings with custom presets, home sections, albums, chart and orbit caches) are parsed once per snapshot. `automationSettingsFlow` now comes from the same snapshot instead of a second DataStore collector.
- Suspend writers (`restoreSnapshot`, `setMotionArtworkEnabled`, `setAutomationSettings`, `persistBackupTreeUri`) still wait for durable persistence. Writes issued before the first load are applied on top of the persisted state, so defaults never overwrite stored values.
- `LevyraApplication` starts the initial load in `onCreate`.
- Player visual mode now defaults to immersive Canvas on fresh installs. Stored choices and the legacy motion-artwork mapping are unchanged.
- Quick Picks: startup seeds (`chart-seed-*` ids) are now accepted. The seed pool covers the language catalog plus global hits, orbit tracks stay excluded, and the shelf targets 20 tracks with no duplicates. Seeds live in UI state, so the existing official-artwork queue replaces YouTube video frames with album covers.
- Quick Picks layout: a horizontal pager of 2×4 compact cards, with actions on long-press.
- Home artists: with nothing cached, loading starts after the short grace delay instead of the full startup delay, and each resolved batch is published.
- Levyra Collections: each card gets a distinct colour pair, and the it/en collection titles are clearer.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactor or maintenance
- [x] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [ ] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Android
- **Area:** Player / UI / System integration

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [x] Targeted tests were added or updated
- [ ] Not applicable, with the reason explained below

Checks that were actually run: `./gradlew :app:testDebugUnitTest` (2014 tests, 0 failures), `./gradlew :app:assembleDebug`, and `python scripts/ai_quality_gate.py --profile fast` (passed). The release lint/test/assemble tasks were not run locally; CI covers them.

New `LevyraPreferencesStoreTest` covers: default snapshot, persisted values and legacy mappings loading into memory, immediate visibility of writes, survival across recreation, 200 rapid writes keeping the last intent, concurrent writes to different keys, writes issued before the initial load, backup restore visibility and durability (custom EQ preset, automation, interface, Jam name), parse-once behaviour of structured values, and the automation flow following in-memory writes.

### Manual testing

All device testing ran on a physical Samsung SM-S936B over ADB Wireless Debugging, not an emulator and not USB.

| Environment | Scenario | Result |
|---|---|---|
| SM-S936B, debug, Wi-Fi ADB | Cold launch, warm launch, onboarding | Pass |
| SM-S936B | Search, playback start, pause/resume, next, previous, Now Playing | Pass |
| SM-S936B | Settings changed (theme Neon Cyan, dynamic colour off, Canvas quality High, visual mode, background Blur, haptics off), force-stop and relaunch | Settings persisted |
| SM-S936B | Background and foreground, last track restored after relaunch | Pass |
| SM-S936B | Fresh install: player visual mode defaults to immersive Canvas | Pass |
| SM-S936B | Fresh install: Quick Picks shows 20 non-orbit tracks in 2×4 horizontal pages | Pass |
| SM-S936B | Logcat during the flows | No crash, ANR or DataStore error from the app |
| SM-S936B | Memory, 3–4 cold starts each, `main` vs this branch | Java heap 40–70 MB vs 38–72 MB. PSS differences come from the Graphics category, which varies similarly on both builds |

Language switching was not exercised on the device.

## Risk and compatibility

- **Risk level:** Medium
- **Compatibility or migration notes:** Preference keys, defaults (except the player visual mode for users with no stored choice), migrations and the backup format are unchanged.
- **Known limitations:** A synchronous read made before the initial DataStore load finishes waits once for that single shared load; `LevyraApplication` starts the load early so the wait is normally negligible. Fire-and-forget setters persist asynchronously, so a write made milliseconds before the process is killed can be lost. If DataStore fails during a backup restore, the restore reports the error, but the in-memory values stay restored until the next process start. Quick Picks seed covers are resolved over the network, so a video frame can show briefly on first launch.
- **Rollback plan:** Revert this PR

## Reviewer notes

- `LevyraPreferencesStore`: memory updates and write enqueueing happen under one lock so memory and disk ordering match. No disk I/O runs under the lock. No DataStore collector runs after the initial load: this process is the only writer, so memory is authoritative.
- `buildQuickPicks` now accepts `chart-seed-*` ids. Orbit exclusion and per-artist limits are unchanged.
- Performance: the PR removes the identified synchronous preference blocking paths. `am start -W` cold `TotalTime` on the debug build was about 1.6 s on this branch versus 2.7–2.9 s on `main` (small sample, debug build). Treat it as indicative, not a benchmark.

## Release note

Faster, non-blocking settings; Quick Picks ready from the first launch; the player opens in Canvas by default.

## Related issues

- Closes #
- Related to #

## Checklist

- [ ] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [ ] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick access now offers up to 20 unique tracks in paged, two-column layouts.
  * Track cards include artwork, visual backgrounds, current-track indicators, and long-press actions.
  * Quick access content refreshes with the selected app language and enriched track artwork.
  * The default player visual mode is now Canvas Immersive.

* **Improvements**
  * Home artist shelves update more consistently as results become available.
  * Updated English and Italian labels improve clarity across editorial collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->