### PR TITLE
fix(home): keep album cards on canonical metadata

### DIFF
--- a/app/src/main/java/com/luc4n3x/levyra/data/HomeAlbumShelfEngine.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/HomeAlbumShelfEngine.kt
@@ -42,11 +42,7 @@ internal fun buildPersonalizedHomeAlbumShelf(
         .filter(::isUsableAlbumTrack)
         .map(::trackToHomeAlbumHit)
 
-    val canonicalPrimaryAlbums = primaryAlbums
-        .asSequence()
-        .map(::canonicalizeHomeAlbumHit)
-
-    return (canonicalPrimaryAlbums + strictDerived + relaxedDerived)
+    return (primaryAlbums.asSequence() + strictDerived + relaxedDerived)
         .filter(::isUsableHomeAlbum)
         .distinctBy(::albumRecommendationDeduplicationKey)
         .take(HOME_ALBUM_SHELF_TARGET_SIZE)
@@ -100,19 +96,5 @@ private fun trackToHomeAlbumHit(track: Track): AlbumHit {
         metadataProvider = track.metadataProvider,
         metadataConfidence = track.metadataConfidence,
         releaseType = ReleaseType.Album
-    )
-}
-
-
-private fun canonicalizeHomeAlbumHit(album: AlbumHit): AlbumHit {
-    val currentArtist = album.artist.trim()
-    if (album.artistBrowseId.isBlank()) return album.copy(artist = currentArtist)
-    val primaryArtist = primaryArtistSegment(currentArtist).ifBlank { currentArtist }
-    if (primaryArtist == currentArtist) return album
-    return album.copy(
-        artist = primaryArtist,
-        query = listOf(album.title.trim(), primaryArtist, "album")
-            .filter(String::isNotBlank)
-            .joinToString(" ")
     )
 }

--- a/app/src/main/java/com/luc4n3x/levyra/data/HomeAlbumShelfEngine.kt
+++ b/app/src/main/java/com/luc4n3x/levyra/data/HomeAlbumShelfEngine.kt
@@ -4,6 +4,7 @@ import com.luc4n3x.levyra.domain.AlbumHit
 import com.luc4n3x.levyra.domain.HomeSection
 import com.luc4n3x.levyra.domain.ReleaseType
 import com.luc4n3x.levyra.domain.Track
+import com.luc4n3x.levyra.domain.primaryArtistSegment
 
 internal const val HOME_ALBUM_SHELF_TARGET_SIZE = 14
 
