### PR TITLE
Add light mode variants for hero README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,26 @@
 **A native music player, stream extractor, and private offline vault for Android & Windows.**
 
 <p align="center">
-  <a href="https://github.com/LUC4N3X/Levyra-deepsound/releases/latest"><img src="docs/assets/levyra-release.svg" alt="Latest release"></a>
-  <a href="https://github.com/LUC4N3X/Levyra-deepsound/releases"><img src="docs/assets/levyra-downloads.svg" alt="Total downloads"></a>
-  <a href="LICENSE"><img src="docs/assets/levyra-license.svg" alt="GPL-3.0 License"></a>
-  <a href="https://github.com/LUC4N3X/Levyra-deepsound/stargazers"><img src="docs/assets/levyra-stars.svg" alt="GitHub Stars"></a>
+  <a href="https://github.com/LUC4N3X/Levyra-deepsound/releases/latest"><picture>
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/levyra-release-light.svg">
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/levyra-release.svg">
+    <img src="docs/assets/levyra-release.svg" alt="Latest release">
+  </picture></a>
+  <a href="https://github.com/LUC4N3X/Levyra-deepsound/releases"><picture>
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/levyra-downloads-light.svg">
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/levyra-downloads.svg">
+    <img src="docs/assets/levyra-downloads.svg" alt="Total downloads">
+  </picture></a>
+  <a href="LICENSE"><picture>
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/levyra-license-light.svg">
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/levyra-license.svg">
+    <img src="docs/assets/levyra-license.svg" alt="GPL-3.0 License">
+  </picture></a>
+  <a href="https://github.com/LUC4N3X/Levyra-deepsound/stargazers"><picture>
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/levyra-stars-light.svg">
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/levyra-stars.svg">
+    <img src="docs/assets/levyra-stars.svg" alt="GitHub Stars">
+  </picture></a>
 </p>
 
 ### ✦ Download

--- a/docs/assets/levyra-downloads-light.svg
+++ b/docs/assets/levyra-downloads-light.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="174" height="40" viewBox="0 0 174 40" role="img" aria-label="Downloads: 3,302">
+<title>Downloads: 3,302</title>
+<defs>
+  <linearGradient id="downloads-bg-light" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#FFFFFF"/><stop offset=".58" stop-color="#F8FAFC"/><stop offset="1" stop-color="#F1F5F9"/></linearGradient>
+  <linearGradient id="downloads-accent-light" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#60A5FA"/><stop offset="1" stop-color="#22D3EE"/></linearGradient>
+</defs>
+<rect x=".5" y=".5" width="173" height="39" rx="12" fill="url(#downloads-bg-light)" stroke="#E2E8F0"/>
+<path d="M13 1h148" stroke="#0F172A" stroke-opacity=".05" stroke-linecap="round"/>
+<rect x="2" y="9" width="3" height="22" rx="1.5" fill="url(#downloads-accent-light)"/>
+<circle cx="22" cy="20" r="11" fill="#60A5FA" fill-opacity=".12" stroke="#60A5FA" stroke-opacity=".35"/>
+<g transform="translate(14 12)" fill="url(#downloads-accent-light)"><path d="M8 2.25a.75.75 0 0 1 .75.75v5.69l1.97-1.97a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.78a.75.75 0 0 1 1.06-1.06l1.97 1.97V3A.75.75 0 0 1 8 2.25Zm-4.75 10a.75.75 0 0 1 .75-.75h8a.75.75 0 0 1 0 1.5H4a.75.75 0 0 1-.75-.75Z"/></g>
+<text x="42" y="24.1" fill="#0F172A" font-family="Segoe UI,Inter,Arial,sans-serif" font-size="11.4" font-weight="800" letter-spacing=".12">Downloads</text>
+<rect x="127" y="6" width="40" height="28" rx="9" fill="url(#downloads-accent-light)"/>
+<rect x="127.5" y="6.5" width="39" height="27" rx="8.5" fill="none" stroke="#FFFFFF" stroke-opacity=".35"/>
+<text x="147" y="24.2" text-anchor="middle" fill="#07111A" font-family="Segoe UI,Inter,Arial,sans-serif" font-size="11" font-weight="900">3,302</text>
+</svg>

