### PR TITLE
Add light mode variants for Download section badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,40 @@
 ### ✦ Download
 
 <p align="center">
-  <a href="https://github.com/LUC4N3X/Levyra-deepsound/releases/latest"><img src="docs/assets/levyra-github-download.svg" alt="Download APK" width="365" /></a>&nbsp;&nbsp;
-  <a href="https://f-droid.org/packages/com.luc4n3x.levyra/"><img src="docs/assets/levyra-fdroid.svg" alt="Get Levyra on F-Droid" width="365" /></a>
+  <a href="https://github.com/LUC4N3X/Levyra-deepsound/releases/latest"><picture>
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/levyra-github-download-light.svg">
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/levyra-github-download.svg">
+    <img src="docs/assets/levyra-github-download.svg" alt="Download APK" width="365">
+  </picture></a>&nbsp;&nbsp;
+  <a href="https://f-droid.org/packages/com.luc4n3x.levyra/"><picture>
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/levyra-fdroid-light.svg">
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/levyra-fdroid.svg">
+    <img src="docs/assets/levyra-fdroid.svg" alt="Get Levyra on F-Droid" width="365">
+  </picture></a>
 </p>
 <p align="center">
-  <a href="https://apps.obtainium.imranr.dev/redirect.html?r=obtainium://add/https://github.com/LUC4N3X/Levyra-deepsound"><img src="docs/assets/levyra-obtainium-download.svg" alt="Install via Obtainium" width="365" /></a>&nbsp;&nbsp;
-  <a href="https://apt.izzysoft.de/fdroid/index/apk/com.luc4n3x.levyra?repo=main"><img src="docs/assets/levyra-izzyondroid.svg" alt="Get Levyra on IzzyOnDroid" width="365" /></a>
+  <a href="https://apps.obtainium.imranr.dev/redirect.html?r=obtainium://add/https://github.com/LUC4N3X/Levyra-deepsound"><picture>
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/levyra-obtainium-download-light.svg">
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/levyra-obtainium-download.svg">
+    <img src="docs/assets/levyra-obtainium-download.svg" alt="Install via Obtainium" width="365">
+  </picture></a>&nbsp;&nbsp;
+  <a href="https://apt.izzysoft.de/fdroid/index/apk/com.luc4n3x.levyra?repo=main"><picture>
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/levyra-izzyondroid-light.svg">
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/levyra-izzyondroid.svg">
+    <img src="docs/assets/levyra-izzyondroid.svg" alt="Get Levyra on IzzyOnDroid" width="365">
+  </picture></a>
 </p>
 <p align="center">
-  <a href="https://appteka.store/apps/b5br313609"><img src="docs/assets/levyra-appteka.svg" alt="Get Levyra on Appteka" width="365" /></a>&nbsp;&nbsp;
-  <a href="https://github.com/LUC4N3X/Levyra-deepsound/releases?q=Levyra+Desktop&expanded=true"><img src="docs/assets/levyra-windows-download.svg" alt="Download Windows Desktop" width="365" /></a>
+  <a href="https://appteka.store/apps/b5br313609"><picture>
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/levyra-appteka-light.svg">
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/levyra-appteka.svg">
+    <img src="docs/assets/levyra-appteka.svg" alt="Get Levyra on Appteka" width="365">
+  </picture></a>&nbsp;&nbsp;
+  <a href="https://github.com/LUC4N3X/Levyra-deepsound/releases?q=Levyra+Desktop&expanded=true"><picture>
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/levyra-windows-download-light.svg">
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/levyra-windows-download.svg">
+    <img src="docs/assets/levyra-windows-download.svg" alt="Download Windows Desktop" width="365">
+  </picture></a>
 </p>
 
 <p align="center">

