### PR TITLE
ui: blend home hero and redesign personal orbit

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -7949,7 +7949,7 @@ private fun HomeEditorialSpotlight(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(520.dp)
+            .height(536.dp)
             .clickable(
                 interactionSource = interaction,
                 indication = null,
@@ -7969,10 +7969,11 @@ private fun HomeEditorialSpotlight(
                         brush = Brush.verticalGradient(
                             colorStops = arrayOf(
                                 0f to Color.Transparent,
-                                0.14f to Color.Black.copy(alpha = 0.55f),
-                                0.30f to Color.Black,
-                                0.74f to Color.Black,
-                                0.90f to Color.Black.copy(alpha = 0.45f),
+                                0.10f to Color.Black.copy(alpha = 0.52f),
+                                0.24f to Color.Black,
+                                0.72f to Color.Black,
+                                0.86f to Color.Black.copy(alpha = 0.72f),
+                                0.95f to Color.Black.copy(alpha = 0.26f),
                                 1f to Color.Transparent
                             )
                         ),
@@ -8004,25 +8005,11 @@ private fun HomeEditorialSpotlight(
                 Brush.verticalGradient(
                     colorStops = arrayOf(
                         0f to Color.Transparent,
-                        0.44f to Color.Transparent,
-                        0.63f to Color.Black.copy(alpha = 0.24f),
-                        0.80f to Color.Black.copy(alpha = 0.58f),
-                        1f to Color.Black.copy(alpha = 0.76f)
-                    )
-                )
-            )
-    )
-    Box(
-        modifier = Modifier
-            .align(Alignment.BottomStart)
-            .fillMaxWidth()
-            .fillMaxHeight(0.52f)
-            .background(
-                Brush.horizontalGradient(
-                    colorStops = arrayOf(
-                        0f to Color.Black.copy(alpha = 0.30f),
-                        0.44f to Color.Black.copy(alpha = 0.07f),
-                        0.78f to Color.Transparent,
+                        0.42f to Color.Transparent,
+                        0.62f to Color.Black.copy(alpha = 0.20f),
+                        0.77f to Color.Black.copy(alpha = 0.52f),
+                        0.88f to Color.Black.copy(alpha = 0.46f),
+                        0.96f to Color.Black.copy(alpha = 0.16f),
                         1f to Color.Transparent
                     )
                 )
@@ -8048,7 +8035,7 @@ private fun HomeEditorialSpotlight(
         modifier = Modifier
             .align(Alignment.BottomStart)
             .fillMaxWidth(0.74f)
-            .padding(start = 22.dp, end = 12.dp, bottom = 38.dp),
+            .padding(start = 22.dp, end = 12.dp, bottom = 56.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         Surface(
@@ -8125,7 +8112,7 @@ private fun HomeEditorialSpotlight(
         border = BorderStroke(1.dp, Color.White.copy(alpha = 0.20f)),
         modifier = Modifier
             .align(Alignment.BottomEnd)
-            .padding(end = 18.dp, bottom = 46.dp)
+            .padding(end = 18.dp, bottom = 64.dp)
             .size(68.dp)
     ) {
         Box(contentAlignment = Alignment.Center) {
@@ -9510,8 +9497,6 @@ private fun HomeCompactPlayAllHeader(
 @Composable
 private fun HomeOrbitHeader(onPlayAll: () -> Unit) {
     val strings = LocalLevyraStrings.current
-    // Title and subtitle share one column so the subtitle sits right under the
-    // title instead of being pushed down by the 48dp touch target of the pill.
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
@@ -9519,45 +9504,59 @@ private fun HomeOrbitHeader(onPlayAll: () -> Unit) {
     ) {
         Column(
             modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(1.dp)
+            verticalArrangement = Arrangement.spacedBy(2.dp)
         ) {
             Text(
                 text = strings.personalOrbitTitle,
                 color = LevyraText,
-                fontSize = 23.sp,
-                lineHeight = LevyraTypeRhythm.lineHeight(23.sp),
+                fontSize = 24.sp,
+                lineHeight = LevyraTypeRhythm.lineHeight(24.sp),
                 fontWeight = FontWeight.Black,
-                letterSpacing = (-0.45).sp,
+                letterSpacing = (-0.55).sp,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
             Text(
                 text = strings.personalOrbitSubtitle,
                 color = LevyraMuted,
-                style = TextStyle(fontSize = 13.5.sp, fontWeight = FontWeight.Medium),
-                autoSize = TextAutoSize.StepBased(minFontSize = 11.sp, maxFontSize = 13.5.sp, stepSize = 0.5.sp),
-                maxLines = 1,
-                softWrap = false,
+                fontSize = 12.5.sp,
+                lineHeight = LevyraTypeRhythm.lineHeight(12.5.sp),
+                fontWeight = FontWeight.Medium,
+                maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )
         }
         Box(
-            modifier = Modifier.height(48.dp).pressable(onClick = onPlayAll),
+            modifier = Modifier
+                .height(44.dp)
+                .pressable(onClick = onPlayAll),
             contentAlignment = Alignment.Center
         ) {
             Surface(
-                color = LevyraPanelSoft.copy(alpha = if (LevyraIsLight) 0.72f else 0.48f),
-                border = BorderStroke(Dp.Hairline, LevyraAdaptiveSoftHairline),
+                color = LevyraPanelSoft.copy(alpha = if (LevyraIsLight) 0.58f else 0.32f),
+                border = BorderStroke(Dp.Hairline, LevyraAdaptiveSoftHairline.copy(alpha = 0.78f)),
                 shape = CircleShape,
-                modifier = Modifier.height(38.dp)
+                modifier = Modifier.height(34.dp)
             ) {
                 Row(
-                    modifier = Modifier.padding(horizontal = 12.dp),
+                    modifier = Modifier.padding(horizontal = 10.dp),
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
-                    Icon(Icons.Rounded.PlayArrow, null, tint = LevyraText.copy(alpha = 0.86f), modifier = Modifier.size(15.dp))
-                    Text(strings.playAll, color = LevyraText, fontWeight = FontWeight.Bold, fontSize = 11.5.sp, maxLines = 1)
+                    Icon(
+                        imageVector = Icons.Rounded.PlayArrow,
+                        contentDescription = null,
+                        tint = LevyraText.copy(alpha = 0.86f),
+                        modifier = Modifier.size(15.dp)
+                    )
+                    Text(
+                        text = strings.playAll,
+                        color = LevyraText.copy(alpha = 0.90f),
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 10.5.sp,
+                        lineHeight = LevyraTypeRhythm.lineHeight(10.5.sp),
+                        maxLines = 1
+                    )
                 }
             }
         }
@@ -9583,39 +9582,218 @@ private fun PersonalListeningShelf(
     }
     if (shelfTracks.isEmpty()) return
 
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    val featuredTrack = shelfTracks.first()
+    val satelliteTracks = shelfTracks.drop(1)
+
+    Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
         HomeSectionInset {
             HomeOrbitHeader(onPlayAll = onPlayAll)
         }
 
-        BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-            val cardWidth = (maxWidth * 0.43f).coerceIn(136.dp, 174.dp)
-            LazyRow(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                contentPadding = PaddingValues(
-                    start = HomeHorizontalInset,
-                    end = HomeHorizontalShelfEndPadding
+        HomeSectionInset {
+            PersonalOrbitFeaturedCard(
+                track = featuredTrack,
+                active = featuredTrack.id == currentId,
+                playing = isPlaying && featuredTrack.id == currentId,
+                resolving = isResolving && featuredTrack.id == currentId,
+                onClick = { onPlay(featuredTrack) },
+                onLongClick = {
+                    haptics.perform(LevyraHapticAction.TrackSwipe)
+                    onTrackActions(featuredTrack)
+                },
+                onLongClickLabel = strings.songOptions
+            )
+        }
+
+        if (satelliteTracks.isNotEmpty()) {
+            BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+                val cardWidth = (maxWidth * 0.31f).coerceIn(106.dp, 126.dp)
+                LazyRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    contentPadding = PaddingValues(
+                        start = HomeHorizontalInset,
+                        end = HomeHorizontalShelfEndPadding
+                    )
+                ) {
+                    itemsIndexed(
+                        items = satelliteTracks,
+                        key = { index, track -> "personal-orbit-${index + 2}-${LevyraPersonalOrbit.identityKey(track)}" },
+                        contentType = { _, _ -> "personal-orbit-satellite" }
+                    ) { index, track ->
+                        PersonalOrbitSatelliteCard(
+                            track = track,
+                            rank = index + 2,
+                            active = track.id == currentId,
+                            playing = isPlaying && track.id == currentId,
+                            resolving = isResolving && track.id == currentId,
+                            cardWidth = cardWidth,
+                            onClick = { onPlay(track) },
+                            onLongClick = {
+                                haptics.perform(LevyraHapticAction.TrackSwipe)
+                                onTrackActions(track)
+                            },
+                            onLongClickLabel = strings.songOptions
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PersonalOrbitFeaturedCard(
+    track: Track,
+    active: Boolean,
+    playing: Boolean,
+    resolving: Boolean,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    onLongClickLabel: String
+) {
+    val shape = RoundedCornerShape(22.dp)
+    val artworkShape = RoundedCornerShape(16.dp)
+    val accentStart = remember(track.id, track.accentStart) { Color(track.accentStart) }
+    val accentEnd = remember(track.id, track.accentEnd) { Color(track.accentEnd) }
+    val surfaceBrush = remember(accentStart, accentEnd) {
+        Brush.linearGradient(
+            listOf(
+                accentStart.copy(alpha = if (LevyraIsLight) 0.11f else 0.16f),
+                LevyraPanelSoft.copy(alpha = if (LevyraIsLight) 0.74f else 0.66f),
+                accentEnd.copy(alpha = if (LevyraIsLight) 0.07f else 0.11f)
+            )
+        )
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(128.dp)
+            .clip(shape)
+            .background(surfaceBrush)
+            .border(
+                width = if (active) 1.5.dp else Dp.Hairline,
+                color = if (active) LevyraCyan.copy(alpha = 0.88f) else LevyraAdaptiveSoftHairline.copy(alpha = 0.82f),
+                shape = shape
+            )
+            .levyraPressable(
+                onClick = onClick,
+                pressedScale = LevyraPressScale.Tile,
+                onLongClickLabel = onLongClickLabel,
+                onLongClick = onLongClick,
+                longPressHaptic = null
+            )
+    ) {
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .background(
+                    Brush.radialGradient(
+                        colors = listOf(
+                            accentStart.copy(alpha = 0.10f),
+                            Color.Transparent
+                        ),
+                        center = Offset.Zero,
+                        radius = 390f
+                    )
                 )
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(108.dp)
+                    .clip(artworkShape)
+                    .border(Dp.Hairline, Color.White.copy(alpha = 0.10f), artworkShape)
             ) {
-                itemsIndexed(
-                    items = shelfTracks,
-                    key = { index, track -> "personal-orbit-$index-${LevyraPersonalOrbit.identityKey(track)}" },
-                    contentType = { _, _ -> "personal-orbit-card" }
-                ) { index, track ->
-                    PersonalOrbitCarouselCard(
-                        track = track,
-                        active = track.id == currentId,
-                        playing = isPlaying && track.id == currentId,
-                        resolving = isResolving && track.id == currentId,
-                        emphasized = index == 0,
-                        cardWidth = cardWidth,
-                        onClick = { onPlay(track) },
-                        onLongClick = {
-                            haptics.perform(LevyraHapticAction.TrackSwipe)
-                            onTrackActions(track)
-                        },
-                        onLongClickLabel = strings.songOptions
+                CoverImage(
+                    track = track,
+                    modifier = Modifier.fillMaxSize(),
+                    highRes = true
+                )
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(8.dp)
+                        .background(Color.Black.copy(alpha = 0.58f), CircleShape)
+                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                ) {
+                    Text(
+                        text = "01",
+                        color = Color.White.copy(alpha = 0.92f),
+                        fontSize = 9.5.sp,
+                        lineHeight = LevyraTypeRhythm.lineHeight(9.5.sp),
+                        fontWeight = FontWeight.Black,
+                        letterSpacing = 0.6.sp
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.width(14.dp))
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(5.dp)
+            ) {
+                Text(
+                    text = track.title,
+                    color = if (active) LevyraCyan else LevyraText,
+                    fontSize = 18.sp,
+                    lineHeight = LevyraTypeRhythm.lineHeight(18.sp),
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = track.artist,
+                    color = LevyraMuted,
+                    fontSize = 12.5.sp,
+                    lineHeight = LevyraTypeRhythm.lineHeight(12.5.sp),
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .background(
+                        if (active) LevyraCyan.copy(alpha = 0.16f) else Color.Black.copy(alpha = if (LevyraIsLight) 0.05f else 0.24f),
+                        CircleShape
+                    )
+                    .border(
+                        Dp.Hairline,
+                        if (active) LevyraCyan.copy(alpha = 0.48f) else Color.White.copy(alpha = 0.10f),
+                        CircleShape
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                when {
+                    resolving -> CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 1.8.dp,
+                        color = LevyraCyan
+                    )
+                    active -> ActiveTrackEqualizer(
+                        color = LevyraCyan,
+                        isPlaying = playing,
+                        width = 16.dp,
+                        height = 11.dp
+                    )
+                    else -> Icon(
+                        imageVector = Icons.Rounded.PlayArrow,
+                        contentDescription = null,
+                        tint = LevyraText.copy(alpha = 0.92f),
+                        modifier = Modifier.size(22.dp)
                     )
                 }
             }
@@ -9624,29 +9802,19 @@ private fun PersonalListeningShelf(
 }
 
 @Composable
-private fun PersonalOrbitCarouselCard(
+private fun PersonalOrbitSatelliteCard(
     track: Track,
+    rank: Int,
     active: Boolean,
     playing: Boolean,
     resolving: Boolean,
-    emphasized: Boolean,
     cardWidth: Dp,
     onClick: () -> Unit,
     onLongClick: () -> Unit,
     onLongClickLabel: String
 ) {
-    val shape = RoundedCornerShape(16.dp)
-    val accentStart = remember(track.id, track.accentStart) { Color(track.accentStart) }
-    val accentEnd = remember(track.id, track.accentEnd) { Color(track.accentEnd) }
-    val emphasisOverlay = remember(accentStart, accentEnd, emphasized) {
-        Brush.linearGradient(
-            listOf(
-                accentStart.copy(alpha = if (emphasized) 0.045f else 0f),
-                Color.Transparent,
-                accentEnd.copy(alpha = if (emphasized) 0.025f else 0f)
-            )
-        )
-    }
+    val shape = RoundedCornerShape(15.dp)
+    val rankText = rank.toString().padStart(2, '0')
 
     Column(
         modifier = Modifier
@@ -9658,7 +9826,7 @@ private fun PersonalOrbitCarouselCard(
                 onLongClick = onLongClick,
                 longPressHaptic = null
             ),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(7.dp)
     ) {
         Box(
             modifier = Modifier
@@ -9667,55 +9835,66 @@ private fun PersonalOrbitCarouselCard(
                 .clip(shape)
                 .border(
                     width = if (active) 1.5.dp else Dp.Hairline,
-                    color = if (active) LevyraCyan.copy(alpha = 0.88f) else LevyraAdaptiveSoftHairline,
+                    color = if (active) LevyraCyan.copy(alpha = 0.88f) else LevyraAdaptiveSoftHairline.copy(alpha = 0.82f),
                     shape = shape
-                ),
-            contentAlignment = Alignment.Center
+                )
         ) {
             CoverImage(
                 track = track,
                 modifier = Modifier.fillMaxSize(),
                 highRes = true
             )
-            if (emphasized) {
-                Box(
-                    modifier = Modifier
-                        .matchParentSize()
-                        .background(emphasisOverlay)
+
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(7.dp)
+                    .background(Color.Black.copy(alpha = 0.58f), CircleShape)
+                    .padding(horizontal = 7.dp, vertical = 3.dp)
+            ) {
+                Text(
+                    text = rankText,
+                    color = Color.White.copy(alpha = 0.92f),
+                    fontSize = 9.sp,
+                    lineHeight = LevyraTypeRhythm.lineHeight(9.sp),
+                    fontWeight = FontWeight.Black,
+                    letterSpacing = 0.45.sp
                 )
             }
+
             if (active) {
                 Box(
                     modifier = Modifier
                         .align(Alignment.TopEnd)
-                        .padding(10.dp)
-                        .size(32.dp)
+                        .padding(7.dp)
+                        .size(28.dp)
                         .background(Color.Black.copy(alpha = 0.62f), CircleShape)
-                        .border(Dp.Hairline, Color.White.copy(alpha = 0.16f), CircleShape),
+                        .border(Dp.Hairline, Color.White.copy(alpha = 0.14f), CircleShape),
                     contentAlignment = Alignment.Center
                 ) {
                     if (resolving) {
                         CircularProgressIndicator(
-                            modifier = Modifier.size(14.dp),
-                            strokeWidth = 1.7.dp,
+                            modifier = Modifier.size(12.dp),
+                            strokeWidth = 1.5.dp,
                             color = LevyraCyan
                         )
                     } else {
                         ActiveTrackEqualizer(
                             color = LevyraCyan,
                             isPlaying = playing,
-                            width = 14.dp,
-                            height = 10.dp
+                            width = 12.dp,
+                            height = 9.dp
                         )
                     }
                 }
             }
         }
+
         Text(
             text = track.title,
             color = if (active) LevyraCyan else LevyraText,
-            fontSize = 15.5.sp,
-            lineHeight = LevyraTypeRhythm.lineHeight(15.5.sp),
+            fontSize = 14.sp,
+            lineHeight = LevyraTypeRhythm.lineHeight(14.sp),
             fontWeight = FontWeight.SemiBold,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
@@ -9724,8 +9903,8 @@ private fun PersonalOrbitCarouselCard(
         Text(
             text = track.artist,
             color = LevyraMuted,
-            fontSize = 12.5.sp,
-            lineHeight = LevyraTypeRhythm.lineHeight(12.5.sp),
+            fontSize = 11.5.sp,
+            lineHeight = LevyraTypeRhythm.lineHeight(11.5.sp),
             fontWeight = FontWeight.Medium,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -9627,7 +9627,6 @@ private fun PersonalListeningShelf(
                     ) { index, track ->
                         PersonalOrbitSatelliteCard(
                             track = track,
-                            rank = index + 2,
                             active = track.id == currentId,
                             playing = isPlaying && track.id == currentId,
                             resolving = isResolving && track.id == currentId,
@@ -9706,22 +9705,6 @@ private fun PersonalOrbitFeaturedCard(
                     modifier = Modifier.fillMaxSize(),
                     highRes = true
                 )
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .padding(8.dp)
-                        .background(Color.Black.copy(alpha = 0.60f), CircleShape)
-                        .padding(horizontal = 8.dp, vertical = 4.dp)
-                ) {
-                    Text(
-                        text = "01",
-                        color = Color.White.copy(alpha = 0.94f),
-                        fontSize = 9.5.sp,
-                        lineHeight = LevyraTypeRhythm.lineHeight(9.5.sp),
-                        fontWeight = FontWeight.Black,
-                        letterSpacing = 0.6.sp
-                    )
-                }
             }
 
             Spacer(modifier = Modifier.width(13.dp))
@@ -9811,7 +9794,6 @@ private fun PersonalOrbitFeaturedCard(
 @Composable
 private fun PersonalOrbitSatelliteCard(
     track: Track,
-    rank: Int,
     active: Boolean,
     playing: Boolean,
     resolving: Boolean,
@@ -9821,7 +9803,6 @@ private fun PersonalOrbitSatelliteCard(
     onLongClickLabel: String
 ) {
     val shape = RoundedCornerShape(15.dp)
-    val rankText = rank.toString().padStart(2, '0')
 
     Column(
         modifier = Modifier
@@ -9851,23 +9832,6 @@ private fun PersonalOrbitSatelliteCard(
                 modifier = Modifier.fillMaxSize(),
                 highRes = true
             )
-
-            Box(
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .padding(7.dp)
-                    .background(Color.Black.copy(alpha = 0.58f), CircleShape)
-                    .padding(horizontal = 7.dp, vertical = 3.dp)
-            ) {
-                Text(
-                    text = rankText,
-                    color = Color.White.copy(alpha = 0.92f),
-                    fontSize = 9.sp,
-                    lineHeight = LevyraTypeRhythm.lineHeight(9.sp),
-                    fontWeight = FontWeight.Black,
-                    letterSpacing = 0.45.sp
-                )
-            }
 
             if (active) {
                 Box(

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -9497,14 +9497,15 @@ private fun HomeCompactPlayAllHeader(
 @Composable
 private fun HomeOrbitHeader(onPlayAll: () -> Unit) {
     val strings = LocalLevyraStrings.current
-    Row(
+
+    Column(
         modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp)
+        verticalArrangement = Arrangement.spacedBy(3.dp)
     ) {
-        Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(2.dp)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             Text(
                 text = strings.personalOrbitTitle,
@@ -9514,52 +9515,55 @@ private fun HomeOrbitHeader(onPlayAll: () -> Unit) {
                 fontWeight = FontWeight.Black,
                 letterSpacing = (-0.55).sp,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f)
             )
-            Text(
-                text = strings.personalOrbitSubtitle,
-                color = LevyraMuted,
-                fontSize = 12.5.sp,
-                lineHeight = LevyraTypeRhythm.lineHeight(12.5.sp),
-                fontWeight = FontWeight.Medium,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
-        Box(
-            modifier = Modifier
-                .height(44.dp)
-                .pressable(onClick = onPlayAll),
-            contentAlignment = Alignment.Center
-        ) {
-            Surface(
-                color = LevyraPanelSoft.copy(alpha = if (LevyraIsLight) 0.58f else 0.32f),
-                border = BorderStroke(Dp.Hairline, LevyraAdaptiveSoftHairline),
-                shape = CircleShape,
-                modifier = Modifier.height(34.dp)
+            Box(
+                modifier = Modifier
+                    .height(44.dp)
+                    .pressable(onClick = onPlayAll),
+                contentAlignment = Alignment.Center
             ) {
-                Row(
-                    modifier = Modifier.padding(horizontal = 10.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                Surface(
+                    color = LevyraPanelSoft.copy(alpha = if (LevyraIsLight) 0.58f else 0.32f),
+                    border = BorderStroke(Dp.Hairline, LevyraAdaptiveSoftHairline),
+                    shape = CircleShape,
+                    modifier = Modifier.height(34.dp)
                 ) {
-                    Icon(
-                        imageVector = Icons.Rounded.PlayArrow,
-                        contentDescription = null,
-                        tint = LevyraText.copy(alpha = 0.86f),
-                        modifier = Modifier.size(15.dp)
-                    )
-                    Text(
-                        text = strings.playAll,
-                        color = LevyraText.copy(alpha = 0.90f),
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 10.5.sp,
-                        lineHeight = LevyraTypeRhythm.lineHeight(10.5.sp),
-                        maxLines = 1
-                    )
+                    Row(
+                        modifier = Modifier.padding(horizontal = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Rounded.PlayArrow,
+                            contentDescription = null,
+                            tint = LevyraText.copy(alpha = 0.86f),
+                            modifier = Modifier.size(15.dp)
+                        )
+                        Text(
+                            text = strings.playAll,
+                            color = LevyraText.copy(alpha = 0.90f),
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 10.5.sp,
+                            lineHeight = LevyraTypeRhythm.lineHeight(10.5.sp),
+                            maxLines = 1
+                        )
+                    }
                 }
             }
         }
+
+        Text(
+            text = strings.personalOrbitSubtitle,
+            color = LevyraMuted,
+            style = TextStyle(fontSize = 13.sp, fontWeight = FontWeight.Medium),
+            autoSize = TextAutoSize.StepBased(minFontSize = 11.sp, maxFontSize = 13.sp, stepSize = 0.5.sp),
+            maxLines = 1,
+            softWrap = false,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.fillMaxWidth()
+        )
     }
 }
 
@@ -9652,29 +9656,14 @@ private fun PersonalOrbitFeaturedCard(
     onLongClick: () -> Unit,
     onLongClickLabel: String
 ) {
-    val shape = RoundedCornerShape(22.dp)
-    val artworkShape = RoundedCornerShape(16.dp)
+    val artworkShape = RoundedCornerShape(18.dp)
     val accentStart = remember(track.id, track.accentStart) { Color(track.accentStart) }
     val accentEnd = remember(track.id, track.accentEnd) { Color(track.accentEnd) }
-    val surfaceBrush = Brush.linearGradient(
-        listOf(
-            accentStart.copy(alpha = if (LevyraIsLight) 0.11f else 0.16f),
-            LevyraPanelSoft.copy(alpha = if (LevyraIsLight) 0.74f else 0.66f),
-            accentEnd.copy(alpha = if (LevyraIsLight) 0.07f else 0.11f)
-        )
-    )
 
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(128.dp)
-            .clip(shape)
-            .background(surfaceBrush)
-            .border(
-                width = if (active) 1.5.dp else Dp.Hairline,
-                color = if (active) LevyraCyan.copy(alpha = 0.88f) else LevyraAdaptiveSoftHairline,
-                shape = shape
-            )
+            .height(116.dp)
             .levyraPressable(
                 onClick = onClick,
                 pressedScale = LevyraPressScale.Tile,
@@ -9687,28 +9676,30 @@ private fun PersonalOrbitFeaturedCard(
             modifier = Modifier
                 .matchParentSize()
                 .background(
-                    Brush.radialGradient(
-                        colors = listOf(
-                            accentStart.copy(alpha = 0.10f),
-                            Color.Transparent
-                        ),
-                        center = Offset.Zero,
-                        radius = 390f
+                    Brush.horizontalGradient(
+                        colorStops = arrayOf(
+                            0f to accentStart.copy(alpha = if (LevyraIsLight) 0.07f else 0.10f),
+                            0.34f to accentStart.copy(alpha = if (LevyraIsLight) 0.025f else 0.045f),
+                            0.72f to accentEnd.copy(alpha = if (LevyraIsLight) 0.015f else 0.025f),
+                            1f to Color.Transparent
+                        )
                     )
                 )
         )
 
         Row(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(10.dp),
+            modifier = Modifier.fillMaxSize(),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Box(
                 modifier = Modifier
-                    .size(108.dp)
+                    .size(110.dp)
                     .clip(artworkShape)
-                    .border(Dp.Hairline, Color.White.copy(alpha = 0.10f), artworkShape)
+                    .border(
+                        width = if (active) 1.5.dp else Dp.Hairline,
+                        color = if (active) LevyraCyan.copy(alpha = 0.88f) else LevyraAdaptiveSoftHairline,
+                        shape = artworkShape
+                    )
             ) {
                 CoverImage(
                     track = track,
@@ -9719,12 +9710,12 @@ private fun PersonalOrbitFeaturedCard(
                     modifier = Modifier
                         .align(Alignment.TopStart)
                         .padding(8.dp)
-                        .background(Color.Black.copy(alpha = 0.58f), CircleShape)
+                        .background(Color.Black.copy(alpha = 0.60f), CircleShape)
                         .padding(horizontal = 8.dp, vertical = 4.dp)
                 ) {
                     Text(
                         text = "01",
-                        color = Color.White.copy(alpha = 0.92f),
+                        color = Color.White.copy(alpha = 0.94f),
                         fontSize = 9.5.sp,
                         lineHeight = LevyraTypeRhythm.lineHeight(9.5.sp),
                         fontWeight = FontWeight.Black,
@@ -9733,7 +9724,24 @@ private fun PersonalOrbitFeaturedCard(
                 }
             }
 
-            Spacer(modifier = Modifier.width(14.dp))
+            Spacer(modifier = Modifier.width(13.dp))
+
+            Box(
+                modifier = Modifier
+                    .width(2.dp)
+                    .height(46.dp)
+                    .background(
+                        Brush.verticalGradient(
+                            listOf(
+                                accentStart.copy(alpha = 0.76f),
+                                accentEnd.copy(alpha = 0.30f)
+                            )
+                        ),
+                        RoundedCornerShape(2.dp)
+                    )
+            )
+
+            Spacer(modifier = Modifier.width(12.dp))
 
             Column(
                 modifier = Modifier.weight(1f),
@@ -9742,8 +9750,8 @@ private fun PersonalOrbitFeaturedCard(
                 Text(
                     text = track.title,
                     color = if (active) LevyraCyan else LevyraText,
-                    fontSize = 18.sp,
-                    lineHeight = LevyraTypeRhythm.lineHeight(18.sp),
+                    fontSize = 18.5.sp,
+                    lineHeight = LevyraTypeRhythm.lineHeight(18.5.sp),
                     fontWeight = FontWeight.Bold,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis
@@ -9763,35 +9771,36 @@ private fun PersonalOrbitFeaturedCard(
 
             Box(
                 modifier = Modifier
-                    .size(40.dp)
+                    .size(38.dp)
                     .background(
-                        if (active) LevyraCyan.copy(alpha = 0.16f) else Color.Black.copy(alpha = if (LevyraIsLight) 0.05f else 0.24f),
+                        if (active) LevyraCyan.copy(alpha = 0.13f)
+                        else Color.White.copy(alpha = if (LevyraIsLight) 0.18f else 0.045f),
                         CircleShape
                     )
                     .border(
                         Dp.Hairline,
-                        if (active) LevyraCyan.copy(alpha = 0.48f) else Color.White.copy(alpha = 0.10f),
+                        if (active) LevyraCyan.copy(alpha = 0.42f) else LevyraAdaptiveSoftHairline,
                         CircleShape
                     ),
                 contentAlignment = Alignment.Center
             ) {
                 when {
                     resolving -> CircularProgressIndicator(
-                        modifier = Modifier.size(16.dp),
-                        strokeWidth = 1.8.dp,
+                        modifier = Modifier.size(15.dp),
+                        strokeWidth = 1.7.dp,
                         color = LevyraCyan
                     )
                     active -> ActiveTrackEqualizer(
                         color = LevyraCyan,
                         isPlaying = playing,
-                        width = 16.dp,
-                        height = 11.dp
+                        width = 15.dp,
+                        height = 10.dp
                     )
                     else -> Icon(
                         imageVector = Icons.Rounded.PlayArrow,
                         contentDescription = null,
-                        tint = LevyraText.copy(alpha = 0.92f),
-                        modifier = Modifier.size(22.dp)
+                        tint = LevyraText.copy(alpha = 0.90f),
+                        modifier = Modifier.size(21.dp)
                     )
                 }
             }

--- a/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/ui/LevyraApp.kt
@@ -9534,7 +9534,7 @@ private fun HomeOrbitHeader(onPlayAll: () -> Unit) {
         ) {
             Surface(
                 color = LevyraPanelSoft.copy(alpha = if (LevyraIsLight) 0.58f else 0.32f),
-                border = BorderStroke(Dp.Hairline, LevyraAdaptiveSoftHairline.copy(alpha = 0.78f)),
+                border = BorderStroke(Dp.Hairline, LevyraAdaptiveSoftHairline),
                 shape = CircleShape,
                 modifier = Modifier.height(34.dp)
             ) {
@@ -9656,15 +9656,13 @@ private fun PersonalOrbitFeaturedCard(
     val artworkShape = RoundedCornerShape(16.dp)
     val accentStart = remember(track.id, track.accentStart) { Color(track.accentStart) }
     val accentEnd = remember(track.id, track.accentEnd) { Color(track.accentEnd) }
-    val surfaceBrush = remember(accentStart, accentEnd) {
-        Brush.linearGradient(
-            listOf(
-                accentStart.copy(alpha = if (LevyraIsLight) 0.11f else 0.16f),
-                LevyraPanelSoft.copy(alpha = if (LevyraIsLight) 0.74f else 0.66f),
-                accentEnd.copy(alpha = if (LevyraIsLight) 0.07f else 0.11f)
-            )
+    val surfaceBrush = Brush.linearGradient(
+        listOf(
+            accentStart.copy(alpha = if (LevyraIsLight) 0.11f else 0.16f),
+            LevyraPanelSoft.copy(alpha = if (LevyraIsLight) 0.74f else 0.66f),
+            accentEnd.copy(alpha = if (LevyraIsLight) 0.07f else 0.11f)
         )
-    }
+    )
 
     Box(
         modifier = Modifier
@@ -9674,7 +9672,7 @@ private fun PersonalOrbitFeaturedCard(
             .background(surfaceBrush)
             .border(
                 width = if (active) 1.5.dp else Dp.Hairline,
-                color = if (active) LevyraCyan.copy(alpha = 0.88f) else LevyraAdaptiveSoftHairline.copy(alpha = 0.82f),
+                color = if (active) LevyraCyan.copy(alpha = 0.88f) else LevyraAdaptiveSoftHairline,
                 shape = shape
             )
             .levyraPressable(
@@ -9835,7 +9833,7 @@ private fun PersonalOrbitSatelliteCard(
                 .clip(shape)
                 .border(
                     width = if (active) 1.5.dp else Dp.Hairline,
-                    color = if (active) LevyraCyan.copy(alpha = 0.88f) else LevyraAdaptiveSoftHairline.copy(alpha = 0.82f),
+                    color = if (active) LevyraCyan.copy(alpha = 0.88f) else LevyraAdaptiveSoftHairline,
                     shape = shape
                 )
         ) {

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -1028,7 +1028,7 @@ private data class HomeProjection(
     val interfaceSettings: LevyraInterfaceSettings
 )
 
-private fun homeProjection(state: LevyraUiState): HomeProjection = HomeProjection(
+internal fun homeProjection(state: LevyraUiState): HomeProjection = HomeProjection(
     animationsEnabled = state.animationsEnabled,
     artistExclusions = state.artistExclusions,
     chartRegions = state.chartRegions,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -985,7 +985,7 @@ private fun isLikelyHomePlaylistOrCompilation(track: Track): Boolean {
     ).any(combined::contains)
 }
 
-private data class HomeProjection(
+internal data class HomeProjection(
     val animationsEnabled: Boolean,
     val artistExclusions: ArtistExclusions,
     val chartRegions: List<ChartRegion>,

--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -987,6 +987,7 @@ private fun isLikelyHomePlaylistOrCompilation(track: Track): Boolean {
 
 private data class HomeProjection(
     val animationsEnabled: Boolean,
+    val artistExclusions: ArtistExclusions,
     val chartRegions: List<ChartRegion>,
     val charts: List<Track>,
     val currentTrack: Track?,
@@ -1013,6 +1014,7 @@ private data class HomeProjection(
     val moods: List<Mood>,
     val personalOrbitTracks: List<Track>,
     val playlists: List<Playlist>,
+    val quickPickSeeds: List<Track>,
     val recentListens: List<Track>,
     val recentSearches: List<Track>,
     val releaseRadar: List<ReleaseRadarEntry>,
@@ -1028,6 +1030,7 @@ private data class HomeProjection(
 
 private fun homeProjection(state: LevyraUiState): HomeProjection = HomeProjection(
     animationsEnabled = state.animationsEnabled,
+    artistExclusions = state.artistExclusions,
     chartRegions = state.chartRegions,
     charts = state.charts,
     currentTrack = state.currentTrack,
@@ -1054,6 +1057,7 @@ private fun homeProjection(state: LevyraUiState): HomeProjection = HomeProjectio
     moods = state.moods,
     personalOrbitTracks = state.personalOrbitTracks,
     playlists = state.playlists,
+    quickPickSeeds = state.quickPickSeeds,
     recentListens = state.recentListens,
     recentSearches = state.recentSearches,
     releaseRadar = state.releaseRadar,

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/HomeRenderSnapshotTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/HomeRenderSnapshotTest.kt
@@ -1,8 +1,12 @@
 package com.luc4n3x.levyra.viewmodel
 
+import com.luc4n3x.levyra.domain.ArtistExclusions
+import com.luc4n3x.levyra.domain.ExcludedArtist
 import com.luc4n3x.levyra.domain.HomeSection
 import com.luc4n3x.levyra.domain.Track
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
 import org.junit.Test
@@ -70,6 +74,40 @@ class HomeRenderSnapshotTest {
         assertEquals(listOf(keptTrack), frozen.state.personalOrbitTracks)
         assertSame(previous.state.tracks, frozen.state.tracks)
         assertSame(previous.state.homeSections, frozen.state.homeSections)
+    }
+
+    @Test
+    fun artistExclusionChangesHomeProjectionImmediately() {
+        val initial = LevyraUiState()
+        val excluded = ExcludedArtist("", "Blocked Artist", 1L)
+        val updated = initial.copy(
+            excludedArtists = listOf(excluded),
+            artistExclusions = ArtistExclusions.from(listOf(excluded))
+        )
+
+        assertNotEquals(homeProjection(initial), homeProjection(updated))
+    }
+
+    @Test
+    fun artistExclusionRemovesQuickPickWhileHomeStructureIsFrozen() {
+        val blocked = track("aaaaaaaaaaa").copy(artist = "Blocked Artist")
+        val allowed = track("bbbbbbbbbbb").copy(artist = "Allowed Artist")
+        val initialState = LevyraUiState(
+            homeSections = listOf(HomeSection("Quick picks", listOf(blocked, allowed))),
+            quickPickSeeds = listOf(blocked, allowed)
+        )
+        val previous = buildHomeRenderSnapshot(initialState)
+        val excluded = ExcludedArtist("", "Blocked Artist", 1L)
+        val updatedState = initialState.copy(
+            excludedArtists = listOf(excluded),
+            artistExclusions = ArtistExclusions.from(listOf(excluded))
+        )
+
+        val frozen = buildStableHomeRenderSnapshot(updatedState, previous, freezeContent = true)
+        val quickPicks = frozen.derived.quickPicks?.tracks.orEmpty()
+
+        assertFalse(quickPicks.any { it.artist == "Blocked Artist" })
+        assertEquals("Allowed Artist", quickPicks.firstOrNull()?.artist)
     }
 
     @Test


### PR DESCRIPTION
## Summary

This PR polishes the Android Home screen in two focused areas: the large editorial hero now blends into the Home atmosphere instead of ending as a visibly separate rectangular block, and Personal Orbit gets a clearer, more distinctive layout that is faster to scan.

## What changed

- Extended the Home spotlight slightly and rebuilt its lower fade so the artwork and dark scrim dissolve into the shared Home atmosphere.
- Removed the hard bottom horizontal overlay that made the hero edge visible while scrolling.
- Moved hero copy and the play control slightly upward so readability is preserved while the final part of the hero can fade cleanly.
- Redesigned Personal Orbit around one featured track followed by smaller satellite cards, with no ranking badges or decorative numbering.
- Kept the existing Personal Orbit ordering, playback behavior, current-track state, long-press actions, deduplication and play-all behavior unchanged.
- Reduced the visual weight of the Play All pill while keeping the label visible.
- Artist exclusions now participate in the Home projection, so “Do not recommend this artist” removes that artist from Quick Picks immediately and the shelf recomputes from the remaining candidates, including while Home structure is frozen during scroll.
- Preserved the existing dark/light theme colors and Home spacing language.

## Type of change

- [x] UI / UX improvement
- [x] Visual bug fix
- [ ] Data / persistence change
- [ ] Playback architecture change
- [ ] Desktop change

## Scope

- **Platform:** Android
- **Area:** Home / Editorial spotlight / Personal Orbit

## Validation

- [ ] Android PR checks
- [ ] APK artifact build
- [ ] Physical-device visual check
- [x] Added regression coverage for immediate Home projection invalidation and Quick Picks filtering after an artist exclusion

The visual work stays isolated to the Home UI. The only behavior change is Home invalidation for existing artist-exclusion state; persistence, playback, networking and recommendation scoring are unchanged.

## Risk and compatibility

- **Risk level:** Low
- Personal Orbit still consumes the same ordered track list and invokes the same callbacks.
- The hero uses the same artwork and palette pipeline; only presentation masks, spacing and overlays changed.
- No migration or stored setting changes.

## Review notes

Please pay particular attention to:
- the transition from the bottom of the hero into the next Home section while scrolling;
- text contrast across bright artist portraits;
- Personal Orbit readability on narrow phones;
- current-track/resolving indicators on both the featured and satellite cards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the Personal Orbit home section with a featured track card and a horizontally scrollable row of additional tracks.
  * Updated the home header with a more compact play control and refreshed layout, spacing, colors, and typography.

* **Bug Fixes**
  * Home content now refreshes immediately when artist exclusions change.
  * Excluded artists are removed from quick picks without disrupting the rest of the home layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->