--- a/docs/assets/levyra-license-light.svg
+++ b/docs/assets/levyra-license-light.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="176" height="40" viewBox="0 0 176 40" role="img" aria-label="License: GPL-3.0">
+<title>License: GPL-3.0</title>
+<defs>
+  <linearGradient id="license-bg-light" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#FFFFFF"/><stop offset=".58" stop-color="#F8FAFC"/><stop offset="1" stop-color="#F1F5F9"/></linearGradient>
+  <linearGradient id="license-accent-light" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#34D399"/><stop offset="1" stop-color="#22C55E"/></linearGradient>
+</defs>
+<rect x=".5" y=".5" width="175" height="39" rx="12" fill="url(#license-bg-light)" stroke="#E2E8F0"/>
+<path d="M13 1h150" stroke="#0F172A" stroke-opacity=".05" stroke-linecap="round"/>
+<rect x="2" y="9" width="3" height="22" rx="1.5" fill="url(#license-accent-light)"/>
+<circle cx="22" cy="20" r="11" fill="#34D399" fill-opacity=".12" stroke="#34D399" stroke-opacity=".35"/>
+<g transform="translate(14 12)" fill="url(#license-accent-light)"><path d="M8 1.25 2.5 3.2v4.16c0 3.42 2.29 6.55 5.5 7.39 3.21-.84 5.5-3.97 5.5-7.39V3.2L8 1.25Zm0 1.59 4 1.42v3.1c0 2.6-1.64 5.05-4 5.82-2.36-.77-4-3.22-4-5.82v-3.1l4-1.42Z"/></g>
+<text x="42" y="24.1" fill="#0F172A" font-family="Segoe UI,Inter,Arial,sans-serif" font-size="11.4" font-weight="800" letter-spacing=".12">License</text>
+<rect x="104" y="6" width="65" height="28" rx="9" fill="url(#license-accent-light)"/>
+<rect x="104.5" y="6.5" width="64" height="27" rx="8.5" fill="none" stroke="#FFFFFF" stroke-opacity=".35"/>
+<text x="136.5" y="24.2" text-anchor="middle" fill="#07130B" font-family="Segoe UI,Inter,Arial,sans-serif" font-size="11" font-weight="900">GPL-3.0</text>
+</svg>

--- a/docs/assets/levyra-release-light.svg
+++ b/docs/assets/levyra-release-light.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="172" height="40" viewBox="0 0 172 40" role="img" aria-label="Latest: v2.5.6">
+<title>Latest: v2.5.6</title>
+<defs>
+  <linearGradient id="latest-bg-light" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#FFFFFF"/><stop offset=".58" stop-color="#F8FAFC"/><stop offset="1" stop-color="#F1F5F9"/></linearGradient>
+  <linearGradient id="latest-accent-light" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#A78BFA"/><stop offset="1" stop-color="#7C3AED"/></linearGradient>
+</defs>
+<rect x=".5" y=".5" width="171" height="39" rx="12" fill="url(#latest-bg-light)" stroke="#E2E8F0"/>
+<path d="M13 1h146" stroke="#0F172A" stroke-opacity=".05" stroke-linecap="round"/>
+<rect x="2" y="9" width="3" height="22" rx="1.5" fill="url(#latest-accent-light)"/>
+<circle cx="22" cy="20" r="11" fill="#A78BFA" fill-opacity=".12" stroke="#A78BFA" stroke-opacity=".35"/>
+<g transform="translate(14 12)" fill="url(#latest-accent-light)"><path d="M7.73 2.5a1.5 1.5 0 0 0-1.06.44L2.44 7.17a1.5 1.5 0 0 0 0 2.12l4.27 4.27a1.5 1.5 0 0 0 2.12 0l4.23-4.23a1.5 1.5 0 0 0 .44-1.06V4A1.5 1.5 0 0 0 12 2.5H7.73Zm0 1.5H12v4.27L7.77 12.5 3.5 8.23 7.73 4ZM9 7a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"/></g>
+<text x="42" y="24.1" fill="#0F172A" font-family="Segoe UI,Inter,Arial,sans-serif" font-size="11.4" font-weight="800" letter-spacing=".12">Latest</text>
+<rect x="103" y="6" width="62" height="28" rx="9" fill="url(#latest-accent-light)"/>
+<rect x="103.5" y="6.5" width="61" height="27" rx="8.5" fill="none" stroke="#FFFFFF" stroke-opacity=".35"/>
+<text x="134" y="24.2" text-anchor="middle" fill="#FFFFFF" font-family="Segoe UI,Inter,Arial,sans-serif" font-size="11" font-weight="900">v2.5.6</text>
+</svg>

