### PR TITLE
fix(home): always fill Quick Picks to 20 tracks

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/viewmodel/LevyraScreenViewModels.kt
@@ -782,7 +782,8 @@ private fun buildQuickPicks(input: HomeDerivedInput): HomeSection? {
         addAll(input.favorites)
         addAll(input.tracks)
         input.currentTrack?.let(::add)
-        addAll(input.quickPickSeeds.ifEmpty { LevyraStartupCatalog.quickPickSeeds(input.languageCode) })
+        addAll(input.quickPickSeeds)
+        addAll(LevyraStartupCatalog.quickPickSeeds(input.languageCode))
     })
 
     val selected = ArrayList<Track>(HOME_QUICK_PICKS_LIMIT)

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/HomeRenderSnapshotTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/HomeRenderSnapshotTest.kt
@@ -3,6 +3,7 @@ package com.luc4n3x.levyra.viewmodel
 import com.luc4n3x.levyra.domain.ArtistExclusions
 import com.luc4n3x.levyra.domain.ExcludedArtist
 import com.luc4n3x.levyra.domain.HomeSection
+import com.luc4n3x.levyra.domain.LevyraPersonalOrbit
 import com.luc4n3x.levyra.domain.Track
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse

--- a/app/src/test/java/com/luc4n3x/levyra/viewmodel/HomeRenderSnapshotTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/viewmodel/HomeRenderSnapshotTest.kt
@@ -157,6 +157,31 @@ class HomeRenderSnapshotTest {
     }
 
     @Test
+    fun partialEnrichedQuickPickSeedsAreBackfilledToTwenty() {
+        val enrichedSeeds = (0 until 9).map { index ->
+            track(("seed" + index.toString().padStart(7, '0')).take(11))
+                .copy(
+                    title = "Enriched $index",
+                    artist = "Enriched Artist $index"
+                )
+        }
+        val state = LevyraUiState(
+            languageCode = "it",
+            quickPickSeeds = enrichedSeeds
+        )
+
+        val snapshot = buildHomeRenderSnapshot(state)
+        val quickPicks = snapshot.derived.quickPicks?.tracks.orEmpty()
+
+        assertEquals(20, quickPicks.size)
+        assertEquals(20, quickPicks.map(LevyraPersonalOrbit::identityKey).distinct().size)
+        assertEquals(
+            enrichedSeeds.map(LevyraPersonalOrbit::identityKey),
+            quickPicks.take(enrichedSeeds.size).map(LevyraPersonalOrbit::identityKey)
+        )
+    }
+
+    @Test
     fun keepsCachedResonanceStableAcrossOtherHomeChanges() {
         val cachedResonance = track("aaaaaaaaaaa")
         val refreshedTrack = track("bbbbbbbbbbb")


### PR DESCRIPTION
## Summary

Fixes the remaining Quick Picks underfill on Home.

After artwork/seed enrichment had produced any non-empty result, `buildQuickPicks` used only that partial enriched list. A partial result such as 9 tracks therefore replaced the full startup fallback pool instead of augmenting it, leaving Scelte rapide visibly incomplete.

## Fix

- Always append the full startup Quick Picks seed pool after enriched seeds.
- Keep enriched tracks first, so resolved artwork/content remains preferred.
- Preserve existing deduplication, Personal Orbit exclusion, artist exclusions, reliability filtering and artist balancing.
- Continue filling from the combined candidate pool until the existing 20-track limit is reached.

## Regression coverage

Added a focused test for the exact failure mode:

- partial enriched seed list: 9 tracks
- expected Quick Picks output: 20 tracks
- all 20 identities must be unique
- the 9 enriched entries remain first

## Scope

Android Home only. No visual redesign, playback, persistence, networking, versioning or recommendation scoring changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Quick Picks now combine explicitly provided picks with startup catalog recommendations, providing more available choices.
  - When fewer than 20 enriched picks are available, additional distinct recommendations are used to complete the Quick Picks list.

- **Bug Fixes**
  - Improved Quick Picks population when only a partial set of enriched recommendations is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->