### PR TITLE
docs: refine documentation badge

### DIFF
--- a/docs/assets/levyra-wiki-light.svg
+++ b/docs/assets/levyra-wiki-light.svg
@@ -1,19 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="172" height="40" viewBox="0 0 172 40" role="img" aria-label="Levyra Docs">
-<title>Levyra Docs</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="172" height="40" viewBox="0 0 172 40" role="img" aria-label="Levyra Documentation">
+<title>Levyra Documentation</title>
 <defs>
-  <linearGradient id="wiki-bg-light" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#FFFFFF"/><stop offset=".58" stop-color="#F8FAFC"/><stop offset="1" stop-color="#F1F5F9"/></linearGradient>
-  <linearGradient id="wiki-accent-light" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#A78BFA"/><stop offset="1" stop-color="#7C3AED"/></linearGradient>
+  <linearGradient id="docs-bg-light" x1="0" y1="0" x2="1" y2="1">
+    <stop offset="0" stop-color="#FFFFFF"/>
+    <stop offset=".58" stop-color="#F8FAFC"/>
+    <stop offset="1" stop-color="#F1F5F9"/>
+  </linearGradient>
+  <linearGradient id="docs-accent-light" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0" stop-color="#A78BFA"/>
+    <stop offset="1" stop-color="#7C3AED"/>
+  </linearGradient>
 </defs>
-<rect x=".5" y=".5" width="171" height="39" rx="12" fill="url(#wiki-bg-light)" stroke="#E2E8F0"/>
+<rect x=".5" y=".5" width="171" height="39" rx="12" fill="url(#docs-bg-light)" stroke="#E2E8F0"/>
 <path d="M13 1h146" stroke="#0F172A" stroke-opacity=".05" stroke-linecap="round"/>
-<rect x="2" y="9" width="3" height="22" rx="1.5" fill="url(#wiki-accent-light)"/>
+<rect x="2" y="9" width="3" height="22" rx="1.5" fill="url(#docs-accent-light)"/>
 <circle cx="22" cy="20" r="11" fill="#A78BFA" fill-opacity=".12" stroke="#A78BFA" stroke-opacity=".35"/>
-<g transform="translate(14 12)" fill="none" stroke="url(#wiki-accent-light)" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M3 3.5h6.2A2.8 2.8 0 0 1 12 6.3V13H5.8A2.8 2.8 0 0 0 3 15.8V3.5Z"/>
-  <path d="M13 3.5H9.8A2.8 2.8 0 0 0 7 6.3"/>
+<g transform="translate(15 12)" fill="none" stroke="url(#docs-accent-light)" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3.2 1.5h5.9l3.7 3.7v8.9H3.2z"/>
+  <path d="M9.1 1.5v3.7h3.7"/>
+  <path d="M5.6 8h4.8"/>
+  <path d="M5.6 10.8h4.8"/>
 </g>
 <text x="42" y="24.1" fill="#0F172A" font-family="Segoe UI,Inter,Arial,sans-serif" font-size="11.4" font-weight="800" letter-spacing=".12">Docs</text>
-<rect x="103" y="6" width="62" height="28" rx="9" fill="url(#wiki-accent-light)"/>
+<rect x="103" y="6" width="62" height="28" rx="9" fill="url(#docs-accent-light)"/>
 <rect x="103.5" y="6.5" width="61" height="27" rx="8.5" fill="none" stroke="#FFFFFF" stroke-opacity=".35"/>
-<text x="134" y="24.2" text-anchor="middle" fill="#FFFFFF" font-family="Segoe UI,Inter,Arial,sans-serif" font-size="11" font-weight="900">Site</text>
+<text x="134" y="24.2" text-anchor="middle" fill="#FFFFFF" font-family="Segoe UI,Inter,Arial,sans-serif" font-size="11" font-weight="900">Read</text>
 </svg>

--- a/docs/assets/levyra-wiki.svg
+++ b/docs/assets/levyra-wiki.svg
@@ -1,19 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="172" height="40" viewBox="0 0 172 40" role="img" aria-label="Levyra Docs">
-<title>Levyra Docs</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="172" height="40" viewBox="0 0 172 40" role="img" aria-label="Levyra Documentation">
+<title>Levyra Documentation</title>
 <defs>
-  <linearGradient id="wiki-bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#111A2B"/><stop offset=".58" stop-color="#0B1220"/><stop offset="1" stop-color="#080D18"/></linearGradient>
-  <linearGradient id="wiki-accent" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#A78BFA"/><stop offset="1" stop-color="#7C3AED"/></linearGradient>
+  <linearGradient id="docs-bg" x1="0" y1="0" x2="1" y2="1">
+    <stop offset="0" stop-color="#111A2B"/>
+    <stop offset=".58" stop-color="#0B1220"/>
+    <stop offset="1" stop-color="#080D18"/>
+  </linearGradient>
+  <linearGradient id="docs-accent" x1="0" y1="0" x2="1" y2="0">
+    <stop offset="0" stop-color="#A78BFA"/>
+    <stop offset="1" stop-color="#7C3AED"/>
+  </linearGradient>
 </defs>