--- a/docs/assets/levyra-stars-light.svg
+++ b/docs/assets/levyra-stars-light.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="142" height="40" viewBox="0 0 142 40" role="img" aria-label="Stars: 119">
+<title>Stars: 119</title>
+<defs>
+  <linearGradient id="stars-bg-light" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#FFFFFF"/><stop offset=".58" stop-color="#F8FAFC"/><stop offset="1" stop-color="#F1F5F9"/></linearGradient>
+  <linearGradient id="stars-accent-light" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#FBBF24"/><stop offset="1" stop-color="#F59E0B"/></linearGradient>
+</defs>
+<rect x=".5" y=".5" width="141" height="39" rx="12" fill="url(#stars-bg-light)" stroke="#E2E8F0"/>
+<path d="M13 1h116" stroke="#0F172A" stroke-opacity=".05" stroke-linecap="round"/>
+<rect x="2" y="9" width="3" height="22" rx="1.5" fill="url(#stars-accent-light)"/>
+<circle cx="22" cy="20" r="11" fill="#FBBF24" fill-opacity=".12" stroke="#FBBF24" stroke-opacity=".35"/>
+<g transform="translate(14 12)" fill="url(#stars-accent-light)"><path d="M8 .75a.75.75 0 0 1 .673.418L10.52 4.9l4.12.599a.75.75 0 0 1 .416 1.279l-2.98 2.905.704 4.103a.75.75 0 0 1-1.088.79L8 12.61l-3.694 1.943a.75.75 0 0 1-1.088-.79l.704-4.103-2.98-2.905a.75.75 0 0 1 .416-1.279l4.12-.599L7.327 1.168A.75.75 0 0 1 8 .75Z"/></g>
+<text x="42" y="24.1" fill="#0F172A" font-family="Segoe UI,Inter,Arial,sans-serif" font-size="11.4" font-weight="800" letter-spacing=".12">Stars</text>
+<rect x="105" y="6" width="30" height="28" rx="9" fill="url(#stars-accent-light)"/>
+<rect x="105.5" y="6.5" width="29" height="27" rx="8.5" fill="none" stroke="#FFFFFF" stroke-opacity=".35"/>
+<text x="120" y="24.2" text-anchor="middle" fill="#15110A" font-family="Segoe UI,Inter,Arial,sans-serif" font-size="11" font-weight="900">119</text>
+</svg>


### PR DESCRIPTION
## Summary

The four hero badges in the README (Latest release, Downloads, License, Stars) use custom SVGs with a fixed dark navy background. They look great when GitHub renders the README in dark mode, but clash with a plain dark chip when the viewer uses GitHub's light theme. This PR adds light-mode counterparts for the four badges and switches the README to `<picture>` with `prefers-color-scheme` so each badge now follows the viewer's theme automatically.

## What changed

- Added `docs/assets/levyra-release-light.svg`, `levyra-downloads-light.svg`, `levyra-license-light.svg`, `levyra-stars-light.svg` — same layout and accent colors as the existing badges, recolored with a light background/border and dark label text for readability on GitHub's light theme.
- Wrapped the four hero badges in `README.md` with `<picture>` elements (`prefers-color-scheme: light` / `dark` sources), keeping the original dark SVGs as fallback `<img>`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor or maintenance
- [x] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [x] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Shared infrastructure
- **Area:** Documentation / UI (README assets)

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [ ] Targeted tests were added or updated
- [x] Not applicable, with the reason explained below

This change only touches README markup and static SVG assets, so the Android/Desktop Gradle suites do not exercise it. Ran `python3 scripts/ai_quality_gate.py --profile fast`, which passed (agent config, AI efficiency, Matt skills, claude-mem, F-Droid review contract validations, and 157 repository script tests).

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Local (cairosvg render) | Rendered all 4 light badges on a white background and the 4 original dark badges on a dark background side by side | Text/icons legible with good contrast in both variants; layout and accent colors match between light/dark pairs |

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** None — purely additive assets plus a markup change in `README.md`; no app code touched.
- **Known limitations:** GitHub Mobile and some third-party README renderers may not honor `prefers-color-scheme` inside `<picture>`; in that case the existing dark badge is shown as before (no regression).
- **Rollback plan:** Revert this PR.

## Reviewer notes

- New SVGs mirror the structure of the existing dark badges (`docs/assets/levyra-release.svg`, `-downloads.svg`, `-license.svg`, `-stars.svg`) with background/border/label-text swapped for light backgrounds; accent gradients and value-pill colors are unchanged for brand consistency.
- Other unrelated badge SVGs in `docs/assets/` (`levyra-all-releases-badge.svg`, `levyra-latest-release-badge.svg`, `levyra-android-platform.svg`, `levyra-windows-platform.svg`) are not referenced anywhere in `README.md`, so they were left untouched as out of scope.

## Release note

Badges in the README now adapt to GitHub's light theme instead of always showing a dark chip.

## Related issues

- Closes #
- Related to #

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README badges to display light or dark variants based on the user’s color-scheme preference.
  - Added dark-theme fallback support for improved badge visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->