--- a/docs/assets/levyra-appteka-light.svg
+++ b/docs/assets/levyra-appteka-light.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="154" viewBox="0 0 760 154" role="img" aria-label="Get Levyra on Appteka">
+  <title>Get Levyra on Appteka</title>
+  <defs>
+    <linearGradient id="ap-bg-light" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="60%" stop-color="#F8FAFC"/>
+      <stop offset="100%" stop-color="#F1F5F9"/>
+    </linearGradient>
+    <linearGradient id="ap-border-light" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#CBD5E1" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#E2E8F0" stop-opacity="0.6"/>
+    </linearGradient>
+    <linearGradient id="ap-accent-light" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#43B51C"/>
+      <stop offset="52%" stop-color="#2F9B04"/>
+      <stop offset="100%" stop-color="#14B8A6"/>
+    </linearGradient>
+    <linearGradient id="ap-btn-grad-light" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#43B51C"/>
+      <stop offset="45%" stop-color="#159E7A"/>
+      <stop offset="100%" stop-color="#06B6D4"/>
+    </linearGradient>
+    <radialGradient id="ap-glow-light" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#43B51C" stop-opacity="0.32"/>
+      <stop offset="62%" stop-color="#14B8A6" stop-opacity="0.11"/>
+      <stop offset="100%" stop-color="#14B8A6" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Base Card -->
+  <rect x="6" y="6" width="748" height="142" rx="22" fill="url(#ap-bg-light)" stroke="url(#ap-border-light)" stroke-width="1.5"/>
+  <path d="M28 7h704" stroke="#0F172A" stroke-opacity="0.05" stroke-linecap="round"/>
+
+  <!-- Left Accent Pillar -->
+  <rect x="18" y="24" width="4" height="106" rx="2" fill="url(#ap-accent-light)"/>
+
+  <!-- Left Icon Container (kept dark so official launcher art stays legible) -->
+  <rect x="36" y="27" width="100" height="100" rx="22" fill="#131927" stroke="#253046" stroke-width="1.5"/>
+  <circle cx="86" cy="77" r="43" fill="url(#ap-glow-light)"/>
+
+  <!-- Official Appteka launcher artwork from solkin/appteka-android -->
+  <g transform="translate(50 41) scale(0.6666667)">
+    <rect width="108" height="108" rx="24" fill="#2F9B04"/>
+    <g transform="translate(33.48 33.48) scale(0.14657143)">
+      <path fill="#F2FFED" d="M25.768,129.575L129.575,25.768C164.08,-8.589 219.727,-8.589 254.232,25.768C288.589,60.126 288.589,115.92 254.232,150.425L150.425,254.232C115.92,288.589 60.126,288.589 25.768,254.232C-8.589,219.727 -8.589,164.08 25.768,129.575ZM46.618,150.425C31.201,165.695 26.062,187.572 31.348,207.1L119.297,119.297L181.552,181.552L233.382,129.575C256.434,106.67 256.434,69.523 233.382,46.618C210.477,23.566 173.33,23.566 150.425,46.618L46.618,150.425Z"/>
+    </g>
+  </g>
+
+  <!-- Eyebrow Tag -->
+  <g transform="translate(156 30)">
+    <rect width="221" height="22" rx="6" fill="#15803D" fill-opacity="0.1" stroke="#0F766E" stroke-opacity="0.3"/>
+    <circle cx="10" cy="11" r="3" fill="#15803D"/>
+    <text x="20" y="15" fill="#0F766E" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="10.5" font-weight="800" letter-spacing="1.08">APPTEKA · ANDROID APP CATALOG</text>
+  </g>
+
+  <!-- Title -->
+  <text x="156" y="80" fill="#0F172A" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="27" font-weight="800" letter-spacing="-0.3">Get Levyra on Appteka</text>
+
+  <!-- Subtitle / Meta -->
+  <text x="156" y="106" fill="#475569" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="14" font-weight="600">Open source · Direct APK · Alternative Android catalog</text>
+
+  <!-- Musical Equalizer Spectrum -->
+  <g transform="translate(156 118)" fill="#0F766E" fill-opacity="0.5">
+    <rect x="0" y="7" width="4" height="9" rx="2"/>
+    <rect x="8" y="2" width="4" height="14" rx="2"/>
+    <rect x="16" y="5" width="4" height="11" rx="2"/>
+    <rect x="24" y="0" width="4" height="16" rx="2"/>
+    <rect x="32" y="6" width="4" height="10" rx="2"/>
+    <rect x="40" y="3" width="4" height="13" rx="2"/>
+    <rect x="48" y="8" width="4" height="8" rx="2"/>
+  </g>
+
+  <!-- Right CTA Button -->
+  <g transform="translate(548 50)">
+    <rect width="176" height="54" rx="16" fill="url(#ap-btn-grad-light)"/>
+    <rect width="176" height="54" rx="16" fill="none" stroke="#FFFFFF" stroke-opacity="0.28"/>
+    <text x="68" y="34" text-anchor="middle" fill="#F8FAFC" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="14.5" font-weight="900" letter-spacing="0.15">Open listing</text>
+    <path d="M146 27h-16M140 21l6 6-6 6" fill="none" stroke="#F8FAFC" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/docs/assets/levyra-fdroid-light.svg
+++ b/docs/assets/levyra-fdroid-light.svg
@@ -1,0 +1,122 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="154" viewBox="0 0 760 154" role="img" aria-label="Get Levyra on F-Droid">
+  <title>Get Levyra on F-Droid</title>
+  <defs>
+    <linearGradient id="fd-bg-light" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="60%" stop-color="#F8FAFC"/>
+      <stop offset="100%" stop-color="#F1F5F9"/>
+    </linearGradient>
+    <linearGradient id="fd-border-light" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#CBD5E1" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#E2E8F0" stop-opacity="0.6"/>
+    </linearGradient>
+    <linearGradient id="fd-accent-light" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#AEEA00"/>
+      <stop offset="45%" stop-color="#29B6F6"/>
+      <stop offset="100%" stop-color="#1976D2"/>
+    </linearGradient>
+    <linearGradient id="fd-btn-grad-light" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1976D2"/>
+      <stop offset="100%" stop-color="#0D47A1"/>
+    </linearGradient>
+    <radialGradient id="fd-glow-light" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#1976D2" stop-opacity="0.52"/>
+      <stop offset="62%" stop-color="#0288D1" stop-opacity="0.17"/>
+      <stop offset="100%" stop-color="#1976D2" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Base Card -->
+  <rect x="6" y="6" width="748" height="142" rx="22" fill="url(#fd-bg-light)" stroke="url(#fd-border-light)" stroke-width="1.5"/>
+  <path d="M28 7h704" stroke="#0F172A" stroke-opacity="0.05" stroke-linecap="round"/>
+
+  <!-- Left Accent Pillar -->
+  <rect x="18" y="24" width="4" height="106" rx="2" fill="url(#fd-accent-light)"/>
+
+  <!-- Left Icon Container (kept dark so official mascot colors stay legible) -->
+  <rect x="36" y="27" width="100" height="100" rx="22" fill="#131927" stroke="#253046" stroke-width="1.5"/>
+  <circle cx="86" cy="77" r="44" fill="url(#fd-glow-light)"/>
+
+  <!-- Official F-Droid mascot geometry from f-droid/artwork -->
+  <g transform="translate(86 77) scale(1.36) translate(-24 -24)">
+    <g transform="translate(0 -1004.3622)">
+      <!-- Antennas -->
+      <g transform="matrix(-1 0 0 1 47.999779 0)">
+        <path fill="#8AB000" stroke="#769616" stroke-width="2.5" stroke-linecap="round" d="m2.5889342 1006.8622 4.25 5.5"/>
+        <path fill="#FFFFFF" fill-opacity="0.3" d="m2.6113281 1005.6094c-.4534623.012-.7616975.189-.9807462.4486 2.0269314 2.4089 2.368401 2.7916 5.1354735 6.2214 1.0195329 1.319 2.0816026.6373 1.0620696-.6817l-4.25-5.5c-.2289894-.3056-.5850813-.478-.9667969-.4883z"/>
+        <path fill="#263238" fill-opacity="0.2" d="m1.6220992 1006.0705c-.1238933.1479-.561176.8046-.02249 1.5562l4.25 5.5c1.0195329 1.319 1.1498748-.6123 1.1498748-.6123s-3.7344514-4.51-5.3773848-6.4439z"/>
+        <path fill="#8AB000" d="m2.3378905 1005.8443c-.438175 0-.959862.1416-.8242183.7986.103561.5016 4.6608262 6.0744 4.6608262 6.0744 1.0195329 1.319 2.4934721.6763 1.4739391-.6425l-4.234375-5.4727c-.2602394-.29-.6085188-.7436-1.076172-.7578z"/>
+      </g>
+      <g>
+        <path fill="#8AB000" stroke="#769616" stroke-width="2.5" stroke-linecap="round" d="m2.5889342 1006.8622 4.25 5.5"/>
+        <path fill="#FFFFFF" fill-opacity="0.3" d="m2.6113281 1005.6094c-.4534623.012-.7616975.189-.9807462.4486 2.0269314 2.4089 2.368401 2.7916 5.1354735 6.2214 1.0195329 1.319 2.0816026.6373 1.0620696-.6817l-4.25-5.5c-.2289894-.3056-.5850813-.478-.9667969-.4883z"/>
+        <path fill="#263238" fill-opacity="0.2" d="m1.6220992 1006.0705c-.1238933.1479-.561176.8046-.02249 1.5562l4.25 5.5c1.0195329 1.319 1.1498748-.6123 1.1498748-.6123s-3.7344514-4.51-5.3773848-6.4439z"/>
+        <path fill="#8AB000" d="m2.3378905 1005.8443c-.438175 0-.959862.1416-.8242183.7986.103561.5016 4.6608262 6.0744 4.6608262 6.0744 1.0195329 1.319 2.4934721.6763 1.4739391-.6425l-4.234375-5.4727c-.2602394-.29-.6085188-.7436-1.076172-.7578z"/>
+      </g>
+
+      <!-- Head -->
+      <g transform="translate(42 0)">
+        <rect fill="#AEEA00" width="38" height="13" x="-37" y="1010.3622" rx="3" ry="3"/>
+        <rect fill="#263238" fill-opacity="0.2" width="38" height="10" x="-37" y="1013.3622" rx="3" ry="3"/>
+        <rect fill="#FFFFFF" fill-opacity="0.3" width="38" height="10" x="-37" y="1010.3622" rx="3" ry="3"/>
+        <rect fill="#AEEA00" width="38" height="11" x="-37" y="1011.3622" rx="3" ry="2.54"/>
+      </g>
+
+      <!-- Body -->
+      <g>
+        <rect fill="#1976D2" width="38" height="26" x="5" y="1024.3622" rx="3" ry="3"/>
+        <rect fill="#263238" fill-opacity="0.2" width="38" height="13" x="5" y="1037.3622" rx="3" ry="3"/>
+        <rect fill="#FFFFFF" fill-opacity="0.2" width="38" height="13" x="5" y="1024.3622" rx="3" ry="3"/>
+        <rect fill="#1976D2" width="38" height="24" x="5" y="1025.3622" rx="3" ry="2.77"/>
+      </g>
+
+      <!-- Inner loop -->
+      <g transform="translate(0 1013.3622)">
+        <path fill="#0D47A1" d="m24 17.75c-2.880662 0-5.319789 1.984685-6.033203 4.650391h3.212891C21.734004 21.415044 22.774798 20.75 24 20.75c1.812692 0 3.25 1.437308 3.25 3.25S25.812692 27.25 24 27.25c-1.307381 0-2.411251-.75269-2.929688-1.849609h-3.154296C18.558263 28.166146 21.04791 30.25 24 30.25c3.434013 0 6.25-2.815987 6.25-6.25S27.434013 17.75 24 17.75z"/>
+        <circle fill="none" stroke="#0D47A1" stroke-width="1.9" cx="24" cy="24" r="9.55"/>
+      </g>
+
+      <!-- Eyes -->
+      <g transform="translate(0 .5)">
+        <ellipse fill="#263238" fill-opacity="0.2" cx="14.375" cy="1016.4872" rx="3.375" ry="3.875"/>
+        <circle fill="#FFFFFF" cx="14.375" cy="1016.9872" r="3.375"/>
+      </g>
+      <g transform="translate(19.5 .5)">
+        <ellipse fill="#263238" fill-opacity="0.2" cx="14.375" cy="1016.4872" rx="3.375" ry="3.875"/>
+        <circle fill="#FFFFFF" cx="14.375" cy="1016.9872" r="3.375"/>
+      </g>
+    </g>
+  </g>
+
+  <!-- Eyebrow Tag -->
+  <g transform="translate(156 30)">
+    <rect width="222" height="22" rx="6" fill="#1976D2" fill-opacity="0.12" stroke="#1D4ED8" stroke-opacity="0.3"/>
+    <circle cx="10" cy="11" r="3" fill="#65A30D"/>
+    <text x="20" y="15" fill="#1D4ED8" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="10.5" font-weight="800" letter-spacing="1.15">F-DROID · OPEN SOURCE REPOSITORY</text>
+  </g>
+
+  <!-- Title -->
+  <text x="156" y="80" fill="#0F172A" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="27" font-weight="800" letter-spacing="-0.3">Get Levyra on F-Droid</text>
+
+  <!-- Subtitle / Meta -->
+  <text x="156" y="106" fill="#475569" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="14" font-weight="600">FOSS repository · Reproducible build · Automatic updates</text>
+
+  <!-- Musical Equalizer Spectrum -->
+  <g transform="translate(156 118)" fill="#1976D2" fill-opacity="0.5">
+    <rect x="0" y="7" width="4" height="9" rx="2"/>
+    <rect x="8" y="2" width="4" height="14" rx="2"/>
+    <rect x="16" y="5" width="4" height="11" rx="2"/>
+    <rect x="24" y="0" width="4" height="16" rx="2"/>
+    <rect x="32" y="6" width="4" height="10" rx="2"/>
+    <rect x="40" y="3" width="4" height="13" rx="2"/>
+    <rect x="48" y="9" width="4" height="7" rx="2"/>
+  </g>
+
+  <!-- Right CTA Button -->
+  <g transform="translate(548 50)">
+    <rect width="176" height="54" rx="16" fill="url(#fd-btn-grad-light)"/>
+    <rect width="176" height="54" rx="16" fill="none" stroke="#FFFFFF" stroke-opacity="0.28"/>
+    <text x="58" y="34" text-anchor="middle" fill="#FFFFFF" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="14.5" font-weight="800" letter-spacing="0.2">Open F-Droid</text>
+    <path d="M142 27h-16M136 21l6 6-6 6" fill="none" stroke="#FFFFFF" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/docs/assets/levyra-github-download-light.svg
+++ b/docs/assets/levyra-github-download-light.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="154" viewBox="0 0 760 154" role="img" aria-label="Download Levyra from GitHub Releases">
+  <title>Download Levyra from GitHub Releases</title>
+  <defs>
+    <linearGradient id="gh-bg-light" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="60%" stop-color="#F8FAFC"/>
+      <stop offset="100%" stop-color="#F1F5F9"/>
+    </linearGradient>
+    <linearGradient id="gh-border-light" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#CBD5E1" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#E2E8F0" stop-opacity="0.6"/>
+    </linearGradient>
+    <linearGradient id="gh-accent-light" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#8B5CF6"/>
+      <stop offset="100%" stop-color="#6366F1"/>
+    </linearGradient>
+    <radialGradient id="gh-glow-light" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#8B5CF6" stop-opacity="0.4"/>
+      <stop offset="100%" stop-color="#8B5CF6" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Base Card -->
+  <rect x="6" y="6" width="748" height="142" rx="22" fill="url(#gh-bg-light)" stroke="url(#gh-border-light)" stroke-width="1.5"/>
+  <path d="M28 7h704" stroke="#0F172A" stroke-opacity="0.05" stroke-linecap="round"/>
+
+  <!-- Left Accent Pillar -->
+  <rect x="18" y="24" width="4" height="106" rx="2" fill="url(#gh-accent-light)"/>
+
+  <!-- Left Icon Container (kept dark so official logo colors stay legible) -->
+  <rect x="36" y="27" width="100" height="100" rx="22" fill="#131927" stroke="#253046" stroke-width="1.5"/>
+  <circle cx="86" cy="77" r="42" fill="url(#gh-glow-light)"/>
+
+  <!-- Official GitHub Mark from Primer Octicons -->
+  <g transform="translate(53 44) scale(2.75)">
+    <path fill="#F8FAFC" d="M10.226 17.284c-2.965-.36-5.054-2.493-5.054-5.256 0-1.123.404-2.336 1.078-3.144-.292-.741-.247-2.314.09-2.965.898-.112 2.111.36 2.83 1.01.853-.269 1.752-.404 2.853-.404 1.1 0 1.999.135 2.807.382.696-.629 1.932-1.1 2.83-.988.315.606.36 2.179.067 2.942.72.854 1.101 2 1.101 3.167 0 2.763-2.089 4.852-5.098 5.234.763.494 1.28 1.572 1.28 2.807v2.336c0 .674.561 1.056 1.235.786 4.066-1.55 7.255-5.615 7.255-10.646C23.5 6.188 18.334 1 11.978 1 5.62 1 .5 6.188.5 12.545c0 4.986 3.167 9.12 7.435 10.669.606.225 1.19-.18 1.19-.786V20.63a2.9 2.9 0 0 1-1.078.224c-1.483 0-2.359-.808-2.987-2.313-.247-.607-.517-.966-1.034-1.033-.27-.023-.359-.135-.359-.27 0-.27.45-.471.898-.471.652 0 1.213.404 1.797 1.235.45.651.921.943 1.483.943.561 0 .92-.202 1.437-.719.382-.381.674-.718.944-.943"/>
+  </g>
+
+  <!-- Eyebrow Tag -->
+  <g transform="translate(156 30)">
+    <rect width="186" height="22" rx="6" fill="#8B5CF6" fill-opacity="0.12" stroke="#8B5CF6" stroke-opacity="0.3"/>
+    <circle cx="10" cy="11" r="3" fill="#7C3AED"/>
+    <text x="20" y="15" fill="#6D28D9" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="10.5" font-weight="800" letter-spacing="1.2">OFFICIAL GITHUB RELEASE</text>
+  </g>
+
+  <!-- Title -->
+  <text x="156" y="80" fill="#0F172A" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="27" font-weight="800" letter-spacing="-0.3">Download Levyra</text>
+
+  <!-- Subtitle / Meta -->
+  <text x="156" y="106" fill="#475569" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="14" font-weight="600">Signed APK · Android 8.0+ · No Play Store</text>
+
+  <!-- Musical Equalizer Spectrum -->
+  <g transform="translate(156 118)" fill="#8B5CF6" fill-opacity="0.55">
+    <rect x="0" y="8" width="4" height="8" rx="2"/>
+    <rect x="8" y="2" width="4" height="14" rx="2"/>
+    <rect x="16" y="5" width="4" height="11" rx="2"/>
+    <rect x="24" y="0" width="4" height="16" rx="2"/>
+    <rect x="32" y="6" width="4" height="10" rx="2"/>
+    <rect x="40" y="3" width="4" height="13" rx="2"/>
+    <rect x="48" y="9" width="4" height="7" rx="2"/>
+  </g>
+
+  <!-- Right CTA Button (Spacious, No Overlap) -->
+  <g transform="translate(572 50)">
+    <rect width="152" height="54" rx="16" fill="url(#gh-accent-light)"/>
+    <rect width="152" height="54" rx="16" fill="none" stroke="#FFFFFF" stroke-opacity="0.3"/>
+    <text x="56" y="34" text-anchor="middle" fill="#FFFFFF" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="15.5" font-weight="800" letter-spacing="0.2">Get APK</text>
+    <path d="M112 27h-16M106 21l6 6-6 6" fill="none" stroke="#FFFFFF" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/docs/assets/levyra-izzyondroid-light.svg
+++ b/docs/assets/levyra-izzyondroid-light.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="154" viewBox="0 0 760 154" role="img" aria-label="Get Levyra on IzzyOnDroid">
+  <title>Get Levyra on IzzyOnDroid</title>
+  <defs>
+    <linearGradient id="iz-bg-light" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="60%" stop-color="#F8FAFC"/>
+      <stop offset="100%" stop-color="#F1F5F9"/>
+    </linearGradient>
+    <linearGradient id="iz-border-light" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#CBD5E1" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#E2E8F0" stop-opacity="0.6"/>
+    </linearGradient>
+    <linearGradient id="iz-accent-light" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#00D2FF"/>
+      <stop offset="55%" stop-color="#22D3EE"/>
+      <stop offset="100%" stop-color="#65E572"/>
+    </linearGradient>
+    <radialGradient id="iz-glow-light" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#00D2FF" stop-opacity="0.42"/>
+      <stop offset="65%" stop-color="#22D3EE" stop-opacity="0.13"/>
+      <stop offset="100%" stop-color="#00D2FF" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect x="6" y="6" width="748" height="142" rx="22" fill="url(#iz-bg-light)" stroke="url(#iz-border-light)" stroke-width="1.5"/>
+  <path d="M28 7h704" stroke="#0F172A" stroke-opacity="0.05" stroke-linecap="round"/>
+
+  <rect x="18" y="24" width="4" height="106" rx="2" fill="url(#iz-accent-light)"/>
+
+  <!-- Icon container kept dark so the official logo art stays legible -->
+  <rect x="36" y="27" width="100" height="100" rx="22" fill="#131927" stroke="#253046" stroke-width="1.5"/>
+  <circle cx="86" cy="77" r="43" fill="url(#iz-glow-light)"/>
+
+  <!-- Official IzzyOnDroid logo asset published by IzzyOnDroid -->
+  <image x="54" y="45" width="64" height="64" preserveAspectRatio="xMidYMid meet" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAMAAABg3Am1AAADAFBMVEUA0////wAA0v8A0v8A0////wD//wAFz/QA0/8A0/8A0/8A0/8A0v///wAA0/8A0/8A0/8A0/8A0//8/gEA0/8A0/8B0/4A0/8A0/8A0/+j5QGAwwIA0//C9yEA0/8A0/8A0/8A0/8A0/8A0/+n4SAA0/8A0/8A0/+o6gCw3lKt7QCv5SC+422b3wC19AC36zAA0/+d1yMA0/8A0/+W2gEA0/+w8ACz8gCKzgG7+QC+9CFLfwkA0/8A0////wAA0/8A0/8A0/8A0/+f2xym3iuHxCGq5BoA1P+m2joI0vONyiCz3mLO7oYA0/8M1Piq3Ei78CbB8EPe8LLj9Ly751G77zWQ1AC96UYC0fi37CL//wAA0/8A0////wD//wCp3jcA0/+j3SGj2i/I72Sx4zHE8FLB8zak1kYeycDI6nRl3qEA0/7V7psA0v6WzTa95mGi2RvB5XkPy9zH5YJ3uwGV1yxVihRLiwdxtQ1ZkAf//wD//wD//wD//wD//wCn5gf//wD//wD//wD//wD//wAA0/+h4A3R6p8A0/+X1w565OD6/ARg237n9csz2vPz+gNt37V/vifO8HW68B/L6ZOCwxXY8KRQsWRzhExAtG/E612a1Rd/pTBpmR9qjysduKVhmxF9mTY51aUozK+CsDSA52T//wD//wAA0////wD//wBJ1JRRxFWjzlxDyXRc0pGT1wCG0CWB3VGUzSTh8h6c0TSr5CCJ5FFxvl6s4H3m8xML0/DA5CvK51EX1N+Y2gSt4Dag3ChE3fax2ki68yO57NF10FRZnUPl88eJxhuCxgCz5EOLwEGf1DFutmahzGW98x0W1PGk3R154MHE6bOn69qv3gy92oG90o+Hn07B7rhCmiyMwECv1nO+0pQfwrCo57xF2daXsVhKrEdenQAduaee1Bsjr42z5D9RoCXy+QNovXpy2Z5MtWDO/TiSukaF3UtE1K6j3B4YwLc5wXlzpyIK0u5zy3uJqg4pu5RTpkZmpVKyAP8A0wBHcExHcEyBUSeEAAABAHRSTlP///9F9wjAAxD7FCEGzBjd08QyEL39abMd6///8P/ZWAnipIv/cC6B//7////////L/1Dz/0D///////86/vYnquY3/v///5T//v///17///////////////84S3QNB/8L/////////////7r/////NP////9l/////wPD4yis/x7Ym2lWSP+em////0n////////v///////////////////7//7pdGN3Urr6/+v/6aT////+//H/o2P/1v+7r7jp4PM/3p4g////g///K///481LxO///v////9w////8v/////9/p3J///a+P9v/5KR/+n///+p/xf//8P//wAAe7FyaAAABCZJREFUSMdj+E8iYKBUgwIHnwQ3N7cEHxcH+///VayoAE0Dh41qR7aBnCIQ8MsJKHH9/99czYYMWlA0cIkJGjMgAKfq//9RNYzIgLcBWYOTiCgDMhDn+B9bh6LebiWyH6L5UZQzONoAHWSHoqEpDkkDsyKqelv1//9rG1HUN9YihZK9AKp6BkG+/6xNqA5ajhSsCkrIipmYGGRa//9vQXVQXSySBnkWJOUMfn5Myuz/G3hR1NdEIUUchwiy+bkTsg4dbW/fu6W/e1c3XMMy5JiOZkFxUFZo74mgKTqaKXu0+2HqVwkja3BH9kFu361JwcHTfPJD4mdfe8ULAdVRyGlJAcVFfg+CQOozZ4XrJ85+JgwBsVXIGriQw5Tp4ZScezd8JiWnBupru30qwJZa+ZAjmWlC8fUZM4qB6kPnLNSPLMWqQQ5ZQ5aOzs1HmamBaQHzFs6y+qAmJCTE8f9/QgKSBg4DJPWc6zVDQkIC09JkZSPD38kukpExFpT4z67uYI/QwCOOCCK/izvu5CWl6AcEWMnKWml7LWbKZfH9/99UkknQHhGsynDz+65eWXv3/JmJrq5eXienVlRUfH/z8VvCf45soKQIH1yDEQsszrp6gwq9C73T87xcXadKl5TkFev4A/2tygmSBqYXqAYJmK+ZuoJydDR1vP09DA0NOy2kpdML81+U/heCpH1JU3jig7lJ5nKOT4i/t6ZHkqGzs4lJmIVHfrj+JR4HqLQSD0yDkCNEpGNn5ix9D03/eJdElTZdKV2TpNOhkwt8YUlNUgimgV0dLMBvf1gz1MolPd5FRcVNSkpDQ8owJeBCDyIhrIDnOD5QcuIU+3/2QKSs9laQ+noNLS0zLWdtqyP7mBAFAw88TwsJgMuJYweBGjYngtWbmeuZOW+bvNQToUFOAlFqOBk4Ov3/L7Z60/aN0p1tUhpa5nqWlub7C3p2I9QzyAghlUvczOz/1fhzPT3XSIfpSmmYAdVbmm1gV0dSz8DSilpUQsqCddIWIA3meuZaJqdMJZEzl6gRqgZIWZAxUdoizERXN8yi5MltcZTChzMaRQM3JNUWHS8rL/+yaPGvMmvr5ywoGoxtkDWwQ+Pb89ycBeWfGSJeL/la+RS1eOPnRtbQKgMRjZg+t8x6PkP273nWQAoFOPAgaeAThKXAmXMrK39Kmr5fsuBlBqoXfJGLe3VbmHjG9Mczi9T//3h7vygXtcDlQtJg44iQiIjIBRbGPO7gghPJy0ZIxT2HOLIUgwxQzsgYrUR350HSIMaJLidhgKY+mw+pflBDrX8E7OGBjPCAPc76gQFSTqAIiYrb/8dRP4CyosJ/rmwU5XIxHMilt4QBJwsSkBMClxOQULBlkRRwEONmR2kJcDGjADX2/+xO8r5iqjExqmLyrWpcPFRta1BfAwCtyN3XpuJ4RgAAAABJRU5ErkJggg=="/>
+
+  <g transform="translate(156 30)">
+    <rect width="238" height="22" rx="6" fill="#00D2FF" fill-opacity="0.1" stroke="#0E7490" stroke-opacity="0.3"/>
+    <circle cx="10" cy="11" r="3" fill="#16A34A"/>
+    <text x="20" y="15" fill="#0E7490" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="10.5" font-weight="800" letter-spacing="1.08">IZZYONDROID · CURATED F-DROID REPO</text>
+  </g>
+
+  <text x="156" y="80" fill="#0F172A" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="27" font-weight="800" letter-spacing="-0.3">Get it on IzzyOnDroid</text>
+
+  <text x="156" y="106" fill="#475569" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="14" font-weight="600">Developer-signed APK · Security scans · F-Droid compatible</text>
+
+  <g transform="translate(156 118)" fill="#0E7490" fill-opacity="0.5">
+    <rect x="0" y="7" width="4" height="9" rx="2"/>
+    <rect x="8" y="2" width="4" height="14" rx="2"/>
+    <rect x="16" y="5" width="4" height="11" rx="2"/>
+    <rect x="24" y="0" width="4" height="16" rx="2"/>
+    <rect x="32" y="6" width="4" height="10" rx="2"/>
+    <rect x="40" y="3" width="4" height="13" rx="2"/>
+    <rect x="48" y="8" width="4" height="8" rx="2"/>
+  </g>
+
+  <g transform="translate(548 50)">
+    <rect width="176" height="54" rx="16" fill="url(#iz-accent-light)"/>
+    <rect width="176" height="54" rx="16" fill="none" stroke="#FFFFFF" stroke-opacity="0.3"/>
+    <text x="68" y="34" text-anchor="middle" fill="#03242B" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="14.5" font-weight="900" letter-spacing="0.15">Open listing</text>
+    <path d="M146 27h-16M140 21l6 6-6 6" fill="none" stroke="#03242B" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/docs/assets/levyra-obtainium-download-light.svg
+++ b/docs/assets/levyra-obtainium-download-light.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="154" viewBox="0 0 760 154" role="img" aria-label="Install Levyra with Obtainium">
+  <title>Install Levyra with Obtainium</title>
+  <defs>
+    <linearGradient id="ob-bg-light" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="60%" stop-color="#F8FAFC"/>
+      <stop offset="100%" stop-color="#F1F5F9"/>
+    </linearGradient>
+    <linearGradient id="ob-border-light" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#CBD5E1" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#E2E8F0" stop-opacity="0.6"/>
+    </linearGradient>
+    <linearGradient id="ob-accent-light" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#34D399"/>
+      <stop offset="100%" stop-color="#059669"/>
+    </linearGradient>
+    <radialGradient id="ob-glow-light" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#A855F7" stop-opacity="0.45"/>
+      <stop offset="100%" stop-color="#A855F7" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="ob-mark-light" x1="76.787094" y1="113.40435" x2="110.68458" y2="152.48038" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#9B58DC"/>
+      <stop offset="1" stop-color="#321C92"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Base Card -->
+  <rect x="6" y="6" width="748" height="142" rx="22" fill="url(#ob-bg-light)" stroke="url(#ob-border-light)" stroke-width="1.5"/>
+  <path d="M28 7h704" stroke="#0F172A" stroke-opacity="0.05" stroke-linecap="round"/>
+
+  <!-- Left Accent Pillar -->
+  <rect x="18" y="24" width="4" height="106" rx="2" fill="url(#ob-accent-light)"/>
+
+  <!-- Left Icon Container (kept dark so official mark stays legible) -->
+  <rect x="36" y="27" width="100" height="100" rx="22" fill="#131927" stroke="#253046" stroke-width="1.5"/>
+  <circle cx="86" cy="77" r="44" fill="url(#ob-glow-light)"/>
+
+  <!-- Official Obtainium icon from ImranR98/Obtainium -->
+  <g transform="translate(17.15 4.68)">
+    <g transform="translate(-30.394373,-54.680428)">
+      <path fill="url(#ob-mark-light)" stroke="url(#ob-mark-light)" stroke-width="0.139" d="m 109.8808,153.22596 c -0.73146,-0.38777 -5.00657,-2.75679 -25.032416,-13.87149 -5.57273,-3.09297 -10.93823,-6.06723 -11.92332,-6.60948 -2.23728,-1.23152 -2.58105,-1.53456 -2.58105,-2.27528 0,-0.3879 0.89293,-2.87231 2.98561,-8.30689 1.64209,-4.2644 3.09426,-8.0014 3.22705,-8.30444 0.3024,-0.69008 0.78972,-1.27621 1.26573,-1.52236 0.44558,-0.23042 11.58052,-4.29685 12.14814,-4.43644 0.61355,-0.1509 1.1428,0.13977 1.45487,0.79901 0.14976,0.31638 0.77213,1.94934 1.38303,3.6288 0.6109,1.67945 1.52036,4.16275 2.02104,5.51844 1.14709,3.10604 1.18992,3.54589 0.3912,4.01771 -0.2117,0.12505 -1.58874,0.66539 -3.06009,1.20075 -1.47136,0.53536 -2.87533,1.08982 -3.11993,1.23213 -0.56422,0.32826 -0.64913,0.83523 -0.20815,1.24273 0.17523,0.16193 3.00434,1.77571 6.28691,3.58618 9.174936,5.06035 8.665596,4.83136 9.277626,4.17097 0.29987,-0.32356 5.78141,-14.266 6.09596,-15.50521 0.1344,-0.5295 0.11969,-0.60308 -0.16695,-0.83519 -0.39165,-0.31714 -0.335,-0.33071 -3.93797,0.9431 -3.56937,1.26192 -3.90926,1.28864 -4.38744,0.34488 -0.25108,-0.49556 -4.095796,-11.05481 -4.334456,-11.90432 -0.15438,-0.5495 0.0344,-1.0717 0.49701,-1.37482 0.19228,-0.12598 2.990116,-1.19935 6.217406,-2.38526 4.78924,-1.75986 6.0081,-2.15842 6.63117,-2.16837 0.8037,-0.0128 0.90917,0.0424 15.64514,8.19599 1.02104,0.56495 1.56579,1.15961 1.56579,1.70925 0,0.21814 -3.6538,9.91011 -8.11957,21.53771 -6.2982,16.39877 -8.19916,21.21114 -8.4744,21.45338 -0.46789,0.41179 -0.8512,0.39392 -1.74794,-0.0815 z"/>
+    </g>
+  </g>
+
+  <!-- Eyebrow Tag -->
+  <g transform="translate(156 30)">
+    <rect width="216" height="22" rx="6" fill="#10B981" fill-opacity="0.12" stroke="#059669" stroke-opacity="0.3"/>
+    <circle cx="10" cy="11" r="3" fill="#059669"/>
+    <text x="20" y="15" fill="#047857" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="10.5" font-weight="800" letter-spacing="1.2">OBTAINIUM · DIRECT FROM GITHUB</text>
+  </g>
+
+  <!-- Title -->
+  <text x="156" y="80" fill="#0F172A" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="27" font-weight="800" letter-spacing="-0.3">Install with Obtainium</text>
+
+  <!-- Subtitle / Meta -->
+  <text x="156" y="106" fill="#475569" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="14" font-weight="600">One tap · Signed APK · Automatic update tracking</text>
+
+  <!-- Musical Equalizer Spectrum -->
+  <g transform="translate(156 118)" fill="#059669" fill-opacity="0.5">
+    <rect x="0" y="6" width="4" height="10" rx="2"/>
+    <rect x="8" y="1" width="4" height="15" rx="2"/>
+    <rect x="16" y="7" width="4" height="9" rx="2"/>
+    <rect x="24" y="0" width="4" height="16" rx="2"/>
+    <rect x="32" y="4" width="4" height="12" rx="2"/>
+    <rect x="40" y="8" width="4" height="8" rx="2"/>
+    <rect x="48" y="2" width="4" height="14" rx="2"/>
+  </g>
+
+  <!-- Right CTA Button (Spacious, No Overlap) -->
+  <g transform="translate(538 50)">
+    <rect width="186" height="54" rx="16" fill="url(#ob-accent-light)"/>
+    <rect width="186" height="54" rx="16" fill="none" stroke="#FFFFFF" stroke-opacity="0.28"/>
+    <text x="74" y="34" text-anchor="middle" fill="#022213" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="14" font-weight="900" letter-spacing="0.2">Add to Obtainium</text>
+    <path d="M156 27h-16M150 21l6 6-6 6" fill="none" stroke="#022213" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/docs/assets/levyra-windows-download-light.svg
+++ b/docs/assets/levyra-windows-download-light.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="154" viewBox="0 0 760 154" role="img" aria-label="Download Levyra for Windows">
+  <title>Download Levyra for Windows</title>
+  <defs>
+    <linearGradient id="win-bg-light" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="60%" stop-color="#F8FAFC"/>
+      <stop offset="100%" stop-color="#F1F5F9"/>
+    </linearGradient>
+    <linearGradient id="win-border-light" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#CBD5E1" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#E2E8F0" stop-opacity="0.6"/>
+    </linearGradient>
+    <linearGradient id="win-accent-light" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#38BDF8"/>
+      <stop offset="100%" stop-color="#0284C7"/>
+    </linearGradient>
+    <radialGradient id="win-glow-light" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#0078D4" stop-opacity="0.48"/>
+      <stop offset="100%" stop-color="#0078D4" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Base Card -->
+  <rect x="6" y="6" width="748" height="142" rx="22" fill="url(#win-bg-light)" stroke="url(#win-border-light)" stroke-width="1.5"/>
+  <path d="M28 7h704" stroke="#0F172A" stroke-opacity="0.05" stroke-linecap="round"/>
+
+  <!-- Left Accent Pillar -->
+  <rect x="18" y="24" width="4" height="106" rx="2" fill="url(#win-accent-light)"/>
+
+  <!-- Left Icon Container (kept dark so the Windows mark stays legible) -->
+  <rect x="36" y="27" width="100" height="100" rx="22" fill="#131927" stroke="#253046" stroke-width="1.5"/>
+  <circle cx="86" cy="77" r="42" fill="url(#win-glow-light)"/>
+
+  <!-- Modern Windows mark: flat four-pane geometry -->
+  <g transform="translate(59 50)" fill="#38BDF8">
+    <rect x="0" y="0" width="25" height="25"/>
+    <rect x="29" y="0" width="25" height="25"/>
+    <rect x="0" y="29" width="25" height="25"/>
+    <rect x="29" y="29" width="25" height="25"/>
+  </g>
+
+  <!-- Eyebrow Tag -->
+  <g transform="translate(156 30)">
+    <rect width="186" height="22" rx="6" fill="#0284C7" fill-opacity="0.12" stroke="#0369A1" stroke-opacity="0.3"/>
+    <circle cx="10" cy="11" r="3" fill="#0284C7"/>
+    <text x="20" y="15" fill="#0369A1" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="10.5" font-weight="800" letter-spacing="1.2">OFFICIAL DESKTOP RELEASE</text>
+  </g>
+
+  <!-- Title -->
+  <text x="156" y="80" fill="#0F172A" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="27" font-weight="800" letter-spacing="-0.3">Levyra for Windows</text>
+
+  <!-- Subtitle / Meta -->
+  <text x="156" y="106" fill="#475569" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="14" font-weight="600">MSI · EXE · Portable ZIP · Windows 10/11 x64</text>
+
+  <!-- Musical Equalizer Spectrum -->
+  <g transform="translate(156 118)" fill="#0284C7" fill-opacity="0.5">
+    <rect x="0" y="5" width="4" height="11" rx="2"/>
+    <rect x="8" y="0" width="4" height="16" rx="2"/>
+    <rect x="16" y="6" width="4" height="10" rx="2"/>
+    <rect x="24" y="2" width="4" height="14" rx="2"/>
+    <rect x="32" y="8" width="4" height="8" rx="2"/>
+    <rect x="40" y="1" width="4" height="15" rx="2"/>
+    <rect x="48" y="7" width="4" height="9" rx="2"/>
+  </g>
+
+  <!-- Right CTA Button -->
+  <g transform="translate(554 50)">
+    <rect width="170" height="54" rx="16" fill="url(#win-accent-light)"/>
+    <rect width="170" height="54" rx="16" fill="none" stroke="#FFFFFF" stroke-opacity="0.28"/>
+    <text x="60" y="34" text-anchor="middle" fill="#031525" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,sans-serif" font-size="14.5" font-weight="900" letter-spacing="0.2">Get Windows</text>
+    <path d="M142 27h-16M136 21l6 6-6 6" fill="none" stroke="#031525" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Follow-up to #577. The six large "Download" section cards in the README (GitHub, F-Droid, Obtainium, IzzyOnDroid, Appteka, Windows) use the same fixed dark navy card background as the hero badges. This PR adds light-mode counterparts for all six and wires them up with `<picture>` + `prefers-color-scheme`, so the whole Download section now follows the viewer's GitHub theme instead of only the four small hero badges.