-<rect x=".5" y=".5" width="171" height="39" rx="12" fill="url(#wiki-bg)" stroke="#2B3850"/>
+<rect x=".5" y=".5" width="171" height="39" rx="12" fill="url(#docs-bg)" stroke="#2B3850"/>
 <path d="M13 1h146" stroke="#FFFFFF" stroke-opacity=".055" stroke-linecap="round"/>
-<rect x="2" y="9" width="3" height="22" rx="1.5" fill="url(#wiki-accent)"/>
+<rect x="2" y="9" width="3" height="22" rx="1.5" fill="url(#docs-accent)"/>
 <circle cx="22" cy="20" r="11" fill="#A78BFA" fill-opacity=".075" stroke="#A78BFA" stroke-opacity=".3"/>
-<g transform="translate(14 12)" fill="none" stroke="url(#wiki-accent)" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M3 3.5h6.2A2.8 2.8 0 0 1 12 6.3V13H5.8A2.8 2.8 0 0 0 3 15.8V3.5Z"/>
-  <path d="M13 3.5H9.8A2.8 2.8 0 0 0 7 6.3"/>
+<g transform="translate(15 12)" fill="none" stroke="url(#docs-accent)" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3.2 1.5h5.9l3.7 3.7v8.9H3.2z"/>
+  <path d="M9.1 1.5v3.7h3.7"/>
+  <path d="M5.6 8h4.8"/>
+  <path d="M5.6 10.8h4.8"/>
 </g>
 <text x="42" y="24.1" fill="#F8FAFC" font-family="Segoe UI,Inter,Arial,sans-serif" font-size="11.4" font-weight="800" letter-spacing=".12">Docs</text>
-<rect x="103" y="6" width="62" height="28" rx="9" fill="url(#wiki-accent)"/>
+<rect x="103" y="6" width="62" height="28" rx="9" fill="url(#docs-accent)"/>
 <rect x="103.5" y="6.5" width="61" height="27" rx="8.5" fill="none" stroke="#FFFFFF" stroke-opacity=".18"/>
-<text x="134" y="24.2" text-anchor="middle" fill="#FFFFFF" font-family="Segoe UI,Inter,Arial,sans-serif" font-size="11" font-weight="900">Site</text>
+<text x="134" y="24.2" text-anchor="middle" fill="#FFFFFF" font-family="Segoe UI,Inter,Arial,sans-serif" font-size="11" font-weight="900">Read</text>
 </svg>


### PR DESCRIPTION
## Summary

Refines the README documentation badge so it reads more clearly and uses a cleaner documentation icon.

## What changed

- Replaced the previous icon with a simple document/page icon.
- Changed the action text from `Site` to `Read`.
- Kept the existing Levyra badge sizing, spacing, gradients, and dark/light variants.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor or maintenance
- [x] UI or UX change
- [ ] Localization or accessibility
- [ ] Build, CI, packaging, or release change
- [x] Documentation
- [ ] Breaking change

## Scope

- **Platform:** Shared infrastructure
- **Area:** README / Documentation badge

## Validation

### Automated checks

- [ ] Android: `./gradlew --no-daemon :app:lintRelease :app:testReleaseUnitTest :app:assembleRelease`
- [ ] Desktop: `cd desktop && ./gradlew check assemble`
- [ ] Targeted tests were added or updated
- [x] Not applicable, SVG-only documentation asset change

### Manual testing

| Environment | Scenario | Result |
|---|---|---|
| SVG review | Dark variant | PASS |
| SVG review | Light variant | PASS |

## Risk and compatibility

- **Risk level:** Low
- **Compatibility or migration notes:** None
- **Known limitations:** None
- **Rollback plan:** Revert this PR

## Reviewer notes

The badge remains the same size as the surrounding README badges, so the badge row layout is unchanged.

## Release note

None

## Related issues

- Closes #
- Related to #

## Checklist

- [x] The PR is focused and contains no unrelated changes
- [x] The implementation follows the existing architecture and naming conventions
- [x] Threading, lifecycle, cancellation, and resource cleanup were reviewed where relevant
- [x] Tests, documentation, localization, and screenshots were updated where required
- [x] No secrets, keystores, generated packages, archives, or local-only files were committed
- [x] Android and Desktop versioning and release channels remain independent
- [ ] CI is green, or every remaining failure is explained in this PR
- [x] The complete Levyra PR template is preserved and the final description passed through `levyra-humanizer` without changing its claims