@@ -41,7 +42,11 @@ internal fun buildPersonalizedHomeAlbumShelf(
         .filter(::isUsableAlbumTrack)
         .map(::trackToHomeAlbumHit)
 
-    return (primaryAlbums.asSequence() + strictDerived + relaxedDerived)
+    val canonicalPrimaryAlbums = primaryAlbums
+        .asSequence()
+        .map(::canonicalizeHomeAlbumHit)
+
+    return (canonicalPrimaryAlbums + strictDerived + relaxedDerived)
         .filter(::isUsableHomeAlbum)
         .distinctBy(::albumRecommendationDeduplicationKey)
         .take(HOME_ALBUM_SHELF_TARGET_SIZE)
@@ -58,7 +63,7 @@ private fun isUsableAlbumTrack(track: Track): Boolean {
     val album = track.album.trim()
     val artist = track.artist.trim()
     if (album.isBlank() || artist.isBlank()) return false
-    if (album.equals(track.title.trim(), ignoreCase = true)) return false
+    if (albumRecommendationTextKey(album) == albumRecommendationTextKey(track.title)) return false
     if (album.equals("YouTube Music", ignoreCase = true) || album.equals("YouTube", ignoreCase = true)) return false
     if (artist.equals("YouTube Music", ignoreCase = true) || artist.equals("YouTube", ignoreCase = true)) return false
     return track.largeThumbnailUrl.isNotBlank() || track.thumbnailUrl.isNotBlank()
@@ -77,7 +82,7 @@ private fun hasLikelyAlbumArtwork(track: Track): Boolean {
 
 private fun trackToHomeAlbumHit(track: Track): AlbumHit {
     val album = track.album.trim()
-    val artist = track.artist.trim()
+    val artist = primaryArtistSegment(track.artist).ifBlank { track.artist.trim() }
     return AlbumHit(
         title = album,
         artist = artist,
@@ -95,5 +100,19 @@ private fun trackToHomeAlbumHit(track: Track): AlbumHit {
         metadataProvider = track.metadataProvider,
         metadataConfidence = track.metadataConfidence,
         releaseType = ReleaseType.Album
+    )
+}
+
+
+private fun canonicalizeHomeAlbumHit(album: AlbumHit): AlbumHit {
+    val currentArtist = album.artist.trim()
+    if (album.artistBrowseId.isBlank()) return album.copy(artist = currentArtist)
+    val primaryArtist = primaryArtistSegment(currentArtist).ifBlank { currentArtist }
+    if (primaryArtist == currentArtist) return album
+    return album.copy(
+        artist = primaryArtist,
+        query = listOf(album.title.trim(), primaryArtist, "album")
+            .filter(String::isNotBlank)
+            .joinToString(" ")
     )
 }

--- a/app/src/test/java/com/luc4n3x/levyra/data/HomeAlbumShelfEngineTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/HomeAlbumShelfEngineTest.kt
@@ -86,26 +86,6 @@ class HomeAlbumShelfEngineTest {
     }
 
     @Test
-    fun canonicalPrimaryAlbumDropsTrackLevelFeaturingFromArtistLabel() {
-        val result = buildPersonalizedHomeAlbumShelf(
-            primaryAlbums = listOf(
-                album("Vangelo", "Shiva, Geolier").copy(artistBrowseId = "UC_SHIVA")
-            ),
-            personalTracks = emptyList(),
-            recentTracks = emptyList(),
-            favoriteTracks = emptyList(),
-            quickPickTracks = emptyList(),
-            localizedReleaseTracks = emptyList(),
-            localizedSections = emptyList(),
-            chartTracks = emptyList(),
-            fallbackTracks = emptyList()
-        )
-
-        assertEquals("Shiva", result.single().artist)
-        assertEquals("Vangelo Shiva album", result.single().query)
-    }
-
-    @Test
     fun trackTitleCannotMasqueradeAsAlbumAfterCreditNormalization() {
         val result = buildPersonalizedHomeAlbumShelf(
             primaryAlbums = emptyList(),

--- a/app/src/test/java/com/luc4n3x/levyra/data/HomeAlbumShelfEngineTest.kt
+++ b/app/src/test/java/com/luc4n3x/levyra/data/HomeAlbumShelfEngineTest.kt
@@ -59,6 +59,76 @@ class HomeAlbumShelfEngineTest {
         assertTrue(result.size >= expectedMinimumShelfSize)
     }
 
+    @Test
+    fun derivedAlbumUsesLeadArtistInsteadOfTrackFeaturingCredit() {
+        val result = buildPersonalizedHomeAlbumShelf(
+            primaryAlbums = emptyList(),
+            personalTracks = listOf(
+                track(
+                    id = "vangelo",
+                    album = "Vangelo",
+                    artist = "Shiva, Geolier",
+                    artistBrowseIds = listOf("UC_SHIVA", "UC_GEOLIER")
+                )
+            ),
+            recentTracks = emptyList(),
+            favoriteTracks = emptyList(),
+            quickPickTracks = emptyList(),
+            localizedReleaseTracks = emptyList(),
+            localizedSections = emptyList(),
+            chartTracks = emptyList(),
+            fallbackTracks = emptyList()
+        )
+
+        assertEquals("Vangelo", result.single().title)
+        assertEquals("Shiva", result.single().artist)
+        assertEquals("UC_SHIVA", result.single().artistBrowseId)
+    }
+
+    @Test
+    fun canonicalPrimaryAlbumDropsTrackLevelFeaturingFromArtistLabel() {
+        val result = buildPersonalizedHomeAlbumShelf(
+            primaryAlbums = listOf(
+                album("Vangelo", "Shiva, Geolier").copy(artistBrowseId = "UC_SHIVA")
+            ),
+            personalTracks = emptyList(),
+            recentTracks = emptyList(),
+            favoriteTracks = emptyList(),
+            quickPickTracks = emptyList(),
+            localizedReleaseTracks = emptyList(),
+            localizedSections = emptyList(),
+            chartTracks = emptyList(),
+            fallbackTracks = emptyList()
+        )
+
+        assertEquals("Shiva", result.single().artist)
+        assertEquals("Vangelo Shiva album", result.single().query)
+    }
+
+    @Test
+    fun trackTitleCannotMasqueradeAsAlbumAfterCreditNormalization() {
+        val result = buildPersonalizedHomeAlbumShelf(
+            primaryAlbums = emptyList(),
+            personalTracks = listOf(
+                track(
+                    id = "per-noi",
+                    album = "PER NOI",
+                    artist = "Geolier",
+                    title = "PER NOI feat. Sfera Ebbasta"
+                )
+            ),
+            recentTracks = emptyList(),
+            favoriteTracks = emptyList(),
+            quickPickTracks = emptyList(),
+            localizedReleaseTracks = emptyList(),
+            localizedSections = emptyList(),
+            chartTracks = emptyList(),
+            fallbackTracks = emptyList()
+        )
+
+        assertTrue(result.none { it.title.equals("PER NOI", ignoreCase = true) })
+    }
+
     private fun album(title: String, artist: String): AlbumHit = AlbumHit(
         title = title,
         artist = artist,
@@ -68,9 +138,15 @@ class HomeAlbumShelfEngineTest {
         browseId = "MPREb_${title.replace(' ', '_')}"
     )
 
-    private fun track(id: String, album: String, artist: String): Track = Track(
+    private fun track(
+        id: String,
+        album: String,
+        artist: String,
+        title: String = "$album Song",
+        artistBrowseIds: List<String> = listOf("UC_$id")
+    ): Track = Track(
         id = id,
-        title = "$album Song",
+        title = title,
         artist = artist,
         album = album,
         durationMs = 180_000L,
@@ -87,6 +163,6 @@ class HomeAlbumShelfEngineTest {
         accentStart = 0xFF3366FF.toInt(),
         accentEnd = 0xFF6633FF.toInt(),
         albumBrowseId = "MPREb_$id",
-        artistBrowseIds = listOf("UC_$id")
+        artistBrowseIds = artistBrowseIds
     )
 }


### PR DESCRIPTION
## Summary

Fixes incorrect metadata in the Home "Album per te" shelf where track-level metadata could leak into album cards.

Examples of the broken behavior:
- `Vangelo` displayed as `Shiva, Geolier` even though the album belongs to Shiva.
- a track title such as `PER NOI` could be mistaken for an album title when track metadata was incomplete or credit-normalized differently.

## Fix

- Derived album cards now use the lead/canonical artist instead of the full track featuring credit.
- Authoritative album entities returned by the provider are left untouched, so genuine collaborative albums keep their real album-level credits.
- Album-vs-track-title validation now uses Levyra's normalized album text identity, so variants such as `PER NOI` and `PER NOI feat. ...` are treated as the same track title and rejected as fake album metadata.
- Album browse IDs, canonical artwork, release metadata and navigation identity remain unchanged.

## Regression coverage

Added tests for:
- `Vangelo` from a `Shiva, Geolier` track resolving to `Vangelo · Shiva`;
- `PER NOI feat. ...` not generating a fake `PER NOI` album card.

## Scope

Android Home album shelf only. No playback, recommendation scoring, persistence or release-version changes.