## What changed

- Added light SVG counterparts: `levyra-github-download-light.svg`, `levyra-fdroid-light.svg`, `levyra-obtainium-download-light.svg`, `levyra-izzyondroid-light.svg`, `levyra-appteka-light.svg`, `levyra-windows-download-light.svg`.
- Each keeps the original layout, accent colors, CTA button, and official logo/mark untouched; only the outer card background/border and the title/subtitle/eyebrow-tag text colors were swapped for light-theme contrast. The small icon container square stays the original dark navy in both variants, since several logos (GitHub octocat, F-Droid mascot) are drawn in white/light colors and depend on a dark tile behind them.
- Wrapped all six cards in `README.md` with `<picture>` elements (`prefers-color-scheme: light` / `dark` sources), keeping the original dark SVGs as fallback `<img>`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor or maintenance
- [x] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [x] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Shared infrastructure
- **Area:** Documentation / UI (README assets)

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [ ] Targeted tests were added or updated
- [x] Not applicable, with the reason explained below

This change only touches README markup and static SVG assets, so the Android/Desktop Gradle suites do not exercise it. Ran `python3 scripts/ai_quality_gate.py --profile fast`, which passed (agent config, AI efficiency, Matt skills, claude-mem, F-Droid review contract validations, and 157 repository script tests).

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| Local (cairosvg render) | Rendered all 6 light cards on a white background and the 6 original dark cards on a dark background side by side | Titles, subtitles, eyebrow tags, and equalizer bars are legible with good contrast in both variants; CTA buttons, logos, and layout are unchanged between the pair |

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** None — purely additive assets plus a markup change in `README.md`; no app code touched.
- **Known limitations:** GitHub Mobile and some third-party README renderers may not honor `prefers-color-scheme` inside `<picture>`; in that case the existing dark card is shown as before (no regression).
- **Rollback plan:** Revert this PR.

## Reviewer notes

- Same approach as #577: new SVGs mirror the structure of the existing dark cards with background/border/text swapped, official logos and CTA buttons untouched.
- The IzzyOnDroid card embeds an official base64 PNG icon; that data URI was copied byte-for-byte into the light variant, no re-encoding.

## Release note

The Download section cards in the README now adapt to GitHub's light theme instead of always showing dark cards.

## Related issues

- Closes #
- Related to #

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated download badges in the README to automatically display light- or dark-theme artwork based on the viewer’s system preference.
  - Preserved the existing download links and badge layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->